### PR TITLE
fix: Coverage status int/string mismatch in member details

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -252,10 +252,10 @@
                                         </CardHeaderContent>
                                         <CardHeaderActions>
                                             <div class="d-flex align-center gap-2">
-                                                <MudChip T="string" Size="Size.Small" Color="@GetCoverageStatusColor(coverage.Status)">
-                                                    @coverage.Status
+                                                <MudChip T="string" Size="Size.Small" Color="@GetCoverageStatusColor(coverage.StatusText)">
+                                                    @coverage.StatusText
                                                 </MudChip>
-                                                @if (coverage.Status == "Active")
+                                                @if (coverage.StatusText == "Active")
                                                 {
                                                     <MudButton Size="Size.Small"
                                                                Variant="Variant.Outlined"
@@ -280,7 +280,7 @@
                                             </MudItem>
                                             <MudItem xs="12" md="4">
                                                 <MudText Typo="Typo.caption" Color="Color.Secondary">STATUS</MudText>
-                                                <MudText Typo="Typo.body2">@coverage.Status</MudText>
+                                                <MudText Typo="Typo.body2">@coverage.StatusText</MudText>
                                             </MudItem>
                                             <MudItem xs="12" md="4">
                                                 <MudText Typo="Typo.caption" Color="Color.Secondary">EFFECTIVE DATE</MudText>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -383,12 +383,21 @@ public class Address
 
 public class Coverage
 {
-    public string CoverageId { get; set; } = string.Empty;
-    public string PlanName { get; set; } = string.Empty;
-    public string GroupNumber { get; set; } = string.Empty;
+    public string? Id { get; set; }
+    public string? CoverageId { get; set; }
+    public string? MemberId { get; set; }
+    public string? PlanId { get; set; }
+    public string? PlanName { get; set; }
+    public string? GroupNumber { get; set; }
+    public string? CoverageLevel { get; set; }
+    public string? InsuranceLineCode { get; set; }
     public DateTime EffectiveDate { get; set; }
     public DateTime? TerminationDate { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public int Status { get; set; }
+    public int LineOfBusiness { get; set; }
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string StatusText => Status switch { 1 => "Active", 2 => "Pending", 3 => "Terminated", 4 => "Suspended", 5 => "COBRA", _ => "Unknown" };
 }
 
 public class AuthorizationSummary


### PR DESCRIPTION
API returns int, portal expected string. Added StatusText property.