### PR TITLE
Redesign capitation run criteria around LOB as primary axis

### DIFF
--- a/scripts/setup/seed-capitation.sh
+++ b/scripts/setup/seed-capitation.sh
@@ -345,26 +345,67 @@ info "Total: 20 members assigned across 3 providers"
 # ---------------------------------------------------------------------------
 banner "Step 4: Create & Execute Capitation Run"
 
-RUN_DATA=$(cat <<ENDJSON
+# --- Run 1: Medicaid Monthly ---
+RUN1_DATA=$(cat <<ENDJSON
 {
+  "runType": "Monthly",
   "capitationPeriod": "${PERIOD_START}T00:00:00Z",
-  "criteria": {},
-  "createdBy": "seed-script",
-  "description": "Demo capitation run for $(date -d "${PERIOD_START}" '+%B %Y' 2>/dev/null || date -j -f '%Y-%m-%d' "${PERIOD_START}" '+%B %Y' 2>/dev/null || echo "${PERIOD_START}")"
+  "criteria": {
+    "lineOfBusiness": "Medicaid"
+  },
+  "createdBy": "seed-script"
 }
 ENDJSON
 )
 
-response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs" "$RUN_DATA")
+response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs" "$RUN1_DATA")
 parse_response "$response"
 
 if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
   RUN_ID=$(echo "$BODY" | jq -r '.id // empty')
   RUN_NUMBER=$(echo "$BODY" | jq -r '.runNumber // empty')
-  info "Created capitation run: ${RUN_NUMBER} (ID: ${RUN_ID})"
+  info "Created Medicaid monthly run: ${RUN_NUMBER} (ID: ${RUN_ID})"
 
-  # Execute the run
-  echo -e "  ${YELLOW}⏳ Executing run (generating statements)...${RESET}"
+  echo -e "  ${YELLOW}⏳ Executing Medicaid run...${RESET}"
+  response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs/${RUN_ID}/execute" '{}')
+  parse_response "$response"
+
+  if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+    STATUS=$(echo "$BODY" | jq -r '.status // empty')
+    TOTAL_STMTS=$(echo "$BODY" | jq -r '.totalStatements // 0')
+    TOTAL_NET=$(echo "$BODY" | jq -r '.totalNetPayable // 0')
+    TOTAL_PROVIDERS=$(echo "$BODY" | jq -r '.totalProviders // 0')
+    info "Run ${STATUS}: ${TOTAL_STMTS} statements, ${TOTAL_PROVIDERS} providers, \$${TOTAL_NET} net"
+  else
+    error "Medicaid run execution failed (HTTP ${HTTP_CODE})"
+  fi
+else
+  error "Failed to create Medicaid run (HTTP ${HTTP_CODE})"
+fi
+RUN1_ID="${RUN_ID:-}"
+
+# --- Run 2: Commercial Monthly ---
+RUN2_DATA=$(cat <<ENDJSON
+{
+  "runType": "Monthly",
+  "capitationPeriod": "${PERIOD_START}T00:00:00Z",
+  "criteria": {
+    "lineOfBusiness": "Commercial"
+  },
+  "createdBy": "seed-script"
+}
+ENDJSON
+)
+
+response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs" "$RUN2_DATA")
+parse_response "$response"
+
+if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+  RUN_ID=$(echo "$BODY" | jq -r '.id // empty')
+  RUN_NUMBER=$(echo "$BODY" | jq -r '.runNumber // empty')
+  info "Created Commercial monthly run: ${RUN_NUMBER} (ID: ${RUN_ID})"
+
+  echo -e "  ${YELLOW}⏳ Executing Commercial run...${RESET}"
   response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs/${RUN_ID}/execute" '{}')
   parse_response "$response"
 
@@ -389,12 +430,38 @@ if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
       warn "${WARNINGS} warning(s) during execution"
     fi
   else
-    error "Run execution failed (HTTP ${HTTP_CODE})"
-    echo "$BODY" | jq '.' 2>/dev/null || echo "$BODY"
+    error "Commercial run execution failed (HTTP ${HTTP_CODE})"
   fi
 else
-  error "Failed to create capitation run (HTTP ${HTTP_CODE})"
-  echo "$BODY" | jq '.' 2>/dev/null || echo "$BODY"
+  error "Failed to create Commercial run (HTTP ${HTTP_CODE})"
+fi
+RUN2_ID="${RUN_ID:-}"
+
+# --- Run 3: Ad-hoc provider run (Dr. Sarah Chen) ---
+RUN3_DATA=$(cat <<ENDJSON
+{
+  "runType": "AdHocProvider",
+  "capitationPeriod": "${PERIOD_START}T00:00:00Z",
+  "criteria": {
+    "lineOfBusiness": "Commercial",
+    "providerNPI": "1234567890"
+  },
+  "createdBy": "seed-script",
+  "description": "Ad-hoc run for Dr. Sarah Chen — mid-month contract activation"
+}
+ENDJSON
+)
+
+response=$(api_post "${CAPITATION_URL}/api/v1/capitation/runs" "$RUN3_DATA")
+parse_response "$response"
+
+if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+  RUN3_ID=$(echo "$BODY" | jq -r '.id // empty')
+  RUN3_NUMBER=$(echo "$BODY" | jq -r '.runNumber // empty')
+  info "Created Ad-hoc provider run: ${RUN3_NUMBER} (ID: ${RUN3_ID})"
+  detail "Provider: Dr. Sarah Chen (NPI: 1234567890)"
+else
+  error "Failed to create ad-hoc provider run (HTTP ${HTTP_CODE})"
 fi
 
 # ---------------------------------------------------------------------------
@@ -402,28 +469,29 @@ fi
 # ---------------------------------------------------------------------------
 banner "Step 5: Approve Generated Statements"
 
-if [[ -n "${RUN_ID:-}" ]]; then
-  response=$(api_get "${CAPITATION_URL}/api/v1/capitation/runs/${RUN_ID}/statements")
-  parse_response "$response"
+APPROVED_COUNT=0
+for run_id in "${RUN1_ID:-}" "${RUN2_ID:-}"; do
+  if [[ -n "$run_id" ]]; then
+    response=$(api_get "${CAPITATION_URL}/api/v1/capitation/runs/${run_id}/statements")
+    parse_response "$response"
 
-  if [[ "$HTTP_CODE" == "200" ]]; then
-    STMT_IDS=$(echo "$BODY" | jq -r '.[].id // empty')
-    APPROVED_COUNT=0
+    if [[ "$HTTP_CODE" == "200" ]]; then
+      STMT_IDS=$(echo "$BODY" | jq -r '.[].id // empty')
 
-    for sid in $STMT_IDS; do
-      response=$(api_put "${CAPITATION_URL}/api/v1/capitation/statements/${sid}/approve" '{}')
-      parse_response "$response"
-      if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
-        STMT_NUM=$(echo "$BODY" | jq -r '.statementNumber // empty')
-        STMT_NET=$(echo "$BODY" | jq -r '.netPayable // 0')
-        info "Approved: ${STMT_NUM} — \$${STMT_NET}"
-        APPROVED_COUNT=$((APPROVED_COUNT + 1))
-      fi
-    done
-
-    info "${APPROVED_COUNT} statements approved and ready for payment"
+      for sid in $STMT_IDS; do
+        response=$(api_put "${CAPITATION_URL}/api/v1/capitation/statements/${sid}/approve" '{}')
+        parse_response "$response"
+        if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+          STMT_NUM=$(echo "$BODY" | jq -r '.statementNumber // empty')
+          STMT_NET=$(echo "$BODY" | jq -r '.netPayable // 0')
+          info "Approved: ${STMT_NUM} — \$${STMT_NET}"
+          APPROVED_COUNT=$((APPROVED_COUNT + 1))
+        fi
+      done
+    fi
   fi
-fi
+done
+info "${APPROVED_COUNT} statements approved and ready for payment"
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -436,9 +504,11 @@ echo -e "    2. Valley Medical Group — Global/Medicaid        — 12 tiers —
 echo -e "    3. Dr. James Park      — BehavioralHealth/Comm  —  4 tiers —  5% withhold"
 echo ""
 echo -e "  ${BOLD}Members:${RESET}         20 assigned across 3 providers"
-echo -e "  ${BOLD}Capitation Run:${RESET}  ${RUN_NUMBER:-N/A} (${STATUS:-N/A})"
-echo -e "  ${BOLD}Statements:${RESET}      ${TOTAL_STMTS:-0} generated and approved"
-echo -e "  ${BOLD}Net Payable:${RESET}     \$${TOTAL_NET:-0}"
+echo -e "  ${BOLD}Capitation Runs:${RESET}"
+echo -e "    1. Medicaid Monthly  (Run 1)"
+echo -e "    2. Commercial Monthly (Run 2)"
+echo -e "    3. Ad-hoc Dr. Chen   (Run 3 — pending)"
+echo -e "  ${BOLD}Statements:${RESET}      ${APPROVED_COUNT:-0} generated and approved"
 echo ""
 echo -e "  ${GREEN}Portal:${RESET} Visit /capitation/contracts, /capitation/runs, /capitation/statements"
 echo ""

--- a/src/portal/CloudHealthOffice.Portal/Dialogs/CreateCapitationRunDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Dialogs/CreateCapitationRunDialog.razor
@@ -28,6 +28,20 @@
                 </MudSelect>
             </MudItem>
             <MudItem xs="12" md="6">
+                <MudSelect @bind-Value="_lineOfBusiness"
+                           Label="Line of Business *"
+                           Variant="Variant.Outlined"
+                           Required="true"
+                           HelperText="Required — capitation runs are scoped to a single LOB">
+                    <MudSelectItem Value="@("Commercial")">Commercial</MudSelectItem>
+                    <MudSelectItem Value="@("Medicare")">Medicare</MudSelectItem>
+                    <MudSelectItem Value="@("Medicaid")">Medicaid</MudSelectItem>
+                    <MudSelectItem Value="@("Exchange")">Exchange</MudSelectItem>
+                    <MudSelectItem Value="@("TRICARE")">TRICARE</MudSelectItem>
+                    <MudSelectItem Value="@("VA")">VA</MudSelectItem>
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" md="6">
                 <MudDatePicker @bind-Date="_capitationPeriod"
                                Label="Capitation Period"
                                Variant="Variant.Outlined"
@@ -36,20 +50,6 @@
                                FixDay="1"
                                DateFormat="MMMM yyyy"
                                HelperText="Month for which capitation is being calculated" />
-            </MudItem>
-            <MudItem xs="12" md="6">
-                <MudSelect @bind-Value="_lineOfBusiness"
-                           Label="@(_isLobRequired ? "Line of Business *" : "Line of Business")"
-                           Variant="Variant.Outlined"
-                           Clearable="@(!_isLobRequired)"
-                           HelperText="@(_isLobRequired ? "Required for this run type" : "Optional — leave blank for all LOBs")">
-                    <MudSelectItem Value="@("Commercial")">Commercial</MudSelectItem>
-                    <MudSelectItem Value="@("Medicare")">Medicare</MudSelectItem>
-                    <MudSelectItem Value="@("Medicaid")">Medicaid</MudSelectItem>
-                    <MudSelectItem Value="@("Exchange")">Exchange</MudSelectItem>
-                    <MudSelectItem Value="@("TRICARE")">TRICARE</MudSelectItem>
-                    <MudSelectItem Value="@("VA")">VA</MudSelectItem>
-                </MudSelect>
             </MudItem>
             <MudItem xs="12" md="6">
                 <MudSelect @bind-Value="_contractType"
@@ -72,7 +72,7 @@
                     <MudTextField @bind-Value="_providerNpi"
                                   Label="@(_isNpiRequired ? "Provider NPI *" : "Provider NPI")"
                                   Variant="Variant.Outlined"
-                                  HelperText="@(_isNpiRequired ? "Required — the provider to generate a statement for" : "Optional — scope to a single provider")"
+                                  HelperText="@(_isNpiRequired ? "Enter the NPI of the provider to generate a statement for" : "Optional — scope to a single provider")"
                                   Mask="@(new PatternMask("0000000000"))" />
                 </MudItem>
             }
