### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, 'release/*']
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/1](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/1)

In general, this problem is fixed by explicitly specifying a `permissions` block in the workflow or in individual jobs to restrict the `GITHUB_TOKEN` to the least privileges required. For a typical CI/coverage workflow that only needs to check out the repo and upload coverage, `contents: read` is sufficient; no write permissions are needed.

For this specific workflow, the safest and simplest fix without changing functionality is to add a `permissions` block at the top level (so it applies to all jobs) with `contents: read`. The workflow only checks out code, installs dependencies, builds, runs tests, and uploads coverage to Codecov using a secret; none of these steps require write access to the repository via `GITHUB_TOKEN`. The best place to add this is after the `on:` trigger block and before `jobs:` in `.github/workflows/codecov.yml`. No additional imports or methods are required, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
