### PR TITLE
Fix duplicate sentinel logos on Welcome page

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/Welcome.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Welcome.razor
@@ -11,9 +11,6 @@
     <div class="w-hero-circuit"></div>
     <div class="w-hero-scan"></div>
     <div class="w-hero-content">
-        <img src="/images/logo-cloudhealthoffice-sentinel-primary.svg"
-             alt="Cloud Health Office"
-             class="w-hero-logo" />
         <div class="w-hero-badge">THE SENTINEL PLATFORM</div>
         <h1 class="w-hero-headline">Cloud Health Office</h1>
         <p class="w-hero-sub">

--- a/src/portal/CloudHealthOffice.Portal/Pages/Welcome.razor.css
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Welcome.razor.css
@@ -60,13 +60,6 @@
     width: 100%;
 }
 
-.w-hero-logo {
-    width: 160px;
-    margin-bottom: 2rem;
-    filter: drop-shadow(0 0 24px rgba(0, 255, 255, 0.5));
-    animation: w-float 7s ease-in-out infinite;
-}
-
 .w-hero-badge {
     display: inline-block;
     font-size: 0.75rem;
@@ -344,11 +337,6 @@
     .w-hero {
         padding: 2rem 1.5rem;
         min-height: 0;
-    }
-
-    .w-hero-logo {
-        width: 80px;
-        margin-bottom: 1.25rem;
     }
 
     .w-hero-badge {


### PR DESCRIPTION
Remove hero logo from Welcome.razor since MainLayout already renders
the sentinel logo in the appbar. This eliminates the duplicate display.

https://claude.ai/code/session_01NaRixkgfHSTsBZ4X2JdqNT