### PR TITLE
Fix Docker build context for .NET services that depend on shared infrastructure

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -96,14 +96,27 @@ jobs:
           - enrollment-import-service
           - trading-partner-service
         include:
-          # tenant-service needs repo root as context so it can reach scripts/setup/
-          - service: tenant-service
+          # Most .NET services need repo root as context to reach
+          # src/services/shared/CloudHealthOffice.Infrastructure/ and/or src/engines/.
+          # Only self-contained services (claims-scrubbing-service, reference-data-service,
+          # provider-service, sponsor-service, trading-partner-service) use their own directory.
+          - service: member-service
             build_context: '.'
-          # benefit-plan-service needs repo root as context so it can reach src/engines/
+          - service: coverage-service
+            build_context: '.'
+          - service: claims-service
+            build_context: '.'
+          - service: eligibility-service
+            build_context: '.'
+          - service: authorization-service
+            build_context: '.'
+          - service: attachment-service
+            build_context: '.'
           - service: benefit-plan-service
             build_context: '.'
-          # attachment-service needs repo root as context so it can reach src/engines/
-          - service: attachment-service
+          - service: enrollment-import-service
+            build_context: '.'
+          - service: tenant-service
             build_context: '.'
 
     steps:


### PR DESCRIPTION
Services like claims-service, member-service, coverage-service, eligibility-service,
authorization-service, and enrollment-import-service all reference
src/services/shared/CloudHealthOffice.Infrastructure/ in their Dockerfiles.
The deploy-azure-aks workflow defaulted their build context to
./src/services/{service}/, causing "not found" errors during Docker builds.

Set build_context to repo root ('.') for all services that need it.

https://claude.ai/code/session_0165mR4DY2wqdrQRjukqoJbj