### PR TITLE
fix(k8s): resolve env var conflict for AzureAd secrets in portal deployment

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
+++ b/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
@@ -114,16 +114,19 @@ spec:
               name: portal-config
               key: Redis__ConnectionString
         - name: AzureAd__TenantId
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config
               key: TenantId
         - name: AzureAd__ClientId
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config
               key: ClientId
         - name: AzureAd__ClientSecret
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config

--- a/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
+++ b/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
@@ -46,7 +46,10 @@ spec:
               name: azure-ad-config
               key: ClientId
         - name: AzureAd__TenantId
-          value: "common"
+          valueFrom:
+            secretKeyRef:
+              name: azure-ad-config
+              key: TenantId
         - name: AzureAd__Audience
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
The portal deployment fails because kubectl apply's strategic merge patch
combines the old hardcoded `value` fields (from the pre-migration deployment)
with the new `valueFrom` secretKeyRef entries, which K8s rejects. Add explicit
`value: ""` to the three AzureAd env vars to clear the old values during merge.

Also migrate trading-partner-service AzureAd__TenantId from hardcoded
"common" to use the azure-ad-config secret, consistent with the tenant
migration in 83564c4.

https://claude.ai/code/session_01QFtc64jXBnvC6CCj9fYGUR