### PR TITLE
fix(ci): mirror .NET base images into ACR before build jobs

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -30,11 +30,61 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────
+  # Preflight: mirror .NET base images from MCR into ACR so the
+  # Dockerfile `FROM ${REGISTRY}/dotnet/...` lines resolve. Every
+  # service Dockerfile defaults REGISTRY to the app ACR, which means
+  # the base images must exist in ACR before any build job can run.
+  #
+  # `az acr import --force` is idempotent and server-side (the image
+  # is copied MCR → ACR inside Azure, never pulled through the GitHub
+  # runner), so it's safe and cheap to run on every workflow invocation.
+  # First run on a fresh ACR takes ~10s per image; subsequent runs are
+  # near-instant no-ops.
+  #
+  # Added after a regression in 71c9d37 that repointed 28 Dockerfiles
+  # at the ACR mirror without populating it, breaking every main deploy
+  # from Apr 9 onward with `dotnet/aspnet:8.0: not found`.
+  # ─────────────────────────────────────────────────────────────
+  ensure-base-images:
+    name: Ensure .NET Base Images Mirrored to ACR
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Import .NET 8 base images from MCR
+        env:
+          ACR_NAME: ${{ vars.ACR_NAME }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ACR_NAME:-}" ]; then
+            echo "::error::vars.ACR_NAME is not set; cannot import base images"
+            exit 1
+          fi
+          for img in dotnet/sdk:8.0 dotnet/aspnet:8.0; do
+            echo "::group::Importing mcr.microsoft.com/${img} → ${ACR_NAME}.azurecr.io/${img}"
+            az acr import \
+              --name "$ACR_NAME" \
+              --source "mcr.microsoft.com/${img}" \
+              --image "${img}" \
+              --force
+            echo "::endgroup::"
+          done
+
+  # ─────────────────────────────────────────────────────────────
   # Build all images and push to ACR
   # ─────────────────────────────────────────────────────────────
   build-push-acr:
     name: Build & Push to ACR
     runs-on: ubuntu-latest
+    needs: ensure-base-images
     permissions:
       id-token: write
       contents: read
@@ -82,6 +132,7 @@ jobs:
   build-push-services:
     name: Build & Push Services (${{ matrix.service }})
     runs-on: ubuntu-latest
+    needs: ensure-base-images
     permissions:
       id-token: write
       contents: read
@@ -206,6 +257,7 @@ jobs:
   build-push-containers:
     name: Build & Push Containers (${{ matrix.container }})
     runs-on: ubuntu-latest
+    needs: ensure-base-images
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Prod AKS deploys have been failing on every merge since Apr 9 4:41 PM MST. The `deploy-azure-aks.yml` workflow dies in ~4 minutes at the `docker buildx build` step with:

```
ERROR: failed to solve: choacrhy6h2vdulfru6.azurecr.io/dotnet/aspnet:8.0:
failed to resolve source metadata ... not found
```

Root cause: commit `71c9d37` ("fix: route .NET base image pulls through ACR to eliminate MCR 403 failures in CI") repointed 28 Dockerfiles from `mcr.microsoft.com/dotnet/*` to the app ACR mirror, but never populated the mirror. Every `FROM ${REGISTRY}/dotnet/sdk:8.0` line in every Dockerfile has been trying to pull from an empty registry for 5 days.

Last successful prod deploy: `71f7918` (Apr 9 4:06 PM MST — "Add FL compliance config models"). Since then, 5 merges have been stuck in main:

- `b9badf7` PA Rule Explorer (#636)
- `71ffdc4` docs: FL AHCA SMMC 3.0
- `d450e4f` 25 claims-service test fixes (#635)
- `4bea473` AI Claims Examiner

**Why PR checks didn't catch it:** `docker-build.yml` has an MCR fallback for PR events (`BUILD_REGISTRY=mcr.microsoft.com` when ACR credentials aren't available), so PR builds pulled base images directly from MCR and never exercised the ACR path. `deploy-azure-aks.yml` has no such fallback, so main merges hit the broken path.

## Fix

Add an `ensure-base-images` preflight job to `deploy-azure-aks.yml` that runs `az acr import --force` for `dotnet/sdk:8.0` and `dotnet/aspnet:8.0` before any docker build runs. `build-push-acr`, `build-push-services`, and `build-push-containers` now `needs: ensure-base-images`.

Why `az acr import`:
- **Server-side** — image copy happens inside Azure (MCR → ACR), never pulled through the GitHub runner, so no runner rate-limit exposure to the original MCR 403 issue.
- **Idempotent** — `--force` makes it safe on every workflow invocation. First run on a fresh ACR takes ~10s per image; subsequent runs are near-instant no-ops.
- **Preserves the ACR-mirror design from `71c9d37`** — that design is the right long-term answer for HIPAA/prod reliability, it just needed a populator.

No Dockerfiles touched. Only `.github/workflows/deploy-azure-aks.yml` — 52 insertions, 0 deletions.

## Test plan

- [ ] PR checks pass (`docker-build.yml` will run on the PR head using its existing MCR fallback — sanity-checks that the workflow YAML is still valid)
- [ ] On merge to main, the `ensure-base-images` job succeeds and imports both base images into ACR
- [ ] `build-push-services (*)`, `build-push-acr`, `build-push-containers` all transition from red → green
- [ ] `deploy-aks` job runs `kubectl rollout restart deployment/portal` and `kubectl rollout status` completes within 900s
- [ ] Load `https://portal.cloudhealthoffice.com/compliance/pa-rules` — PA Rule Explorer renders (was the user-visible trigger for finding this)
- [ ] Verify `kubectl describe deployment/portal -n cloudhealthoffice | grep Image:` shows `sha-4bea473...` (current HEAD)

## Risks

- **`az acr import` requires `Contributor` or `AcrImport` on the target registry.** The existing deploy SP has been pushing to ACR successfully pre-`71c9d37` so it has `AcrPush`, which is insufficient for import. If the preflight job fails with `AuthorizationFailed`, escalate the SP to `Contributor` on the ACR resource or add the `AcrImport` custom role.
- **First successful deploy in 5 days will roll out 4 merges of code at once.** If the AKS rollout fails (e.g., CrashLoopBackOff from a runtime regression in one of the 4 commits), the existing `Diagnose portal rollout failure` step in `deploy-azure-aks.yml:627` dumps pod logs — use those to triage rather than reverting this fix, since this fix is unrelated to the rollout-time issue.

## Follow-up (not in this PR)

Delete the MCR fallback in `docker-build.yml:113-119` so PR checks exercise the same ACR path main does. That's what would have caught `71c9d37` at PR time. Happy to do this as a separate PR on request.

https://claude.ai/code/session_0199N9v4iWXhiM5MYf2M4wPa