### PR TITLE
fix: remaining camelCase reference in seed script

### DIFF
--- a/scripts/setup/seed-demo-data.js
+++ b/scripts/setup/seed-demo-data.js
@@ -635,7 +635,7 @@ function pickClaimCpt(claimIdx) {
 // Track per-member accumulations for consistency
 const memberAccumData = {};
 members.forEach(function (m) {
-  memberAccumData[m.memberId] = { deductible: 0, copay: 0, coinsurance: 0, planPaid: 0, ptVisits: 0, mhVisits: 0 };
+  memberAccumData[m.MemberId] = { deductible: 0, copay: 0, coinsurance: 0, planPaid: 0, ptVisits: 0, mhVisits: 0 };
 });
 
 const claims = [];


### PR DESCRIPTION
## Summary
- `m.memberId` on line 638 was missed in the PascalCase conversion → `m.MemberId`
- This caused `TypeError: Cannot read properties of undefined (reading 'deductible')` when seeding claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)