### PR TITLE
Fix repricing API URL to include /pricing ingress path prefix

### DIFF
--- a/src/site/claims-repricing.html
+++ b/src/site/claims-repricing.html
@@ -586,7 +586,7 @@
       const resultDiv = document.getElementById('lookupResult');
       resultDiv.classList.remove('visible');
 
-      let url = `https://api.cloudhealthoffice.com/api/v1/lookup/${encodeURIComponent(code)}?feeScheduleId=${encodeURIComponent(fs)}&facility=${facility}`;
+      let url = `https://api.cloudhealthoffice.com/pricing/api/v1/lookup/${encodeURIComponent(code)}?feeScheduleId=${encodeURIComponent(fs)}&facility=${facility}`;
       if (locality) url += `&locality=${encodeURIComponent(locality)}`;
 
       try {


### PR DESCRIPTION
The frontend was calling api.cloudhealthoffice.com/api/v1/lookup/... but the
Kubernetes ingress routes through /pricing/* and rewrites to strip the prefix.
Without /pricing in the path, requests never matched the ingress rule, causing
"Could not reach the repricing API" errors.

https://claude.ai/code/session_01XyTxHEgB364czLySCZ1tv1