### PR TITLE
Exempt /api/v1/lookup from API key requirement for public web demo

### DIFF
--- a/src/services/CloudHealthOffice.PricingApi/Middleware/ApiKeyMiddleware.cs
+++ b/src/services/CloudHealthOffice.PricingApi/Middleware/ApiKeyMiddleware.cs
@@ -30,8 +30,9 @@ public class ApiKeyMiddleware
     {
         var path = context.Request.Path.Value ?? "";
 
-        // Skip auth for exempt paths
-        if (ExemptPaths.Any(p => path.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+        // Skip auth for exempt paths (segment-aware to avoid matching e.g. /api/v1/lookup2)
+        var requestPath = context.Request.Path;
+        if (ExemptPaths.Any(p => requestPath.StartsWithSegments(p, StringComparison.OrdinalIgnoreCase)))
         {
             await _next(context);
             return;


### PR DESCRIPTION
The claims-repricing page promises "No signup required" but the lookup endpoint was behind API key auth, causing a 401 that the frontend displayed as "Not Found" with an API key registration message.

The single-code lookup is a read-only demo endpoint. Batch repricing (/reprice, /reprice/batch) still requires authentication.

https://claude.ai/code/session_01XyTxHEgB364czLySCZ1tv1