### PR TITLE
fix(k8s): add value: "" to trading-partner-service AzureAd env vars

### DIFF
--- a/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
+++ b/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
@@ -41,16 +41,19 @@ spec:
         - name: COSMOS_CONTAINER_TRADING_PARTNERS
           value: "TradingPartners"
         - name: AzureAd__ClientId
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config
               key: ClientId
         - name: AzureAd__TenantId
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config
               key: TenantId
         - name: AzureAd__Audience
+          value: ""
           valueFrom:
             secretKeyRef:
               name: azure-ad-config


### PR DESCRIPTION
Same strategic-merge issue as the portal: if the live deployment has old hardcoded values for AzureAd__ClientId, AzureAd__TenantId, or AzureAd__Audience, kubectl apply will merge both value and valueFrom, which K8s rejects. Add explicit value: "" to clear stale values.

https://claude.ai/code/session_01QFtc64jXBnvC6CCj9fYGUR