### PR TITLE
Make api-docs deploy step non-blocking

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -517,6 +517,7 @@ jobs:
           done
 
       - name: Deploy api-docs (Swagger UI + OpenAPI specs)
+        continue-on-error: true
         run: |
           kubectl apply -f infrastructure/k8s/services/api-docs.yaml
           kubectl apply -f infrastructure/k8s/api-docs-ingress.yaml


### PR DESCRIPTION
## Summary
- api-docs container image is in ImagePullBackOff, causing the entire AKS deploy to fail
- Adds `continue-on-error: true` to the api-docs deploy step so portal and backend services deploy regardless

## Test plan
- [ ] Deploy pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)