@@ -96,7 +96,7 @@
                               Label="Description"
                               Variant="Variant.Outlined"
                               Lines="2"
-                              HelperText="Optional notes about this run" />
+                              HelperText="Optional — auto-generated if left blank" />
             </MudItem>
         </MudGrid>
 
@@ -129,31 +129,30 @@
 
     private string _runType = "Monthly";
     private DateTime? _capitationPeriod = new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
-    private string? _lineOfBusiness;
+    private string _lineOfBusiness = "Commercial";
     private string? _contractType;
     private string? _providerNpi;
     private DateTime? _originalPeriod;
     private string? _description;
     private bool _creating = false;
 
-    private bool _isLobRequired => _runType is "Monthly" or "WithholdRelease";
     private bool _isNpiRequired => _runType is "AdHocProvider";
     private bool _showProviderNpi => _runType is "AdHocProvider" or "RetroAdjustment" or "WithholdRelease";
     private bool _showOriginalPeriod => _runType is "RetroAdjustment";
 
     private string GetRunTypeHelperText() => _runType switch
     {
-        "Monthly" => "Standard monthly run for all providers in an LOB",
-        "AdHocProvider" => "Ad-hoc run for a single provider",
-        "RetroAdjustment" => "Reprocess a prior period for retro changes",
-        "WithholdRelease" => "Release withheld funds for quality metrics",
+        "Monthly" => "Generates statements for all active capitated providers in the selected LOB",
+        "AdHocProvider" => "Generates a statement for a specific provider's contract",
+        "RetroAdjustment" => "Reprocesses a prior period for enrollment or rate changes",
+        "WithholdRelease" => "Releases withheld funds for providers meeting quality targets",
         _ => ""
     };
 
     private bool IsValid()
     {
         if (!_capitationPeriod.HasValue) return false;
-        if (_isLobRequired && string.IsNullOrEmpty(_lineOfBusiness)) return false;
+        if (string.IsNullOrEmpty(_lineOfBusiness)) return false;
         if (_isNpiRequired && string.IsNullOrWhiteSpace(_providerNpi)) return false;
         if (_showOriginalPeriod && !_originalPeriod.HasValue) return false;
         return true;
@@ -169,11 +168,14 @@
             {
                 RunType = _runType,
                 CapitationPeriod = _capitationPeriod!.Value,
-                LineOfBusiness = _lineOfBusiness,
-                ProviderNPI = string.IsNullOrWhiteSpace(_providerNpi) ? null : _providerNpi.Trim(),
-                ContractType = _contractType,
-                OriginalPeriod = _originalPeriod,
-                Description = _description,
+                Criteria = new CreateCapRunCriteria
+                {
+                    LineOfBusiness = _lineOfBusiness,
+                    ProviderNPI = string.IsNullOrWhiteSpace(_providerNpi) ? null : _providerNpi.Trim(),
+                    ContractType = _contractType,
+                    OriginalPeriod = _originalPeriod
+                },
+                Description = string.IsNullOrWhiteSpace(_description) ? null : _description,
                 CreatedBy = "portal-user"
             };
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/CapitationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/CapitationRuns.razor
@@ -31,7 +31,7 @@
             <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,255,0.05); border: 1px solid rgba(0,255,255,0.2); border-radius: 12px;">
                 <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Style="color: #00ffff; font-size: 2rem;" />
                 <div>
