### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-wave-053ff9e1e.yml
+++ b/.github/workflows/azure-static-web-apps-kind-wave-053ff9e1e.yml
@@ -56,6 +56,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      contents: read
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/2](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/2)

To fix the problem, we should explicitly define GITHUB_TOKEN permissions for the `close_pull_request_job`, limiting it to the minimal scope it needs. Because this job just triggers the Azure Static Web Apps deploy action to close a pull request environment and does not read or modify repository contents, we can start from a restrictive baseline like `contents: read`. This both documents the intended permissions and prevents the job from inheriting broader write permissions from the repository or organization defaults.

Concretely, in `.github/workflows/azure-static-web-apps-kind-wave-053ff9e1e.yml`, add a `permissions` block under the `close_pull_request_job` definition, at the same indentation level as `runs-on` and `name`. We’ll set `contents: read` as a minimal, safe default. No additional imports, methods, or definitions are needed because this is a pure YAML configuration change. The existing `build_and_deploy_job` permissions remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
