### PR TITLE
Potential fix for code scanning alert no. 151: Uncontrolled command line

### DIFF
--- a/services/tenant-service/Services/SftpProvisioningService.cs
+++ b/services/tenant-service/Services/SftpProvisioningService.cs
@@ -67,11 +67,19 @@ public class SftpProvisioningService : ISftpProvisioningService
             // Build arguments
             var keyVault = keyVaultName ?? _configuration["Azure:KeyVault:Name"] ?? "cho-keyvault-prod";
             var environmentsArg = string.Join(",", environments);
-            
-            var arguments = $"{tenantId} \"{tenantName}\" {keyVault} --environments {environmentsArg}";
+
+            // Build structured argument list to avoid shell parsing of user-controlled values
+            var scriptArguments = new[]
+            {
+                tenantId,
+                tenantName,
+                keyVault,
+                "--environments",
+                environmentsArg
+            };
 
             // Execute script
-            var processResult = await ExecuteBashScriptAsync(scriptPath, arguments);
+            var processResult = await ExecuteBashScriptAsync(scriptPath, scriptArguments);
             
             result.Success = processResult.ExitCode == 0;
             result.Output = processResult.Output;
@@ -112,7 +120,7 @@ public class SftpProvisioningService : ISftpProvisioningService
         }
     }
 
-    private async Task<ProcessExecutionResult> ExecuteBashScriptAsync(string scriptPath, string arguments)
+    private async Task<ProcessExecutionResult> ExecuteBashScriptAsync(string scriptPath, IEnumerable<string> arguments)
     {
         var result = new ProcessExecutionResult();
         var outputBuilder = new StringBuilder();
@@ -122,12 +130,17 @@ public class SftpProvisioningService : ISftpProvisioningService
         {
             var processInfo = new ProcessStartInfo
             {
-                FileName = "/bin/bash",
-                Arguments = $"{scriptPath} {arguments}",
+                // Execute the script directly and supply each argument separately to avoid shell interpretation
+                FileName = scriptPath,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
+            foreach (var arg in arguments)
+            {
+                processInfo.ArgumentList.Add(arg);
+            }
+
             };
 
             using var process = new Process { StartInfo = processInfo };


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/151](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/151)

General approach: avoid passing raw concatenated user input into a shell command string. Instead, either (a) avoid `/bin/bash` entirely and call the script directly using `ProcessStartInfo` with properly separated arguments, or (b) if Bash must be used, construct the argument *list* so that no user-controlled string is parsed by Bash as shell syntax. The safest approach here is to execute the script directly and add each argument as an individual entry in `ProcessStartInfo.ArgumentList`, letting the OS and runtime perform quoting instead of building a single string.

Best fix for this code without changing existing functionality:

1. Keep the script path and the high-level semantics (invoke `provision-sftp-tenant.sh` with tenantId, tenantName, keyVault, and environments).
2. Change `ExecuteBashScriptAsync` so it:
   - Uses `FileName = scriptPath` (i.e., executes the script directly).
   - Uses `ArgumentList` to add `tenantId`, `tenantName`, `keyVault`, the literal `"--environments"`, and `environmentsArg` as *separate* arguments instead of interpolating them into one shell-processed string.
3. To support that, adjust `ProvisionTenantSftpAsync` and `ExecuteBashScriptAsync` so that they pass structured arguments (e.g., a `string[]` or `IEnumerable<string>`) instead of a single concatenated string:
   - Change the `ExecuteBashScriptAsync` signature to take `IEnumerable<string> arguments`.
   - Change its call site in `ProvisionTenantSftpAsync` to build `string[] args = { tenantId, tenantName, keyVault, "--environments", environmentsArg };` and pass that array.
4. Keep all logging, timeout handling, and result mapping as-is.

These changes are all confined to `services/tenant-service/Services/SftpProvisioningService.cs` in the methods and call site shown. No new imports are needed; we can use `IEnumerable<string>` from `System.Collections.Generic`, which is already implicitly available in C# projects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
