### PR TITLE
fix(claims-examiner): yield at startup + bounded Consume poll to unblock Kestrel

### DIFF
--- a/src/services/claims-examiner-service/Services/Kafka/ClaimPendedConsumer.cs
+++ b/src/services/claims-examiner-service/Services/Kafka/ClaimPendedConsumer.cs
@@ -38,6 +38,16 @@ public class ClaimPendedConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // Yield to the thread pool immediately so BackgroundService.StartAsync
+        // returns Task.CompletedTask and the generic host can proceed to start
+        // other services (including Kestrel). Without this, the synchronous
+        // librdkafka Consume loop below blocks the calling thread, which is
+        // whatever thread the host was using to invoke StartAsync sequentially,
+        // and Kestrel never gets its turn to bind the HTTP port. Symptom is
+        // probes failing with "connection refused" and Kestrel.BindAsync
+        // eventually throwing TaskCanceledException during host shutdown.
+        await Task.Yield();
+
         var bootstrap = _configuration["Kafka:BootstrapServers"];
         if (string.IsNullOrEmpty(bootstrap))
         {
@@ -83,7 +93,15 @@ public class ClaimPendedConsumer : BackgroundService
                 ConsumeResult<string, string>? result;
                 try
                 {
-                    result = consumer.Consume(stoppingToken);
+                    // Poll with a bounded timeout instead of blocking on the
+                    // cancellation-token overload. The token overload blocks
+                    // the calling thread indefinitely when the topic is empty,
+                    // which (a) makes cancellation laggy and (b) caused the
+                    // host-startup hang symptom when combined with a missing
+                    // await at the top of this method. A 1-second poll keeps
+                    // the while loop iterating so cancellation is checked
+                    // every tick.
+                    result = consumer.Consume(TimeSpan.FromSeconds(1));
                 }
                 catch (OperationCanceledException)
                 {
@@ -97,6 +115,9 @@ public class ClaimPendedConsumer : BackgroundService
 
                 if (result?.Message is null)
                 {
+                    // No message within the poll window — loop back to the
+                    // cancellation check. This is the hot path when the topic
+                    // is idle.
                     continue;
                 }
 

--- a/src/services/claims-examiner-service/Services/Kafka/ClaimPendedConsumer.cs
+++ b/src/services/claims-examiner-service/Services/Kafka/ClaimPendedConsumer.cs
@@ -38,11 +38,17 @@ public class ClaimPendedConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Yield to the thread pool immediately so BackgroundService.StartAsync
-        // returns Task.CompletedTask and the generic host can proceed to start
-        // other services (including Kestrel). Without this, the synchronous
-        // librdkafka Consume loop below blocks the calling thread, which is
-        // whatever thread the host was using to invoke StartAsync sequentially,
+        // Yield execution back to the host/startup sequence before we touch
+        // anything synchronous. Task.Yield() schedules the remainder of this
+        // method as a continuation (on the thread pool when no sync context
+        // is present, which is the case during generic-host startup), so
+        // BackgroundService.StartAsync can finish capturing _executeTask and
+        // return Task.CompletedTask — letting the host proceed to start the
+        // next hosted service (including Kestrel).
+        //
+        // Without this yield, the synchronous librdkafka Consume loop below
+        // runs on whatever thread the host used to invoke our StartAsync
+        // sequentially, blocks it waiting for a message that never arrives,
         // and Kestrel never gets its turn to bind the HTTP port. Symptom is
         // probes failing with "connection refused" and Kestrel.BindAsync
         // eventually throwing TaskCanceledException during host shutdown.


### PR DESCRIPTION
## Summary

Fixes a latent host-startup hang in `claims-examiner-service` that surfaces whenever Kafka is reachable but the `claims.pended.v1` topic is idle — which is always the case on a fresh Kafka install. Discovered in prod while getting claims-examiner deployed for the first time.

## Symptom

Pod enters `CrashLoopBackOff`. Logs show:

```
info: ClaimsExaminerService.Services.Kafka.ClaimPendedConsumer[0]
      Claims-pended consumer subscribed to claims.pended.v1 ...
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      System.Threading.Tasks.TaskCanceledException: A task was canceled.
         at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.BindAsync
         at Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerImpl.StartAsync
         at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync
         at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__15_1(...)
```

Kestrel never actually binds port 8080, so readiness/liveness probes fail with `connection refused`, and eventually the host is shut down with Kestrel's `BindAsync` throwing `TaskCanceledException`.

## Root cause

The generic host starts hosted services **sequentially** by default (`HostOptions.ServicesStartConcurrently = false` in .NET 8). `BackgroundService.StartAsync` invokes `ExecuteAsync` **synchronously** until it hits the first `await`, captures the returned Task, and returns `Task.CompletedTask` to let the host proceed.

In `ClaimPendedConsumer.ExecuteAsync`, the first `await` was buried **inside** the consume loop, after a call to `consumer.Consume(stoppingToken)` — librdkafka's **blocking** overload that waits indefinitely for the first message. On an idle topic, no message ever arrives. The synchronous portion of `ExecuteAsync` never completes, `BackgroundService.StartAsync` never returns, and the generic host is stuck waiting for it — so `GenericWebHostService` (which owns Kestrel) never gets its turn to start.

Eventually the host startup sequence is cancelled and the pending `KestrelServerImpl.BindAsync` throws `TaskCanceledException` as it's torn down.

## Fix

Two changes to `ClaimPendedConsumer.cs`:

### 1. `await Task.Yield()` as the first line of ExecuteAsync

```csharp
protected override async Task ExecuteAsync(CancellationToken stoppingToken)
{
    // Yield to the thread pool immediately so BackgroundService.StartAsync
    // returns Task.CompletedTask and the generic host can proceed to start
    // other services (including Kestrel)...
    await Task.Yield();

    var bootstrap = _configuration["Kafka:BootstrapServers"];
    ...
}
```

Forces the async state machine to return to the caller immediately. `BackgroundService.StartAsync` captures the still-running Task and returns `Task.CompletedTask`. The host proceeds to start Kestrel, which binds the HTTP port. The consumer resumes on a thread pool thread after Kestrel is ready.

### 2. Replace `consumer.Consume(stoppingToken)` with `consumer.Consume(TimeSpan.FromSeconds(1))`

The cancellation-token overload blocks indefinitely. The TimeSpan overload polls with a bounded timeout and returns `null` if no message arrived. The existing null check at `if (result?.Message is null) continue;` already handles that case — we just needed the right overload.

The while loop now iterates at least once per second even when the topic is idle, so:
- Cancellation is checked on every iteration via `while (!stoppingToken.IsCancellationRequested)`
- Transient broker downtime surfaces as `ConsumeException` (already caught and logged) rather than a blocked thread
- Host startup is never blocked even if fix #1 were somehow bypassed

## Testing

- **28/28** existing `CloudHealthOffice.ClaimsExaminerService.Tests` pass on net8.0 with the fix
- **Build clean**: 0 warnings, 0 errors

### Tests NOT added (filing as follow-up)

The ideal regression test would spin up the generic host with an unreachable Kafka bootstrap address and assert the host starts (Kestrel binds) within N seconds. The existing `ClaimsApiFactory` test harness uses `WebApplicationFactory` which sidesteps the real startup path. Writing a dedicated host-startup integration test is structurally different from the unit test style currently used in this test project. Worth doing but out of scope for this hotfix.

## Ops note

After this merges and the new image rolls out, the temporary `ASPNETCORE_URLS` runtime override applied during debugging can be removed:

```bash
kubectl set env deployment/claims-examiner-service -n cloudhealthoffice \
  ASPNETCORE_URLS-
```

The `dotnet/aspnet:8.0` base image sets `ASPNETCORE_HTTP_PORTS=8080` by default, which makes the `ASPNETCORE_URLS` override redundant once Kestrel is no longer being starved by the blocked consumer thread.

## Test plan

- [ ] PR CI: `Build Microservices (claims-service)` passes (this PR doesn't touch claims-service but validates the Dockerfile is still healthy)
- [ ] Post-merge: `deploy-azure-aks.yml` pushes a new `cloudhealthoffice-claims-examiner-service:sha-<merge>` image
- [ ] Post-merge: `kubectl rollout restart deployment/claims-examiner-service -n cloudhealthoffice` picks up the new image
- [ ] Post-merge: with `Kafka__BootstrapServers=kafka.cloudhealthoffice:9092` (Bitnami Kafka installed in the same namespace), the pod reaches `1/1 Running` within ~60 seconds
- [ ] Logs show `Now listening on: http://[::]:8080` followed by `Claims-pended consumer subscribed to claims.pended.v1` — in either order
- [ ] No `TaskCanceledException` or `Hosting failed to start` lines

## Risk notes

- **Behaviorally additive** — the fix does not change the consumer's event handling, offset commit semantics, or error paths. It only changes when the consumer yields control during startup.
- **No config changes** — `ClaimPendedConsumer.cs` only; no Dockerfile, manifest, or ConfigMap changes.
- **No new dependencies** — `Task.Yield()` and `Consume(TimeSpan)` are both in the existing API surface.

## Follow-up (not in this PR)

1. Host-startup integration test for BackgroundService implementations (see "Tests NOT added" above)
2. Apply the same `await Task.Yield()` pattern to any other BackgroundService in the repo that might have the same latent issue (audit needed)

https://claude.ai/code/session_0199N9v4iWXhiM5MYf2M4wPa