### PR TITLE
fix(docker): copy Events project + Directory.Build.props into claims-service/claims-examiner builds

### DIFF
--- a/src/services/claims-examiner-service/Dockerfile
+++ b/src/services/claims-examiner-service/Dockerfile
@@ -2,7 +2,13 @@ ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 
-# Copy csproj files and restore (preserves layer caching)
+# Copy csproj files and restore (preserves layer caching).
+# Directory.Build.props pins minimum versions for CVE-2024-43485
+# (System.Formats.Asn1 RCE) and CVE-2024-21907 (Newtonsoft.Json).
+# MSBuild auto-imports it by walking up from the csproj, so it must
+# exist at /repo/src/ before `dotnet restore` runs — otherwise the
+# resolved graph silently uses older, vulnerable package versions.
+COPY src/Directory.Build.props src/
 COPY src/services/claims-examiner-service/claims-examiner-service.csproj src/services/claims-examiner-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
 COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/

--- a/src/services/claims-examiner-service/Dockerfile
+++ b/src/services/claims-examiner-service/Dockerfile
@@ -5,11 +5,13 @@ WORKDIR /repo
 # Copy csproj files and restore (preserves layer caching)
 COPY src/services/claims-examiner-service/claims-examiner-service.csproj src/services/claims-examiner-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/
 RUN dotnet restore src/services/claims-examiner-service/claims-examiner-service.csproj
 
 # Copy source code and build
 COPY src/services/claims-examiner-service/ src/services/claims-examiner-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/ src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/ src/services/shared/CloudHealthOffice.Events/
 RUN dotnet build src/services/claims-examiner-service/claims-examiner-service.csproj -c Release --no-restore
 
 FROM build AS publish

--- a/src/services/claims-service/Dockerfile
+++ b/src/services/claims-service/Dockerfile
@@ -2,7 +2,13 @@ ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 
-# Copy csproj files and restore (preserves layer caching)
+# Copy csproj files and restore (preserves layer caching).
+# Directory.Build.props pins minimum versions for CVE-2024-43485
+# (System.Formats.Asn1 RCE) and CVE-2024-21907 (Newtonsoft.Json).
+# MSBuild auto-imports it by walking up from the csproj, so it must
+# exist at /repo/src/ before `dotnet restore` runs — otherwise the
+# resolved graph silently uses older, vulnerable package versions.
+COPY src/Directory.Build.props src/
 COPY src/services/claims-service/claims-service.csproj src/services/claims-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
 COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/

--- a/src/services/claims-service/Dockerfile
+++ b/src/services/claims-service/Dockerfile
@@ -5,11 +5,13 @@ WORKDIR /repo
 # Copy csproj files and restore (preserves layer caching)
 COPY src/services/claims-service/claims-service.csproj src/services/claims-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/
 RUN dotnet restore src/services/claims-service/claims-service.csproj
 
 # Copy source code and build
 COPY src/services/claims-service/ src/services/claims-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/ src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/ src/services/shared/CloudHealthOffice.Events/
 RUN dotnet build src/services/claims-service/claims-service.csproj -c Release --no-restore
 
 # Publish stage


### PR DESCRIPTION
## Summary

Two commits. The first fixes a critical build break; the second addresses a latent CVE-pinning gap that Copilot caught during review of the first.

### `4d41517` fix(docker): copy CloudHealthOffice.Events into builds

Both `claims-service` and `claims-examiner-service` have been failing their Docker builds silently since PR #639 (extract shared `ClaimPendedEvent` contract) merged.

PR #639 added a `ProjectReference` to `CloudHealthOffice.Events` in both service csproj files but didn't update the Dockerfiles to copy the new shared project. Every docker build since has been failing at `dotnet restore` with:

```
error NU1101: Unable to find project
'../shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj'
```

**Impact:**
- `cloudhealthoffice-claims-examiner-service` repository does not exist in ACR at all. Confirmed via `az acr repository show-tags`. The k8s deployment manifest from PR #642 cannot be applied until an image is pushed.
- `claims-service` prod AKS deployment is running a stale pre-#639 image. Every attempted build since #639 has failed, so the `:latest` tag never advanced. New code paths (shared event contract, tenant-id enforcement from #641, AnthropicAuthHandler from #640) have never reached prod.

