### PR TITLE
Replace Azure Logic Apps references with Argo Workflows on AKS across site pages

### DIFF
--- a/src/site/assessment.html
+++ b/src/site/assessment.html
@@ -130,10 +130,10 @@
 <p>Cloud Health Office deploys production-grade, HIPAA-compliant EDI infrastructure in <strong>under one hour</strong>—with zero custom code.</p>
 <p><strong>Azure-Native Foundation:</strong></p>
 <ul>
-<li>Logic Apps Standard for workflow orchestration</li>
+<li>Argo Workflows on AKS for Kubernetes-native workflow orchestration</li>
 <li>Service Bus for event-driven architecture</li>
 <li>Data Lake Gen2 for hierarchical storage</li>
-<li>Integration Account for X12 processing</li>
+<li>Container-based microservices for X12 processing</li>
 <li>Key Vault Premium with HSM-backed keys</li>
 </ul>
 <p><strong>Multi-Payer by Design:</strong></p>
@@ -259,8 +259,8 @@ cd generated/your-payer/infrastructure &amp;&amp; ./deploy.sh
 <p><strong>What Gets Deployed:</strong></p>
 <ul>
 <li>Complete Azure infrastructure (Bicep)</li>
-<li>All Logic App workflows with X12 processing</li>
-<li>Integration Account with schemas and agreements</li>
+<li>All Argo workflow templates with X12 processing</li>
+<li>Trading partner configurations and schemas</li>
 <li>Service Bus topics and subscriptions</li>
 <li>Data Lake storage with hierarchical namespace</li>
 <li>Key Vault with HSM-backed keys</li>
@@ -341,7 +341,7 @@ cd generated/your-payer/infrastructure &amp;&amp; ./deploy.sh
 <p><strong>Low Risk Factors:</strong></p>
 <ul>
 <li>Mature Azure platform</li>
-<li>Battle-tested Logic Apps runtime</li>
+<li>Battle-tested Argo Workflows runtime on Kubernetes</li>
 <li>Standard X12 transaction sets</li>
 <li>Proven deployment automation</li>
 </ul>
@@ -478,14 +478,14 @@ cd generated/your-payer/infrastructure &amp;&amp; ./deploy.sh
 <li>Real-time security monitoring</li>
 </ul>
 <h3>Industry Standards</h3>
-<p><strong>X12 Transaction Sets:</strong> 005010X212 (277), 005010X217 (278), 005010X222 (837)<br><strong>NCPDP Support:</strong> Telecom D.0, Script 10.6<br><strong>FHIR R4:</strong> Planned for Q2 2026<br><strong>HL7 v2.x:</strong> Extensible via Logic Apps</p>
+<p><strong>X12 Transaction Sets:</strong> 005010X212 (277), 005010X217 (278), 005010X222 (837)<br><strong>NCPDP Support:</strong> Telecom D.0, Script 10.6<br><strong>FHIR R4:</strong> Planned for Q2 2026<br><strong>HL7 v2.x:</strong> Extensible via Argo Workflows</p>
 <hr>
 <h2>Success Metrics</h2>
 <h3>Deployment Success</h3>
 <ul>
 <li>Infrastructure deployed in &lt;60 minutes: ✅</li>
 <li>Zero custom code required: ✅</li>
-<li>All Logic App workflows operational: ✅</li>
+<li>All Argo workflow templates operational: ✅</li>
 <li>Trading partner connectivity validated: ✅</li>
 </ul>
 <h3>Operational Success</h3>

--- a/src/site/assets/cho-assessment.md
+++ b/src/site/assets/cho-assessment.md
@@ -47,7 +47,7 @@ Cloud Health Office represents the inevitable evolution of healthcare payer EDI 
 Cloud Health Office deploys production-grade, HIPAA-compliant EDI infrastructure in **under one hour**—with zero custom code.
 
 **Azure-Native Foundation:**
-- Logic Apps Standard for workflow orchestration
+- Argo Workflows on AKS for Kubernetes-native workflow orchestration
 - Service Bus for event-driven architecture
 - Data Lake Gen2 for hierarchical storage
 - Integration Account for X12 processing
@@ -177,8 +177,8 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 
 **What Gets Deployed:**
 - Complete Azure infrastructure (Bicep)
-- All Logic App workflows with X12 processing
-- Integration Account with schemas and agreements
+- All Argo workflow templates with X12 processing
+- Trading partner configurations and schemas
 - Service Bus topics and subscriptions
 - Data Lake storage with hierarchical namespace
 - Key Vault with HSM-backed keys
@@ -264,7 +264,7 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 
 **Low Risk Factors:**
 - Mature Azure platform
-- Battle-tested Logic Apps runtime
+- Battle-tested Argo Workflows runtime on Kubernetes
 - Standard X12 transaction sets
 - Proven deployment automation
 
@@ -396,7 +396,7 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 **X12 Transaction Sets:** 005010X212 (277), 005010X217 (278), 005010X222 (837)  
 **NCPDP Support:** Telecom D.0, Script 10.6  
 **FHIR R4:** Planned for Q2 2026  
