### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   # Pre-approval security validation
   pre-approval-checks:
+    permissions:
+      contents: read
     uses: ./.github/workflows/pre-approval-checks.yml
     with:
       environment: PROD


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/7](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/7)

In general, to fix this issue you should add an explicit `permissions` block to each job (or at the workflow root) so that `GITHUB_TOKEN` has only the scopes required. For this workflow, the missing block is on the `pre-approval-checks` job that invokes a reusable workflow. GitHub lets you set permissions on a job that uses a reusable workflow; those permissions become the defaults for all jobs in the called workflow that do not override them.

The best targeted fix without changing functionality is to add a minimal `permissions` block to the `pre-approval-checks` job. Since we do not see any write operations here and the reusable workflow is named as a security check, a conservative and safe choice is read-only repository access: `contents: read`. If the called workflow actually needs more (for example, `security-events: write` for uploading results), that can be added later, but starting with `contents: read` satisfies the CodeQL requirement and enforces least privilege relative to potentially read-write defaults.

Concretely, in `.github/workflows/deploy.yml`, edit the `pre-approval-checks` job section (lines 10–14). Insert a `permissions:` block under the job definition (at the same indentation level as `uses:` and `with:`), specifying `contents: read`. No imports or other definitions are needed; this is purely a YAML configuration change inside the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
