### PR TITLE
Remove Logic Apps references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ cloudhealthoffice/
 │   ├── azure/              # Bicep IaC
 │   ├── helm/               # Helm chart
 │   ├── k8s/                # Kubernetes manifests
-│   ├── monitoring/         # Grafana + Prometheus
-│   └── logicapps/          # Azure Logic Apps (attachment workflows)
+│   └── monitoring/         # Grafana + Prometheus
 ├── containers/             # Sidecar containers (parsers, encoders, SFTP)
 ├── schemas/                # X12 XSD schemas, JSON schemas (auth, appeals)
 ├── tests/                  # Unit, integration, E2E, fixtures
@@ -219,7 +218,6 @@ cloudhealthoffice/
 
 |Option                      |Best For                               |Time to Production|
 |----------------------------|---------------------------------------|------------------|
-|**Azure Logic Apps**        |Azure-first orgs, minimal ops overhead |< 1 hour          |
 |**Kubernetes (AKS/EKS/GKE)**|Enterprise control, multi-cloud, hybrid|1–2 hours         |
 |**Docker Compose**          |Development, evaluation, POC           |5 minutes         |
 


### PR DESCRIPTION
The Logic Apps code was deleted in a recent PR and replaced by Argo
Workflows. Remove the logicapps/ directory listing from the project
structure and the Azure Logic Apps row from the deployment options table.

https://claude.ai/code/session_01Ctbd1v6uRhmumwUxXvLpW5