### PR TITLE
Potential fix for code scanning alert no. 14: Insecure randomness

### DIFF
--- a/scripts/utils/generate-payer-exchange-data.ts
+++ b/scripts/utils/generate-payer-exchange-data.ts
@@ -23,6 +23,7 @@
 import { Patient, Claim, Encounter, ExplanationOfBenefit, ServiceRequest } from 'fhir/r4';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as crypto from 'crypto';
 
 interface SyntheticDataOptions {
   patientCount: number;
@@ -31,6 +32,10 @@ interface SyntheticDataOptions {
   eobsPerPatient: number;
   priorAuthsPerPatient: number;
   outputDir: string;
+}
+
+function secureRandomInt(min: number, maxExclusive: number): number {
+  return crypto.randomInt(min, maxExclusive);
 }
 
 /**
@@ -47,9 +52,9 @@ function generateSyntheticPatients(count: number): Patient[] {
     const firstName = firstNames[Math.floor(Math.random() * firstNames.length)];
     const lastName = lastNames[Math.floor(Math.random() * lastNames.length)];
     const gender = Math.random() > 0.5 ? 'male' : 'female';
-    const birthYear = 1940 + Math.floor(Math.random() * 70);
-    const birthMonth = String(Math.floor(Math.random() * 12) + 1).padStart(2, '0');
-    const birthDay = String(Math.floor(Math.random() * 28) + 1).padStart(2, '0');
+    const birthYear = secureRandomInt(1940, 2010);
+    const birthMonth = String(secureRandomInt(1, 13)).padStart(2, '0');
+    const birthDay = String(secureRandomInt(1, 29)).padStart(2, '0');
     const cityIndex = Math.floor(Math.random() * cities.length);
 
     const patient: Patient = {


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/14](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/14)

In general, to fix insecure randomness findings, replace uses of `Math.random()` in any value considered “security-sensitive” with randomness sourced from a cryptographically secure pseudo-random number generator. In Node.js, this typically means using the `crypto` module (e.g., `crypto.randomInt` or `crypto.randomBytes`), and then mapping the secure random output into the desired range without introducing significant bias.

For this specific file and function, the simplest, least-invasive fix is to (1) import Node’s `crypto` module, (2) introduce a small helper, e.g. `secureRandomInt(min, maxExclusive)`, that uses `crypto.randomInt`, and then (3) replace the direct `Math.random()` calls used to compute `birthYear`, `birthMonth`, and `birthDay` with calls to this helper. This preserves the intended ranges and formatting while ensuring that the random birth date components are generated using a cryptographically secure RNG. The rest of the logic (IDs, names, etc.) can remain as is, since the alert is specifically about the birth date path.

Concretely:
- In `scripts/utils/generate-payer-exchange-data.ts`, add `import * as crypto from 'crypto';` alongside the other imports.
- Just above `generateSyntheticPatients`, define:

  ```ts
  function secureRandomInt(min: number, maxExclusive: number): number {
    return crypto.randomInt(min, maxExclusive);
  }
  ```

- Then change:
  - `const birthYear = 1940 + Math.floor(Math.random() * 70);`
  - `const birthMonth = String(Math.floor(Math.random() * 12) + 1).padStart(2, '0');`
  - `const birthDay = String(Math.floor(Math.random() * 28) + 1).padStart(2, '0');`
  
  to use `secureRandomInt` with the same ranges:
  - `const birthYear = secureRandomInt(1940, 2010);` (1940–2009 inclusive, i.e., 70 years)
  - `const birthMonth = String(secureRandomInt(1, 13)).padStart(2, '0');`
  - `const birthDay = String(secureRandomInt(1, 29)).padStart(2, '0');`

This addresses both alert variants that point to the randomization of birth year and month/day while keeping the rest of the generator unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
