### PR TITLE
Fix all services failing in AKS: add missing secrets, fix image refs

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -325,12 +325,58 @@ jobs:
             -n ${{ env.NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Create MongoDB secret (Cosmos DB MongoDB API)
+        run: |
+          kubectl create secret generic mongodb-secret \
+            --from-literal=connectionString="${{ secrets.COSMOS_DB_CONNECTION_STRING }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Cosmos DB endpoint/key secret
+        run: |
+          kubectl create secret generic cosmos-db-secret \
+            --from-literal=endpoint="${{ secrets.COSMOS_DB_ENDPOINT }}" \
+            --from-literal=key="${{ secrets.COSMOS_DB_KEY }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Cosmos config secret (trading-partner)
+        run: |
+          kubectl create secret generic cosmos-config \
+            --from-literal=endpoint="${{ secrets.COSMOS_DB_ENDPOINT }}" \
+            --from-literal=key="${{ secrets.COSMOS_DB_KEY }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Redis secret
+        run: |
+          kubectl create secret generic redis-secret \
+            --from-literal=connectionString="${{ secrets.REDIS_CONNECTION_STRING }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Kafka secret
+        run: |
+          kubectl create secret generic kafka-secret \
+            --from-literal=saslUsername="${{ secrets.KAFKA_SASL_USERNAME }}" \
+            --from-literal=saslPassword="${{ secrets.KAFKA_SASL_PASSWORD }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Azure Storage secret
+        run: |
+          kubectl create secret generic azure-storage-secret \
+            --from-literal=connectionString="${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
       - name: Create Azure AD secret
         run: |
           kubectl create secret generic azure-ad-config \
             --from-literal=TenantId="${{ secrets.AZURE_AD_TENANT_ID }}" \
             --from-literal=ClientId="${{ secrets.AZURE_AD_CLIENT_ID }}" \
             --from-literal=ClientSecret="${{ secrets.AZURE_AD_CLIENT_SECRET }}" \
+            --from-literal=Audience="${{ secrets.AZURE_AD_AUDIENCE }}" \
             -n ${{ env.NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -380,6 +426,7 @@ jobs:
             echo "Applying ${manifest}..."
             sed \
               -e "s|choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
+              -e "s|ghcr.io/aurelianware/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|:latest|:${SHA}|g" \
               "$manifest" \
               | kubectl apply -f -

--- a/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
+++ b/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         image: ghcr.io/aurelianware/cloudhealthoffice-trading-partner-service:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: http
         env:
         - name: ASPNETCORE_ENVIRONMENT


### PR DESCRIPTION
Root cause: nearly all services (0/N replicas) because the deploy workflow only created 3 K8s secrets but services reference 9 distinct secrets.

Secrets added:
- mongodb-secret (from Cosmos DB connection string, MongoDB API)
- cosmos-db-secret (endpoint + key for Cosmos DB SDK services)
- cosmos-config (same, used by trading-partner-service)
- redis-secret (for claims-service, benefit-plan-service)
- kafka-secret (for claims-scrubbing-service)
- azure-storage-secret (for appeals, claims-scrubbing)
- azure-ad-config: added missing Audience key

Also fixed:
- sed replacement now handles ghcr.io image refs (6 services)
- trading-partner-service containerPort 80 → 8080 (matches health probes)

Required GitHub secrets to add:
  COSMOS_DB_ENDPOINT, COSMOS_DB_KEY, REDIS_CONNECTION_STRING, KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD, AZURE_STORAGE_CONNECTION_STRING, AZURE_AD_AUDIENCE

https://claude.ai/code/session_01A95Uah18uxLJpuAR5HShNS