### PR TITLE
Potential fix for code scanning alert no. 17: Use of externally-controlled format string

### DIFF
--- a/services/claims-scrubbing-service/src/claims-scrubber.ts
+++ b/services/claims-scrubbing-service/src/claims-scrubber.ts
@@ -288,7 +288,7 @@ export class ClaimsScrubberService {
         messages: [message],
       });
     } catch (error) {
-      console.error(`Failed to route claim ${claim.claimId}:`, error);
+      console.error('Failed to route claim', { claimId: claim.claimId }, error);
     }
   }
 
@@ -320,7 +320,7 @@ export class ClaimsScrubberService {
         blobHTTPHeaders: { blobContentType: 'application/json' },
       });
     } catch (error) {
-      console.error(`Failed to archive claim ${claim.claimId}:`, error);
+      console.error('Failed to archive claim', { claimId: claim.claimId }, error);
     }
   }
 

--- a/services/eligibility-service/src/eligibility-service.ts
+++ b/services/eligibility-service/src/eligibility-service.ts
@@ -96,7 +96,7 @@ export class EligibilityService {
         throw new Error('Invalid request format or missing request data');
       }
     } catch (error) {
-      console.error(`Eligibility check failed: ${error}`);
+      console.error('Eligibility check failed:', error);
       throw error;
     }
   }
@@ -381,7 +381,7 @@ export class EligibilityService {
 
       return record;
     } catch (error) {
-      console.error(`Cache lookup failed: ${error}`);
+      console.error('Cache lookup failed:', error);
       return null;
     }
   }
@@ -425,7 +425,7 @@ export class EligibilityService {
     try {
       await this.container.items.create(record);
     } catch (error) {
-      console.error(`Cache write failed: ${error}`);
+      console.error('Cache write failed:', error);
     }
   }
 
@@ -460,7 +460,7 @@ export class EligibilityService {
     try {
       await this.container.items.create(record);
     } catch (error) {
-      console.error(`FHIR cache write failed: ${error}`);
+      console.error('FHIR cache write failed:', error);
     }
   }
 
@@ -593,7 +593,7 @@ export class EligibilityService {
     try {
       await this.eventGridClient.send([event]);
     } catch (error) {
-      console.error(`Failed to publish EligibilityChecked event: ${error}`);
+      console.error('Failed to publish EligibilityChecked event:', error);
     }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/17](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/17)

General fix approach: Never let untrusted data control or become part of a format string. Instead, use a static format string and pass untrusted values as additional arguments or as structured objects. For `console.*`, that means either: 
- `console.error('Failed to audit claim %s:', claim.claimId, error);` or 
- `console.error('Failed to audit claim:', { claimId: claim.claimId, error });`.

Best fix here without changing functionality: adjust the `console.error` in `auditValidation` so that the first argument is a purely static string, and the untrusted `claim.claimId` is passed as a separate argument (e.g., in an object). This preserves all information currently logged while eliminating any possibility that user data is interpreted as part of a format string.

Concretely, in `services/claims-scrubbing-service/src/claims-scrubber.ts`, around line 414, replace:
```ts
console.error(`Failed to audit claim ${claim.claimId}:`, error);
```
with something like:
```ts
console.error('Failed to audit claim', { claimId: claim.claimId }, error);
```
No new imports or helpers are needed; this is a straightforward change within the shown method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
