### PR TITLE
Fix rfai-service build error blocking all deployments

### DIFF
--- a/src/services/authorization-service/AuthorizationService.Tests/Services/SlaWatchdogServiceTests.cs
+++ b/src/services/authorization-service/AuthorizationService.Tests/Services/SlaWatchdogServiceTests.cs
@@ -1,6 +1,7 @@
 using AuthorizationService.Models;
 using AuthorizationService.Repositories;
 using AuthorizationService.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace AuthorizationService.Tests.Services;
@@ -188,8 +189,11 @@ public class SlaWatchdogServiceTests
 
     private async Task RunWatchdog()
     {
-        var service = new SlaWatchdogService(
-            _repositoryMock.Object, _loggerMock.Object);
+        var services = new ServiceCollection();
+        services.AddSingleton(_repositoryMock.Object);
+        var sp = services.BuildServiceProvider();
+
+        var service = new SlaWatchdogService(sp, _loggerMock.Object);
         await service.EvaluateAllAuthorizationsAsync();
     }
 

--- a/src/services/authorization-service/Services/SlaWatchdogService.cs
+++ b/src/services/authorization-service/Services/SlaWatchdogService.cs
@@ -24,26 +24,12 @@ public class SlaWatchdogService : BackgroundService
     private readonly IAuthorizationRepository _repository;
     private readonly ILogger<SlaWatchdogService> _logger;
 
-    /// <summary>
-    /// Production constructor — receives a scoped repository via IServiceProvider.
-    /// </summary>
     public SlaWatchdogService(
         IServiceProvider serviceProvider,
         ILogger<SlaWatchdogService> logger)
     {
         var scope = serviceProvider.CreateScope();
         _repository = scope.ServiceProvider.GetRequiredService<IAuthorizationRepository>();
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Test constructor — direct repository injection.
-    /// </summary>
-    public SlaWatchdogService(
-        IAuthorizationRepository repository,
-        ILogger<SlaWatchdogService> logger)
-    {
-        _repository = repository;
         _logger = logger;
     }
 

--- a/src/services/rfai-service/Services/KafkaProducerService.cs
+++ b/src/services/rfai-service/Services/KafkaProducerService.cs
@@ -28,13 +28,13 @@ public class KafkaProducerService : IKafkaProducerService, IHostedService, IAsyn
         _configuration = configuration;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public Task StartAsync(CancellationToken cancellationToken)
     {
         var bootstrapServers = _configuration["Kafka:BootstrapServers"];
         if (string.IsNullOrEmpty(bootstrapServers))
         {
             _logger.LogWarning("Kafka:BootstrapServers not configured — Kafka producer disabled");
-            return;
+            return Task.CompletedTask;
         }
 
         var producerConfig = new ProducerConfig
@@ -57,8 +57,8 @@ public class KafkaProducerService : IKafkaProducerService, IHostedService, IAsyn
 
         try
         {
-            using var adminClient = new Confluent.Kafka.Admin.AdminClientBuilder(
-                new Confluent.Kafka.Admin.AdminClientConfig
+            using var adminClient = new AdminClientBuilder(
+                new AdminClientConfig
                 {
                     BootstrapServers = producerConfig.BootstrapServers,
                     SocketTimeoutMs = 10_000,
@@ -80,6 +80,8 @@ public class KafkaProducerService : IKafkaProducerService, IHostedService, IAsyn
             _producer = null;
             _available = false;
         }
+
+        return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- **Fix rfai-service Kafka namespace error**: `AdminClientBuilder` and `AdminClientConfig` are in `Confluent.Kafka`, not `Confluent.Kafka.Admin` (Confluent.Kafka 2.6.1). This build failure has been blocking the entire "Deploy to Azure" workflow since PR #594, preventing any services from deploying to AKS.
- **Fix SlaWatchdogService ambiguous constructor**: Removed the second "test" constructor that caused DI resolution failures, breaking all AuthorizationsControllerTests integration tests.

## Impact
The deploy workflow (`deploy-aks`) depends on `build-push-services` completing — one failing service (`rfai-service`) blocked deployment of **all** services. This is why Claims, Members, Providers, Appeals, and other services are currently unreachable from the portal.

## Test plan
- [ ] "Test .NET Projects" CI passes (SlaWatchdogService fix)
- [ ] "Build and Push Docker Images" CI passes (rfai-service fix)  
- [ ] "Deploy to Azure (AKS + Container Apps)" succeeds after merge
- [ ] Portal pages (Dashboard, Claims, Members, Providers, Appeals) reconnect to backend services

🤖 Generated with [Claude Code](https://claude.com/claude-code)