### PR TITLE
test: add portal endpoint contract tests to catch URL mismatches

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/EndpointContractTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/EndpointContractTests.cs
@@ -26,7 +26,11 @@ public class EndpointContractTests
     /// </summary>
     private class RecordingHandler : HttpMessageHandler
     {
-        public List<string> RecordedUrls { get; } = new();
+        /// <summary>Full absolute URI including host, path, and query string</summary>
+        public List<string> RecordedFullUrls { get; } = new();
+        /// <summary>Path + query only (for assertions that don't care about host)</summary>
+        public List<string> RecordedPaths { get; } = new();
+
         private readonly HttpStatusCode _responseCode;
         private readonly string _responseBody;
 
@@ -39,7 +43,8 @@ public class EndpointContractTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            RecordedUrls.Add(request.RequestUri?.PathAndQuery ?? "");
+            RecordedFullUrls.Add(request.RequestUri?.AbsoluteUri ?? "");
+            RecordedPaths.Add(request.RequestUri?.PathAndQuery ?? "");
             return Task.FromResult(new HttpResponseMessage(_responseCode)
             {
                 Content = new StringContent(_responseBody, System.Text.Encoding.UTF8, "application/json")
@@ -77,7 +82,7 @@ public class EndpointContractTests
 
         await sut.GetRecentClaimsAsync(5);
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/claims/recent?count=5");
     }
 
@@ -92,7 +97,7 @@ public class EndpointContractTests
 
         await sut.SearchClaimsAsync(new ClaimSearchRequest { MemberId = "MEM001" });
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().StartWith("/api/claims/search");
     }
 
@@ -107,7 +112,7 @@ public class EndpointContractTests
 
         await sut.GetClaimByIdAsync("CLM-001");
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/claims/CLM-001");
     }
 
@@ -122,10 +127,12 @@ public class EndpointContractTests
             new HttpClient(handler) { BaseAddress = new Uri("http://member-service") },
             config, Mock.Of<ILogger<MemberService>>());
 
-        await sut.SearchMembersAsync("Smith");
+        // Use URL-unsafe characters to verify encoding
+        await sut.SearchMembersAsync("O'Brien & Sons");
 
-        handler.RecordedUrls.Should().ContainSingle()
-            .Which.Should().StartWith("/api/v1/members/search?q=Smith");
+        handler.RecordedPaths.Should().ContainSingle()
+            .Which.Should().StartWith("/api/v1/members/search?q=O")
+            .And.Subject.Should().NotContain("&Sons", "ampersand should be URL-encoded");
     }
 
     [Fact]
@@ -139,7 +146,7 @@ public class EndpointContractTests
 
         await sut.GetMemberByIdAsync("MEM-001");
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/v1/members/MEM-001");
     }
 
@@ -154,7 +161,7 @@ public class EndpointContractTests
 
         await sut.GetAccumulatorsAsync("MEM-001");
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/v1/members/MEM-001/accumulators");
     }
 
@@ -169,7 +176,7 @@ public class EndpointContractTests
 
         await sut.GetMemberPcpAsync("MEM-001");
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/v1/members/MEM-001/pcp");
     }
 
@@ -186,7 +193,7 @@ public class EndpointContractTests
 
         await sut.GetSummaryAsync();
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/appeals/summary");
     }
 
@@ -201,7 +208,7 @@ public class EndpointContractTests
 
         await sut.SearchAppealsAsync(memberId: "MEM-001");
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Contain("/api/appeals/search")
             .And.Contain("memberId=MEM-001");
     }
@@ -217,9 +224,9 @@ public class EndpointContractTests
 
         await sut.GetSummaryAsync();
 
-        // Verify the URL uses appeals-service, NOT claims-service
-        handler.RecordedUrls.Should().ContainSingle()
-            .Which.Should().NotContain("claims");
+        // Verify the full URL uses appeals-service host, NOT claims-service
+        handler.RecordedFullUrls.Should().ContainSingle()
+            .Which.Should().StartWith("http://appeals-service/");
     }
 
     // ── Provider Service Contracts ────────────────────────────────
@@ -233,10 +240,12 @@ public class EndpointContractTests
             new HttpClient(handler) { BaseAddress = new Uri("http://provider-service") },
             config, Mock.Of<ILogger<ProviderService>>());
 
-        await sut.SearchProvidersAsync("Chen");
+        // Use URL-unsafe characters to verify encoding
+        await sut.SearchProvidersAsync("Chen & Associates");
 
-        handler.RecordedUrls.Should().ContainSingle()
-            .Which.Should().StartWith("/api/providers/search?q=Chen");
+        handler.RecordedPaths.Should().ContainSingle()
+            .Which.Should().StartWith("/api/providers/search?q=")
+            .And.Subject.Should().NotContain("& A", "ampersand should be URL-encoded");
     }
 
     // ── Capitation Service Contracts ──────────────────────────────
@@ -252,7 +261,7 @@ public class EndpointContractTests
 
         await sut.GetContractsAsync();
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().StartWith("/api/v1/capitation/contracts");
     }
 
@@ -267,7 +276,7 @@ public class EndpointContractTests
 
         await sut.GetRunsAsync();
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().StartWith("/api/v1/capitation/runs");
     }
 
@@ -282,7 +291,7 @@ public class EndpointContractTests
 
         await sut.GetUnpaidStatementsAsync();
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/v1/capitation/statements/unpaid");
     }
 
@@ -299,7 +308,7 @@ public class EndpointContractTests
 
         await sut.GetQueueSummaryAsync();
 
-        handler.RecordedUrls.Should().ContainSingle()
+        handler.RecordedPaths.Should().ContainSingle()
             .Which.Should().Be("/api/work-queue/summary");
     }
 
@@ -314,7 +323,8 @@ public class EndpointContractTests
 
         await sut.GetQueueItemsAsync(limit: 50);
 
-        handler.RecordedUrls.Should().ContainSingle()
-            .Which.Should().StartWith("/api/work-queue/items");
+        handler.RecordedPaths.Should().ContainSingle()
+            .Which.Should().StartWith("/api/work-queue/items")
+            .And.Subject.Should().Contain("limit=50");
     }
 }


### PR DESCRIPTION
## Summary

Adds 16 endpoint contract tests that catch the class of bugs that caused all the recent "Unable to connect to X Service" portal errors.

### How they work

Each test uses a `RecordingHandler` that captures the actual HTTP request URL when a portal service method is called, then asserts it matches the expected pattern. This catches:

- **Base URL / route mismatches** — e.g., portal sends `/api/members/...` but controller is at `/api/v1/members/...`
- **Wrong service URL** — e.g., AppealsService accidentally calling ClaimsService
- **Missing paths** — e.g., portal calls `/claims/recent` but no such endpoint exists

### Tests added

| Service | Tests | Verifies |
|---------|-------|----------|
| ClaimsService | 3 | `/recent`, `/search`, `/{id}` URLs |
| MemberService | 4 | `/v1/` prefix, `/search?q=`, `/pcp`, `/accumulators` |
| AppealsService | 3 | Uses appeals-service URL (NOT claims-service) |
| ProviderService | 1 | `/search?q=` param support |
| CapitationService | 3 | `/contracts`, `/runs`, `/statements/unpaid` |
| WorkQueueService | 2 | `/work-queue/summary`, `/work-queue/items` |

These would have caught every "Unable to connect" issue we hit today before deploy.

## Test plan
- [x] All 16 tests passing
- [x] Portal test suite still passes (163 + 16 = 179 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)