### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -1,5 +1,8 @@
 name: Deploy UAT - Cloud Health Office
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/5](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/5)

To fix this, explicitly define restricted `GITHUB_TOKEN` permissions so that jobs do not inherit potentially broad repository defaults. The cleanest approach is:

1. Add a minimal `permissions` block at the workflow root (just under `name:` or `on:`) to apply to all jobs by default, e.g. `contents: read`.
2. Keep or add job-level `permissions` blocks only where they differ from the default. In this snippet, `validate` already has `permissions: contents: read`, which is consistent with the desired default and can be left as-is.
3. This automatically restricts `approval-gate` (and any other jobs without their own `permissions`) to read-only repository contents, which is sufficient since they only run shell commands and don’t write to the repo.

Concretely for `.github/workflows/deploy-uat.yml`:

- Insert a `permissions:` section near the top of the file (e.g. after line 1) with `contents: read`. No other imports or definitions are required. No behavioral change occurs for the existing steps, but the `GITHUB_TOKEN` will now be limited by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