Fix: two `COPY` lines added to each Dockerfile — one for the csproj (so `dotnet restore` can resolve the reference) and one for the source directory (so `dotnet build` can compile against it).

### `9f64ffd` fix(docker): copy Directory.Build.props so CVE pins apply in container builds

**Addresses Copilot review feedback on the first commit.** The root `src/Directory.Build.props` file pins minimum safe versions for two High-severity CVEs:

- **CVE-2024-43485** (System.Formats.Asn1 RCE) — pinned to 8.0.1
- **CVE-2024-21907** (Newtonsoft.Json deserialization) — pinned to 13.0.4

MSBuild auto-imports `Directory.Build.props` by walking up from the csproj directory. In a local `dotnet build` the file exists on disk at `/repo/src/Directory.Build.props` and the walk succeeds. Inside the Docker build context, however, nothing was copying it in — so the walk hit the repo root and found nothing, and the resolved package graph silently used the default (vulnerable) transitive versions rather than the safe pinned ones.

**This means both services have been building Docker images with unpatched versions of System.Formats.Asn1 and Newtonsoft.Json.** My local `dotnet build` verification on the first commit gave a false-positive signal because local builds pick up the props file from disk — the gap only exists inside Docker.

Fix: `COPY src/Directory.Build.props src/` added before `dotnet restore` runs, so MSBuild's auto-import finds it at the same relative path it would in a repo-root build.

## Local verification

Both services build clean on .NET 8 SDK 8.0.419 (with the props file active from disk):
- `claims-examiner-service`: Build succeeded, 0 warnings, 0 errors (~23s)
- `claims-service`: Build succeeded, 0 warnings, 0 errors (~8s)

The Docker build path can only be validated in CI; the second commit is a defensive fix for a gap local builds don't exercise.

## Test plan

- [ ] PR CI: `Build Microservices (claims-service)` in `docker-build.yml` goes green on the PR event
- [ ] Post-merge: `deploy-azure-aks.yml` on push-to-main successfully builds and pushes `cloudhealthoffice-claims-examiner-service:latest` + `sha-<merge-sha>` to ACR for the first time
- [ ] Post-merge: `cloudhealthoffice-claims-service:latest` tag advances past pre-#639 state
- [ ] After deploy lands: user creates `anthropic-secret` with real API key, applies `src/services/claims-examiner-service/k8s/claims-examiner-service-deployment.yaml`, verifies pod reaches `Ready`

## Risk notes

- **The CVE-pin fix is symmetric with the local build behavior** — it doesn't _weaken_ anything, it aligns Docker builds with what repo-root builds have been doing all along. Existing deployed images of these services were silently using vulnerable package versions; the next image built from this PR will use the pinned safe versions.
- **No csproj or code changes** — pure Dockerfile changes. The PR's entire blast radius is two files.
- **Fork PRs will still fail the ACR fallback removal from #638.** Intentional, unchanged by this PR.

## Follow-up recommendations (not in this PR)

1. **Apply the `Directory.Build.props` COPY to the other ~26 service Dockerfiles**, or factor a shared `dotnet-build-base` image that does the COPY once and is inherited. The second approach is better — it prevents this class of bug from recurring when new props or shared projects land.
2. **Expand `deploy-azure-aks.yml` path filter or wire services build into `docker-build.yml` PR paths** so PR checks exercise the same Docker build path as main deploys. This is the same class of bug PR #638 tried to prevent for base-image pulls — we caught that one (PR green / main red) and should catch Dockerfile regressions the same way.
3. **Add a smoke test** that runs `docker build` (not `dotnet build`) against each service in the PR matrix. MSBuild resolves csproj references from disk regardless of what's copied — only Docker surfaces the COPY-vs-reference mismatch.
4. **Security scan the current production images** to confirm which services are currently deployed with vulnerable System.Formats.Asn1 / Newtonsoft.Json transitive dependencies. The other 26 services whose Dockerfiles don't copy the props file are all suspect.

https://claude.ai/code/session_0199N9v4iWXhiM5MYf2M4wPa