### PR TITLE
fix(auth): correct API client ID and tenant extraction for AADSTS650052 error

### DIFF
--- a/docs/features/ADMIN-CONSENT-SETUP.md
+++ b/docs/features/ADMIN-CONSENT-SETUP.md
@@ -10,7 +10,7 @@ This guide explains how to grant admin consent for the Cloud Health Office API a
 
 **Full Error**:
 ```
-The app is trying to access a service '31f76844-b2cb-47b1-aede-f5b2b6dc59c8' 
+The app is trying to access a service 'cfada1ac-f251-48ea-9330-39212aa4c862' 
 (Cloud Health Office API) that your organization lacks a service principal for.
 ```
 
@@ -25,11 +25,11 @@ The app is trying to access a service '31f76844-b2cb-47b1-aede-f5b2b6dc59c8'
 
 2. **Replace placeholders**:
    - `{TENANT_ID}`: Your Azure AD tenant ID (e.g., `32177734-051b-4fdc-9568-cc35530191b1`)
-   - `{API_CLIENT_ID}`: API app client ID (e.g., `31f76844-b2cb-47b1-aede-f5b2b6dc59c8`)
+   - `{API_CLIENT_ID}`: API app client ID (e.g., `cfada1ac-f251-48ea-9330-39212aa4c862`)
 
 3. **Example URL**:
    ```
-   https://login.microsoftonline.com/32177734-051b-4fdc-9568-cc35530191b1/adminconsent?client_id=31f76844-b2cb-47b1-aede-f5b2b6dc59c8
+   https://login.microsoftonline.com/32177734-051b-4fdc-9568-cc35530191b1/adminconsent?client_id=cfada1ac-f251-48ea-9330-39212aa4c862
    ```
 
 4. **Have an Azure AD admin**:
@@ -136,7 +136,7 @@ Disconnect-MgGraph
 ```powershell
 .\Grant-CloudHealthOfficeAdminConsent.ps1 `
     -TenantId "32177734-051b-4fdc-9568-cc35530191b1" `
-    -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8" `
+    -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862" `
     -PortalClientId "YOUR_PORTAL_CLIENT_ID"
 ```
 
@@ -147,10 +147,10 @@ Disconnect-MgGraph
 az login --tenant 32177734-051b-4fdc-9568-cc35530191b1
 
 # Create service principal for API
-az ad sp create --id 31f76844-b2cb-47b1-aede-f5b2b6dc59c8
+az ad sp create --id cfada1ac-f251-48ea-9330-39212aa4c862
 
 # Verify
-az ad sp show --id 31f76844-b2cb-47b1-aede-f5b2b6dc59c8
+az ad sp show --id cfada1ac-f251-48ea-9330-39212aa4c862
 ```
 
 ## Who Can Grant Admin Consent?

--- a/docs/features/FIX-AADSTS1003031.md
+++ b/docs/features/FIX-AADSTS1003031.md
@@ -60,7 +60,7 @@ Save this as `Configure-PortalApiPermissions.ps1`:
     API app registration client ID
 
 .EXAMPLE
