### PR TITLE
fix: seed cleanup handles both PascalCase and camelCase documents

### DIFF
--- a/scripts/setup/seed-demo-data.js
+++ b/scripts/setup/seed-demo-data.js
@@ -118,7 +118,8 @@ const COLLECTIONS = [
 ];
 
 COLLECTIONS.forEach(function (col) {
-  const r = choDb[col].deleteMany({ TenantId: TENANT_ID });
+  // Clear both PascalCase (C# driver) and camelCase (legacy seed) documents
+  const r = choDb[col].deleteMany({ $or: [{ TenantId: TENANT_ID }, { tenantId: TENANT_ID }] });
   if (r.deletedCount > 0) print("  Cleared " + r.deletedCount + " from " + col);
 });
 


### PR DESCRIPTION
## Summary
- Previous seed runs wrote camelCase `tenantId` fields, new seed writes PascalCase `TenantId`
- The cleanup `deleteMany` only matched PascalCase, leaving old camelCase documents behind
- This caused duplicate `_id` errors when re-seeding
- Fix: use `$or` to match both `{ TenantId: ... }` and `{ tenantId: ... }`

## Test plan
- [ ] Merge, re-run seed action, verify no duplicate key errors
- [ ] Verify all portal pages show seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)