### PR TITLE
fix: resolve portal pod deployment failure due to CPU quota exhaustion

### DIFF
--- a/infrastructure/k8s/namespaces.yaml
+++ b/infrastructure/k8s/namespaces.yaml
@@ -18,7 +18,7 @@ spec:
   hard:
     requests.cpu: "8"
     requests.memory: 16Gi
-    limits.cpu: "16"
+    limits.cpu: "20"
     limits.memory: 32Gi
     pods: "50"
 ---

--- a/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
+++ b/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
@@ -39,6 +39,7 @@ spec:
   selector:
     matchLabels:
       app: portal
+  revisionHistoryLimit: 5
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -216,7 +217,7 @@ spec:
             cpu: "250m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "500m"
         startupProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
The portal deployment was failing because the namespace CPU limit quota
(16 cores) was fully consumed, preventing new pods from being created
during rolling updates. Three changes:

- Reduce portal CPU limit from 1000m to 500m (actual usage is ~250m)
- Increase namespace CPU quota from 16 to 20 for deployment headroom
- Add revisionHistoryLimit: 5 to clean up stale ReplicaSets (23 accumulated)

https://claude.ai/code/session_018UBoaPAMucWd1WodLDzyMs