### PR TITLE
Fix portal rollout timeout by increasing to 600s and adding startup probe

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -391,7 +391,7 @@ jobs:
       - name: Rollout restart portal
         run: |
           kubectl rollout restart deployment/portal -n ${{ env.NAMESPACE }}
-          kubectl rollout status deployment/portal -n ${{ env.NAMESPACE }} --timeout=180s
+          kubectl rollout status deployment/portal -n ${{ env.NAMESPACE }} --timeout=600s
 
       - name: Deployment summary
         run: |

--- a/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
+++ b/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
@@ -36,6 +36,11 @@ spec:
   selector:
     matchLabels:
       app: portal
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -192,18 +197,22 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "1000m"
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 5
         livenessProbe:
           httpGet:
             path: /health
             port: 8080
-          initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /health
             port: 8080
-          initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 5
 ---


### PR DESCRIPTION
The portal deployment was timing out at 180s during rollout. Root causes:
- HPA scales to 2 replicas but timeout only allowed 180s for both
- .NET Blazor Server app needs significant startup time plus image pull
- No startup probe meant liveness probe could kill slow-starting pods

Changes:
- Increase rollout status timeout from 180s to 600s
- Add rolling update strategy (maxUnavailable: 0, maxSurge: 1)
- Add startupProbe (30 attempts × 5s = 150s startup budget)
- Remove initialDelaySeconds from liveness/readiness (startup probe handles this)

https://claude.ai/code/session_01A95Uah18uxLJpuAR5HShNS