### PR TITLE
Add integration tests for claims-service using WebApplicationFactory

### DIFF
--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encounter-service", "src\se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "risk-adjustment-service", "src\services\risk-adjustment-service\risk-adjustment-service.csproj", "{B2C3D4E5-F6A7-4B5C-AD8E-8F7A6B5C4D3E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.ClaimsService.Tests", "tests\CloudHealthOffice.ClaimsService.Tests\CloudHealthOffice.ClaimsService.Tests.csproj", "{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -439,6 +441,18 @@ Global
 		{B2C3D4E5-F6A7-4B5C-AD8E-8F7A6B5C4D3E}.Release|x64.Build.0 = Release|Any CPU
 		{B2C3D4E5-F6A7-4B5C-AD8E-8F7A6B5C4D3E}.Release|x86.ActiveCfg = Release|Any CPU
 		{B2C3D4E5-F6A7-4B5C-AD8E-8F7A6B5C4D3E}.Release|x86.Build.0 = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|x64.Build.0 = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -478,6 +492,7 @@ Global
 		{E205BB9C-7305-480A-A8CA-BA872D56DB89} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D} = {5854FF58-B8C5-05C6-5BF2-ACE42193F22B}
 		{B2C3D4E5-F6A7-4B5C-AD8E-8F7A6B5C4D3E} = {5854FF58-B8C5-05C6-5BF2-ACE42193F22B}
+		{7F2A3B4C-D5E6-4F7A-8B9C-0D1E2F3A4B5C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C10C3349-5BEE-4B34-9987-23F0142F9D98}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -113,3 +113,6 @@ app.MapControllers();
 app.MapHealthChecks("/health");
 
 app.Run();
