### PR TITLE
fix: resolve GetAuthenticationStateAsync scope error on claims search

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/TenantHttpMessageHandlerTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/TenantHttpMessageHandlerTests.cs
@@ -193,6 +193,42 @@ public class TenantHttpMessageHandlerTests
         await Assert.ThrowsAsync<HttpRequestException>(async () =>
             await failingInvoker.SendAsync(request, CancellationToken.None));
     }
+
+    [Fact]
+    public async Task SendAsync_WhenHeaderAlreadyPresent_SkipsResolution()
+    {
+        // Arrange — simulates the header set by HttpClient.DefaultRequestHeaders in MainLayout
+        var requestUri = new Uri("https://api.example.com/claims");
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Add("X-Tenant-ID", "pre-set-tenant");
+
+        // Act
+        var response = await _invoker.SendAsync(request, CancellationToken.None);
+
+        // Assert — handler must NOT call ITenantContextService at all
+        _tenantContextService.Verify(x => x.GetTenantIdAsync(), Times.Never);
+        request.Headers.GetValues("X-Tenant-ID").Should().ContainSingle().Which.Should().Be("pre-set-tenant");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenAuthStateProviderThrows_DoesNotCrash()
+    {
+        // Arrange — simulates the IHttpClientFactory scope issue in Blazor Server
+        var requestUri = new Uri("https://api.example.com/claims");
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        _tenantContextService.Setup(x => x.GetTenantIdAsync())
+            .ThrowsAsync(new InvalidOperationException(
+                "Do not call GetAuthenticationStateAsync outside of the DI scope for a Razor component."));
+
+        // Act
+        var response = await _invoker.SendAsync(request, CancellationToken.None);
+
+        // Assert — request should proceed without the header, not throw
+        request.Headers.Should().NotContain(h => h.Key == "X-Tenant-ID");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }
 
 // Test helper: HTTP handler that always returns OK

--- a/src/portal/CloudHealthOffice.Portal/Services/TenantContextService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/TenantContextService.cs
@@ -6,6 +6,13 @@ namespace CloudHealthOffice.Portal.Services;
 /// <summary>
 /// Service to manage tenant context for the current authenticated user.
 /// Extracts tenant information from Azure AD claims and subscription data.
+///
+/// IMPORTANT: This service depends on AuthenticationStateProvider, which is only
+/// valid inside a Blazor component DI scope. Do NOT call GetCurrentTenantContextAsync
+/// or GetTenantIdAsync from DelegatingHandlers or other infrastructure that resolves
+/// outside the Razor circuit scope. Instead, have Razor components (e.g. MainLayout)
+/// pre-resolve the tenant context and propagate the tenant ID via
+/// HttpClient.DefaultRequestHeaders["X-Tenant-ID"].
 /// </summary>
 public interface ITenantContextService
 {

--- a/src/portal/CloudHealthOffice.Portal/Services/TenantHttpMessageHandler.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/TenantHttpMessageHandler.cs
@@ -3,6 +3,15 @@ namespace CloudHealthOffice.Portal.Services;
 /// <summary>
 /// HTTP message handler that adds the X-Tenant-ID header to all outgoing requests.
 /// This ensures backend microservices can apply tenant-specific data filtering.
+///
+/// In Blazor Server the preferred mechanism is for MainLayout to set the header on
+/// HttpClient.DefaultRequestHeaders once the tenant context is resolved inside the
+/// Razor component DI scope.  This handler acts as a safety-net: it checks whether
+/// the header was already set and only attempts dynamic resolution as a fallback.
+///
+/// Dynamic resolution can fail when IHttpClientFactory resolves this handler in its
+/// own DI scope (separate from the Blazor circuit), because
+/// AuthenticationStateProvider is only valid inside a Razor component scope.
 /// </summary>
 public class TenantHttpMessageHandler : DelegatingHandler
 {
@@ -21,18 +30,35 @@ public class TenantHttpMessageHandler : DelegatingHandler
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
-        // Get tenant ID from current context
-        var tenantId = await _tenantContextService.GetTenantIdAsync();
-
-        if (!string.IsNullOrEmpty(tenantId))
+        // If the header was already set (e.g. via HttpClient.DefaultRequestHeaders
+        // from MainLayout), skip resolution entirely.
+        if (request.Headers.Contains("X-Tenant-ID"))
         {
-            // Add X-Tenant-ID header to request
-            request.Headers.Add("X-Tenant-ID", tenantId);
-            _logger.LogDebug("Added X-Tenant-ID header: {TenantId} for {RequestUri}", tenantId, request.RequestUri);
+            return await base.SendAsync(request, cancellationToken);
         }
-        else
+
+        // Fallback: try to resolve from ITenantContextService.  This may fail when
+        // the handler runs outside the Blazor circuit DI scope.
+        try
         {
-            _logger.LogWarning("No tenant ID available for request to {RequestUri}", request.RequestUri);
+            var tenantId = await _tenantContextService.GetTenantIdAsync();
+
+            if (!string.IsNullOrEmpty(tenantId))
+            {
+                request.Headers.Add("X-Tenant-ID", tenantId);
+                _logger.LogDebug("Added X-Tenant-ID header: {TenantId} for {RequestUri}", tenantId, request.RequestUri);
+            }
+            else
+            {
+                _logger.LogWarning("No tenant ID available for request to {RequestUri}", request.RequestUri);
+            }
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("GetAuthenticationStateAsync"))
+        {
+            _logger.LogWarning(
+                "Cannot resolve tenant ID outside Razor component scope for {RequestUri}. " +
+                "Ensure MainLayout sets X-Tenant-ID on HttpClient.DefaultRequestHeaders.",
+                request.RequestUri);
         }
 
         return await base.SendAsync(request, cancellationToken);

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
@@ -5,6 +5,7 @@
 @inject ITenantContextService TenantContextService
 @inject NavigationManager Navigation
 @inject IUserContextService UserContextService
+@inject HttpClient HttpClient
 
 <MudThemeProvider Theme="_theme" />
 <MudDialogProvider />
@@ -288,6 +289,14 @@
             {
                 _tenantName = tenantContext.TenantName;
                 _isDemo = tenantContext.IsDemo;
+
+                // Set X-Tenant-ID on the shared HttpClient so the
+                // TenantHttpMessageHandler does not need to call
+                // AuthenticationStateProvider (which is only valid
+                // inside a Razor component DI scope).
+                HttpClient.DefaultRequestHeaders.Remove("X-Tenant-ID");
+                HttpClient.DefaultRequestHeaders.Add("X-Tenant-ID", tenantContext.TenantId);
+
                 StateHasChanged();
             }
         }


### PR DESCRIPTION
## Problem

Claims search (and potentially other service calls) throws:

> Do not call GetAuthenticationStateAsync outside of the DI scope for a Razor component.

`TenantHttpMessageHandler` calls `ITenantContextService.GetTenantIdAsync()` which internally uses `AuthenticationStateProvider`. However, `IHttpClientFactory` resolves `DelegatingHandler` instances in its own DI scope — separate from the Blazor circuit — so `AuthenticationStateProvider` is not wired to the active user session and throws.

## Fix

- **MainLayout.razor** — After resolving tenant context (inside the Razor component scope where `AuthenticationStateProvider` works), sets `X-Tenant-ID` on `HttpClient.DefaultRequestHeaders`. Every outgoing HTTP request now carries the header automatically.
- **TenantHttpMessageHandler.cs** — Checks if `X-Tenant-ID` is already present on the request. If so, skips `ITenantContextService` resolution entirely. Falls back to dynamic resolution with a catch for `InvalidOperationException` as a safety net.
- **TenantContextService.cs** — Added doc comment explaining the DI scope constraint to prevent future regressions.
- **TenantHttpMessageHandlerTests.cs** — Added 2 new tests: header-already-present skips resolution, and `InvalidOperationException` is caught gracefully.

## Testing

- 163 portal unit tests pass (8 handler tests, including 2 new)
- Build succeeds with 0 errors