-                    <MudText Typo="Typo.h5" Style="color: #00ffff; font-weight: 700;">@_runs.Count</MudText>
+                    <MudText Typo="Typo.h5" Style="color: #00ffff; font-weight: 700;">@FilteredRuns.Count()</MudText>
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Total Runs</MudText>
                 </div>
             </MudPaper>
@@ -40,7 +40,7 @@
             <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,136,0.05); border: 1px solid rgba(0,255,136,0.2); border-radius: 12px;">
                 <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Style="color: #00ff88; font-size: 2rem;" />
                 <div>
-                    <MudText Typo="Typo.h5" Style="color: #00ff88; font-weight: 700;">@_runs.Sum(r => r.TotalNetPayable).ToString("C0")</MudText>
+                    <MudText Typo="Typo.h5" Style="color: #00ff88; font-weight: 700;">@FilteredRuns.Sum(r => r.TotalNetPayable).ToString("C0")</MudText>
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Total Net Payable</MudText>
                 </div>
             </MudPaper>
@@ -49,7 +49,7 @@
             <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,170,0,0.05); border: 1px solid rgba(255,170,0,0.2); border-radius: 12px;">
                 <MudIcon Icon="@Icons.Material.Filled.People" Style="color: #ffaa00; font-size: 2rem;" />
                 <div>
-                    <MudText Typo="Typo.h5" Style="color: #ffaa00; font-weight: 700;">@_runs.Sum(r => r.TotalMemberMonths)</MudText>
+                    <MudText Typo="Typo.h5" Style="color: #ffaa00; font-weight: 700;">@FilteredRuns.Sum(r => r.TotalMemberMonths)</MudText>
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Member-Months</MudText>
                 </div>
             </MudPaper>
@@ -58,23 +58,42 @@
             <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,0,85,0.05); border: 1px solid rgba(255,0,85,0.2); border-radius: 12px;">
                 <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Style="color: #ff0055; font-size: 2rem;" />
                 <div>
-                    <MudText Typo="Typo.h5" Style="color: #ff0055; font-weight: 700;">@_runs.Count(r => r.Status == "Failed")</MudText>
+                    <MudText Typo="Typo.h5" Style="color: #ff0055; font-weight: 700;">@FilteredRuns.Count(r => r.Status == "Failed")</MudText>
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Failed</MudText>
                 </div>
             </MudPaper>
         </MudItem>
     </MudGrid>
 
-    <div class="d-flex align-center gap-3 mb-4">
+    <div class="d-flex align-center gap-3 mb-4 flex-wrap">
         <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
                    OnClick="OpenCreateRunDialog">New Capitation Run</MudButton>
