### PR TITLE
Fix Docker build context for provider, sponsor, trading-partner, and reference-data services

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -98,8 +98,7 @@ jobs:
         include:
           # Most .NET services need repo root as context to reach
           # src/services/shared/CloudHealthOffice.Infrastructure/ and/or src/engines/.
-          # Only self-contained services (claims-scrubbing-service, reference-data-service,
-          # provider-service, sponsor-service, trading-partner-service) use their own directory.
+          # Only claims-scrubbing-service (Node.js) is truly self-contained.
           - service: member-service
             build_context: '.'
           - service: coverage-service
@@ -117,6 +116,14 @@ jobs:
           - service: enrollment-import-service
             build_context: '.'
           - service: tenant-service
+            build_context: '.'
+          - service: provider-service
+            build_context: '.'
+          - service: sponsor-service
+            build_context: '.'
+          - service: trading-partner-service
+            build_context: '.'
+          - service: reference-data-service
             build_context: '.'
 
     steps:


### PR DESCRIPTION
These four .NET services depend on the shared CloudHealthOffice.Infrastructure
project but were missing build_context: '.' in the deploy workflow matrix,
causing Docker builds to fail because COPY commands couldn't find the shared
project from the service-level context.

Also corrects the misleading comment that listed these services as
"self-contained" — only claims-scrubbing-service (Node.js) is truly
self-contained.

https://claude.ai/code/session_0135EGrsX3C8F4wbB9H4s4cx