### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -28,6 +28,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     environment: DEV
+    permissions:
+      contents: read
     outputs:
       bicep-path: ${{ steps.set-params.outputs.bicep-path }}
       workflows-path: ${{ steps.set-params.outputs.workflows-path }}


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/3](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/3)

To fix the problem, explicitly set minimal `GITHUB_TOKEN` permissions for the `validate` job so it does not inherit broader repository defaults. Since `validate` only needs to read the repository contents (for `actions/checkout`) and does not perform any writes, `contents: read` is an appropriate least‑privilege setting.

The best fix without changing existing functionality is to add a `permissions` block directly under the `validate` job’s configuration (near line 29), mirroring the pattern already used in the `deploy-infrastructure` job. Concretely, in `.github/workflows/deploy-dev.yml`, within the `jobs.validate` mapping, insert:

```yaml
permissions:
  contents: read
```

indented to align with `runs-on` and `environment`. No additional imports, methods, or definitions are required; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
