### PR TITLE
Restore demo links on trial buttons to feature pages

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/Authorizations.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Authorizations.razor
@@ -1,5 +1,8 @@
 @page "/authorizations"
+@page "/demo/authorizations"
+@using Microsoft.AspNetCore.Authorization
 @using CloudHealthOffice.Portal.Services
+@attribute [AllowAnonymous]
 @inject IAuthorizationService AuthorizationService
 @inject IDialogService DialogService
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/Claims.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Claims.razor
@@ -1,5 +1,8 @@
 @page "/claims"
+@page "/demo/claims"
+@using Microsoft.AspNetCore.Authorization
 @using CloudHealthOffice.Portal.Services
+@attribute [AllowAnonymous]
 @inject IClaimsService ClaimsService
 @inject NavigationManager NavigationManager
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/Demo.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Demo.razor
@@ -40,7 +40,7 @@
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton StartIcon="@Icons.Material.Filled.Description" Color="Color.Primary"
-                               Href="/signup" Variant="Variant.Text">
+                               Href="/demo/claims" Variant="Variant.Text">
                         Start Trial to Explore →
                     </MudButton>
                 </MudCardActions>
@@ -57,7 +57,7 @@
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton StartIcon="@Icons.Material.Filled.VerifiedUser" Color="Color.Primary"
-                               Href="/signup" Variant="Variant.Text">
+                               Href="/demo/eligibility" Variant="Variant.Text">
                         Start Trial to Explore →
                     </MudButton>
                 </MudCardActions>
@@ -74,7 +74,7 @@
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton StartIcon="@Icons.Material.Filled.Approval" Color="Color.Primary"
-                               Href="/signup" Variant="Variant.Text">
+                               Href="/demo/authorizations" Variant="Variant.Text">
                         Start Trial to Explore →
                     </MudButton>
                 </MudCardActions>
@@ -91,7 +91,7 @@
                 </MudCardContent>
                 <MudCardActions>
                     <MudButton StartIcon="@Icons.Material.Filled.People" Color="Color.Primary"
-                               Href="/signup" Variant="Variant.Text">
+                               Href="/demo/members" Variant="Variant.Text">
                         Start Trial to Explore →
                     </MudButton>
                 </MudCardActions>

--- a/src/portal/CloudHealthOffice.Portal/Pages/Eligibility.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Eligibility.razor
@@ -1,5 +1,8 @@
 @page "/eligibility"
+@page "/demo/eligibility"
+@using Microsoft.AspNetCore.Authorization
 @using CloudHealthOffice.Portal.Services
+@attribute [AllowAnonymous]
 @inject IEligibilityService EligibilityService
 @inject IMemberService MemberService
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/Members.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Members.razor
@@ -1,5 +1,8 @@
 @page "/members"
+@page "/demo/members"
+@using Microsoft.AspNetCore.Authorization
 @using CloudHealthOffice.Portal.Services
+@attribute [AllowAnonymous]
 @inject IMemberService MemberService
 @inject ICoverageService CoverageService
 @inject IDialogService DialogService


### PR DESCRIPTION
The "Start Trial to Explore" buttons on the demo dashboard were pointing
to /signup instead of the actual demo feature pages. Updated links to
/demo/claims, /demo/eligibility, /demo/authorizations, and /demo/members.
Added secondary @page routes and [AllowAnonymous] to each feature page
so demo visitors can access them without authentication.

https://claude.ai/code/session_01P4R8L1YMKPVb3MSLymRWD2