### PR TITLE
Remove Logic Apps references from types, config, validation, CLI, and tests

### DIFF
--- a/config/ai-resolution-config.example.json
+++ b/config/ai-resolution-config.example.json
@@ -106,9 +106,10 @@
       "retryDelayMs": 5000
     },
     "integration": {
-      "logicApps": {
+      "argoWorkflows": {
         "enabled": true,
-        "workflowName": "rfai277",
+        "workflowTemplateName": "rfai277",
+        "namespace": "edi-workflows",
         "autoResolveEnabled": false
       },
       "serviceBus": {

--- a/core/examples/medicaid-mco-config.json
+++ b/core/examples/medicaid-mco-config.json
@@ -232,11 +232,6 @@
         }
       ]
     },
-    "logicAppConfig": {
-      "sku": "WS1",
-      "workerCount": 1,
-      "alwaysOn": true
-    },
     "keyVaultConfig": {
       "sku": "standard",
       "enableSoftDelete": true,

--- a/core/examples/regional-blues-config.json
+++ b/core/examples/regional-blues-config.json
@@ -273,11 +273,6 @@
         }
       ]
     },
-    "logicAppConfig": {
-      "sku": "WS1",
-      "workerCount": 3,
-      "alwaysOn": true
-    },
     "keyVaultConfig": {
       "sku": "premium",
       "enableSoftDelete": true,

--- a/core/types/payer-config.ts
+++ b/core/types/payer-config.ts
@@ -138,11 +138,6 @@ export interface InfrastructureConfig {
     topics: TopicConfig[];
     queues: QueueConfig[];
   };
-  logicAppConfig: {
-    sku: string;
-    workerCount: number;
-    alwaysOn: boolean;
-  };
   keyVaultConfig: {
     sku: 'standard' | 'premium';
     enableSoftDelete: boolean;

--- a/core/validation/config-validator.ts
+++ b/core/validation/config-validator.ts
@@ -147,15 +147,6 @@ export class ConfigValidator {
       });
     }
 
-    if (config.infrastructure?.logicAppConfig && 
-        config.infrastructure.logicAppConfig.workerCount < 2 && 
-        config.infrastructure.environment === 'prod') {
-      warnings.push({
-        field: 'infrastructure.logicAppConfig.workerCount',
-        message: 'Production environment should have at least 2 workers for high availability',
-        suggestion: 'Increase workerCount to 2 or more',
-      });
-    }
   }
 }
 

--- a/docs/generated/examples/BLUES02/config/payer-config.json
+++ b/docs/generated/examples/BLUES02/config/payer-config.json
@@ -290,11 +290,6 @@
         }
       ]
     },
-    "logicAppConfig": {
-      "sku": "WS1",
-      "workerCount": 3,
-      "alwaysOn": true
-    },
     "keyVaultConfig": {
       "sku": "premium",
       "enableSoftDelete": true,

--- a/docs/generated/examples/MCO001/config/payer-config.json
+++ b/docs/generated/examples/MCO001/config/payer-config.json
@@ -244,11 +244,6 @@
         }
       ]
     },
-    "logicAppConfig": {
-      "sku": "WS1",
-      "workerCount": 1,
-      "alwaysOn": true
-    },
     "keyVaultConfig": {
       "sku": "standard",
       "enableSoftDelete": true,

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "saas",
     "multi-tenant",
     "hipaa",
-    "logic-apps",
+    "argo-workflows",
     "azure",
+    "aks",
     "generator",
     "automation",
     "x12"

--- a/scripts/cli/interactive-wizard.ts
+++ b/scripts/cli/interactive-wizard.ts
@@ -430,11 +430,6 @@ export class InteractiveWizard {
           },
         ],
       },
