### PR TITLE
fix: portal zero-downtime deploys + broken test project builds

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
+++ b/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
@@ -17,6 +17,7 @@ data:
   Services__BillingService: "http://billing-service.cloudhealthoffice/api"
   Services__RfaiService: "http://claims-service.cloudhealthoffice/api"
   Services__PricingApi: "http://pricing-api.cloudhealthoffice"
+  Services__CapitationService: "http://capitation-service.cloudhealthoffice/api"
   Services__ArgoWorkflows: "http://argo-workflows-server.cloudhealthoffice:2746"
   Services__Prometheus: "http://cho-monitoring-prometheus-server.cho-monitoring"
   Portal__Title: "Cloud Health Office"
@@ -33,12 +34,15 @@ metadata:
     app: portal
     version: v1
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: portal
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -190,6 +194,11 @@ spec:
             configMapKeyRef:
               name: portal-config
               key: Services__PricingApi
+        - name: Services__CapitationService
+          valueFrom:
+            configMapKeyRef:
+              name: portal-config
+              key: Services__CapitationService
         - name: PricingApi__AdminSecret
           valueFrom:
             secretKeyRef:
@@ -253,7 +262,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: portal
-  minReplicas: 1  # Safe with Redis-backed session + token cache
+  minReplicas: 2  # 2 replicas ensures zero-downtime rolling deploys
   maxReplicas: 5
   metrics:
   - type: Resource

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/CloudHealthOffice.AdjudicationController.Tests.csproj
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/CloudHealthOffice.AdjudicationController.Tests.csproj
@@ -16,4 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\benefit-plan-service\benefit-plan-service.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 </Project>

--- a/tests/CloudHealthOffice.ClaimsScrubEngine.Tests/CloudHealthOffice.ClaimsScrubEngine.Tests.csproj
+++ b/tests/CloudHealthOffice.ClaimsScrubEngine.Tests/CloudHealthOffice.ClaimsScrubEngine.Tests.csproj
@@ -15,4 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\engines\CloudHealthOffice.ClaimsScrubEngine\CloudHealthOffice.ClaimsScrubEngine.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Followup to #534 (capitation-service). Fixes three issues discovered post-merge.

### Portal downtime during deploys
- **Root cause**: Deployment strategy was `Recreate` with `replicas: 1` — Kubernetes kills the only pod before starting the new one
- **Fix**: Switch to `RollingUpdate` with `maxUnavailable: 0, maxSurge: 1` and bump replicas to 2
- HPA `minReplicas` updated to match (1 → 2)
- Safe because Redis-backed data protection keys + `sessionAffinity: ClientIP` already configured
- Also adds `Services__CapitationService` to the portal ConfigMap

### Broken test project builds
- **ClaimsScrubEngine.Tests**: had xunit package reference but no `using Xunit;` anywhere — 46 tests were silently not building or running
- **AdjudicationController.Tests**: same issue — 9 tests not building
- **Fix**: Added `<Using Include="Xunit" />` to both csproj files (matching PremiumBillingService.Tests pattern)
- Recovers 55 tests that were invisible to CI

## Test plan
- [x] ClaimsScrubEngine.Tests: 46/46 passing
- [x] AdjudicationController.Tests: 5/9 passing (4 pre-existing failures unrelated to build fix)
- [x] All other test projects unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)