+
+// Expose Program class for WebApplicationFactory in integration tests
+public partial class Program { }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -1,0 +1,47 @@
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+public class ClaimsApiFactory : WebApplicationFactory<Program>
+{
+    public IClaimRepository ClaimRepository { get; } = Substitute.For<IClaimRepository>();
+    public IClaimAcknowledgmentService AcknowledgmentService { get; } = Substitute.For<IClaimAcknowledgmentService>();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureServices(services =>
+        {
+            // Remove real repository and acknowledgment service registrations
+            var descriptorsToRemove = services
+                .Where(d => d.ServiceType == typeof(IClaimRepository)
+                         || d.ServiceType == typeof(IClaimAcknowledgmentService))
+                .ToList();
+
+            foreach (var descriptor in descriptorsToRemove)
+            {
+                services.Remove(descriptor);
+            }
+
+            // Also remove Cosmos/Mongo registrations that would fail without config
+            var cosmosDescriptors = services
+                .Where(d => d.ServiceType.FullName?.Contains("Cosmos") == true
+                         || d.ServiceType.FullName?.Contains("Mongo") == true)
+                .ToList();
+
+            foreach (var descriptor in cosmosDescriptors)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddSingleton(ClaimRepository);
+            services.AddSingleton(AcknowledgmentService);
+        });
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -1,0 +1,265 @@
+using System.Net;
+using System.Net.Http.Json;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
+{
+    private readonly ClaimsApiFactory _factory;
+    private readonly HttpClient _client;
+    private readonly IClaimRepository _repo;
+    private readonly IClaimAcknowledgmentService _ackService;
+
+    public ClaimsControllerTests(ClaimsApiFactory factory)
+    {
+        _factory = factory;
+        _repo = factory.ClaimRepository;
+        _ackService = factory.AcknowledgmentService;
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════════
+
+    private static Claim CreateValidClaim(List<ClaimLine>? lines = null)
+    {
+        var serviceDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new Claim
+        {
+            TenantId = "test-tenant",
+            ClaimNumber = "CLM-20260115-001",
+            MemberId = "MEM-001",
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            DiagnosisCodes = new List<DiagnosisCode>
+            {
+                new() { Code = "E11.9", CodeQualifier = "ABK", PointerNumber = 1, Description = "Type 2 diabetes" }
+            },
+            ClaimLines = lines ?? new List<ClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150.00m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                    DiagnosisPointers = new List<int> { 1 }
+                }
+            }
+        };
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SUBMIT CLAIM
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SubmitClaim_ValidClaim_Returns201WithIdAssigned()
+    {
+        var claim = CreateValidClaim();
+
+        _repo.CreateAsync(Arg.Any<Claim>())
+            .Returns(ci => ci.Arg<Claim>());
+
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(created);
+        Assert.NotNull(created.Id);
+        Assert.NotEmpty(created.Id);
+        Assert.Equal(ClaimStatus.Submitted, created.Status);
+    }
+
+    [Fact]
+    public async Task SubmitClaim_ZeroLines_Returns400()
+    {
+        var claim = CreateValidClaim(lines: new List<ClaimLine>());
+
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitClaim_CalculatesTotalChargeFromLines()
+    {
+        var serviceDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var lines = new List<ClaimLine>
+        {
+            new()
+            {
+                LineNumber = 1,
+                ProcedureCode = "99213",
+                ChargeAmount = 150.00m,
+                Units = 2,
+                ServiceDateFrom = serviceDate,
+                ServiceDateTo = serviceDate,
+                DiagnosisPointers = new List<int> { 1 }
+            },
+            new()
+            {
+                LineNumber = 2,
+                ProcedureCode = "85025",
+                ChargeAmount = 35.50m,
+                Units = 1,
+                ServiceDateFrom = serviceDate,
+                ServiceDateTo = serviceDate,
+                DiagnosisPointers = new List<int> { 1 }
+            }
+        };
+        var claim = CreateValidClaim(lines: lines);
+
+        Claim? capturedClaim = null;
+        _repo.CreateAsync(Arg.Any<Claim>())
+            .Returns(ci =>
+            {
+                capturedClaim = ci.Arg<Claim>();
+                return capturedClaim;
+            });
+
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(capturedClaim);
+        // 150 * 2 + 35.50 * 1 = 335.50
+        Assert.Equal(335.50m, capturedClaim.TotalChargeAmount);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // GET CLAIM BY ID
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetClaimById_ExistingClaim_Returns200()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-123";
+
+        _repo.GetByIdAsync("claim-123").Returns(claim);
+
+        var response = await _client.GetAsync("/api/claims/claim-123");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var returned = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(returned);
+        Assert.Equal("claim-123", returned.Id);
+        Assert.Equal("MEM-001", returned.MemberId);
+    }
+
+    [Fact]
+    public async Task GetClaimById_NonexistentClaim_Returns404()
+    {
+        _repo.GetByIdAsync("nonexistent").Returns((Claim?)null);
+
+        var response = await _client.GetAsync("/api/claims/nonexistent");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // GET CLAIM BY NUMBER
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetClaimByNumber_ExistingClaim_Returns200()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-456";
+
+        _repo.GetByClaimNumberAsync("CLM-20260115-001").Returns(claim);
+
+        var response = await _client.GetAsync("/api/claims/number/CLM-20260115-001");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var returned = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(returned);
+        Assert.Equal("CLM-20260115-001", returned.ClaimNumber);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // SEARCH CLAIMS
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task SearchClaims_ByMemberId_ReturnsFilteredResults()
+    {
+        var claim1 = CreateValidClaim();
+        claim1.Id = "c1";
+        claim1.MemberId = "MEM-001";
+
+        var claim2 = CreateValidClaim();
+        claim2.Id = "c2";
+        claim2.MemberId = "MEM-001";
+
+        _repo.SearchAsync("MEM-001", null, null, null, null, null, 1, 50)
+            .Returns(new List<Claim> { claim1, claim2 });
+
+        var response = await _client.GetAsync("/api/claims/search?memberId=MEM-001");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var results = await response.Content.ReadFromJsonAsync<List<Claim>>();
+        Assert.NotNull(results);
+        Assert.Equal(2, results.Count);
+        Assert.All(results, c => Assert.Equal("MEM-001", c.MemberId));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 277CA ACKNOWLEDGMENT
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task GetAcknowledgment_ExistingClaim_Returns200WithEdiContent()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-ack";
+
+        _repo.GetByIdAsync("claim-ack").Returns(claim);
+        _ackService.Generate277CA(Arg.Any<Claim>(), Arg.Any<ClaimAcknowledgmentConfig>())
+            .Returns("ISA*00*...");
+
+        var response = await _client.GetAsync("/api/claims/claim-ack/277ca");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Equal("ISA*00*...", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // TENANT HEADER
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task MissingTenantHeader_FallsBackToDefaultTenant()
+    {
+        // TenantMiddleware falls back to "default-tenant" when no header is present.
+        // Verify the request passes through (no 4xx from middleware).
+        var clientNoTenant = _factory.CreateClient();
+        // No X-Tenant-ID header added
+
+        _repo.GetByIdAsync("any-id").Returns((Claim?)null);
+
+        var response = await clientNoTenant.GetAsync("/api/claims/any-id");
+
+        // 404 means the middleware did NOT reject the request — it passed through
+        // to the controller which returned 404 for a nonexistent claim.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\services\claims-service\claims-service.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Create xUnit test project at tests/CloudHealthOffice.ClaimsService.Tests/
with NSubstitute mocks for IClaimRepository and IClaimAcknowledgmentService.

Tests cover: submit valid claim (201), zero lines (400), get by ID (200/404),
get by claim number, search by member ID, TotalChargeAmount calculation from
line items, 277CA acknowledgment generation, and missing X-Tenant-ID fallback.

https://claude.ai/code/session_01NsfzumBFzMvXiNdjvpqsJY