-      logicAppConfig: {
-        sku: answers.environment === 'prod' ? 'WS2' : 'WS1',
-        workerCount: 1,
-        alwaysOn: true,
-      },
       keyVaultConfig: {
         sku: 'standard' as 'standard' | 'premium',
         enableSoftDelete: true,

--- a/scripts/cli/payer-generator-cli.ts
+++ b/scripts/cli/payer-generator-cli.ts
@@ -54,7 +54,7 @@ const program = new Command();
 
 program
   .name('payer-generator')
-  .description('Generate Logic App deployments from payer configuration')
+  .description('Generate Argo Workflow deployments from payer configuration')
   .version('1.0.0');
 
 /**
@@ -101,8 +101,8 @@ program
           console.log(`  ${enabled ? '✅' : '❌'} ${module}`);
         });
         console.log('\nWould generate:');
-        console.log('  - Logic App workflows');
-        console.log('  - Bicep infrastructure templates');
+        console.log('  - Argo Workflow manifests');
+        console.log('  - AKS infrastructure templates');
         console.log('  - Documentation (DEPLOYMENT.md, CONFIGURATION.md, TESTING.md)');
         console.log('  - JSON schemas');
         console.log('  - Deployment package');
@@ -360,7 +360,7 @@ program
         console.log(`  1. Generate deployment artifacts (1 min)`);
         console.log(`  2. Deploy Azure infrastructure (3-5 min)`);
         console.log(`  3. Configure FHIR endpoints (1-2 min)`);
-        console.log(`  4. Deploy Logic App workflows (2-3 min)`);
+        console.log(`  4. Deploy Argo Workflows to AKS (2-3 min)`);
         console.log(`  5. Run compliance validation (1 min)`);
         console.log(`\nEstimated Total Time: <10 minutes`);
         return;
@@ -416,9 +416,9 @@ program
 
       console.log(chalk.cyan('\n🔍 Step 4/5: FHIR Endpoint Configuration\n'));
       console.log(chalk.green('Configure your FHIR endpoints:'));
-      console.log(chalk.cyan(`  - Patient Access: https://<logic-app>.azurewebsites.net/api/patient`));
-      console.log(chalk.cyan(`  - Prior Auth: https://<logic-app>.azurewebsites.net/api/prior-auth`));
-      console.log(chalk.cyan(`  - Claims: https://<logic-app>.azurewebsites.net/api/claim`));
+      console.log(chalk.cyan(`  - Patient Access: https://<aks-ingress>/api/patient`));
+      console.log(chalk.cyan(`  - Prior Auth: https://<aks-ingress>/api/prior-auth`));
+      console.log(chalk.cyan(`  - Claims: https://<aks-ingress>/api/claim`));
 
       console.log(chalk.cyan('\n✅ Step 5/5: Timeline Monitoring\n'));
       console.log(chalk.green('Monitor CMS-0057-F timeline compliance:'));

--- a/scripts/setup/generate-patient-access-specs.ts
+++ b/scripts/setup/generate-patient-access-specs.ts
@@ -53,12 +53,12 @@ function generateCapabilityStatement(): CapabilityStatement {
     date: new Date().toISOString(),
     kind: 'instance',
     software: {
-      name: 'PatientAccessApi Logic App',
+      name: 'PatientAccessApi',
       version: '1.0.0'
     },
     implementation: {
-      description: 'CMS-0057-F Patient Access API implemented as Azure Logic App',
-      url: 'https://example.azurelogicapps.net/patient-access'
+      description: 'CMS-0057-F Patient Access API on AKS',
+      url: 'https://edi.aks-ingress.example.com/patient-access'
     },
     fhirVersion: '4.0.1',
     format: ['json'],
@@ -99,9 +99,9 @@ function buildOpenApiYaml(): string {
 info:
   title: CMS-0057-F Patient Access API
   version: 1.0.0
-  description: FHIR R4 Patient Access API served by Azure Logic App
+  description: FHIR R4 Patient Access API served by AKS
 servers:
-  - url: https://example.azurelogicapps.net
+  - url: https://edi.aks-ingress.example.com
 paths:
   /Patient:
     get:

--- a/scripts/setup/generate-payer-deployment.ts
+++ b/scripts/setup/generate-payer-deployment.ts
@@ -1,6 +1,9 @@
 /**
  * Main Payer Deployment Generator
- * Generates Logic App workflows, infrastructure, and documentation from payer configuration
+ * Generates Argo Workflow manifests, infrastructure, and documentation from payer configuration
+ *
+ * NOTE: Logic App workflow generation has been removed. Orchestration is now handled
+ * by Argo Workflows on AKS. See infrastructure/argo-workflows/ for workflow templates.
  */
 
 import * as fs from 'fs';
@@ -308,8 +311,8 @@ This deployment package was generated for **${config.payerName}** (${config.paye
 
 - Azure CLI (version 2.40.0 or higher)
 - Azure subscription with appropriate permissions
-- Logic Apps Standard runtime
-- PowerShell 7+ (for Windows deployments)
+- AKS cluster with Argo Workflows installed
+- kubectl configured for AKS cluster
 
 ## Deployment Steps
 
@@ -332,21 +335,15 @@ ${config.appeals?.authentication.keyVaultSecretName ? `- \`${config.appeals.auth
 ${config.ecs?.authentication.keyVaultSecretName ? `- \`${config.ecs.authentication.keyVaultSecretName}\`: ECS API credentials` : ''}
 ${config.attachments?.sftpConfig.keyVaultSecretName ? `- \`${config.attachments.sftpConfig.keyVaultSecretName}\`: SFTP private key` : ''}
 
-### 4. Deploy Workflows
+### 4. Deploy Argo Workflows
 
 \`\`\`bash
-cd workflows
-zip -r workflows.zip ./*
-az webapp deploy \\
-  --resource-group ${config.infrastructure.resourceNamePrefix}-rg \\
-  --name ${config.infrastructure.resourceNamePrefix}-la \\
-  --src-path workflows.zip \\
-  --type zip
+kubectl apply -f workflows/ -n edi-workflows
 \`\`\`
 
 ### 5. Verify Deployment
 
-Check that all workflows are enabled and running in the Azure Portal.
+Check that all workflows are running via the Argo Workflows UI or \`argo list -n edi-workflows\`.
 
 ## Enabled Modules
 
@@ -456,9 +453,7 @@ ${config.attachments?.enabled ? `
 - **Resource Name Prefix**: ${config.infrastructure.resourceNamePrefix}
 - **Location**: ${config.infrastructure.location}
 - **Environment**: ${config.infrastructure.environment}
-- **Logic App SKU**: ${config.infrastructure.logicAppConfig.sku}
-- **Worker Count**: ${config.infrastructure.logicAppConfig.workerCount}
-- **Always On**: ${config.infrastructure.logicAppConfig.alwaysOn}
+- **Orchestration**: Argo Workflows on AKS
 
 ## Tags
 

--- a/scripts/tests/validator.test.ts
+++ b/scripts/tests/validator.test.ts
@@ -72,11 +72,6 @@ describe('ConfigValidator', () => {
             topics: [],
             queues: []
           },
-          logicAppConfig: {
-            sku: 'WS1',
-            workerCount: 1,
-            alwaysOn: true
-          },
           keyVaultConfig: {
             sku: 'standard',
             enableSoftDelete: true,
@@ -154,7 +149,6 @@ describe('ConfigValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -192,11 +186,6 @@ describe('ConfigValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: {
-            sku: 'WS1',
-            workerCount: 1, // Low worker count for prod
-            alwaysOn: true
-          },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -246,7 +235,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -288,7 +276,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -329,7 +316,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -381,7 +367,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -426,7 +411,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -466,7 +450,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -506,7 +489,6 @@ describe('ConfigValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -561,7 +543,6 @@ describe('DeploymentValidator - Additional Coverage', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -646,7 +627,6 @@ describe('DeploymentValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -717,7 +697,6 @@ describe('DeploymentValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -756,7 +735,6 @@ describe('DeploymentValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {
@@ -809,7 +787,6 @@ describe('DeploymentValidator', () => {
           tags: {},
           storageConfig: { sku: 'Standard_LRS', containers: [], lifecycleRules: [] },
           serviceBusConfig: { sku: 'Standard', topics: [], queues: [] },
-          logicAppConfig: { sku: 'WS1', workerCount: 1, alwaysOn: true },
           keyVaultConfig: { sku: 'standard', enableSoftDelete: true, softDeleteRetentionDays: 90 }
         },
         monitoring: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,7 @@
     "scripts/**/*",
     "core/**/*",
     "src/security/**/*",
-    "src/fhir/**/*",
-    "src/logicapps/**/*"
+    "src/fhir/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Logic Apps orchestration has been replaced by Argo Workflows on AKS (per ADR 004).
This removes all remaining logicAppConfig references from:
- InfrastructureConfig type definition
- Config validator business rules
- Example configuration files (medicaid-mco, regional-blues, generated examples)
- AI resolution config (replaced logicApps with argoWorkflows integration)
- Interactive wizard and CLI tooling (updated messages to reference Argo/AKS)
- Deployment generator documentation templates
- Patient access spec generator (updated URLs from azurelogicapps.net to AKS ingress)
- All validator test fixtures
- tsconfig.json (removed deleted src/logicapps path)
- package.json keywords (replaced logic-apps with argo-workflows, aks)

TypeScript compiles cleanly and all 26 validator tests pass.

https://claude.ai/code/session_01DKTpVcpb4JNGQ2zAUcwEFE