-**HL7 v2.x:** Extensible via Logic Apps
+**HL7 v2.x:** Extensible via Argo Workflows
 
 ---
 
@@ -406,7 +406,7 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 
 - Infrastructure deployed in <60 minutes: ✅
 - Zero custom code required: ✅
-- All Logic App workflows operational: ✅
+- All Argo workflow templates operational: ✅
 - Trading partner connectivity validated: ✅
 
 ### Operational Success

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -224,7 +224,7 @@
           <div class="feature-card">
             <div class="feature-icon" aria-hidden="true">&#127760;</div>
             <h3>Flexible Deployment</h3>
-            <p>Azure Logic Apps for rapid delivery or Kubernetes for enterprise control. Identical capabilities across both. Deploy to your own subscription.</p>
+            <p>Kubernetes-native architecture with Argo Workflows on AKS, EKS, or GKE. Container-based microservices with full infrastructure ownership. Deploy to your own subscription.</p>
           </div>
           <div class="feature-card">
             <div class="feature-icon" aria-hidden="true">&#128184;</div>
@@ -346,36 +346,22 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow">Infrastructure</span>
-          <h2 class="section-title">Two paths.<br><span>Same destination.</span></h2>
-          <p class="section-subtitle">Both deployment options provide identical healthcare integration capabilities. Choose based on your team&rsquo;s priorities.</p>
+          <h2 class="section-title">One platform.<br><span>Any cloud.</span></h2>
+          <p class="section-subtitle">Kubernetes-native architecture with Argo Workflows. Deploy on any cloud or on-premise with full infrastructure control.</p>
         </div>
 
         <div class="deploy-grid">
           <div class="deploy-card">
-            <span class="deploy-icon" aria-hidden="true">&#9729;&#65039;</span>
-            <h3>Azure Logic Apps</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:20px;">
-              <strong style="color:#00ffff;">Best for:</strong> Rapid deployment, Azure-first organizations, minimal operational overhead
-            </p>
-            <ul class="benefit-list">
-              <li>Fastest time to production (&lt;1 hour)</li>
-              <li>Microsoft-managed infrastructure</li>
-              <li>Built-in HIPAA compliance controls</li>
-              <li>Lower ongoing operational overhead</li>
-              <li>Native Azure Logic Apps Standard</li>
-            </ul>
-          </div>
-
-          <div class="deploy-card">
             <span class="deploy-icon" aria-hidden="true">&#9881;&#65039;</span>
-            <h3>Kubernetes Multi-Cloud</h3>
+            <h3>Kubernetes with Argo Workflows</h3>
             <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:20px;">
-              <strong style="color:#00ffff;">Best for:</strong> Enterprise control, cloud independence, hybrid architectures
+              <strong style="color:#00ffff;">Best for:</strong> Enterprise control, cloud independence, production-grade orchestration
             </p>
             <ul class="benefit-list">
-              <li>Deploy on Azure, AWS, or GCP</li>
-              <li>No cloud vendor lock-in</li>
+              <li>Deploy on Azure AKS, AWS EKS, or GCP GKE</li>
+              <li>Argo Workflows for Kubernetes-native orchestration</li>
               <li>Full infrastructure ownership and control</li>
+              <li>Container-based microservices architecture</li>
               <li>Hybrid and on-premise capable</li>
               <li>BSL 1.1 &mdash; bring your own environment</li>
             </ul>
@@ -383,7 +369,7 @@
         </div>
 
         <p style="text-align:center; margin-top:32px; font-size:0.9rem; color:rgba(176,176,176,0.45);">
-          Both options provide identical FHIR R4, EDI, and compliance capabilities.
+          Complete FHIR R4, EDI, and compliance capabilities on any Kubernetes cluster.
         </p>
       </div>
     </section>

--- a/src/site/js/markdown-converter.js
+++ b/src/site/js/markdown-converter.js
@@ -49,7 +49,7 @@ function generateHtmlPage(title, content, filename) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="${title} - Cloud Health Office platform assessment and technical analysis">
-  <meta name="keywords" content="healthcare EDI, HIPAA compliance, Azure Logic Apps, payer integration, platform assessment">
+  <meta name="keywords" content="healthcare EDI, HIPAA compliance, Argo Workflows, Kubernetes, AKS, payer integration, platform assessment">
   <title>${escapeHtml(title)} - Cloud Health Office</title>
   <!-- Privacy-friendly analytics by Plausible -->
   <script async src="https://plausible.io/js/pa-JQNNrBf52mV2BxHPtkLAv.js"></script>

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -314,12 +314,12 @@
 
       <section class="assessment-section">
         <h2>Architecture Overview</h2>
-        <p>Azure-native infrastructure leveraging Logic Apps Standard, Service Bus, Data Lake Gen2, and Integration Account for complete X12 transaction processing.</p>
+        <p>Kubernetes-native infrastructure leveraging Argo Workflows on AKS, Service Bus, Data Lake Gen2, and container-based microservices for complete X12 transaction processing.</p>
         
         <div class="card">
           <h3>Deployment Components</h3>
           <ul>
