### PR TITLE
fix: use HttpContext instead of Context in _Host.cshtml

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/_Host.cshtml
+++ b/src/portal/CloudHealthOffice.Portal/Pages/_Host.cshtml
@@ -9,7 +9,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     @{
-        var path = Context.Request.Path.Value?.ToLowerInvariant() ?? "/";
+        var path = HttpContext.Request.Path.Value?.ToLowerInvariant() ?? "/";
         var publicPaths = new[] { "/welcome", "/signup", "/demo", "/apis", "/docs", "/pricing", "/contact-sales", "/legal" };
         var isPublicPage = publicPaths.Any(p => path.StartsWith(p));
         var robotsContent = isPublicPage ? "index, follow" : "noindex, nofollow";


### PR DESCRIPTION
Context is not available in Razor Pages - use HttpContext to access the request path for conditional robots meta tag.

https://claude.ai/code/session_01CvDn7HaKaxaGk4TLPHp3wV