+        <MudSelect @bind-Value="_filterLob" Label="LOB" Variant="Variant.Outlined" Dense="true"
+                   Clearable="true" Style="max-width: 180px;" Margin="Margin.Dense"
+                   ValueChanged="@((string? _) => LoadRuns())">
+            <MudSelectItem Value="@((string?)null)">All LOBs</MudSelectItem>
+            <MudSelectItem Value="@("Commercial")">Commercial</MudSelectItem>
+            <MudSelectItem Value="@("Medicare")">Medicare</MudSelectItem>
+            <MudSelectItem Value="@("Medicaid")">Medicaid</MudSelectItem>
+            <MudSelectItem Value="@("Exchange")">Exchange</MudSelectItem>
+            <MudSelectItem Value="@("TRICARE")">TRICARE</MudSelectItem>
+            <MudSelectItem Value="@("VA")">VA</MudSelectItem>
+        </MudSelect>
+        <MudSelect @bind-Value="_filterRunType" Label="Run Type" Variant="Variant.Outlined" Dense="true"
+                   Clearable="true" Style="max-width: 180px;" Margin="Margin.Dense">
+            <MudSelectItem Value="@((string?)null)">All Types</MudSelectItem>
+            <MudSelectItem Value="@("Monthly")">Monthly</MudSelectItem>
+            <MudSelectItem Value="@("AdHocProvider")">Ad-Hoc Provider</MudSelectItem>
+            <MudSelectItem Value="@("RetroAdjustment")">Retro Adjustment</MudSelectItem>
+            <MudSelectItem Value="@("WithholdRelease")">Withhold Release</MudSelectItem>
+        </MudSelect>
         <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Refresh"
                    OnClick="LoadRuns" Disabled="_loading">Refresh</MudButton>
     </div>
 
     @if (_loading) { <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" /> }
 
-    <MudTable Items="_runs" Dense="true" Hover="true" T="CapRunSummary"
+    <MudTable Items="FilteredRuns" Dense="true" Hover="true" T="CapRunSummary"
               Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 12px;">
         <HeaderContent>
             <MudTh><MudTableSortLabel SortBy="new Func<CapRunSummary,object>(x=>x.RunNumber)">Run Number</MudTableSortLabel></MudTh>
@@ -92,11 +111,17 @@
             <MudTd DataLabel="Run Number">
                 <MudButton Variant="Variant.Text" OnClick="@(() => Navigation.NavigateTo("/capitation/runs/" + context.Id))"
                            Style="font-family: monospace; color: #00ffff;">@context.RunNumber</MudButton>
+                @if (context.Criteria?.ProviderNPI != null)
+                {
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.4);">NPI: @context.Criteria.ProviderNPI</MudText>
+                }
             </MudTd>
             <MudTd DataLabel="Type">
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetRunTypeColor(context.RunType)">@context.RunType</MudChip>
             </MudTd>
-            <MudTd DataLabel="LOB">@(context.LineOfBusiness ?? "—")</MudTd>
+            <MudTd DataLabel="LOB">
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetLobColor(context.LineOfBusiness)">@(context.LineOfBusiness ?? "—")</MudChip>
+            </MudTd>
             <MudTd DataLabel="Period">@context.CapitationPeriod.ToString("MMM yyyy")</MudTd>
             <MudTd DataLabel="Status">
                 <MudChip T="string" Size="Size.Small" Color="@GetRunStatusColor(context.Status)"
@@ -131,15 +156,23 @@ else
                    OnClick="@(() => Navigation.NavigateTo("/capitation/runs"))" Class="mb-3">Back to Runs</MudButton>
 
         <MudPaper Class="pa-4 mb-4" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 12px;">
-            <div class="d-flex align-center gap-3 mb-3">
+            <div class="d-flex align-center gap-3 mb-3 flex-wrap">
                 <MudText Typo="Typo.h5" Style="font-family: monospace; color: #00ffff;">@_selectedRun.RunNumber</MudText>
                 <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetRunTypeColor(_selectedRun.RunType)">@_selectedRun.RunType</MudChip>
                 @if (!string.IsNullOrEmpty(_selectedRun.LineOfBusiness))
                 {
-                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined">@_selectedRun.LineOfBusiness</MudChip>
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="@GetLobColor(_selectedRun.LineOfBusiness)">@_selectedRun.LineOfBusiness</MudChip>
                 }
                 <MudChip T="string" Size="Size.Small" Color="@GetRunStatusColor(_selectedRun.Status)">@_selectedRun.Status</MudChip>
+                @if (_selectedRun.Criteria?.ProviderNPI != null)
+                {
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info">NPI: @_selectedRun.Criteria.ProviderNPI</MudChip>
+                }
             </div>
+            @if (!string.IsNullOrEmpty(_selectedRun.Description))
+            {
+                <MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.5);" Class="mb-3">@_selectedRun.Description</MudText>
+            }
             <MudGrid>
                 <MudItem xs="6" md="2"><MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Period</MudText><MudText>@_selectedRun.CapitationPeriod.ToString("MMM yyyy")</MudText></MudItem>
                 <MudItem xs="6" md="2"><MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.5);">Providers</MudText><MudText>@_selectedRun.TotalProviders</MudText></MudItem>
@@ -196,6 +229,11 @@ else
     private List<CapStatementSummary> _runStatements = new();
     private bool _loading = true;
     private string? _serviceError;
+    private string? _filterLob;
+    private string? _filterRunType;
+
+    private IEnumerable<CapRunSummary> FilteredRuns => _runs
+        .Where(r => string.IsNullOrEmpty(_filterRunType) || r.RunType == _filterRunType);
 
     protected override async Task OnInitializedAsync() => await LoadData();
 
@@ -225,7 +263,7 @@ else
     private async Task LoadRuns()
     {
         _loading = true;
-        try { _runs = await CapitationService.GetRunsAsync(); }
+        try { _runs = await CapitationService.GetRunsAsync(lineOfBusiness: _filterLob); }
         catch (ServiceUnavailableException ex) { _serviceError = ex.Message; }
         finally { _loading = false; }
     }
@@ -264,6 +302,14 @@ else
         try { await CapitationService.ApproveStatementAsync(stmt.Id); Snackbar.Add("Statement approved", Severity.Success); await LoadData(); }
         catch (Exception ex) { Snackbar.Add($"Error: {ex.Message}", Severity.Error); }
     }
+
+    private static Color GetLobColor(string? lob) => lob switch
+    {
+        "Commercial" => Color.Primary, "Medicare" => Color.Info,
+        "Medicaid" => Color.Success, "Exchange" => Color.Warning,
+        "TRICARE" => Color.Secondary, "VA" => Color.Tertiary,
+        _ => Color.Default
+    };
 
     private static Color GetRunTypeColor(string runType) => runType switch
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -1700,7 +1700,7 @@ public interface ICapitationService
     Task TerminateContractAsync(string id, string reason, DateTime? terminationDate = null);
 
     // Runs
-    Task<List<CapRunSummary>> GetRunsAsync(DateTime? from = null, DateTime? to = null);
+    Task<List<CapRunSummary>> GetRunsAsync(DateTime? from = null, DateTime? to = null, string? lineOfBusiness = null);
     Task<CapRunSummary?> GetRunByIdAsync(string id);
     Task<string> CreateRunAsync(CreateCapRunRequest request);
     Task<CapRunSummary> ExecuteRunAsync(string id);
@@ -1762,6 +1762,8 @@ public class CapRunSummary
     public DateTime CapitationPeriod { get; set; }
     public string Status { get; set; } = "Pending";
     public string? LineOfBusiness { get; set; }