-            <li><strong>Logic Apps Standard:</strong> Workflow orchestration for all EDI transaction types</li>
+            <li><strong>Argo Workflows on AKS:</strong> Kubernetes-native workflow orchestration for all EDI transaction types</li>
             <li><strong>Service Bus:</strong> Event-driven architecture with topics for pub/sub patterns</li>
             <li><strong>Data Lake Gen2:</strong> Hierarchical namespace for organized PHI storage</li>
             <li><strong>Integration Account:</strong> X12 schema validation and trading partner agreements</li>
@@ -333,10 +333,10 @@
           <h3>Multi-Tenant Architecture</h3>
           <p>Each payer tenant receives complete logical isolation while sharing infrastructure efficiency:</p>
           <ul>
-            <li>Dedicated Logic App workflows per payer</li>
+            <li>Dedicated Argo workflow templates per payer</li>
             <li>Isolated Service Bus topics and subscriptions</li>
             <li>Separate Data Lake containers with hierarchical paths</li>
-            <li>Individual Integration Account agreements</li>
+            <li>Individual trading partner configurations</li>
             <li>Zero shared secrets or configuration</li>
           </ul>
         </div>

--- a/src/site/release-notes.html
+++ b/src/site/release-notes.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Cloud Health Office release notes and version history. Track new features, CMS compliance updates, EDI enhancements, and platform improvements across all releases.">
-  <meta name="keywords" content="healthcare EDI releases, FHIR R4, CMS-0057-F, version history, Azure Logic Apps, Kubernetes, release roadmap">
+  <meta name="keywords" content="healthcare EDI releases, FHIR R4, CMS-0057-F, version history, Argo Workflows, Kubernetes, AKS, release roadmap">
   <meta name="author" content="Aurelianware">
   <link rel="canonical" href="https://cloudhealthoffice.com/release-notes">
 

--- a/src/site/solutions-payers.html
+++ b/src/site/solutions-payers.html
@@ -169,7 +169,7 @@
         <li><strong>Multi-Clearinghouse Support:</strong> Connect to Change Healthcare, Availity, Waystar, Relay Health via unified API. Add new clearinghouses in <1 day.</li>
         <li><strong>X12 EDI Automation:</strong> 275, 276, 277, 278, 834, 835, 837 workflows included. Production-tested with 1,018+ test cases.</li>
         <li><strong>Zero-Code Deployment:</strong> Config-driven payer onboarding. Add new trading partners via JSON, no custom development.</li>
-        <li><strong>Azure-Native Architecture:</strong> Logic Apps Standard, Service Bus, Data Lake Gen2. Scales to millions of members.</li>
+        <li><strong>Kubernetes-Native Architecture:</strong> Argo Workflows on AKS, Service Bus, Data Lake Gen2. Scales to millions of members.</li>
         <li><strong>Deployment Options:</strong> Managed SaaS or self-hosted in your Azure tenant. You choose the model.</li>
         <li><strong>Source-Available Core:</strong> BSL 1.1 license. Full source transparency. Audit every line, customize for your environment. No black-box vendor lock-in.</li>
       </ul>
@@ -215,7 +215,7 @@ Claims Platform → Cloud Health Office → Clearinghouses
         <p><strong>Key Components:</strong></p>
         <ul style="margin-top:15px;">
           <li><strong>FHIR Gateway:</strong> Translates QNXT data to FHIR R4 resources (Patient, Coverage, ExplanationOfBenefit)</li>
-          <li><strong>EDI Orchestration:</strong> Logic Apps Standard workflows for 275/276/277/278/834/835/837</li>
+          <li><strong>EDI Orchestration:</strong> Argo Workflows on AKS for 275/276/277/278/834/835/837</li>
           <li><strong>Prior Auth Engine:</strong> Automated 278 request routing with real-time status tracking</li>
           <li><strong>Multi-Tenant Isolation:</strong> Separate Azure Service Bus namespaces per payer/clearinghouse</li>
           <li><strong>Audit Trail:</strong> Every transaction logged to Data Lake Gen2 with 7-year retention</li>


### PR DESCRIPTION
Per ADR 004, the platform migrated from Azure Logic Apps to Argo Workflows
on Kubernetes. Update all src/site/ pages to reflect the current architecture:

- index.html: Replace dual deployment (Logic Apps / K8s) with single
  Kubernetes/Argo deployment option
- platform.html: Replace Logic Apps Standard with Argo Workflows on AKS
  in architecture and multi-tenant sections
- solutions-payers.html: Update architecture and EDI orchestration references
- assessment.html + cho-assessment.md: Replace workflow orchestration,
  X12 processing, risk assessment, and success metric references
- release-notes.html: Update meta keywords
- js/markdown-converter.js: Update meta keywords template

Azure remains as the cloud platform (AKS); only the workflow runtime changed.

https://claude.ai/code/session_013HZN7Ldh2uzaQNJGv5yLrR