### PR TITLE
Potential fix for code scanning alert no. 178: Log entries created from user input

### DIFF
--- a/services/eligibility-service/Repositories/EligibilityRepositoryMongo.cs
+++ b/services/eligibility-service/Repositories/EligibilityRepositoryMongo.cs
@@ -118,7 +118,7 @@ public class EligibilityRepositoryMongo : IEligibilityRepository
             await _inquiryCollection.InsertOneAsync(inquiry);
         }
         
-        _logger.LogInformation("Updated eligibility inquiry {InquiryId} (Mongo)", inquiry.Id);
+        _logger.LogInformation("Updated eligibility inquiry {InquiryId} (Mongo)", SanitizeForLog(inquiry.Id));
     }
 
     // Response Methods
@@ -153,6 +153,18 @@ public class EligibilityRepositoryMongo : IEligibilityRepository
         await _responseCollection.InsertOneAsync(response);
         
         _logger.LogInformation("Created eligibility response {ResponseId} for inquiry {InquiryId} (Mongo)", 
-            response.Id, response.InquiryId);
+            SanitizeForLog(response.Id), SanitizeForLog(response.InquiryId));
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        // Remove newline characters to prevent log forging via user-controlled data.
+        return value.Replace("\r", string.Empty)
+                    .Replace("\n", string.Empty);
     }
 }

--- a/services/eligibility-service/Services/EligibilityService.cs
+++ b/services/eligibility-service/Services/EligibilityService.cs
@@ -84,13 +84,13 @@ public class EligibilityServiceImpl : IEligibilityService
             // Store response
             await _repository.CreateResponseAsync(response);
 
-            _logger.LogInformation("Eligibility inquiry {InquiryId} completed successfully", inquiry.Id);
+            _logger.LogInformation("Eligibility inquiry {InquiryId} completed successfully", SanitizeForLog(inquiry.Id));
             
             return response;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing eligibility inquiry {InquiryId}", inquiry.Id);
+            _logger.LogError(ex, "Error processing eligibility inquiry {InquiryId}", SanitizeForLog(inquiry.Id));
             
             inquiry.Status = EligibilityInquiryStatus.Failed;
             inquiry.CompletedDate = DateTime.UtcNow;
@@ -332,6 +332,17 @@ public class EligibilityServiceImpl : IEligibilityService
             ResponseCode = "N", // No - no active coverage
             StatusCode = "6", // Inactive
             RejectionReason = "No active coverage found for the service date",
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        // Remove newline characters to prevent log forging via user-controlled data.
+        return value.Replace("\r", string.Empty)
+                    .Replace("\n", string.Empty);
+    }
             IsCovered = false,
             CoverageLevel = string.Empty,
             CreatedDate = DateTime.UtcNow


### PR DESCRIPTION
Potential fix for [https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/178](https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/178)

General approach: Sanitize user-controlled strings before logging them. For plain-text logs, this usually means stripping newline and carriage-return characters (and optionally other control characters) so an attacker cannot break the log line structure. We should apply this specifically to the tainted values passed to logging calls (`response.InquiryId`, `inquiry.Id`, and `inquiry.SubscriberId`), without changing their stored values in the database or returned API payloads.

Best fix here: introduce a small helper method in `EligibilityRepositoryMongo` that takes a string and removes `\r` and `\n`, and use it when logging `inquiry.Id` and `response.InquiryId`. Similarly, add a helper in `EligibilityServiceImpl` to sanitize strings for logging and use it around `inquiry.Id` and `SubscriberId` in the existing `_logger.LogInformation` / `_logger.LogError` calls. This keeps functionality intact (we only affect log output), and the code change is localized. No external packages are needed; `string.Replace` is sufficient.

Concretely:
- In `services/eligibility-service/Repositories/EligibilityRepositoryMongo.cs`, add a private static method like `SanitizeForLog(string? value)` near the bottom of the class, which returns `value?.Replace("\r", string.Empty).Replace("\n", string.Empty) ?? string.Empty;`. Then:
  - In `UpdateInquiryAsync`, change the log call to use `SanitizeForLog(inquiry.Id)` instead of `inquiry.Id`.
  - In `CreateResponseAsync`, change the log call to use `SanitizeForLog(response.Id)` and `SanitizeForLog(response.InquiryId)`.
- In `services/eligibility-service/Services/EligibilityService.cs`, similarly add a private static `SanitizeForLog` helper in `EligibilityServiceImpl` and wrap:
  - `inquiry.SubscriberId` in `SubmitInquiry` log in the controller? We are constrained to only edit files specified; for the taint path, we need to treat `inquiry.Id` in `ProcessInquiryAsync` logs: `LogInformation` and `LogError` should log `SanitizeForLog(inquiry.Id)` instead of `inquiry.Id`.
- Optionally we could also sanitize `SubscriberId` in the controller logging line, but the core CodeQL-reported sink is `response.InquiryId` and the other logs on the path; we will address those within the shown snippets and allowed files.

No changes to method signatures or behavior outside of logging are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
