### PR TITLE
Fix PHI scan false positives for .test TLD emails in seed data

### DIFF
--- a/.github/workflows/phi-validation.yml
+++ b/.github/workflows/phi-validation.yml
@@ -113,7 +113,7 @@ jobs:
             # SSN patterns (but allow test cases)
             '(?<!\w)\d{3}-\d{2}-\d{4}(?!\w)',
             # Email patterns in strings (but allow examples and company domains)
-            '[\w\.-]+@(?!example\.com|test\.com|healthplan\.com|cloudhealthoffice\.com|aurelianware\.com)[\w\.-]+\.\w+'
+            '[\w\.-]+@(?!example\.com|test\.com|healthplan\.com|cloudhealthoffice\.com|aurelianware\.com|[\w\.-]+\.test\b)[\w\.-]+\.\w+'
           )
 
           $violations = @()


### PR DESCRIPTION
The hardcoded PHI pattern checker was flagging demo email addresses
using the IANA-reserved .test TLD (e.g., provider-001@demo-clinic.test)
as potential real PHI. Add .test TLD to the exclusion list in the email
regex pattern.

https://claude.ai/code/session_01KV9Y83mVr9WnQNxoXPtCDD