### PR TITLE
Port Provider Directory API from TypeScript to C#

### DIFF
--- a/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
+++ b/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
@@ -1,0 +1,335 @@
+using System.Text.Json;
+using FhirService.Mappers;
+using FhirService.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FhirService.Controllers;
+
+/// <summary>
+/// Provider Directory API controller — exposes FHIR R4 provider directory resources
+/// (Practitioner, PractitionerRole, Organization, Location) backed by NPPES data
+/// fetched from provider-service via HTTP.
+///
+/// Port of the TypeScript provider-directory-api.ts.
+/// </summary>
+[Route("fhir/r4")]
+public class ProviderDirectoryController : FhirControllerBase
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<ProviderDirectoryController> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public ProviderDirectoryController(
+        IHttpClientFactory httpClientFactory,
+        ILogger<ProviderDirectoryController> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient("NppesApi");
+        _logger = logger;
+    }
+
+    // ── Practitioner ─────────────────────────────────────────────────────────
+
+    /// <summary>GET /fhir/r4/Practitioner/{id} — read Practitioner by NPI</summary>
+    [HttpGet("Practitioner/{id}")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> ReadPractitioner(string id, CancellationToken ct)
+    {
+        var nppes = await LookupNppesAsync(id, ct);
+        if (nppes is null || nppes.EnumerationType != "NPI-1")
+            return FhirNotFound("Practitioner", id);
+
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(nppes);
+        return Ok(practitioner);
+    }
+
+    /// <summary>GET /fhir/r4/Practitioner?npi=&amp;given=&amp;family=&amp;... — search Practitioners</summary>
+    [HttpGet("Practitioner")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> SearchPractitioners(
+        [FromQuery] string? npi,
+        [FromQuery] string? given,
+        [FromQuery] string? family,
+        [FromQuery] string? city,
+        [FromQuery] string? state,
+        [FromQuery(Name = "postal-code")] string? postalCode,
+        [FromQuery] string? specialty,
+        [FromQuery] int _count = 50,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        _count = ClampPageSize(_count, 200);
+
+        if (!string.IsNullOrEmpty(npi))
+        {
+            var nppes = await LookupNppesAsync(npi, ct);
+            if (nppes is null || nppes.EnumerationType != "NPI-1")
+                return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", []));
+
+            var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(nppes);
+            return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", [practitioner]));
+        }
+
+        var results = await SearchNppesAsync(new Dictionary<string, string?>
+        {
+            ["first_name"] = given,
+            ["last_name"] = family,
+            ["city"] = city,
+            ["state"] = state,
+            ["postal_code"] = postalCode,
+            ["taxonomy_description"] = specialty,
+            ["enumeration_type"] = "NPI-1",
+            ["limit"] = _count.ToString(),
+            ["skip"] = ((_page - 1) * _count).ToString()
+        }, ct);
+
+        var practitioners = results
+            .Where(r => r.EnumerationType == "NPI-1")
+            .Select(ProviderDirectoryMapper.MapNppesToPractitioner)
+            .Cast<FhirResource>()
+            .ToList();
+
+        return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", practitioners));
+    }
+
+    // ── Organization ─────────────────────────────────────────────────────────
+
+    /// <summary>GET /fhir/r4/Organization/{id} — read Organization by NPI</summary>
+    [HttpGet("Organization/{id}")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> ReadOrganization(string id, CancellationToken ct)
+    {
+        var nppes = await LookupNppesAsync(id, ct);
+        if (nppes is null || nppes.EnumerationType != "NPI-2")
+            return FhirNotFound("Organization", id);
+
+        var organization = ProviderDirectoryMapper.MapNppesToOrganization(nppes);
+        return Ok(organization);
+    }
+
+    /// <summary>GET /fhir/r4/Organization?npi=&amp;name=&amp;... — search Organizations</summary>
+    [HttpGet("Organization")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> SearchOrganizations(
+        [FromQuery] string? npi,
+        [FromQuery] string? name,
+        [FromQuery] string? city,
+        [FromQuery] string? state,
+        [FromQuery(Name = "postal-code")] string? postalCode,
+        [FromQuery] int _count = 50,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        _count = ClampPageSize(_count, 200);
+
+        if (!string.IsNullOrEmpty(npi))
+        {
+            var nppes = await LookupNppesAsync(npi, ct);
+            if (nppes is null || nppes.EnumerationType != "NPI-2")
+                return Ok(ProviderDirectoryMapper.CreateSearchBundle("Organization", []));
+
+            var org = ProviderDirectoryMapper.MapNppesToOrganization(nppes);
+            return Ok(ProviderDirectoryMapper.CreateSearchBundle("Organization", [org]));
+        }
+
+        var results = await SearchNppesAsync(new Dictionary<string, string?>
+        {
+            ["organization_name"] = name,
+            ["city"] = city,
+            ["state"] = state,
+            ["postal_code"] = postalCode,
+            ["enumeration_type"] = "NPI-2",
+            ["limit"] = _count.ToString(),
+            ["skip"] = ((_page - 1) * _count).ToString()
+        }, ct);
+
+        var organizations = results
+            .Where(r => r.EnumerationType == "NPI-2")
+            .Select(ProviderDirectoryMapper.MapNppesToOrganization)
+            .Cast<FhirResource>()
+            .ToList();
+
+        return Ok(ProviderDirectoryMapper.CreateSearchBundle("Organization", organizations));
+    }
+
+    // ── PractitionerRole ─────────────────────────────────────────────────────
+
+    /// <summary>GET /fhir/r4/PractitionerRole/{id} — read PractitionerRole by practitioner NPI</summary>
+    [HttpGet("PractitionerRole/{id}")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> ReadPractitionerRole(string id, CancellationToken ct)
+    {
+        // ID format: {NPI}-role
+        var npi = id.EndsWith("-role", StringComparison.Ordinal) ? id[..^5] : id;
+        var nppes = await LookupNppesAsync(npi, ct);
+        if (nppes is null || nppes.EnumerationType != "NPI-1")
+            return FhirNotFound("PractitionerRole", id);
+
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(nppes);
+        return Ok(role);
+    }
+
+    /// <summary>GET /fhir/r4/PractitionerRole?practitioner=&amp;specialty=&amp;... — search PractitionerRoles</summary>
+    [HttpGet("PractitionerRole")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> SearchPractitionerRoles(
+        [FromQuery] string? practitioner,
+        [FromQuery] string? organization,
+        [FromQuery] string? specialty,
+        [FromQuery] int _count = 50,
+        CancellationToken ct = default)
+    {
+        _count = ClampPageSize(_count, 200);
+        var roles = new List<FhirResource>();
+
+        if (!string.IsNullOrEmpty(practitioner))
+        {
+            var npi = practitioner.Replace("Practitioner/", "", StringComparison.Ordinal);
+            var nppes = await LookupNppesAsync(npi, ct);
+            if (nppes is not null && nppes.EnumerationType == "NPI-1")
+            {
+                var orgRef = !string.IsNullOrEmpty(organization)
+                    ? new FhirReference { Reference = organization }
+                    : null;
+                roles.Add(ProviderDirectoryMapper.MapNppesToPractitionerRole(nppes, orgRef));
+            }
+        }
+        else if (!string.IsNullOrEmpty(specialty))
+        {
+            var results = await SearchNppesAsync(new Dictionary<string, string?>
+            {
+                ["taxonomy_description"] = specialty,
+                ["enumeration_type"] = "NPI-1",
+                ["limit"] = _count.ToString()
+            }, ct);
+
+            foreach (var r in results.Where(r => r.EnumerationType == "NPI-1"))
+                roles.Add(ProviderDirectoryMapper.MapNppesToPractitionerRole(r));
+        }
+
+        return Ok(ProviderDirectoryMapper.CreateSearchBundle("PractitionerRole", roles));
+    }
+
+    // ── Location ─────────────────────────────────────────────────────────────
+
+    /// <summary>GET /fhir/r4/Location/{id} — read Location by ID ({NPI}-loc-{index})</summary>
+    [HttpGet("Location/{id}")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> ReadLocation(string id, CancellationToken ct)
+    {
+        var match = System.Text.RegularExpressions.Regex.Match(id, @"^(\d{10})-loc-(\d+)$");
+        if (!match.Success)
+            return FhirNotFound("Location", id);
+
+        var npi = match.Groups[1].Value;
+        var index = int.Parse(match.Groups[2].Value);
+
+        var nppes = await LookupNppesAsync(npi, ct);
+        if (nppes is null || index >= nppes.Addresses.Count)
+            return FhirNotFound("Location", id);
+
+        var location = ProviderDirectoryMapper.MapNppesToLocation(nppes, index);
+        return Ok(location);
+    }
+
+    /// <summary>GET /fhir/r4/Location?organization=&amp;city=&amp;... — search Locations</summary>
+    [HttpGet("Location")]
+    [Produces("application/fhir+json")]
+    public async Task<IActionResult> SearchLocations(
+        [FromQuery] string? organization,
+        [FromQuery] string? city,
+        [FromQuery] string? state,
+        [FromQuery(Name = "postal-code")] string? postalCode,
+        [FromQuery] int _count = 50,
+        CancellationToken ct = default)
+    {
+        _count = ClampPageSize(_count, 200);
+        var locations = new List<FhirResource>();
+
+        if (!string.IsNullOrEmpty(organization))
+        {
+            var npi = organization.Replace("Organization/", "", StringComparison.Ordinal);
+            var nppes = await LookupNppesAsync(npi, ct);
+            if (nppes is not null)
+            {
+                for (var i = 0; i < nppes.Addresses.Count; i++)
+                    locations.Add(ProviderDirectoryMapper.MapNppesToLocation(nppes, i));
+            }
+        }
+        else
+        {
+            var results = await SearchNppesAsync(new Dictionary<string, string?>
+            {
+                ["city"] = city,
+                ["state"] = state,
+                ["postal_code"] = postalCode,
+                ["limit"] = _count.ToString()
+            }, ct);
+
+            foreach (var r in results)
+            {
+                for (var i = 0; i < r.Addresses.Count; i++)
+                    locations.Add(ProviderDirectoryMapper.MapNppesToLocation(r, i));
+            }
+        }
+
+        return Ok(ProviderDirectoryMapper.CreateSearchBundle("Location", locations));
+    }
+
+    // ── NPPES HTTP Integration ───────────────────────────────────────────────
+
+    private async Task<NppesResult?> LookupNppesAsync(string npi, CancellationToken ct)
+    {
+        if (!ProviderDirectoryMapper.ValidateNpi(npi))
+        {
+            _logger.LogWarning("Invalid NPI format: {Npi}", npi);
+            return null;
+        }
+
+        try
+        {
+            var response = await _httpClient.GetAsync($"?version=2.1&number={npi}", ct);
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<NppesResponse>(JsonOptions, ct);
+            if (data is null || data.ResultCount == 0 || data.Results is null || data.Results.Count == 0)
+                return null;
+
+            return data.Results[0];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "NPPES lookup failed for NPI {Npi}", npi);
+            throw;
+        }
+    }
+
+    private async Task<IReadOnlyList<NppesResult>> SearchNppesAsync(
+        Dictionary<string, string?> queryParams,
+        CancellationToken ct)
+    {
+        var query = new List<string> { "version=2.1" };
+        foreach (var (key, value) in queryParams)
+        {
+            if (!string.IsNullOrEmpty(value))
+                query.Add($"{key}={Uri.EscapeDataString(value)}");
+        }
+
+        try
+        {
+            var response = await _httpClient.GetAsync($"?{string.Join('&', query)}", ct);
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<NppesResponse>(JsonOptions, ct);
+            return data?.Results ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "NPPES search failed");
+            throw;
+        }
+    }
+}

--- a/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
+++ b/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
@@ -1,0 +1,494 @@
+using System.Text.RegularExpressions;
+using FhirService.Models;
+
+namespace FhirService.Mappers;
+
+/// <summary>
+/// Maps NPPES provider data to FHIR R4 Provider Directory resources.
+/// Port of the TypeScript provider-directory-api.ts mapping logic.
+/// </summary>
+public static partial class ProviderDirectoryMapper
+{
+    /// <summary>
+    /// CMS-assigned prefix for NPI Luhn check digit calculation.
+    /// </summary>
+    private const string NpiLuhnPrefix = "80840";
+
+    // ── NPI Validation ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Validates NPI format (10 digits) and Luhn check digit.
+    /// </summary>
+    public static bool ValidateNpi(string npi)
+    {
+        if (!NpiRegex().IsMatch(npi))
+            return false;
+
+        return LuhnCheck(NpiLuhnPrefix + npi);
+    }
+
+    [GeneratedRegex(@"^\d{10}$")]
+    private static partial Regex NpiRegex();
+
+    private static bool LuhnCheck(string value)
+    {
+        var sum = 0;
+        var isEven = false;
+        for (var i = value.Length - 1; i >= 0; i--)
+        {
+            var digit = value[i] - '0';
+            if (isEven)
+            {
+                digit *= 2;
+                if (digit > 9)
+                    digit -= 9;
+            }
+            sum += digit;
+            isEven = !isEven;
+        }
+        return sum % 10 == 0;
+    }
+
+    // ── NPPES → Practitioner ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Maps an NPI-1 (individual) NPPES result to a FHIR Practitioner resource.
+    /// </summary>
+    public static FhirPractitioner MapNppesToPractitioner(NppesResult nppes)
+    {
+        if (nppes.EnumerationType != "NPI-1")
+            throw new InvalidOperationException(
+                "Cannot map NPI-2 (organization) to Practitioner. Use MapNppesToOrganization instead.");
+
+        return new FhirPractitioner
+        {
+            Id = nppes.Number,
+            Meta = new FhirMeta
+            {
+                Profile = ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"]
+            },
+            Identifier =
+            [
+                new FhirIdentifier
+                {
+                    System = "http://hl7.org/fhir/sid/us-npi",
+                    Value = nppes.Number
+                }
+            ],
+            Active = !HasDeactivationDate(nppes) || HasReactivationDate(nppes),
+            Name = [MapToHumanName(nppes.Basic)],
+            Gender = MapGender(nppes.Basic.Gender),
+            Address = MapAddresses(nppes.Addresses),
+            Telecom = MapTelecom(nppes.Addresses),
+            Qualification = MapQualifications(nppes)
+        };
+    }
+
+    // ── NPPES → Organization ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Maps an NPI-2 (organizational) NPPES result to a FHIR Organization resource.
+    /// </summary>
+    public static FhirOrganization MapNppesToOrganization(NppesResult nppes)
+    {
+        if (nppes.EnumerationType != "NPI-2")
+            throw new InvalidOperationException(
+                "Cannot map NPI-1 (individual) to Organization. Use MapNppesToPractitioner instead.");
+
+        return new FhirOrganization
+        {
+            Id = nppes.Number,
+            Meta = new FhirMeta
+            {
+                Profile = ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"]
+            },
+            Identifier =
+            [
+                new FhirIdentifier
+                {
+                    System = "http://hl7.org/fhir/sid/us-npi",
+                    Value = nppes.Number
+                }
+            ],
+            Active = !HasDeactivationDate(nppes) || HasReactivationDate(nppes),
+            Type = MapOrganizationType(nppes.Taxonomies),
+            Name = nppes.Basic.OrganizationName ?? "",
+            Alias = nppes.OtherNames?
+                .Select(n => n.OrganizationName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Cast<string>()
+                .ToList(),
+            Address = MapAddresses(nppes.Addresses),
+            Telecom = MapTelecom(nppes.Addresses)
+        };
+    }
+
+    // ── NPPES → PractitionerRole ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Maps an NPI-1 NPPES result to a FHIR PractitionerRole resource.
+    /// </summary>
+    public static FhirPractitionerRole MapNppesToPractitionerRole(
+        NppesResult practitionerNppes,
+        FhirReference? organizationRef = null)
+    {
+        return new FhirPractitionerRole
+        {
+            Id = $"{practitionerNppes.Number}-role",
+            Meta = new FhirMeta
+            {
+                Profile = ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"]
+            },
+            Active = !HasDeactivationDate(practitionerNppes) || HasReactivationDate(practitionerNppes),
+            Practitioner = new FhirReference
+            {
+                Reference = $"Practitioner/{practitionerNppes.Number}",
+                Display = FormatProviderName(practitionerNppes.Basic)
+            },
+            Organization = organizationRef,
+            Code = MapTaxonomiesToRoleCode(practitionerNppes.Taxonomies),
+            Specialty = MapTaxonomiesToSpecialty(practitionerNppes.Taxonomies),
+            Location = MapToLocationReferences(practitionerNppes),
+            Telecom = MapTelecom(practitionerNppes.Addresses)
+        };
+    }
+
+    // ── NPPES → Location ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Maps an NPPES result address to a FHIR Location resource.
+    /// </summary>
+    public static FhirLocation MapNppesToLocation(NppesResult nppes, int addressIndex = 0)
+    {
+        var address = nppes.Addresses.FirstOrDefault(a => a.AddressPurpose == "LOCATION");
+        if (address is null && addressIndex < nppes.Addresses.Count)
+            address = nppes.Addresses[addressIndex];
+
+        if (address is null)
+            throw new InvalidOperationException(
+                $"No address found for NPI {nppes.Number} at index {addressIndex}. Available addresses: {nppes.Addresses.Count}");
+
+        return new FhirLocation
+        {
+            Id = $"{nppes.Number}-loc-{addressIndex}",
+            Meta = new FhirMeta
+            {
+                Profile = ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"]
+            },
+            Status = (!HasDeactivationDate(nppes) || HasReactivationDate(nppes)) ? "active" : "inactive",
+            Name = nppes.EnumerationType == "NPI-2"
+                ? nppes.Basic.OrganizationName
+                : FormatProviderName(nppes.Basic),
+            Mode = "instance",
+            Type = MapLocationTypeFromTaxonomy(nppes.Taxonomies),
+            Telecom = MapAddressToTelecom(address),
+            Address = MapAddressToFhir(address),
+            ManagingOrganization = nppes.EnumerationType == "NPI-2"
+                ? new FhirReference { Reference = $"Organization/{nppes.Number}" }
+                : null
+        };
+    }
+
+    // ── Search Bundle ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a FHIR searchset Bundle from a list of resources.
+    /// </summary>
+    public static FhirSearchBundle CreateSearchBundle(string resourceType, IReadOnlyList<FhirResource> resources)
+    {
+        return new FhirSearchBundle
+        {
+            Total = resources.Count,
+            Link =
+            [
+                new FhirBundleLink
+                {
+                    Relation = "self",
+                    Url = $"{resourceType}?_count={resources.Count}"
+                }
+            ],
+            Entry = resources.Select(r => new FhirBundleEntryWithSearch
+            {
+                FullUrl = $"{resourceType}/{r.Id}",
+                Resource = r,
+                Search = new FhirBundleSearch { Mode = "match" }
+            }).ToList()
+        };
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private static bool HasDeactivationDate(NppesResult nppes)
+        => !string.IsNullOrEmpty(nppes.Basic.DeactivationDate);
+
+    private static bool HasReactivationDate(NppesResult nppes)
+        => !string.IsNullOrEmpty(nppes.Basic.ReactivationDate);
+
+    private static FhirHumanName MapToHumanName(NppesBasicInfo basic)
+    {
+        var given = new List<string>();
+        if (!string.IsNullOrEmpty(basic.FirstName)) given.Add(basic.FirstName);
+        if (!string.IsNullOrEmpty(basic.MiddleName)) given.Add(basic.MiddleName);
+
+        var suffix = new List<string>();
+        if (!string.IsNullOrEmpty(basic.NameSuffix)) suffix.Add(basic.NameSuffix);
+        if (!string.IsNullOrEmpty(basic.Credential)) suffix.Add(basic.Credential);
+
+        return new FhirHumanName
+        {
+            Use = "official",
+            Family = basic.LastName ?? "",
+            Given = given,
+            Prefix = !string.IsNullOrEmpty(basic.NamePrefix) ? [basic.NamePrefix] : null,
+            Suffix = suffix.Count > 0 ? suffix : null
+        };
+    }
+
+    private static string MapGender(string? gender)
+    {
+        return gender?.ToUpperInvariant() switch
+        {
+            "M" => "male",
+            "F" => "female",
+            _ => "unknown"
+        };
+    }
+
+    private static List<FhirAddress> MapAddresses(IReadOnlyList<NppesAddress> addresses)
+    {
+        return addresses.Select(MapAddressToFhir).ToList();
+    }
+
+    private static FhirAddress MapAddressToFhir(NppesAddress addr)
+    {
+        var lines = new List<string> { addr.Address1 };
+        if (!string.IsNullOrEmpty(addr.Address2))
+            lines.Add(addr.Address2);
+
+        return new FhirAddress
+        {
+            Use = addr.AddressPurpose == "LOCATION" ? "work" : "billing",
+            Type = "physical",
+            Line = lines,
+            City = addr.City,
+            State = addr.State,
+            PostalCode = addr.PostalCode,
+            Country = addr.CountryCode
+        };
+    }
+
+    private static List<FhirContactPoint> MapTelecom(IReadOnlyList<NppesAddress> addresses)
+    {
+        var telecom = new List<FhirContactPoint>();
+        foreach (var addr in addresses)
+        {
+            if (!string.IsNullOrEmpty(addr.TelephoneNumber))
+            {
+                telecom.Add(new FhirContactPoint
+                {
+                    System = "phone",
+                    Value = FormatPhoneNumber(addr.TelephoneNumber),
+                    Use = "work"
+                });
+            }
+            if (!string.IsNullOrEmpty(addr.FaxNumber))
+            {
+                telecom.Add(new FhirContactPoint
+                {
+                    System = "fax",
+                    Value = FormatPhoneNumber(addr.FaxNumber),
+                    Use = "work"
+                });
+            }
+        }
+        return telecom;
+    }
+
+    private static List<FhirContactPoint> MapAddressToTelecom(NppesAddress addr)
+    {
+        var telecom = new List<FhirContactPoint>();
+        if (!string.IsNullOrEmpty(addr.TelephoneNumber))
+        {
+            telecom.Add(new FhirContactPoint
+            {
+                System = "phone",
+                Value = FormatPhoneNumber(addr.TelephoneNumber),
+                Use = "work"
+            });
+        }
+        if (!string.IsNullOrEmpty(addr.FaxNumber))
+        {
+            telecom.Add(new FhirContactPoint
+            {
+                System = "fax",
+                Value = FormatPhoneNumber(addr.FaxNumber),
+                Use = "work"
+            });
+        }
+        return telecom;
+    }
+
+    private static string FormatPhoneNumber(string phone)
+    {
+        var digits = DigitsOnly().Replace(phone, "");
+        if (digits.Length == 10)
+            return $"{digits[..3]}-{digits[3..6]}-{digits[6..]}";
+        return phone;
+    }
+
+    [GeneratedRegex(@"\D")]
+    private static partial Regex DigitsOnly();
+
+    private static List<FhirQualification> MapQualifications(NppesResult nppes)
+    {
+        return nppes.Taxonomies.Select(tax => new FhirQualification
+        {
+            Identifier =
+            [
+                new FhirIdentifier
+                {
+                    System = "http://nucc.org/provider-taxonomy",
+                    Value = tax.Code
+                }
+            ],
+            Code = new FhirCodeableConcept
+            {
+                Coding =
+                [
+                    new FhirCoding
+                    {
+                        System = "http://nucc.org/provider-taxonomy",
+                        Code = tax.Code,
+                        Display = tax.Desc
+                    }
+                ]
+            },
+            Period = !string.IsNullOrEmpty(tax.License)
+                ? new FhirPeriod { Start = nppes.Basic.EnumerationDate }
+                : null,
+            Issuer = !string.IsNullOrEmpty(tax.State)
+                ? new FhirReference { Display = $"State of {tax.State}" }
+                : null
+        }).ToList();
+    }
+
+    private static List<FhirCodeableConcept> MapOrganizationType(IReadOnlyList<NppesTaxonomy> taxonomies)
+    {
+        if (taxonomies.Count == 0)
+        {
+            return
+            [
+                new FhirCodeableConcept
+                {
+                    Coding =
+                    [
+                        new FhirCoding
+                        {
+                            System = "http://terminology.hl7.org/CodeSystem/organization-type",
+                            Code = "prov",
+                            Display = "Healthcare Provider"
+                        }
+                    ]
+                }
+            ];
+        }
+
+        return taxonomies.Select(tax => new FhirCodeableConcept
+        {
+            Coding =
+            [
+                new FhirCoding
+                {
+                    System = "http://nucc.org/provider-taxonomy",
+                    Code = tax.Code,
+                    Display = tax.Desc
+                }
+            ]
+        }).ToList();
+    }
+
+    private static List<FhirCodeableConcept> MapTaxonomiesToRoleCode(IReadOnlyList<NppesTaxonomy> taxonomies)
+    {
+        var primary = taxonomies.FirstOrDefault(t => t.Primary) ?? taxonomies.FirstOrDefault();
+        if (primary is null)
+            return [];
+
+        return
+        [
+            new FhirCodeableConcept
+            {
+                Coding =
+                [
+                    new FhirCoding
+                    {
+                        System = "http://nucc.org/provider-taxonomy",
+                        Code = primary.Code,
+                        Display = primary.Desc
+                    }
+                ]
+            }
+        ];
+    }
+
+    private static List<FhirCodeableConcept> MapTaxonomiesToSpecialty(IReadOnlyList<NppesTaxonomy> taxonomies)
+    {
+        return taxonomies.Select(tax => new FhirCodeableConcept
+        {
+            Coding =
+            [
+                new FhirCoding
+                {
+                    System = "http://nucc.org/provider-taxonomy",
+                    Code = tax.Code,
+                    Display = tax.Desc
+                }
+            ]
+        }).ToList();
+    }
+
+    private static List<FhirReference> MapToLocationReferences(NppesResult nppes)
+    {
+        return nppes.Addresses
+            .Where(a => a.AddressPurpose == "LOCATION")
+            .Select((_, index) => new FhirReference
+            {
+                Reference = $"Location/{nppes.Number}-loc-{index}"
+            })
+            .ToList();
+    }
+
+    private static List<FhirCodeableConcept> MapLocationTypeFromTaxonomy(IReadOnlyList<NppesTaxonomy> taxonomies)
+    {
+        var primary = taxonomies.FirstOrDefault(t => t.Primary) ?? taxonomies.FirstOrDefault();
+        var isHospital = primary?.Desc?.Contains("hospital", StringComparison.OrdinalIgnoreCase) == true;
+
+        return
+        [
+            new FhirCodeableConcept
+            {
+                Coding =
+                [
+                    new FhirCoding
+                    {
+                        System = "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                        Code = isHospital ? "HOSP" : "OF",
+                        Display = isHospital ? "Hospital" : "Outpatient facility"
+                    }
+                ]
+            }
+        ];
+    }
+
+    private static string FormatProviderName(NppesBasicInfo basic)
+    {
+        if (!string.IsNullOrEmpty(basic.OrganizationName))
+            return basic.OrganizationName;
+
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(basic.FirstName)) parts.Add(basic.FirstName);
+        if (!string.IsNullOrEmpty(basic.MiddleName)) parts.Add(basic.MiddleName);
+        if (!string.IsNullOrEmpty(basic.LastName)) parts.Add(basic.LastName);
+        if (!string.IsNullOrEmpty(basic.Credential)) parts.Add(basic.Credential);
+        return string.Join(' ', parts);
+    }
+}

--- a/src/services/fhir-service/Models/FhirResources.cs
+++ b/src/services/fhir-service/Models/FhirResources.cs
@@ -148,6 +148,12 @@ public record FhirHumanName
 
     [JsonPropertyName("given")]
     public IReadOnlyList<string>? Given { get; init; }
+
+    [JsonPropertyName("prefix")]
+    public IReadOnlyList<string>? Prefix { get; init; }
+
+    [JsonPropertyName("suffix")]
+    public IReadOnlyList<string>? Suffix { get; init; }
 }
 
 /// <summary>
@@ -157,6 +163,9 @@ public record FhirAddress
 {
     [JsonPropertyName("use")]
     public string? Use { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
 
     [JsonPropertyName("line")]
     public IReadOnlyList<string>? Line { get; init; }
@@ -169,6 +178,9 @@ public record FhirAddress
 
     [JsonPropertyName("postalCode")]
     public string? PostalCode { get; init; }
+
+    [JsonPropertyName("country")]
+    public string? Country { get; init; }
 }
 
 /// <summary>
@@ -446,4 +458,344 @@ public record FhirBundle
 
     [JsonPropertyName("entry")]
     public IReadOnlyList<FhirBundleEntry>? Entry { get; init; }
+}
+
+// ── FHIR Bundle Search Component ─────────────────────────────────────────────
+
+/// <summary>
+/// FHIR R4 Bundle entry search component.
+/// </summary>
+public record FhirBundleSearch
+{
+    [JsonPropertyName("mode")]
+    public string? Mode { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 Bundle entry with search component.
+/// </summary>
+public record FhirBundleEntryWithSearch
+{
+    [JsonPropertyName("fullUrl")]
+    public string? FullUrl { get; init; }
+
+    [JsonPropertyName("resource")]
+    public FhirResource? Resource { get; init; }
+
+    [JsonPropertyName("search")]
+    public FhirBundleSearch? Search { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 searchset Bundle with search mode support.
+/// </summary>
+public record FhirSearchBundle
+{
+    [JsonPropertyName("resourceType")]
+    public string ResourceType => "Bundle";
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = "searchset";
+
+    [JsonPropertyName("total")]
+    public int Total { get; init; }
+
+    [JsonPropertyName("link")]
+    public IReadOnlyList<FhirBundleLink>? Link { get; init; }
+
+    [JsonPropertyName("entry")]
+    public IReadOnlyList<FhirBundleEntryWithSearch>? Entry { get; init; }
+}
+
+// ============================================================================
+// Provider Directory FHIR R4 Resources
+// ============================================================================
+
+/// <summary>
+/// FHIR R4 Qualification component for Practitioner.
+/// </summary>
+public record FhirQualification
+{
+    [JsonPropertyName("identifier")]
+    public IReadOnlyList<FhirIdentifier>? Identifier { get; init; }
+
+    [JsonPropertyName("code")]
+    public FhirCodeableConcept? Code { get; init; }
+
+    [JsonPropertyName("period")]
+    public FhirPeriod? Period { get; init; }
+
+    [JsonPropertyName("issuer")]
+    public FhirReference? Issuer { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 Practitioner resource (US Core profile).
+/// </summary>
+public record FhirPractitioner : FhirResource
+{
+    [JsonPropertyName("resourceType")]
+    public override string ResourceType => "Practitioner";
+
+    [JsonPropertyName("identifier")]
+    public IReadOnlyList<FhirIdentifier>? Identifier { get; init; }
+
+    [JsonPropertyName("active")]
+    public bool? Active { get; init; }
+
+    [JsonPropertyName("name")]
+    public IReadOnlyList<FhirHumanName>? Name { get; init; }
+
+    [JsonPropertyName("gender")]
+    public string? Gender { get; init; }
+
+    [JsonPropertyName("address")]
+    public IReadOnlyList<FhirAddress>? Address { get; init; }
+
+    [JsonPropertyName("telecom")]
+    public IReadOnlyList<FhirContactPoint>? Telecom { get; init; }
+
+    [JsonPropertyName("qualification")]
+    public IReadOnlyList<FhirQualification>? Qualification { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 Organization resource (US Core profile).
+/// </summary>
+public record FhirOrganization : FhirResource
+{
+    [JsonPropertyName("resourceType")]
+    public override string ResourceType => "Organization";
+
+    [JsonPropertyName("identifier")]
+    public IReadOnlyList<FhirIdentifier>? Identifier { get; init; }
+
+    [JsonPropertyName("active")]
+    public bool? Active { get; init; }
+
+    [JsonPropertyName("type")]
+    public IReadOnlyList<FhirCodeableConcept>? Type { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("alias")]
+    public IReadOnlyList<string>? Alias { get; init; }
+
+    [JsonPropertyName("address")]
+    public IReadOnlyList<FhirAddress>? Address { get; init; }
+
+    [JsonPropertyName("telecom")]
+    public IReadOnlyList<FhirContactPoint>? Telecom { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 PractitionerRole resource (US Core profile).
+/// </summary>
+public record FhirPractitionerRole : FhirResource
+{
+    [JsonPropertyName("resourceType")]
+    public override string ResourceType => "PractitionerRole";
+
+    [JsonPropertyName("active")]
+    public bool? Active { get; init; }
+
+    [JsonPropertyName("practitioner")]
+    public FhirReference? Practitioner { get; init; }
+
+    [JsonPropertyName("organization")]
+    public FhirReference? Organization { get; init; }
+
+    [JsonPropertyName("code")]
+    public IReadOnlyList<FhirCodeableConcept>? Code { get; init; }
+
+    [JsonPropertyName("specialty")]
+    public IReadOnlyList<FhirCodeableConcept>? Specialty { get; init; }
+
+    [JsonPropertyName("location")]
+    public IReadOnlyList<FhirReference>? Location { get; init; }
+
+    [JsonPropertyName("telecom")]
+    public IReadOnlyList<FhirContactPoint>? Telecom { get; init; }
+}
+
+/// <summary>
+/// FHIR R4 Location resource (US Core profile).
+/// </summary>
+public record FhirLocation : FhirResource
+{
+    [JsonPropertyName("resourceType")]
+    public override string ResourceType => "Location";
+
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("mode")]
+    public string? Mode { get; init; }
+
+    [JsonPropertyName("type")]
+    public IReadOnlyList<FhirCodeableConcept>? Type { get; init; }
+
+    [JsonPropertyName("telecom")]
+    public IReadOnlyList<FhirContactPoint>? Telecom { get; init; }
+
+    [JsonPropertyName("address")]
+    public FhirAddress? Address { get; init; }
+
+    [JsonPropertyName("managingOrganization")]
+    public FhirReference? ManagingOrganization { get; init; }
+}
+
+// ============================================================================
+// NPPES Integration Models (Provider Directory source data)
+// ============================================================================
+
+/// <summary>
+/// NPPES API response wrapper.
+/// </summary>
+public record NppesResponse
+{
+    [JsonPropertyName("result_count")]
+    public int ResultCount { get; init; }
+
+    [JsonPropertyName("results")]
+    public IReadOnlyList<NppesResult>? Results { get; init; }
+}
+
+/// <summary>
+/// Individual NPPES provider result.
+/// </summary>
+public record NppesResult
+{
+    [JsonPropertyName("number")]
+    public string Number { get; init; } = "";
+
+    [JsonPropertyName("enumeration_type")]
+    public string EnumerationType { get; init; } = "";
+
+    [JsonPropertyName("basic")]
+    public NppesBasicInfo Basic { get; init; } = new();
+
+    [JsonPropertyName("addresses")]
+    public IReadOnlyList<NppesAddress> Addresses { get; init; } = [];
+
+    [JsonPropertyName("taxonomies")]
+    public IReadOnlyList<NppesTaxonomy> Taxonomies { get; init; } = [];
+
+    [JsonPropertyName("other_names")]
+    public IReadOnlyList<NppesOtherName>? OtherNames { get; init; }
+}
+
+/// <summary>
+/// NPPES basic provider information.
+/// </summary>
+public record NppesBasicInfo
+{
+    [JsonPropertyName("first_name")]
+    public string? FirstName { get; init; }
+
+    [JsonPropertyName("last_name")]
+    public string? LastName { get; init; }
+
+    [JsonPropertyName("middle_name")]
+    public string? MiddleName { get; init; }
+
+    [JsonPropertyName("name_prefix")]
+    public string? NamePrefix { get; init; }
+
+    [JsonPropertyName("name_suffix")]
+    public string? NameSuffix { get; init; }
+
+    [JsonPropertyName("credential")]
+    public string? Credential { get; init; }
+
+    [JsonPropertyName("organization_name")]
+    public string? OrganizationName { get; init; }
+
+    [JsonPropertyName("gender")]
+    public string? Gender { get; init; }
+
+    [JsonPropertyName("enumeration_date")]
+    public string? EnumerationDate { get; init; }
+
+    [JsonPropertyName("last_updated")]
+    public string? LastUpdated { get; init; }
+
+    [JsonPropertyName("deactivation_date")]
+    public string? DeactivationDate { get; init; }
+
+    [JsonPropertyName("reactivation_date")]
+    public string? ReactivationDate { get; init; }
+
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+}
+
+/// <summary>
+/// NPPES address information.
+/// </summary>
+public record NppesAddress
+{
+    [JsonPropertyName("address_purpose")]
+    public string AddressPurpose { get; init; } = "";
+
+    [JsonPropertyName("address_1")]
+    public string Address1 { get; init; } = "";
+
+    [JsonPropertyName("address_2")]
+    public string? Address2 { get; init; }
+
+    [JsonPropertyName("city")]
+    public string City { get; init; } = "";
+
+    [JsonPropertyName("state")]
+    public string State { get; init; } = "";
+
+    [JsonPropertyName("postal_code")]
+    public string PostalCode { get; init; } = "";
+
+    [JsonPropertyName("country_code")]
+    public string CountryCode { get; init; } = "";
+
+    [JsonPropertyName("telephone_number")]
+    public string? TelephoneNumber { get; init; }
+
+    [JsonPropertyName("fax_number")]
+    public string? FaxNumber { get; init; }
+}
+
+/// <summary>
+/// NPPES taxonomy (specialty) information.
+/// </summary>
+public record NppesTaxonomy
+{
+    [JsonPropertyName("code")]
+    public string Code { get; init; } = "";
+
+    [JsonPropertyName("desc")]
+    public string Desc { get; init; } = "";
+
+    [JsonPropertyName("primary")]
+    public bool Primary { get; init; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; init; }
+
+    [JsonPropertyName("license")]
+    public string? License { get; init; }
+}
+
+/// <summary>
+/// NPPES other name entry.
+/// </summary>
+public record NppesOtherName
+{
+    [JsonPropertyName("organization_name")]
+    public string? OrganizationName { get; init; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
 }

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -42,6 +42,14 @@ builder.Services.AddSingleton<IFhirDataAdapter, MockFhirDataAdapter>();
 builder.Services.AddSingleton<FhirBundleBuilder>();
 builder.Services.AddSingleton<IPatientAccessDataProvider, MockPatientAccessDataProvider>();
 
+// ── Provider Directory: typed HttpClient for NPPES API ────────────────────────
+builder.Services.AddHttpClient("NppesApi", client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Nppes:BaseUrl"] ?? "https://npiregistry.cms.hhs.gov/api/");
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+});
+
 // Insert FHIR formatters first so they take priority over default System.Text.Json
 builder.Services.AddControllers(options =>
 {

--- a/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
@@ -1,0 +1,483 @@
+using FluentAssertions;
+using FhirService.Mappers;
+using FhirService.Models;
+
+namespace CloudHealthOffice.FhirService.Tests;
+
+/// <summary>
+/// Unit tests for ProviderDirectoryMapper — port of the TypeScript
+/// provider-directory-api.test.ts test suite.
+/// </summary>
+public class ProviderDirectoryMapperTests
+{
+    // ── Mock NPPES data ──────────────────────────────────────────────────────
+
+    private static readonly NppesResult MockPractitionerNppes = new()
+    {
+        Number = "1234567893",
+        EnumerationType = "NPI-1",
+        Basic = new NppesBasicInfo
+        {
+            FirstName = "Jane",
+            LastName = "Smith",
+            MiddleName = "Marie",
+            NamePrefix = "Dr.",
+            NameSuffix = "MD",
+            Credential = "MD",
+            Gender = "F",
+            EnumerationDate = "2010-01-15",
+            LastUpdated = "2024-01-01",
+            Status = "A"
+        },
+        Addresses =
+        [
+            new NppesAddress
+            {
+                AddressPurpose = "LOCATION",
+                Address1 = "123 Medical Center Drive",
+                Address2 = "Suite 400",
+                City = "Boston",
+                State = "MA",
+                PostalCode = "02101",
+                CountryCode = "US",
+                TelephoneNumber = "6175551234",
+                FaxNumber = "6175551235"
+            },
+            new NppesAddress
+            {
+                AddressPurpose = "MAILING",
+                Address1 = "PO Box 1234",
+                City = "Boston",
+                State = "MA",
+                PostalCode = "02102",
+                CountryCode = "US"
+            }
+        ],
+        Taxonomies =
+        [
+            new NppesTaxonomy
+            {
+                Code = "207R00000X",
+                Desc = "Internal Medicine",
+                Primary = true,
+                State = "MA",
+                License = "MA12345"
+            },
+            new NppesTaxonomy
+            {
+                Code = "207RC0000X",
+                Desc = "Cardiovascular Disease",
+                Primary = false,
+                State = "MA",
+                License = "MA12346"
+            }
+        ]
+    };
+
+    private static readonly NppesResult MockOrganizationNppes = new()
+    {
+        Number = "9876543213",
+        EnumerationType = "NPI-2",
+        Basic = new NppesBasicInfo
+        {
+            OrganizationName = "Boston Medical Center",
+            EnumerationDate = "2005-06-01",
+            LastUpdated = "2024-02-15",
+            Status = "A"
+        },
+        Addresses =
+        [
+            new NppesAddress
+            {
+                AddressPurpose = "LOCATION",
+                Address1 = "1 Medical Center Plaza",
+                City = "Boston",
+                State = "MA",
+                PostalCode = "02118",
+                CountryCode = "US",
+                TelephoneNumber = "6176381000",
+                FaxNumber = "6176381001"
+            }
+        ],
+        Taxonomies =
+        [
+            new NppesTaxonomy
+            {
+                Code = "282N00000X",
+                Desc = "General Acute Care Hospital",
+                Primary = true
+            }
+        ],
+        OtherNames =
+        [
+            new NppesOtherName
+            {
+                OrganizationName = "BMC",
+                Type = "DBA"
+            }
+        ]
+    };
+
+    // ── NPI Validation ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateNpi_AcceptsCorrectNpi()
+    {
+        ProviderDirectoryMapper.ValidateNpi("1234567893").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("123456789")]   // 9 digits
+    [InlineData("12345678931")] // 11 digits
+    public void ValidateNpi_RejectsWrongLength(string npi)
+    {
+        ProviderDirectoryMapper.ValidateNpi(npi).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("123456789A")]
+    [InlineData("123-456-78")]
+    public void ValidateNpi_RejectsNonNumericCharacters(string npi)
+    {
+        ProviderDirectoryMapper.ValidateNpi(npi).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateNpi_RejectsNpiFailingLuhnCheck()
+    {
+        ProviderDirectoryMapper.ValidateNpi("1234567891").Should().BeFalse();
+    }
+
+    // ── NPPES → Practitioner Mapping ─────────────────────────────────────────
+
+    [Fact]
+    public void MapNppesToPractitioner_CreatesResourceWithCorrectTypeAndId()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        practitioner.ResourceType.Should().Be("Practitioner");
+        practitioner.Id.Should().Be("1234567893");
+        practitioner.Active.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_IncludesUsCoreProfile()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        practitioner.Meta!.Profile.Should().Contain(
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsNpiIdentifier()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        var npiId = practitioner.Identifier!.FirstOrDefault(
+            i => i.System == "http://hl7.org/fhir/sid/us-npi");
+        npiId.Should().NotBeNull();
+        npiId!.Value.Should().Be("1234567893");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsNameWithPrefixAndSuffix()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        var name = practitioner.Name![0];
+        name.Family.Should().Be("Smith");
+        name.Given.Should().Contain("Jane");
+        name.Given.Should().Contain("Marie");
+        name.Prefix.Should().Contain("Dr.");
+        name.Suffix.Should().Contain("MD");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsGenderCorrectly()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+        practitioner.Gender.Should().Be("female");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsAddresses()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        practitioner.Address.Should().HaveCount(2);
+
+        var workAddr = practitioner.Address!.FirstOrDefault(a => a.Use == "work");
+        workAddr.Should().NotBeNull();
+        workAddr!.Line.Should().Contain("123 Medical Center Drive");
+        workAddr.City.Should().Be("Boston");
+        workAddr.State.Should().Be("MA");
+        workAddr.PostalCode.Should().Be("02101");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsTelecom()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        var phone = practitioner.Telecom!.FirstOrDefault(t => t.System == "phone");
+        phone.Should().NotBeNull();
+        phone!.Value.Should().Contain("617");
+
+        var fax = practitioner.Telecom!.FirstOrDefault(t => t.System == "fax");
+        fax.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MapsQualificationsFromTaxonomies()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+
+        practitioner.Qualification.Should().HaveCount(2);
+
+        var primaryQual = practitioner.Qualification![0];
+        primaryQual.Code!.Coding![0].Code.Should().Be("207R00000X");
+        primaryQual.Code.Coding[0].Display.Should().Be("Internal Medicine");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_ThrowsForNpi2()
+    {
+        var act = () => ProviderDirectoryMapper.MapNppesToPractitioner(MockOrganizationNppes);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cannot map NPI-2*");
+    }
+
+    [Fact]
+    public void MapNppesToPractitioner_MarksDeactivatedAsInactive()
+    {
+        var deactivated = MockPractitionerNppes with
+        {
+            Basic = MockPractitionerNppes.Basic with { DeactivationDate = "2023-01-01" }
+        };
+
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(deactivated);
+        practitioner.Active.Should().BeFalse();
+    }
+
+    // ── NPPES → Organization Mapping ─────────────────────────────────────────
+
+    [Fact]
+    public void MapNppesToOrganization_CreatesResourceWithCorrectTypeAndId()
+    {
+        var org = ProviderDirectoryMapper.MapNppesToOrganization(MockOrganizationNppes);
+
+        org.ResourceType.Should().Be("Organization");
+        org.Id.Should().Be("9876543213");
+        org.Active.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapNppesToOrganization_IncludesUsCoreProfile()
+    {
+        var org = ProviderDirectoryMapper.MapNppesToOrganization(MockOrganizationNppes);
+
+        org.Meta!.Profile.Should().Contain(
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization");
+    }
+
+    [Fact]
+    public void MapNppesToOrganization_MapsOrganizationName()
+    {
+        var org = ProviderDirectoryMapper.MapNppesToOrganization(MockOrganizationNppes);
+        org.Name.Should().Be("Boston Medical Center");
+    }
+
+    [Fact]
+    public void MapNppesToOrganization_IncludesAlias()
+    {
+        var org = ProviderDirectoryMapper.MapNppesToOrganization(MockOrganizationNppes);
+        org.Alias.Should().Contain("BMC");
+    }
+
+    [Fact]
+    public void MapNppesToOrganization_MapsTypeFromTaxonomy()
+    {
+        var org = ProviderDirectoryMapper.MapNppesToOrganization(MockOrganizationNppes);
+
+        org.Type.Should().HaveCount(1);
+        org.Type![0].Coding![0].Code.Should().Be("282N00000X");
+        org.Type[0].Coding[0].Display.Should().Be("General Acute Care Hospital");
+    }
+
+    [Fact]
+    public void MapNppesToOrganization_ThrowsForNpi1()
+    {
+        var act = () => ProviderDirectoryMapper.MapNppesToOrganization(MockPractitionerNppes);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Cannot map NPI-1*");
+    }
+
+    // ── NPPES → PractitionerRole Mapping ─────────────────────────────────────
+
+    [Fact]
+    public void MapNppesToPractitionerRole_CreatesResourceWithCorrectIdFormat()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+
+        role.ResourceType.Should().Be("PractitionerRole");
+        role.Id.Should().Be("1234567893-role");
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_IncludesUsCoreProfile()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+
+        role.Meta!.Profile.Should().Contain(
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole");
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_ReferencesPractitioner()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+        role.Practitioner!.Reference.Should().Be("Practitioner/1234567893");
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_IncludesOrganizationRefWhenProvided()
+    {
+        var orgRef = new FhirReference { Reference = "Organization/9876543213" };
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes, orgRef);
+
+        role.Organization.Should().Be(orgRef);
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_MapsSpecialtiesFromTaxonomies()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+
+        role.Specialty.Should().HaveCount(2);
+        role.Specialty![0].Coding![0].Code.Should().Be("207R00000X");
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_MapsRoleCodeFromPrimaryTaxonomy()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+
+        role.Code.Should().HaveCount(1);
+        role.Code![0].Coding![0].Display.Should().Be("Internal Medicine");
+    }
+
+    [Fact]
+    public void MapNppesToPractitionerRole_IncludesLocationReferences()
+    {
+        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(MockPractitionerNppes);
+
+        role.Location.Should().HaveCount(1);
+        role.Location![0].Reference.Should().Be("Location/1234567893-loc-0");
+    }
+
+    // ── NPPES → Location Mapping ─────────────────────────────────────────────
+
+    [Fact]
+    public void MapNppesToLocation_CreatesResourceWithCorrectId()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockPractitionerNppes, 0);
+
+        location.ResourceType.Should().Be("Location");
+        location.Id.Should().Be("1234567893-loc-0");
+    }
+
+    [Fact]
+    public void MapNppesToLocation_IncludesUsCoreProfile()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockPractitionerNppes, 0);
+
+        location.Meta!.Profile.Should().Contain(
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location");
+    }
+
+    [Fact]
+    public void MapNppesToLocation_MapsAddress()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockPractitionerNppes, 0);
+
+        location.Address!.Line.Should().Contain("123 Medical Center Drive");
+        location.Address.City.Should().Be("Boston");
+        location.Address.State.Should().Be("MA");
+    }
+
+    [Fact]
+    public void MapNppesToLocation_SetsStatusBasedOnEnumerationStatus()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockPractitionerNppes, 0);
+        location.Status.Should().Be("active");
+
+        var deactivated = MockPractitionerNppes with
+        {
+            Basic = MockPractitionerNppes.Basic with { DeactivationDate = "2023-01-01" }
+        };
+        var inactiveLocation = ProviderDirectoryMapper.MapNppesToLocation(deactivated, 0);
+        inactiveLocation.Status.Should().Be("inactive");
+    }
+
+    [Fact]
+    public void MapNppesToLocation_IncludesTelecomFromAddress()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockPractitionerNppes, 0);
+
+        location.Telecom.Should().NotBeNull();
+        location.Telecom!.FirstOrDefault(t => t.System == "phone").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MapNppesToLocation_IncludesManagingOrganizationForNpi2()
+    {
+        var location = ProviderDirectoryMapper.MapNppesToLocation(MockOrganizationNppes, 0);
+        location.ManagingOrganization!.Reference.Should().Be("Organization/9876543213");
+    }
+
+    [Fact]
+    public void MapNppesToLocation_ThrowsForOutOfRangeIndex()
+    {
+        var nppesMailingOnly = MockPractitionerNppes with
+        {
+            Addresses =
+            [
+                new NppesAddress
+                {
+                    AddressPurpose = "MAILING",
+                    Address1 = "PO Box 1234",
+                    City = "Boston",
+                    State = "MA",
+                    PostalCode = "02102",
+                    CountryCode = "US"
+                }
+            ]
+        };
+
+        var act = () => ProviderDirectoryMapper.MapNppesToLocation(nppesMailingOnly, 10);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*at index 10*");
+    }
+
+    // ── Search Bundle Creation ───────────────────────────────────────────────
+
+    [Fact]
+    public void CreateSearchBundle_CreatesValidSearchsetBundle()
+    {
+        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(MockPractitionerNppes);
+        var bundle = ProviderDirectoryMapper.CreateSearchBundle("Practitioner", [practitioner]);
+
+        bundle.ResourceType.Should().Be("Bundle");
+        bundle.Type.Should().Be("searchset");
+        bundle.Total.Should().Be(1);
+        bundle.Entry.Should().HaveCount(1);
+        bundle.Entry![0].Search!.Mode.Should().Be("match");
+    }
+
+    [Fact]
+    public void CreateSearchBundle_HandlesEmptyResults()
+    {
+        var bundle = ProviderDirectoryMapper.CreateSearchBundle("Practitioner", []);
+
+        bundle.Total.Should().Be(0);
+        bundle.Entry.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Add FHIR R4 Provider Directory implementation that maps NPPES provider data
to Practitioner, PractitionerRole, Organization, and Location resources:

- Mappers/ProviderDirectoryMapper.cs: static mapper with NPI Luhn validation,
  NPPES-to-FHIR resource mapping for all 4 resource types, and search bundle
  creation. Ports all mapping logic from provider-directory-api.ts.

- Controllers/ProviderDirectoryController.cs: REST endpoints for search and
  read operations on all provider directory resources. Calls NPPES API via
  typed HttpClient registered in Program.cs.

- Models/FhirResources.cs: adds FhirPractitioner, FhirOrganization,
  FhirPractitionerRole, FhirLocation records plus NPPES deserialization
  models. Extends FhirHumanName with prefix/suffix and FhirAddress with
  type/country fields.

- ProviderDirectoryMapperTests.cs: 30 xUnit tests ported from the TypeScript
  test suite covering NPI validation, all 4 resource mappings, deactivation
  handling, type safety, and search bundle creation.

https://claude.ai/code/session_01Rxq2SggkbMkWzFqDr7Q3Jx