### PR TITLE
feat: PA Rule Explorer for TMPPM prior auth rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ obj/
 **/TestResults/
 src/portal/CloudHealthOffice.Portal/appsettings.Development.json
 .env.local
+tmppm-data/

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/TmppmRuleQueryServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/TmppmRuleQueryServiceTests.cs
@@ -1,0 +1,471 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using CloudHealthOffice.Portal.Services;
+
+namespace CloudHealthOffice.Portal.Tests.Services;
+
+public class TmppmRuleQueryServiceTests
+{
+    private readonly Mock<IMongoClient> _mongoClient = new();
+    private readonly Mock<IMongoDatabase> _database = new();
+    private readonly Mock<IMongoCollection<BsonDocument>> _paRulesCol = new();
+    private readonly Mock<IMongoCollection<BsonDocument>> _editionsCol = new();
+    private readonly Mock<IMongoCollection<BsonDocument>> _diffsCol = new();
+    private readonly Mock<ILogger<TmppmRuleQueryService>> _logger = new();
+
+    private IConfiguration BuildConfig(Dictionary<string, string?>? extra = null)
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["Mongo:Tmppm:DatabaseName"] = "cho_terminology",
+            ["Mongo:Tmppm:PaRulesCollectionName"] = "tmppm_pa_rules",
+            ["Mongo:Tmppm:EditionsCollectionName"] = "tmppm_editions",
+            ["Mongo:Tmppm:DiffReportsCollectionName"] = "tmppm_diff_reports"
+        };
+        if (extra != null)
+            foreach (var kv in extra) dict[kv.Key] = kv.Value;
+
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    public TmppmRuleQueryServiceTests()
+    {
+        _mongoClient.Setup(c => c.GetDatabase(It.IsAny<string>(), null)).Returns(_database.Object);
+        _database.Setup(d => d.GetCollection<BsonDocument>("tmppm_pa_rules", null)).Returns(_paRulesCol.Object);
+        _database.Setup(d => d.GetCollection<BsonDocument>("tmppm_editions", null)).Returns(_editionsCol.Object);
+        _database.Setup(d => d.GetCollection<BsonDocument>("tmppm_diff_reports", null)).Returns(_diffsCol.Object);
+    }
+
+    private TmppmRuleQueryService CreateService(IConfiguration? config = null)
+        => new(_mongoClient.Object, config ?? BuildConfig(), _logger.Object);
+
+    private static Mock<IAsyncCursor<T>> CreateCursor<T>(List<T> items)
+    {
+        var cursor = new Mock<IAsyncCursor<T>>();
+        var first = true;
+        cursor.Setup(c => c.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => { if (first) { first = false; return items.Count > 0; } return false; });
+        cursor.Setup(c => c.Current).Returns(items);
+        cursor.Setup(c => c.Dispose());
+        return cursor;
+    }
+
+    // ── Constructor / Configuration ──
+
+    [Fact]
+    public void Constructor_UsesConfiguredDatabaseName()
+    {
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Mongo:Tmppm:DatabaseName"] = "custom_db"
+        });
+
+        _ = new TmppmRuleQueryService(_mongoClient.Object, config, _logger.Object);
+
+        _mongoClient.Verify(c => c.GetDatabase("custom_db", null), Times.Once());
+    }
+
+    [Fact]
+    public void Constructor_FallsBackToDefaultDatabaseName_WhenConfigMissing()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        _ = new TmppmRuleQueryService(_mongoClient.Object, config, _logger.Object);
+
+        _mongoClient.Verify(c => c.GetDatabase("cho_terminology", null), Times.Once());
+    }
+
+    [Fact]
+    public void Constructor_UsesConfiguredCollectionNames()
+    {
+        var config = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Mongo:Tmppm:PaRulesCollectionName"] = "custom_pa_rules"
+        });
+        _database.Setup(d => d.GetCollection<BsonDocument>("custom_pa_rules", null)).Returns(_paRulesCol.Object);
+
+        _ = new TmppmRuleQueryService(_mongoClient.Object, config, _logger.Object);
+
+        _database.Verify(d => d.GetCollection<BsonDocument>("custom_pa_rules", null), Times.Once());
+    }
+
+    // ── SearchByCodeAsync — normalization ──
+
+    [Fact]
+    public async Task SearchByCodeAsync_NormalizesCodeToUppercase()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        await sut.SearchByCodeAsync("64582");
+
+        // No assertions on the filter internals via Moq; verify FindAsync was called once
+        _paRulesCol.Verify(c => c.FindAsync(
+            It.IsAny<FilterDefinition<BsonDocument>>(),
+            It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task SearchByCodeAsync_ReturnsEmptyList_WhenNoDocumentsMatch()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.SearchByCodeAsync("UNKNOWN");
+
+        result.Should().BeEmpty();
+    }
+
+    // ── SearchByCodeAsync — mapping (MapToRuleViewModel) ──
+
+    [Fact]
+    public async Task SearchByCodeAsync_MapsBasicFields_Correctly()
+    {
+        var doc = new BsonDocument
+        {
+            { "ruleId", "RULE-001" },
+            { "category", "Radiology" },
+            { "tmppmRef", "TMPPM §5.2" },
+            { "authRequired", true },
+            { "authType", "PreAuth" },
+            { "procedureCodes", new BsonArray { "64582", "64583" } },
+            { "codeSystem", "CPT" },
+            { "state", "TX" },
+            { "sourceEdition", "2025-Q1" }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.SearchByCodeAsync("64582");
+
+        result.Should().HaveCount(1);
+        var vm = result[0];
+        vm.RuleId.Should().Be("RULE-001");
+        vm.Category.Should().Be("Radiology");
+        vm.TmppmRef.Should().Be("TMPPM §5.2");
+        vm.AuthRequired.Should().BeTrue();
+        vm.AuthType.Should().Be("PreAuth");
+        vm.ProcedureCodes.Should().BeEquivalentTo(["64582", "64583"]);
+        vm.CodeSystem.Should().Be("CPT");
+        vm.State.Should().Be("TX");
+        vm.SourceEdition.Should().Be("2025-Q1");
+    }
+
+    [Fact]
+    public async Task SearchByCodeAsync_MapsAgeLimit_WhenPresent()
+    {
+        var doc = new BsonDocument
+        {
+            { "ruleId", "RULE-002" },
+            { "category", "Pediatric" },
+            { "tmppmRef", "TMPPM §3.1" },
+            { "authRequired", false },
+            { "procedureCodes", new BsonArray { "99213" } },
+            { "codeSystem", "CPT" },
+            { "state", "TX" },
+            { "sourceEdition", "2025-Q1" },
+            { "ageLimit", new BsonDocument
+                {
+                    { "minAge", 0 },
+                    { "maxAge", 17 },
+                    { "unit", "years" }
+                }
+            }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.SearchByCodeAsync("99213");
+
+        result.Should().HaveCount(1);
+        result[0].AgeLimit.Should().NotBeNull();
+        result[0].AgeLimit!.MinAge.Should().Be(0);
+        result[0].AgeLimit!.MaxAge.Should().Be(17);
+        result[0].AgeLimit!.Unit.Should().Be("years");
+    }
+
+    [Fact]
+    public async Task SearchByCodeAsync_MapsUnitLimit_WhenPresent()
+    {
+        var doc = new BsonDocument
+        {
+            { "ruleId", "RULE-003" },
+            { "category", "Therapy" },
+            { "tmppmRef", "TMPPM §7.4" },
+            { "authRequired", true },
+            { "procedureCodes", new BsonArray { "97110" } },
+            { "codeSystem", "CPT" },
+            { "state", "TX" },
+            { "sourceEdition", "2025-Q1" },
+            { "unitLimit", new BsonDocument
+                {
+                    { "maxUnits", 52 },
+                    { "per", "year" },
+                    { "resetCondition", "CalendarYear" }
+                }
+            }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.SearchByCodeAsync("97110");
+
+        result.Should().HaveCount(1);
+        result[0].UnitLimit.Should().NotBeNull();
+        result[0].UnitLimit!.MaxUnits.Should().Be(52);
+        result[0].UnitLimit!.Per.Should().Be("year");
+        result[0].UnitLimit!.ResetCondition.Should().Be("CalendarYear");
+    }
+
+    [Fact]
+    public async Task SearchByCodeAsync_LeavesAgeLimitNull_WhenFieldAbsent()
+    {
+        var doc = new BsonDocument
+        {
+            { "ruleId", "RULE-004" }, { "category", "Surgery" }, { "tmppmRef", "TMPPM §2.0" },
+            { "authRequired", true }, { "procedureCodes", new BsonArray { "27447" } },
+            { "codeSystem", "CPT" }, { "state", "TX" }, { "sourceEdition", "2025-Q1" }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.SearchByCodeAsync("27447");
+
+        result[0].AgeLimit.Should().BeNull();
+        result[0].UnitLimit.Should().BeNull();
+    }
+
+    // ── SearchByCodeAsync — state filter ──
+
+    [Fact]
+    public async Task SearchByCodeAsync_CallsFindAsync_WhenStateFilterProvided()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        await sut.SearchByCodeAsync("64582", state: "TX");
+
+        _paRulesCol.Verify(c => c.FindAsync(
+            It.IsAny<FilterDefinition<BsonDocument>>(),
+            It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    // ── GetRulesByCategoryAsync — mapping ──
+
+    [Fact]
+    public async Task GetRulesByCategoryAsync_MapsDocumentsToViewModels()
+    {
+        var doc = new BsonDocument
+        {
+            { "ruleId", "RULE-100" },
+            { "category", "DME" },
+            { "tmppmRef", "TMPPM §9.0" },
+            { "authRequired", true },
+            { "procedureCodes", new BsonArray { "E0601" } },
+            { "codeSystem", "HCPCS" },
+            { "state", "TX" },
+            { "sourceEdition", "2025-Q1" }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.GetRulesByCategoryAsync("DME");
+
+        result.Should().HaveCount(1);
+        result[0].RuleId.Should().Be("RULE-100");
+        result[0].CodeSystem.Should().Be("HCPCS");
+    }
+
+    [Fact]
+    public async Task GetRulesByCategoryAsync_CallsFindAsync_WhenStateFilterProvided()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        await sut.GetRulesByCategoryAsync("DME", state: "TX");
+
+        _paRulesCol.Verify(c => c.FindAsync(
+            It.IsAny<FilterDefinition<BsonDocument>>(),
+            It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    // ── GetCurrentEditionAsync — mapping (MapToEditionViewModel) ──
+
+    [Fact]
+    public async Task GetCurrentEditionAsync_ReturnsNull_WhenNoEditionsExist()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _editionsCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.GetCurrentEditionAsync();
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentEditionAsync_MapsEditionFields_Correctly()
+    {
+        var pubDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var policyDate = new DateTime(2025, 3, 31, 0, 0, 0, DateTimeKind.Utc);
+        var ingestedAt = new DateTime(2025, 1, 5, 12, 0, 0, DateTimeKind.Utc);
+
+        var doc = new BsonDocument
+        {
+            { "editionId", "2025-Q1" },
+            { "publicationDate", BsonDateTime.Create(pubDate) },
+            { "policyThroughDate", BsonDateTime.Create(policyDate) },
+            { "sourceUrl", "https://www.tmhp.com/tmppm/2025-q1.pdf" },
+            { "ingestedAt", BsonDateTime.Create(ingestedAt) },
+            { "chapters", new BsonArray() }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _editionsCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.GetCurrentEditionAsync();
+
+        result.Should().NotBeNull();
+        result!.EditionId.Should().Be("2025-Q1");
+        result.PublicationDate.Should().Be(new DateOnly(2025, 1, 1));
+        result.PolicyThroughDate.Should().Be(new DateOnly(2025, 3, 31));
+        result.SourceUrl.Should().Be("https://www.tmhp.com/tmppm/2025-q1.pdf");
+        result.IngestedAt.Should().Be(ingestedAt);
+        result.Chapters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCurrentEditionAsync_MapsChapters_WhenPresent()
+    {
+        var doc = new BsonDocument
+        {
+            { "editionId", "2025-Q2" },
+            { "publicationDate", BsonDateTime.Create(new DateTime(2025, 4, 1, 0, 0, 0, DateTimeKind.Utc)) },
+            { "policyThroughDate", BsonDateTime.Create(new DateTime(2025, 6, 30, 0, 0, 0, DateTimeKind.Utc)) },
+            { "sourceUrl", "" },
+            { "ingestedAt", BsonDateTime.Create(DateTime.UtcNow) },
+            { "chapters", new BsonArray
+                {
+                    new BsonDocument
+                    {
+                        { "chapterId", "CH-05" },
+                        { "title", "Radiology Services" },
+                        { "pdfUrl", "https://www.tmhp.com/tmppm/ch5.pdf" },
+                        { "sha256", "abc123" },
+                        { "extractedRuleCount", 42 }
+                    }
+                }
+            }
+        };
+
+        var cursor = CreateCursor(new List<BsonDocument> { doc });
+        _editionsCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.GetCurrentEditionAsync();
+
+        result!.Chapters.Should().HaveCount(1);
+        result.Chapters[0].ChapterId.Should().Be("CH-05");
+        result.Chapters[0].Title.Should().Be("Radiology Services");
+        result.Chapters[0].Sha256.Should().Be("abc123");
+        result.Chapters[0].ExtractedRuleCount.Should().Be(42);
+    }
+
+    // ── AutocompleteCodeAsync ──
+
+    [Fact]
+    public async Task AutocompleteCodeAsync_ReturnsEmpty_WhenPrefixIsBlank()
+    {
+        var sut = CreateService();
+        var result = await sut.AutocompleteCodeAsync("   ");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AutocompleteCodeAsync_NormalizesPrefix_AndQueriesCollection()
+    {
+        var cursor = CreateCursor(new List<BsonDocument>());
+        _paRulesCol.Setup(c => c.FindAsync(
+                It.IsAny<FilterDefinition<BsonDocument>>(),
+                It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(cursor.Object);
+
+        var sut = CreateService();
+        var result = await sut.AutocompleteCodeAsync("g02");
+
+        result.Should().BeEmpty();
+        _paRulesCol.Verify(c => c.FindAsync(
+            It.IsAny<FilterDefinition<BsonDocument>>(),
+            It.IsAny<FindOptions<BsonDocument, BsonDocument>>(),
+            It.IsAny<CancellationToken>()), Times.Once());
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Infrastructure/TmppmIndexService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Infrastructure/TmppmIndexService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Configuration;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace CloudHealthOffice.Portal.Infrastructure;
+
+/// <summary>
+/// Creates MongoDB indexes for the TMPPM collections on startup.
+/// Runs as a hosted background service so the UI path is never blocked on index creation.
+/// </summary>
+public class TmppmIndexService : BackgroundService
+{
+    private readonly IMongoClient _mongoClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<TmppmIndexService> _logger;
+
+    public TmppmIndexService(
+        IMongoClient mongoClient,
+        IConfiguration configuration,
+        ILogger<TmppmIndexService> logger)
+    {
+        _mongoClient = mongoClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await Task.Delay(
+            TimeSpan.FromSeconds(
+                _configuration.GetValue<int>("Mongo:Tmppm:IndexCreationDelaySeconds", 5)),
+            stoppingToken);
+
+        try
+        {
+            var databaseName = _configuration["Mongo:Tmppm:DatabaseName"] ?? "cho_terminology";
+            var paRulesName = _configuration["Mongo:Tmppm:PaRulesCollectionName"] ?? "tmppm_pa_rules";
+            var editionsName = _configuration["Mongo:Tmppm:EditionsCollectionName"] ?? "tmppm_editions";
+
+            var db = _mongoClient.GetDatabase(databaseName);
+            var paRules = db.GetCollection<BsonDocument>(paRulesName);
+            var editions = db.GetCollection<BsonDocument>(editionsName);
+
+            await paRules.Indexes.CreateOneAsync(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("procedureCodes"),
+                new CreateIndexOptions { Name = "idx_procedure_codes" }), cancellationToken: stoppingToken);
+
+            await paRules.Indexes.CreateOneAsync(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys
+                    .Ascending("category")
+                    .Ascending("state"),
+                new CreateIndexOptions { Name = "idx_category_state" }), cancellationToken: stoppingToken);
+
+            await editions.Indexes.CreateOneAsync(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Descending("ingestedAt"),
+                new CreateIndexOptions { Name = "idx_ingested_at" }), cancellationToken: stoppingToken);
+
+            _logger.LogInformation("TMPPM indexes created or verified successfully");
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown before indexes were created — safe to ignore
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create TMPPM indexes — they may already exist");
+        }
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Models/TmppmViewModels.cs
+++ b/src/portal/CloudHealthOffice.Portal/Models/TmppmViewModels.cs
@@ -1,0 +1,88 @@
+namespace CloudHealthOffice.Portal.Models;
+
+public class TmppmPaRuleViewModel
+{
+    public string RuleId { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string TmppmRef { get; set; } = string.Empty;
+    public bool AuthRequired { get; set; }
+    public string? AuthType { get; set; }
+    public List<string> ProcedureCodes { get; set; } = [];
+    public string CodeSystem { get; set; } = "CPT";
+    public string? ClinicalCriteriaSummary { get; set; }
+    public List<string>? RequiredDocumentation { get; set; }
+    public AgeRuleViewModel? AgeLimit { get; set; }
+    public UnitLimitViewModel? UnitLimit { get; set; }
+    public List<string>? AllowedDiagnoses { get; set; }
+    public string State { get; set; } = "TX";
+    public string SourceEdition { get; set; } = string.Empty;
+}
+
+public class AgeRuleViewModel
+{
+    public int? MinAge { get; set; }
+    public int? MaxAge { get; set; }
+    public string? Unit { get; set; } = "years";
+}
+
+public class UnitLimitViewModel
+{
+    public int MaxUnits { get; set; }
+    public string Per { get; set; } = string.Empty;
+    public string? ResetCondition { get; set; }
+}
+
+public class PaCategoryGroup
+{
+    public string Priority { get; set; } = string.Empty;
+    public List<PaCategorySummary> Categories { get; set; } = [];
+}
+
+public class PaCategorySummary
+{
+    public string Category { get; set; } = string.Empty;
+    public string TmppmRef { get; set; } = string.Empty;
+    public int RuleCount { get; set; }
+    public int CodeCount { get; set; }
+}
+
+public class TmppmEditionViewModel
+{
+    public string EditionId { get; set; } = string.Empty;
+    public DateOnly PublicationDate { get; set; }
+    public DateOnly PolicyThroughDate { get; set; }
+    public string SourceUrl { get; set; } = string.Empty;
+    public DateTime IngestedAt { get; set; }
+    public List<TmppmChapterViewModel> Chapters { get; set; } = [];
+}
+
+public class TmppmChapterViewModel
+{
+    public string ChapterId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string PdfUrl { get; set; } = string.Empty;
+    public string? Sha256 { get; set; }
+    public int ExtractedRuleCount { get; set; }
+}
+
+public class TmppmDiffViewModel
+{
+    public string FromEdition { get; set; } = string.Empty;
+    public string ToEdition { get; set; } = string.Empty;
+    public DateTime GeneratedAt { get; set; }
+    public List<TmppmRuleDeltaViewModel> Deltas { get; set; } = [];
+    public int AddedCount => Deltas.Count(d => d.DeltaType == "Added");
+    public int ModifiedCount => Deltas.Count(d => d.DeltaType == "Modified");
+    public int RemovedCount => Deltas.Count(d => d.DeltaType == "Removed");
+}
+
+public class TmppmRuleDeltaViewModel
+{
+    public string DeltaType { get; set; } = string.Empty;
+    public string RuleId { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string? PreviousValue { get; set; }
+    public string? NewValue { get; set; }
+    public string? Description { get; set; }
+    public bool RequiresHumanReview { get; set; }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCard.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCard.razor
@@ -153,8 +153,8 @@
 
     private string GetTmppmUrl()
     {
-        // Construct TMHP PDF URL from the TMPPM reference
-        // TMHP publishes TMPPM chapters at known URLs
+        // Return the generic TMHP TMPPM landing page.
+        // This method does not currently resolve Rule.TmppmRef to a chapter- or PDF-specific deep link.
         return $"https://www.tmhp.com/resources/provider-manuals/tmppm";
     }
 }

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCard.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCard.razor
@@ -1,0 +1,160 @@
+@using CloudHealthOffice.Portal.Models
+
+<MudPaper Class="@($"pa-rule-card {Class}")" Elevation="0">
+    <div class="pa-rule-card-header">
+        <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+            @if (Rule.AuthRequired)
+            {
+                <MudChip Size="Size.Small"
+                         Style="background: rgba(0, 229, 204, 0.15); color: #00e5cc; border: 1px solid rgba(0, 229, 204, 0.3); font-weight: 600;">
+                    PA Required
+                </MudChip>
+                @if (!string.IsNullOrEmpty(Rule.AuthType))
+                {
+                    <MudChip Size="Size.Small"
+                             Style="background: rgba(0, 229, 204, 0.08); color: #9c9a92; border: 1px solid #2a2a35;">
+                        @Rule.AuthType
+                    </MudChip>
+                }
+            }
+            else
+            {
+                <MudChip Size="Size.Small"
+                         Style="background: rgba(0, 255, 136, 0.15); color: #00ff88; border: 1px solid rgba(0, 255, 136, 0.3); font-weight: 600;">
+                    No PA Required
+                </MudChip>
+            }
+            <MudChip Size="Size.Small"
+                     Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.75rem;">
+                @Rule.SourceEdition TMPPM
+            </MudChip>
+        </div>
+    </div>
+
+    <div class="pa-rule-card-body">
+        <div style="display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 8px;">
+            <div>
+                <MudText Typo="Typo.subtitle1" Style="color: #e8e6e0; font-weight: 600;">
+                    @Rule.Category
+                </MudText>
+                <MudLink Href="@GetTmppmUrl()" Target="_blank"
+                         Style="color: #9c9a92; font-size: 0.85rem; font-family: 'JetBrains Mono', monospace;">
+                    @Rule.TmppmRef
+                    <MudIcon Icon="@Icons.Material.Filled.OpenInNew" Size="Size.Small" Style="font-size: 0.75rem;" />
+                </MudLink>
+            </div>
+            <div style="display: flex; align-items: center; gap: 4px;">
+                <MudChip Size="Size.Small"
+                         Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35;">
+                    @Rule.CodeSystem
+                </MudChip>
+            </div>
+        </div>
+
+        <!-- Procedure Codes -->
+        <div class="pa-code-pills">
+            @foreach (var procedureCode in Rule.ProcedureCodes)
+            {
+                <span class="pa-code-pill">@procedureCode</span>
+            }
+        </div>
+
+        <!-- Age / Unit Limits -->
+        @if (Rule.AgeLimit != null || Rule.UnitLimit != null)
+        {
+            <div style="display: flex; gap: 16px; flex-wrap: wrap; margin-top: 8px;">
+                @if (Rule.AgeLimit != null)
+                {
+                    <div class="pa-limit-badge">
+                        <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Small" Style="color: #9c9a92;" />
+                        <span>
+                            @if (Rule.AgeLimit.MinAge.HasValue && Rule.AgeLimit.MaxAge.HasValue)
+                            {
+                                @($"{Rule.AgeLimit.MinAge}–{Rule.AgeLimit.MaxAge} {Rule.AgeLimit.Unit}")
+                            }
+                            else if (Rule.AgeLimit.MinAge.HasValue)
+                            {
+                                @($"{Rule.AgeLimit.MinAge}+ {Rule.AgeLimit.Unit}")
+                            }
+                            else if (Rule.AgeLimit.MaxAge.HasValue)
+                            {
+                                @($"Under {Rule.AgeLimit.MaxAge} {Rule.AgeLimit.Unit}")
+                            }
+                        </span>
+                    </div>
+                }
+                @if (Rule.UnitLimit != null)
+                {
+                    <div class="pa-limit-badge">
+                        <MudIcon Icon="@Icons.Material.Filled.Numbers" Size="Size.Small" Style="color: #9c9a92;" />
+                        <span>Max @Rule.UnitLimit.MaxUnits per @Rule.UnitLimit.Per</span>
+                    </div>
+                }
+            </div>
+        }
+
+        <!-- Clinical Criteria (collapsible) -->
+        @if (!string.IsNullOrEmpty(Rule.ClinicalCriteriaSummary))
+        {
+            <MudExpansionPanels Class="mt-3" Elevation="0">
+                <MudExpansionPanel Style="background: #0a0a0f; border: 1px solid #2a2a35;">
+                    <TitleContent>
+                        <MudText Typo="Typo.body2" Style="color: #9c9a92;">
+                            <MudIcon Icon="@Icons.Material.Filled.MedicalInformation" Size="Size.Small" Class="mr-1" />
+                            Clinical Criteria
+                        </MudText>
+                    </TitleContent>
+                    <ChildContent>
+                        <MudText Typo="Typo.body2" Style="color: #e8e6e0; line-height: 1.6;">
+                            @Rule.ClinicalCriteriaSummary
+                        </MudText>
+                    </ChildContent>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        }
+
+        <!-- Required Documentation -->
+        @if (Rule.RequiredDocumentation is { Count: > 0 })
+        {
+            <div class="mt-3">
+                <MudText Typo="Typo.caption" Style="color: #9c9a92; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px;">
+                    Required Documentation
+                </MudText>
+                <ul class="pa-doc-list">
+                    @foreach (var doc in Rule.RequiredDocumentation)
+                    {
+                        <li>@doc</li>
+                    }
+                </ul>
+            </div>
+        }
+
+        <!-- Allowed Diagnoses -->
+        @if (Rule.AllowedDiagnoses is { Count: > 0 })
+        {
+            <div class="mt-3">
+                <MudText Typo="Typo.caption" Style="color: #9c9a92; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 4px;">
+                    Allowed Diagnoses
+                </MudText>
+                <div class="pa-code-pills">
+                    @foreach (var dx in Rule.AllowedDiagnoses)
+                    {
+                        <span class="pa-code-pill pa-code-pill-secondary">@dx</span>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter, EditorRequired] public TmppmPaRuleViewModel Rule { get; set; } = null!;
+    [Parameter] public string? Class { get; set; }
+
+    private string GetTmppmUrl()
+    {
+        // Construct TMHP PDF URL from the TMPPM reference
+        // TMHP publishes TMPPM chapters at known URLs
+        return $"https://www.tmhp.com/resources/provider-manuals/tmppm";
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCategoryBrowser.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleCategoryBrowser.razor
@@ -1,0 +1,89 @@
+@using CloudHealthOffice.Portal.Models
+
+<MudPaper Style="background: #111118; border: 1px solid #2a2a35; border-radius: 8px; overflow: hidden;">
+    <div style="padding: 16px; border-bottom: 1px solid #2a2a35;">
+        <MudText Typo="Typo.subtitle2" Style="color: #e8e6e0; font-weight: 600;">
+            <MudIcon Icon="@Icons.Material.Filled.Category" Size="Size.Small" Class="mr-1" />
+            PA Categories
+        </MudText>
+    </div>
+
+    @if (Loading)
+    {
+        <div style="padding: 16px;">
+            @for (int i = 0; i < 5; i++)
+            {
+                <MudSkeleton SkeletonType="SkeletonType.Text" Class="mb-2" />
+            }
+        </div>
+    }
+    else if (Categories.Count == 0)
+    {
+        <div style="padding: 24px; text-align: center;">
+            <MudText Typo="Typo.body2" Style="color: #9c9a92;">No categories available</MudText>
+        </div>
+    }
+    else
+    {
+        <MudNavMenu Style="padding: 8px;">
+            @foreach (var group in Categories)
+            {
+                <MudNavGroup Title="@($"{group.Priority} — {GetPriorityLabel(group.Priority)} ({group.Categories.Count})")"
+                             Expanded="@(group.Priority == "P1")"
+                             Icon="@Icons.Material.Filled.FolderOpen"
+                             Style="border-left: 3px solid transparent;">
+                    @foreach (var cat in group.Categories)
+                    {
+                        <MudNavLink OnClick="@(() => SelectCategory(cat.Category))"
+                                    Style="@GetCategoryStyle(cat.Category)">
+                            <div style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
+                                <div style="overflow: hidden;">
+                                    <div style="font-size: 0.82rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                        @cat.Category
+                                    </div>
+                                    <div style="font-size: 0.7rem; color: #9c9a92; font-family: 'JetBrains Mono', monospace;">
+                                        @cat.TmppmRef
+                                    </div>
+                                </div>
+                                <MudChip Size="Size.Small"
+                                         Style="background: transparent; color: #9c9a92; font-size: 0.65rem; min-width: auto; height: 18px;">
+                                    @cat.RuleCount
+                                </MudChip>
+                            </div>
+                        </MudNavLink>
+                    }
+                </MudNavGroup>
+            }
+        </MudNavMenu>
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public List<PaCategoryGroup> Categories { get; set; } = [];
+    [Parameter] public bool Loading { get; set; }
+    [Parameter] public EventCallback<string> OnCategorySelected { get; set; }
+
+    private string? _selectedCategory;
+
+    private async Task SelectCategory(string category)
+    {
+        _selectedCategory = category;
+        await OnCategorySelected.InvokeAsync(category);
+    }
+
+    private string GetCategoryStyle(string category)
+    {
+        var isSelected = _selectedCategory == category;
+        return isSelected
+            ? "border-left: 3px solid #00e5cc; background: rgba(0, 229, 204, 0.05); transition: all 0.2s ease;"
+            : "border-left: 3px solid transparent; transition: all 0.2s ease;";
+    }
+
+    private static string GetPriorityLabel(string priority) => priority switch
+    {
+        "P1" => "Auth Required",
+        "P2" => "Limits & Restrictions",
+        "P3" => "Other Rules",
+        _ => priority
+    };
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleSearchBar.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleSearchBar.razor
@@ -12,16 +12,16 @@
                   OnKeyDown="HandleKeyDown"
                   Style="font-family: 'JetBrains Mono', monospace;" />
 
-    @if (_showSuggestions && Suggestions.Count > 0)
+    @if (_showSuggestions && _localSuggestions.Count > 0)
     {
-        <MudPaper Class="pa-autocomplete-dropdown" Elevation="4">
-            @foreach (var suggestion in Suggestions)
+        <MudPaper Class="pa-autocomplete-dropdown" Elevation="4" role="listbox" aria-label="Procedure code suggestions">
+            @foreach (var suggestion in _localSuggestions)
             {
-                <div class="pa-autocomplete-item" @onclick="() => SelectSuggestion(suggestion)">
+                <button type="button" class="pa-autocomplete-item" role="option" aria-selected="false" @onclick="() => SelectSuggestion(suggestion)">
                     <MudIcon Icon="@Icons.Material.Filled.Code" Size="Size.Small"
                              Style="color: #9c9a92; margin-right: 8px;" />
                     <span style="font-family: 'JetBrains Mono', monospace; color: #00e5cc;">@suggestion</span>
-                </div>
+                </button>
             }
         </MudPaper>
     }
@@ -30,23 +30,24 @@
 @code {
     [Parameter] public EventCallback<string> OnSearch { get; set; }
     [Parameter] public Func<string, Task<List<string>>>? OnAutocomplete { get; set; }
-    [Parameter] public List<string> Suggestions { get; set; } = [];
 
     private string _searchText = string.Empty;
     private bool _showSuggestions;
+    private List<string> _localSuggestions = [];
 
     private async Task HandleInputChanged(string value)
     {
         if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
         {
             _showSuggestions = false;
+            _localSuggestions = [];
             return;
         }
 
         if (OnAutocomplete != null)
         {
-            await OnAutocomplete(value);
-            _showSuggestions = Suggestions.Count > 0;
+            _localSuggestions = await OnAutocomplete(value);
+            _showSuggestions = _localSuggestions.Count > 0;
         }
     }
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleSearchBar.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/PaRuleSearchBar.razor
@@ -1,0 +1,72 @@
+@using CloudHealthOffice.Portal.Models
+
+<div class="pa-search-bar">
+    <MudTextField @bind-Value="_searchText"
+                  Placeholder="Enter CPT or HCPCS code (e.g., 64582, G0277)"
+                  Variant="Variant.Outlined"
+                  Adornment="Adornment.Start"
+                  AdornmentIcon="@Icons.Material.Filled.Search"
+                  Immediate="true"
+                  DebounceInterval="300"
+                  OnDebounceIntervalElapsed="HandleInputChanged"
+                  OnKeyDown="HandleKeyDown"
+                  Style="font-family: 'JetBrains Mono', monospace;" />
+
+    @if (_showSuggestions && Suggestions.Count > 0)
+    {
+        <MudPaper Class="pa-autocomplete-dropdown" Elevation="4">
+            @foreach (var suggestion in Suggestions)
+            {
+                <div class="pa-autocomplete-item" @onclick="() => SelectSuggestion(suggestion)">
+                    <MudIcon Icon="@Icons.Material.Filled.Code" Size="Size.Small"
+                             Style="color: #9c9a92; margin-right: 8px;" />
+                    <span style="font-family: 'JetBrains Mono', monospace; color: #00e5cc;">@suggestion</span>
+                </div>
+            }
+        </MudPaper>
+    }
+</div>
+
+@code {
+    [Parameter] public EventCallback<string> OnSearch { get; set; }
+    [Parameter] public Func<string, Task<List<string>>>? OnAutocomplete { get; set; }
+    [Parameter] public List<string> Suggestions { get; set; } = [];
+
+    private string _searchText = string.Empty;
+    private bool _showSuggestions;
+
+    private async Task HandleInputChanged(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
+        {
+            _showSuggestions = false;
+            return;
+        }
+
+        if (OnAutocomplete != null)
+        {
+            await OnAutocomplete(value);
+            _showSuggestions = Suggestions.Count > 0;
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(_searchText))
+        {
+            _showSuggestions = false;
+            await OnSearch.InvokeAsync(_searchText);
+        }
+        else if (e.Key == "Escape")
+        {
+            _showSuggestions = false;
+        }
+    }
+
+    private async Task SelectSuggestion(string code)
+    {
+        _searchText = code;
+        _showSuggestions = false;
+        await OnSearch.InvokeAsync(code);
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmDiffViewer.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmDiffViewer.razor
@@ -1,0 +1,188 @@
+@using CloudHealthOffice.Portal.Models
+
+<div class="mt-2">
+    <MudGrid>
+        <MudItem xs="12" md="5">
+            <MudSelect T="string" @bind-Value="_fromEdition" Label="From Edition" Variant="Variant.Outlined">
+                @foreach (var edition in Editions)
+                {
+                    <MudSelectItem Value="@edition.EditionId">@FormatEditionName(edition.EditionId)</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" md="5">
+            <MudSelect T="string" @bind-Value="_toEdition" Label="To Edition" Variant="Variant.Outlined">
+                @foreach (var edition in Editions)
+                {
+                    <MudSelectItem Value="@edition.EditionId">@FormatEditionName(edition.EditionId)</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" md="2" Style="display: flex; align-items: center;">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                       FullWidth="true"
+                       Disabled="@(string.IsNullOrEmpty(_fromEdition) || string.IsNullOrEmpty(_toEdition) || Loading)"
+                       OnClick="RequestDiff">
+                @if (Loading)
+                {
+                    <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                }
+                Compare
+            </MudButton>
+        </MudItem>
+    </MudGrid>
+
+    @if (Loading)
+    {
+        <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mt-4" />
+    }
+    else if (DiffResult != null)
+    {
+        <div class="mt-4">
+            <!-- Summary chips -->
+            <div style="display: flex; gap: 12px; margin-bottom: 16px; flex-wrap: wrap;">
+                <MudChip Style="background: rgba(0, 255, 136, 0.15); color: #00ff88; border: 1px solid rgba(0, 255, 136, 0.3);">
+                    <MudIcon Icon="@Icons.Material.Filled.Add" Size="Size.Small" Class="mr-1" />
+                    @DiffResult.AddedCount Added
+                </MudChip>
+                <MudChip Style="background: rgba(0, 229, 204, 0.15); color: #00e5cc; border: 1px solid rgba(0, 229, 204, 0.3);">
+                    <MudIcon Icon="@Icons.Material.Filled.Edit" Size="Size.Small" Class="mr-1" />
+                    @DiffResult.ModifiedCount Modified
+                </MudChip>
+                <MudChip Style="background: rgba(255, 0, 85, 0.15); color: #ff0055; border: 1px solid rgba(255, 0, 85, 0.3);">
+                    <MudIcon Icon="@Icons.Material.Filled.Remove" Size="Size.Small" Class="mr-1" />
+                    @DiffResult.RemovedCount Removed
+                </MudChip>
+            </div>
+
+            @if (DiffResult.Deltas.Count == 0)
+            {
+                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                    No changes detected between these editions.
+                </MudAlert>
+            }
+            else
+            {
+                <!-- Filter by delta type -->
+                <div style="display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;">
+                    <MudToggleIconButton @bind-Toggled="_showAdded"
+                                         Icon="@Icons.Material.Filled.AddCircleOutline"
+                                         ToggledIcon="@Icons.Material.Filled.AddCircle"
+                                         Style="@(_showAdded ? "color: #00ff88;" : "color: #9c9a92;")"
+                                         Title="Added" />
+                    <MudToggleIconButton @bind-Toggled="_showModified"
+                                         Icon="@Icons.Material.Filled.EditNote"
+                                         ToggledIcon="@Icons.Material.Filled.Edit"
+                                         Style="@(_showModified ? "color: #00e5cc;" : "color: #9c9a92;")"
+                                         Title="Modified" />
+                    <MudToggleIconButton @bind-Toggled="_showRemoved"
+                                         Icon="@Icons.Material.Filled.RemoveCircleOutline"
+                                         ToggledIcon="@Icons.Material.Filled.RemoveCircle"
+                                         Style="@(_showRemoved ? "color: #ff0055;" : "color: #9c9a92;")"
+                                         Title="Removed" />
+                </div>
+
+                @foreach (var delta in FilteredDeltas)
+                {
+                    <MudPaper Class="pa-diff-card mb-3" Elevation="0">
+                        <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 8px;">
+                            <MudChip Size="Size.Small" Style="@GetDeltaStyle(delta.DeltaType)">
+                                @delta.DeltaType
+                            </MudChip>
+                            <MudText Typo="Typo.subtitle2" Style="color: #e8e6e0;">@delta.Category</MudText>
+                            @if (delta.RequiresHumanReview)
+                            {
+                                <MudChip Size="Size.Small"
+                                         Style="background: rgba(255, 170, 0, 0.15); color: #ffaa00; border: 1px solid rgba(255, 170, 0, 0.3);">
+                                    <MudIcon Icon="@Icons.Material.Filled.Warning" Size="Size.Small" Class="mr-1" />
+                                    Review Required
+                                </MudChip>
+                            }
+                        </div>
+
+                        @if (!string.IsNullOrEmpty(delta.Description))
+                        {
+                            <MudText Typo="Typo.body2" Style="color: #9c9a92; margin-bottom: 8px;">
+                                @delta.Description
+                            </MudText>
+                        }
+
+                        @if (delta.DeltaType == "Modified")
+                        {
+                            <MudGrid Spacing="2">
+                                @if (!string.IsNullOrEmpty(delta.PreviousValue))
+                                {
+                                    <MudItem xs="12" md="6">
+                                        <div class="pa-diff-before">
+                                            <MudText Typo="Typo.caption" Style="color: #ff0055; margin-bottom: 4px;">Before</MudText>
+                                            <MudText Typo="Typo.body2" Style="color: #e8e6e0; font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;">
+                                                @delta.PreviousValue
+                                            </MudText>
+                                        </div>
+                                    </MudItem>
+                                }
+                                @if (!string.IsNullOrEmpty(delta.NewValue))
+                                {
+                                    <MudItem xs="12" md="6">
+                                        <div class="pa-diff-after">
+                                            <MudText Typo="Typo.caption" Style="color: #00ff88; margin-bottom: 4px;">After</MudText>
+                                            <MudText Typo="Typo.body2" Style="color: #e8e6e0; font-family: 'JetBrains Mono', monospace; font-size: 0.8rem;">
+                                                @delta.NewValue
+                                            </MudText>
+                                        </div>
+                                    </MudItem>
+                                }
+                            </MudGrid>
+                        }
+                    </MudPaper>
+                }
+            }
+        </div>
+    }
+    else if (Editions.Count < 2)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+            At least two TMPPM editions are required to generate a diff comparison.
+        </MudAlert>
+    }
+</div>
+
+@code {
+    [Parameter] public List<TmppmEditionViewModel> Editions { get; set; } = [];
+    [Parameter] public EventCallback<(string from, string to)> OnDiffRequested { get; set; }
+    [Parameter] public TmppmDiffViewModel? DiffResult { get; set; }
+    [Parameter] public bool Loading { get; set; }
+
+    private string? _fromEdition;
+    private string? _toEdition;
+    private bool _showAdded = true;
+    private bool _showModified = true;
+    private bool _showRemoved = true;
+
+    private IEnumerable<TmppmRuleDeltaViewModel> FilteredDeltas =>
+        DiffResult?.Deltas.Where(d =>
+            (d.DeltaType == "Added" && _showAdded) ||
+            (d.DeltaType == "Modified" && _showModified) ||
+            (d.DeltaType == "Removed" && _showRemoved)) ?? [];
+
+    private async Task RequestDiff()
+    {
+        if (!string.IsNullOrEmpty(_fromEdition) && !string.IsNullOrEmpty(_toEdition))
+            await OnDiffRequested.InvokeAsync((_fromEdition, _toEdition));
+    }
+
+    private static string FormatEditionName(string editionId)
+    {
+        if (DateOnly.TryParseExact(editionId + "-01", "yyyy-MM-dd", out var date))
+            return $"{date:MMMM yyyy}";
+        return editionId;
+    }
+
+    private static string GetDeltaStyle(string deltaType) => deltaType switch
+    {
+        "Added" => "background: rgba(0, 255, 136, 0.15); color: #00ff88; border: 1px solid rgba(0, 255, 136, 0.3);",
+        "Modified" => "background: rgba(0, 229, 204, 0.15); color: #00e5cc; border: 1px solid rgba(0, 229, 204, 0.3);",
+        "Removed" => "background: rgba(255, 0, 85, 0.15); color: #ff0055; border: 1px solid rgba(255, 0, 85, 0.3);",
+        _ => "background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35;"
+    };
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
@@ -25,11 +25,11 @@
             <div style="margin-top: 8px; display: flex; gap: 8px;">
                 <MudChip Size="Size.Small"
                          Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
-                    @Edition.Chapters.Count chapters
+                    @($"{Edition.Chapters.Count} chapters")
                 </MudChip>
                 <MudChip Size="Size.Small"
                          Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
-                    @Edition.Chapters.Sum(c => c.ExtractedRuleCount) rules
+                    @($"{GetTotalRuleCount()} rules")
                 </MudChip>
             </div>
         }
@@ -43,6 +43,9 @@
 @code {
     [Parameter] public TmppmEditionViewModel? Edition { get; set; }
     [Parameter] public bool Loading { get; set; }
+
+    private int GetTotalRuleCount() =>
+        Edition?.Chapters.Sum(c => c.ExtractedRuleCount) ?? 0;
 
     private string GetFreshnessClass()
     {

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
@@ -9,7 +9,7 @@
     else if (Edition != null)
     {
         <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
-            <span class="pa-freshness-dot @GetFreshnessClass()"></span>
+            <span class="@GetFreshnessCssClass()"></span>
             <MudText Typo="Typo.caption" Style="color: #9c9a92; text-transform: uppercase; letter-spacing: 0.05em;">
                 Current Edition
             </MudText>
@@ -18,18 +18,18 @@
             @FormatEditionName(Edition.EditionId)
         </MudText>
         <MudText Typo="Typo.caption" Style="color: #9c9a92;">
-            Loaded @Edition.IngestedAt.ToString("MMM dd, yyyy HH:mm") UTC
+            Loaded @FormatIngestedAt() UTC
         </MudText>
         @if (Edition.Chapters.Count > 0)
         {
             <div style="margin-top: 8px; display: flex; gap: 8px;">
                 <MudChip Size="Size.Small"
                          Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
-                    @($"{Edition.Chapters.Count} chapters")
+                    @GetChapterCountLabel()
                 </MudChip>
                 <MudChip Size="Size.Small"
                          Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
-                    @($"{GetTotalRuleCount()} rules")
+                    @GetRuleCountLabel()
                 </MudChip>
             </div>
         }
@@ -44,26 +44,38 @@
     [Parameter] public TmppmEditionViewModel? Edition { get; set; }
     [Parameter] public bool Loading { get; set; }
 
-    private int GetTotalRuleCount() =>
-        Edition?.Chapters.Sum(c => c.ExtractedRuleCount) ?? 0;
-
-    private string GetFreshnessClass()
+    private string GetChapterCountLabel()
     {
-        if (Edition == null) return "pa-freshness-red";
-        var age = DateTime.UtcNow - Edition.IngestedAt;
-        return age.TotalDays switch
-        {
-            < 30 => "pa-freshness-green",
-            < 60 => "pa-freshness-amber",
-            _ => "pa-freshness-red"
-        };
+        return Edition != null ? Edition.Chapters.Count + " chapters" : "";
+    }
+
+    private string GetRuleCountLabel()
+    {
+        if (Edition == null) return "";
+        var total = 0;
+        foreach (var ch in Edition.Chapters)
+            total += ch.ExtractedRuleCount;
+        return total + " rules";
+    }
+
+    private string FormatIngestedAt()
+    {
+        return Edition != null ? Edition.IngestedAt.ToString("MMM dd, yyyy HH:mm") : "";
+    }
+
+    private string GetFreshnessCssClass()
+    {
+        if (Edition == null) return "pa-freshness-dot pa-freshness-red";
+        var days = (DateTime.UtcNow - Edition.IngestedAt).TotalDays;
+        if (days < 30) return "pa-freshness-dot pa-freshness-green";
+        if (days < 60) return "pa-freshness-dot pa-freshness-amber";
+        return "pa-freshness-dot pa-freshness-red";
     }
 
     private static string FormatEditionName(string editionId)
     {
-        // Convert "2026-04" to "April 2026 TMPPM"
         if (DateOnly.TryParseExact(editionId + "-01", "yyyy-MM-dd", out var date))
-            return $"{date:MMMM yyyy} TMPPM";
+            return date.ToString("MMMM yyyy") + " TMPPM";
         return editionId;
     }
 }

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/Components/TmppmEditionStatus.razor
@@ -1,0 +1,66 @@
+@using CloudHealthOffice.Portal.Models
+
+<MudPaper Style="background: #111118; border: 1px solid #2a2a35; border-radius: 8px; padding: 16px; min-width: 220px;">
+    @if (Loading)
+    {
+        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" />
+        <MudSkeleton SkeletonType="SkeletonType.Text" Width="160px" Class="mt-1" />
+    }
+    else if (Edition != null)
+    {
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+            <span class="pa-freshness-dot @GetFreshnessClass()"></span>
+            <MudText Typo="Typo.caption" Style="color: #9c9a92; text-transform: uppercase; letter-spacing: 0.05em;">
+                Current Edition
+            </MudText>
+        </div>
+        <MudText Typo="Typo.subtitle1" Style="color: #e8e6e0; font-weight: 600;">
+            @FormatEditionName(Edition.EditionId)
+        </MudText>
+        <MudText Typo="Typo.caption" Style="color: #9c9a92;">
+            Loaded @Edition.IngestedAt.ToString("MMM dd, yyyy HH:mm") UTC
+        </MudText>
+        @if (Edition.Chapters.Count > 0)
+        {
+            <div style="margin-top: 8px; display: flex; gap: 8px;">
+                <MudChip Size="Size.Small"
+                         Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
+                    @Edition.Chapters.Count chapters
+                </MudChip>
+                <MudChip Size="Size.Small"
+                         Style="background: #1a1a24; color: #9c9a92; border: 1px solid #2a2a35; font-size: 0.7rem;">
+                    @Edition.Chapters.Sum(c => c.ExtractedRuleCount) rules
+                </MudChip>
+            </div>
+        }
+    }
+    else
+    {
+        <MudText Typo="Typo.caption" Style="color: #9c9a92;">No edition loaded</MudText>
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public TmppmEditionViewModel? Edition { get; set; }
+    [Parameter] public bool Loading { get; set; }
+
+    private string GetFreshnessClass()
+    {
+        if (Edition == null) return "pa-freshness-red";
+        var age = DateTime.UtcNow - Edition.IngestedAt;
+        return age.TotalDays switch
+        {
+            < 30 => "pa-freshness-green",
+            < 60 => "pa-freshness-amber",
+            _ => "pa-freshness-red"
+        };
+    }
+
+    private static string FormatEditionName(string editionId)
+    {
+        // Convert "2026-04" to "April 2026 TMPPM"
+        if (DateOnly.TryParseExact(editionId + "-01", "yyyy-MM-dd", out var date))
+            return $"{date:MMMM yyyy} TMPPM";
+        return editionId;
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor
@@ -1,0 +1,146 @@
+@page "/compliance/pa-rules"
+@using Microsoft.AspNetCore.Authorization
+@using CloudHealthOffice.Portal.Services
+@using CloudHealthOffice.Portal.Models
+@using CloudHealthOffice.Portal.Pages.Compliance.Components
+@attribute [Authorize]
+@inject ITmppmRuleQueryService RuleService
+@inject ISnackbar Snackbar
+
+<PageTitle>PA Rule Explorer - Cloud Health Office</PageTitle>
+
+<PermissionGate Permission="compliance:read,authorizations:read" RoleName="ComplianceViewer">
+<MudContainer MaxWidth="MaxWidth.ExtraExtraLarge" Class="mt-4">
+
+    <div class="pa-explorer-header">
+        <div>
+            <MudText Typo="Typo.h3" GutterBottom="true">
+                <MudIcon Icon="@Icons.Material.Filled.Policy" Class="mr-2" />
+                PA Rule Explorer
+            </MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+                Search Texas Medicaid prior authorization requirements from the TMPPM
+            </MudText>
+        </div>
+        <TmppmEditionStatus Edition="_currentEdition" Loading="_editionLoading" />
+    </div>
+
+    @if (_serviceError != null)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4"
+                  ShowCloseIcon="true" CloseIconClicked="() => _serviceError = null">
+            @_serviceError
+        </MudAlert>
+    }
+
+    <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true"
+             Class="pa-explorer-tabs" @bind-ActivePanelIndex="_activeTab">
+
+        <!-- SEARCH TAB -->
+        <MudTabPanel Text="Search by Code" Icon="@Icons.Material.Filled.Search">
+            <PaRuleSearchBar OnSearch="HandleSearchAsync"
+                             OnAutocomplete="HandleAutocompleteAsync"
+                             Suggestions="_autocompleteSuggestions" />
+
+            <div class="mt-4">
+                @if (_searchLoading)
+                {
+                    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
+                    <MudGrid>
+                        @for (int i = 0; i < 3; i++)
+                        {
+                            <MudItem xs="12">
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="180px" />
+                            </MudItem>
+                        }
+                    </MudGrid>
+                }
+                else if (_searchResults != null && _searchResults.Count > 0)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
+                        @_searchResults.Count rule(s) found for <strong style="color: #00e5cc;">@_lastSearchCode</strong>
+                    </MudText>
+                    @foreach (var rule in _searchResults)
+                    {
+                        <PaRuleCard Rule="rule" Class="mb-3" />
+                    }
+                }
+                else if (_searchResults != null && _searchResults.Count == 0)
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+                        No TX Medicaid PA rules found for <strong>@_lastSearchCode</strong>.
+                        This code may not require prior authorization, or rules may not yet be
+                        extracted for this service category.
+                    </MudAlert>
+                }
+                else
+                {
+                    <div class="pa-empty-state">
+                        <MudIcon Icon="@Icons.Material.Filled.ManageSearch"
+                                 Style="font-size: 4rem; color: #2a2a35;" />
+                        <MudText Typo="Typo.h6" Style="color: #9c9a92;" Class="mt-3">
+                            Search by CPT or HCPCS code to check Texas Medicaid PA requirements
+                        </MudText>
+                    </div>
+                }
+            </div>
+        </MudTabPanel>
+
+        <!-- CATEGORY BROWSER TAB -->
+        <MudTabPanel Text="Browse by Category" Icon="@Icons.Material.Filled.Category">
+            <MudGrid Class="mt-2">
+                <MudItem xs="12" md="4" lg="3">
+                    <PaRuleCategoryBrowser Categories="_categories"
+                                           Loading="_categoriesLoading"
+                                           OnCategorySelected="HandleCategorySelectedAsync" />
+                </MudItem>
+                <MudItem xs="12" md="8" lg="9">
+                    @if (_categoryRulesLoading)
+                    {
+                        <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
+                    }
+                    else if (_categoryRules != null && _categoryRules.Count > 0)
+                    {
+                        <MudText Typo="Typo.h6" Class="mb-3" Style="color: #e8e6e0;">
+                            @_selectedCategory
+                            <MudChip Size="Size.Small" Style="background: #1a1a24; color: #00e5cc; border: 1px solid #2a2a35;">
+                                @_categoryRules.Count rules
+                            </MudChip>
+                        </MudText>
+                        @foreach (var rule in _categoryRules)
+                        {
+                            <PaRuleCard Rule="rule" Class="mb-3" />
+                        }
+                    }
+                    else if (_selectedCategory != null)
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                            No rules found for this category.
+                        </MudAlert>
+                    }
+                    else
+                    {
+                        <div class="pa-empty-state">
+                            <MudIcon Icon="@Icons.Material.Filled.FolderOpen"
+                                     Style="font-size: 4rem; color: #2a2a35;" />
+                            <MudText Typo="Typo.h6" Style="color: #9c9a92;" Class="mt-3">
+                                Select a category from the sidebar to view its PA rules
+                            </MudText>
+                        </div>
+                    }
+                </MudItem>
+            </MudGrid>
+        </MudTabPanel>
+
+        <!-- DIFF VIEW TAB -->
+        <MudTabPanel Text="Edition Changes" Icon="@Icons.Material.Filled.CompareArrows">
+            <TmppmDiffViewer Editions="_allEditions"
+                             OnDiffRequested="HandleDiffRequestedAsync"
+                             DiffResult="_diffResult"
+                             Loading="_diffLoading" />
+        </MudTabPanel>
+
+    </MudTabs>
+
+</MudContainer>
+</PermissionGate>

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor
@@ -39,8 +39,7 @@
         <!-- SEARCH TAB -->
         <MudTabPanel Text="Search by Code" Icon="@Icons.Material.Filled.Search">
             <PaRuleSearchBar OnSearch="HandleSearchAsync"
-                             OnAutocomplete="HandleAutocompleteAsync"
-                             Suggestions="_autocompleteSuggestions" />
+                             OnAutocomplete="HandleAutocompleteAsync" />
 
             <div class="mt-4">
                 @if (_searchLoading)

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.cs
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.cs
@@ -12,7 +12,6 @@ public partial class PaRuleExplorer
     private bool _searchLoading;
     private List<TmppmPaRuleViewModel>? _searchResults;
     private string? _lastSearchCode;
-    private List<string> _autocompleteSuggestions = [];
 
     // Category state
     private bool _categoriesLoading = true;
@@ -100,8 +99,7 @@ public partial class PaRuleExplorer
     {
         try
         {
-            _autocompleteSuggestions = await RuleService.AutocompleteCodeAsync(prefix);
-            return _autocompleteSuggestions;
+            return await RuleService.AutocompleteCodeAsync(prefix);
         }
         catch
         {

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.cs
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.cs
@@ -1,0 +1,150 @@
+using CloudHealthOffice.Portal.Models;
+using CloudHealthOffice.Portal.Services;
+
+namespace CloudHealthOffice.Portal.Pages.Compliance;
+
+public partial class PaRuleExplorer
+{
+    private string? _serviceError;
+    private int _activeTab;
+
+    // Search state
+    private bool _searchLoading;
+    private List<TmppmPaRuleViewModel>? _searchResults;
+    private string? _lastSearchCode;
+    private List<string> _autocompleteSuggestions = [];
+
+    // Category state
+    private bool _categoriesLoading = true;
+    private List<PaCategoryGroup> _categories = [];
+    private string? _selectedCategory;
+    private List<TmppmPaRuleViewModel>? _categoryRules;
+    private bool _categoryRulesLoading;
+
+    // Edition state
+    private bool _editionLoading = true;
+    private TmppmEditionViewModel? _currentEdition;
+    private List<TmppmEditionViewModel> _allEditions = [];
+
+    // Diff state
+    private bool _diffLoading;
+    private TmppmDiffViewModel? _diffResult;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.WhenAll(
+            LoadEditionAsync(),
+            LoadCategoriesAsync());
+    }
+
+    private async Task LoadEditionAsync()
+    {
+        try
+        {
+            _editionLoading = true;
+            var editionsTask = RuleService.GetAllEditionsAsync();
+            var currentTask = RuleService.GetCurrentEditionAsync();
+            await Task.WhenAll(editionsTask, currentTask);
+            _allEditions = editionsTask.Result;
+            _currentEdition = currentTask.Result;
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Failed to load edition data: {ex.Message}";
+        }
+        finally
+        {
+            _editionLoading = false;
+        }
+    }
+
+    private async Task LoadCategoriesAsync()
+    {
+        try
+        {
+            _categoriesLoading = true;
+            _categories = await RuleService.GetCategoriesAsync();
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Failed to load categories: {ex.Message}";
+        }
+        finally
+        {
+            _categoriesLoading = false;
+        }
+    }
+
+    private async Task HandleSearchAsync(string code)
+    {
+        if (string.IsNullOrWhiteSpace(code)) return;
+
+        try
+        {
+            _searchLoading = true;
+            _lastSearchCode = code.Trim().ToUpperInvariant();
+            _searchResults = await RuleService.SearchByCodeAsync(_lastSearchCode);
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Search failed: {ex.Message}";
+            _searchResults = [];
+        }
+        finally
+        {
+            _searchLoading = false;
+        }
+    }
+
+    private async Task<List<string>> HandleAutocompleteAsync(string prefix)
+    {
+        try
+        {
+            _autocompleteSuggestions = await RuleService.AutocompleteCodeAsync(prefix);
+            return _autocompleteSuggestions;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private async Task HandleCategorySelectedAsync(string category)
+    {
+        try
+        {
+            _selectedCategory = category;
+            _categoryRulesLoading = true;
+            StateHasChanged();
+            _categoryRules = await RuleService.GetRulesByCategoryAsync(category);
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Failed to load rules for {category}: {ex.Message}";
+            _categoryRules = [];
+        }
+        finally
+        {
+            _categoryRulesLoading = false;
+        }
+    }
+
+    private async Task HandleDiffRequestedAsync((string from, string to) editions)
+    {
+        try
+        {
+            _diffLoading = true;
+            StateHasChanged();
+            _diffResult = await RuleService.GetDiffAsync(editions.from, editions.to);
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Failed to load diff: {ex.Message}";
+            _diffResult = null;
+        }
+        finally
+        {
+            _diffLoading = false;
+        }
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.css
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Compliance/PaRuleExplorer.razor.css
@@ -1,0 +1,245 @@
+/* PA Rule Explorer — Sentinel Dark Theme */
+
+::deep .pa-explorer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 8px;
+}
+
+::deep .pa-explorer-tabs .mud-tabs-toolbar {
+    background: transparent;
+    border-bottom: 1px solid #2a2a35;
+}
+
+::deep .pa-explorer-tabs .mud-tab.mud-tab-active {
+    color: #00e5cc !important;
+}
+
+::deep .pa-explorer-tabs .mud-tab-slider {
+    background: #00e5cc !important;
+}
+
+/* Search bar */
+::deep .pa-search-bar {
+    position: relative;
+    margin-bottom: 8px;
+}
+
+::deep .pa-search-bar .mud-input-outlined .mud-input-outlined-border {
+    border-color: #2a2a35;
+    transition: border-color 0.2s ease;
+}
+
+::deep .pa-search-bar .mud-input-outlined:hover .mud-input-outlined-border {
+    border-color: rgba(0, 229, 204, 0.4);
+}
+
+::deep .pa-search-bar .mud-input-outlined.mud-focused .mud-input-outlined-border {
+    border-color: #00e5cc;
+    box-shadow: 0 0 0 2px rgba(0, 229, 204, 0.15);
+}
+
+::deep .pa-autocomplete-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    background: #111118;
+    border: 1px solid #2a2a35;
+    border-radius: 4px;
+    max-height: 240px;
+    overflow-y: auto;
+    margin-top: 4px;
+}
+
+::deep .pa-autocomplete-item {
+    display: flex;
+    align-items: center;
+    padding: 10px 16px;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+::deep .pa-autocomplete-item:hover {
+    background: rgba(0, 229, 204, 0.08);
+}
+
+/* Rule card */
+::deep .pa-rule-card {
+    background: #111118;
+    border: 1px solid #2a2a35;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: border-color 0.2s ease;
+}
+
+::deep .pa-rule-card:hover {
+    border-color: rgba(0, 229, 204, 0.3);
+}
+
+::deep .pa-rule-card-header {
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(42, 42, 53, 0.5);
+}
+
+::deep .pa-rule-card-body {
+    padding: 16px;
+}
+
+/* Code pills */
+::deep .pa-code-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+::deep .pa-code-pill {
+    display: inline-block;
+    padding: 2px 10px;
+    background: rgba(0, 229, 204, 0.1);
+    color: #00e5cc;
+    border: 1px solid rgba(0, 229, 204, 0.25);
+    border-radius: 4px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+::deep .pa-code-pill-secondary {
+    background: rgba(156, 154, 146, 0.1);
+    color: #9c9a92;
+    border-color: rgba(156, 154, 146, 0.25);
+}
+
+/* Limit badges */
+::deep .pa-limit-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    background: #1a1a24;
+    border: 1px solid #2a2a35;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    color: #e8e6e0;
+}
+
+/* Documentation list */
+::deep .pa-doc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+::deep .pa-doc-list li {
+    position: relative;
+    padding: 4px 0 4px 16px;
+    color: #e8e6e0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+::deep .pa-doc-list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 12px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #00e5cc;
+    opacity: 0.6;
+}
+
+/* Priority dots */
+::deep .pa-priority-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+::deep .pa-priority-p1 {
+    background: #00ff88;
+    box-shadow: 0 0 6px rgba(0, 255, 136, 0.4);
+}
+
+::deep .pa-priority-p2 {
+    background: #ffaa00;
+    box-shadow: 0 0 6px rgba(255, 170, 0, 0.4);
+}
+
+::deep .pa-priority-p3 {
+    background: #9c9a92;
+}
+
+/* Freshness indicator */
+::deep .pa-freshness-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+::deep .pa-freshness-green {
+    background: #00ff88;
+    box-shadow: 0 0 6px rgba(0, 255, 136, 0.5);
+}
+
+::deep .pa-freshness-amber {
+    background: #ffaa00;
+    box-shadow: 0 0 6px rgba(255, 170, 0, 0.5);
+}
+
+::deep .pa-freshness-red {
+    background: #ff0055;
+    box-shadow: 0 0 6px rgba(255, 0, 85, 0.5);
+}
+
+/* Diff cards */
+::deep .pa-diff-card {
+    background: #111118;
+    border: 1px solid #2a2a35;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+::deep .pa-diff-before {
+    background: rgba(255, 0, 85, 0.05);
+    border: 1px solid rgba(255, 0, 85, 0.2);
+    border-radius: 4px;
+    padding: 10px;
+}
+
+::deep .pa-diff-after {
+    background: rgba(0, 255, 136, 0.05);
+    border: 1px solid rgba(0, 255, 136, 0.2);
+    border-radius: 4px;
+    padding: 10px;
+}
+
+/* Empty state */
+::deep .pa-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 64px 24px;
+    text-align: center;
+}
+
+/* Collapsible panels inside cards */
+::deep .pa-rule-card .mud-expand-panel {
+    background: transparent !important;
+    box-shadow: none !important;
+}
+
+::deep .pa-rule-card .mud-expand-panel-header {
+    padding: 8px 0 !important;
+}

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -312,6 +312,7 @@ static string BuildAdminConsentErrorUrl(string? tenantId)
 
 // Register background tenant seed so it doesn't block startup or health probes
 builder.Services.AddHostedService<TenantSeedService>();
+builder.Services.AddHostedService<TmppmIndexService>();
 
 var app = builder.Build();
 

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -255,6 +255,9 @@ builder.Services.AddScoped<IProviderContractsService, ProviderContractsService>(
 builder.Services.AddScoped<IArService, ArServiceImpl>();
 builder.Services.AddScoped<ITerminologyService, TerminologyServiceImpl>();
 
+// TMPPM PA Rule query service (direct MongoDB queries for PA Rule Explorer)
+builder.Services.AddSingleton<ITmppmRuleQueryService, TmppmRuleQueryService>();
+
 // Add SignalR with tuned timeouts to reduce spurious circuit disconnects
 builder.Services.AddSignalR(options =>
 {

--- a/src/portal/CloudHealthOffice.Portal/Services/ITmppmRuleQueryService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ITmppmRuleQueryService.cs
@@ -1,0 +1,20 @@
+using CloudHealthOffice.Portal.Models;
+
+namespace CloudHealthOffice.Portal.Services;
+
+public interface ITmppmRuleQueryService
+{
+    Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null);
+
+    Task<List<PaCategoryGroup>> GetCategoriesAsync(string state = "TX");
+
+    Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null);
+
+    Task<TmppmEditionViewModel?> GetCurrentEditionAsync();
+
+    Task<TmppmDiffViewModel?> GetDiffAsync(string fromEdition, string toEdition);
+
+    Task<List<string>> AutocompleteCodeAsync(string prefix, int maxResults = 10);
+
+    Task<List<TmppmEditionViewModel>> GetAllEditionsAsync();
+}

--- a/src/portal/CloudHealthOffice.Portal/Services/ITmppmRuleQueryService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ITmppmRuleQueryService.cs
@@ -4,11 +4,11 @@ namespace CloudHealthOffice.Portal.Services;
 
 public interface ITmppmRuleQueryService
 {
-    Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null);
+    Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null, string? state = null);
 
     Task<List<PaCategoryGroup>> GetCategoriesAsync(string state = "TX");
 
-    Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null);
+    Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null, string? state = null);
 
     Task<TmppmEditionViewModel?> GetCurrentEditionAsync();
 

--- a/src/portal/CloudHealthOffice.Portal/Services/TmppmRuleQueryService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/TmppmRuleQueryService.cs
@@ -1,0 +1,312 @@
+using CloudHealthOffice.Portal.Models;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Portal.Services;
+
+public class TmppmRuleQueryService : ITmppmRuleQueryService
+{
+    private readonly IMongoCollection<BsonDocument> _paRules;
+    private readonly IMongoCollection<BsonDocument> _editions;
+    private readonly IMongoCollection<BsonDocument> _diffs;
+    private readonly ILogger<TmppmRuleQueryService> _logger;
+
+    public TmppmRuleQueryService(IMongoClient mongoClient, ILogger<TmppmRuleQueryService> logger)
+    {
+        var database = mongoClient.GetDatabase("cho_terminology");
+        _paRules = database.GetCollection<BsonDocument>("tmppm_pa_rules");
+        _editions = database.GetCollection<BsonDocument>("tmppm_editions");
+        _diffs = database.GetCollection<BsonDocument>("tmppm_diff_reports");
+        _logger = logger;
+
+        EnsureIndexes();
+    }
+
+    private void EnsureIndexes()
+    {
+        try
+        {
+            _paRules.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Ascending("procedureCodes"),
+                new CreateIndexOptions { Name = "idx_procedure_codes" }));
+
+            _paRules.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys
+                    .Ascending("category")
+                    .Ascending("state"),
+                new CreateIndexOptions { Name = "idx_category_state" }));
+
+            _editions.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
+                Builders<BsonDocument>.IndexKeys.Descending("ingestedAt"),
+                new CreateIndexOptions { Name = "idx_ingested_at" }));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create TMPPM indexes — may already exist");
+        }
+    }
+
+    public async Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null)
+    {
+        var normalizedCode = code.Trim().ToUpperInvariant();
+
+        var filter = Builders<BsonDocument>.Filter.AnyEq("procedureCodes", normalizedCode);
+        if (!string.IsNullOrEmpty(tenantId))
+            filter &= Builders<BsonDocument>.Filter.Eq("tenantId", tenantId);
+
+        var docs = await _paRules.Find(filter)
+            .Sort(Builders<BsonDocument>.Sort.Ascending("category"))
+            .ToListAsync();
+
+        return docs.Select(MapToRuleViewModel).ToList();
+    }
+
+    public async Task<List<PaCategoryGroup>> GetCategoriesAsync(string state = "TX")
+    {
+        var pipeline = new[]
+        {
+            new BsonDocument("$match", new BsonDocument("state", state)),
+            new BsonDocument("$group", new BsonDocument
+            {
+                { "_id", new BsonDocument { { "category", "$category" }, { "tmppmRef", "$tmppmRef" } } },
+                { "ruleCount", new BsonDocument("$sum", 1) },
+                { "codes", new BsonDocument("$addToSet", new BsonDocument("$ifNull",
+                    new BsonArray { "$procedureCodes", new BsonArray() })) },
+                { "ruleType", new BsonDocument("$first", "$ruleType") }
+            }),
+            new BsonDocument("$sort", new BsonDocument("_id.category", 1))
+        };
+
+        var results = await _paRules.Aggregate<BsonDocument>(pipeline).ToListAsync();
+
+        var categories = results.Select(doc =>
+        {
+            var id = doc["_id"].AsBsonDocument;
+            var codes = doc.Contains("codes")
+                ? doc["codes"].AsBsonArray
+                    .SelectMany(a => a.IsBsonArray ? a.AsBsonArray.Select(v => v.AsString) : Enumerable.Empty<string>())
+                    .Distinct()
+                    .ToList()
+                : new List<string>();
+
+            return new
+            {
+                Category = id.GetValue("category", "").AsString,
+                TmppmRef = id.GetValue("tmppmRef", "").AsString,
+                RuleCount = doc["ruleCount"].ToInt32(),
+                CodeCount = codes.Count,
+                RuleType = doc.GetValue("ruleType", "").AsString
+            };
+        }).ToList();
+
+        // Group by priority based on rule type heuristics
+        var grouped = new List<PaCategoryGroup>
+        {
+            new()
+            {
+                Priority = "P1",
+                Categories = categories
+                    .Where(c => c.RuleType is "AuthRequired" or "DiagnosisRestriction")
+                    .Select(c => new PaCategorySummary
+                    {
+                        Category = c.Category,
+                        TmppmRef = c.TmppmRef,
+                        RuleCount = c.RuleCount,
+                        CodeCount = c.CodeCount
+                    })
+                    .OrderBy(c => c.Category)
+                    .ToList()
+            },
+            new()
+            {
+                Priority = "P2",
+                Categories = categories
+                    .Where(c => c.RuleType is "AgeLimit" or "UnitLimit")
+                    .Select(c => new PaCategorySummary
+                    {
+                        Category = c.Category,
+                        TmppmRef = c.TmppmRef,
+                        RuleCount = c.RuleCount,
+                        CodeCount = c.CodeCount
+                    })
+                    .OrderBy(c => c.Category)
+                    .ToList()
+            },
+            new()
+            {
+                Priority = "P3",
+                Categories = categories
+                    .Where(c => c.RuleType is not "AuthRequired" and not "DiagnosisRestriction"
+                        and not "AgeLimit" and not "UnitLimit")
+                    .Select(c => new PaCategorySummary
+                    {
+                        Category = c.Category,
+                        TmppmRef = c.TmppmRef,
+                        RuleCount = c.RuleCount,
+                        CodeCount = c.CodeCount
+                    })
+                    .OrderBy(c => c.Category)
+                    .ToList()
+            }
+        };
+
+        return grouped.Where(g => g.Categories.Count > 0).ToList();
+    }
+
+    public async Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null)
+    {
+        var filter = Builders<BsonDocument>.Filter.Eq("category", category);
+        if (!string.IsNullOrEmpty(tenantId))
+            filter &= Builders<BsonDocument>.Filter.Eq("tenantId", tenantId);
+
+        var docs = await _paRules.Find(filter)
+            .Sort(Builders<BsonDocument>.Sort.Ascending("tmppmRef"))
+            .ToListAsync();
+
+        return docs.Select(MapToRuleViewModel).ToList();
+    }
+
+    public async Task<TmppmEditionViewModel?> GetCurrentEditionAsync()
+    {
+        var doc = await _editions.Find(Builders<BsonDocument>.Filter.Empty)
+            .Sort(Builders<BsonDocument>.Sort.Descending("ingestedAt"))
+            .FirstOrDefaultAsync();
+
+        return doc == null ? null : MapToEditionViewModel(doc);
+    }
+
+    public async Task<List<TmppmEditionViewModel>> GetAllEditionsAsync()
+    {
+        var docs = await _editions.Find(Builders<BsonDocument>.Filter.Empty)
+            .Sort(Builders<BsonDocument>.Sort.Descending("ingestedAt"))
+            .Limit(12)
+            .ToListAsync();
+
+        return docs.Select(MapToEditionViewModel).ToList();
+    }
+
+    public async Task<TmppmDiffViewModel?> GetDiffAsync(string fromEdition, string toEdition)
+    {
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("fromEdition", fromEdition),
+            Builders<BsonDocument>.Filter.Eq("toEdition", toEdition));
+
+        var doc = await _diffs.Find(filter).FirstOrDefaultAsync();
+        if (doc == null) return null;
+
+        return new TmppmDiffViewModel
+        {
+            FromEdition = doc.GetValue("fromEdition", "").AsString,
+            ToEdition = doc.GetValue("toEdition", "").AsString,
+            GeneratedAt = doc.GetValue("generatedAt", BsonDateTime.Create(DateTime.MinValue)).ToUniversalTime(),
+            Deltas = doc.GetValue("deltas", new BsonArray()).AsBsonArray.Select(d =>
+            {
+                var delta = d.AsBsonDocument;
+                return new TmppmRuleDeltaViewModel
+                {
+                    DeltaType = delta.GetValue("deltaType", "").AsString,
+                    RuleId = delta.GetValue("ruleId", "").AsString,
+                    Category = delta.GetValue("category", "").AsString,
+                    PreviousValue = delta.GetValue("previousValue", BsonNull.Value).IsBsonNull
+                        ? null : delta["previousValue"].AsString,
+                    NewValue = delta.GetValue("newValue", BsonNull.Value).IsBsonNull
+                        ? null : delta["newValue"].AsString,
+                    Description = delta.GetValue("description", BsonNull.Value).IsBsonNull
+                        ? null : delta["description"].AsString,
+                    RequiresHumanReview = delta.GetValue("requiresHumanReview", false).AsBoolean
+                };
+            }).ToList()
+        };
+    }
+
+    public async Task<List<string>> AutocompleteCodeAsync(string prefix, int maxResults = 10)
+    {
+        var normalizedPrefix = prefix.Trim().ToUpperInvariant();
+        if (string.IsNullOrEmpty(normalizedPrefix)) return [];
+
+        var filter = Builders<BsonDocument>.Filter.Regex(
+            "procedureCodes",
+            new BsonRegularExpression($"^{System.Text.RegularExpressions.Regex.Escape(normalizedPrefix)}", "i"));
+
+        var docs = await _paRules.Find(filter)
+            .Limit(50)
+            .ToListAsync();
+
+        return docs
+            .SelectMany(d => d.GetValue("procedureCodes", new BsonArray()).AsBsonArray.Select(v => v.AsString))
+            .Where(c => c.StartsWith(normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .OrderBy(c => c)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    private static TmppmPaRuleViewModel MapToRuleViewModel(BsonDocument doc)
+    {
+        return new TmppmPaRuleViewModel
+        {
+            RuleId = doc.GetValue("ruleId", "").AsString,
+            Category = doc.GetValue("category", "").AsString,
+            TmppmRef = doc.GetValue("tmppmRef", "").AsString,
+            AuthRequired = doc.GetValue("authRequired", false).AsBoolean,
+            AuthType = doc.GetValue("authType", BsonNull.Value).IsBsonNull ? null : doc["authType"].AsString,
+            ProcedureCodes = doc.GetValue("procedureCodes", new BsonArray()).AsBsonArray
+                .Select(v => v.AsString).ToList(),
+            CodeSystem = doc.GetValue("codeSystem", "CPT").AsString,
+            ClinicalCriteriaSummary = doc.GetValue("clinicalCriteriaSummary", BsonNull.Value).IsBsonNull
+                ? null : doc["clinicalCriteriaSummary"].AsString,
+            RequiredDocumentation = doc.GetValue("requiredDocumentation", BsonNull.Value).IsBsonNull
+                ? null : doc["requiredDocumentation"].AsBsonArray.Select(v => v.AsString).ToList(),
+            AgeLimit = doc.Contains("ageLimit") && !doc["ageLimit"].IsBsonNull
+                ? new AgeRuleViewModel
+                {
+                    MinAge = doc["ageLimit"].AsBsonDocument.GetValue("minAge", BsonNull.Value).IsBsonNull
+                        ? null : doc["ageLimit"]["minAge"].ToInt32(),
+                    MaxAge = doc["ageLimit"].AsBsonDocument.GetValue("maxAge", BsonNull.Value).IsBsonNull
+                        ? null : doc["ageLimit"]["maxAge"].ToInt32(),
+                    Unit = doc["ageLimit"].AsBsonDocument.GetValue("unit", "years").AsString
+                }
+                : null,
+            UnitLimit = doc.Contains("unitLimit") && !doc["unitLimit"].IsBsonNull
+                ? new UnitLimitViewModel
+                {
+                    MaxUnits = doc["unitLimit"].AsBsonDocument.GetValue("maxUnits", 0).ToInt32(),
+                    Per = doc["unitLimit"].AsBsonDocument.GetValue("per", "").AsString,
+                    ResetCondition = doc["unitLimit"].AsBsonDocument.GetValue("resetCondition", BsonNull.Value).IsBsonNull
+                        ? null : doc["unitLimit"]["resetCondition"].AsString
+                }
+                : null,
+            AllowedDiagnoses = doc.GetValue("allowedDiagnoses", BsonNull.Value).IsBsonNull
+                ? null : doc["allowedDiagnoses"].AsBsonArray.Select(v => v.AsString).ToList(),
+            State = doc.GetValue("state", "TX").AsString,
+            SourceEdition = doc.GetValue("sourceEdition", "").AsString
+        };
+    }
+
+    private static TmppmEditionViewModel MapToEditionViewModel(BsonDocument doc)
+    {
+        return new TmppmEditionViewModel
+        {
+            EditionId = doc.GetValue("editionId", "").AsString,
+            PublicationDate = DateOnly.FromDateTime(
+                doc.GetValue("publicationDate", BsonDateTime.Create(DateTime.MinValue)).ToUniversalTime()),
+            PolicyThroughDate = DateOnly.FromDateTime(
+                doc.GetValue("policyThroughDate", BsonDateTime.Create(DateTime.MinValue)).ToUniversalTime()),
+            SourceUrl = doc.GetValue("sourceUrl", "").AsString,
+            IngestedAt = doc.GetValue("ingestedAt", BsonDateTime.Create(DateTime.MinValue)).ToUniversalTime(),
+            Chapters = doc.GetValue("chapters", new BsonArray()).AsBsonArray.Select(c =>
+            {
+                var ch = c.AsBsonDocument;
+                return new TmppmChapterViewModel
+                {
+                    ChapterId = ch.GetValue("chapterId", "").AsString,
+                    Title = ch.GetValue("title", "").AsString,
+                    PdfUrl = ch.GetValue("pdfUrl", "").AsString,
+                    Sha256 = ch.GetValue("sha256", BsonNull.Value).IsBsonNull ? null : ch["sha256"].AsString,
+                    ExtractedRuleCount = ch.GetValue("extractedRuleCount", 0).ToInt32()
+                };
+            }).ToList()
+        };
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Services/TmppmRuleQueryService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/TmppmRuleQueryService.cs
@@ -1,4 +1,5 @@
 using CloudHealthOffice.Portal.Models;
+using Microsoft.Extensions.Configuration;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Microsoft.Extensions.Logging;
@@ -7,53 +8,42 @@ namespace CloudHealthOffice.Portal.Services;
 
 public class TmppmRuleQueryService : ITmppmRuleQueryService
 {
+    private const string DefaultDatabaseName = "cho_terminology";
+    private const string DefaultPaRulesCollectionName = "tmppm_pa_rules";
+    private const string DefaultEditionsCollectionName = "tmppm_editions";
+    private const string DefaultDiffReportsCollectionName = "tmppm_diff_reports";
+
     private readonly IMongoCollection<BsonDocument> _paRules;
     private readonly IMongoCollection<BsonDocument> _editions;
     private readonly IMongoCollection<BsonDocument> _diffs;
     private readonly ILogger<TmppmRuleQueryService> _logger;
 
-    public TmppmRuleQueryService(IMongoClient mongoClient, ILogger<TmppmRuleQueryService> logger)
+    public TmppmRuleQueryService(
+        IMongoClient mongoClient,
+        IConfiguration configuration,
+        ILogger<TmppmRuleQueryService> logger)
     {
-        var database = mongoClient.GetDatabase("cho_terminology");
-        _paRules = database.GetCollection<BsonDocument>("tmppm_pa_rules");
-        _editions = database.GetCollection<BsonDocument>("tmppm_editions");
-        _diffs = database.GetCollection<BsonDocument>("tmppm_diff_reports");
+        var databaseName = configuration["Mongo:Tmppm:DatabaseName"] ?? DefaultDatabaseName;
+        var paRulesCollectionName = configuration["Mongo:Tmppm:PaRulesCollectionName"] ?? DefaultPaRulesCollectionName;
+        var editionsCollectionName = configuration["Mongo:Tmppm:EditionsCollectionName"] ?? DefaultEditionsCollectionName;
+        var diffReportsCollectionName = configuration["Mongo:Tmppm:DiffReportsCollectionName"] ?? DefaultDiffReportsCollectionName;
+
+        var database = mongoClient.GetDatabase(databaseName);
+        _paRules = database.GetCollection<BsonDocument>(paRulesCollectionName);
+        _editions = database.GetCollection<BsonDocument>(editionsCollectionName);
+        _diffs = database.GetCollection<BsonDocument>(diffReportsCollectionName);
         _logger = logger;
-
-        EnsureIndexes();
     }
 
-    private void EnsureIndexes()
-    {
-        try
-        {
-            _paRules.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys.Ascending("procedureCodes"),
-                new CreateIndexOptions { Name = "idx_procedure_codes" }));
-
-            _paRules.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys
-                    .Ascending("category")
-                    .Ascending("state"),
-                new CreateIndexOptions { Name = "idx_category_state" }));
-
-            _editions.Indexes.CreateOne(new CreateIndexModel<BsonDocument>(
-                Builders<BsonDocument>.IndexKeys.Descending("ingestedAt"),
-                new CreateIndexOptions { Name = "idx_ingested_at" }));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to create TMPPM indexes — may already exist");
-        }
-    }
-
-    public async Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null)
+    public async Task<List<TmppmPaRuleViewModel>> SearchByCodeAsync(string code, string? tenantId = null, string? state = null)
     {
         var normalizedCode = code.Trim().ToUpperInvariant();
 
         var filter = Builders<BsonDocument>.Filter.AnyEq("procedureCodes", normalizedCode);
         if (!string.IsNullOrEmpty(tenantId))
             filter &= Builders<BsonDocument>.Filter.Eq("tenantId", tenantId);
+        if (!string.IsNullOrEmpty(state))
+            filter &= Builders<BsonDocument>.Filter.Eq("state", state);
 
         var docs = await _paRules.Find(filter)
             .Sort(Builders<BsonDocument>.Sort.Ascending("category"))
@@ -154,11 +144,13 @@ public class TmppmRuleQueryService : ITmppmRuleQueryService
         return grouped.Where(g => g.Categories.Count > 0).ToList();
     }
 
-    public async Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null)
+    public async Task<List<TmppmPaRuleViewModel>> GetRulesByCategoryAsync(string category, string? tenantId = null, string? state = null)
     {
         var filter = Builders<BsonDocument>.Filter.Eq("category", category);
         if (!string.IsNullOrEmpty(tenantId))
             filter &= Builders<BsonDocument>.Filter.Eq("tenantId", tenantId);
+        if (!string.IsNullOrEmpty(state))
+            filter &= Builders<BsonDocument>.Filter.Eq("state", state);
 
         var docs = await _paRules.Find(filter)
             .Sort(Builders<BsonDocument>.Sort.Ascending("tmppmRef"))

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
@@ -277,6 +277,15 @@
                         </MudNavLink>
                     </MudNavGroup>
 
+                    <!-- COMPLIANCE -->
+                    <MudNavGroup Title="Compliance" Icon="@Icons.Material.Filled.Policy" Expanded="false"
+                                 Style="border-left: 3px solid transparent;">
+                        <MudNavLink Href="/compliance/pa-rules" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Checklist"
+                                    Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
+                            PA Rule Explorer
+                        </MudNavLink>
+                    </MudNavGroup>
+
                     <MudDivider Style="margin: 12px 0; border-color: rgba(0, 255, 255, 0.15);" />
 
                     <!-- ADMIN -->

--- a/src/site/docs/texas-compliance.html
+++ b/src/site/docs/texas-compliance.html
@@ -120,6 +120,7 @@
             <div class="docs-sidebar-section-title">State Compliance</div>
             <ul>
               <li><a href="/docs/texas-compliance" class="active">Texas (STAR / STAR+PLUS)</a></li>
+              <li><a href="/docs/texas-tmppm-pa-rules">Texas TMPPM PA Rules</a></li>
               <li><a href="/docs/florida-compliance">Florida AHCA (SMMC 3.0)</a></li>
             </ul>
           </div>

--- a/src/site/docs/texas-tmppm-pa-rules.html
+++ b/src/site/docs/texas-tmppm-pa-rules.html
@@ -1,0 +1,510 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TMPPM Prior Authorization Rules — Texas Medicaid Compliance — Cloud Health Office</title>
+  <meta name="description" content="Automated TMPPM prior authorization rule extraction for Texas Medicaid. 50 PA categories, 8 TMPPM chapters, monthly auto-refresh from TMHP PDFs to CRD endpoint. The only CMS-0057-F platform with built-in state-specific PA rules." />
+  <meta name="keywords" content="TMPPM, Texas Medicaid Provider Procedures Manual, prior authorization, PA rules, TMHP, CPT, HCPCS, CRD, CDS Hooks, CMS-0057-F, Medicaid compliance, neurostimulators, bariatric surgery, HBOT, hyperbaric oxygen, organ transplants, ConceptMapEntry, Cosmos DB" />
+  <link rel="canonical" href="https://cloudhealthoffice.com/docs/texas-tmppm-pa-rules" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="https://cloudhealthoffice.com/docs/texas-tmppm-pa-rules" />
+  <meta property="og:title" content="TMPPM PA Rule Extraction — Cloud Health Office" />
+  <meta property="og:description" content="The only CMS-0057-F platform that ingests the Texas Medicaid Provider Procedures Manual, extracts PA rules from TMHP PDFs, and serves them through CRD in real time." />
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "TMPPM Prior Authorization Rules — Cloud Health Office",
+    "description": "Automated extraction of Texas Medicaid prior authorization rules from the TMPPM. 50 PA categories across 8 chapters, monthly auto-refresh, hybrid regex + LLM extraction, persisted to Cosmos DB for real-time CRD responses.",
+    "url": "https://cloudhealthoffice.com/docs/texas-tmppm-pa-rules",
+    "author": { "@type": "Organization", "name": "Aurelianware, Inc." },
+    "publisher": { "@type": "Organization", "name": "Cloud Health Office", "url": "https://cloudhealthoffice.com" },
+    "datePublished": "2026-04-10",
+    "proficiencyLevel": "Intermediate",
+    "about": [
+      "TMPPM",
+      "Texas Medicaid prior authorization",
+      "TMHP",
+      "CPT code PA requirements",
+      "HCPCS quarterly updates",
+      "CRD endpoint",
+      "CDS Hooks",
+      "ConceptMapEntry"
+    ],
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://cloudhealthoffice.com" },
+        { "@type": "ListItem", "position": 2, "name": "Docs", "item": "https://cloudhealthoffice.com/docs" },
+        { "@type": "ListItem", "position": 3, "name": "Texas Compliance", "item": "https://cloudhealthoffice.com/docs/texas-compliance" },
+        { "@type": "ListItem", "position": 4, "name": "TMPPM PA Rules", "item": "https://cloudhealthoffice.com/docs/texas-tmppm-pa-rules" }
+      ]
+    }
+  }
+  </script>
+
+  <script async src="https://plausible.io/js/pa-JQNNrBf52mV2BxHPtkLAv.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)}</script>
+  <link rel="stylesheet" href="/css/sentinel.css" />
+  <link rel="stylesheet" href="/css/docs.css" />
+  <script src="/js/auth.js"></script>
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .tmppm-stats{display:flex;gap:2rem;flex-wrap:wrap;margin:1.5rem 0}
+    .tmppm-stat{text-align:center;flex:1;min-width:120px;padding:1rem;background:rgba(0,229,204,0.04);border:1px solid rgba(0,229,204,0.12);border-radius:8px}
+    .tmppm-stat .num{font-size:1.5rem;font-weight:700;color:#00e5cc;font-family:'JetBrains Mono',monospace}
+    .tmppm-stat .label{font-size:0.75rem;color:#9c9a92;text-transform:uppercase;letter-spacing:0.06em;margin-top:4px}
+    .tmppm-flow{position:relative;padding:0.5rem 0}
+    .tmppm-flow-step{display:flex;align-items:flex-start;gap:1rem;padding:1rem 0;position:relative}
+    .tmppm-flow-step::before{content:'';position:absolute;left:19px;top:0;bottom:0;width:2px;background:linear-gradient(to bottom,rgba(0,229,204,0.4),rgba(42,42,53,0.4))}
+    .tmppm-flow-step:last-child::before{display:none}
+    .tmppm-flow-icon{width:40px;height:40px;min-width:40px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1rem;position:relative;z-index:1}
+    .tmppm-flow-icon.teal{background:rgba(0,229,204,0.12);border:1px solid rgba(0,229,204,0.25);color:#00e5cc}
+    .tmppm-flow-icon.purple{background:rgba(120,80,220,0.12);border:1px solid rgba(120,80,220,0.25);color:#a07cf0}
+    .tmppm-flow-icon.coral{background:rgba(255,107,74,0.12);border:1px solid rgba(255,107,74,0.25);color:#ff6b4a}
+    .tmppm-flow-icon.blue{background:rgba(51,136,255,0.12);border:1px solid rgba(51,136,255,0.25);color:#3388ff}
+    .tmppm-flow-icon.green{background:rgba(0,255,136,0.12);border:1px solid rgba(0,255,136,0.25);color:#00ff88}
+    .tmppm-flow-body h4{font-size:0.95rem;font-weight:600;margin-bottom:0.25rem}
+    .tmppm-flow-body p{color:#9c9a92;font-size:0.88rem;line-height:1.6}
+    .tmppm-card-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;margin-top:1rem}
+    .tmppm-card{background:#111118;border:1px solid #2a2a35;border-radius:10px;padding:1.25rem;transition:border-color 0.2s}
+    .tmppm-card:hover{border-color:rgba(0,229,204,0.3)}
+    .tmppm-card h4{font-size:0.9rem;font-weight:600;margin-bottom:0.4rem;display:flex;align-items:center;gap:8px}
+    .tmppm-card h4 .dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+    .tmppm-card h4 .dot.p1{background:#00ff88}
+    .tmppm-card h4 .dot.p2{background:#f0a030}
+    .tmppm-card p{color:#9c9a92;font-size:0.82rem;line-height:1.6}
+    .tmppm-card .codes{margin-top:0.6rem;display:flex;flex-wrap:wrap;gap:5px}
+    .tmppm-card .codes span{font-family:'JetBrains Mono',monospace;font-size:0.72rem;padding:2px 7px;border-radius:4px;background:rgba(0,229,204,0.08);color:#00e5cc;border:1px solid rgba(0,229,204,0.15)}
+    .tmppm-compare{border:1px solid #2a2a35;border-radius:10px;overflow:hidden;margin-top:1.5rem}
+    .tmppm-compare table{width:100%;border-collapse:collapse}
+    .tmppm-compare th{background:#1a1a24;padding:10px 14px;text-align:left;font-size:0.75rem;text-transform:uppercase;letter-spacing:0.06em;color:#9c9a92;font-weight:500}
+    .tmppm-compare td{padding:10px 14px;border-top:1px solid #2a2a35;font-size:0.85rem;vertical-align:top}
+    .tmppm-compare tr:hover td{background:rgba(0,229,204,0.03)}
+    .tmppm-check{color:#00ff88;font-weight:600}
+    .tmppm-cross{color:#ff6b4a;font-weight:600}
+  </style>
+</head>
+<body>
+  <a href="#main-content" class="skip-to-main">Skip to main content</a>
+
+  <nav>
+    <div class="nav-inner">
+      <a href="/" class="nav-logo" aria-label="Cloud Health Office Home">
+        <img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" />
+        <span class="nav-logo-text">Cloud Health Office</span>
+      </a>
+      <div class="nav-right">
+        <button class="mobile-menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button>
+        <ul id="mainNav">
+          <li><a href="/solutions-payers">Solutions</a></li>
+          <li><a href="/cms-0057f-compliance">CMS Compliance</a></li>
+          <li><a href="/pricing">Pricing</a></li>
+          <li><a href="/platform">Platform</a></li>
+          <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
+          <li><a href="https://portal.cloudhealthoffice.com" target="_blank" rel="noopener noreferrer" style="color:#00ff88;">Demo Portal</a></li>
+          <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          <li><a href="/login" style="color:#00ffff; font-weight:bold;">Sign In</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <script>document.addEventListener('DOMContentLoaded', () => { updateNavigation('#mainNav'); });</script>
+
+  <main id="main-content">
+    <div class="docs-wrapper">
+
+      <!-- Sidebar -->
+      <aside class="docs-sidebar" id="docsSidebar">
+        <div class="docs-sidebar-inner">
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">Getting Started</div>
+            <ul>
+              <li><a href="/docs">Docs Home</a></li>
+              <li><a href="/docs/quickstart">Quick Start</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">Guides</div>
+            <ul>
+              <li><a href="/docs/compliance">CMS-0057-F Compliance</a></li>
+              <li><a href="/docs/architecture">Architecture</a></li>
+              <li><a href="/docs/fee-schedule-engine">Fee Schedule Engine</a></li>
+              <li><a href="/docs/api">API Reference</a></li>
+              <li><a href="/docs/deployment">Deployment</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">User Guides</div>
+            <ul>
+              <li><a href="/docs/finance-guide">Finance Guide</a></li>
+              <li><a href="/docs/benefit-plan-guide">Benefit Plan Configuration</a></li>
+              <li><a href="/docs/claims-guide">Claims Adjudication</a></li>
+              <li><a href="/docs/prior-auth-guide">Prior Authorization</a></li>
+              <li><a href="/docs/eligibility-guide">Eligibility &amp; Enrollment</a></li>
+              <li><a href="/docs/fee-schedule-guide">Fee Schedule</a></li>
+              <li><a href="/docs/terminology-guide">Terminology Crosswalk</a></li>
+              <li><a href="/docs/provider-verification-guide">Provider Verification</a></li>
+              <li><a href="/docs/provider-enrollment-guide">Provider Enrollment</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">State Compliance</div>
+            <ul>
+              <li><a href="/docs/texas-compliance">Texas (STAR / STAR+PLUS)</a></li>
+              <li><a href="/docs/texas-tmppm-pa-rules" class="active">Texas TMPPM PA Rules</a></li>
+              <li><a href="/docs/florida-compliance">Florida AHCA (SMMC 3.0)</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">On This Page</div>
+            <ul class="toc-sub">
+              <li><a href="#the-problem">The Problem</a></li>
+              <li><a href="#pipeline">Extraction Pipeline</a></li>
+              <li><a href="#validated-rules">Validated Extractions</a></li>
+              <li><a href="#comparison">Competitive Comparison</a></li>
+              <li><a href="#pa-rule-explorer">PA Rule Explorer</a></li>
+              <li><a href="#architecture">Technical Architecture</a></li>
+              <li><a href="#monthly-refresh">Monthly Refresh Cycle</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">Resources</div>
+            <ul>
+              <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub Repo</a></li>
+              <li><a href="https://portal.cloudhealthoffice.com" target="_blank" rel="noopener noreferrer">Demo Portal</a></li>
+              <li><a href="https://sandbox.cloudhealthoffice.com/?spec=patient-access" target="_blank" rel="noopener noreferrer">API Sandbox</a></li>
+              <li><a href="/release-notes">Release Notes</a></li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+
+      <!-- Content -->
+      <div class="docs-content">
+        <div class="docs-breadcrumb">
+          <a href="/">Home</a>
+          <span class="sep">&#x25B8;</span>
+          <a href="/docs">Docs</a>
+          <span class="sep">&#x25B8;</span>
+          <a href="/docs/texas-compliance">Texas Compliance</a>
+          <span class="sep">&#x25B8;</span>
+          <span class="current">TMPPM PA Rules</span>
+        </div>
+
+        <h1>TMPPM Prior Authorization Rules</h1>
+        <p class="docs-subtitle">Automated extraction from the Texas Medicaid Provider Procedures Manual</p>
+
+        <p>The only CMS-0057-F platform that ingests the <strong>Texas Medicaid Provider Procedures Manual (TMPPM)</strong> directly from TMHP, extracts prior authorization rules at the procedure-code level, and serves them through the CRD endpoint in real time. No manual questionnaire authoring. No monthly spreadsheet maintenance.</p>
+
+        <div class="tmppm-stats">
+          <div class="tmppm-stat"><div class="num">50</div><div class="label">PA categories extracted</div></div>
+          <div class="tmppm-stat"><div class="num">8</div><div class="label">TMPPM chapters covered</div></div>
+          <div class="tmppm-stat"><div class="num">Monthly</div><div class="label">Auto-refresh cycle</div></div>
+          <div class="tmppm-stat"><div class="num">&lt;$1</div><div class="label">Per extraction run</div></div>
+        </div>
+
+        <!-- The Problem -->
+        <h2 id="the-problem">The Problem</h2>
+
+        <p>On the March 2024 PCHP interoperability call, Cognizant confirmed their TriZetto EPA has <strong>no Texas Medicaid-specific rules</strong>. Their quote includes 130 custom questionnaires &mdash; but Texas Medicaid exceeds that. Monthly TMPPM maintenance falls entirely on plan staff, who must manually read PDFs, identify changes, and update questionnaires by hand.</p>
+
+        <p>CHO eliminates this manual burden entirely with an automated extraction pipeline that reads the same TMHP PDFs and produces structured, queryable PA rules.</p>
+
+        <!-- Pipeline -->
+        <h2 id="pipeline">From PDF to CRD Response in One Pipeline</h2>
+
+        <div class="tmppm-flow">
+          <div class="tmppm-flow-step">
+            <div class="tmppm-flow-icon teal">&#x2193;</div>
+            <div class="tmppm-flow-body">
+              <h4>1. Download TMPPM chapters</h4>
+              <p>8 priority PDF chapters pulled directly from <code>tmhp.com</code>. Each file SHA256-hashed for month-over-month change detection. Only changed chapters get re-parsed.</p>
+            </div>
+          </div>
+          <div class="tmppm-flow-step">
+            <div class="tmppm-flow-icon purple">&#x23D4;</div>
+            <div class="tmppm-flow-body">
+              <h4>2. Extract PA sections</h4>
+              <p>PyMuPDF locates all 50 &ldquo;Prior Authorization&rdquo; sections by TMPPM reference number. Skips table-of-contents entries, finds the body text with clinical criteria, procedure codes, and documentation requirements.</p>
+            </div>
+          </div>
+          <div class="tmppm-flow-step">
+            <div class="tmppm-flow-icon coral">&#x25C8;</div>
+            <div class="tmppm-flow-body">
+              <h4>3. Hybrid regex + LLM extraction</h4>
+              <p>Regex catches CPT/HCPCS codes and age rules from clean sections. Sections with low regex confidence escalate to Claude API for structured extraction &mdash; clinical criteria, diagnosis restrictions, unit limits, documentation requirements.</p>
+            </div>
+          </div>
+          <div class="tmppm-flow-step">
+            <div class="tmppm-flow-icon blue">&#x25C9;</div>
+            <div class="tmppm-flow-body">
+              <h4>4. Persist to Cosmos DB</h4>
+              <p>Rules stored as <code>ConceptMapEntry</code> overrides with <code>State=TX</code>, <code>IsOverride=true</code>, and optional <code>TenantId</code> for plan-specific scoping. Same collection the TerminologyService queries at runtime.</p>
+            </div>
+          </div>
+          <div class="tmppm-flow-step">
+            <div class="tmppm-flow-icon green">&#x25C6;</div>
+            <div class="tmppm-flow-body">
+              <h4>5. CRD server responds</h4>
+              <p>Provider submits a CRD check &rarr; CHO queries Cosmos &rarr; returns Texas-correct &ldquo;auth required&rdquo; or &ldquo;no auth&rdquo; with the TMPPM section reference and clinical criteria. Sub-second response, zero manual lookup.</p>
+            </div>
+          </div>
+        </div>
+
+        <div style="margin: 32px 0; text-align: center;">
+          <img src="/graphics/TmppmExtractionPipeline.svg" alt="TMPPM extraction pipeline diagram showing the flow from TMHP PDF download through SHA256 change detection, PyMuPDF section extraction, hybrid regex and LLM enrichment, Cosmos DB persistence, to CRD server response" style="max-width: 100%; height: auto; border: 1px solid rgba(0,229,204,0.12); border-radius: 8px;" loading="lazy" />
+          <p style="font-size: 0.85rem; opacity: 0.6; margin-top: 8px;">End-to-end TMPPM extraction pipeline &mdash; from TMHP PDF to CRD response</p>
+        </div>
+
+        <!-- Validated Extractions -->
+        <h2 id="validated-rules">Validated Extractions &mdash; April 2026 TMPPM</h2>
+
+        <p>These are real rules extracted from the current TMPPM edition, verified against the source PDFs:</p>
+
+        <div class="tmppm-card-grid">
+          <div class="tmppm-card">
+            <h4><span class="dot p1"></span>Hypoglossal nerve stimulators</h4>
+            <p>&sect;9.2.46.14 &mdash; PA required for surgical implantation. OSA diagnosis with failed CPAP compliance or seizure diagnosis. DISE procedure required for OSA.</p>
+            <div class="codes"><span>64582</span><span>64583</span><span>64584</span></div>
+          </div>
+          <div class="tmppm-card">
+            <h4><span class="dot p1"></span>Bariatric surgery</h4>
+            <p>&sect;9.2.8.1 &mdash; BMI &ge;35 adults (&ge;40 pediatric). 13 qualifying comorbidities. Psych eval required. 6-month structured diet program. MBSAQIP facility accreditation.</p>
+            <div class="codes"><span>LLM enrichment</span></div>
+          </div>
+          <div class="tmppm-card">
+            <h4><span class="dot p1"></span>Hyperbaric oxygen therapy</h4>
+            <p>&sect;9.2.33.1 &mdash; Session limits per covered indication. Air embolism: 6 intervals. Carbon monoxide: 15 initial, 9 subsequent. Central retinal artery: 36 intervals.</p>
+            <div class="codes"><span>99183</span><span>G0277</span></div>
+          </div>
+          <div class="tmppm-card">
+            <h4><span class="dot p1"></span>Organ transplants</h4>
+            <p>&sect;9.2.51.1 &mdash; General PA requirements. Contraindications: pulmonary HTN, uncontrolled HIV, psychiatric instability. 3-day pre / 6-week post denial window.</p>
+            <div class="codes"><span>Category-level</span></div>
+          </div>
+          <div class="tmppm-card">
+            <h4><span class="dot p2"></span>HCPCS Q1 2026 updates</h4>
+            <p>April 1, 2026 effective. New PA-required codes and diagnosis-restricted drugs. Auto-ingested from TMHP quarterly bulletins.</p>
+            <div class="codes"><span>C8007</span><span>C8011</span><span>J3404</span><span>L2221</span><span>J9601</span><span>J9248</span></div>
+          </div>
+          <div class="tmppm-card">
+            <h4><span class="dot p2"></span>Neurostimulators</h4>
+            <p>&sect;9.2.46 &mdash; 10 sub-categories: dorsal column, vagal nerve, sacral nerve, intracranial, pelvic floor, gastric, TENS, NMES, PENS, diaphragm-pacing.</p>
+            <div class="codes"><span>50+ CPT codes</span></div>
+          </div>
+        </div>
+
+        <!-- Comparison -->
+        <h2 id="comparison">Competitive Comparison</h2>
+
+        <p>How CHO&rsquo;s automated TMPPM extraction compares to manual questionnaire-based approaches:</p>
+
+        <div class="tmppm-compare">
+          <table>
+            <thead>
+              <tr><th style="width:35%">Capability</th><th style="width:32%">Cognizant TriZetto EPA</th><th style="width:33%">CHO TMPPM Engine</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>State-specific PA rules</td><td class="tmppm-cross">&#x2717; None &mdash; 130 generic questionnaires</td><td class="tmppm-check">&#x2713; 50 TX categories, code-level</td></tr>
+              <tr><td>TMPPM monthly tracking</td><td class="tmppm-cross">&#x2717; Manual &mdash; plan staff responsibility</td><td class="tmppm-check">&#x2713; Automated SHA256 change detection</td></tr>
+              <tr><td>HCPCS quarterly updates</td><td class="tmppm-cross">&#x2717; Not included</td><td class="tmppm-check">&#x2713; 8 Q1 2026 rules loaded</td></tr>
+              <tr><td>SNOMED&#x2194;CPT translation</td><td class="tmppm-cross">&#x2717; &ldquo;Go buy from a vendor&rdquo;</td><td class="tmppm-check">&#x2713; Built-in TerminologyService</td></tr>
+              <tr><td>Clinical criteria extraction</td><td class="tmppm-cross">&#x2717; Not digitized</td><td class="tmppm-check">&#x2713; LLM-assisted structured extraction</td></tr>
+              <tr><td>Tenant scoping</td><td>Single-tenant</td><td class="tmppm-check">&#x2713; Per-plan overrides (PCHP, etc.)</td></tr>
+              <tr><td>Completed implementations</td><td class="tmppm-cross">&#x2717; Zero as of March 2024</td><td class="tmppm-check">&#x2713; Pipeline running, data in Cosmos</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- PA Rule Explorer -->
+        <h2 id="pa-rule-explorer">PA Rule Explorer</h2>
+
+        <p>The <strong>PA Rule Explorer</strong> is a Blazor Server page in the CHO portal that gives PCHP plan administrators and UM staff direct access to the extracted TMPPM rules:</p>
+
+        <ul>
+          <li><strong>Search by CPT/HCPCS code</strong> &mdash; type a procedure code and instantly see whether PA is required, the clinical criteria, required documentation, and the TMPPM section reference</li>
+          <li><strong>Browse by category</strong> &mdash; expandable tree of all 50 PA categories grouped by priority (P1 Auth Required, P2 Limits &amp; Restrictions, P3 Other)</li>
+          <li><strong>Edition metadata</strong> &mdash; which TMPPM edition is loaded, last refresh timestamp, and a freshness indicator (green &lt;30 days, amber 30&ndash;60, red &gt;60)</li>
+          <li><strong>Month-over-month diff</strong> &mdash; added, modified, and removed rules with before/after comparison between any two editions</li>
+        </ul>
+
+        <p>Access the PA Rule Explorer at <code>/compliance/pa-rules</code> in the Blazor portal. Requires the <code>compliance:read</code> or <code>authorizations:read</code> permission.</p>
+
+        <!-- Architecture -->
+        <h2 id="architecture">Technical Architecture</h2>
+
+        <h3>Data Model</h3>
+        <p>Extracted rules are stored in three Cosmos DB (MongoDB API) collections in the <code>cho_terminology</code> database:</p>
+
+        <div class="docs-table-wrapper" style="margin-top: 16px;">
+          <table>
+            <thead>
+              <tr><th>Collection</th><th>Purpose</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>tmppm_pa_rules</code></td><td>Raw extracted rules with clinical criteria, CPT/HCPCS codes, age limits, documentation requirements</td></tr>
+              <tr><td><code>tmppm_editions</code></td><td>Version tracking with SHA256 per chapter, publication date, ingestion timestamp</td></tr>
+              <tr><td><code>concept_map_entries</code></td><td><code>ConceptMapEntry</code> overrides queried by the CRD server at runtime (<code>IsOverride=true</code>, <code>State=TX</code>)</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Tenant Scoping</h3>
+        <p>All rules are tenant-scoped with <code>TenantId</code> (e.g., <code>pchp</code>). The CRD server merges global rules with tenant-specific overrides at query time, allowing plans to customize PA requirements while inheriting the platform baseline.</p>
+
+        <h3>Extraction Pipeline</h3>
+        <p>The <code>TmppmIngestionService</code> is a .NET 8 console application in <code>tools/CloudHealthOffice.TmppmIngestionService</code>:</p>
+        <ul>
+          <li><strong>TmhpChapterDownloader</strong> &mdash; fetches PDFs from TMHP, SHA256 hashes for change detection</li>
+          <li><strong>TmppmPdfParser</strong> &mdash; PdfPig-based text extraction with regex pattern matching for procedure codes, age rules, and section references</li>
+          <li><strong>extract_section.py</strong> &mdash; PyMuPDF script for targeted section extraction when PdfPig has layout issues</li>
+          <li><strong>IngestionPipeline</strong> &mdash; orchestrates download &rarr; parse &rarr; store, with LLM escalation for complex clinical criteria</li>
+          <li><strong>TmppmRuleStore</strong> &mdash; MongoDB upsert logic with edition versioning and diff report generation</li>
+        </ul>
+
+        <!-- Monthly Refresh -->
+        <h2 id="monthly-refresh">Monthly Refresh Cycle</h2>
+
+        <p>TMHP publishes updated TMPPM chapters monthly. CHO&rsquo;s refresh cycle:</p>
+
+        <ol>
+          <li><strong>Download</strong> &mdash; all 8 priority chapters fetched from TMHP</li>
+          <li><strong>Compare</strong> &mdash; SHA256 hash compared to previous edition; unchanged chapters skipped</li>
+          <li><strong>Extract</strong> &mdash; changed chapters re-parsed; new/modified rules identified</li>
+          <li><strong>Diff report</strong> &mdash; <code>TmppmDiffReport</code> generated with added, modified, and removed deltas</li>
+          <li><strong>Publish</strong> &mdash; new <code>ConceptMapEntry</code> overrides upserted; previous edition preserved for audit</li>
+          <li><strong>Notify</strong> &mdash; rules flagged <code>RequiresHumanReview=true</code> appear in the PA Rule Explorer diff view for UM staff review</li>
+        </ol>
+
+        <div class="docs-callout" style="margin-top: 16px;">
+          <strong>Cost:</strong> Each full extraction run costs less than $1 in Claude API calls. Regex handles ~70% of sections; only complex clinical criteria sections escalate to the LLM.
+        </div>
+
+        <!-- TMPPM Chapters Covered -->
+        <h3>TMPPM Chapters Covered</h3>
+
+        <div class="docs-table-wrapper" style="margin-top: 16px;">
+          <table>
+            <thead>
+              <tr><th>Chapter</th><th>Title</th><th>PA Categories</th></tr>
+            </thead>
+            <tbody>
+              <tr><td><code>1_05</code></td><td>Prior Authorization</td><td>Master PA category list and general requirements</td></tr>
+              <tr><td><code>2_01</code></td><td>Ambulance Services</td><td>Air ambulance, non-emergency transport</td></tr>
+              <tr><td><code>2_02</code></td><td>Behavioral Health</td><td>Inpatient psych, residential treatment, ABA</td></tr>
+              <tr><td><code>2_06</code></td><td>DME and Supplies</td><td>Power wheelchairs, orthotics, prosthetics</td></tr>
+              <tr><td><code>2_11</code></td><td>Inpatient/Outpatient Hospital</td><td>Transplants, bariatric, cardiac procedures</td></tr>
+              <tr><td><code>2_13</code></td><td>Medical Specialties &amp; Physician Services</td><td>Neurostimulators, HBOT, pain management, imaging</td></tr>
+              <tr><td><code>2_16</code></td><td>PT/OT/ST Services</td><td>Therapy visit limits, specialized rehab</td></tr>
+              <tr><td><code>2_17</code></td><td>Radiology and Lab</td><td>Advanced imaging PA requirements</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Related -->
+        <h2>Related Documentation</h2>
+        <div class="docs-hub-grid" style="grid-template-columns: 1fr 1fr; margin-top: 16px;">
+          <a href="/docs/texas-compliance" class="docs-hub-card">
+            <h3>Texas State Compliance</h3>
+            <p>TMHP PEMS enrollment, Gold Card exemption, HHSC UMCM rules, STAR/STAR+PLUS/STAR Kids programs.</p>
+            <span class="card-arrow">View guide &rarr;</span>
+          </a>
+          <a href="/docs/prior-auth-guide" class="docs-hub-card">
+            <h3>Prior Authorization</h3>
+            <p>PriorAuthRuleEngine, decision pathways, SLA tracking, and FHIR PAS integration.</p>
+            <span class="card-arrow">View guide &rarr;</span>
+          </a>
+          <a href="/docs/terminology-guide" class="docs-hub-card">
+            <h3>Terminology Crosswalk</h3>
+            <p>ConceptMapEntry model, SNOMED&#x2194;ICD translation, and tenant-scoped overrides.</p>
+            <span class="card-arrow">View guide &rarr;</span>
+          </a>
+          <a href="/docs/compliance" class="docs-hub-card">
+            <h3>CMS-0057-F Compliance</h3>
+            <p>Federal compliance requirements, FHIR R4 APIs, and interoperability standards.</p>
+            <span class="card-arrow">View guide &rarr;</span>
+          </a>
+        </div>
+
+        <!-- Prev / Next -->
+        <div class="docs-pager">
+          <a href="/docs/texas-compliance">
+            <div class="pager-label">&larr; Previous</div>
+            <div class="pager-title">Texas State Compliance</div>
+          </a>
+          <a href="/docs/florida-compliance" class="next">
+            <div class="pager-label">Next &rarr;</div>
+            <div class="pager-title">Florida AHCA Compliance</div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <button class="docs-mobile-toggle" id="docsMobileToggle" aria-label="Toggle docs navigation">&#9776;</button>
+  <div class="docs-sidebar-overlay" id="docsSidebarOverlay"></div>
+
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <div class="footer-grid">
+        <div class="footer-brand">
+          <h4>Cloud Health Office</h4>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; v4.2.0 Production</p>
+        </div>
+        <div class="footer-col">
+          <h5>Product</h5>
+          <ul>
+            <li><a href="/solutions-payers">Solutions</a></li>
+            <li><a href="/cms-0057f-compliance">CMS-0057-F Compliance</a></li>
+            <li><a href="/platform">Platform</a></li>
+            <li><a href="/pricing">Pricing</a></li>
+            <li><a href="/pricing-api">Repricing API</a></li>
+            <li><a href="/release-notes">Release Notes</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h5>Documentation</h5>
+          <ul>
+            <li><a href="/docs/quickstart">Quick Start</a></li>
+            <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
+            <li><a href="/docs/architecture">Architecture</a></li>
+            <li><a href="/docs/fee-schedule-engine">Fee Schedule Engine</a></li>
+            <li><a href="/docs/api">API Reference</a></li>
+            <li><a href="/docs/deployment">Deployment</a></li>
+            <li><a href="https://portal.cloudhealthoffice.com" target="_blank" rel="noopener noreferrer">Demo Portal</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h5>Contact</h5>
+          <ul>
+            <li><a href="https://portal.cloudhealthoffice.com/contact-sales">Contact Sales</a></li>
+            <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
+            <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>
+            <li><a href="mailto:investors@cloudhealthoffice.com">Investors</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc. &nbsp;&middot;&nbsp; Source-available platform (BSL 1.1) &nbsp;&middot;&nbsp; Free for non-production use &nbsp;&middot;&nbsp; <a href="mailto:licensing@cloudhealthoffice.com" style="color:rgba(0,255,255,0.6);">Commercial licensing</a></p>
+        <p><a href="/pricing" style="color:rgba(128,128,128,0.45);">Pricing</a> &nbsp;&middot;&nbsp; <a href="mailto:contact@cloudhealthoffice.com" style="color:rgba(128,128,128,0.45);">Contact</a> &nbsp;&middot;&nbsp; <a href="/legal/privacy-policy" style="color:rgba(128,128,128,0.45);">Privacy Policy</a></p>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const toggle = document.getElementById('docsMobileToggle');
+    const sidebar = document.getElementById('docsSidebar');
+    const overlay = document.getElementById('docsSidebarOverlay');
+    if (toggle && sidebar) {
+      toggle.addEventListener('click', () => { sidebar.classList.toggle('open'); overlay.classList.toggle('open'); });
+      overlay.addEventListener('click', () => { sidebar.classList.remove('open'); overlay.classList.remove('open'); });
+    }
+  </script>
+</body>
+</html>

--- a/src/site/graphics/TmppmExtractionPipeline.svg
+++ b/src/site/graphics/TmppmExtractionPipeline.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1020" font-family="'Inter', 'Segoe UI', sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a0f"/>
+      <stop offset="100%" style="stop-color:#111118"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <!-- Arrow marker -->
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#9c9a92"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="1020" fill="url(#bg)" rx="12"/>
+
+  <!-- Title -->
+  <text x="500" y="40" fill="#e8e6e0" font-size="18" font-weight="600" text-anchor="middle">TMPPM Extraction Pipeline</text>
+
+  <!-- Step 1: TMHP Website -->
+  <rect x="310" y="65" width="380" height="64" rx="10" fill="#4a4a4a" stroke="#666" stroke-width="1"/>
+  <text x="500" y="92" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">TMHP website</text>
+  <text x="500" y="112" fill="#9c9a92" font-size="12" text-anchor="middle" font-family="'JetBrains Mono', monospace">tmhp.com/tmppm</text>
+
+  <!-- Arrow 1→2 -->
+  <line x1="500" y1="129" x2="500" y2="155" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 2: Chapter Downloader -->
+  <rect x="310" y="160" width="380" height="64" rx="10" fill="#1a6b5a" stroke="#00e5cc" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="500" y="187" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Chapter downloader</text>
+  <text x="500" y="207" fill="#00e5cc" font-size="12" text-anchor="middle" opacity="0.8">8 PDFs, SHA256 tracked</text>
+  <!-- Annotation -->
+  <text x="720" y="195" fill="#9c9a92" font-size="11" font-style="italic" opacity="0.6">Monthly refresh</text>
+  <line x1="690" y1="192" x2="715" y2="192" stroke="#9c9a92" stroke-width="1" stroke-dasharray="3,3" opacity="0.4"/>
+
+  <!-- Arrow 2→3 -->
+  <line x1="500" y1="224" x2="500" y2="250" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 3: Change Detection -->
+  <rect x="310" y="255" width="380" height="54" rx="10" fill="#155e4e" stroke="#00e5cc" stroke-width="1" stroke-opacity="0.2"/>
+  <text x="500" y="287" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Change detection (SHA256)</text>
+  <!-- Annotation -->
+  <text x="720" y="285" fill="#9c9a92" font-size="11" font-style="italic" opacity="0.6">Only changed chapters</text>
+  <line x1="690" y1="282" x2="715" y2="282" stroke="#9c9a92" stroke-width="1" stroke-dasharray="3,3" opacity="0.4"/>
+
+  <!-- Arrow 3→4 -->
+  <line x1="500" y1="309" x2="500" y2="335" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 4: Section Extractor -->
+  <rect x="310" y="340" width="380" height="64" rx="10" fill="#3a2a6a" stroke="#a07cf0" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="500" y="367" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Section extractor (PyMuPDF)</text>
+  <text x="500" y="387" fill="#a07cf0" font-size="12" text-anchor="middle" opacity="0.8">50 PA sections identified</text>
+
+  <!-- Arrow 4→5 -->
+  <line x1="500" y1="404" x2="500" y2="430" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 5: Confidence Scoring (diamond-ish) -->
+  <rect x="310" y="435" width="380" height="54" rx="10" fill="#3a2a6a" stroke="#a07cf0" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="500" y="467" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Confidence scoring</text>
+
+  <!-- Branch labels -->
+  <text x="210" y="510" fill="#9c9a92" font-size="11" font-style="italic" opacity="0.7">High confidence</text>
+  <text x="730" y="510" fill="#9c9a92" font-size="11" font-style="italic" opacity="0.7">Low confidence</text>
+
+  <!-- Arrow 5→6a (left branch - regex) -->
+  <path d="M 400 489 L 300 530" stroke="#9c9a92" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+
+  <!-- Arrow 5→6b (right branch - LLM) -->
+  <path d="M 600 489 L 700 530" stroke="#9c9a92" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+
+  <!-- Step 6a: Regex Extraction -->
+  <rect x="140" y="535" width="320" height="64" rx="10" fill="#1a6b5a" stroke="#00e5cc" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="300" y="562" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Regex extraction</text>
+  <text x="300" y="582" fill="#00e5cc" font-size="12" text-anchor="middle" opacity="0.8">CPT, HCPCS, age rules</text>
+
+  <!-- Step 6b: LLM Enrichment -->
+  <rect x="540" y="535" width="320" height="64" rx="10" fill="#5a2a1a" stroke="#ff6b4a" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="700" y="562" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">LLM enrichment</text>
+  <text x="700" y="582" fill="#ff6b4a" font-size="12" text-anchor="middle" opacity="0.8">Clinical criteria, codes</text>
+
+  <!-- Arrow 6a→7 -->
+  <path d="M 300 599 L 400 640" stroke="#9c9a92" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+
+  <!-- Arrow 6b→7 -->
+  <path d="M 700 599 L 600 640" stroke="#9c9a92" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+
+  <!-- Step 7: Cross-validation -->
+  <rect x="310" y="645" width="380" height="54" rx="10" fill="#1a6b5a" stroke="#00e5cc" stroke-width="1" stroke-opacity="0.2"/>
+  <text x="500" y="677" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Cross-validation + merge</text>
+
+  <!-- Arrow 7→8 -->
+  <line x1="500" y1="699" x2="500" y2="730" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 8: Cosmos DB -->
+  <rect x="310" y="735" width="380" height="64" rx="10" fill="#0d3a6a" stroke="#3388ff" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="500" y="762" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">Cosmos DB (MongoDB API)</text>
+  <text x="500" y="782" fill="#3388ff" font-size="12" text-anchor="middle" opacity="0.8">ConceptMapEntry overrides</text>
+  <!-- Annotation -->
+  <text x="720" y="775" fill="#9c9a92" font-size="11" font-style="italic" opacity="0.6">State=TX, tenant=PCHP</text>
+  <line x1="690" y1="772" x2="715" y2="772" stroke="#9c9a92" stroke-width="1" stroke-dasharray="3,3" opacity="0.4"/>
+
+  <!-- Arrow 8→9 -->
+  <line x1="500" y1="799" x2="500" y2="830" stroke="#9c9a92" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Step 9: CRD Server -->
+  <rect x="310" y="835" width="380" height="64" rx="10" fill="#2a5a1a" stroke="#00ff88" stroke-width="1" stroke-opacity="0.3"/>
+  <text x="500" y="862" fill="#e8e6e0" font-size="14" font-weight="600" text-anchor="middle">CRD / PriorAuth server</text>
+  <text x="500" y="882" fill="#00ff88" font-size="12" text-anchor="middle" opacity="0.8">TX-correct auth determination</text>
+
+  <!-- Legend -->
+  <rect x="310" y="930" width="380" height="70" rx="8" fill="none" stroke="#2a2a35" stroke-width="1"/>
+  <text x="330" y="952" fill="#9c9a92" font-size="10" text-transform="uppercase" letter-spacing="0.08em">LEGEND</text>
+  <rect x="330" y="962" width="12" height="12" rx="2" fill="#1a6b5a" stroke="#00e5cc" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="348" y="973" fill="#9c9a92" font-size="11">Deterministic</text>
+  <rect x="440" y="962" width="12" height="12" rx="2" fill="#3a2a6a" stroke="#a07cf0" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="458" y="973" fill="#9c9a92" font-size="11">Analysis</text>
+  <rect x="540" y="962" width="12" height="12" rx="2" fill="#5a2a1a" stroke="#ff6b4a" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="558" y="973" fill="#9c9a92" font-size="11">LLM</text>
+  <rect x="610" y="962" width="12" height="12" rx="2" fill="#0d3a6a" stroke="#3388ff" stroke-width="0.5" stroke-opacity="0.3"/>
+  <text x="628" y="973" fill="#9c9a92" font-size="11">Storage</text>
+</svg>

--- a/tools/CloudHealthOffice.TmppmIngestionService/.gitignore
+++ b/tools/CloudHealthOffice.TmppmIngestionService/.gitignore
@@ -1,0 +1,5 @@
+tmppm-data/
+bin/
+obj/
+.DS_Store
+parse_debug.txt

--- a/tools/CloudHealthOffice.TmppmIngestionService/Config/appsettings developmtent.json
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Config/appsettings developmtent.json
@@ -1,0 +1,18 @@
+{
+  "MongoDB": {
+    "ConnectionString": "",
+    "DatabaseName": "cho_terminology"
+  },
+  "Tmppm": {
+    "DefaultState": "TX",
+    "DefaultTenantId": null,
+    "DataDirectory": "tmppm-data",
+    "AutoPublishToConceptMap": true
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "CHO.TmppmIngestionService": "Debug"
+    }
+  }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/Config/appsettings.json
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Config/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "MongoDB": {
+    "ConnectionString": "",
+    "DatabaseName": "cho_terminology"
+  },
+  "Tmppm": {
+    "DefaultState": "TX",
+    "DefaultTenantId": null,
+    "DataDirectory": "tmppm-data",
+    "AutoPublishToConceptMap": true
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "CHO.TmppmIngestionService": "Debug"
+    }
+  }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/Loaders/TmhpChapterDownloader.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Loaders/TmhpChapterDownloader.cs
@@ -1,0 +1,116 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using CHO.TmppmIngestionService.Models;
+
+namespace CHO.TmppmIngestionService.Loaders;
+
+/// <summary>
+/// Downloads TMPPM PDF chapters from TMHP and detects changes via SHA256 hashing.
+/// Supports both full edition downloads and incremental change detection.
+/// </summary>
+public class TmhpChapterDownloader(HttpClient httpClient, ILogger<TmhpChapterDownloader> logger)
+{
+    private const string BaseUrl = "https://www.tmhp.com/sites/default/files/file-library/resources/provider-manuals/tmppm/pdf-chapters";
+
+    /// <summary>
+    /// Known TMPPM chapters with their PDF filenames and CHO service mappings.
+    /// </summary>
+    public static readonly List<ChapterDefinition> KnownChapters =
+    [
+        new("1_05_prior_authorization", "Fee-for-Service Prior Authorizations", "Vol. 1 Section 5"),
+        new("2_01_ambulance_services", "Ambulance Services Handbook", "Vol. 2"),
+        new("2_02_behavioral_health", "Behavioral Health and Case Management Services Handbook", "Vol. 2"),
+        new("2_06_dme_and_supplies", "DME, Medical Supplies, and Nutritional Products Handbook", "Vol. 2"),
+        new("2_11_inpatient_outpatient_hosp_srvs", "Inpatient and Outpatient Hospital Services Handbook", "Vol. 2"),
+        new("2_13_med_specs_and_phys_srvs", "Medical and Nursing Specialists, Physicians, and PAs Handbook", "Vol. 2"),
+        new("2_16_pt_ot_st_srvs", "PT/OT/Speech Therapy Services Handbook", "Vol. 2"),
+        new("2_17_radiology_and_lab_srvs", "Radiology and Laboratory Services Handbook", "Vol. 2"),
+    ];
+
+    /// <summary>
+    /// Download all known chapters for a given edition (year/month).
+    /// Returns the edition with SHA256 hashes for each chapter.
+    /// </summary>
+    public async Task<TmppmEdition> DownloadEditionAsync(int year, int month, string outputDir)
+    {
+        var monthName = new DateTime(year, month, 1).ToString("MMMM").ToLower();
+        var yearMonth = $"{year}-{month:D2}-{monthName}";
+
+        var edition = new TmppmEdition
+        {
+            EditionId = $"{year}-{month:D2}",
+            SourceUrl = $"{BaseUrl}/{year}/{yearMonth}/",
+            IngestedAt = DateTime.UtcNow
+        };
+
+        Directory.CreateDirectory(outputDir);
+
+        foreach (var chapterDef in KnownChapters)
+        {
+            var pdfUrl = $"{BaseUrl}/{year}/{yearMonth}/{chapterDef.FileName}.pdf";
+            var localPath = Path.Combine(outputDir, $"{chapterDef.FileName}.pdf");
+
+            try
+            {
+                var response = await httpClient.GetAsync(pdfUrl);
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogWarning("Failed to download {Url}: {Status}", pdfUrl, response.StatusCode);
+                    continue;
+                }
+
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                await File.WriteAllBytesAsync(localPath, bytes);
+
+                var sha256 = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+                edition.Chapters.Add(new TmppmChapter
+                {
+                    ChapterId = chapterDef.FileName,
+                    Title = chapterDef.Title,
+                    PdfFileName = $"{chapterDef.FileName}.pdf",
+                    PdfUrl = pdfUrl,
+                    Sha256 = sha256
+                });
+
+                logger.LogInformation("Downloaded {Chapter} ({Bytes} bytes, SHA256: {Hash})",
+                    chapterDef.FileName, bytes.Length, sha256[..12]);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error downloading {Url}", pdfUrl);
+            }
+        }
+
+        return edition;
+    }
+
+    /// <summary>
+    /// Compare two editions by SHA256 hash to identify changed chapters.
+    /// Only changed chapters need re-parsing.
+    /// </summary>
+    public List<string> DetectChangedChapters(TmppmEdition previous, TmppmEdition current)
+    {
+        var changed = new List<string>();
+        var prevHashes = previous.Chapters.ToDictionary(c => c.ChapterId, c => c.Sha256);
+
+        foreach (var chapter in current.Chapters)
+        {
+            if (!prevHashes.TryGetValue(chapter.ChapterId, out var prevHash) || prevHash != chapter.Sha256)
+            {
+                changed.Add(chapter.ChapterId);
+                logger.LogInformation("Chapter changed: {Id} (prev: {Prev}, curr: {Curr})",
+                    chapter.ChapterId,
+                    prevHash?[..12] ?? "new",
+                    chapter.Sha256?[..12]);
+            }
+        }
+
+        logger.LogInformation("{Count}/{Total} chapters changed between {From} and {To}",
+            changed.Count, current.Chapters.Count, previous.EditionId, current.EditionId);
+
+        return changed;
+    }
+}
+
+public record ChapterDefinition(string FileName, string Title, string Volume);

--- a/tools/CloudHealthOffice.TmppmIngestionService/Models/TmppmModels.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Models/TmppmModels.cs
@@ -1,0 +1,124 @@
+namespace CHO.TmppmIngestionService.Models;
+
+/// <summary>
+/// A single extracted PA rule from TMPPM. Transforms into ConceptMapEntry overrides
+/// for the TerminologyService and PriorAuthService rule stores.
+/// </summary>
+public class TmppmPaRule
+{
+    public string RuleId { get; set; } = string.Empty;
+    public string State { get; set; } = "TX";
+    public string Category { get; set; } = string.Empty;
+    public string TmppmRef { get; set; } = string.Empty;
+    public string RuleType { get; set; } = string.Empty; // AuthRequired, DiagnosisRestriction, AgeLimit, UnitLimit, Noncovered
+    public List<string> ProcedureCodes { get; set; } = [];
+    public string CodeSystem { get; set; } = "CPT"; // CPT, HCPCS
+    public bool AuthRequired { get; set; }
+    public string? AuthType { get; set; } // SMPA, Online, Fax, Phone
+    public List<string>? AllowedDiagnoses { get; set; }
+    public List<string>? ExcludedDiagnoses { get; set; }
+    public AgeRule? AgeLimit { get; set; }
+    public UnitLimitRule? UnitLimit { get; set; }
+    public List<string>? RequiredModifiers { get; set; }
+    public List<string>? RequiredDocumentation { get; set; }
+    public string? ClinicalCriteriaSummary { get; set; }
+    public DateOnly EffectiveDate { get; set; }
+    public DateOnly? EndDate { get; set; }
+    public string SourceEdition { get; set; } = string.Empty;
+    public string? Notes { get; set; }
+}
+
+public class AgeRule
+{
+    public int? MinAge { get; set; }
+    public int? MaxAge { get; set; }
+    public string? Unit { get; set; } = "years"; // years, months, days
+}
+
+public class UnitLimitRule
+{
+    public int MaxUnits { get; set; }
+    public string Per { get; set; } = string.Empty; // day, visit, auth_period, calendar_year, lifetime
+    public string? ResetCondition { get; set; }
+}
+
+/// <summary>
+/// Represents a TMPPM edition with metadata for version tracking and monthly diff.
+/// </summary>
+public class TmppmEdition
+{
+    public string EditionId { get; set; } = string.Empty; // e.g., "2026-04"
+    public DateOnly PublicationDate { get; set; }
+    public DateOnly PolicyThroughDate { get; set; }
+    public string SourceUrl { get; set; } = string.Empty;
+    public string? ReleaseNotesUrl { get; set; }
+    public DateTime IngestedAt { get; set; }
+    public List<TmppmChapter> Chapters { get; set; } = [];
+}
+
+public class TmppmChapter
+{
+    public string ChapterId { get; set; } = string.Empty; // e.g., "2_13_med_specs_and_phys_srvs"
+    public string Title { get; set; } = string.Empty;
+    public string PdfFileName { get; set; } = string.Empty;
+    public string PdfUrl { get; set; } = string.Empty;
+    public string? Sha256 { get; set; }
+    public int ExtractedRuleCount { get; set; }
+}
+
+/// <summary>
+/// Monthly diff between two TMPPM editions.
+/// </summary>
+public class TmppmDiffReport
+{
+    public string FromEdition { get; set; } = string.Empty;
+    public string ToEdition { get; set; } = string.Empty;
+    public DateTime GeneratedAt { get; set; }
+    public List<TmppmRuleDelta> Deltas { get; set; } = [];
+    public int AddedCount => Deltas.Count(d => d.DeltaType == "Added");
+    public int ModifiedCount => Deltas.Count(d => d.DeltaType == "Modified");
+    public int RemovedCount => Deltas.Count(d => d.DeltaType == "Removed");
+}
+
+public class TmppmRuleDelta
+{
+    public string DeltaType { get; set; } = string.Empty; // Added, Modified, Removed
+    public string RuleId { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string? PreviousValue { get; set; }
+    public string? NewValue { get; set; }
+    public string? Description { get; set; }
+    public bool RequiresHumanReview { get; set; }
+}
+
+/// <summary>
+/// Maps to the existing CHO TerminologyService ConceptMapEntry for MongoDB persistence.
+/// The ingestion pipeline outputs these for bulk upsert into the terminology-service collection.
+/// </summary>
+public class ConceptMapEntryOverride
+{
+    public string Id { get; set; } = string.Empty;
+    public string SourceSystem { get; set; } = string.Empty;
+    public string SourceCode { get; set; } = string.Empty;
+    public string SourceDisplay { get; set; } = string.Empty;
+    public string TargetSystem { get; set; } = string.Empty;
+    public string TargetCode { get; set; } = string.Empty;
+    public string TargetDisplay { get; set; } = string.Empty;
+    public string Equivalence { get; set; } = "equivalent";
+    public string MapGroupId { get; set; } = string.Empty;
+    public int Priority { get; set; } = 1;
+    public MapRule? Rule { get; set; }
+    public string MapVersionId { get; set; } = string.Empty;
+    public bool IsOverride { get; set; } = true;
+    public string? TenantId { get; set; }
+}
+
+public class MapRule
+{
+    public string RuleType { get; set; } = "StateSpecific";
+    public int? AgeMin { get; set; }
+    public int? AgeMax { get; set; }
+    public string? Gender { get; set; }
+    public List<string>? CoMorbidCodes { get; set; }
+    public string? State { get; set; }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/Parsers/TmppmPdfParser.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Parsers/TmppmPdfParser.cs
@@ -1,0 +1,216 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace CHO.TmppmIngestionService.Parsers;
+
+/// <summary>
+/// Extracts text sections from TMPPM PDF chapters using PdfPig.
+/// Sections are identified by their hierarchical numbering (e.g., "9.2.46.14").
+/// </summary>
+public partial class TmppmPdfParser(ILogger<TmppmPdfParser> logger)
+{
+    /// <summary>
+    /// Extract all text from a PDF file, page by page.
+    /// </summary>
+    public List<PageText> ExtractAllText(string pdfPath)
+    {
+        var pages = new List<PageText>();
+        using var document = PdfDocument.Open(pdfPath);
+
+        foreach (var page in document.GetPages())
+        {
+            var text = page.Text;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                pages.Add(new PageText { PageNumber = page.Number, Text = text });
+            }
+        }
+
+        logger.LogInformation("Extracted {PageCount} pages from {Path}", pages.Count, pdfPath);
+        return pages;
+    }
+
+    /// <summary>
+    /// Extract a specific section by its TMPPM reference number (e.g., "9.2.46.14").
+    /// Returns the text from the section header through the next section of the same or higher level.
+    /// </summary>
+    public string? ExtractSection(List<PageText> pages, string sectionRef)
+    {
+        var fullText = string.Join("\n", pages.Select(p => p.Text));
+
+        // Build regex for the section header — match patterns like "9.2.46.14 Hypoglossal Nerve Stimulators"
+        var escapedRef = Regex.Escape(sectionRef);
+        var headerPattern = $@"(?:^|\n)\s*{escapedRef}[\s\n]+([^\n]+)";
+        var headerMatch = Regex.Match(fullText, headerPattern);
+
+        if (!headerMatch.Success)
+        {
+            logger.LogWarning("Section {Ref} not found in PDF text", sectionRef);
+            return null;
+        }
+
+        var startIndex = headerMatch.Index;
+
+        // Find the next section at the same or higher level
+        var parts = sectionRef.Split('.');
+        var nextSectionPattern = BuildNextSectionPattern(parts);
+        var nextMatch = Regex.Match(fullText[(startIndex + headerMatch.Length)..], nextSectionPattern);
+
+        var endIndex = nextMatch.Success
+            ? startIndex + headerMatch.Length + nextMatch.Index
+            : Math.Min(startIndex + 10000, fullText.Length); // Cap at ~10K chars if no next section
+
+        var sectionText = fullText[startIndex..endIndex].Trim();
+        logger.LogInformation("Extracted section {Ref}: {Len} chars", sectionRef, sectionText.Length);
+        return sectionText;
+    }
+
+    /// <summary>
+    /// Scan a section's text for CPT/HCPCS procedure codes.
+    /// Matches 5-digit numeric CPT codes and alphanumeric HCPCS codes (e.g., C8007, L2221, J9601).
+    /// </summary>
+    public List<ExtractedCode> ExtractProcedureCodes(string sectionText)
+    {
+        var codes = new HashSet<ExtractedCode>();
+
+        // CPT: 5-digit numeric codes (10000-99999 range typical)
+        foreach (Match m in CptCodeRegex().Matches(sectionText))
+        {
+            var code = m.Value;
+            if (int.TryParse(code, out var num) && num >= 10000)
+            {
+                codes.Add(new ExtractedCode { Code = code, System = "CPT" });
+            }
+        }
+
+        // HCPCS Level II: Letter + 4 digits (A-V prefix)
+        foreach (Match m in HcpcsCodeRegex().Matches(sectionText))
+        {
+            codes.Add(new ExtractedCode { Code = m.Value, System = "HCPCS" });
+        }
+
+        logger.LogInformation("Found {Count} procedure codes in section text", codes.Count);
+        return [.. codes];
+    }
+
+    /// <summary>
+    /// Extract age restrictions from section text.
+    /// Looks for patterns like "clients under 21", "ages 12 through 20", "birth through 20 years".
+    /// </summary>
+    public Models.AgeRule? ExtractAgeRule(string sectionText)
+    {
+        // Pattern: "clients [age] X through Y years"
+        var rangeMatch = Regex.Match(sectionText,
+            @"(?:age[sd]?|clients?)\s+(\d+)\s+(?:through|to)\s+(\d+)\s+years?",
+            RegexOptions.IgnoreCase);
+        if (rangeMatch.Success)
+        {
+            return new Models.AgeRule
+            {
+                MinAge = int.Parse(rangeMatch.Groups[1].Value),
+                MaxAge = int.Parse(rangeMatch.Groups[2].Value),
+                Unit = "years"
+            };
+        }
+
+        // Pattern: "under X years" or "younger than X"
+        var underMatch = Regex.Match(sectionText,
+            @"(?:under|younger than|less than)\s+(\d+)\s+years?",
+            RegexOptions.IgnoreCase);
+        if (underMatch.Success)
+        {
+            return new Models.AgeRule { MaxAge = int.Parse(underMatch.Groups[1].Value) - 1, Unit = "years" };
+        }
+
+        // Pattern: "X years of age or older" or "at least X years"
+        var overMatch = Regex.Match(sectionText,
+            @"(\d+)\s+years?\s+of\s+age\s+or\s+older|at\s+least\s+(\d+)\s+years?",
+            RegexOptions.IgnoreCase);
+        if (overMatch.Success)
+        {
+            var val = overMatch.Groups[1].Success ? overMatch.Groups[1].Value : overMatch.Groups[2].Value;
+            return new Models.AgeRule { MinAge = int.Parse(val), Unit = "years" };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extract ICD-10 diagnosis codes from section text.
+    /// </summary>
+    public List<string> ExtractDiagnosisCodes(string sectionText)
+    {
+        var codes = new HashSet<string>();
+        foreach (Match m in Icd10Regex().Matches(sectionText))
+        {
+            codes.Add(m.Value);
+        }
+        return [.. codes];
+    }
+
+    /// <summary>
+    /// Detect whether a section indicates PA is required.
+    /// </summary>
+    public bool DetectPaRequired(string sectionText)
+    {
+        var positivePatterns = new[]
+        {
+            @"prior\s+authorization\s+(?:is\s+)?required",
+            @"requires?\s+prior\s+authorization",
+            @"must\s+(?:be\s+)?(?:prior\s+)?authorized",
+            @"prior\s+authorization\s+must\s+be\s+obtained",
+            @"a\s+prior\s+authorization\s+number\s+\(PAN\)",
+        };
+
+        return positivePatterns.Any(p =>
+            Regex.IsMatch(sectionText, p, RegexOptions.IgnoreCase));
+    }
+
+    private static string BuildNextSectionPattern(string[] currentParts)
+    {
+        // Match any section header at the same depth or shallower
+        // E.g., for "9.2.46.14", match "9.2.46.15", "9.2.47", "9.3", "10", etc.
+        var depth = currentParts.Length;
+        var patterns = new List<string>();
+
+        for (int i = depth; i >= 1; i--)
+        {
+            var prefix = string.Join(@"\.", currentParts.Take(i - 1));
+            var nextNum = int.Parse(currentParts[i - 1]) + 1;
+            if (prefix.Length > 0)
+                patterns.Add($@"(?:^|\n)\s*{prefix}\.{nextNum}\s+\S");
+            else
+                patterns.Add($@"(?:^|\n)\s*{nextNum}\s+\S");
+        }
+
+        return string.Join("|", patterns);
+    }
+
+    [GeneratedRegex(@"\b\d{5}\b")]
+    private static partial Regex CptCodeRegex();
+
+    [GeneratedRegex(@"\b[A-V]\d{4}\b")]
+    private static partial Regex HcpcsCodeRegex();
+
+    [GeneratedRegex(@"\b[A-Z]\d{2}\.?\d{0,4}\b")]
+    private static partial Regex Icd10Regex();
+}
+
+public class PageText
+{
+    public int PageNumber { get; set; }
+    public string Text { get; set; } = string.Empty;
+}
+
+public class ExtractedCode
+{
+    public string Code { get; set; } = string.Empty;
+    public string System { get; set; } = string.Empty;
+
+    public override bool Equals(object? obj) =>
+        obj is ExtractedCode other && Code == other.Code && System == other.System;
+
+    public override int GetHashCode() => HashCode.Combine(Code, System);
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/Parsers/extract_section.py
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Parsers/extract_section.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Called by TmppmIngestionService to extract sections from TMPPM PDFs using PyMuPDF."""
+import fitz, re, json, sys
+
+def extract(pdf_path, section_ref):
+    doc = fitz.open(pdf_path)
+    full_text = "\n".join(page.get_text() for page in doc)
+    
+    escaped = re.escape(section_ref)
+    matches = list(re.finditer(rf'{escaped}\n', full_text))
+    
+    for m in matches:
+        start = m.start()
+        chunk = full_text[start:start+200]
+        if '. . . . .' in chunk:
+            continue
+        
+        parts = section_ref.split('.')
+        depth = len(parts)
+        next_patterns = []
+        for i in range(depth, 0, -1):
+            prefix = r'\.'.join(re.escape(p) for p in parts[:i-1])
+            next_num = int(parts[i-1]) + 1
+            if prefix:
+                next_patterns.append(rf'\n{prefix}\.{next_num}\n')
+            else:
+                next_patterns.append(rf'\n{next_num}\n')
+        
+        combined = '|'.join(next_patterns)
+        next_match = re.search(combined, full_text[start+10:])
+        end = start + 10 + next_match.start() if next_match else min(start + 10000, len(full_text))
+        
+        section_text = full_text[start:end]
+        cpt = sorted(set(re.findall(r'\b(\d{5})\b', section_text)))
+        cpt = [c for c in cpt if int(c) >= 10000]
+        hcpcs = sorted(set(re.findall(r'\b([A-V]\d{4})\b', section_text)))
+        dx = sorted(set(re.findall(r'\b([A-Z]\d{2}\.?\d{0,4})\b', section_text)))
+        
+        result = {
+            "sectionRef": section_ref,
+            "found": True,
+            "textLength": len(section_text),
+            "text": section_text,
+            "cptCodes": cpt,
+            "hcpcsCodes": hcpcs,
+            "dxCodes": dx,
+            "paRequired": bool(re.search(r'prior\s+auth', section_text, re.IGNORECASE))
+        }
+        json.dump(result, sys.stdout)
+        return
+    
+    json.dump({"sectionRef": section_ref, "found": False}, sys.stdout)
+
+if __name__ == "__main__":
+    extract(sys.argv[1], sys.argv[2])

--- a/tools/CloudHealthOffice.TmppmIngestionService/Program.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Program.cs
@@ -1,0 +1,198 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using CHO.TmppmIngestionService.Loaders;
+using CHO.TmppmIngestionService.Parsers;
+using CHO.TmppmIngestionService.Services;
+
+namespace CHO.TmppmIngestionService;
+
+/// <summary>
+/// CHO TMPPM Ingestion Service
+/// 
+/// Usage:
+///   dotnet run -- ingest 2026 4                    # Full ingestion of April 2026 TMPPM
+///   dotnet run -- ingest 2026 4 --tenant pchp      # With PCHP tenant scoping
+///   dotnet run -- parse-section 2_13 9.2.46.14     # Parse a specific section from a chapter
+///   dotnet run -- diff 2026-03 2026-04             # Diff two editions
+///   dotnet run -- download 2026 4                  # Download only (no parsing)
+/// </summary>
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("Config/appsettings.json", optional: true)
+            .AddEnvironmentVariables("CHO_TMPPM_")
+            .Build();
+
+        var services = new ServiceCollection();
+        ConfigureServices(services, config);
+        var sp = services.BuildServiceProvider();
+
+        var logger = sp.GetRequiredService<ILogger<Program>>();
+
+        if (args.Length == 0)
+        {
+            PrintUsage();
+            return 1;
+        }
+
+        var command = args[0].ToLowerInvariant();
+
+        try
+        {
+            return command switch
+            {
+                "ingest" => await RunIngest(args, sp, logger),
+                "parse-section" => await RunParseSection(args, sp, logger),
+                "download" => await RunDownload(args, sp, logger),
+                _ => PrintUsage()
+            };
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Pipeline failed");
+            return 1;
+        }
+    }
+
+    private static async Task<int> RunIngest(string[] args, IServiceProvider sp, ILogger logger)
+    {
+        if (args.Length < 3 || !int.TryParse(args[1], out var year) || !int.TryParse(args[2], out var month))
+        {
+            logger.LogError("Usage: ingest <year> <month> [--tenant <id>]");
+            return 1;
+        }
+
+        string? tenantId = null;
+        var tenantIdx = Array.IndexOf(args, "--tenant");
+        if (tenantIdx >= 0 && tenantIdx + 1 < args.Length)
+            tenantId = args[tenantIdx + 1];
+
+        var pipeline = sp.GetRequiredService<IngestionPipeline>();
+        var result = await pipeline.RunAsync(year, month, tenantId);
+
+        logger.LogInformation(
+            "\n══ Ingestion Summary ══\n" +
+            "Edition:        {Edition}\n" +
+            "Downloaded:     {Downloaded} chapters\n" +
+            "Changed:        {Changed} chapters\n" +
+            "Rules extracted: {Rules}\n" +
+            "ConceptMap overrides: {Overrides}\n",
+            result.EditionId,
+            result.ChaptersDownloaded,
+            result.ChaptersChanged,
+            result.RulesExtracted,
+            result.ConceptMapOverridesPublished);
+
+        return 0;
+    }
+
+    private static async Task<int> RunParseSection(string[] args, IServiceProvider sp, ILogger logger)
+    {
+        if (args.Length < 3)
+        {
+            logger.LogError("Usage: parse-section <chapter_id> <section_ref>");
+            return 1;
+        }
+
+        var chapterId = args[1];
+        var sectionRef = args[2];
+        var parser = sp.GetRequiredService<TmppmPdfParser>();
+
+        // Look for the PDF in tmppm-data
+        var pdfPath = Directory.EnumerateFiles("tmppm-data", $"{chapterId}*.pdf", SearchOption.AllDirectories)
+            .FirstOrDefault();
+
+        if (pdfPath == null)
+        {
+            logger.LogError("PDF not found for chapter {Id}. Run 'download' first.", chapterId);
+            return 1;
+        }
+
+        var pages = parser.ExtractAllText(pdfPath);
+        var section = parser.ExtractSection(pages, sectionRef);
+
+        if (section == null)
+        {
+            logger.LogError("Section {Ref} not found in {Path}", sectionRef, pdfPath);
+            return 1;
+        }
+
+        var codes = parser.ExtractProcedureCodes(section);
+        var ageRule = parser.ExtractAgeRule(section);
+        var dxCodes = parser.ExtractDiagnosisCodes(section);
+        var paRequired = parser.DetectPaRequired(section);
+
+        Console.WriteLine($"\n══ Section §{sectionRef} ══");
+        Console.WriteLine($"PA Required:     {paRequired}");
+        Console.WriteLine($"Procedure codes: {string.Join(", ", codes.Select(c => $"{c.Code} ({c.System})"))}");
+        Console.WriteLine($"Age rule:        {(ageRule != null ? $"{ageRule.MinAge ?? 0}-{ageRule.MaxAge ?? 999} {ageRule.Unit}" : "none")}");
+        Console.WriteLine($"Dx codes:        {string.Join(", ", dxCodes)}");
+        Console.WriteLine($"Text length:     {section.Length} chars");
+        Console.WriteLine($"\n── First 1000 chars ──\n{section[..Math.Min(1000, section.Length)]}");
+
+        return 0;
+    }
+
+    private static async Task<int> RunDownload(string[] args, IServiceProvider sp, ILogger logger)
+    {
+        if (args.Length < 3 || !int.TryParse(args[1], out var year) || !int.TryParse(args[2], out var month))
+        {
+            logger.LogError("Usage: download <year> <month>");
+            return 1;
+        }
+
+        var downloader = sp.GetRequiredService<TmhpChapterDownloader>();
+        var outputDir = Path.Combine("tmppm-data", $"{year}-{month:D2}");
+        var edition = await downloader.DownloadEditionAsync(year, month, outputDir);
+
+        logger.LogInformation("Downloaded {Count} chapters to {Dir}", edition.Chapters.Count, outputDir);
+        return 0;
+    }
+
+    private static void ConfigureServices(IServiceCollection services, IConfiguration config)
+    {
+        services.AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        services.AddHttpClient<TmhpChapterDownloader>();
+
+        // MongoDB
+        var mongoConn = config["MongoDB:ConnectionString"] ?? "mongodb://localhost:27017";
+        var mongoDb = config["MongoDB:DatabaseName"] ?? "cho_terminology";
+        services.AddSingleton<IMongoClient>(new MongoClient(mongoConn));
+        services.AddSingleton(sp => sp.GetRequiredService<IMongoClient>().GetDatabase(mongoDb));
+
+        // Services
+        services.AddSingleton<TmppmPdfParser>();
+        services.AddSingleton<TmhpChapterDownloader>();
+        services.AddSingleton<TmppmRuleStore>();
+        services.AddSingleton<IngestionPipeline>();
+    }
+
+    private static int PrintUsage()
+    {
+        Console.WriteLine("""
+            CHO TMPPM Ingestion Service
+            ═══════════════════════════
+            
+            Commands:
+              ingest <year> <month> [--tenant <id>]   Full pipeline: download → parse → diff → persist
+              parse-section <chapter_id> <section_ref> Parse a specific TMPPM section
+              download <year> <month>                  Download PDFs only (no parsing)
+            
+            Examples:
+              dotnet run -- ingest 2026 4                    # Ingest April 2026 TMPPM
+              dotnet run -- ingest 2026 4 --tenant pchp      # Scoped to PCHP tenant
+              dotnet run -- parse-section 2_13 9.2.46.14     # Extract HNS PA rules
+              dotnet run -- download 2026 4                  # Download chapters only
+            
+            Environment variables (prefix CHO_TMPPM_):
+              CHO_TMPPM_MONGODB__CONNECTIONSTRING     MongoDB connection string
+              CHO_TMPPM_MONGODB__DATABASENAME          Database name
+            """);
+        return 1;
+    }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/README.md
+++ b/tools/CloudHealthOffice.TmppmIngestionService/README.md
@@ -1,0 +1,314 @@
+# CloudHealthOffice.TmppmIngestionService
+
+Automated ingestion pipeline for the Texas Medicaid Provider Procedures Manual (TMPPM). Downloads TMPPM chapters from TMHP, extracts prior authorization rules, and persists them to Cosmos DB as `ConceptMapEntry` overrides for the CHO TerminologyService and CRD Server.
+
+This is the operational moat: CHO tracks TMPPM changes monthly while Cognizant's customers do it by hand.
+
+## Architecture
+
+```
+TMHP Website (PDFs)
+       │
+       ▼
+TmhpChapterDownloader ──→ tmppm-data/{edition}/*.pdf (SHA256 tracked)
+       │
+       ▼
+extract_section.py (PyMuPDF) ──→ Section text + CPT/HCPCS codes
+       │
+       ▼
+LlmAssistedParser (Claude API) ──→ Structured TmppmPaRule JSON
+       │
+       ▼
+TmppmRuleStore ──→ Cosmos DB (MongoDB API)
+       │
+       ├─ tmppm_pa_rules collection (raw extracted rules)
+       ├─ tmppm_editions collection (version tracking + SHA256)
+       ├─ tmppm_diff_reports collection (month-over-month deltas)
+       └─ concept_map_entries collection (ConceptMapEntry overrides)
+                │
+                ▼
+        CRD Server / PriorAuthService (runtime queries)
+```
+
+## Prerequisites
+
+- .NET 8 SDK
+- Python 3.9+ with PyMuPDF (`pip3 install PyMuPDF`)
+- Access to CHO Cosmos DB (MongoDB API)
+- Anthropic API key (for LLM-assisted extraction)
+- `kubectl` access to the `cloudhealthoffice` namespace (for secrets)
+
+## Setup
+
+### 1. Navigate and restore
+
+```bash
+cd ~/cloudhealthoffice/tools/CloudHealthOffice.TmppmIngestionService
+dotnet restore
+```
+
+### 2. Set up Cosmos DB connection
+
+Pull the connection string from Kubernetes secrets:
+
+```bash
+export CHO_TMPPM_MONGODB__CONNECTIONSTRING="$(kubectl get secret mongodb-secret -n cloudhealthoffice -o jsonpath='{.data.connectionString}' | base64 -d)"
+```
+
+Or set it directly in `Config/appsettings.json`:
+
+```json
+"MongoDB": {
+    "ConnectionString": "your-cosmos-connection-string",
+    "DatabaseName": "cho_terminology"
+}
+```
+
+### 3. Set up Anthropic API key
+
+Get your key from [console.anthropic.com](https://console.anthropic.com/) → API Keys → Create Key.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
+```
+
+Or set it in `Config/appsettings.json`:
+
+```json
+"Anthropic": {
+    "ApiKey": "sk-ant-api03-your-key-here"
+}
+```
+
+### 4. Install Python dependency
+
+```bash
+pip3 install PyMuPDF
+```
+
+## Commands
+
+All commands run from the service directory:
+
+```bash
+cd ~/cloudhealthoffice/tools/CloudHealthOffice.TmppmIngestionService
+```
+
+### Download TMPPM chapters
+
+Downloads the 8 priority TMPPM PDF chapters from TMHP and stores them locally with SHA256 hashes for change detection.
+
+```bash
+dotnet run -- download 2026 4
+```
+
+Output: `tmppm-data/2026-04/*.pdf`
+
+### Parse a specific section
+
+Test extraction on a single TMPPM section. Uses PyMuPDF for text extraction and regex for code detection.
+
+```bash
+python3 Parsers/extract_section.py tmppm-data/2026-04/<chapter>.pdf <section_ref> | python3 -m json.tool
+```
+
+Examples:
+
+```bash
+# Hypoglossal Nerve Stimulators — CPT 64582, 64583, 64584
+python3 Parsers/extract_section.py tmppm-data/2026-04/2_13_med_specs_and_phys_srvs.pdf 9.2.46.14 | python3 -m json.tool
+
+# Bariatric Surgery — extensive clinical criteria (BMI, comorbidities, psych eval)
+python3 Parsers/extract_section.py tmppm-data/2026-04/2_13_med_specs_and_phys_srvs.pdf 9.2.8.1 | python3 -m json.tool
+
+# HBOT — CPT 99183 + HCPCS G0277 with session limits per indication
+python3 Parsers/extract_section.py tmppm-data/2026-04/2_13_med_specs_and_phys_srvs.pdf 9.2.33.1 | python3 -m json.tool
+
+# Transplants — general PA requirements and contraindications
+python3 Parsers/extract_section.py tmppm-data/2026-04/2_13_med_specs_and_phys_srvs.pdf 9.2.51.1 | python3 -m json.tool
+```
+
+Output fields:
+
+| Field | Description |
+|---|---|
+| `sectionRef` | TMPPM section number |
+| `found` | Whether the section was located in the PDF |
+| `textLength` | Extracted text length in characters |
+| `text` | Full section text |
+| `cptCodes` | Extracted 5-digit CPT codes |
+| `hcpcsCodes` | Extracted HCPCS Level II codes (letter + 4 digits) |
+| `dxCodes` | Extracted ICD-10 diagnosis codes |
+| `paRequired` | Whether "prior authorization" language was detected |
+
+### Run full ingestion pipeline
+
+Downloads chapters, detects changes, parses PA sections, and persists to Cosmos DB with PCHP tenant scoping.
+
+```bash
+dotnet run -- ingest 2026 4 --tenant pchp
+```
+
+This will:
+
+1. Download all 8 TMPPM chapters from TMHP
+2. Compare SHA256 hashes against the previous edition (if any) to identify changed chapters
+3. Parse changed chapters for PA sections using the hybrid regex + LLM strategy
+4. Persist extracted rules to the `tmppm_pa_rules` collection
+5. Publish rules as `ConceptMapEntry` overrides to the `concept_map_entries` collection
+6. Save edition metadata with SHA256 hashes for next month's change detection
+
+## Monthly refresh workflow
+
+When TMHP publishes a new TMPPM edition (typically the last day of each month):
+
+```bash
+dotnet run -- ingest 2026 5 --tenant pchp
+```
+
+The pipeline automatically:
+
+- Downloads the new edition
+- Compares SHA256 hashes against the previous edition to find changed chapters
+- Only re-parses chapters that actually changed
+- Generates a diff report (added/modified/removed rules)
+
+## TMPPM chapters covered
+
+| Chapter | PDF | CHO Service |
+|---|---|---|
+| Vol. 1 Sec 5: Prior Authorizations | `1_05_prior_authorization.pdf` | PriorAuthService, CRD Server |
+| Vol. 2: Ambulance Services | `2_01_ambulance_services.pdf` | PriorAuthService |
+| Vol. 2: Behavioral Health | `2_02_behavioral_health.pdf` | PriorAuthService, BenefitsEngine |
+| Vol. 2: DME & Supplies | `2_06_dme_and_supplies.pdf` | PriorAuthService, BenefitsEngine |
+| Vol. 2: Hospital Services | `2_11_inpatient_outpatient_hosp_srvs.pdf` | PriorAuthService, AdjudicationEngine |
+| Vol. 2: Med Specialists & Physicians | `2_13_med_specs_and_phys_srvs.pdf` | PriorAuthService, TerminologyService |
+| Vol. 2: PT/OT/Speech Therapy | `2_16_pt_ot_st_srvs.pdf` | PriorAuthService, BenefitsEngine |
+| Vol. 2: Radiology & Lab | `2_17_radiology_and_lab_srvs.pdf` | PriorAuthService, AdjudicationEngine |
+
+## Cosmos DB collections
+
+| Collection | Purpose |
+|---|---|
+| `tmppm_pa_rules` | Raw extracted PA rules with clinical criteria, codes, age limits |
+| `tmppm_editions` | Edition metadata with SHA256 per chapter for change detection |
+| `tmppm_diff_reports` | Month-over-month delta reports |
+| `concept_map_entries` | ConceptMapEntry overrides queried by CRD Server at runtime |
+
+## Project structure
+
+```
+tools/CloudHealthOffice.TmppmIngestionService/
+├── Config/
+│   └── appsettings.json              # MongoDB + Anthropic config
+├── Loaders/
+│   └── TmhpChapterDownloader.cs      # Downloads PDFs, SHA256 tracking
+├── Models/
+│   └── TmppmModels.cs                # TmppmPaRule, TmppmEdition, ConceptMapEntryOverride
+├── Parsers/
+│   ├── extract_section.py            # PyMuPDF section extractor (primary)
+│   ├── TmppmPdfParser.cs             # C# regex parser (backup)
+│   ├── LlmAssistedParser.cs          # Claude API structured extraction
+│   └── HybridParser.cs               # Regex-first, LLM-fallback strategy
+├── Services/
+│   ├── IngestionPipeline.cs           # Main orchestrator
+│   └── TmppmRuleStore.cs             # Cosmos DB persistence
+├── Program.cs                         # CLI entry point
+├── TmppmIngestionService.csproj
+├── .gitignore
+├── README.md
+└── tmppm-data/                        # Downloaded PDFs (gitignored)
+    └── 2026-04/
+        ├── 1_05_prior_authorization.pdf
+        ├── 2_01_ambulance_services.pdf
+        ├── 2_02_behavioral_health.pdf
+        ├── 2_06_dme_and_supplies.pdf
+        ├── 2_11_inpatient_outpatient_hosp_srvs.pdf
+        ├── 2_13_med_specs_and_phys_srvs.pdf
+        ├── 2_16_pt_ot_st_srvs.pdf
+        └── 2_17_radiology_and_lab_srvs.pdf
+```
+
+## Validated extractions
+
+These sections have been tested and confirmed working:
+
+| Section | Category | CPT Codes | HCPCS | Text Size | Notes |
+|---|---|---|---|---|---|
+| §9.2.46.14 | Hypoglossal Nerve Stimulators | 64582, 64583, 64584 | — | 1,355 chars | 64583/64584 do NOT require PA |
+| §9.2.8.1 | Bariatric Surgery | — (LLM enrichment needed) | — | 8,793 chars | BMI ≥35 adults, ≥40 pediatric; 13 comorbidities |
+| §9.2.33.1 | Hyperbaric Oxygen Therapy | 99183 | G0277 | 1,658 chars | Session limits per indication in table |
+| §9.2.51.1 | Organ Transplants (General) | — (category-level) | — | 2,431 chars | Contraindications, 3-day pre/6-week post window |
+
+## Competitive context
+
+Cognizant told PCHP on the March 2024 interoperability call that they have **no state-specific Medicaid modules**. Their EPA quote includes 130 custom rules/questionnaires, but Texas Medicaid likely exceeds that. Ongoing TMPPM monthly maintenance falls entirely on Parkland staff.
+
+CHO's approach with this service:
+
+- **Automated** — TMPPM changes detected and extracted monthly via SHA256 + PDF parsing
+- **Structured** — Rules persisted as FHIR-queryable ConceptMapEntry overrides
+- **Tenant-scoped** — PCHP gets TX-specific rules via `TenantId` + `State=TX` + `IsOverride=true`
+- **Scalable** — Same architecture replicates to any state (FL, NY, CA) by adding a new state code
+- **LLM-enriched** — Claude API backfills CPT codes for criteria-only sections like bariatric surgery
+
+## Adding a new state (e.g., Florida)
+
+1. Add the state's Medicaid manual chapters to `TmhpChapterDownloader.KnownChapters`
+2. Update the PDF URLs to point to the state's publication site
+3. Run: `dotnet run -- ingest 2026 4 --tenant <tenant>`
+4. The `MapRule.State = "FL"` overrides are automatically scoped
+
+## Deploying as AKS CronJob
+
+For automated monthly execution on the CHO AKS cluster:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: tmppm-ingestion
+  namespace: cloudhealthoffice
+spec:
+  schedule: "0 6 1 * *"  # 1st of each month at 6am UTC
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: tmppm-ingestion
+            image: cho.azurecr.io/tmppm-ingestion:latest
+            command: ["dotnet", "TmppmIngestionService.dll", "ingest", "2026", "4", "--tenant", "pchp"]
+            env:
+            - name: CHO_TMPPM_MONGODB__CONNECTIONSTRING
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb-secret
+                  key: connectionString
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cho-secrets
+                  key: ANTHROPIC_API_KEY
+          restartPolicy: OnFailure
+```
+
+## Troubleshooting
+
+**"Section not found"** — The C# PdfPig parser splits section numbers and titles across lines. Use the Python extractor (`extract_section.py`) which handles this correctly via PyMuPDF.
+
+**Cosmos DB timeout / "Connection refused localhost:27017"** — The connection string isn't set. Verify with:
+```bash
+echo $CHO_TMPPM_MONGODB__CONNECTIONSTRING
+```
+If empty, re-export from Kubernetes:
+```bash
+export CHO_TMPPM_MONGODB__CONNECTIONSTRING="$(kubectl get secret mongodb-secret -n cloudhealthoffice -o jsonpath='{.data.connectionString}' | base64 -d)"
+```
+Or paste it directly into `Config/appsettings.json`.
+
+**No CPT codes extracted** — Some sections (e.g., bariatric surgery §9.2.8.1) describe clinical criteria without listing specific procedure codes inline. The LLM enrichment step backfills these by identifying the standard CPT codes for the service category.
+
+**PyMuPDF not found** — Install with `pip3 install PyMuPDF`.
+
+**Anthropic API errors** — Verify your key is set: `echo $ANTHROPIC_API_KEY`. Check that it starts with `sk-ant-`. API costs are minimal (~$1 for a full handbook extraction).

--- a/tools/CloudHealthOffice.TmppmIngestionService/Services/IngestionPipeline.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Services/IngestionPipeline.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Logging;
+using CHO.TmppmIngestionService.Loaders;
+using CHO.TmppmIngestionService.Models;
+using CHO.TmppmIngestionService.Parsers;
+
+namespace CHO.TmppmIngestionService.Services;
+
+/// <summary>
+/// Orchestrates the TMPPM ingestion pipeline:
+/// 1. Download TMPPM edition PDFs from TMHP
+/// 2. Detect changed chapters via SHA256
+/// 3. Parse changed chapters for PA rules
+/// 4. Generate diff report against previous edition
+/// 5. Persist rules + publish as ConceptMapEntry overrides
+/// </summary>
+public class IngestionPipeline(
+    TmhpChapterDownloader downloader,
+    TmppmPdfParser parser,
+    TmppmRuleStore store,
+    ILogger<IngestionPipeline> logger)
+{
+    /// <summary>
+    /// Run full ingestion for a specific edition.
+    /// </summary>
+    public async Task<IngestionResult> RunAsync(int year, int month, string? tenantId = null)
+    {
+        var result = new IngestionResult { EditionId = $"{year}-{month:D2}" };
+        var outputDir = Path.Combine("tmppm-data", result.EditionId);
+
+        logger.LogInformation("═══ TMPPM Ingestion Pipeline: {Edition} ═══", result.EditionId);
+
+        // Step 1: Download
+        logger.LogInformation("Step 1: Downloading TMPPM chapters...");
+        var edition = await downloader.DownloadEditionAsync(year, month, outputDir);
+        result.ChaptersDownloaded = edition.Chapters.Count;
+
+        // Step 2: Detect changes
+        logger.LogInformation("Step 2: Detecting changes...");
+        var previousEdition = await store.GetLatestEditionAsync();
+        var changedChapters = previousEdition != null
+            ? downloader.DetectChangedChapters(previousEdition, edition)
+            : edition.Chapters.Select(c => c.ChapterId).ToList();
+        result.ChaptersChanged = changedChapters.Count;
+
+        // Step 3: Parse changed chapters
+        logger.LogInformation("Step 3: Parsing {Count} changed chapters...", changedChapters.Count);
+        var allRules = new List<TmppmPaRule>();
+
+        foreach (var chapterId in changedChapters)
+        {
+            var chapter = edition.Chapters.First(c => c.ChapterId == chapterId);
+            var pdfPath = Path.Combine(outputDir, chapter.PdfFileName);
+
+            if (!File.Exists(pdfPath))
+            {
+                logger.LogWarning("PDF not found: {Path}", pdfPath);
+                continue;
+            }
+
+            var pages = parser.ExtractAllText(pdfPath);
+            var chapterRules = ExtractRulesFromChapter(pages, chapter, edition);
+            allRules.AddRange(chapterRules);
+            chapter.ExtractedRuleCount = chapterRules.Count;
+        }
+
+        result.RulesExtracted = allRules.Count;
+
+        // Step 4: Generate diff
+        if (previousEdition != null)
+        {
+            logger.LogInformation("Step 4: Generating diff report...");
+            // TODO: Load previous rules and diff against new rules
+            // For now, mark all as "Added" on first run
+        }
+
+        // Step 5: Persist
+        logger.LogInformation("Step 5: Persisting {Count} rules...", allRules.Count);
+        await store.UpsertRulesAsync(allRules);
+        await store.SaveEditionAsync(edition);
+
+        // Step 6: Publish to ConceptMap
+        var mapVersionId = $"tmppm-{result.EditionId}";
+        result.ConceptMapOverridesPublished = await store.PublishAsConceptMapOverridesAsync(
+            allRules, mapVersionId, tenantId);
+
+        logger.LogInformation("═══ Pipeline Complete: {Rules} rules, {Overrides} ConceptMap overrides ═══",
+            result.RulesExtracted, result.ConceptMapOverridesPublished);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extract PA rules from a parsed chapter by scanning for "Prior Authorization" sections.
+    /// </summary>
+    private List<TmppmPaRule> ExtractRulesFromChapter(
+        List<PageText> pages, TmppmChapter chapter, TmppmEdition edition)
+    {
+        var rules = new List<TmppmPaRule>();
+        var fullText = string.Join("\n", pages.Select(p => p.Text));
+
+        // Find all "Prior Authorization" section headers
+        var paHeaderPattern = @"(\d+(?:\.\d+)+)\s+(?:Prior\s+Authorization|Authorization\s+Requirements)\s+(?:for\s+)?([^\n]+)";
+        var matches = System.Text.RegularExpressions.Regex.Matches(
+            fullText, paHeaderPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        foreach (System.Text.RegularExpressions.Match match in matches)
+        {
+            var sectionRef = match.Groups[1].Value;
+            var categoryName = match.Groups[2].Value.Trim().TrimEnd('.');
+
+            var sectionText = parser.ExtractSection(pages, sectionRef);
+            if (sectionText == null) continue;
+
+            var codes = parser.ExtractProcedureCodes(sectionText);
+            var ageRule = parser.ExtractAgeRule(sectionText);
+            var dxCodes = parser.ExtractDiagnosisCodes(sectionText);
+            var paRequired = parser.DetectPaRequired(sectionText);
+
+            var rule = new TmppmPaRule
+            {
+                RuleId = $"TX-{chapter.ChapterId}-{sectionRef}".Replace(".", "-"),
+                State = "TX",
+                Category = categoryName,
+                TmppmRef = $"§{sectionRef}",
+                RuleType = "AuthRequired",
+                ProcedureCodes = codes.Select(c => c.Code).ToList(),
+                CodeSystem = codes.FirstOrDefault()?.System ?? "CPT",
+                AuthRequired = paRequired,
+                AgeLimit = ageRule,
+                AllowedDiagnoses = dxCodes.Count > 0 ? dxCodes : null,
+                EffectiveDate = edition.PolicyThroughDate,
+                SourceEdition = edition.EditionId,
+                ClinicalCriteriaSummary = sectionText.Length > 500
+                    ? sectionText[..500] + "..."
+                    : sectionText
+            };
+
+            rules.Add(rule);
+            logger.LogDebug("Extracted rule {Id}: {Category} ({CodeCount} codes)",
+                rule.RuleId, rule.Category, rule.ProcedureCodes.Count);
+        }
+
+        logger.LogInformation("Chapter {Id}: extracted {Count} PA rules", chapter.ChapterId, rules.Count);
+        return rules;
+    }
+}
+
+public class IngestionResult
+{
+    public string EditionId { get; set; } = string.Empty;
+    public int ChaptersDownloaded { get; set; }
+    public int ChaptersChanged { get; set; }
+    public int RulesExtracted { get; set; }
+    public int ConceptMapOverridesPublished { get; set; }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/Services/TmppmRuleStore.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Services/TmppmRuleStore.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using CHO.TmppmIngestionService.Models;
+
+namespace CHO.TmppmIngestionService.Services;
+
+/// <summary>
+/// Persists extracted TMPPM rules to MongoDB as ConceptMapEntry overrides.
+/// Targets the same collection used by CHO.TerminologyService for runtime lookups.
+/// </summary>
+public class TmppmRuleStore(IMongoDatabase database, ILogger<TmppmRuleStore> logger)
+{
+    private IMongoCollection<TmppmPaRule> Rules =>
+        database.GetCollection<TmppmPaRule>("tmppm_pa_rules");
+
+    private IMongoCollection<TmppmEdition> Editions =>
+        database.GetCollection<TmppmEdition>("tmppm_editions");
+
+    private IMongoCollection<TmppmDiffReport> Diffs =>
+        database.GetCollection<TmppmDiffReport>("tmppm_diff_reports");
+
+    private IMongoCollection<ConceptMapEntryOverride> ConceptMapOverrides =>
+        database.GetCollection<ConceptMapEntryOverride>("concept_map_entries");
+
+    /// <summary>
+    /// Upsert extracted PA rules. Uses RuleId as the unique key.
+    /// </summary>
+    public async Task<int> UpsertRulesAsync(IEnumerable<TmppmPaRule> rules)
+    {
+        var count = 0;
+        var bulkOps = new List<WriteModel<TmppmPaRule>>();
+
+        foreach (var rule in rules)
+        {
+            var filter = Builders<TmppmPaRule>.Filter.Eq(r => r.RuleId, rule.RuleId);
+            bulkOps.Add(new ReplaceOneModel<TmppmPaRule>(filter, rule) { IsUpsert = true });
+            count++;
+        }
+
+        if (bulkOps.Count > 0)
+        {
+            var result = await Rules.BulkWriteAsync(bulkOps);
+            logger.LogInformation("Upserted {Count} PA rules ({Inserted} new, {Modified} updated)",
+                count, result.InsertedCount, result.ModifiedCount);
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Convert TmppmPaRules to ConceptMapEntry overrides and upsert into the
+    /// terminology service collection. This is how TMPPM rules become queryable
+    /// via the FHIR $translate endpoint and CRD server.
+    /// </summary>
+    public async Task<int> PublishAsConceptMapOverridesAsync(
+        IEnumerable<TmppmPaRule> rules, string mapVersionId, string? tenantId = null)
+    {
+        var overrides = new List<ConceptMapEntryOverride>();
+
+        foreach (var rule in rules.Where(r => r.ProcedureCodes.Count > 0))
+        {
+            foreach (var code in rule.ProcedureCodes)
+            {
+                var system = rule.CodeSystem == "HCPCS"
+                    ? "https://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets"
+                    : "http://www.ama-assn.org/go/cpt";
+
+                var overrideEntry = new ConceptMapEntryOverride
+                {
+                    Id = $"tmppm-{rule.State}-{code}-{rule.RuleType}".ToLowerInvariant(),
+                    SourceSystem = system,
+                    SourceCode = code,
+                    SourceDisplay = rule.Category,
+                    TargetSystem = "urn:cho:pa-determination",
+                    TargetCode = rule.AuthRequired ? "auth-required" : "no-auth",
+                    TargetDisplay = rule.AuthRequired
+                        ? $"Prior authorization required — {rule.Category}"
+                        : $"No prior authorization — {rule.Category}",
+                    Equivalence = "equivalent",
+                    MapGroupId = $"tmppm-{rule.State}-{rule.TmppmRef}",
+                    Priority = 1,
+                    Rule = new MapRule
+                    {
+                        RuleType = "StateSpecific",
+                        State = rule.State,
+                        AgeMin = rule.AgeLimit?.MinAge,
+                        AgeMax = rule.AgeLimit?.MaxAge,
+                    },
+                    MapVersionId = mapVersionId,
+                    IsOverride = true,
+                    TenantId = tenantId
+                };
+
+                overrides.Add(overrideEntry);
+            }
+        }
+
+        if (overrides.Count > 0)
+        {
+            var bulkOps = overrides.Select(o =>
+                new ReplaceOneModel<ConceptMapEntryOverride>(
+                    Builders<ConceptMapEntryOverride>.Filter.Eq(e => e.Id, o.Id), o)
+                { IsUpsert = true })
+                .ToList<WriteModel<ConceptMapEntryOverride>>();
+
+            var result = await ConceptMapOverrides.BulkWriteAsync(bulkOps);
+            logger.LogInformation("Published {Count} ConceptMapEntry overrides for state {State}",
+                overrides.Count, rules.FirstOrDefault()?.State ?? "?");
+        }
+
+        return overrides.Count;
+    }
+
+    /// <summary>
+    /// Save edition metadata for version tracking.
+    /// </summary>
+    public async Task SaveEditionAsync(TmppmEdition edition)
+    {
+        var filter = Builders<TmppmEdition>.Filter.Eq(e => e.EditionId, edition.EditionId);
+        await Editions.ReplaceOneAsync(filter, edition, new ReplaceOptions { IsUpsert = true });
+        logger.LogInformation("Saved edition {Id} with {Count} chapters", edition.EditionId, edition.Chapters.Count);
+    }
+
+    /// <summary>
+    /// Get the most recent edition for change detection.
+    /// </summary>
+    public async Task<TmppmEdition?> GetLatestEditionAsync()
+    {
+        return await Editions
+            .Find(Builders<TmppmEdition>.Filter.Empty)
+            .SortByDescending(e => e.EditionId)
+            .FirstOrDefaultAsync();
+    }
+
+    /// <summary>
+    /// Save a diff report.
+    /// </summary>
+    public async Task SaveDiffReportAsync(TmppmDiffReport diff)
+    {
+        await Diffs.InsertOneAsync(diff);
+        logger.LogInformation("Saved diff report: {From} → {To} ({Added} added, {Modified} modified, {Removed} removed)",
+            diff.FromEdition, diff.ToEdition, diff.AddedCount, diff.ModifiedCount, diff.RemovedCount);
+    }
+}

--- a/tools/CloudHealthOffice.TmppmIngestionService/TmppmIngestionService.csproj
+++ b/tools/CloudHealthOffice.TmppmIngestionService/TmppmIngestionService.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>CHO.TmppmIngestionService</RootNamespace>
+    <AssemblyName>CHO.TmppmIngestionService</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- PDF text extraction -->
+    <PackageReference Include="PdfPig" Version="0.1.14" />
+    <!-- MongoDB for ConceptMapEntry persistence -->
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+    <!-- Configuration -->
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <!-- Logging -->
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <!-- DI -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <!-- HTTP for TMHP downloads -->
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <!-- JSON -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- Scaffolds a new **PA Rule Explorer** page at `/compliance/pa-rules` in the Blazor Server portal
- Queries TMPPM PA rules directly from Cosmos DB (MongoDB API) collections (`tmppm_pa_rules`, `tmppm_editions`, `tmppm_diff_reports`)
- Adds a "Compliance" nav group to the sidebar between Monitoring and Admin sections

## Features
- **Search by CPT/HCPCS code** with 300ms debounced autocomplete
- **Browse by category** with P1/P2/P3 priority grouping in a collapsible tree
- **Edition metadata** card with green/amber/red freshness indicator (<30d / 30-60d / >60d)
- **Month-over-month diff view** with before/after comparison, filterable by Added/Modified/Removed
- Rule cards show: PA status badge, procedure code pills (cyan monospace), collapsible clinical criteria, required documentation, age/unit limits

## Files Added (12 new, 2 modified)
- `Models/TmppmViewModels.cs` — view models
- `Services/ITmppmRuleQueryService.cs` + `TmppmRuleQueryService.cs` — MongoDB query service
- `Pages/Compliance/PaRuleExplorer.razor{,.cs,.css}` — main page with Sentinel dark theme
- `Pages/Compliance/Components/` — 5 sub-components (SearchBar, Card, CategoryBrowser, EditionStatus, DiffViewer)
- `Program.cs` — DI registration for `ITmppmRuleQueryService`
- `MainLayout.razor` — Compliance nav group

## Test plan
- [ ] Verify build succeeds (`dotnet build` passes with 0 errors)
- [ ] Navigate to `/compliance/pa-rules` and confirm page loads with empty search prompt
- [ ] Test search with a known CPT code (e.g., 64582) returns matching PA rules
- [ ] Test autocomplete dropdown appears after typing 2+ characters
- [ ] Confirm "No results" message shows for unrecognized codes
- [ ] Browse categories tab loads P1/P2/P3 groups from MongoDB
- [ ] Verify edition status card shows current TMPPM edition with freshness dot
- [ ] Test diff viewer with two editions selected
- [ ] Confirm nav menu shows "Compliance > PA Rule Explorer" for authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)