-    .\Configure-PortalApiPermissions.ps1 -TenantId "32177734-..." -PortalClientId "portal-client-id" -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8"
+    .\Configure-PortalApiPermissions.ps1 -TenantId "32177734-..." -PortalClientId "portal-client-id" -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862"
 #>
 
 param(
@@ -194,7 +194,7 @@ Disconnect-MgGraph
 az login --tenant YOUR_TENANT_ID
 
 # Get API app details
-API_APP_ID=$(az ad app show --id 31f76844-b2cb-47b1-aede-f5b2b6dc59c8 --query id -o tsv)
+API_APP_ID=$(az ad app show --id cfada1ac-f251-48ea-9330-39212aa4c862 --query id -o tsv)
 API_SCOPE_ID=$(az ad app show --id $API_APP_ID --query "api.oauth2PermissionScopes[0].id" -o tsv)
 
 # Get portal app details
@@ -203,7 +203,7 @@ PORTAL_APP_ID=$(az ad app show --id YOUR_PORTAL_CLIENT_ID --query id -o tsv)
 # Add API permission to portal
 az ad app permission add \
   --id $PORTAL_APP_ID \
-  --api 31f76844-b2cb-47b1-aede-f5b2b6dc59c8 \
+  --api cfada1ac-f251-48ea-9330-39212aa4c862 \
   --api-permissions $API_SCOPE_ID=Scope
 
 # Grant admin consent
@@ -220,7 +220,7 @@ az ad app permission admin-consent --id $PORTAL_APP_ID
 {
   "requiredResourceAccess": [
     {
-      "resourceAppId": "31f76844-b2cb-47b1-aede-f5b2b6dc59c8",  // API Client ID
+      "resourceAppId": "cfada1ac-f251-48ea-9330-39212aa4c862",  // API Client ID
       "resourceAccess": [
         {
           "id": "user_impersonation_scope_id",  // API's exposed scope ID
@@ -238,7 +238,7 @@ The API app registration must have exposed API scopes:
 
 1. Go to API app registration
 2. Click **Expose an API**
-3. Verify **Application ID URI** is set (e.g., `api://31f76844-b2cb-47b1-aede-f5b2b6dc59c8`)
+3. Verify **Application ID URI** is set (e.g., `api://cfada1ac-f251-48ea-9330-39212aa4c862`)
 4. Add a scope if missing:
    - **Scope name**: `user_impersonation`
    - **Who can consent**: Admins and users

--- a/scripts/setup/Configure-PortalApiPermissions.ps1
+++ b/scripts/setup/Configure-PortalApiPermissions.ps1
@@ -19,7 +19,7 @@
     API app registration client ID
 
 .EXAMPLE
-    .\Configure-PortalApiPermissions.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -PortalClientId "abc123..." -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8"
+    .\Configure-PortalApiPermissions.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -PortalClientId "abc123..." -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862"
 #>
 
 param(

--- a/scripts/setup/Grant-AdminConsent.ps1
+++ b/scripts/setup/Grant-AdminConsent.ps1
@@ -22,10 +22,10 @@
     Use device code authentication (for environments without browser access)
 
 .EXAMPLE
-    .\Grant-AdminConsent.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8"
+    .\Grant-AdminConsent.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862"
 
 .EXAMPLE
-    .\Grant-AdminConsent.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8" -PortalClientId "abc123..."
+    .\Grant-AdminConsent.ps1 -TenantId "32177734-051b-4fdc-9568-cc35530191b1" -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862" -PortalClientId "b8975dfe-3227-4dea-a053-c5bfb15b7cfd"
 #>
 
 param(

--- a/scripts/setup/TENANT_ONBOARDING_CHECKLIST.md
+++ b/scripts/setup/TENANT_ONBOARDING_CHECKLIST.md
@@ -59,7 +59,7 @@ You can also run the existing script from the admin's machine or with their cred
 ```powershell
 .\scripts\setup\Grant-AdminConsent.ps1 `
   -TenantId "TENANT_ID" `
-  -ApiClientId "31f76844-b2cb-47b1-aede-f5b2b6dc59c8" `
+  -ApiClientId "cfada1ac-f251-48ea-9330-39212aa4c862" `
   -PortalClientId "54f3419d-0d69-4b06-939a-c1a260596556"
 ```
 
@@ -67,7 +67,7 @@ This creates the service principals and grants consent for both the API and Port
 
 ## 5. Downstream API Consent
 
-The portal calls the CHO Authorization Service API (`31f76844-b2cb-47b1-aede-f5b2b6dc59c8`) with these scopes:
+The portal calls the CHO Authorization Service API (`cfada1ac-f251-48ea-9330-39212aa4c862`) with these scopes:
 - `Authorization.ReadWrite`
 - `Attachments.ReadWrite`
 - `Eligibility.Query`
@@ -76,7 +76,7 @@ The portal calls the CHO Authorization Service API (`31f76844-b2cb-47b1-aede-f5b
 The tenant admin must also consent to the **API** app registration. The `Grant-AdminConsent.ps1` script (Option C) handles both. If using the URL method, send a second URL:
 
 ```
-https://login.microsoftonline.com/TENANT_ID/adminconsent?client_id=31f76844-b2cb-47b1-aede-f5b2b6dc59c8
+https://login.microsoftonline.com/TENANT_ID/adminconsent?client_id=cfada1ac-f251-48ea-9330-39212aa4c862
 ```
 
 ## 6. Verify End-to-End

--- a/src/portal/CloudHealthOffice.Portal/Pages/Error/AdminConsentRequired.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Error/AdminConsentRequired.razor
@@ -1,5 +1,6 @@
 @page "/Error/AdminConsentRequired"
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.WebUtilities
 
 <PageTitle>Admin Consent Required - Cloud Health Office</PageTitle>
 
@@ -118,7 +119,7 @@
                         <strong>Error Code:</strong> AADSTS650052<br />
                         <strong>Tenant ID:</strong> @tenantId<br />
                         <strong>API Client ID:</strong> @apiClientId<br />
-                        <strong>API Name:</strong> Cloud Health Office API
+                        <strong>API Name:</strong> cloudhealthoffice-api
                     </MudText>
                 </MudPaper>
 
@@ -175,22 +176,37 @@
 </MudContainer>
 
 @code {
-    private string tenantId = "YOUR_TENANT_ID"; // Will be populated from config or error
-    private string apiClientId = "31f76844-b2cb-47b1-aede-f5b2b6dc59c8";
-    
+    private string tenantId = "YOUR_TENANT_ID";
+    private string apiClientId = "cfada1ac-f251-48ea-9330-39212aa4c862";
+
     private string GetAdminConsentUrl() => $"https://login.microsoftonline.com/{tenantId}/adminconsent?client_id={apiClientId}";
 
     [Inject]
     private IConfiguration Configuration { get; set; } = default!;
 
     [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    [Inject]
     private ISnackbar Snackbar { get; set; } = default!;
 
     protected override void OnInitialized()
     {
-        // Try to get tenant ID from configuration
-        tenantId = Configuration["AzureAd:TenantId"] ?? tenantId;
-        apiClientId = Configuration["AzureAd:ClientId"] ?? apiClientId;
+        // Extract the API client ID from DownstreamApi scopes (the resource the portal calls)
+        var scopes = Configuration["DownstreamApi:Scopes"] ?? "";
+        var scopeMatch = System.Text.RegularExpressions.Regex.Match(scopes, @"api://([0-9a-f\-]{36})/");
+        if (scopeMatch.Success)
+        {
+            apiClientId = scopeMatch.Groups[1].Value;
+        }
+
+        // Try to get tenant ID from the query string (passed by error handler)
+        var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
+        if (QueryHelpers.ParseQuery(uri.Query).TryGetValue("tenantId", out var qsTenantId) &&
+            !string.IsNullOrEmpty(qsTenantId))
+        {
+            tenantId = qsTenantId!;
+        }
     }
 
     private void CopyToClipboard()

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -67,30 +67,38 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
         options.Events.OnAuthenticationFailed = context =>
         {
             var error = context.Exception.Message;
-            
+
             // Check for admin consent required error (AADSTS650052)
             if (error.Contains("AADSTS650052") || error.Contains("lacks a service principal"))
             {
-                context.Response.Redirect("/Error/AdminConsentRequired");
+                var tenantId = ExtractTenantIdFromError(error);
+                var redirectUrl = BuildAdminConsentErrorUrl(tenantId);
+                context.Response.Redirect(redirectUrl);
                 context.HandleResponse();
             }
-            
+
             return Task.CompletedTask;
         };
-        
+
         // Also handle remote failure (covers more error scenarios)
         options.Events.OnRemoteFailure = context =>
         {
             var error = context.Failure?.Message ?? "";
-            
-            if (error.Contains("AADSTS650052") || 
+            var queryError = context.Request.Query["error_description"].FirstOrDefault() ?? "";
+            var combinedError = string.IsNullOrEmpty(queryError) ? error : queryError;
+
+            if (error.Contains("AADSTS650052") ||
                 error.Contains("lacks a service principal") ||
-                error.Contains("AADSTS65001")) // User/admin hasn't consented
+                error.Contains("AADSTS65001") ||
+                queryError.Contains("AADSTS650052") ||
+                queryError.Contains("AADSTS65001"))
             {
-                context.Response.Redirect("/Error/AdminConsentRequired");
+                var tenantId = ExtractTenantIdFromError(combinedError);
+                var redirectUrl = BuildAdminConsentErrorUrl(tenantId);
+                context.Response.Redirect(redirectUrl);
                 context.HandleResponse();
             }
-            
+
             return Task.CompletedTask;
         };
     })
@@ -244,6 +252,26 @@ builder.Services.AddSession(options =>
     options.Cookie.SameSite = SameSiteMode.Lax; // Changed from None to Lax
     options.Cookie.Name = ".CloudHealthOffice.Session";
 });
+
+// Helper: extract tenant ID from Azure AD error messages
+static string? ExtractTenantIdFromError(string error)
+{
+    // Pattern: "your organization '{tenant-id}'"
+    var match = System.Text.RegularExpressions.Regex.Match(
+        error, @"organization\s+'([0-9a-f\-]{36})'", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    return match.Success ? match.Groups[1].Value : null;
+}
+
+// Helper: build redirect URL with tenant context for admin consent error page
+static string BuildAdminConsentErrorUrl(string? tenantId)
+{
+    var url = "/Error/AdminConsentRequired";
+    if (!string.IsNullOrEmpty(tenantId))
+    {
+        url += $"?tenantId={Uri.EscapeDataString(tenantId)}";
+    }
+    return url;
+}
 
 var app = builder.Build();
 


### PR DESCRIPTION
The admin consent error page and scripts referenced a stale API client ID
(31f76844...) instead of the actual API app registration (cfada1ac...).
The error handler also failed to extract the tenant ID from the Azure AD
error message, causing the admin consent URL to be generated with
"organizations" instead of the real tenant GUID.

- Extract tenant ID from AADSTS650052 error description via regex
- Pass tenant ID to error page via query string
- Read API client ID from DownstreamApi:Scopes config instead of AzureAd:ClientId
- Also check query string error_description in OnRemoteFailure handler
- Update all scripts and docs to reference correct API client ID

https://claude.ai/code/session_01BGTyKPKLrQavaqRvXbmcyB