### PR TITLE
fix(ci): update trivy-action from 0.30.0 to 0.35.0

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -96,7 +96,7 @@ jobs:
             VCS_REF=${{ github.sha }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.container.name }}:${{ steps.meta.outputs.version }}
           format: 'sarif'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in fs mode
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -132,7 +132,7 @@ jobs:
 
       - name: Generate Trivy report
         if: always()
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
The trivy-action@0.30.0 release was deleted during the Trivy security incident on 2026-03-01 (GitHub Releases v0.27.0–v0.69.1 were removed). Update to v0.35.0 (bundles Trivy v0.69.3) which is the latest stable release after the incident was resolved.

https://claude.ai/code/session_01BGTyKPKLrQavaqRvXbmcyB