### PR TITLE
Add MongoDB connection to 5 services causing runtime errors

### DIFF
--- a/src/services/CHO.TerminologyService/k8s/deployment.yaml
+++ b/src/services/CHO.TerminologyService/k8s/deployment.yaml
@@ -35,6 +35,13 @@ spec:
               value: "cho_terminology"
             - name: ASPNETCORE_ENVIRONMENT
               value: "Production"
+            - name: MongoDb__ConnectionString
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: connectionString
+            - name: MongoDb__DatabaseName
+              value: "cloudhealthoffice"
           resources:
             requests:
               memory: "256Mi"

--- a/src/services/appeals-service/k8s/appeals-service-deployment.yaml
+++ b/src/services/appeals-service/k8s/appeals-service-deployment.yaml
@@ -72,6 +72,13 @@ spec:
             configMapKeyRef:
               name: appeals-service-config
               key: ClaimsService__BaseUrl
+        - name: MongoDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: database-secret
+              key: connectionString
+        - name: MongoDb__DatabaseName
+          value: "cloudhealthoffice"
         resources:
           requests:
             cpu: 100m

--- a/src/services/fhir-service/k8s/fhir-service-deployment.yaml
+++ b/src/services/fhir-service/k8s/fhir-service-deployment.yaml
@@ -56,6 +56,14 @@ spec:
                 name: fhir-service-config
             - secretRef:
                 name: fhir-service-secrets
+          env:
+            - name: MongoDb__ConnectionString
+              valueFrom:
+                secretKeyRef:
+                  name: database-secret
+                  key: connectionString
+            - name: MongoDb__DatabaseName
+              value: "cloudhealthoffice"
           resources:
             requests:
               memory: "256Mi"

--- a/src/services/reference-data-service/k8s/reference-data-service-deployment.yaml
+++ b/src/services/reference-data-service/k8s/reference-data-service-deployment.yaml
@@ -109,6 +109,14 @@ spec:
             name: reference-data-service-config
         - secretRef:
             name: reference-data-service-secret
+        env:
+        - name: MongoDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: database-secret
+              key: connectionString
+        - name: MongoDb__DatabaseName
+          value: "cloudhealthoffice"
         resources:
           requests:
             memory: "256Mi"

--- a/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
+++ b/src/services/trading-partner-service/k8s/trading-partner-service-deployment.yaml
@@ -58,6 +58,13 @@ spec:
             secretKeyRef:
               name: azure-ad-config
               key: Audience
+        - name: MongoDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: database-secret
+              key: connectionString
+        - name: MongoDb__DatabaseName
+          value: "cloudhealthoffice"
         resources:
           requests:
             memory: "256Mi"


### PR DESCRIPTION
## Summary
- appeals-service, trading-partner-service, reference-data-service, fhir-service, and terminology-service were missing `MongoDb__ConnectionString` in their k8s manifests
- Without it, they fell back to the CosmosDB native SDK path which throws `CosmosDb:Endpoint and CosmosDb:Key must be configured`
- Now all 5 inject the connection string from the shared `database-secret`, matching the other 20 services

## Test plan
- [ ] CI passes
- [ ] Deploy to Azure succeeds
- [ ] Appeals, Trading Partners, FHIR, Reference Data, and Terminology pages work in the portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)