### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,5 +1,8 @@
 name: Smoke Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/11](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/11)

In general, to fix this issue you explicitly declare a `permissions` block for the workflow or for each job, specifying only the minimal scopes needed. For a read-only validation workflow like this, `contents: read` is typically sufficient, since the job only needs to fetch the repository contents and run local commands.

The single best fix with no behavioral change is to add a `permissions` block at the workflow root (applies to all jobs) with `contents: read`. This documents intent and ensures the `GITHUB_TOKEN` cannot be escalated via broader repo/org defaults. Concretely, in `.github/workflows/sanity.yml`, add:

```yaml
permissions:
  contents: read
```

near the top-level of the workflow, e.g., immediately after the `name: Smoke Tests` line and before the `on:` block. No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
