### PR TITLE
Wire email GitHub secrets into AKS deployment for Contact Sales page

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -451,6 +451,19 @@ jobs:
             -n ${{ env.NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Create email config secret
+        run: |
+          kubectl create secret generic email-config \
+            --from-literal=SmtpHost="${{ secrets.EMAIL_SMTP_HOST }}" \
+            --from-literal=SmtpPort="${{ secrets.EMAIL_SMTP_PORT }}" \
+            --from-literal=EnableSsl="${{ secrets.EMAIL_ENABLE_SSL }}" \
+            --from-literal=FromAddress="${{ secrets.EMAIL_FROM_ADDRESS }}" \
+            --from-literal=SalesTeamAddress="${{ secrets.EMAIL_SALES_TEAM_ADDRESS }}" \
+            --from-literal=Username="${{ secrets.EMAIL_USERNAME }}" \
+            --from-literal=Password="${{ secrets.EMAIL_PASSWORD }}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
       - name: Apply core manifests
         run: |
           kubectl apply -f infrastructure/k8s/namespaces.yaml

--- a/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
+++ b/src/portal/CloudHealthOffice.Portal/k8s/portal-deployment.yaml
@@ -229,6 +229,41 @@ spec:
             secretKeyRef:
               name: pricing-api-secret
               key: AdminSecret
+        - name: Email__SmtpHost
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: SmtpHost
+        - name: Email__SmtpPort
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: SmtpPort
+        - name: Email__EnableSsl
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: EnableSsl
+        - name: Email__FromAddress
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: FromAddress
+        - name: Email__SalesTeamAddress
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: SalesTeamAddress
+        - name: Email__Username
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: Username
+        - name: Email__Password
+          valueFrom:
+            secretKeyRef:
+              name: email-config
+              key: Password
         resources:
           requests:
             memory: "512Mi"


### PR DESCRIPTION
Add email-config Kubernetes secret creation step in the deploy workflow
and inject Email__* env vars into the portal pod so the
SmtpEmailNotificationService can read SMTP configuration at runtime.

https://claude.ai/code/session_01SL7E83aU2UrEwcXFn9qv2B