### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phi-validation.yml
+++ b/.github/workflows/phi-validation.yml
@@ -1,5 +1,8 @@
 name: PHI Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main, release/*]


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/9](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/9)

In general, to fix this issue you add a `permissions:` block either at the workflow root (applies to all jobs) or under the specific job, and grant only the minimal scopes the workflow actually needs. For a read-only workflow that just checks out code and runs local analysis/tests, `contents: read` is typically sufficient, and often no other scopes are required.

For this particular workflow, the steps only (1) check out the repository, (2) set up Node.js, (3) install dependencies, (4) build and test, and (5) run local scripts/grep-style checks. There are no steps that interact with GitHub APIs in a way that requires write permissions (no pushing commits, commenting on PRs, modifying issues, etc.). Therefore, the single best minimal-change fix is to add a root-level `permissions:` block that sets `contents: read`. This both satisfies the CodeQL rule and documents that the workflow only needs read access to repository contents.

Concretely:
- Edit `.github/workflows/phi-validation.yml`.
- Insert a `permissions:` block after the `name:` (line 1) and before `on:` (line 3), like:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or additional definitions are required, as this is purely GitHub Actions YAML configuration and does not change any runtime behavior of the steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