+    public string? Description { get; set; }
+    public CapRunCriteriaSummary? Criteria { get; set; }
     public int TotalStatements { get; set; }
     public int TotalMemberMonths { get; set; }
     public decimal TotalGrossCapitation { get; set; }
@@ -1777,16 +1779,29 @@ public class CapRunSummary
     public List<string> Errors { get; set; } = new();
 }
 
-public class CreateCapRunRequest
+public class CapRunCriteriaSummary
 {
-    public string RunType { get; set; } = "Monthly";
-    public DateTime CapitationPeriod { get; set; }
     public string? LineOfBusiness { get; set; }
     public string? ProviderNPI { get; set; }
     public string? ContractType { get; set; }
     public DateTime? OriginalPeriod { get; set; }
+}
+
+public class CreateCapRunRequest
+{
+    public string RunType { get; set; } = "Monthly";
+    public DateTime CapitationPeriod { get; set; }
+    public CreateCapRunCriteria Criteria { get; set; } = new();
     public string? CreatedBy { get; set; }
     public string? Description { get; set; }
+}
+
+public class CreateCapRunCriteria
+{
+    public string LineOfBusiness { get; set; } = "Commercial";
+    public string? ProviderNPI { get; set; }
+    public string? ContractType { get; set; }
+    public DateTime? OriginalPeriod { get; set; }
 }
 
 public class CapStatementSummary

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -2574,13 +2574,14 @@ public class CapitationService : ICapitationService
     }
 
     // Runs
-    public async Task<List<CapRunSummary>> GetRunsAsync(DateTime? from = null, DateTime? to = null)
+    public async Task<List<CapRunSummary>> GetRunsAsync(DateTime? from = null, DateTime? to = null, string? lineOfBusiness = null)
     {
         try
         {
             var qs = new List<string>();
             if (from.HasValue) qs.Add($"from={from.Value:O}");
             if (to.HasValue) qs.Add($"to={to.Value:O}");
+            if (!string.IsNullOrEmpty(lineOfBusiness)) qs.Add($"lineOfBusiness={lineOfBusiness}");
             var query = qs.Count > 0 ? "?" + string.Join("&", qs) : "";
             return await _httpClient.GetFromJsonAsync<List<CapRunSummary>>($"{BaseUrl}/v1/capitation/runs{query}") ?? new();
         }

--- a/src/services/capitation-service/CapitationService.Tests/Controllers/CapitationRunsControllerTests.cs
+++ b/src/services/capitation-service/CapitationService.Tests/Controllers/CapitationRunsControllerTests.cs
@@ -116,10 +116,10 @@ public class CapitationRunsControllerTests
     {
         var runs = new List<CapitationRun>
         {
-            new() { RunNumber = "CAPRUN-2026-03-AAAA" },
-            new() { RunNumber = "CAPRUN-2026-02-BBBB" }
+            new() { RunNumber = "CAPRUN-COM-2026-03-AAAA" },
+            new() { RunNumber = "CAPRUN-MCD-2026-02-BBBB" }
         };
-        _runService.Setup(s => s.GetRunsAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>()))
+        _runService.Setup(s => s.GetRunsAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null))
             .ReturnsAsync(runs);
 
         var result = await _controller.GetRuns(null, null);
@@ -127,6 +127,24 @@ public class CapitationRunsControllerTests
         var ok = result.Result as OkObjectResult;
         ok.Should().NotBeNull();
         (ok!.Value as IEnumerable<CapitationRun>)!.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetRuns_WithLobFilter_PassesLobToService()
+    {
+        var runs = new List<CapitationRun>
+        {
+            new() { RunNumber = "CAPRUN-MCD-2026-03-AAAA", LineOfBusiness = LineOfBusiness.Medicaid }
+        };
+        _runService.Setup(s => s.GetRunsAsync(null, null, LineOfBusiness.Medicaid))
+            .ReturnsAsync(runs);
+
+        var result = await _controller.GetRuns(null, null, LineOfBusiness.Medicaid);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        (ok!.Value as IEnumerable<CapitationRun>)!.Should().HaveCount(1);
+        _runService.Verify(s => s.GetRunsAsync(null, null, LineOfBusiness.Medicaid), Times.Once);
     }
 
     [Fact]

--- a/src/services/capitation-service/CapitationService.Tests/Services/CapitationRunServiceTests.cs
+++ b/src/services/capitation-service/CapitationService.Tests/Services/CapitationRunServiceTests.cs
@@ -523,18 +523,20 @@ public class CapitationRunServiceTests
 
         savedRun.Should().NotBeNull();
         savedRun!.CapitationPeriod.Day.Should().Be(1); // Normalized to first
-        savedRun.RunNumber.Should().StartWith("CAPRUN-2026-03-");
+        savedRun.RunNumber.Should().StartWith("CAPRUN-COM-2026-03-");
         savedRun.RunType.Should().Be(CapitationRunType.Monthly);
+        savedRun.LineOfBusiness.Should().Be(LineOfBusiness.Commercial);
         savedRun.Status.Should().Be(CapitationRunStatus.Pending);
     }
 
     [Fact]
-    public async Task CreateRunAsync_MonthlyWithoutLob_ThrowsArgumentException()
+    public async Task CreateRunAsync_WithoutValidLob_ThrowsArgumentException()
     {
         var act = () => _service.CreateRunAsync(new CreateCapitationRunRequest
         {
             RunType = CapitationRunType.Monthly,
-            CapitationPeriod = new DateTime(2026, 3, 1)
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = (LineOfBusiness)999 }
         }, "admin");
 
         await act.Should().ThrowAsync<ArgumentException>()
@@ -547,7 +549,8 @@ public class CapitationRunServiceTests
         var act = () => _service.CreateRunAsync(new CreateCapitationRunRequest
         {
             RunType = CapitationRunType.AdHocProvider,
-            CapitationPeriod = new DateTime(2026, 3, 1)
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Commercial }
         }, "admin");
 
         await act.Should().ThrowAsync<ArgumentException>()
@@ -560,7 +563,8 @@ public class CapitationRunServiceTests
         var act = () => _service.CreateRunAsync(new CreateCapitationRunRequest
         {
             RunType = CapitationRunType.RetroAdjustment,
-            CapitationPeriod = new DateTime(2026, 3, 1)
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Commercial }
         }, "admin");
 
         await act.Should().ThrowAsync<ArgumentException>()
