### PR TITLE
Potential fix for code scanning alert no. 901: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-meadow-0da15b31e.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-meadow-0da15b31e.yml
@@ -9,14 +9,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,6 +40,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      contents: read
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
Potential fix for <a href="https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/901">https://github.com/aurelianware/cloudhealthoffice/security/code-scanning/901</a>

The fix explicitly sets `permissions:` blocks per-job to restrict the default `GITHUB_TOKEN` scope to the least privileges required for each job, preserving existing functionality.

Concretely, in `.github/workflows/azure-static-web-apps-agreeable-meadow-0da15b31e.yml`:

- **`build_and_deploy_job`** receives:
  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```
  The `pull-requests: write` scope is required for `Azure/static-web-apps-deploy@v1` to post and update PR comments via `repo_token`.

- **`close_pull_request_job`** receives:
  ```yaml
  permissions:
    contents: read
  ```
  This job only closes the staging environment and does not require PR write access.

Scoping permissions per-job (rather than at the workflow level) ensures each job holds only the minimum privileges it actually needs.

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._