### PR TITLE
Fix broken Quickstart link in Docs page

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/Docs.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Docs.razor
@@ -26,7 +26,7 @@
                     </MudList>
                 </MudCardContent>
                 <MudCardActions>
-                    <MudButton Href="https://github.com/aurelianware/cloudhealthoffice/blob/main/QUICKSTART.md" 
+                    <MudButton Href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/guides/QUICKSTART.md"
                                Target="_blank" 
                                Variant="Variant.Text" 
                                Color="Color.Primary">


### PR DESCRIPTION
The "View Quickstart" button pointed to QUICKSTART.md at the repo root,
but the file lives at docs/guides/QUICKSTART.md, causing a GitHub 404.

https://claude.ai/code/session_01BFYFLePZKGMo7FWYnTLsC4