@@ -582,12 +586,183 @@ public class CapitationRunServiceTests
     public async Task GetRunsAsync_DelegatesToRepo()
     {
         var runs = new List<CapitationRun> { CreatePendingRun() };
-        _runRepo.Setup(r => r.SearchAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null))
+        _runRepo.Setup(r => r.SearchAsync(It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), null, null))
             .ReturnsAsync(runs);
 
         var result = await _service.GetRunsAsync(new DateTime(2026, 1, 1), new DateTime(2026, 12, 31));
 
         result.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetRunsAsync_WithLobFilter_PassesLobToRepo()
+    {
+        var runs = new List<CapitationRun> { CreatePendingRun() };
+        _runRepo.Setup(r => r.SearchAsync(null, null, null, LineOfBusiness.Medicaid))
+            .ReturnsAsync(runs);
+
+        var result = await _service.GetRunsAsync(null, null, LineOfBusiness.Medicaid);
+
+        result.Should().HaveCount(1);
+        _runRepo.Verify(r => r.SearchAsync(null, null, null, LineOfBusiness.Medicaid), Times.Once);
+    }
+
+    #endregion
+
+    #region CreateRunAsync — RunNumber, Description, Denormalized Fields
+
+    [Fact]
+    public async Task CreateRunAsync_GeneratesRunNumberWithLobAbbreviation()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.Monthly,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Medicaid }
+        }, "admin");
+
+        savedRun!.RunNumber.Should().StartWith("CAPRUN-MCD-2026-03-");
+    }
+
+    [Fact]
+    public async Task CreateRunAsync_MedicareRunNumber_UsesMcrAbbreviation()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.Monthly,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Medicare }
+        }, "admin");
+
+        savedRun!.RunNumber.Should().StartWith("CAPRUN-MCR-2026-03-");
+    }
+
+    [Fact]
+    public async Task CreateRunAsync_AutoGeneratesDescription_Monthly()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.Monthly,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Commercial }
+            // Description intentionally omitted
+        }, "admin");
+
+        savedRun!.Description.Should().Be("Monthly Commercial capitation for March 2026");
+    }
+
+    [Fact]
+    public async Task CreateRunAsync_AutoGeneratesDescription_AdHocProvider()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.AdHocProvider,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Medicaid, ProviderNPI = "1234567890" }
+        }, "admin");
+
+        savedRun!.Description.Should().Be("Ad-hoc Medicaid capitation for provider 1234567890, March 2026");
+    }
+
+    [Fact]
+    public async Task CreateRunAsync_ExplicitDescription_PreservesIt()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.Monthly,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Commercial },
+            Description = "Custom description for testing"
+        }, "admin");
+
+        savedRun!.Description.Should().Be("Custom description for testing");
+    }
+
+    [Fact]
+    public async Task CreateRunAsync_SetsDenormalizedLineOfBusiness()
+    {
+        CapitationRun? savedRun = null;
+        _runRepo.Setup(r => r.CreateAsync(It.IsAny<CapitationRun>()))
+            .Callback<CapitationRun>(r => savedRun = r)
+            .ReturnsAsync((CapitationRun r) => r);
+
+        await _service.CreateRunAsync(new CreateCapitationRunRequest
+        {
+            RunType = CapitationRunType.Monthly,
+            CapitationPeriod = new DateTime(2026, 3, 1),
+            Criteria = new CapitationRunCriteria { LineOfBusiness = LineOfBusiness.Medicare }
+        }, "admin");
+
+        savedRun!.LineOfBusiness.Should().Be(LineOfBusiness.Medicare);
+    }
+
+    #endregion
+
+    #region ExecuteRunAsync — No Contracts Warning
+
+    [Fact]
+    public async Task ExecuteRunAsync_NoMatchingContracts_AddsWarning()
+    {
+        var run = CreatePendingRun();
+        _runRepo.Setup(r => r.GetByIdAsync("run-1")).ReturnsAsync(run);
+        SetupDefaultRepos();
+
+        _contractRepo.Setup(r => r.GetActiveContractsAsync(LineOfBusiness.Commercial, null))
+            .ReturnsAsync(new List<CapitationContract>());
+
+        var result = await _service.ExecuteRunAsync("run-1");
+
+        result.Status.Should().Be(CapitationRunStatus.Completed);
+        result.TotalStatements.Should().Be(0);
+        result.Warnings.Should().ContainSingle();
+        result.Warnings[0].Should().Contain("Commercial");
+    }
+
+    [Fact]
+    public async Task ExecuteRunAsync_AdHocNoContracts_WarningIncludesNpi()
+    {
+        var run = CreatePendingRun();
+        run.RunType = CapitationRunType.AdHocProvider;
+        run.Criteria = new CapitationRunCriteria
+        {
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ProviderNPI = "9999999999"
+        };
+        _runRepo.Setup(r => r.GetByIdAsync("run-1")).ReturnsAsync(run);
+        SetupDefaultRepos();
+
+        _contractRepo.Setup(r => r.GetActiveContractsAsync(LineOfBusiness.Commercial, null))
+            .ReturnsAsync(new List<CapitationContract>());
+
+        var result = await _service.ExecuteRunAsync("run-1");
+
+        result.Warnings.Should().ContainSingle();
+        result.Warnings[0].Should().Contain("9999999999");
     }
 
     #endregion

--- a/src/services/capitation-service/Controllers/CapitationRunsController.cs
+++ b/src/services/capitation-service/Controllers/CapitationRunsController.cs
@@ -94,9 +94,10 @@ public class CapitationRunsController : ControllerBase
     [ProducesResponseType(typeof(IEnumerable<CapitationRun>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<CapitationRun>>> GetRuns(
         [FromQuery] DateTime? from,
-        [FromQuery] DateTime? to)
+        [FromQuery] DateTime? to,
+        [FromQuery] LineOfBusiness? lineOfBusiness = null)
     {
-        var runs = await _runService.GetRunsAsync(from, to);
+        var runs = await _runService.GetRunsAsync(from, to, lineOfBusiness);
         return Ok(runs);
     }
 

--- a/src/services/capitation-service/Models/CapitationRun.cs
+++ b/src/services/capitation-service/Models/CapitationRun.cs
@@ -37,6 +37,12 @@ public class CapitationRun
     public CapitationRunType RunType { get; set; } = CapitationRunType.Monthly;
 
     /// <summary>
+    /// Line of business this run covers (denormalized from Criteria for display/filtering)
+    /// </summary>
+    [Required]
+    public LineOfBusiness LineOfBusiness { get; set; }
+
+    /// <summary>
     /// Description of the capitation run
     /// </summary>
     public string? Description { get; set; }
@@ -136,29 +142,31 @@ public class CapitationRun
 }
 
 /// <summary>
-/// Filter criteria for a capitation run. Structured around LOB as the primary axis,
-/// reflecting how health plans actually execute capitation: monthly by LOB, with
-/// optional ad-hoc provider runs, retro adjustments, and withhold releases.
+/// Criteria for a capitation run. LineOfBusiness is always required.
+/// Additional fields are required or optional depending on RunType.
 /// </summary>
 public class CapitationRunCriteria
 {
     /// <summary>
-    /// Line of business for this run. Required for Monthly runs (the primary organizing axis).
-    /// Optional for AdHocProvider and RetroAdjustment runs (if omitted, processes across all LOBs
-    /// for the specified provider). Required for WithholdRelease runs.
+    /// Line of business for this capitation run (REQUIRED for all run types).
+    /// Capitation runs are always scoped to a single LOB because rate structures,
+    /// provider networks, and approval workflows differ by LOB.
     /// </summary>
-    public LineOfBusiness? LineOfBusiness { get; set; }
+    [Required]
+    public LineOfBusiness LineOfBusiness { get; set; }
 
     /// <summary>
-    /// Single provider NPI for ad-hoc runs. Required for AdHocProvider runs.
-    /// Optional for RetroAdjustment and WithholdRelease runs to scope to a single provider.
-    /// Must be null/empty for Monthly runs (which process all active providers in the LOB).
+    /// Specific provider NPI for ad-hoc runs (REQUIRED for AdHocProvider type,
+    /// ignored for other run types). When set, the run generates statements for
+    /// only this provider's active contract(s) in the specified LOB.
     /// </summary>
+    [StringLength(10, MinimumLength = 10)]
     public string? ProviderNPI { get; set; }
 
     /// <summary>
-    /// Filter by contract type within the LOB. Optional — if omitted, includes all
-    /// contract types (GlobalCapitation, ProfessionalOnly, etc.) for the LOB.
+    /// Optional: filter by contract type (e.g., run Professional cap separately
+    /// from Global cap when they have different approval workflows).
+    /// When null, includes all contract types in the LOB.
     /// </summary>
     public ContractType? ContractType { get; set; }
 

--- a/src/services/capitation-service/Repositories/CapitationRunRepository.cs
+++ b/src/services/capitation-service/Repositories/CapitationRunRepository.cs
@@ -6,7 +6,7 @@ namespace CapitationService.Repositories;
 public interface ICapitationRunRepository
 {
     Task<CapitationRun?> GetByIdAsync(string id);
-    Task<IEnumerable<CapitationRun>> SearchAsync(DateTime? from = null, DateTime? to = null, CapitationRunStatus? status = null);
+    Task<IEnumerable<CapitationRun>> SearchAsync(DateTime? from = null, DateTime? to = null, CapitationRunStatus? status = null, LineOfBusiness? lineOfBusiness = null);
     Task<IEnumerable<CapitationRun>> GetByStatusAsync(CapitationRunStatus status);
     Task<CapitationRun> CreateAsync(CapitationRun run);
     Task<CapitationRun> UpdateAsync(CapitationRun run);
@@ -52,7 +52,7 @@ public class CapitationRunRepository : ICapitationRunRepository
         }
     }
 
-    public async Task<IEnumerable<CapitationRun>> SearchAsync(DateTime? from = null, DateTime? to = null, CapitationRunStatus? status = null)
+    public async Task<IEnumerable<CapitationRun>> SearchAsync(DateTime? from = null, DateTime? to = null, CapitationRunStatus? status = null, LineOfBusiness? lineOfBusiness = null)
     {
         var tenantId = GetTenantId();
         var queryText = "SELECT * FROM c WHERE c.tenantId = @tenantId";
@@ -72,6 +72,11 @@ public class CapitationRunRepository : ICapitationRunRepository
         {
             queryText += " AND c.status = @status";
             parameters.Add(("@status", status.Value.ToString()));
+        }
+        if (lineOfBusiness.HasValue)
+        {
+            queryText += " AND c.lineOfBusiness = @lineOfBusiness";
+            parameters.Add(("@lineOfBusiness", lineOfBusiness.Value.ToString()));
         }
 
         queryText += " ORDER BY c.createdAt DESC";

--- a/src/services/capitation-service/Services/CapitationRunService.cs
+++ b/src/services/capitation-service/Services/CapitationRunService.cs
@@ -9,7 +9,7 @@ public interface ICapitationRunService
     Task<CapitationRun> CreateRunAsync(CreateCapitationRunRequest request, string? createdBy);
     Task<CapitationRun> ExecuteRunAsync(string runId);
     Task<CapitationRun> GetRunAsync(string runId);
-    Task<IEnumerable<CapitationRun>> GetRunsAsync(DateTime? from, DateTime? to);
+    Task<IEnumerable<CapitationRun>> GetRunsAsync(DateTime? from, DateTime? to, LineOfBusiness? lineOfBusiness = null);
     Task CancelRunAsync(string runId);
     Task<CapitationStatement> ApproveStatementAsync(string statementId);
     Task<CapitationStatement> VoidStatementAsync(string statementId, string reason);
@@ -44,6 +44,19 @@ public class CapitationRunService : ICapitationRunService
         _logger = logger;
     }
 
+    /// <summary>
+    /// Maps LineOfBusiness enum values to 3-character abbreviations for RunNumber formatting.
+    /// </summary>
+    private static readonly Dictionary<LineOfBusiness, string> LobAbbreviations = new()
+    {
+        [LineOfBusiness.Commercial] = "COM",
+        [LineOfBusiness.Medicare] = "MCR",
+        [LineOfBusiness.Medicaid] = "MCD",
+        [LineOfBusiness.Exchange] = "EXC",
+        [LineOfBusiness.TRICARE] = "TRI",
+        [LineOfBusiness.VA] = "VA"
+    };
+
     public async Task<CapitationRun> CreateRunAsync(CreateCapitationRunRequest request, string? createdBy)
     {
         // Validate run type + criteria consistency
@@ -52,12 +65,15 @@ public class CapitationRunService : ICapitationRunService
         // Normalize capitation period to first of month
         var period = new DateTime(request.CapitationPeriod.Year, request.CapitationPeriod.Month, 1, 0, 0, 0, DateTimeKind.Utc);
 
+        var lobAbbrev = LobAbbreviations.GetValueOrDefault(request.Criteria.LineOfBusiness, "UNK");
+
         var run = new CapitationRun
         {
-            RunNumber = $"CAPRUN-{period:yyyy-MM}-{Guid.NewGuid().ToString()[..4].ToUpperInvariant()}",
+            RunNumber = $"CAPRUN-{lobAbbrev}-{period:yyyy-MM}-{Guid.NewGuid().ToString()[..4].ToUpperInvariant()}",
             RunType = request.RunType,
+            LineOfBusiness = request.Criteria.LineOfBusiness,
             CapitationPeriod = period,
-            Description = request.Description,
+            Description = request.Description ?? GenerateDefaultDescription(request.RunType, request.Criteria, period),
             Criteria = request.Criteria,
             CreatedBy = createdBy,
             Status = CapitationRunStatus.Pending
@@ -66,13 +82,28 @@ public class CapitationRunService : ICapitationRunService
         return await _runRepository.CreateAsync(run);
     }
 
+    private static string GenerateDefaultDescription(CapitationRunType runType, CapitationRunCriteria criteria, DateTime period)
+    {
+        var lob = criteria.LineOfBusiness.ToString();
+        return runType switch
+        {
+            CapitationRunType.Monthly => $"Monthly {lob} capitation for {period:MMMM yyyy}",
+            CapitationRunType.AdHocProvider => $"Ad-hoc {lob} capitation for provider {criteria.ProviderNPI}, {period:MMMM yyyy}",
+            CapitationRunType.RetroAdjustment => $"Retro adjustment — {lob} {period:MMMM yyyy}",
+            CapitationRunType.WithholdRelease => $"Withhold release — {lob} {period:MMMM yyyy}",
+            _ => $"Capitation run for {period:MMMM yyyy}"
+        };
+    }
+
     private static void ValidateRunCriteria(CapitationRunType runType, CapitationRunCriteria criteria)
     {
+        // LineOfBusiness is always required — capitation runs are scoped to a single LOB
+        if (!Enum.IsDefined(typeof(LineOfBusiness), criteria.LineOfBusiness))
+            throw new ArgumentException("A valid LineOfBusiness is required for all capitation runs");
+
         switch (runType)
         {
             case CapitationRunType.Monthly:
-                if (criteria.LineOfBusiness == null)
-                    throw new ArgumentException("Monthly capitation runs require a LineOfBusiness");
                 if (!string.IsNullOrEmpty(criteria.ProviderNPI))
                     throw new ArgumentException("Monthly runs process all providers in the LOB; ProviderNPI must not be set");
                 if (criteria.OriginalPeriod.HasValue)
@@ -92,8 +123,6 @@ public class CapitationRunService : ICapitationRunService
                 break;
 
             case CapitationRunType.WithholdRelease:
-                if (criteria.LineOfBusiness == null)
-                    throw new ArgumentException("WithholdRelease runs require a LineOfBusiness");
                 if (criteria.OriginalPeriod.HasValue)
                     throw new ArgumentException("OriginalPeriod is only valid for RetroAdjustment runs");
                 break;
@@ -129,6 +158,13 @@ public class CapitationRunService : ICapitationRunService
             // Apply single-provider filter for AdHocProvider, or optional provider scoping
             if (!string.IsNullOrEmpty(run.Criteria.ProviderNPI))
                 contracts = contracts.Where(c => c.ProviderNPI == run.Criteria.ProviderNPI).ToList();
+
+            if (contracts.Count == 0)
+            {
+                run.Warnings.Add($"No active capitation contracts found for {run.Criteria.LineOfBusiness}" +
+                    (!string.IsNullOrEmpty(run.Criteria.ProviderNPI) ? $", provider {run.Criteria.ProviderNPI}" : "") +
+                    (run.Criteria.ContractType.HasValue ? $", contract type {run.Criteria.ContractType}" : ""));
+            }
 
             _logger.LogInformation("Found {Count} active capitation contracts for run {RunNumber}",
                 contracts.Count, run.RunNumber);
@@ -198,9 +234,9 @@ public class CapitationRunService : ICapitationRunService
             ?? throw new InvalidOperationException($"Capitation run {runId} not found");
     }
 
-    public async Task<IEnumerable<CapitationRun>> GetRunsAsync(DateTime? from, DateTime? to)
+    public async Task<IEnumerable<CapitationRun>> GetRunsAsync(DateTime? from, DateTime? to, LineOfBusiness? lineOfBusiness = null)
     {
-        return await _runRepository.SearchAsync(from, to);
+        return await _runRepository.SearchAsync(from, to, lineOfBusiness: lineOfBusiness);
     }
 
     public async Task CancelRunAsync(string runId)


### PR DESCRIPTION
Model:
- Make LineOfBusiness required on CapitationRunCriteria (was nullable)
- Add denormalized LineOfBusiness field to CapitationRun for display/filtering
- Replace ProviderNPIs list with single ProviderNPI, remove PlanIds
- Add OriginalPeriod for RetroAdjustment runs
- Update RunNumber format: CAPRUN-{LOB}-{yyyy-MM}-{guid4} (e.g. CAPRUN-MCD-2026-03-A1B2)

Service:
- LOB abbreviation mapping (COM, MCR, MCD, EXC, TRI, VA)
- Auto-generate Description based on RunType + LOB when not provided
- Set denormalized LineOfBusiness on run creation
- Add no-contracts warning in ExecuteRunAsync
- Add LineOfBusiness filter to GetRunsAsync

Repository:
- Add lineOfBusiness parameter to SearchAsync

Controller:
- Add lineOfBusiness query parameter to GET /runs endpoint

Portal:
- LOB is now always required in CreateCapitationRunDialog
- CreateCapRunRequest uses nested Criteria object matching backend shape
- Add LOB and RunType filter dropdowns above run list table
- LOB displayed as colored chips in table and detail view
- Summary cards reflect active filters
- Show provider NPI for ad-hoc runs in table and detail header

Tests:
- Update existing tests for new criteria shape (non-nullable LOB)
- Add tests: RunNumber LOB abbreviation, auto-generated descriptions, denormalized LineOfBusiness, LOB filter passthrough, no-contracts warning

Seed:
- Create separate Medicaid Monthly and Commercial Monthly runs
- Add ad-hoc provider run for Dr. Sarah Chen
- Use new RunType + Criteria shape in API calls

https://claude.ai/code/session_013gWXtBCNgPrBpk2iQLEABJ