### PR TITLE
feat(member-service): elevate Member to full FHIR Patient projection (5.1)

### DIFF
--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -179,6 +179,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{F078A4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.Events", "src\services\shared\CloudHealthOffice.Events\CloudHealthOffice.Events.csproj", "{8DC1EBCE-63CF-42DE-8313-D82F4B949B68}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoverageService.Tests", "src\services\coverage-service\CoverageService.Tests\CoverageService.Tests.csproj", "{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnrollmentImportService.Tests", "src\services\enrollment-import-service\EnrollmentImportService.Tests\EnrollmentImportService.Tests.csproj", "{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -897,6 +901,30 @@ Global
 		{89C2115B-CB20-4920-9067-27750122AF95}.Release|x64.Build.0 = Release|Any CPU
 		{89C2115B-CB20-4920-9067-27750122AF95}.Release|x86.ActiveCfg = Release|Any CPU
 		{89C2115B-CB20-4920-9067-27750122AF95}.Release|x86.Build.0 = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Debug|x86.Build.0 = Debug|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|x64.Build.0 = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1A2B3C4-D5E6-4F7A-8B9C-0D1E2F3A4B5D}.Release|x86.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|x64.Build.0 = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}.Release|x86.Build.0 = Release|Any CPU
 		{266F3BD4-0495-41E3-BA95-1C7A73BED792}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{266F3BD4-0495-41E3-BA95-1C7A73BED792}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{266F3BD4-0495-41E3-BA95-1C7A73BED792}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/docs/architecture/member-foundation.md
+++ b/docs/architecture/member-foundation.md
@@ -179,7 +179,61 @@ downstreams fall back to `Fake*Client` stand-ins (not used in production).
 - `Members` container — PK `/tenantId` (unchanged).
 - `member-events` container — PK `/partitionKey`
   (`{tenantId}:{memberId}`) so per-member streams remain co-located for
-  future Change Feed consumers.
+  future Change Feed consumers. **Unique-key policy on `/version`** so
+  concurrent writers to the same `(tenantId, memberId)` collide at the
+  index level; the Cosmos repository converts the resulting HTTP 409 with
+  `SubStatusCode=1009` into a version retry
+  (`CosmosMemberEventPublisher`, backoff 2/5/25/100/250 ms, max 5
+  attempts, then `ConcurrencyException`).
+
+### Provisioning script
+
+See `scripts/cosmos/provision-member-events.sh`. Usage:
+
+```bash
+scripts/cosmos/provision-member-events.sh \
+  --account my-cosmos \
+  --resource-group rg-cho \
+  --database CloudHealthOffice
+```
+
+### Sample `az` command (runbook-inline copy)
+
+```bash
+az cosmosdb sql container create \
+  --account-name my-cosmos \
+  --resource-group rg-cho \
+  --database-name CloudHealthOffice \
+  --name member-events \
+  --partition-key-path "/partitionKey" \
+  --unique-key-policy '{"uniqueKeys":[{"paths":["/version"]}]}' \
+  --throughput 400
+```
+
+### Migration
+
+Unique-key policies are immutable after container creation. For **dev /
+staging**: drop and recreate the container (data loss acceptable). For
+**prod**: create a new container with the policy, copy documents via Data
+Migration Tool or a Change-Feed pump, swap reads/writes, then delete the
+old container.
+
+### PII dedupe (HMAC fingerprint)
+
+PII identifier values (SSN, MBI, Medicaid) are encrypted with AES-GCM, so
+two writes of the same plaintext produce different ciphertexts and can't
+be compared by `Value`. To catch duplicates, the controller computes an
+HMAC-SHA256 fingerprint of the NORMALIZED plaintext (dashes, spaces,
+parentheses stripped; uppercased) before encryption, and stores it in
+`MemberIdentifier.ValueFingerprint`.
+
+- Fingerprint HMAC key is a **distinct** Key Vault secret
+  (`Encryption:IdentifierFingerprintKeySecret`) — not reused from the AES
+  data key — so the two secrets can rotate independently.
+- `IdentifierNormalization.Normalize` is the only normalizer; both
+  `Add` and `Remove` flows call it.
+- Dedupe scope is `(system, fingerprint)` within a member.
+- Non-PII identifiers skip fingerprinting and dedupe by `Value`.
 
 ## Future work (explicitly out of scope for this PR)
 

--- a/docs/architecture/member-foundation.md
+++ b/docs/architecture/member-foundation.md
@@ -1,0 +1,193 @@
+# Member Foundation (5.1)
+
+Elevates `Member` from an 834 enrollment record to a full FHIR R4 **Patient**
+operational projection, with typed identifiers, an append-only event stream,
+and downstream-service fan-out via typed clients.
+
+## Scope of this PR
+- Extended `Member` model (FHIR-aligned demographics + identifiers + communication).
+- Append-only `member-events` stream (Cosmos container / Mongo collection).
+- `IMemberEventPublisher` (decorator-friendly so a future bus publisher can be
+  layered in without touching call sites).
+- `IFhirPatientProjector` projecting `Member` → FHIR R4 Patient (hand-built
+  JSON, no `Hl7.Fhir.R4` dependency).
+- `IdentifiersController` for typed identifier management.
+- Typed downstream HTTP clients (coverage-service, enrollment-import-service,
+  accumulator-service) with 503 Problem Detail when unconfigured and dev-only
+  fakes gated by `IHostEnvironment.IsDevelopment()`.
+
+## Component diagram
+
+```mermaid
+flowchart LR
+  subgraph Client
+    Portal[Portal / 834 import]
+  end
+
+  Portal -->|HTTP| MC[MembersController]
+  Portal -->|HTTP| IC[IdentifiersController]
+
+  subgraph member-service
+    MC -->|IMemberRepository| MR[(Cosmos/Mongo Members)]
+    MC -->|IMemberEventPublisher| MEP
+    MC -->|IFhirPatientProjector| FP
+    MC -->|ICoverageServiceClient| Cov[[coverage-service]]
+    MC -->|IEnrollmentImportServiceClient| Enr[[enrollment-import-service]]
+    MC -->|IAccumulatorServiceClient| Acc[[accumulator-service]]
+
+    IC -->|IMemberRepository| MR
+    IC -->|IIdentifierEncryptor| KV[(Azure Key Vault)]
+    IC -->|IMemberEventPublisher| MEP
+
+    MEP[CosmosMemberEventPublisher] -->|IMemberEventRepository| ME[(Cosmos member-events)]
+    FP[FhirPatientProjector] -->|JsonObject| MC
+  end
+
+  ME -.->|Change Feed (future PR)| Bus[(Service Bus fan-out)]
+```
+
+## Data model additions
+
+| Field | Type | Notes |
+|---|---|---|
+| `Identifiers` | `List<MemberIdentifier>` | Typed identifiers. PII values (SSN/MBI/Medicaid) stored ciphertext; `IsEncrypted=true`. |
+| `PreferredLanguage` | `string?` (BCP-47) | Projects to `Patient.communication[preferred=true]`. |
+| `Languages` | `List<string>` | Additional BCP-47 languages. |
+| `Race` / `RaceDetail` | `CodedConcept?` / `List<CodedConcept>` | us-core-race ombCategory + detailed. |
+| `Ethnicity` / `EthnicityDetail` | ditto | us-core-ethnicity. |
+| `GenderIdentity` | `CodedConcept?` | us-core-genderIdentity. |
+| `Pronouns` | `string?` | `individual-pronouns` extension. |
+| `MaritalStatus` | `CodedConcept?` | v3 MaritalStatus. |
+| `Deceased` / `DeceasedDate` | `bool` / `DateTime?` | `deceasedBoolean` vs `deceasedDateTime`. |
+| `BirthSex` | `string?` (M/F/UNK) | us-core-birthsex. |
+| `CommunicationPreferences` | `List<CommunicationPreference>` | Channel + window + opt-in. |
+
+## Identifier system URIs (`FhirIdentifierSystems`)
+
+| Type | System |
+|---|---|
+| `MemberId` | `urn:cho:member-id` |
+| `SSN` | `http://hl7.org/fhir/sid/us-ssn` |
+| `MedicareMbi` | `http://hl7.org/fhir/sid/us-mbi` |
+| `Medicaid` | `http://hl7.org/fhir/sid/us-medicaid` |
+| `Exchange` | `urn:cho:exchange-id` |
+| `Portal` | `urn:cho:portal-id` |
+| `Legacy` | `urn:cho:legacy:{slug}` (slug is tenant-configured) |
+
+## Event stream
+
+### Envelope
+
+```jsonc
+{
+  "id": "evt-uuid",                 // Cosmos doc id, defaults to eventId
+  "partitionKey": "{tenantId}:{memberId}",
+  "tenantId": "tenant-1",
+  "memberId": "M-001",
+  "eventId": "evt-uuid",            // client-supplied, unique key for idempotency
+  "eventType": "MemberCreated",
+  "version": 1,                     // monotonically increasing per aggregate
+  "schemaVersion": 1,
+  "occurredAt": "2026-04-17T15:00:00Z",
+  "actorId": "user@tenant",
+  "correlationId": "trace-abc",
+  "payload": { "...": "see below" }
+}
+```
+
+- **Cosmos container**: `member-events`, partition key path `/partitionKey`.
+- **Mongo collection**: `member-events` with unique compound indexes on
+  `(tenantId, memberId, eventId)` and `(tenantId, memberId, version)`.
+- **Idempotency**: duplicate writes with the same `eventId` are no-ops.
+  Callers may safely retry.
+- **Ordering**: `version` is assigned server-side by the publisher
+  (`max(version)+1` per aggregate). Concurrent writers conflict on the
+  unique index and retry.
+- **Genesis rule**: `MemberCreated` payloads MUST contain the full member
+  snapshot so projections can be rebuilt from the stream without
+  special-casing. Subsequent events (`MemberUpdated`, `AddressChanged`,
+  `PcpChanged`, `MemberTerminated`) SHOULD contain diffs of changed fields.
+
+### Event types
+
+| Type | Trigger | Payload |
+|---|---|---|
+| `MemberCreated` | `POST /members` | Full member snapshot (genesis). |
+| `MemberUpdated` | `PUT /members/{id}` (any field change) | Diff of changed fields. |
+| `AddressChanged` | `PUT /members/{id}` with address fields | Diff of address fields. |
+| `MemberTerminated` | `DELETE /members/{id}` or `POST /terminate` | `{ terminationDate, reasonCode }` |
+| `PcpChanged` | `PUT /members/{id}/pcp` | `{ providerId, effectiveDate, reason }` |
+
+## API contract
+
+| Method | Path | Response |
+|---|---|---|
+| GET | `/api/v1/members` | List (paged). |
+| GET | `/api/v1/members/{memberId}` | `Member` or 404. |
+| POST | `/api/v1/members` | 201 + `Location` header; emits `MemberCreated`. |
+| PUT | `/api/v1/members/{memberId}` | 200 / 404; emits `MemberUpdated` (+ `AddressChanged` if applicable). |
+| DELETE | `/api/v1/members/{memberId}` | 204 / 404; emits `MemberTerminated`. |
+| POST | `/api/v1/members/{memberId}/terminate` | 200 / 404 / 503. |
+| GET | `/api/v1/members/{memberId}/eligibility` | `EligibilityCheckResponse`. |
+| **GET** | **`/api/v1/members/{memberId}/fhir`** | **`application/fhir+json` R4 Patient.** |
+| **GET** | **`/api/v1/members/{memberId}/events`** | **List of `MemberEvent`, ordered by version.** |
+| GET | `/api/v1/members/{memberId}/pcp` | `MemberPcpResponse` / 503 (coverage-service). |
+| PUT | `/api/v1/members/{memberId}/pcp` | 200 / 503; emits `PcpChanged`. |
+| GET | `/api/v1/members/{memberId}/coverage-history` | 200 / 503 (coverage-service). |
+| GET | `/api/v1/members/{memberId}/834-transactions` | 200 / 503 (enrollment-import-service). |
+| GET | `/api/v1/members/{memberId}/accumulators` | 200 / 503 (accumulator-service). |
+| GET | `/api/v1/members/{memberId}/dependents` | `List<Member>`. |
+| GET | `/api/v1/members/{memberId}/identifiers` | `List<IdentifierResponse>` (PII redacted). |
+| POST | `/api/v1/members/{memberId}/identifiers` | 201 / 400 / 404 / 409; emits `MemberUpdated`. |
+| DELETE | `/api/v1/members/{memberId}/identifiers?system=&value=` | 204 / 404. |
+
+### 503 contract (downstream unavailable)
+
+When `Downstream:{Service}:BaseUrl` is not configured (or the downstream is
+unreachable), endpoints that depend on it return RFC 7807 ProblemDetails:
+
+```json
+{
+  "type": "https://cloudhealthoffice.com/problems/downstream-unavailable",
+  "title": "Downstream service unavailable",
+  "status": 503,
+  "detail": "Configure Downstream:CoverageService:BaseUrl to enable coverage integrations.",
+  "service": "coverage-service"
+}
+```
+
+In **development** only (`IHostEnvironment.IsDevelopment()`), unconfigured
+downstreams fall back to `Fake*Client` stand-ins (not used in production).
+
+## PII encryption
+
+- Field-level AES-256-GCM on PII identifier values (`SSN`, `Medicaid`,
+  `MedicareMbi`).
+- Data encryption key is sourced from Azure Key Vault via the shared
+  `ISecretProvider` abstraction (`Member:IdentifierEncryption:KeySecretName`).
+- Ciphertext envelope: `[version:1][nonce:12][tag:16][ciphertext]`,
+  base64url-encoded.
+- `Member.Identifiers[i].IsEncrypted=true` marks ciphertext values. The FHIR
+  projector redacts encrypted values to `[REDACTED]`; `IdentifiersController`
+  decrypts by the `IIdentifierEncryptor` when matching for removal.
+- Dev fallback is the `NoOpIdentifierEncryptor`; Program.cs **throws at
+  startup** in non-development environments when the key secret name is
+  unset.
+
+## Cosmos provisioning
+
+- `Members` container — PK `/tenantId` (unchanged).
+- `member-events` container — PK `/partitionKey`
+  (`{tenantId}:{memberId}`) so per-member streams remain co-located for
+  future Change Feed consumers.
+
+## Future work (explicitly out of scope for this PR)
+
+- Cosmos Change Feed → Service Bus fan-out (next PR).
+- `ServiceBusMemberEventPublisher` decorator layered onto
+  `CosmosMemberEventPublisher`.
+- Change Feed subscriber that materializes a `CurrentPcpSnapshot` read-through
+  cache on `Member` from `PcpChanged` events.
+- Full `UpdateMember` surface for the new demographic fields (currently the
+  controller accepts the core subset; race/ethnicity/communication are
+  populated through `POST /members` or the future terminology-service sync).

--- a/scripts/cosmos/provision-member-events.sh
+++ b/scripts/cosmos/provision-member-events.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Provisions the Cosmos SQL container backing the member-events stream.
+#
+# Requirements:
+#   - Partition key path: /partitionKey (format "{tenantId}:{memberId}")
+#   - Unique key policy on path /version → enforces at-most-one document per
+#     (partitionKey, version) tuple so concurrent writers collide at index
+#     time. MemberEventRepository converts the 409/1009 result into a version
+#     retry in CosmosMemberEventPublisher.
+#
+# Unique key policies are IMMUTABLE after container creation. Migrating an
+# existing container requires: create new container with the policy → dual-
+# write or copy documents → swap reads → delete old container. In dev/staging
+# a drop-and-recreate is acceptable.
+#
+# Usage:
+#   scripts/cosmos/provision-member-events.sh \
+#     --account my-cosmos \
+#     --resource-group rg-cho \
+#     --database CloudHealthOffice \
+#     [--container member-events] \
+#     [--throughput 400]
+#
+# Prereqs: Azure CLI logged in, cosmosdb-preview extension if needed.
+
+set -euo pipefail
+
+CONTAINER="member-events"
+THROUGHPUT=400
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --account)        ACCOUNT="$2"; shift 2 ;;
+    --resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+    --database)       DATABASE="$2"; shift 2 ;;
+    --container)      CONTAINER="$2"; shift 2 ;;
+    --throughput)     THROUGHPUT="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${ACCOUNT:?--account is required}"
+: "${RESOURCE_GROUP:?--resource-group is required}"
+: "${DATABASE:?--database is required}"
+
+echo "==> Creating Cosmos SQL container '${CONTAINER}' on '${ACCOUNT}/${DATABASE}'"
+
+az cosmosdb sql container create \
+  --account-name "${ACCOUNT}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --database-name "${DATABASE}" \
+  --name "${CONTAINER}" \
+  --partition-key-path "/partitionKey" \
+  --unique-key-policy '{"uniqueKeys":[{"paths":["/version"]}]}' \
+  --throughput "${THROUGHPUT}"
+
+echo "OK: ${CONTAINER} created with unique-key policy on /version"

--- a/scripts/smoke/member-foundation-smoke.sh
+++ b/scripts/smoke/member-foundation-smoke.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Member Foundation smoke test.
+#
+# Exercises the member-service end-to-end against a running instance:
+#   1. POST create member
+#   2. GET member by id
+#   3. GET FHIR Patient projection
+#   4. GET event stream (expects MemberCreated at version 1)
+#   5. PUT address update (expects AddressChanged event)
+#   6. POST typed identifier (Portal)
+#
+# Usage:
+#   BASE_URL=http://localhost:5005 TENANT_ID=tenant-smoke \
+#     scripts/smoke/member-foundation-smoke.sh
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:5005}"
+TENANT_ID="${TENANT_ID:-tenant-smoke}"
+MEMBER_ID="${MEMBER_ID:-SMOKE-$(date +%s)}"
+
+hdr=(-H "Content-Type: application/json" -H "X-Tenant-ID: ${TENANT_ID}")
+
+echo "==> POST /api/v1/members (memberId=${MEMBER_ID})"
+curl -sS -f -X POST "${BASE_URL}/api/v1/members" "${hdr[@]}" -d @- <<JSON | jq '.memberId, .status'
+{
+  "memberId": "${MEMBER_ID}",
+  "groupNumber": "SMOKE-GRP",
+  "isSubscriber": true,
+  "firstName": "Smoke",
+  "lastName": "Test",
+  "dateOfBirth": "1990-01-01",
+  "effectiveDate": "2024-01-01",
+  "gender": "F",
+  "preferredLanguage": "en-US",
+  "birthSex": "F"
+}
+JSON
+
+echo "==> GET /api/v1/members/${MEMBER_ID}"
+curl -sS -f "${BASE_URL}/api/v1/members/${MEMBER_ID}" "${hdr[@]}" | jq '.memberId'
+
+echo "==> GET /api/v1/members/${MEMBER_ID}/fhir"
+fhir=$(curl -sS -f "${BASE_URL}/api/v1/members/${MEMBER_ID}/fhir" "${hdr[@]}")
+echo "$fhir" | jq '.resourceType, .birthDate'
+[ "$(echo "$fhir" | jq -r '.resourceType')" = "Patient" ] || { echo "FAIL: resourceType != Patient"; exit 1; }
+
+echo "==> GET /api/v1/members/${MEMBER_ID}/events"
+events=$(curl -sS -f "${BASE_URL}/api/v1/members/${MEMBER_ID}/events" "${hdr[@]}")
+created_count=$(echo "$events" | jq '[.[] | select(.eventType=="MemberCreated" or .eventType==1)] | length')
+[ "$created_count" -ge 1 ] || { echo "FAIL: no MemberCreated event"; exit 1; }
+
+echo "==> PUT /api/v1/members/${MEMBER_ID} (address change)"
+curl -sS -f -X PUT "${BASE_URL}/api/v1/members/${MEMBER_ID}" "${hdr[@]}" -d '{
+  "address": "1 Smoke Plaza", "city": "Austin", "state": "TX", "zipCode": "78701"
+}' > /dev/null
+
+echo "==> POST /api/v1/members/${MEMBER_ID}/identifiers (portal)"
+curl -sS -f -X POST "${BASE_URL}/api/v1/members/${MEMBER_ID}/identifiers" "${hdr[@]}" -d '{
+  "type": 6, "value": "smoke-portal-uid"
+}' > /dev/null
+
+echo "==> GET /api/v1/members/${MEMBER_ID}/identifiers"
+curl -sS -f "${BASE_URL}/api/v1/members/${MEMBER_ID}/identifiers" "${hdr[@]}" | jq '.[0].system'
+
+echo "OK: member-foundation smoke completed."

--- a/src/services/coverage-service/Controllers/CoverageController.cs
+++ b/src/services/coverage-service/Controllers/CoverageController.cs
@@ -349,12 +349,197 @@ public class CoverageController : ControllerBase
         return Ok(coverages);
     }
 
+    // ── Member-scoped PCP and termination endpoints ──────────────────
+    //
+    // These are called by member-service via HttpCoverageServiceClient. Coverage
+    // is the authoritative store for PCP assignment; member-service proxies.
+
+    /// <summary>
+    /// Get the member's currently-assigned PCP derived from their active coverage.
+    /// </summary>
+    [HttpGet("member/{memberId}/pcp")]
+    [ProducesResponseType(typeof(MemberPcpResponse), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetMemberPcp(
+        [FromRoute] string memberId,
+        [FromQuery] DateTime? serviceDate = null)
+    {
+        _logger.LogInformation("Fetching PCP for member {MemberId}", SanitizeForLog(memberId));
+
+        var checkDate = serviceDate ?? DateTime.UtcNow.Date;
+        var active = await _coverageRepository.GetActiveCoverageByMemberIdAsync(
+            TenantId, memberId, checkDate);
+
+        var withPcp = active.FirstOrDefault(c => !string.IsNullOrEmpty(c.PcpNpi));
+        if (withPcp == null)
+        {
+            return NotFound(new
+            {
+                MemberId = memberId,
+                Message = "No active coverage with PCP assignment found."
+            });
+        }
+
+        return Ok(new MemberPcpResponse
+        {
+            ProviderId = withPcp.PcpNpi ?? string.Empty,
+            ProviderName = withPcp.PcpName ?? string.Empty,
+            NPI = withPcp.PcpNpi ?? string.Empty,
+            AssignedDate = withPcp.PcpAssignmentDate ?? withPcp.EffectiveDate,
+            NetworkStatus = "In-Network"
+        });
+    }
+
+    /// <summary>
+    /// Assign or change the member's PCP. Writes <c>PcpNpi</c> + <c>PcpAssignmentDate</c>
+    /// on all active coverages for the member and moves the prior <c>PcpNpi</c> into
+    /// <c>PreviousPcpNpi</c>.
+    ///
+    /// TODO(roadmap 5.7 Phase 2): track PCP changes in a dedicated
+    /// <c>PcpAssignmentHistory</c> collection with effective-dated rows rather than
+    /// overwriting. Leaving the overwrite pattern in place for PR #650 per scope.
+    /// </summary>
+    [HttpPut("member/{memberId}/pcp")]
+    [ProducesResponseType(typeof(MemberPcpResponse), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> AssignMemberPcp(
+        [FromRoute] string memberId,
+        [FromBody] AssignPcpBody request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        if (string.IsNullOrWhiteSpace(request.ProviderId) && string.IsNullOrWhiteSpace(request.ProviderNpi))
+            return BadRequest(new { Message = "providerId or providerNpi is required" });
+
+        var npi = request.ProviderNpi ?? request.ProviderId;
+        if (npi.Length != 10 || !npi.All(char.IsDigit))
+            return BadRequest(new { Message = "providerNpi must be exactly 10 digits" });
+
+        var checkDate = request.EffectiveDate == default ? DateTime.UtcNow.Date : request.EffectiveDate;
+        var active = (await _coverageRepository.GetActiveCoverageByMemberIdAsync(
+            TenantId, memberId, checkDate)).ToList();
+
+        if (active.Count == 0)
+        {
+            return NotFound(new
+            {
+                MemberId = memberId,
+                Message = "No active coverage for member; cannot assign PCP."
+            });
+        }
+
+        foreach (var coverage in active)
+        {
+            if (!string.IsNullOrEmpty(coverage.PcpNpi) && coverage.PcpNpi != npi)
+                coverage.PreviousPcpNpi = coverage.PcpNpi;
+            coverage.PcpNpi = npi;
+            coverage.PcpName = request.ProviderName;
+            coverage.PcpAssignmentDate = checkDate;
+            coverage.PcpAssignmentMethod = PcpAssignmentMethod.MemberSelected;
+            coverage.LastUpdatedDate = DateTime.UtcNow;
+            coverage.LastUpdatedBy = User.Identity?.Name ?? "member-service";
+            await _coverageRepository.UpdateAsync(coverage);
+        }
+
+        return Ok(new MemberPcpResponse
+        {
+            ProviderId = npi,
+            ProviderName = request.ProviderName ?? string.Empty,
+            NPI = npi,
+            AssignedDate = checkDate,
+            NetworkStatus = "In-Network"
+        });
+    }
+
+    /// <summary>
+    /// Terminate all active coverages for a member.
+    /// </summary>
+    [HttpPost("member/{memberId}/terminate")]
+    [ProducesResponseType(typeof(TerminateMemberCoverageResponse), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> TerminateMemberCoverage(
+        [FromRoute] string memberId,
+        [FromBody] TerminateMemberCoverageBody request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var asOf = request.TerminationDate == default ? DateTime.UtcNow.Date : request.TerminationDate;
+        var active = (await _coverageRepository.GetActiveCoverageByMemberIdAsync(
+            TenantId, memberId, asOf)).ToList();
+
+        if (active.Count == 0)
+        {
+            return NotFound(new
+            {
+                MemberId = memberId,
+                Message = "No active coverage for member."
+            });
+        }
+
+        foreach (var coverage in active)
+        {
+            coverage.Status = CoverageStatus.Terminated;
+            coverage.TerminationDate = asOf;
+            if (!string.IsNullOrEmpty(request.ReasonCode))
+                coverage.MaintenanceReasonCode = request.ReasonCode;
+            coverage.LastUpdatedDate = DateTime.UtcNow;
+            coverage.LastUpdatedBy = User.Identity?.Name ?? "member-service";
+            await _coverageRepository.UpdateAsync(coverage);
+        }
+
+        return Ok(new TerminateMemberCoverageResponse
+        {
+            MemberId = memberId,
+            TerminatedCount = active.Count,
+            TerminationDate = asOf,
+            ReasonCode = request.ReasonCode
+        });
+    }
+
     private static string SanitizeForLog(string? value)
     {
         if (string.IsNullOrEmpty(value))
             return string.Empty;
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
+}
+
+public class AssignPcpBody
+{
+    public string? ProviderId { get; set; }
+    public string? ProviderNpi { get; set; }
+    public string? ProviderName { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public string? Reason { get; set; }
+}
+
+public class MemberPcpResponse
+{
+    public string ProviderId { get; set; } = string.Empty;
+    public string ProviderName { get; set; } = string.Empty;
+    public string NPI { get; set; } = string.Empty;
+    public string Specialty { get; set; } = string.Empty;
+    public string NetworkStatus { get; set; } = string.Empty;
+    public DateTime AssignedDate { get; set; }
+    public string? PracticeName { get; set; }
+    public string? Phone { get; set; }
+}
+
+public class TerminateMemberCoverageBody
+{
+    public DateTime TerminationDate { get; set; }
+    public string? ReasonCode { get; set; }
+    public string? Notes { get; set; }
+}
+
+public class TerminateMemberCoverageResponse
+{
+    public string MemberId { get; set; } = string.Empty;
+    public int TerminatedCount { get; set; }
+    public DateTime TerminationDate { get; set; }
+    public string? ReasonCode { get; set; }
 }
 
 #region Request/Response Models

--- a/src/services/coverage-service/CoverageService.Tests/Controllers/CoverageMemberEndpointsTests.cs
+++ b/src/services/coverage-service/CoverageService.Tests/Controllers/CoverageMemberEndpointsTests.cs
@@ -1,0 +1,141 @@
+using CoverageService.Controllers;
+using CoverageService.Models;
+using CoverageService.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CoverageService.Tests.Controllers;
+
+public class CoverageMemberEndpointsTests
+{
+    private const string Tenant = "t1";
+
+    private static (CoverageController ctl, Mock<ICoverageRepository> repo) Build()
+    {
+        var repo = new Mock<ICoverageRepository>();
+        var ctl = new CoverageController(repo.Object, NullLogger<CoverageController>.Instance);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, repo);
+    }
+
+    private static Coverage ActiveCoverage(string memberId, string? pcpNpi = null) => new()
+    {
+        TenantId = Tenant,
+        MemberId = memberId,
+        GroupNumber = "G",
+        PlanId = "P",
+        EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+        Status = CoverageStatus.Active,
+        PcpNpi = pcpNpi,
+        PcpAssignmentDate = pcpNpi != null ? DateTime.UtcNow.AddMonths(-3) : null
+    };
+
+    [Fact]
+    public async Task GetMemberPcp_WithAssignment_ReturnsPcp()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { ActiveCoverage("M1", "1234567890") });
+
+        var resp = await ctl.GetMemberPcp("M1");
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberPcpResponse>().Subject;
+        body.NPI.Should().Be("1234567890");
+    }
+
+    [Fact]
+    public async Task GetMemberPcp_NoActiveCoverage_Returns404()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage>());
+
+        (await ctl.GetMemberPcp("M1")).Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMemberPcp_ActiveCoverageWithoutPcp_Returns404()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { ActiveCoverage("M1") });
+
+        (await ctl.GetMemberPcp("M1")).Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task AssignMemberPcp_ValidNpi_WritesAndMovesPrior()
+    {
+        var (ctl, repo) = Build();
+        var existing = ActiveCoverage("M1", "9999999999");
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { existing });
+        repo.Setup(r => r.UpdateAsync(It.IsAny<Coverage>()))
+            .ReturnsAsync((Coverage c) => c);
+
+        var resp = await ctl.AssignMemberPcp("M1",
+            new AssignPcpBody { ProviderNpi = "1234567890", EffectiveDate = DateTime.UtcNow.Date });
+
+        resp.Should().BeOfType<OkObjectResult>();
+        existing.PcpNpi.Should().Be("1234567890");
+        existing.PreviousPcpNpi.Should().Be("9999999999");
+        repo.Verify(r => r.UpdateAsync(It.IsAny<Coverage>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignMemberPcp_InvalidNpi_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        var resp = await ctl.AssignMemberPcp("M1", new AssignPcpBody { ProviderNpi = "bad" });
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task AssignMemberPcp_NoActiveCoverage_Returns404()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage>());
+
+        var resp = await ctl.AssignMemberPcp("M1",
+            new AssignPcpBody { ProviderNpi = "1234567890" });
+        resp.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task TerminateMemberCoverage_ActiveCoverages_MarksTerminated()
+    {
+        var (ctl, repo) = Build();
+        var c1 = ActiveCoverage("M1");
+        var c2 = ActiveCoverage("M1");
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { c1, c2 });
+        repo.Setup(r => r.UpdateAsync(It.IsAny<Coverage>())).ReturnsAsync((Coverage c) => c);
+
+        var resp = await ctl.TerminateMemberCoverage("M1",
+            new TerminateMemberCoverageBody { TerminationDate = DateTime.UtcNow.Date, ReasonCode = "25" });
+
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<TerminateMemberCoverageResponse>().Subject;
+        body.TerminatedCount.Should().Be(2);
+        c1.Status.Should().Be(CoverageStatus.Terminated);
+        c2.Status.Should().Be(CoverageStatus.Terminated);
+        repo.Verify(r => r.UpdateAsync(It.IsAny<Coverage>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task TerminateMemberCoverage_NoActiveCoverage_Returns404()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage>());
+
+        var resp = await ctl.TerminateMemberCoverage("M1",
+            new TerminateMemberCoverageBody { TerminationDate = DateTime.UtcNow.Date });
+        resp.Should().BeOfType<NotFoundObjectResult>();
+    }
+}

--- a/src/services/coverage-service/CoverageService.Tests/CoverageService.Tests.csproj
+++ b/src/services/coverage-service/CoverageService.Tests/CoverageService.Tests.csproj
@@ -25,17 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\member-service.csproj" />
-    <!--
-      The downstream-route contract tests instantiate WebApplicationFactory
-      against coverage-service and enrollment-import-service so they can
-      enumerate the remote route table at test time and compare it with the
-      paths baked into HttpCoverageServiceClient / HttpEnrollmentImportServiceClient.
-      Catches pluralization / prefix mismatches that would otherwise only
-      surface as runtime 404s in prod.
-    -->
-    <ProjectReference Include="..\..\coverage-service\coverage-service.csproj" />
-    <ProjectReference Include="..\..\enrollment-import-service\EnrollmentImportService.csproj" />
+    <ProjectReference Include="..\coverage-service.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/coverage-service/coverage-service.csproj
+++ b/src/services/coverage-service/coverage-service.csproj
@@ -10,6 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="CoverageService.Tests/**" />
+    <Content Remove="CoverageService.Tests/**" />
+    <None Remove="CoverageService.Tests/**" />
+    <EmbeddedResource Remove="CoverageService.Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />

--- a/src/services/enrollment-import-service/Controllers/TransactionsController.cs
+++ b/src/services/enrollment-import-service/Controllers/TransactionsController.cs
@@ -1,0 +1,42 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnrollmentImportService.Controllers;
+
+/// <summary>
+/// Read-side API for individual 834 transactions persisted by the import path.
+/// Consumed by member-service's <c>GET /api/v1/members/{id}/834-transactions</c>.
+/// </summary>
+[ApiController]
+[Route("api/v1/enrollment")]
+public class TransactionsController : ControllerBase
+{
+    private readonly IEnrollmentTransactionRepository _transactions;
+
+    public TransactionsController(IEnrollmentTransactionRepository transactions)
+    {
+        _transactions = transactions;
+    }
+
+    /// <summary>
+    /// List 834 transactions for a member, most recent first, capped at <c>limit</c>.
+    /// </summary>
+    [HttpGet("transactions")]
+    [ProducesResponseType(typeof(List<EnrollmentTransaction>), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> ListTransactions(
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId,
+        [FromQuery] string memberId,
+        [FromQuery] int limit = 100)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest("X-Tenant-ID header is required");
+        if (string.IsNullOrWhiteSpace(memberId))
+            return BadRequest("memberId query parameter is required");
+        if (limit < 1 || limit > 500) limit = 100;
+
+        var list = await _transactions.ListByMemberAsync(tenantId, memberId, limit);
+        return Ok(list);
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/TransactionsControllerTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/TransactionsControllerTests.cs
@@ -1,0 +1,61 @@
+using EnrollmentImportService.Controllers;
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace EnrollmentImportService.Tests.Controllers;
+
+public class TransactionsControllerTests
+{
+    private static (TransactionsController ctl, Mock<IEnrollmentTransactionRepository> repo) Build()
+    {
+        var repo = new Mock<IEnrollmentTransactionRepository>();
+        var ctl = new TransactionsController(repo.Object);
+        return (ctl, repo);
+    }
+
+    [Fact]
+    public async Task ListTransactions_ReturnsRepoResult()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.ListByMemberAsync("t1", "M-001", 100))
+            .ReturnsAsync(new List<EnrollmentTransaction>
+            {
+                new() { TenantId = "t1", MemberId = "M-001", BatchId = "B1", TransactionId = "T1" }
+            });
+
+        var resp = await ctl.ListTransactions("t1", "M-001", 100);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var list = (IReadOnlyList<EnrollmentTransaction>)ok.Value!;
+        list.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ListTransactions_MissingTenant_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        (await ctl.ListTransactions("", "M-001")).Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ListTransactions_MissingMemberId_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        (await ctl.ListTransactions("t1", "")).Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ListTransactions_LimitOutOfRange_ClampsTo100()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.ListByMemberAsync("t1", "M-001", 100))
+            .ReturnsAsync(new List<EnrollmentTransaction>());
+
+        await ctl.ListTransactions("t1", "M-001", 99999);
+        repo.Verify(r => r.ListByMemberAsync("t1", "M-001", 100), Times.Once);
+
+        await ctl.ListTransactions("t1", "M-001", 0);
+        repo.Verify(r => r.ListByMemberAsync("t1", "M-001", 100), Times.Exactly(2));
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/EnrollmentImportService.Tests.csproj
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/EnrollmentImportService.Tests.csproj
@@ -25,17 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\member-service.csproj" />
-    <!--
-      The downstream-route contract tests instantiate WebApplicationFactory
-      against coverage-service and enrollment-import-service so they can
-      enumerate the remote route table at test time and compare it with the
-      paths baked into HttpCoverageServiceClient / HttpEnrollmentImportServiceClient.
-      Catches pluralization / prefix mismatches that would otherwise only
-      surface as runtime 404s in prod.
-    -->
-    <ProjectReference Include="..\..\coverage-service\coverage-service.csproj" />
-    <ProjectReference Include="..\..\enrollment-import-service\EnrollmentImportService.csproj" />
+    <ProjectReference Include="..\EnrollmentImportService.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/enrollment-import-service/EnrollmentImportService.csproj
+++ b/src/services/enrollment-import-service/EnrollmentImportService.csproj
@@ -9,6 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="EnrollmentImportService.Tests/**" />
+    <Content Remove="EnrollmentImportService.Tests/**" />
+    <None Remove="EnrollmentImportService.Tests/**" />
+    <EmbeddedResource Remove="EnrollmentImportService.Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />

--- a/src/services/enrollment-import-service/Models/EnrollmentTransaction.cs
+++ b/src/services/enrollment-import-service/Models/EnrollmentTransaction.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnrollmentImportService.Models;
+
+/// <summary>
+/// Single 834 transaction (one <c>MemberEnrollment</c> row out of a batch)
+/// persisted for audit + member-service /834-transactions queries.
+/// </summary>
+public class EnrollmentTransaction
+{
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public string TransactionId { get; set; } = string.Empty;
+
+    [Required]
+    public string BatchId { get; set; } = string.Empty;
+
+    [Required]
+    public string MemberId { get; set; } = string.Empty;
+
+    public string MemberName { get; set; } = string.Empty;
+
+    public string MaintenanceTypeCode { get; set; } = string.Empty;
+
+    public DateTime TransactionDate { get; set; } = DateTime.UtcNow;
+
+    public DateTime ReceivedAt { get; set; } = DateTime.UtcNow;
+
+    public string Status { get; set; } = "Accepted";
+
+    public string? FileName { get; set; }
+
+    public string? SubscriberId { get; set; }
+}

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddSingleton<CosmosClient>(sp =>
 
 // Repositories and services
 builder.Services.AddScoped<IEnrollmentRepository, EnrollmentRepository>();
+builder.Services.AddScoped<IEnrollmentTransactionRepository, EnrollmentTransactionRepository>();
 builder.Services.AddScoped<IEnrollmentImportService, EnrollmentImportService.Services.EnrollmentImportService>();
 
 // Health checks (MongoDB or Cosmos DB)
@@ -70,3 +71,6 @@ app.MapControllers();
 app.MapChoHealthChecks();
 
 app.Run();
+
+// Required so WebApplicationFactory<Program> works in the test project.
+public partial class Program { }

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -10,14 +10,19 @@ public interface IEnrollmentImportService
 public class EnrollmentImportService : IEnrollmentImportService
 {
     private readonly IEnrollmentRepository _repository;
+    private readonly IEnrollmentTransactionRepository _transactions;
     private readonly ILogger<EnrollmentImportService> _logger;
-    
-    public EnrollmentImportService(IEnrollmentRepository repository, ILogger<EnrollmentImportService> logger)
+
+    public EnrollmentImportService(
+        IEnrollmentRepository repository,
+        IEnrollmentTransactionRepository transactions,
+        ILogger<EnrollmentImportService> logger)
     {
         _repository = repository;
+        _transactions = transactions;
         _logger = logger;
     }
-    
+
     public async Task<ImportResult> ImportEnrollmentAsync(Enrollment834 enrollment, string tenantId)
     {
         var result = new ImportResult
@@ -25,28 +30,71 @@ public class EnrollmentImportService : IEnrollmentImportService
             FileName = enrollment.FileName,
             StartedAt = DateTime.UtcNow
         };
-        
+
+        var batchId = $"BATCH-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
+
         foreach (var memberEnrollment in enrollment.Enrollments)
         {
+            var txnStatus = "Accepted";
             try
             {
                 await ProcessMemberEnrollmentAsync(memberEnrollment, tenantId, result);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error processing enrollment for subscriber {SubscriberId}", 
+                _logger.LogError(ex, "Error processing enrollment for subscriber {SubscriberId}",
                     SanitizeForLog(memberEnrollment.SubscriberId));
                 result.Errors.Add($"Subscriber {memberEnrollment.SubscriberId}: {ex.Message}");
                 result.FailedCount++;
+                txnStatus = "Rejected";
             }
+
+            await RecordTransactionAsync(tenantId, batchId, enrollment, memberEnrollment, txnStatus);
         }
-        
+
         result.CompletedAt = DateTime.UtcNow;
         _logger.LogInformation(
             "Import completed: {SuccessCount} success, {FailedCount} failed, {SkippedCount} skipped",
             result.SuccessCount, result.FailedCount, result.SkippedCount);
-        
+
         return result;
+    }
+
+    private async Task RecordTransactionAsync(
+        string tenantId,
+        string batchId,
+        Enrollment834 batch,
+        MemberEnrollment memberEnrollment,
+        string status)
+    {
+        try
+        {
+            var memberId = memberEnrollment.SubscriberId ?? string.Empty;
+            var firstName = memberEnrollment.Demographics?.FirstName ?? string.Empty;
+            var lastName = memberEnrollment.Demographics?.LastName ?? string.Empty;
+
+            await _transactions.CreateAsync(new EnrollmentTransaction
+            {
+                TenantId = tenantId,
+                BatchId = batchId,
+                TransactionId = $"{batchId}-{Guid.NewGuid():N}".Substring(0, 40),
+                MemberId = memberId,
+                SubscriberId = memberEnrollment.SubscriberId,
+                MemberName = $"{firstName} {lastName}".Trim(),
+                MaintenanceTypeCode = memberEnrollment.MaintenanceType ?? string.Empty,
+                TransactionDate = batch.ParsedAt == default ? DateTime.UtcNow : batch.ParsedAt,
+                ReceivedAt = DateTime.UtcNow,
+                Status = status,
+                FileName = batch.FileName
+            });
+        }
+        catch (Exception ex)
+        {
+            // Transaction-log failures must not bring down the import; log and move on.
+            _logger.LogWarning(ex,
+                "Failed to persist EnrollmentTransaction for subscriber {SubscriberId}",
+                SanitizeForLog(memberEnrollment.SubscriberId));
+        }
     }
     
     private async Task ProcessMemberEnrollmentAsync(MemberEnrollment enrollment, string tenantId, ImportResult result)

--- a/src/services/enrollment-import-service/Services/EnrollmentTransactionRepository.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentTransactionRepository.cs
@@ -1,0 +1,62 @@
+using EnrollmentImportService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace EnrollmentImportService.Services;
+
+public interface IEnrollmentTransactionRepository
+{
+    Task<EnrollmentTransaction> CreateAsync(EnrollmentTransaction txn);
+    Task<IReadOnlyList<EnrollmentTransaction>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        int limit = 100);
+}
+
+/// <summary>
+/// Cosmos DB repository for individual 834 transaction records. Partition key
+/// is <c>/tenantId</c>, consistent with the Members container.
+/// </summary>
+public class EnrollmentTransactionRepository : IEnrollmentTransactionRepository
+{
+    private readonly CosmosClient _cosmosClient;
+    private readonly IConfiguration _config;
+
+    public EnrollmentTransactionRepository(CosmosClient cosmosClient, IConfiguration config)
+    {
+        _cosmosClient = cosmosClient;
+        _config = config;
+    }
+
+    private Container TransactionsContainer => _cosmosClient.GetContainer(
+        _config["CosmosDb:DatabaseName"] ?? "CloudHealthOffice",
+        _config["CosmosDb:TransactionsContainerName"] ?? "enrollment-transactions");
+
+    public async Task<EnrollmentTransaction> CreateAsync(EnrollmentTransaction txn)
+    {
+        if (string.IsNullOrEmpty(txn.Id)) txn.Id = Guid.NewGuid().ToString();
+        var response = await TransactionsContainer.CreateItemAsync(
+            txn, new PartitionKey(txn.TenantId));
+        return response.Resource;
+    }
+
+    public async Task<IReadOnlyList<EnrollmentTransaction>> ListByMemberAsync(
+        string tenantId, string memberId, int limit = 100)
+    {
+        var query = new QueryDefinition(
+            "SELECT TOP @limit * FROM c WHERE c.tenantId = @t AND c.memberId = @m ORDER BY c.receivedAt DESC")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@m", memberId)
+            .WithParameter("@limit", limit);
+
+        var iterator = TransactionsContainer.GetItemQueryIterator<EnrollmentTransaction>(
+            query, requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<EnrollmentTransaction>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+        return results;
+    }
+}

--- a/src/services/member-service/Controllers/IdentifiersController.cs
+++ b/src/services/member-service/Controllers/IdentifiersController.cs
@@ -1,0 +1,248 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using MemberService.Middleware;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MemberService.Controllers;
+
+/// <summary>
+/// Typed identifier management (Medicaid, MBI, Medicare, Exchange, Portal, Legacy).
+///
+/// PII identifiers (SSN, MBI, Medicaid) are encrypted-at-rest via
+/// <see cref="IIdentifierEncryptor"/> and are returned redacted when listed.
+/// </summary>
+[ApiController]
+[Route("api/v1/members/{memberId}/identifiers")]
+public class IdentifiersController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IMemberRepository _memberRepository;
+    private readonly IIdentifierEncryptor _encryptor;
+    private readonly IMemberEventPublisher _eventPublisher;
+
+    public IdentifiersController(
+        IMemberRepository memberRepository,
+        IIdentifierEncryptor encryptor,
+        IMemberEventPublisher eventPublisher)
+    {
+        _memberRepository = memberRepository;
+        _encryptor = encryptor;
+        _eventPublisher = eventPublisher;
+    }
+
+    /// <summary>List typed identifiers for a member. PII values are redacted.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(List<IdentifierResponse>), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> List([FromRoute] string memberId)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var response = member.Identifiers
+            .Select(i => new IdentifierResponse
+            {
+                Type = i.Type,
+                System = i.System,
+                Value = i.IsEncrypted ? "[REDACTED]" : i.Value,
+                Use = i.Use,
+                PeriodStart = i.PeriodStart,
+                PeriodEnd = i.PeriodEnd,
+                Assigner = i.Assigner,
+                IsEncrypted = i.IsEncrypted
+            })
+            .ToList();
+        return Ok(response);
+    }
+
+    /// <summary>Add a typed identifier to a member. Idempotent on (system, value).</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(IdentifierResponse), 201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(409)]
+    public async Task<IActionResult> Add(
+        [FromRoute] string memberId,
+        [FromBody] AddIdentifierRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var system = ResolveSystem(request);
+
+        var isPii = IsPii(request.Type);
+        var storedValue = isPii
+            ? await _encryptor.EncryptAsync(request.Value, ct) ?? request.Value
+            : request.Value;
+
+        if (member.Identifiers.Any(i => i.System == system && i.Value == storedValue))
+            return Conflict(new { message = "Identifier already exists on this member." });
+
+        var identifier = new MemberIdentifier
+        {
+            Type = request.Type,
+            System = system,
+            Value = storedValue,
+            Use = string.IsNullOrEmpty(request.Use) ? "official" : request.Use,
+            PeriodStart = request.PeriodStart,
+            PeriodEnd = request.PeriodEnd,
+            Assigner = request.Assigner,
+            IsEncrypted = isPii && _encryptor.IsEnabled
+        };
+        member.Identifiers.Add(identifier);
+        member.LastUpdatedDate = DateTime.UtcNow;
+        member.LastUpdatedBy = User.Identity?.Name ?? "System";
+
+        await _memberRepository.UpdateAsync(member);
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberUpdated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["identifierAdded"] = new JsonObject
+                {
+                    ["type"] = identifier.Type.ToString(),
+                    ["system"] = identifier.System
+                }
+            }
+        }, ct);
+
+        return CreatedAtAction(nameof(List), new { memberId }, new IdentifierResponse
+        {
+            Type = identifier.Type,
+            System = identifier.System,
+            Value = identifier.IsEncrypted ? "[REDACTED]" : identifier.Value,
+            Use = identifier.Use,
+            PeriodStart = identifier.PeriodStart,
+            PeriodEnd = identifier.PeriodEnd,
+            Assigner = identifier.Assigner,
+            IsEncrypted = identifier.IsEncrypted
+        });
+    }
+
+    /// <summary>Remove an identifier by (system, value) — value must be plaintext for non-PII.</summary>
+    [HttpDelete]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> Remove(
+        [FromRoute] string memberId,
+        [FromQuery, Required] string system,
+        [FromQuery, Required] string value,
+        CancellationToken ct)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var removed = 0;
+        var kept = new List<MemberIdentifier>(member.Identifiers.Count);
+        foreach (var i in member.Identifiers)
+        {
+            if (i.System != system) { kept.Add(i); continue; }
+
+            var plain = i.IsEncrypted
+                ? await _encryptor.DecryptAsync(i.Value, ct)
+                : i.Value;
+            if (plain == value) { removed++; continue; }
+            kept.Add(i);
+        }
+
+        if (removed == 0) return NotFound();
+
+        member.Identifiers = kept;
+        member.LastUpdatedDate = DateTime.UtcNow;
+        member.LastUpdatedBy = User.Identity?.Name ?? "System";
+        await _memberRepository.UpdateAsync(member);
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberUpdated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["identifierRemoved"] = new JsonObject
+                {
+                    ["system"] = system
+                }
+            }
+        }, ct);
+
+        return NoContent();
+    }
+
+    private static string ResolveSystem(AddIdentifierRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.System)) return request.System!;
+        if (request.Type == MemberIdentifierType.Legacy)
+        {
+            if (string.IsNullOrWhiteSpace(request.LegacySlug))
+                throw new ValidationException(
+                    "LegacySlug is required when Type=Legacy and System is not explicitly provided.");
+            return FhirIdentifierSystems.LegacyForSystem(request.LegacySlug);
+        }
+        return FhirIdentifierSystems.FromType(request.Type);
+    }
+
+    private static bool IsPii(MemberIdentifierType type) => type switch
+    {
+        MemberIdentifierType.SSN => true,
+        MemberIdentifierType.MedicareMbi => true,
+        MemberIdentifierType.Medicaid => true,
+        _ => false
+    };
+}
+
+public class AddIdentifierRequest
+{
+    [Required]
+    public MemberIdentifierType Type { get; set; }
+
+    [Required]
+    [StringLength(512)]
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>Optional explicit system URI. If omitted, derived from <see cref="Type"/>.</summary>
+    [StringLength(256)]
+    public string? System { get; set; }
+
+    /// <summary>Required when <see cref="Type"/>=<see cref="MemberIdentifierType.Legacy"/> and <see cref="System"/> is omitted.</summary>
+    [StringLength(64)]
+    public string? LegacySlug { get; set; }
+
+    [StringLength(16)]
+    public string? Use { get; set; }
+
+    public DateTime? PeriodStart { get; set; }
+    public DateTime? PeriodEnd { get; set; }
+
+    [StringLength(200)]
+    public string? Assigner { get; set; }
+}
+
+public class IdentifierResponse
+{
+    public MemberIdentifierType Type { get; set; }
+    public string System { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string Use { get; set; } = "official";
+    public DateTime? PeriodStart { get; set; }
+    public DateTime? PeriodEnd { get; set; }
+    public string? Assigner { get; set; }
+    public bool IsEncrypted { get; set; }
+}

--- a/src/services/member-service/Controllers/IdentifiersController.cs
+++ b/src/services/member-service/Controllers/IdentifiersController.cs
@@ -12,7 +12,10 @@ namespace MemberService.Controllers;
 /// Typed identifier management (Medicaid, MBI, Medicare, Exchange, Portal, Legacy).
 ///
 /// PII identifiers (SSN, MBI, Medicaid) are encrypted-at-rest via
-/// <see cref="IIdentifierEncryptor"/> and are returned redacted when listed.
+/// <see cref="IIdentifierEncryptor"/> and carry an HMAC fingerprint
+/// (<see cref="IIdentifierFingerprinter"/>) of the normalized plaintext so we
+/// can detect duplicates across different AES-GCM nonces. Values are redacted
+/// when listed.
 /// </summary>
 [ApiController]
 [Route("api/v1/members/{memberId}/identifiers")]
@@ -22,15 +25,18 @@ public class IdentifiersController : ControllerBase
 
     private readonly IMemberRepository _memberRepository;
     private readonly IIdentifierEncryptor _encryptor;
+    private readonly IIdentifierFingerprinter _fingerprinter;
     private readonly IMemberEventPublisher _eventPublisher;
 
     public IdentifiersController(
         IMemberRepository memberRepository,
         IIdentifierEncryptor encryptor,
+        IIdentifierFingerprinter fingerprinter,
         IMemberEventPublisher eventPublisher)
     {
         _memberRepository = memberRepository;
         _encryptor = encryptor;
+        _fingerprinter = fingerprinter;
         _eventPublisher = eventPublisher;
     }
 
@@ -59,7 +65,16 @@ public class IdentifiersController : ControllerBase
         return Ok(response);
     }
 
-    /// <summary>Add a typed identifier to a member. Idempotent on (system, value).</summary>
+    /// <summary>
+    /// Add a typed identifier to a member.
+    ///
+    /// Dedupe rules (scoped to the same <c>system</c>):
+    ///   - PII types (SSN, MBI, Medicaid): compare <c>ValueFingerprint</c> of the
+    ///     normalized plaintext. Stripping dashes/spaces/case means "123-45-6789"
+    ///     and "123456789" collide; differing AES-GCM nonces on encrypt do NOT
+    ///     defeat the check (fingerprint is computed before encryption).
+    ///   - Non-PII types: compare <c>Value</c> directly.
+    /// </summary>
     [HttpPost]
     [ProducesResponseType(typeof(IdentifierResponse), 201)]
     [ProducesResponseType(400)]
@@ -76,14 +91,31 @@ public class IdentifiersController : ControllerBase
         if (member == null) return NotFound();
 
         var system = ResolveSystem(request);
-
         var isPii = IsPii(request.Type);
-        var storedValue = isPii
-            ? await _encryptor.EncryptAsync(request.Value, ct) ?? request.Value
-            : request.Value;
 
-        if (member.Identifiers.Any(i => i.System == system && i.Value == storedValue))
-            return Conflict(new { message = "Identifier already exists on this member." });
+        string? fingerprint = null;
+        string storedValue;
+
+        if (isPii)
+        {
+            var normalized = IdentifierNormalization.Normalize(request.Value);
+            if (string.IsNullOrEmpty(normalized))
+                return BadRequest(new { message = "Identifier value cannot be empty after normalization." });
+
+            fingerprint = await _fingerprinter.FingerprintAsync(normalized, ct);
+
+            if (member.Identifiers.Any(i => i.System == system && i.ValueFingerprint == fingerprint))
+                return Conflict(new { message = "Identifier already exists on this member." });
+
+            storedValue = await _encryptor.EncryptAsync(request.Value, ct) ?? request.Value;
+        }
+        else
+        {
+            storedValue = request.Value;
+
+            if (member.Identifiers.Any(i => i.System == system && i.Value == storedValue))
+                return Conflict(new { message = "Identifier already exists on this member." });
+        }
 
         var identifier = new MemberIdentifier
         {
@@ -94,7 +126,8 @@ public class IdentifiersController : ControllerBase
             PeriodStart = request.PeriodStart,
             PeriodEnd = request.PeriodEnd,
             Assigner = request.Assigner,
-            IsEncrypted = isPii && _encryptor.IsEnabled
+            IsEncrypted = isPii && _encryptor.IsEnabled,
+            ValueFingerprint = fingerprint
         };
         member.Identifiers.Add(identifier);
         member.LastUpdatedDate = DateTime.UtcNow;
@@ -133,7 +166,11 @@ public class IdentifiersController : ControllerBase
         });
     }
 
-    /// <summary>Remove an identifier by (system, value) — value must be plaintext for non-PII.</summary>
+    /// <summary>
+    /// Remove an identifier by (system, value). For PII types the caller
+    /// supplies plaintext; we fingerprint it and match against
+    /// <c>ValueFingerprint</c>. For non-PII we match on <c>Value</c>.
+    /// </summary>
     [HttpDelete]
     [ProducesResponseType(204)]
     [ProducesResponseType(404)]
@@ -146,16 +183,29 @@ public class IdentifiersController : ControllerBase
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
+        var normalized = IdentifierNormalization.Normalize(value);
+        var fingerprintLookup = string.IsNullOrEmpty(normalized)
+            ? null
+            : await _fingerprinter.FingerprintAsync(normalized, ct);
+
         var removed = 0;
         var kept = new List<MemberIdentifier>(member.Identifiers.Count);
         foreach (var i in member.Identifiers)
         {
             if (i.System != system) { kept.Add(i); continue; }
 
-            var plain = i.IsEncrypted
-                ? await _encryptor.DecryptAsync(i.Value, ct)
-                : i.Value;
-            if (plain == value) { removed++; continue; }
+            bool match;
+            if (!string.IsNullOrEmpty(i.ValueFingerprint))
+            {
+                match = i.ValueFingerprint == fingerprintLookup;
+            }
+            else
+            {
+                // Non-PII identifier or one stored before fingerprinting was introduced.
+                match = i.Value == value;
+            }
+
+            if (match) { removed++; continue; }
             kept.Add(i);
         }
 

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -256,11 +256,16 @@ public class MembersController : ControllerBase
 
         await _memberRepository.UpdateAsync(member);
 
+        // Parent event id is the anchor for any sub-events spawned from this update.
+        // Re-posting the same UpdateMemberRequest (same EventId) must produce the same
+        // set of events — so sub-event ids are deterministic suffixes of the parent.
+        var parentEventId = request.EventId ?? Guid.NewGuid().ToString();
+
         await _eventPublisher.PublishAsync(new MemberEvent
         {
             TenantId = TenantId,
             MemberId = member.MemberId,
-            EventId = request.EventId ?? Guid.NewGuid().ToString(),
+            EventId = parentEventId,
             EventType = MemberEventType.MemberUpdated,
             ActorId = User.Identity?.Name,
             CorrelationId = HttpContext.TraceIdentifier,
@@ -273,7 +278,7 @@ public class MembersController : ControllerBase
             {
                 TenantId = TenantId,
                 MemberId = member.MemberId,
-                EventId = Guid.NewGuid().ToString(),
+                EventId = $"{parentEventId}:address",
                 EventType = MemberEventType.AddressChanged,
                 ActorId = User.Identity?.Name,
                 CorrelationId = HttpContext.TraceIdentifier,
@@ -292,12 +297,13 @@ public class MembersController : ControllerBase
         [FromRoute] string memberId,
         [FromQuery] DateTime? terminationDate = null,
         [FromQuery] string? reasonCode = null,
+        [FromQuery] string? eventId = null,
         CancellationToken ct = default)
     {
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
-        await TerminateInternal(member, terminationDate ?? DateTime.UtcNow, reasonCode, ct);
+        await TerminateInternal(member, terminationDate ?? DateTime.UtcNow, reasonCode, eventId, ct);
         return NoContent();
     }
 
@@ -314,7 +320,7 @@ public class MembersController : ControllerBase
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
-        await TerminateInternal(member, request.TerminationDate, request.ReasonCode, ct);
+        await TerminateInternal(member, request.TerminationDate, request.ReasonCode, request.EventId, ct);
 
         try
         {
@@ -328,7 +334,12 @@ public class MembersController : ControllerBase
         return Ok(new { memberId, terminationDate = request.TerminationDate, reasonCode = request.ReasonCode });
     }
 
-    private async Task TerminateInternal(Member member, DateTime terminationDate, string? reasonCode, CancellationToken ct)
+    private async Task TerminateInternal(
+        Member member,
+        DateTime terminationDate,
+        string? reasonCode,
+        string? eventId,
+        CancellationToken ct)
     {
         member.Status = EnrollmentStatus.Terminated;
         member.TerminationDate = terminationDate;
@@ -348,7 +359,7 @@ public class MembersController : ControllerBase
         {
             TenantId = TenantId,
             MemberId = member.MemberId,
-            EventId = Guid.NewGuid().ToString(),
+            EventId = eventId ?? Guid.NewGuid().ToString(),
             EventType = MemberEventType.MemberTerminated,
             ActorId = User.Identity?.Name,
             CorrelationId = HttpContext.TraceIdentifier,
@@ -487,11 +498,14 @@ public class MembersController : ControllerBase
             return DownstreamUnavailable(ex);
         }
 
+        // PUT /pcp is its own primary event — not a sub-event of an UpdateMember
+        // call — so its EventId comes from the request body (caller-supplied
+        // idempotency key) or a fresh GUID if none was supplied.
         await _eventPublisher.PublishAsync(new MemberEvent
         {
             TenantId = TenantId,
             MemberId = memberId,
-            EventId = Guid.NewGuid().ToString(),
+            EventId = request.EventId ?? Guid.NewGuid().ToString(),
             EventType = MemberEventType.PcpChanged,
             ActorId = User.Identity?.Name,
             CorrelationId = HttpContext.TraceIdentifier,
@@ -734,8 +748,12 @@ public class AssignPcpRequest
 {
     public string MemberId { get; set; } = string.Empty;
     public string ProviderId { get; set; } = string.Empty;
+    public string? ProviderNpi { get; set; }
     public DateTime EffectiveDate { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>Optional idempotency key for the PcpChanged event.</summary>
+    public string? EventId { get; set; }
 }
 
 public class TerminateMemberRequest
@@ -745,6 +763,9 @@ public class TerminateMemberRequest
     public DateTime TerminationDate { get; set; }
     public string ReasonCode { get; set; } = string.Empty;
     public string? Notes { get; set; }
+
+    /// <summary>Optional idempotency key for the MemberTerminated event.</summary>
+    public string? EventId { get; set; }
 }
 
 #endregion

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -1,18 +1,21 @@
-using Microsoft.AspNetCore.Mvc;
-using MemberService.Middleware;
-using MemberService.Models;
-using MemberService.Repositories;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
+using MemberService.Middleware;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace MemberService.Controllers;
 
 /// <summary>
-/// Member management API - manages health plan subscribers and dependents.
-/// Data populated by X12 834 Enrollment transactions.
+/// Member management API — manages health plan subscribers and dependents.
+/// Data populated by X12 834 Enrollment transactions; surfaced as FHIR R4 Patient.
 /// </summary>
 [ApiController]
 [Route("api/v1/members")]
@@ -22,23 +25,37 @@ public class MembersController : ControllerBase
     private string TenantId => HttpContext.GetTenantId();
 
     private readonly IMemberRepository _memberRepository;
-    public MembersController(IMemberRepository memberRepository)
+    private readonly IMemberEventPublisher _eventPublisher;
+    private readonly IMemberEventRepository _eventRepository;
+    private readonly IFhirPatientProjector _fhirProjector;
+    private readonly IIdentifierEncryptor _encryptor;
+    private readonly ICoverageServiceClient _coverage;
+    private readonly IEnrollmentImportServiceClient _enrollment;
+    private readonly IAccumulatorServiceClient _accumulators;
+
+    public MembersController(
+        IMemberRepository memberRepository,
+        IMemberEventPublisher eventPublisher,
+        IMemberEventRepository eventRepository,
+        IFhirPatientProjector fhirProjector,
+        IIdentifierEncryptor encryptor,
+        ICoverageServiceClient coverage,
+        IEnrollmentImportServiceClient enrollment,
+        IAccumulatorServiceClient accumulators)
     {
         _memberRepository = memberRepository;
+        _eventPublisher = eventPublisher;
+        _eventRepository = eventRepository;
+        _fhirProjector = fhirProjector;
+        _encryptor = encryptor;
+        _coverage = coverage;
+        _enrollment = enrollment;
+        _accumulators = accumulators;
     }
 
-    /// <summary>
-    /// Search members by various criteria
-    /// </summary>
-    /// <param name="memberId">Filter by member ID</param>
-    /// <param name="groupNumber">Filter by sponsor group number</param>
-    /// <param name="subscriberId">Filter dependents by subscriber ID</param>
-    /// <param name="lastName">Search by last name (partial match)</param>
-    /// <param name="dateOfBirth">Filter by date of birth</param>
-    /// <param name="activeOnly">Return only active members</param>
-    /// <param name="subscribersOnly">Return only subscribers (exclude dependents)</param>
-    /// <param name="pageSize">Page size (max 100)</param>
-    /// <param name="continuationToken">Continuation token for pagination</param>
+    // ── Search / read ────────────────────────────────────────────────
+
+    /// <summary>Search members by various criteria.</summary>
     [HttpGet]
     [ProducesResponseType(typeof(MemberListResponse), 200)]
     public async Task<IActionResult> SearchMembers(
@@ -52,7 +69,6 @@ public class MembersController : ControllerBase
         [FromQuery][Range(1, 100)] int pageSize = 20,
         [FromQuery] string? continuationToken = null)
     {
-        // If memberId is provided, do a direct lookup
         if (!string.IsNullOrEmpty(memberId))
         {
             var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
@@ -68,18 +84,16 @@ public class MembersController : ControllerBase
             TenantId, groupNumber, lastName, dateOfBirth,
             activeOnly, subscribersOnly, pageSize, continuationToken);
 
+        var list = items.ToList();
         return Ok(new MemberListResponse
         {
-            Members = items.ToList(),
+            Members = list,
             ContinuationToken = token,
-            TotalCount = items.Count()
+            TotalCount = list.Count
         });
     }
 
-    /// <summary>
-    /// Search members by free-text query (portal autocomplete).
-    /// Searches across memberId, lastName, and subscriberId.
-    /// </summary>
+    /// <summary>Free-text search across memberId and lastName.</summary>
     [HttpGet("search")]
     [ProducesResponseType(typeof(List<Member>), 200)]
     public async Task<IActionResult> SearchByQuery([FromQuery] string? q = null)
@@ -87,7 +101,6 @@ public class MembersController : ControllerBase
         if (string.IsNullOrWhiteSpace(q))
             return await SearchMembers(pageSize: 20);
 
-        // Try memberId lookup first, then fall back to lastName search
         var byId = await _memberRepository.GetByMemberIdAsync(TenantId, q);
         if (byId != null)
             return Ok(new List<Member> { byId });
@@ -98,44 +111,59 @@ public class MembersController : ControllerBase
             subscribersOnly: false, pageSize: 20, continuationToken: null);
     }
 
-    /// <summary>
-    /// Get member details by member ID
-    /// </summary>
-    /// <param name="memberId">Member ID (834 REF*0F)</param>
+    /// <summary>Get member details by member ID.</summary>
     [HttpGet("{memberId}")]
     [ProducesResponseType(typeof(Member), 200)]
     [ProducesResponseType(404)]
     public async Task<IActionResult> GetMember([FromRoute] string memberId)
     {
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
-        if (member == null)
-            return NotFound();
-
+        if (member == null) return NotFound();
         return Ok(member);
     }
 
-    /// <summary>
-    /// Create a new member (typically from 834 transaction)
-    /// </summary>
-    /// <param name="request">Member creation request</param>
+    // ── Create / update / terminate ──────────────────────────────────
+
+    /// <summary>Create a new member. Idempotent on MemberId within a tenant.</summary>
     [HttpPost]
     [ProducesResponseType(typeof(Member), 201)]
     [ProducesResponseType(400)]
-    public async Task<IActionResult> CreateMember([FromBody] CreateMemberRequest request)
+    [ProducesResponseType(409)]
+    public async Task<IActionResult> CreateMember(
+        [FromBody] CreateMemberRequest request,
+        CancellationToken ct)
     {
-        if (!ModelState.IsValid)
-            return BadRequest(ModelState);
+        if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        // TODO: Validate business rules
-        // - Check GroupNumber exists in Sponsor Service
-        // - If dependent, validate SubscriberMemberId exists
-        // - Check for duplicate MemberId
+        if (!string.IsNullOrEmpty(request.SubscriberMemberId))
+        {
+            var subscriber = await _memberRepository.GetByMemberIdAsync(TenantId, request.SubscriberMemberId);
+            if (subscriber == null)
+                return BadRequest($"Subscriber '{request.SubscriberMemberId}' not found in tenant.");
+        }
+
+        var existing = await _memberRepository.GetByMemberIdAsync(TenantId, request.MemberId);
+        if (existing != null)
+            return Conflict(new { memberId = request.MemberId, message = "MemberId already exists in this tenant." });
+
+        var identifiers = new List<MemberIdentifier>();
+        if (!string.IsNullOrEmpty(request.SSN))
+        {
+            var cipher = await _encryptor.EncryptAsync(request.SSN, ct);
+            identifiers.Add(new MemberIdentifier
+            {
+                Type = MemberIdentifierType.SSN,
+                System = FhirIdentifierSystems.SSN,
+                Value = cipher ?? string.Empty,
+                IsEncrypted = _encryptor.IsEnabled
+            });
+        }
 
         var member = new Member
         {
             TenantId = TenantId,
             MemberId = request.MemberId,
-            SSN = request.SSN,
+            SSN = _encryptor.IsEnabled ? null : request.SSN,
             GroupNumber = request.GroupNumber,
             IsSubscriber = request.IsSubscriber,
             SubscriberMemberId = request.SubscriberMemberId,
@@ -159,92 +187,188 @@ public class MembersController : ControllerBase
             EmploymentStatus = request.EmploymentStatus,
             TobaccoUser = request.TobaccoUser,
             IsStudent = request.IsStudent,
+            Identifiers = identifiers,
+            PreferredLanguage = request.PreferredLanguage,
+            BirthSex = request.BirthSex,
             CreatedDate = DateTime.UtcNow,
             LastUpdatedDate = DateTime.UtcNow,
             CreatedBy = User.Identity?.Name ?? "System"
         };
 
-        // TODO: Save to Cosmos DB
-        // await _memberRepository.CreateAsync(member);
+        await _memberRepository.CreateAsync(member);
+
+        var eventId = !string.IsNullOrEmpty(request.EventId)
+            ? request.EventId
+            : Guid.NewGuid().ToString();
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = member.MemberId,
+            EventId = eventId,
+            EventType = MemberEventType.MemberCreated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = SnapshotPayload(member)   // genesis = full snapshot
+        }, ct);
 
         return CreatedAtAction(nameof(GetMember), new { memberId = member.MemberId }, member);
     }
 
-    /// <summary>
-    /// Update member information
-    /// </summary>
-    /// <param name="memberId">Member ID</param>
-    /// <param name="request">Update request</param>
+    /// <summary>Update member information. Emits MemberUpdated and, if the address changed, AddressChanged.</summary>
     [HttpPut("{memberId}")]
     [ProducesResponseType(typeof(Member), 200)]
     [ProducesResponseType(404)]
     public async Task<IActionResult> UpdateMember(
         [FromRoute] string memberId,
-        [FromBody] UpdateMemberRequest request)
+        [FromBody] UpdateMemberRequest request,
+        CancellationToken ct)
     {
-        if (!ModelState.IsValid)
-            return BadRequest(ModelState);
+        if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        // TODO: Fetch existing member
-        var member = new Member { TenantId = TenantId, MemberId = memberId };
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
 
-        // Update fields
-        if (request.Address != null) member.Address = request.Address;
-        if (request.City != null) member.City = request.City;
-        if (request.State != null) member.State = request.State;
-        if (request.ZipCode != null) member.ZipCode = request.ZipCode;
-        if (request.Phone != null) member.Phone = request.Phone;
-        if (request.Email != null) member.Email = request.Email;
-        if (request.Status.HasValue) member.Status = request.Status.Value;
-        if (request.EmploymentStatus.HasValue) member.EmploymentStatus = request.EmploymentStatus.Value;
+        var diff = new JsonObject();
+        var addressDiff = new JsonObject();
+
+        if (request.Address != null && request.Address != member.Address)
+        { diff["address"] = request.Address; addressDiff["address"] = request.Address; member.Address = request.Address; }
+        if (request.City != null && request.City != member.City)
+        { diff["city"] = request.City; addressDiff["city"] = request.City; member.City = request.City; }
+        if (request.State != null && request.State != member.State)
+        { diff["state"] = request.State; addressDiff["state"] = request.State; member.State = request.State; }
+        if (request.ZipCode != null && request.ZipCode != member.ZipCode)
+        { diff["zipCode"] = request.ZipCode; addressDiff["zipCode"] = request.ZipCode; member.ZipCode = request.ZipCode; }
+        if (request.Phone != null && request.Phone != member.Phone)
+        { diff["phone"] = request.Phone; member.Phone = request.Phone; }
+        if (request.Email != null && request.Email != member.Email)
+        { diff["email"] = request.Email; member.Email = request.Email; }
+        if (request.Status.HasValue && request.Status.Value != member.Status)
+        { diff["status"] = request.Status.Value.ToString(); member.Status = request.Status.Value; }
+        if (request.EmploymentStatus.HasValue && request.EmploymentStatus.Value != member.EmploymentStatus)
+        { diff["employmentStatus"] = request.EmploymentStatus.Value.ToString(); member.EmploymentStatus = request.EmploymentStatus.Value; }
 
         member.LastUpdatedDate = DateTime.UtcNow;
         member.LastUpdatedBy = User.Identity?.Name ?? "System";
 
-        // TODO: Save to Cosmos DB
-        // await _memberRepository.UpdateAsync(member);
+        if (diff.Count == 0) return Ok(member);
+
+        await _memberRepository.UpdateAsync(member);
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = member.MemberId,
+            EventId = request.EventId ?? Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberUpdated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = diff
+        }, ct);
+
+        if (addressDiff.Count > 0)
+        {
+            await _eventPublisher.PublishAsync(new MemberEvent
+            {
+                TenantId = TenantId,
+                MemberId = member.MemberId,
+                EventId = Guid.NewGuid().ToString(),
+                EventType = MemberEventType.AddressChanged,
+                ActorId = User.Identity?.Name,
+                CorrelationId = HttpContext.TraceIdentifier,
+                Payload = addressDiff
+            }, ct);
+        }
 
         return Ok(member);
     }
 
-    /// <summary>
-    /// Terminate member coverage
-    /// </summary>
-    /// <param name="memberId">Member ID</param>
-    /// <param name="terminationDate">Termination effective date</param>
-    /// <param name="reasonCode">Termination reason code</param>
+    /// <summary>Terminate member coverage (DELETE variant). Equivalent to the body-based <c>/terminate</c> endpoint.</summary>
     [HttpDelete("{memberId}")]
     [ProducesResponseType(204)]
     [ProducesResponseType(404)]
     public async Task<IActionResult> TerminateMember(
         [FromRoute] string memberId,
         [FromQuery] DateTime? terminationDate = null,
-        [FromQuery] string? reasonCode = null)
+        [FromQuery] string? reasonCode = null,
+        CancellationToken ct = default)
     {
-        // TODO: Update member status
-        // If subscriber, optionally terminate all dependents
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
 
+        await TerminateInternal(member, terminationDate ?? DateTime.UtcNow, reasonCode, ct);
         return NoContent();
     }
 
-    /// <summary>
-    /// Get all dependents for a subscriber
-    /// </summary>
-    /// <param name="memberId">Subscriber member ID</param>
+    /// <summary>Terminate member coverage (body-based variant used by portal).</summary>
+    [HttpPost("{memberId}/terminate")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> TerminateMember(
+        [FromRoute] string memberId,
+        [FromBody] TerminateMemberRequest request,
+        CancellationToken ct)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        await TerminateInternal(member, request.TerminationDate, request.ReasonCode, ct);
+
+        try
+        {
+            await _coverage.TerminateCoverageAsync(TenantId, memberId, request, ct);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
+
+        return Ok(new { memberId, terminationDate = request.TerminationDate, reasonCode = request.ReasonCode });
+    }
+
+    private async Task TerminateInternal(Member member, DateTime terminationDate, string? reasonCode, CancellationToken ct)
+    {
+        member.Status = EnrollmentStatus.Terminated;
+        member.TerminationDate = terminationDate;
+        if (!string.IsNullOrEmpty(reasonCode)) member.MaintenanceReasonCode = reasonCode;
+        member.LastUpdatedDate = DateTime.UtcNow;
+        member.LastUpdatedBy = User.Identity?.Name ?? "System";
+
+        await _memberRepository.UpdateAsync(member);
+
+        var payload = new JsonObject
+        {
+            ["terminationDate"] = terminationDate.ToString("o"),
+            ["reasonCode"] = reasonCode
+        };
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = member.MemberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberTerminated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = payload
+        }, ct);
+    }
+
+    // ── Dependents ───────────────────────────────────────────────────
+
     [HttpGet("{memberId}/dependents")]
     [ProducesResponseType(typeof(List<Member>), 200)]
-    [ProducesResponseType(404)]
     public async Task<IActionResult> GetDependents([FromRoute] string memberId)
     {
         var dependents = await _memberRepository.GetDependentsAsync(TenantId, memberId);
         return Ok(dependents);
     }
 
-    /// <summary>
-    /// Verify member eligibility (quick check for active coverage)
-    /// </summary>
-    /// <param name="memberId">Member ID</param>
-    /// <param name="serviceDate">Service date to check (defaults to today)</param>
+    // ── Eligibility ──────────────────────────────────────────────────
+
+    /// <summary>Verify member eligibility for a service date.</summary>
     [HttpGet("{memberId}/eligibility")]
     [ProducesResponseType(typeof(EligibilityCheckResponse), 200)]
     [ProducesResponseType(404)]
@@ -252,11 +376,25 @@ public class MembersController : ControllerBase
         [FromRoute] string memberId,
         [FromQuery] DateTime? serviceDate = null)
     {
-        var checkDate = serviceDate ?? DateTime.UtcNow.Date;
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
 
-        // TODO: Query member and check coverage dates
-        var isEligible = true;  // Mock
-        var reason = "Active coverage";
+        var checkDate = (serviceDate ?? DateTime.UtcNow).Date;
+        var effective = member.EffectiveDate.Date;
+        var term = member.TerminationDate?.Date;
+
+        bool isEligible;
+        string reason;
+        if (member.Status == EnrollmentStatus.Terminated)
+        { isEligible = false; reason = "Coverage terminated"; }
+        else if (checkDate < effective)
+        { isEligible = false; reason = "Service date before effective date"; }
+        else if (term.HasValue && checkDate > term.Value)
+        { isEligible = false; reason = "Service date after termination date"; }
+        else if (member.Status != EnrollmentStatus.Active)
+        { isEligible = false; reason = $"Member status is {member.Status}"; }
+        else
+        { isEligible = true; reason = "Active coverage"; }
 
         return Ok(new EligibilityCheckResponse
         {
@@ -264,103 +402,200 @@ public class MembersController : ControllerBase
             ServiceDate = checkDate,
             IsEligible = isEligible,
             Reason = reason,
-            EffectiveDate = DateTime.UtcNow.AddMonths(-6),
-            TerminationDate = null
+            EffectiveDate = member.EffectiveDate,
+            TerminationDate = member.TerminationDate
         });
+    }
+
+    // ── FHIR projection ──────────────────────────────────────────────
+
+    /// <summary>FHIR R4 Patient projection of this member.</summary>
+    [HttpGet("{memberId}/fhir")]
+    [Produces("application/fhir+json", "application/json")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetFhirPatient([FromRoute] string memberId)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var patient = _fhirProjector.Project(member);
+        return new ContentResult
+        {
+            ContentType = "application/fhir+json",
+            Content = patient.ToJsonString(),
+            StatusCode = 200
+        };
+    }
+
+    // ── Event stream ─────────────────────────────────────────────────
+
+    /// <summary>Return the member-events stream for this member, ordered by version.</summary>
+    [HttpGet("{memberId}/events")]
+    [ProducesResponseType(typeof(List<MemberEvent>), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetEvents([FromRoute] string memberId, CancellationToken ct)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var events = await _eventRepository.ListByMemberAsync(TenantId, memberId, ct);
+        return Ok(events);
     }
 
     // ── Portal integration endpoints ─────────────────────────────────
 
-    /// <summary>
-    /// Get member's PCP assignment
-    /// </summary>
     [HttpGet("{memberId}/pcp")]
     [ProducesResponseType(typeof(MemberPcpResponse), 200)]
     [ProducesResponseType(404)]
-    public async Task<IActionResult> GetMemberPcp([FromRoute] string memberId)
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetMemberPcp([FromRoute] string memberId, CancellationToken ct)
     {
-        // TODO: Look up PCP assignment from coverage-service or member record
-        return Ok(new MemberPcpResponse
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        try
         {
-            ProviderId = "prov-001",
-            ProviderName = "Dr. Sarah Chen, MD",
-            NPI = "1234567890",
-            Specialty = "Internal Medicine",
-            NetworkStatus = "In-Network",
-            AssignedDate = DateTime.UtcNow.AddMonths(-6),
-            PracticeName = "Austin Primary Care Associates",
-            Phone = "512-555-0100"
-        });
+            var pcp = await _coverage.GetPcpAsync(TenantId, memberId, ct);
+            return Ok(pcp);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
     }
 
-    /// <summary>
-    /// Assign or change member's PCP
-    /// </summary>
     [HttpPut("{memberId}/pcp")]
     [ProducesResponseType(200)]
-    public async Task<IActionResult> AssignPcp([FromRoute] string memberId, [FromBody] AssignPcpRequest request)
+    [ProducesResponseType(404)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> AssignPcp(
+        [FromRoute] string memberId,
+        [FromBody] AssignPcpRequest request,
+        CancellationToken ct)
     {
-        // TODO: Update PCP assignment in coverage-service
-        return Ok(new { memberId, providerId = request.ProviderId, effectiveDate = request.EffectiveDate });
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        MemberPcpResponse result;
+        try
+        {
+            result = await _coverage.AssignPcpAsync(TenantId, memberId, request, ct);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.PcpChanged,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["providerId"] = request.ProviderId,
+                ["effectiveDate"] = request.EffectiveDate.ToString("o"),
+                ["reason"] = request.Reason
+            }
+        }, ct);
+
+        return Ok(result);
     }
 
-    /// <summary>
-    /// Get member's coverage history (enrollments, plan changes, terminations)
-    /// </summary>
     [HttpGet("{memberId}/coverage-history")]
     [ProducesResponseType(typeof(List<CoverageHistoryEvent>), 200)]
-    public async Task<IActionResult> GetCoverageHistory([FromRoute] string memberId)
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetCoverageHistory([FromRoute] string memberId, CancellationToken ct)
     {
-        // TODO: Query coverage-service for history
-        return Ok(new List<CoverageHistoryEvent>
+        try
         {
-            new() { EventDate = DateTime.UtcNow.AddMonths(-6), EventType = "Enrolled", Description = "Initial enrollment via 834", ChangedBy = "System" },
-            new() { EventDate = DateTime.UtcNow.AddMonths(-3), EventType = "PcpChange", Description = "PCP changed to Dr. Chen", ChangedBy = "Member Portal" }
-        });
+            var history = await _coverage.GetCoverageHistoryAsync(TenantId, memberId, ct);
+            return Ok(history);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
     }
 
-    /// <summary>
-    /// Get member's 834 enrollment transaction history
-    /// </summary>
     [HttpGet("{memberId}/834-transactions")]
     [ProducesResponseType(typeof(List<Enrollment834Record>), 200)]
-    public async Task<IActionResult> Get834Transactions([FromRoute] string memberId)
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> Get834Transactions([FromRoute] string memberId, CancellationToken ct)
     {
-        // TODO: Query enrollment-import-service for 834 records
-        return Ok(new List<Enrollment834Record>
+        try
         {
-            new() { TransactionId = "TXN-001", BatchId = "BATCH-001", MemberId = memberId, MemberName = "Member",
-                     MaintenanceTypeCode = "021", TransactionDate = DateTime.UtcNow.AddMonths(-6), Status = "Accepted" }
-        });
+            var txns = await _enrollment.Get834TransactionsAsync(TenantId, memberId, ct);
+            return Ok(txns);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
     }
 
-    /// <summary>
-    /// Get member's accumulator balances (deductible, OOP, service limits)
-    /// </summary>
     [HttpGet("{memberId}/accumulators")]
     [ProducesResponseType(typeof(MemberAccumulatorsResponse), 200)]
-    public async Task<IActionResult> GetAccumulators([FromRoute] string memberId)
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetAccumulators([FromRoute] string memberId, CancellationToken ct)
     {
-        // TODO: Query accumulator service / claims-service for plan year totals
-        return Ok(new MemberAccumulatorsResponse
+        try
         {
-            IndividualDeductibleUsed = 750m, IndividualDeductibleLimit = 2000m,
-            FamilyDeductibleUsed = 1500m, FamilyDeductibleLimit = 6000m,
-            IndividualOopUsed = 1200m, IndividualOopLimit = 8150m,
-            FamilyOopUsed = 2400m, FamilyOopLimit = 16300m
-        });
+            var acc = await _accumulators.GetAccumulatorsAsync(TenantId, memberId, ct);
+            return Ok(acc);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
     }
 
-    /// <summary>
-    /// Terminate member enrollment
-    /// </summary>
-    [HttpPost("{memberId}/terminate")]
-    [ProducesResponseType(200)]
-    public async Task<IActionResult> TerminateMember([FromRoute] string memberId, [FromBody] TerminateMemberRequest request)
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    private IActionResult DownstreamUnavailable(DownstreamUnavailableException ex)
     {
-        // TODO: Process termination via coverage-service
-        return Ok(new { memberId, terminationDate = request.TerminationDate, reasonCode = request.ReasonCode });
+        var problem = new ProblemDetails
+        {
+            Type = "https://cloudhealthoffice.com/problems/downstream-unavailable",
+            Title = "Downstream service unavailable",
+            Status = StatusCodes.Status503ServiceUnavailable,
+            Detail = ex.Detail ?? ex.Message
+        };
+        problem.Extensions["service"] = ex.ServiceName;
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, problem);
     }
+
+    private static JsonObject SnapshotPayload(Member member) => new()
+    {
+        ["id"] = member.Id,
+        ["memberId"] = member.MemberId,
+        ["tenantId"] = member.TenantId,
+        ["groupNumber"] = member.GroupNumber,
+        ["isSubscriber"] = member.IsSubscriber,
+        ["subscriberMemberId"] = member.SubscriberMemberId,
+        ["firstName"] = member.FirstName,
+        ["lastName"] = member.LastName,
+        ["middleName"] = member.MiddleName,
+        ["dateOfBirth"] = member.DateOfBirth.ToString("yyyy-MM-dd"),
+        ["gender"] = member.Gender,
+        ["effectiveDate"] = member.EffectiveDate.ToString("o"),
+        ["terminationDate"] = member.TerminationDate?.ToString("o"),
+        ["status"] = member.Status.ToString(),
+        ["lineOfBusiness"] = member.LineOfBusiness.ToString(),
+        ["address"] = member.Address,
+        ["city"] = member.City,
+        ["state"] = member.State,
+        ["zipCode"] = member.ZipCode,
+        ["phone"] = member.Phone,
+        ["email"] = member.Email,
+        ["preferredLanguage"] = member.PreferredLanguage,
+        ["birthSex"] = member.BirthSex,
+        ["identifierCount"] = member.Identifiers.Count
+    };
 }
 
 #region Request/Response Models
@@ -409,6 +644,12 @@ public class CreateMemberRequest
     public EmploymentStatus? EmploymentStatus { get; set; }
     public bool? TobaccoUser { get; set; }
     public bool? IsStudent { get; set; }
+
+    public string? PreferredLanguage { get; set; }
+    public string? BirthSex { get; set; }
+
+    /// <summary>Optional client-supplied idempotency key for the MemberCreated event.</summary>
+    public string? EventId { get; set; }
 }
 
 public class UpdateMemberRequest
@@ -421,6 +662,9 @@ public class UpdateMemberRequest
     public string? Email { get; set; }
     public EnrollmentStatus? Status { get; set; }
     public EmploymentStatus? EmploymentStatus { get; set; }
+
+    /// <summary>Optional idempotency key for the MemberUpdated event.</summary>
+    public string? EventId { get; set; }
 }
 
 public class MemberListResponse

--- a/src/services/member-service/HostedServices/MemberEventIndexInitializer.cs
+++ b/src/services/member-service/HostedServices/MemberEventIndexInitializer.cs
@@ -1,0 +1,92 @@
+using MemberService.Models;
+using MemberService.Repositories;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace MemberService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the member-events stream once at startup.
+/// Running index creation from a hosted service (instead of the repository
+/// constructor) keeps repository construction side-effect free and lets us
+/// register the repository as a singleton.
+///
+/// Idempotent: Mongo silently no-ops an index that already exists with the
+/// same spec.
+/// </summary>
+public sealed class MemberEventIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly string _collectionName;
+    private readonly ILogger<MemberEventIndexInitializer> _logger;
+
+    public MemberEventIndexInitializer(
+        IMongoDatabase db,
+        string collectionName,
+        ILogger<MemberEventIndexInitializer> logger)
+    {
+        _db = db;
+        _collectionName = collectionName;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<MemberEvent>(_collectionName);
+
+        var idemKeys = Builders<MemberEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.MemberId)
+            .Ascending(x => x.EventId);
+        collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
+            idemKeys,
+            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_event" }),
+            cancellationToken: cancellationToken);
+
+        var orderKeys = Builders<MemberEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.MemberId)
+            .Ascending(x => x.Version);
+        collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
+            orderKeys,
+            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_version" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("Member event indexes ensured on collection '{Collection}'.", _collectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// Creates the Mongo indexes used by the <c>Members</c> collection at startup.
+/// </summary>
+public sealed class MemberIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly ILogger<MemberIndexInitializer> _logger;
+
+    public MemberIndexInitializer(IMongoDatabase db, ILogger<MemberIndexInitializer> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<Member>("Members");
+        var keys = Builders<Member>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.MemberId);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<Member>(keys, new CreateIndexOptions { Name = "ix_tenant_member" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("Member indexes ensured.");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/AddressChangedIdempotencyTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/AddressChangedIdempotencyTests.cs
@@ -1,0 +1,96 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace MemberService.Tests.Controllers;
+
+/// <summary>
+/// Verifies that the retried PUT /members/{id} request (same EventId) produces
+/// exactly ONE <c>MemberUpdated</c> and ONE <c>AddressChanged</c> in the event
+/// stream. The sub-event id is derived as <c>{parentEventId}:address</c> so
+/// retries collide on EventId and become idempotent no-ops.
+/// </summary>
+public class AddressChangedIdempotencyTests
+{
+    private const string Tenant = "tenant-test";
+
+    private static (MembersController ctl, InMemoryMemberEventRepository events) Build()
+    {
+        var repo = new InMemoryMemberRepository();
+        repo.Members.Add(new Member
+        {
+            TenantId = Tenant,
+            MemberId = "M-001",
+            Id = Guid.NewGuid().ToString(),
+            GroupNumber = "G",
+            IsSubscriber = true,
+            FirstName = "Alice",
+            LastName = "Example",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1),
+            Address = "1 Main",
+            City = "Austin"
+        });
+
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var ctl = new MembersController(
+            repo,
+            publisher,
+            events,
+            new FhirPatientProjector(),
+            new NoOpIdentifierEncryptor(),
+            Mock.Of<ICoverageServiceClient>(),
+            Mock.Of<IEnrollmentImportServiceClient>(),
+            Mock.Of<IAccumulatorServiceClient>());
+
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, events);
+    }
+
+    [Fact]
+    public async Task UpdateMember_SameEventIdTwice_ProducesExactlyOneUpdateAndOneAddressChange()
+    {
+        var (ctl, events) = Build();
+        var request = new UpdateMemberRequest
+        {
+            Address = "500 New St",
+            City = "Dallas",
+            EventId = "evt-client-42"
+        };
+
+        (await ctl.UpdateMember("M-001", request, CancellationToken.None))
+            .Should().BeOfType<OkObjectResult>();
+        (await ctl.UpdateMember("M-001", request, CancellationToken.None))
+            .Should().BeOfType<OkObjectResult>();
+
+        events.All.Count(e => e.EventType == MemberEventType.MemberUpdated).Should().Be(1);
+        events.All.Count(e => e.EventType == MemberEventType.AddressChanged).Should().Be(1);
+
+        events.All.Single(e => e.EventType == MemberEventType.MemberUpdated)
+            .EventId.Should().Be("evt-client-42");
+        events.All.Single(e => e.EventType == MemberEventType.AddressChanged)
+            .EventId.Should().Be("evt-client-42:address");
+    }
+
+    [Fact]
+    public async Task UpdateMember_DifferentEventIds_ProduceDistinctEvents()
+    {
+        var (ctl, events) = Build();
+
+        await ctl.UpdateMember("M-001",
+            new UpdateMemberRequest { Address = "A1", EventId = "evt-A" }, CancellationToken.None);
+        await ctl.UpdateMember("M-001",
+            new UpdateMemberRequest { Address = "A2", EventId = "evt-B" }, CancellationToken.None);
+
+        events.All.Count(e => e.EventType == MemberEventType.MemberUpdated).Should().Be(2);
+        events.All.Count(e => e.EventType == MemberEventType.AddressChanged).Should().Be(2);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/IdentifiersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/IdentifiersControllerTests.cs
@@ -20,8 +20,9 @@ public class IdentifiersControllerTests
         var repo = new InMemoryMemberRepository();
         var events = new InMemoryMemberEventRepository();
         var enc = new NoOpIdentifierEncryptor();
+        var fp = new NoOpIdentifierFingerprinter();
         var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
-        var ctl = new IdentifiersController(repo, enc, publisher);
+        var ctl = new IdentifiersController(repo, enc, fp, publisher);
         var http = new DefaultHttpContext();
         http.Items["TenantId"] = Tenant;
         ctl.ControllerContext = new ControllerContext { HttpContext = http };

--- a/src/services/member-service/MemberService.Tests/Controllers/IdentifiersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/IdentifiersControllerTests.cs
@@ -1,0 +1,181 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Controllers;
+
+public class IdentifiersControllerTests
+{
+    private const string Tenant = "tenant-test";
+
+    private static (IdentifiersController ctl,
+                    InMemoryMemberRepository repo,
+                    InMemoryMemberEventRepository events,
+                    NoOpIdentifierEncryptor enc) Build()
+    {
+        var repo = new InMemoryMemberRepository();
+        var events = new InMemoryMemberEventRepository();
+        var enc = new NoOpIdentifierEncryptor();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var ctl = new IdentifiersController(repo, enc, publisher);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, repo, events, enc);
+    }
+
+    private static Member SeedMember(InMemoryMemberRepository repo, string memberId = "M-001") =>
+        repo.CreateAsync(new Member
+        {
+            TenantId = Tenant,
+            MemberId = memberId,
+            GroupNumber = "GRP",
+            IsSubscriber = true,
+            FirstName = "A", LastName = "B",
+            DateOfBirth = new DateTime(2000, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1)
+        }).Result;
+
+    [Fact]
+    public async Task Add_Typed_PersistsAndEmitsEvent()
+    {
+        var (ctl, repo, events, _) = Build();
+        SeedMember(repo);
+
+        var resp = await ctl.Add("M-001", new AddIdentifierRequest
+        {
+            Type = MemberIdentifierType.MedicareMbi,
+            Value = "1EG4-TE5-MK73"
+        }, CancellationToken.None);
+
+        resp.Should().BeOfType<CreatedAtActionResult>();
+        repo.Members[0].Identifiers.Should().ContainSingle(i => i.Type == MemberIdentifierType.MedicareMbi
+            && i.System == FhirIdentifierSystems.MedicareMbi);
+        events.All.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Add_Legacy_RequiresSlug()
+    {
+        var (ctl, repo, _, _) = Build();
+        SeedMember(repo);
+
+        var act = async () => await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.Legacy, Value = "X" },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
+    }
+
+    [Fact]
+    public async Task Add_LegacyWithSlug_UsesScopedUri()
+    {
+        var (ctl, repo, _, _) = Build();
+        SeedMember(repo);
+
+        await ctl.Add("M-001", new AddIdentifierRequest
+        {
+            Type = MemberIdentifierType.Legacy,
+            LegacySlug = "acme-v1",
+            Value = "ACME-001"
+        }, CancellationToken.None);
+
+        repo.Members[0].Identifiers[0].System.Should().Be("urn:cho:legacy:acme-v1");
+    }
+
+    [Fact]
+    public async Task Add_Duplicate_Returns409()
+    {
+        var (ctl, repo, _, _) = Build();
+        SeedMember(repo);
+
+        var req = new AddIdentifierRequest
+        {
+            Type = MemberIdentifierType.Portal,
+            Value = "portal-uid"
+        };
+        await ctl.Add("M-001", req, CancellationToken.None);
+        var second = await ctl.Add("M-001", req, CancellationToken.None);
+
+        second.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task Add_UnknownMember_Returns404()
+    {
+        var (ctl, _, _, _) = Build();
+        var resp = await ctl.Add("missing",
+            new AddIdentifierRequest { Type = MemberIdentifierType.Portal, Value = "x" },
+            CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task List_Redacts_EncryptedValues()
+    {
+        var (ctl, repo, _, _) = Build();
+        var m = SeedMember(repo);
+        m.Identifiers.Add(new MemberIdentifier
+        {
+            Type = MemberIdentifierType.SSN,
+            System = FhirIdentifierSystems.SSN,
+            Value = "ciphertext-foo",
+            IsEncrypted = true
+        });
+
+        var resp = await ctl.List("M-001");
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var list = (List<IdentifierResponse>)ok.Value!;
+        list.Should().ContainSingle(i => i.Type == MemberIdentifierType.SSN)
+            .Which.Value.Should().Be("[REDACTED]");
+    }
+
+    [Fact]
+    public async Task Remove_ByPlaintext_Removes()
+    {
+        var (ctl, repo, _, _) = Build();
+        var m = SeedMember(repo);
+        m.Identifiers.Add(new MemberIdentifier
+        {
+            Type = MemberIdentifierType.Portal,
+            System = FhirIdentifierSystems.PortalId,
+            Value = "portal-uid"
+        });
+
+        var resp = await ctl.Remove("M-001", FhirIdentifierSystems.PortalId, "portal-uid", CancellationToken.None);
+        resp.Should().BeOfType<NoContentResult>();
+        repo.Members[0].Identifiers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Remove_Unknown_Returns404()
+    {
+        var (ctl, repo, _, _) = Build();
+        SeedMember(repo);
+        var resp = await ctl.Remove("M-001", "urn:cho:portal-id", "no-such-value", CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Operations_AreTenantIsolated()
+    {
+        var (ctl, repo, _, _) = Build();
+        repo.Members.Add(new Member
+        {
+            TenantId = "other-tenant",
+            MemberId = "M-001",
+            GroupNumber = "GRP", IsSubscriber = true,
+            FirstName = "X", LastName = "Y",
+            DateOfBirth = new DateTime(2000,1,1), EffectiveDate = new DateTime(2024,1,1)
+        });
+
+        var resp = await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.Portal, Value = "v" },
+            CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
@@ -141,7 +141,11 @@ public class MembersControllerTests
         var (ctl, repo, events, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
-        var resp = await ctl.TerminateMember("M-001", new DateTime(2024, 12, 31), "25", CancellationToken.None);
+        var resp = await ctl.TerminateMember("M-001",
+            terminationDate: new DateTime(2024, 12, 31),
+            reasonCode: "25",
+            eventId: null,
+            ct: CancellationToken.None);
         resp.Should().BeOfType<NoContentResult>();
 
         repo.Members[0].Status.Should().Be(EnrollmentStatus.Terminated);

--- a/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
@@ -1,0 +1,295 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace MemberService.Tests.Controllers;
+
+public class MembersControllerTests
+{
+    private const string Tenant = "tenant-test";
+
+    private static (MembersController ctl,
+                    InMemoryMemberRepository repo,
+                    InMemoryMemberEventRepository events,
+                    Mock<ICoverageServiceClient> coverage,
+                    Mock<IEnrollmentImportServiceClient> enrollment,
+                    Mock<IAccumulatorServiceClient> acc) Build()
+    {
+        var repo = new InMemoryMemberRepository();
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var projector = new FhirPatientProjector();
+        var enc = new NoOpIdentifierEncryptor();
+        var coverage = new Mock<ICoverageServiceClient>();
+        var enrollment = new Mock<IEnrollmentImportServiceClient>();
+        var acc = new Mock<IAccumulatorServiceClient>();
+
+        var ctl = new MembersController(repo, publisher, events, projector, enc,
+            coverage.Object, enrollment.Object, acc.Object);
+
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, repo, events, coverage, enrollment, acc);
+    }
+
+    private static CreateMemberRequest CreateReq(string memberId = "M-001") => new()
+    {
+        MemberId = memberId,
+        GroupNumber = "GRP",
+        IsSubscriber = true,
+        FirstName = "Alice",
+        LastName = "Example",
+        DateOfBirth = new DateTime(1985, 6, 15),
+        EffectiveDate = new DateTime(2024, 1, 1),
+        Gender = "F",
+        Address = "1 Main",
+        City = "Austin",
+        State = "TX",
+        ZipCode = "78701",
+        SSN = "123-45-6789"
+    };
+
+    [Fact]
+    public async Task CreateMember_Persists_AndEmitsMemberCreatedWithSnapshot()
+    {
+        var (ctl, repo, events, _, _, _) = Build();
+        var resp = await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        resp.Should().BeOfType<CreatedAtActionResult>();
+        repo.Members.Should().ContainSingle();
+        var member = repo.Members[0];
+        member.Status.Should().Be(EnrollmentStatus.Pending);
+        member.Identifiers.Should().ContainSingle(i => i.Type == MemberIdentifierType.SSN);
+
+        events.All.Should().ContainSingle();
+        var created = events.All[0];
+        created.EventType.Should().Be(MemberEventType.MemberCreated);
+        created.Version.Should().Be(1);
+        created.Payload.Should().NotBeNull();
+        created.Payload!["memberId"]!.ToString().Should().Be("M-001");
+        // Genesis event carries full snapshot, not just a diff.
+        created.Payload!["firstName"]!.ToString().Should().Be("Alice");
+        created.Payload!["lineOfBusiness"].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateMember_DuplicateMemberId_Returns409()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        var second = await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        second.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateMember_DependentWithUnknownSubscriber_ReturnsBadRequest()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        var req = CreateReq("D-001");
+        req.IsSubscriber = false;
+        req.SubscriberMemberId = "DOES-NOT-EXIST";
+        var resp = await ctl.CreateMember(req, CancellationToken.None);
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task UpdateMember_AddressChange_EmitsAddressChangedAndMemberUpdated()
+    {
+        var (ctl, _, events, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        var resp = await ctl.UpdateMember("M-001",
+            new UpdateMemberRequest { Address = "500 New St", City = "Dallas" },
+            CancellationToken.None);
+        resp.Should().BeOfType<OkObjectResult>();
+
+        events.All.Select(e => e.EventType).Should()
+            .Contain(MemberEventType.MemberCreated)
+            .And.Contain(MemberEventType.MemberUpdated)
+            .And.Contain(MemberEventType.AddressChanged);
+    }
+
+    [Fact]
+    public async Task UpdateMember_NoChanges_IsNoOp()
+    {
+        var (ctl, repo, events, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        var baselineCount = events.All.Count;
+
+        var resp = await ctl.UpdateMember("M-001", new UpdateMemberRequest(), CancellationToken.None);
+        resp.Should().BeOfType<OkObjectResult>();
+        events.All.Count.Should().Be(baselineCount); // no new events
+    }
+
+    [Fact]
+    public async Task UpdateMember_NotFound_Returns404()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        var resp = await ctl.UpdateMember("MISSING", new UpdateMemberRequest { City = "X" }, CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task TerminateMember_Delete_MarksTerminatedAndEmits()
+    {
+        var (ctl, repo, events, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        var resp = await ctl.TerminateMember("M-001", new DateTime(2024, 12, 31), "25", CancellationToken.None);
+        resp.Should().BeOfType<NoContentResult>();
+
+        repo.Members[0].Status.Should().Be(EnrollmentStatus.Terminated);
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberTerminated);
+    }
+
+    [Fact]
+    public async Task CheckEligibility_ActiveMember_ReturnsEligible()
+    {
+        var (ctl, repo, _, _, _, _) = Build();
+        var req = CreateReq();
+        req.EffectiveDate = DateTime.UtcNow.AddMonths(-1);
+        await ctl.CreateMember(req, CancellationToken.None);
+        repo.Members[0].Status = EnrollmentStatus.Active;
+
+        var resp = await ctl.CheckEligibility("M-001", null);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<EligibilityCheckResponse>().Subject;
+        body.IsEligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckEligibility_Terminated_ReturnsNotEligible()
+    {
+        var (ctl, repo, _, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        repo.Members[0].Status = EnrollmentStatus.Terminated;
+
+        var resp = await ctl.CheckEligibility("M-001", null);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<EligibilityCheckResponse>().Subject;
+        body.IsEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckEligibility_Missing_Returns404()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        (await ctl.CheckEligibility("nope", null)).Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task GetFhirPatient_ReturnsFhirContentType_And_PatientResource()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        var resp = await ctl.GetFhirPatient("M-001");
+        var content = resp.Should().BeOfType<ContentResult>().Subject;
+        content.ContentType.Should().Be("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"Patient\"");
+    }
+
+    [Fact]
+    public async Task GetEvents_ReturnsOrderedStream()
+    {
+        var (ctl, _, _, _, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        await ctl.UpdateMember("M-001", new UpdateMemberRequest { City = "Houston" }, CancellationToken.None);
+
+        var resp = await ctl.GetEvents("M-001", CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var events = (IReadOnlyList<MemberEvent>)ok.Value!;
+        events.Count.Should().BeGreaterThanOrEqualTo(2);
+        events.Select(e => e.Version).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task GetMemberPcp_WhenCoverageUnavailable_Returns503ProblemDetails()
+    {
+        var (ctl, _, _, coverage, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        coverage.Setup(c => c.GetPcpAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DownstreamUnavailableException("coverage-service", "no base url"));
+
+        var resp = await ctl.GetMemberPcp("M-001", CancellationToken.None);
+        var status = resp.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        var problem = status.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(503);
+        problem.Extensions["service"].Should().Be("coverage-service");
+    }
+
+    [Fact]
+    public async Task AssignPcp_EmitsPcpChangedEvent()
+    {
+        var (ctl, _, events, coverage, _, _) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+        coverage.Setup(c => c.AssignPcpAsync(Tenant, "M-001", It.IsAny<AssignPcpRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemberPcpResponse { ProviderId = "prov-1" });
+
+        var resp = await ctl.AssignPcp("M-001",
+            new AssignPcpRequest { ProviderId = "prov-1", EffectiveDate = DateTime.UtcNow },
+            CancellationToken.None);
+        resp.Should().BeOfType<OkObjectResult>();
+        events.All.Should().Contain(e => e.EventType == MemberEventType.PcpChanged);
+    }
+
+    [Fact]
+    public async Task GetCoverageHistory_WhenUnavailable_Returns503()
+    {
+        var (ctl, _, _, coverage, _, _) = Build();
+        coverage.Setup(c => c.GetCoverageHistoryAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DownstreamUnavailableException("coverage-service"));
+
+        var resp = await ctl.GetCoverageHistory("M-001", CancellationToken.None);
+        ((ObjectResult)resp).StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task Get834Transactions_WhenUnavailable_Returns503()
+    {
+        var (ctl, _, _, _, enrollment, _) = Build();
+        enrollment.Setup(e => e.Get834TransactionsAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DownstreamUnavailableException("enrollment-import-service"));
+
+        var resp = await ctl.Get834Transactions("M-001", CancellationToken.None);
+        ((ObjectResult)resp).StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task GetAccumulators_WhenUnavailable_Returns503()
+    {
+        var (ctl, _, _, _, _, accu) = Build();
+        accu.Setup(a => a.GetAccumulatorsAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DownstreamUnavailableException("accumulator-service"));
+
+        var resp = await ctl.GetAccumulators("M-001", CancellationToken.None);
+        ((ObjectResult)resp).StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task GetDependents_ReturnsOnlyNonSubscribersLinked()
+    {
+        var (ctl, repo, _, _, _, _) = Build();
+        var sub = CreateReq("SUB-1");
+        await ctl.CreateMember(sub, CancellationToken.None);
+
+        var dep = CreateReq("DEP-1");
+        dep.IsSubscriber = false;
+        dep.SubscriberMemberId = "SUB-1";
+        await ctl.CreateMember(dep, CancellationToken.None);
+
+        var resp = await ctl.GetDependents("SUB-1");
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var deps = ok.Value.Should().BeAssignableTo<IEnumerable<Member>>().Subject;
+        deps.Should().ContainSingle().Which.MemberId.Should().Be("DEP-1");
+    }
+
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
@@ -1,0 +1,143 @@
+using System.Security.Cryptography;
+using CloudHealthOffice.Infrastructure.Configuration;
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Controllers;
+
+/// <summary>
+/// Verifies that PII identifier dedupe survives encryption nonce randomness
+/// (same plaintext SSN encrypted twice yields different ciphertexts, but the
+/// fingerprint matches) and normalization (dashes/spaces/case stripped).
+/// </summary>
+public class PiiIdentifierDedupeTests
+{
+    private const string Tenant = "t1";
+
+    private sealed class StaticSecretProvider : ISecretProvider
+    {
+        private readonly string _secret;
+        public StaticSecretProvider(string secret) { _secret = secret; }
+        public Task<string?> GetSecretAsync(string n, CancellationToken ct = default) => Task.FromResult<string?>(_secret);
+        public Task<IDictionary<string, string>> GetSecretsAsync(string p, CancellationToken ct = default)
+            => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
+        public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+    }
+
+    private static (IdentifiersController ctl, InMemoryMemberRepository repo) Build(
+        IIdentifierEncryptor encryptor,
+        IIdentifierFingerprinter fingerprinter)
+    {
+        var repo = new InMemoryMemberRepository();
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var ctl = new IdentifiersController(repo, encryptor, fingerprinter, publisher);
+
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+
+        repo.Members.Add(new Member
+        {
+            TenantId = Tenant, MemberId = "M-001",
+            GroupNumber = "G", IsSubscriber = true,
+            FirstName = "A", LastName = "B",
+            DateOfBirth = new DateTime(2000, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1)
+        });
+        return (ctl, repo);
+    }
+
+    private static (KeyVaultIdentifierEncryptor enc, HmacSha256IdentifierFingerprinter fp) RealKeys()
+    {
+        var encKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var fpKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var enc = new KeyVaultIdentifierEncryptor(
+            new StaticSecretProvider(encKey),
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "enc");
+        var fp = new HmacSha256IdentifierFingerprinter(
+            new StaticSecretProvider(fpKey),
+            NullLogger<HmacSha256IdentifierFingerprinter>.Instance,
+            "fp");
+        return (enc, fp);
+    }
+
+    [Fact]
+    public async Task SameSsn_AddedTwice_AcrossDifferentNonces_Returns409()
+    {
+        var (enc, fp) = RealKeys();
+        var (ctl, repo) = Build(enc, fp);
+
+        var req1 = new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "123-45-6789" };
+        var req2 = new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "123-45-6789" };
+
+        var first = await ctl.Add("M-001", req1, CancellationToken.None);
+        first.Should().BeOfType<CreatedAtActionResult>();
+
+        // Different AES-GCM nonce on the second call → different ciphertext.
+        // Fingerprint-based dedupe must still catch this.
+        var second = await ctl.Add("M-001", req2, CancellationToken.None);
+        second.Should().BeOfType<ConflictObjectResult>();
+
+        repo.Members[0].Identifiers.Should().ContainSingle();
+        // Ciphertext stored is not equal to plaintext — encryption really happened.
+        repo.Members[0].Identifiers[0].Value.Should().NotBe("123-45-6789");
+        repo.Members[0].Identifiers[0].ValueFingerprint.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task NormalizedSsn_DashesVsRaw_Returns409()
+    {
+        var (enc, fp) = RealKeys();
+        var (ctl, _) = Build(enc, fp);
+
+        (await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "123-45-6789" },
+            CancellationToken.None)).Should().BeOfType<CreatedAtActionResult>();
+
+        (await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "123456789" },
+            CancellationToken.None)).Should().BeOfType<ConflictObjectResult>();
+
+        (await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "123 45 6789" },
+            CancellationToken.None)).Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task NormalizedMbi_CaseAndDashVariations_Returns409()
+    {
+        var (enc, fp) = RealKeys();
+        var (ctl, _) = Build(enc, fp);
+
+        (await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.MedicareMbi, Value = "1eg4-te5-mk73" },
+            CancellationToken.None)).Should().BeOfType<CreatedAtActionResult>();
+
+        (await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.MedicareMbi, Value = "1EG4TE5MK73" },
+            CancellationToken.None)).Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task DifferentSsns_BothPersist()
+    {
+        var (enc, fp) = RealKeys();
+        var (ctl, repo) = Build(enc, fp);
+
+        await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "111-22-3333" },
+            CancellationToken.None);
+        await ctl.Add("M-001",
+            new AddIdentifierRequest { Type = MemberIdentifierType.SSN, Value = "444-55-6666" },
+            CancellationToken.None);
+
+        repo.Members[0].Identifiers.Should().HaveCount(2);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/ConflictingMemberEventRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/ConflictingMemberEventRepository.cs
@@ -1,0 +1,45 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>
+/// Wraps <see cref="InMemoryMemberEventRepository"/> and simulates a Cosmos
+/// <c>/version</c> unique-key violation for the first N append attempts. Lets
+/// us exercise <c>CosmosMemberEventPublisher</c>'s retry loop.
+/// </summary>
+public sealed class ConflictingMemberEventRepository : IMemberEventRepository
+{
+    private readonly InMemoryMemberEventRepository _inner;
+    private int _remainingConflicts;
+
+    public ConflictingMemberEventRepository(InMemoryMemberEventRepository inner, int conflicts)
+    {
+        _inner = inner;
+        _remainingConflicts = conflicts;
+    }
+
+    public int AttemptsSeen { get; private set; }
+
+    public async Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)
+    {
+        AttemptsSeen++;
+        if (_remainingConflicts > 0)
+        {
+            _remainingConflicts--;
+            // Emulate Cosmos unique-key-policy violation on /version: Appended=false
+            // with no existing event — forces the publisher to bump Version and retry.
+            return new AppendResult(evt, Appended: false);
+        }
+        return await _inner.AppendAsync(evt, ct);
+    }
+
+    public Task<IReadOnlyList<MemberEvent>> ListByMemberAsync(string tenantId, string memberId, CancellationToken ct = default)
+        => _inner.ListByMemberAsync(tenantId, memberId, ct);
+
+    public Task<MemberEvent?> GetByIdAsync(string tenantId, string memberId, string eventId, CancellationToken ct = default)
+        => _inner.GetByIdAsync(tenantId, memberId, eventId, ct);
+
+    public Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default)
+        => _inner.GetNextVersionAsync(tenantId, memberId, ct);
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberEventRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberEventRepository.cs
@@ -1,0 +1,71 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>In-memory repository with the same idempotency and ordering semantics as prod.</summary>
+public sealed class InMemoryMemberEventRepository : IMemberEventRepository
+{
+    private readonly List<MemberEvent> _events = new();
+    private readonly object _lock = new();
+
+    public IReadOnlyList<MemberEvent> All
+    {
+        get { lock (_lock) return _events.ToList(); }
+    }
+
+    public Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var existing = _events.FirstOrDefault(e =>
+                e.TenantId == evt.TenantId && e.MemberId == evt.MemberId && e.EventId == evt.EventId);
+            if (existing != null) return Task.FromResult(new AppendResult(existing, false));
+
+            var versionConflict = _events.Any(e =>
+                e.TenantId == evt.TenantId && e.MemberId == evt.MemberId && e.Version == evt.Version);
+            if (versionConflict) return Task.FromResult(new AppendResult(evt, false));
+
+            if (string.IsNullOrEmpty(evt.PartitionKey))
+                evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+            if (string.IsNullOrEmpty(evt.Id)) evt.Id = evt.EventId;
+
+            _events.Add(evt);
+            return Task.FromResult(new AppendResult(evt, true));
+        }
+    }
+
+    public Task<IReadOnlyList<MemberEvent>> ListByMemberAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var list = _events
+                .Where(e => e.TenantId == tenantId && e.MemberId == memberId)
+                .OrderBy(e => e.Version)
+                .ToList();
+            return Task.FromResult<IReadOnlyList<MemberEvent>>(list);
+        }
+    }
+
+    public Task<MemberEvent?> GetByIdAsync(string tenantId, string memberId, string eventId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var match = _events.FirstOrDefault(e =>
+                e.TenantId == tenantId && e.MemberId == memberId && e.EventId == eventId);
+            return Task.FromResult<MemberEvent?>(match);
+        }
+    }
+
+    public Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var max = _events
+                .Where(e => e.TenantId == tenantId && e.MemberId == memberId)
+                .Select(e => (int?)e.Version)
+                .Max();
+            return Task.FromResult((max ?? 0) + 1);
+        }
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberRepository.cs
@@ -1,0 +1,71 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>In-memory <see cref="IMemberRepository"/> for controller and integration tests.</summary>
+public sealed class InMemoryMemberRepository : IMemberRepository
+{
+    public List<Member> Members { get; } = new();
+
+    public Task<Member?> GetByIdAsync(string tenantId, string id)
+        => Task.FromResult(Members.FirstOrDefault(m => m.TenantId == tenantId && m.Id == id));
+
+    public Task<Member?> GetByMemberIdAsync(string tenantId, string memberId)
+        => Task.FromResult(Members.FirstOrDefault(m => m.TenantId == tenantId && m.MemberId == memberId));
+
+    public Task<(IEnumerable<Member> Items, string? ContinuationToken)> SearchAsync(
+        string tenantId,
+        string? groupNumber = null,
+        string? lastName = null,
+        DateTime? dateOfBirth = null,
+        bool activeOnly = false,
+        bool subscribersOnly = false,
+        int pageSize = 20,
+        string? continuationToken = null)
+    {
+        IEnumerable<Member> q = Members.Where(m => m.TenantId == tenantId);
+        if (!string.IsNullOrEmpty(groupNumber)) q = q.Where(m => m.GroupNumber == groupNumber);
+        if (!string.IsNullOrEmpty(lastName)) q = q.Where(m => m.LastName.Contains(lastName, StringComparison.OrdinalIgnoreCase));
+        if (dateOfBirth.HasValue) q = q.Where(m => m.DateOfBirth.Date == dateOfBirth.Value.Date);
+        if (activeOnly) q = q.Where(m => m.Status == EnrollmentStatus.Active);
+        if (subscribersOnly) q = q.Where(m => m.IsSubscriber);
+        return Task.FromResult<(IEnumerable<Member>, string?)>((q.Take(pageSize).ToList(), null));
+    }
+
+    public Task<List<Member>> GetDependentsAsync(string tenantId, string subscriberMemberId)
+        => Task.FromResult(Members
+            .Where(m => m.TenantId == tenantId && m.SubscriberMemberId == subscriberMemberId && !m.IsSubscriber)
+            .ToList());
+
+    public Task<int> GetCountByGroupAsync(string tenantId, string groupNumber)
+        => Task.FromResult(Members.Count(m => m.TenantId == tenantId && m.GroupNumber == groupNumber));
+
+    public Task<Member> CreateAsync(Member member)
+    {
+        Members.Add(member);
+        return Task.FromResult(member);
+    }
+
+    public Task<Member> UpdateAsync(Member member)
+    {
+        var idx = Members.FindIndex(m => m.TenantId == member.TenantId && m.Id == member.Id);
+        if (idx >= 0) Members[idx] = member;
+        else Members.Add(member);
+        return Task.FromResult(member);
+    }
+
+    public Task DeleteAsync(string tenantId, string id)
+    {
+        Members.RemoveAll(m => m.TenantId == tenantId && m.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> ExistsAsync(string tenantId, string memberId)
+        => Task.FromResult(Members.Any(m => m.TenantId == tenantId && m.MemberId == memberId));
+
+    public Task<Member?> GetByIdentifierAsync(string tenantId, string system, string value)
+        => Task.FromResult(Members.FirstOrDefault(m =>
+            m.TenantId == tenantId &&
+            m.Identifiers.Any(i => i.System == system && i.Value == value)));
+}

--- a/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
@@ -1,0 +1,151 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MemberService.Tests.Integration;
+
+/// <summary>
+/// Contract tests verifying that every HTTP path embedded in member-service's
+/// downstream typed clients maps to a real, registered endpoint on the
+/// downstream service. Catches the class of bug that broke PR #650 (path
+/// pluralization mismatch between caller and callee) at build/test time
+/// instead of at runtime.
+/// </summary>
+public class DownstreamRouteContractTests
+{
+    private sealed class CoverageFactory : WebApplicationFactory<CoverageService.Controllers.CoverageController>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    // Force Mongo branch (no Cosmos creds required). Fake host so
+                    // the MongoClient constructor succeeds; no I/O runs because
+                    // we replace the repository below.
+                    ["MongoDb:ConnectionString"] = "mongodb://fake-contract-host:27017",
+                    ["MongoDb:DatabaseName"] = "contract"
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                RemoveAll<CoverageService.Repositories.ICoverageRepository>(services);
+                services.AddSingleton<CoverageService.Repositories.ICoverageRepository>(
+                    new Mock<CoverageService.Repositories.ICoverageRepository>().Object);
+            });
+        }
+    }
+
+    private sealed class EnrollmentFactory : WebApplicationFactory<EnrollmentImportService.Controllers.EnrollmentController>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    // Enrollment-import only speaks Cosmos; emulator defaults
+                    // keep the CosmosClient constructor happy. Repositories are
+                    // replaced below so no actual I/O happens.
+                    ["CosmosDb:Endpoint"] = "https://localhost:8081",
+                    ["CosmosDb:Key"] = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                RemoveAll<EnrollmentImportService.Services.IEnrollmentRepository>(services);
+                RemoveAll<EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
+                services.AddSingleton<EnrollmentImportService.Services.IEnrollmentRepository>(
+                    new Mock<EnrollmentImportService.Services.IEnrollmentRepository>().Object);
+                services.AddSingleton<EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
+                    new Mock<EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
+            });
+        }
+
+        private static void RemoveAll<T>(IServiceCollection services)
+        {
+            var toRemove = services.Where(d => d.ServiceType == typeof(T)).ToList();
+            foreach (var d in toRemove) services.Remove(d);
+        }
+    }
+
+    private static void RemoveAll<T>(IServiceCollection services)
+    {
+        var toRemove = services.Where(d => d.ServiceType == typeof(T)).ToList();
+        foreach (var d in toRemove) services.Remove(d);
+    }
+
+    [Fact]
+    public void HttpCoverageServiceClient_PathsMapToRegisteredEndpoints()
+    {
+        using var factory = new CoverageFactory();
+        var endpoints = GetRegisteredPatterns(factory.Services);
+
+        var expected = new (string Verb, string PathTemplate)[]
+        {
+            ("GET",  "api/v1/coverage/member/{memberId}/pcp"),
+            ("PUT",  "api/v1/coverage/member/{memberId}/pcp"),
+            ("GET",  "api/v1/coverage/member/{memberId}/history"),
+            ("POST", "api/v1/coverage/member/{memberId}/terminate"),
+        };
+
+        foreach (var (verb, template) in expected)
+        {
+            AssertRouteRegistered(endpoints, verb, template);
+        }
+    }
+
+    [Fact]
+    public void HttpEnrollmentImportServiceClient_PathsMapToRegisteredEndpoints()
+    {
+        using var factory = new EnrollmentFactory();
+        var endpoints = GetRegisteredPatterns(factory.Services);
+
+        AssertRouteRegistered(endpoints, "GET", "api/v1/enrollment/transactions");
+    }
+
+    private static List<(string Verb, string Pattern)> GetRegisteredPatterns(IServiceProvider sp)
+    {
+        var dataSources = sp.GetServices<EndpointDataSource>();
+        var list = new List<(string, string)>();
+        foreach (var ds in dataSources)
+        {
+            foreach (var ep in ds.Endpoints.OfType<RouteEndpoint>())
+            {
+                var verbs = ep.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods
+                            ?? new[] { "GET" };
+                foreach (var v in verbs)
+                    list.Add((v, ep.RoutePattern.RawText ?? string.Empty));
+            }
+        }
+        return list;
+    }
+
+    private static void AssertRouteRegistered(
+        IReadOnlyList<(string Verb, string Pattern)> endpoints,
+        string verb,
+        string expectedTemplate)
+    {
+        bool match = endpoints.Any(e =>
+            string.Equals(e.Verb, verb, StringComparison.OrdinalIgnoreCase) &&
+            RoutePatternEquals(e.Pattern, expectedTemplate));
+
+        match.Should().BeTrue(
+            $"downstream client calls {verb} /{expectedTemplate} but no such route is registered. " +
+            $"Registered routes: {string.Join(", ", endpoints.Select(e => $"{e.Verb} {e.Pattern}"))}");
+    }
+
+    private static bool RoutePatternEquals(string a, string b)
+    {
+        // Normalize route parameter segments: "{memberId}" ~= "{id}" — only
+        // structure + literal segments are compared, not parameter names.
+        static string Normalize(string p) => Regex.Replace(p.Trim('/'), "\\{[^}]+\\}", "{}")
+            .Replace("//", "/");
+        return string.Equals(Normalize(a), Normalize(b), StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
@@ -1,7 +1,11 @@
+extern alias CoverageSvc;
+extern alias EnrollmentSvc;
+
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MemberService.Tests.Integration;
@@ -15,7 +19,7 @@ namespace MemberService.Tests.Integration;
 /// </summary>
 public class DownstreamRouteContractTests
 {
-    private sealed class CoverageFactory : WebApplicationFactory<CoverageService.Controllers.CoverageController>
+    private sealed class CoverageFactory : WebApplicationFactory<CoverageSvc::CoverageService.Controllers.CoverageController>
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
@@ -33,14 +37,14 @@ public class DownstreamRouteContractTests
             });
             builder.ConfigureServices(services =>
             {
-                RemoveAll<CoverageService.Repositories.ICoverageRepository>(services);
-                services.AddSingleton<CoverageService.Repositories.ICoverageRepository>(
-                    new Mock<CoverageService.Repositories.ICoverageRepository>().Object);
+                RemoveAll<CoverageSvc::CoverageService.Repositories.ICoverageRepository>(services);
+                services.AddSingleton<CoverageSvc::CoverageService.Repositories.ICoverageRepository>(
+                    new Mock<CoverageSvc::CoverageService.Repositories.ICoverageRepository>().Object);
             });
         }
     }
 
-    private sealed class EnrollmentFactory : WebApplicationFactory<EnrollmentImportService.Controllers.EnrollmentController>
+    private sealed class EnrollmentFactory : WebApplicationFactory<EnrollmentSvc::EnrollmentImportService.Controllers.EnrollmentController>
     {
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
@@ -58,12 +62,12 @@ public class DownstreamRouteContractTests
             });
             builder.ConfigureServices(services =>
             {
-                RemoveAll<EnrollmentImportService.Services.IEnrollmentRepository>(services);
-                RemoveAll<EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
-                services.AddSingleton<EnrollmentImportService.Services.IEnrollmentRepository>(
-                    new Mock<EnrollmentImportService.Services.IEnrollmentRepository>().Object);
-                services.AddSingleton<EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
-                    new Mock<EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
+                RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(services);
+                RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
+                services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(
+                    new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>().Object);
+                services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
+                    new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
             });
         }
 

--- a/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
@@ -9,6 +9,7 @@ using MemberService.Tests.Fakes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace MemberService.Tests.Integration;
@@ -45,6 +46,10 @@ public class MemberFhirSmokeTests : IClassFixture<MemberFhirSmokeTests.Factory>
                 RemoveAll<IMemberEventRepository>(services);
                 RemoveAll<MongoDB.Driver.IMongoClient>(services);
                 RemoveAll<MongoDB.Driver.IMongoDatabase>(services);
+
+                // Strip the hosted services that would otherwise try to
+                // create Mongo indexes against the fake host.
+                services.RemoveAll<IHostedService>();
 
                 services.AddSingleton<IMemberRepository>(MemberRepo);
                 services.AddSingleton<IMemberEventRepository>(EventRepo);

--- a/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
@@ -2,12 +2,14 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using MemberService.Controllers;
+using MemberService.HostedServices;
 using MemberService.Models;
 using MemberService.Repositories;
 using MemberService.Services;
 using MemberService.Tests.Fakes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -47,9 +49,12 @@ public class MemberFhirSmokeTests : IClassFixture<MemberFhirSmokeTests.Factory>
                 RemoveAll<MongoDB.Driver.IMongoClient>(services);
                 RemoveAll<MongoDB.Driver.IMongoDatabase>(services);
 
-                // Strip the hosted services that would otherwise try to
-                // create Mongo indexes against the fake host.
-                services.RemoveAll<IHostedService>();
+                // Remove the Mongo index initializers that would try to connect to the
+                // fake MongoDB host at startup. Don't use RemoveAll<IHostedService>() as
+                // that would also remove the Kestrel host service and prevent the test
+                // server from starting.
+                RemoveAll<MemberEventIndexInitializer>(services);
+                RemoveAll<MemberIndexInitializer>(services);
 
                 services.AddSingleton<IMemberRepository>(MemberRepo);
                 services.AddSingleton<IMemberEventRepository>(EventRepo);

--- a/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MemberService.Tests.Integration;
+
+/// <summary>
+/// End-to-end smoke over the real Program pipeline using an in-memory repo so the
+/// test doesn't require Cosmos/Mongo. Exercises: create member → event written →
+/// GET FHIR returns a Patient resource with the expected extensions and identifiers.
+/// </summary>
+public class MemberFhirSmokeTests : IClassFixture<MemberFhirSmokeTests.Factory>
+{
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        public InMemoryMemberRepository MemberRepo { get; } = new();
+        public InMemoryMemberEventRepository EventRepo { get; } = new();
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((ctx, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    // Force the Mongo branch in Program.cs so we never try to contact Cosmos
+                    // before our overrides land. The Mongo db registration is replaced below.
+                    ["MongoDb:ConnectionString"] = "mongodb://fake-host:27017",
+                    ["MongoDb:DatabaseName"] = "CloudHealthOffice",
+                    ["Member:IdentifierEncryption:KeySecretName"] = ""
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                RemoveAll<IMemberRepository>(services);
+                RemoveAll<IMemberEventRepository>(services);
+                RemoveAll<MongoDB.Driver.IMongoClient>(services);
+                RemoveAll<MongoDB.Driver.IMongoDatabase>(services);
+
+                services.AddSingleton<IMemberRepository>(MemberRepo);
+                services.AddSingleton<IMemberEventRepository>(EventRepo);
+            });
+            return base.CreateHost(builder);
+        }
+
+        private static void RemoveAll<T>(IServiceCollection services)
+        {
+            var toRemove = services.Where(d => d.ServiceType == typeof(T)).ToList();
+            foreach (var d in toRemove) services.Remove(d);
+        }
+    }
+
+    private readonly Factory _factory;
+
+    public MemberFhirSmokeTests(Factory factory) { _factory = factory; }
+
+    private HttpClient NewClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", "tenant-int");
+        return client;
+    }
+
+    [Fact]
+    public async Task CreateMember_Then_GetFhir_And_Events_RoundTrip()
+    {
+        _factory.MemberRepo.Members.Clear();
+        var client = NewClient();
+
+        var createResp = await client.PostAsJsonAsync("/api/v1/members", new CreateMemberRequest
+        {
+            MemberId = "INT-001",
+            GroupNumber = "GRP",
+            IsSubscriber = true,
+            FirstName = "Iris",
+            LastName = "Integration",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1),
+            Gender = "F",
+            PreferredLanguage = "en-US",
+            BirthSex = "F"
+        });
+        createResp.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var fhirResp = await client.GetAsync("/api/v1/members/INT-001/fhir");
+        fhirResp.IsSuccessStatusCode.Should().BeTrue();
+        fhirResp.Content.Headers.ContentType!.MediaType.Should().Be("application/fhir+json");
+
+        var body = await fhirResp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("resourceType").GetString().Should().Be("Patient");
+        doc.RootElement.GetProperty("birthDate").GetString().Should().Be("1990-01-01");
+
+        // Events stream contains MemberCreated with Version=1.
+        var eventsResp = await client.GetAsync("/api/v1/members/INT-001/events");
+        eventsResp.IsSuccessStatusCode.Should().BeTrue();
+        var events = await eventsResp.Content.ReadFromJsonAsync<List<MemberEvent>>();
+        events.Should().NotBeNull();
+        events!.Should().ContainSingle(e => e.EventType == MemberEventType.MemberCreated && e.Version == 1);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/MemberService.Tests.csproj
+++ b/src/services/member-service/MemberService.Tests/MemberService.Tests.csproj
@@ -33,9 +33,18 @@
       paths baked into HttpCoverageServiceClient / HttpEnrollmentImportServiceClient.
       Catches pluralization / prefix mismatches that would otherwise only
       surface as runtime 404s in prod.
+
+      Aliases isolate each service's global `Program` type so it does not
+      collide with member-service's `Program` in this test assembly.
+      DownstreamRouteContractTests uses `extern alias` to access the types
+      from these assemblies.
     -->
-    <ProjectReference Include="..\..\coverage-service\coverage-service.csproj" />
-    <ProjectReference Include="..\..\enrollment-import-service\EnrollmentImportService.csproj" />
+    <ProjectReference Include="..\..\coverage-service\coverage-service.csproj">
+      <Aliases>CoverageSvc</Aliases>
+    </ProjectReference>
+    <ProjectReference Include="..\..\enrollment-import-service\EnrollmentImportService.csproj">
+      <Aliases>EnrollmentSvc</Aliases>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/member-service/MemberService.Tests/Models/MemberEventTests.cs
+++ b/src/services/member-service/MemberService.Tests/Models/MemberEventTests.cs
@@ -1,0 +1,21 @@
+using MemberService.Models;
+
+namespace MemberService.Tests.Models;
+
+public class MemberEventTests
+{
+    [Fact]
+    public void BuildPartitionKey_Composes_Tenant_Member()
+    {
+        MemberEvent.BuildPartitionKey("t1", "m1").Should().Be("t1:m1");
+    }
+
+    [Fact]
+    public void Event_Defaults_SchemaVersion_One_And_OccurredAt_Recent()
+    {
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        var evt = new MemberEvent();
+        evt.SchemaVersion.Should().Be(1);
+        evt.OccurredAt.Should().BeOnOrAfter(before);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Models/MemberIdentifierTests.cs
+++ b/src/services/member-service/MemberService.Tests/Models/MemberIdentifierTests.cs
@@ -1,0 +1,44 @@
+using MemberService.Models;
+
+namespace MemberService.Tests.Models;
+
+public class MemberIdentifierTests
+{
+    [Fact]
+    public void FromType_MapsStandardTypes_ToCanonicalSystemUris()
+    {
+        FhirIdentifierSystems.FromType(MemberIdentifierType.SSN).Should().Be("http://hl7.org/fhir/sid/us-ssn");
+        FhirIdentifierSystems.FromType(MemberIdentifierType.MedicareMbi).Should().Be("http://hl7.org/fhir/sid/us-mbi");
+        FhirIdentifierSystems.FromType(MemberIdentifierType.Medicaid).Should().Be("http://hl7.org/fhir/sid/us-medicaid");
+        FhirIdentifierSystems.FromType(MemberIdentifierType.MemberId).Should().Be("urn:cho:member-id");
+        FhirIdentifierSystems.FromType(MemberIdentifierType.Portal).Should().Be("urn:cho:portal-id");
+        FhirIdentifierSystems.FromType(MemberIdentifierType.Exchange).Should().Be("urn:cho:exchange-id");
+    }
+
+    [Fact]
+    public void LegacyForSystem_BuildsSlugScopedUri()
+    {
+        FhirIdentifierSystems.LegacyForSystem("acme-enroll-v1")
+            .Should().Be("urn:cho:legacy:acme-enroll-v1");
+    }
+
+    [Fact]
+    public void LegacyForSystem_EmptySlug_Throws()
+    {
+        var act = () => FhirIdentifierSystems.LegacyForSystem("");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Identifier_Defaults_ToOfficialUse_AndNotEncrypted()
+    {
+        var id = new MemberIdentifier
+        {
+            Type = MemberIdentifierType.MemberId,
+            System = FhirIdentifierSystems.MemberId,
+            Value = "M-0001"
+        };
+        id.Use.Should().Be("official");
+        id.IsEncrypted.Should().BeFalse();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Repositories/MemberEventRepositoryTests.cs
+++ b/src/services/member-service/MemberService.Tests/Repositories/MemberEventRepositoryTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Nodes;
+using MemberService.Models;
+using MemberService.Tests.Fakes;
+
+namespace MemberService.Tests.Repositories;
+
+public class MemberEventRepositoryTests
+{
+    [Fact]
+    public async Task Append_AssignsVersionAndReturnsAppended()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var version = await repo.GetNextVersionAsync("t1", "m1");
+        version.Should().Be(1);
+
+        var evt = new MemberEvent
+        {
+            TenantId = "t1",
+            MemberId = "m1",
+            EventId = "evt-1",
+            EventType = MemberEventType.MemberCreated,
+            Version = version,
+            Payload = new JsonObject { ["x"] = 1 }
+        };
+
+        var result = await repo.AppendAsync(evt);
+        result.Appended.Should().BeTrue();
+        (await repo.GetNextVersionAsync("t1", "m1")).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Append_DuplicateEventId_IsNoOp()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var evt = new MemberEvent
+        {
+            TenantId = "t1", MemberId = "m1",
+            EventId = "same", EventType = MemberEventType.MemberCreated, Version = 1
+        };
+        (await repo.AppendAsync(evt)).Appended.Should().BeTrue();
+
+        var dup = new MemberEvent
+        {
+            TenantId = "t1", MemberId = "m1",
+            EventId = "same", EventType = MemberEventType.MemberUpdated, Version = 2
+        };
+        var second = await repo.AppendAsync(dup);
+        second.Appended.Should().BeFalse();
+
+        var list = await repo.ListByMemberAsync("t1", "m1");
+        list.Should().HaveCount(1);
+        list[0].EventType.Should().Be(MemberEventType.MemberCreated);
+    }
+
+    [Fact]
+    public async Task ListByMember_OrdersByVersionAscending()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        await repo.AppendAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="c",EventType=MemberEventType.MemberTerminated,Version=3 });
+        await repo.AppendAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="a",EventType=MemberEventType.MemberCreated,Version=1 });
+        await repo.AppendAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="b",EventType=MemberEventType.MemberUpdated,Version=2 });
+
+        var list = await repo.ListByMemberAsync("t", "m");
+        list.Select(e => e.Version).Should().ContainInOrder(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task ListByMember_IsTenantScoped()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        await repo.AppendAsync(new MemberEvent { TenantId="t1",MemberId="m",EventId="a",Version=1 });
+        await repo.AppendAsync(new MemberEvent { TenantId="t2",MemberId="m",EventId="b",Version=1 });
+
+        (await repo.ListByMemberAsync("t1", "m")).Should().ContainSingle();
+        (await repo.ListByMemberAsync("t2", "m")).Should().ContainSingle();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/FhirPatientProjectorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FhirPatientProjectorTests.cs
@@ -1,0 +1,172 @@
+using MemberService.Models;
+using MemberService.Services;
+
+namespace MemberService.Tests.Services;
+
+public class FhirPatientProjectorTests
+{
+    private static Member BuildMember() => new()
+    {
+        TenantId = "t1",
+        Id = "guid-1",
+        MemberId = "M-001",
+        FirstName = "Alice",
+        LastName = "Example",
+        MiddleName = "Q",
+        DateOfBirth = new DateTime(1985, 6, 15),
+        Gender = "F",
+        Address = "123 Main St",
+        City = "Austin",
+        State = "TX",
+        ZipCode = "78701",
+        Phone = "512-555-0000",
+        Email = "alice@example.com",
+        EffectiveDate = new DateTime(2024, 1, 1),
+        Status = EnrollmentStatus.Active,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        GroupNumber = "GRP-001",
+        IsSubscriber = true,
+        PreferredLanguage = "en-US",
+        Languages = new List<string> { "en-US", "es-MX" },
+        BirthSex = "F",
+        Pronouns = "she/her",
+        Race = new CodedConcept
+        {
+            System = "urn:oid:2.16.840.1.113883.6.238",
+            Code = "2106-3",
+            Display = "White"
+        },
+        Ethnicity = new CodedConcept
+        {
+            System = "urn:oid:2.16.840.1.113883.6.238",
+            Code = "2186-5",
+            Display = "Not Hispanic or Latino"
+        },
+        MaritalStatus = new CodedConcept
+        {
+            System = "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus",
+            Code = "M",
+            Display = "Married"
+        },
+        GenderIdentity = new CodedConcept
+        {
+            System = "http://snomed.info/sct",
+            Code = "446141000124107",
+            Display = "Female gender identity"
+        },
+        Identifiers = new List<MemberIdentifier>
+        {
+            new() { Type = MemberIdentifierType.MedicareMbi, System = FhirIdentifierSystems.MedicareMbi, Value = "1EG4-TE5-MK73" },
+            new() { Type = MemberIdentifierType.SSN, System = FhirIdentifierSystems.SSN, Value = "ciphertext", IsEncrypted = true }
+        }
+    };
+
+    [Fact]
+    public void Project_ProducesPatientResource_WithCoreFields()
+    {
+        var m = BuildMember();
+        var json = new FhirPatientProjector().Project(m);
+
+        json["resourceType"]!.ToString().Should().Be("Patient");
+        json["id"]!.ToString().Should().Be(m.Id);
+        json["active"]!.GetValue<bool>().Should().BeTrue();
+        json["birthDate"]!.ToString().Should().Be("1985-06-15");
+        json["gender"]!.ToString().Should().Be("female");
+    }
+
+    [Fact]
+    public void Project_IncludesUsCoreRaceAndEthnicityExtensions()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        var extensions = json["extension"]!.AsArray();
+        extensions.Any(e => e!["url"]!.ToString() == FhirExtensionBuilder.UsCoreRace).Should().BeTrue();
+        extensions.Any(e => e!["url"]!.ToString() == FhirExtensionBuilder.UsCoreEthnicity).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Project_IncludesBirthSexAndGenderIdentityExtensions()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        var extensions = json["extension"]!.AsArray();
+        var birthSex = extensions.Single(e => e!["url"]!.ToString() == FhirExtensionBuilder.UsCoreBirthSex);
+        birthSex["valueCode"]!.ToString().Should().Be("F");
+
+        extensions.Any(e => e!["url"]!.ToString() == FhirExtensionBuilder.UsCoreGenderIdentity).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Project_IdentifiersContainPrimaryAndTypedWithSystemUris()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        var ids = json["identifier"]!.AsArray();
+        ids.Should().HaveCount(3); // MemberId + MBI + SSN
+        ids.Any(i => i!["system"]!.ToString() == "urn:cho:member-id").Should().BeTrue();
+        ids.Any(i => i!["system"]!.ToString() == "http://hl7.org/fhir/sid/us-mbi").Should().BeTrue();
+
+        var ssn = ids.Single(i => i!["system"]!.ToString() == "http://hl7.org/fhir/sid/us-ssn");
+        ssn["value"]!.ToString().Should().Be("[REDACTED]");
+    }
+
+    [Fact]
+    public void Project_DeceasedDate_PopulatesDeceasedDateTime()
+    {
+        var m = BuildMember();
+        m.Deceased = true;
+        m.DeceasedDate = new DateTime(2023, 12, 1, 0, 0, 0, DateTimeKind.Utc);
+        var json = new FhirPatientProjector().Project(m);
+        json["deceasedDateTime"].Should().NotBeNull();
+        json["deceasedBoolean"].Should().BeNull();
+    }
+
+    [Fact]
+    public void Project_DeceasedBoolean_WithoutDate_PopulatesBool()
+    {
+        var m = BuildMember();
+        m.Deceased = true;
+        m.DeceasedDate = null;
+        var json = new FhirPatientProjector().Project(m);
+        json["deceasedBoolean"]!.GetValue<bool>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Project_Communication_MarksPreferredLanguage()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        var comms = json["communication"]!.AsArray();
+        var preferred = comms.Single(c => c!["preferred"]!.GetValue<bool>());
+        preferred["language"]!["coding"]!.AsArray()[0]!["code"]!.ToString().Should().Be("en-US");
+    }
+
+    [Fact]
+    public void Project_MaritalStatus_EmitsCodeableConcept()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        json["maritalStatus"]!["coding"]!.AsArray()[0]!["code"]!.ToString().Should().Be("M");
+    }
+
+    [Fact]
+    public void Project_Address_EmittedWhenAnyFieldPresent()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember());
+        var address = json["address"]!.AsArray()[0]!;
+        address["city"]!.ToString().Should().Be("Austin");
+        address["state"]!.ToString().Should().Be("TX");
+        address["postalCode"]!.ToString().Should().Be("78701");
+    }
+
+    [Fact]
+    public void Project_MinimalMember_DoesNotCrashAndProducesValidResourceType()
+    {
+        var min = new Member
+        {
+            TenantId = "t", MemberId = "m1",
+            GroupNumber = "g", IsSubscriber = true,
+            FirstName = "A", LastName = "B",
+            DateOfBirth = new DateTime(2000, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1)
+        };
+        var json = new FhirPatientProjector().Project(min);
+        json["resourceType"]!.ToString().Should().Be("Patient");
+        json["identifier"]!.AsArray().Should().ContainSingle();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
@@ -1,0 +1,101 @@
+using System.Security.Cryptography;
+using CloudHealthOffice.Infrastructure.Configuration;
+using MemberService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+public class IdentifierEncryptorTests
+{
+    private sealed class StaticSecretProvider : ISecretProvider
+    {
+        private readonly string _secret;
+        public StaticSecretProvider(string secret) { _secret = secret; }
+        public Task<string?> GetSecretAsync(string name, CancellationToken ct = default) => Task.FromResult<string?>(_secret);
+        public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
+            => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
+        public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+    }
+
+    [Fact]
+    public async Task NoOp_PassesThroughValues()
+    {
+        var enc = new NoOpIdentifierEncryptor();
+        enc.IsEnabled.Should().BeFalse();
+        (await enc.EncryptAsync("abc")).Should().Be("abc");
+        (await enc.DecryptAsync("abc")).Should().Be("abc");
+        (await enc.EncryptAsync(null)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task KeyVaultEncryptor_RoundTripsPlaintext()
+    {
+        var keyBytes = RandomNumberGenerator.GetBytes(32);
+        var enc = new KeyVaultIdentifierEncryptor(
+            new StaticSecretProvider(Convert.ToBase64String(keyBytes)),
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "cho-member-id-dek");
+
+        var cipher = await enc.EncryptAsync("123-45-6789");
+        cipher.Should().NotBeNullOrEmpty();
+        cipher.Should().NotBe("123-45-6789");
+
+        var plain = await enc.DecryptAsync(cipher);
+        plain.Should().Be("123-45-6789");
+    }
+
+    [Fact]
+    public async Task KeyVaultEncryptor_EmptyIn_EmptyOut()
+    {
+        var enc = new KeyVaultIdentifierEncryptor(
+            new StaticSecretProvider(Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))),
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "k");
+        (await enc.EncryptAsync("")).Should().Be("");
+        (await enc.DecryptAsync("")).Should().Be("");
+    }
+
+    [Fact]
+    public async Task KeyVaultEncryptor_WrongKeyLength_Throws()
+    {
+        var enc = new KeyVaultIdentifierEncryptor(
+            new StaticSecretProvider("short"),
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "k");
+        var act = async () => await enc.EncryptAsync("anything");
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task KeyVaultEncryptor_MissingKey_Throws()
+    {
+        var provider = new Moq.Mock<ISecretProvider>();
+        provider.Setup(p => p.GetSecretAsync(Moq.It.IsAny<string>(), Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var enc = new KeyVaultIdentifierEncryptor(
+            provider.Object,
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "k");
+        var act = async () => await enc.EncryptAsync("anything");
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task KeyVaultEncryptor_TamperedCiphertext_ThrowsCrypto()
+    {
+        var keyBytes = RandomNumberGenerator.GetBytes(32);
+        var enc = new KeyVaultIdentifierEncryptor(
+            new StaticSecretProvider(Convert.ToBase64String(keyBytes)),
+            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
+            "k");
+        var cipher = await enc.EncryptAsync("secret-mbi");
+        cipher.Should().NotBeNull();
+        // Flip a byte in the middle.
+        var chars = cipher!.ToCharArray();
+        chars[^5] = chars[^5] == 'A' ? 'B' : 'A';
+        var tampered = new string(chars);
+
+        var act = async () => await enc.DecryptAsync(tampered);
+        await act.Should().ThrowAsync<CryptographicException>();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/MemberEventPublisherTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/MemberEventPublisherTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Nodes;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+public class MemberEventPublisherTests
+{
+    private static CosmosMemberEventPublisher NewPublisher(InMemoryMemberEventRepository repo)
+        => new(repo, NullLogger<CosmosMemberEventPublisher>.Instance);
+
+    [Fact]
+    public async Task Publish_StampsVersionAndPartitionKey()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var pub = NewPublisher(repo);
+
+        var result = await pub.PublishAsync(new MemberEvent
+        {
+            TenantId = "t1",
+            MemberId = "m1",
+            EventId = "e1",
+            EventType = MemberEventType.MemberCreated,
+            Payload = new JsonObject { ["firstName"] = "Alice" }
+        });
+
+        result.Version.Should().Be(1);
+        result.PartitionKey.Should().Be("t1:m1");
+        result.OccurredAt.Should().BeAfter(DateTime.UtcNow.AddMinutes(-1));
+        repo.All.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Publish_IsIdempotentOnEventId()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var pub = NewPublisher(repo);
+        var evt = new MemberEvent
+        {
+            TenantId = "t1", MemberId = "m1",
+            EventId = "same",
+            EventType = MemberEventType.AddressChanged,
+            Payload = new JsonObject { ["city"] = "Austin" }
+        };
+        await pub.PublishAsync(evt);
+        await pub.PublishAsync(evt);
+        await pub.PublishAsync(evt);
+
+        repo.All.Should().ContainSingle();
+        repo.All[0].Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Publish_IncrementsVersionPerAggregate()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var pub = NewPublisher(repo);
+
+        await pub.PublishAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="1",EventType=MemberEventType.MemberCreated });
+        await pub.PublishAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="2",EventType=MemberEventType.MemberUpdated });
+        await pub.PublishAsync(new MemberEvent { TenantId="t",MemberId="m",EventId="3",EventType=MemberEventType.MemberTerminated });
+
+        var list = await repo.ListByMemberAsync("t", "m");
+        list.Select(e => e.Version).Should().ContainInOrder(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task Publish_MissingEventId_Throws()
+    {
+        var pub = NewPublisher(new InMemoryMemberEventRepository());
+        var act = () => pub.PublishAsync(new MemberEvent
+        {
+            TenantId = "t", MemberId = "m", EventType = MemberEventType.MemberCreated
+        });
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Publish_DifferentMembers_HaveIndependentVersionStreams()
+    {
+        var repo = new InMemoryMemberEventRepository();
+        var pub = NewPublisher(repo);
+        await pub.PublishAsync(new MemberEvent { TenantId="t",MemberId="m1",EventId="a",EventType=MemberEventType.MemberCreated });
+        await pub.PublishAsync(new MemberEvent { TenantId="t",MemberId="m2",EventId="b",EventType=MemberEventType.MemberCreated });
+
+        repo.All.Single(e => e.MemberId == "m1").Version.Should().Be(1);
+        repo.All.Single(e => e.MemberId == "m2").Version.Should().Be(1);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/VersionConflictRetryTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/VersionConflictRetryTests.cs
@@ -1,0 +1,48 @@
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+public class VersionConflictRetryTests
+{
+    [Fact]
+    public async Task Publish_RetriesOnVersionConflict_ThenSucceeds()
+    {
+        var inner = new InMemoryMemberEventRepository();
+        var racing = new ConflictingMemberEventRepository(inner, conflicts: 3);
+        var pub = new CosmosMemberEventPublisher(racing, NullLogger<CosmosMemberEventPublisher>.Instance);
+
+        var result = await pub.PublishAsync(new MemberEvent
+        {
+            TenantId = "t1",
+            MemberId = "m1",
+            EventId = "e1",
+            EventType = MemberEventType.MemberCreated
+        });
+
+        result.Version.Should().Be(1);
+        racing.AttemptsSeen.Should().Be(4); // 3 conflicts + 1 success
+        inner.All.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Publish_ExceedsRetryBudget_ThrowsConcurrencyException()
+    {
+        var inner = new InMemoryMemberEventRepository();
+        var racing = new ConflictingMemberEventRepository(inner, conflicts: 10);
+        var pub = new CosmosMemberEventPublisher(racing, NullLogger<CosmosMemberEventPublisher>.Instance);
+
+        var act = async () => await pub.PublishAsync(new MemberEvent
+        {
+            TenantId = "t1",
+            MemberId = "m1",
+            EventId = "e1",
+            EventType = MemberEventType.MemberCreated
+        });
+
+        await act.Should().ThrowAsync<ConcurrencyException>();
+        inner.All.Should().BeEmpty();
+    }
+}

--- a/src/services/member-service/Models/CodedConcept.cs
+++ b/src/services/member-service/Models/CodedConcept.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// Minimal FHIR Coding value object: system + code + optional display.
+/// Reused for Race, Ethnicity, MaritalStatus, BirthSex, etc.
+/// </summary>
+public class CodedConcept
+{
+    [Required]
+    [StringLength(256)]
+    public string System { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(64)]
+    public string Code { get; set; } = string.Empty;
+
+    [StringLength(256)]
+    public string? Display { get; set; }
+}

--- a/src/services/member-service/Models/CommunicationPreference.cs
+++ b/src/services/member-service/Models/CommunicationPreference.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// Member communication channel preference (notifications, appointment reminders, etc.).
+/// </summary>
+public class CommunicationPreference
+{
+    [Required]
+    public CommunicationChannel Channel { get; set; }
+
+    /// <summary>
+    /// BCP-47 language tag (e.g. "en-US", "es-MX"). Falls back to <c>Member.PreferredLanguage</c>.
+    /// </summary>
+    [StringLength(16)]
+    public string? Language { get; set; }
+
+    public bool OptedIn { get; set; } = true;
+
+    /// <summary>
+    /// Preferred contact window in 24h HH:mm form (inclusive start, exclusive end).
+    /// </summary>
+    [StringLength(5)]
+    public string? WindowStart { get; set; }
+
+    [StringLength(5)]
+    public string? WindowEnd { get; set; }
+}
+
+public enum CommunicationChannel
+{
+    Email = 1,
+    SMS = 2,
+    Mail = 3,
+    Phone = 4,
+    PortalMessage = 5
+}

--- a/src/services/member-service/Models/FhirIdentifierSystems.cs
+++ b/src/services/member-service/Models/FhirIdentifierSystems.cs
@@ -1,0 +1,47 @@
+namespace MemberService.Models;
+
+/// <summary>
+/// Central registry of identifier system URIs used by the Member Service.
+/// Keeps FHIR Identifier.system values DRY across projector, controllers, and tests.
+/// </summary>
+public static class FhirIdentifierSystems
+{
+    // Standard FHIR US-Core / sid URIs
+    public const string SSN = "http://hl7.org/fhir/sid/us-ssn";
+    public const string MedicareMbi = "http://hl7.org/fhir/sid/us-mbi";
+    public const string Medicaid = "http://hl7.org/fhir/sid/us-medicaid";
+
+    // CHO-internal URIs (tenant scoping is carried in the identifier value prefix)
+    public const string MemberId = "urn:cho:member-id";
+    public const string PortalId = "urn:cho:portal-id";
+    public const string ExchangeId = "urn:cho:exchange-id";
+
+    /// <summary>
+    /// Legacy/external identifier URI prefix. Concatenate with a tenant-config-driven
+    /// slug (e.g. "urn:cho:legacy:acme-enrollment-v1").
+    /// </summary>
+    public const string LegacyPrefix = "urn:cho:legacy";
+
+    public static string LegacyForSystem(string systemSlug)
+    {
+        if (string.IsNullOrWhiteSpace(systemSlug))
+            throw new ArgumentException("systemSlug is required", nameof(systemSlug));
+        return $"{LegacyPrefix}:{systemSlug}";
+    }
+
+    /// <summary>
+    /// Map a <see cref="MemberIdentifierType"/> to its canonical system URI.
+    /// Legacy requires a slug and must be built via <see cref="LegacyForSystem"/>.
+    /// </summary>
+    public static string FromType(MemberIdentifierType type) => type switch
+    {
+        MemberIdentifierType.SSN => SSN,
+        MemberIdentifierType.MedicareMbi => MedicareMbi,
+        MemberIdentifierType.Medicaid => Medicaid,
+        MemberIdentifierType.MemberId => MemberId,
+        MemberIdentifierType.Portal => PortalId,
+        MemberIdentifierType.Exchange => ExchangeId,
+        MemberIdentifierType.Legacy => LegacyPrefix,
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown identifier type")
+    };
+}

--- a/src/services/member-service/Models/Member.cs
+++ b/src/services/member-service/Models/Member.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -211,6 +212,77 @@ public class Member
     /// Full name helper property
     /// </summary>
     public string FullName => $"{FirstName} {MiddleName} {LastName}".Replace("  ", " ").Trim();
+
+    // ── FHIR Patient projection fields (US Core) ─────────────────────
+
+    /// <summary>
+    /// Typed identifiers (Medicaid, MBI, Exchange, Portal, Legacy, etc.).
+    /// PII identifiers (SSN/MBI/Medicaid) should be stored encrypted-at-rest.
+    /// </summary>
+    public List<MemberIdentifier> Identifiers { get; set; } = new();
+
+    /// <summary>
+    /// BCP-47 preferred language (e.g. "en-US"). Projects to FHIR Patient.communication.preferred=true.
+    /// </summary>
+    [StringLength(16)]
+    public string? PreferredLanguage { get; set; }
+
+    /// <summary>
+    /// Additional BCP-47 languages the member speaks.
+    /// </summary>
+    public List<string> Languages { get; set; } = new();
+
+    /// <summary>
+    /// OMB race category (US Core us-core-race extension, ombCategory).
+    /// System: urn:oid:2.16.840.1.113883.6.238
+    /// </summary>
+    public CodedConcept? Race { get; set; }
+
+    /// <summary>
+    /// Detailed race codes beyond the five OMB buckets.
+    /// </summary>
+    public List<CodedConcept> RaceDetail { get; set; } = new();
+
+    /// <summary>
+    /// OMB ethnicity (us-core-ethnicity, ombCategory).
+    /// </summary>
+    public CodedConcept? Ethnicity { get; set; }
+
+    public List<CodedConcept> EthnicityDetail { get; set; } = new();
+
+    /// <summary>
+    /// Self-reported gender identity (us-core-genderIdentity extension).
+    /// </summary>
+    public CodedConcept? GenderIdentity { get; set; }
+
+    [StringLength(100)]
+    public string? Pronouns { get; set; }
+
+    /// <summary>
+    /// MaritalStatus (HL7 v3 MaritalStatus code system).
+    /// </summary>
+    public CodedConcept? MaritalStatus { get; set; }
+
+    /// <summary>
+    /// Deceased indicator (FHIR Patient.deceasedBoolean). True when the member is deceased.
+    /// </summary>
+    public bool Deceased { get; set; }
+
+    /// <summary>
+    /// Date of death (FHIR Patient.deceasedDateTime) when known.
+    /// </summary>
+    public DateTime? DeceasedDate { get; set; }
+
+    /// <summary>
+    /// Sex assigned at birth (us-core-birthsex extension). M | F | UNK.
+    /// </summary>
+    [StringLength(3)]
+    public string? BirthSex { get; set; }
+
+    /// <summary>
+    /// Communication channel preferences (opt-in, windows, per-channel language override).
+    /// </summary>
+    public List<CommunicationPreference> CommunicationPreferences { get; set; } = new();
 }
 
 /// <summary>

--- a/src/services/member-service/Models/MemberEvent.cs
+++ b/src/services/member-service/Models/MemberEvent.cs
@@ -1,0 +1,116 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// Append-only event record for the member-events stream.
+///
+/// Idempotency: clients supply <see cref="EventId"/> on write; the repository rejects or
+/// no-ops duplicates keyed on <c>(TenantId, MemberId, EventId)</c>.
+///
+/// Ordering: <see cref="Version"/> is a monotonically increasing per-aggregate sequence.
+/// Concurrent writers to the same <c>(TenantId, MemberId)</c> must retry on conflict
+/// (Cosmos optimistic ETag / Mongo unique index on <c>(tenantId, memberId, version)</c>).
+///
+/// Partition: Cosmos container uses <c>/partitionKey</c> (format <c>{tenantId}:{memberId}</c>)
+/// so per-member Change Feed consumers see in-order events.
+///
+/// Genesis rule: <see cref="MemberEventType.MemberCreated"/> payloads MUST contain the full
+/// member snapshot so projections can be rebuilt from the stream without special-casing.
+/// Subsequent events SHOULD contain diffs (changed fields only).
+/// </summary>
+[BsonIgnoreExtraElements]
+public class MemberEvent
+{
+    /// <summary>
+    /// Cosmos document id. Defaults to <see cref="EventId"/> so duplicate writes collide.
+    /// </summary>
+    [Required]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Cosmos partition key path = <c>{TenantId}:{MemberId}</c>.
+    /// Stored as a first-class property so Cosmos/Mongo both see it.
+    /// </summary>
+    [Required]
+    [StringLength(256)]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client-supplied idempotency key. Unique within <c>(TenantId, MemberId)</c>.
+    /// </summary>
+    [Required]
+    [StringLength(128)]
+    public string EventId { get; set; } = string.Empty;
+
+    [Required]
+    public MemberEventType EventType { get; set; }
+
+    /// <summary>
+    /// Monotonically increasing per-aggregate sequence number. 1-based.
+    /// </summary>
+    [Required]
+    public int Version { get; set; }
+
+    /// <summary>
+    /// Envelope schema version. Bump when <see cref="MemberEvent"/> shape changes.
+    /// </summary>
+    public int SchemaVersion { get; set; } = 1;
+
+    [Required]
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? ActorId { get; set; }
+
+    [StringLength(128)]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Event-specific payload. For <see cref="MemberEventType.MemberCreated"/>: full
+    /// member snapshot. For updates: diff (changed fields only).
+    ///
+    /// Cosmos serialization (System.Text.Json) emits this as a nested JSON object.
+    /// Mongo serialization goes through <see cref="PayloadJson"/> as a string because
+    /// the BSON driver has no built-in serializer for <see cref="JsonObject"/>.
+    /// </summary>
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    /// <summary>
+    /// Mongo-facing mirror of <see cref="Payload"/>. Not emitted by System.Text.Json
+    /// (Cosmos path) — only used by the BSON driver.
+    /// </summary>
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string memberId) =>
+        $"{tenantId}:{memberId}";
+}
+
+public enum MemberEventType
+{
+    MemberCreated = 1,
+    MemberUpdated = 2,
+    MemberTerminated = 3,
+    AddressChanged = 4,
+    PcpChanged = 5
+}

--- a/src/services/member-service/Models/MemberIdentifier.cs
+++ b/src/services/member-service/Models/MemberIdentifier.cs
@@ -43,6 +43,15 @@ public class MemberIdentifier
     /// True when <see cref="Value"/> is ciphertext from <c>IIdentifierEncryptor</c>.
     /// </summary>
     public bool IsEncrypted { get; set; }
+
+    /// <summary>
+    /// Keyed HMAC fingerprint of the NORMALIZED plaintext (dashes/spaces/case
+    /// stripped). Populated for PII identifier types (SSN, MBI, Medicaid) to
+    /// enable dedupe without storing plaintext. Null for non-PII types where
+    /// <see cref="Value"/> itself is sufficient for equality comparison.
+    /// </summary>
+    [StringLength(128)]
+    public string? ValueFingerprint { get; set; }
 }
 
 /// <summary>

--- a/src/services/member-service/Models/MemberIdentifier.cs
+++ b/src/services/member-service/Models/MemberIdentifier.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// Typed identifier attached to a <see cref="Member"/>.
+/// Projects to a FHIR R4 Identifier with <c>use</c> + <c>type</c> + <c>system</c> + <c>value</c> + <c>period</c>.
+/// </summary>
+public class MemberIdentifier
+{
+    [Required]
+    public MemberIdentifierType Type { get; set; }
+
+    /// <summary>
+    /// Canonical identifier system URI. For <see cref="MemberIdentifierType.Legacy"/>
+    /// this is the tenant-config slug-scoped URI (<c>urn:cho:legacy:{slug}</c>).
+    /// </summary>
+    [Required]
+    [StringLength(256)]
+    public string System { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The identifier value as stored. PII identifiers (SSN, MBI, Medicaid) are
+    /// expected to be encrypted-at-rest; <see cref="IsEncrypted"/> marks them.
+    /// </summary>
+    [Required]
+    [StringLength(512)]
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>
+    /// FHIR Identifier.use: usual | official | temp | secondary | old
+    /// </summary>
+    [StringLength(16)]
+    public string Use { get; set; } = "official";
+
+    public DateTime? PeriodStart { get; set; }
+    public DateTime? PeriodEnd { get; set; }
+
+    [StringLength(200)]
+    public string? Assigner { get; set; }
+
+    /// <summary>
+    /// True when <see cref="Value"/> is ciphertext from <c>IIdentifierEncryptor</c>.
+    /// </summary>
+    public bool IsEncrypted { get; set; }
+}
+
+/// <summary>
+/// Known identifier types. Legacy is the escape hatch for external/tenant-specific systems.
+/// </summary>
+public enum MemberIdentifierType
+{
+    MemberId = 1,
+    SSN = 2,
+    MedicareMbi = 3,
+    Medicaid = 4,
+    Exchange = 5,
+    Portal = 6,
+    Legacy = 7
+}

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -201,9 +201,6 @@ app.MapChoHealthChecks();
 
 app.Run();
 
-// Required so WebApplicationFactory<Program> works in the test project.
-public partial class Program { }
-
 // ── Helpers ──────────────────────────────────────────────────────────
 static void RegisterDownstream<TInterface, THttpClient, TFakeClient>(
     WebApplicationBuilder builder,
@@ -237,3 +234,8 @@ static void RegisterDownstream<TInterface, THttpClient, TFakeClient>(
         });
     }
 }
+
+// Required so WebApplicationFactory<Program> works in the test project.
+// Must appear after all top-level statements (including local functions) —
+// otherwise CS8803.
+public partial class Program { }

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -1,10 +1,12 @@
-using Microsoft.Azure.Cosmos;
+using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.HealthChecks;
 using MemberService.Middleware;
 using MemberService.Repositories;
-using CloudHealthOffice.Infrastructure.HealthChecks;
-using CloudHealthOffice.Infrastructure.Configuration;
+using MemberService.Services;
+using Microsoft.Azure.Cosmos;
 
 var builder = WebApplication.CreateBuilder(args);
+
 // Secret provider (Azure Key Vault / none)
 builder.Services.AddSecretProvider(builder.Configuration);
 builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
@@ -13,25 +15,24 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
-    options.SwaggerDoc("v1", new() 
-    { 
-        Title = "Cloud Health Office - Member Service API", 
+    options.SwaggerDoc("v1", new()
+    {
+        Title = "Cloud Health Office - Member Service API",
         Version = "v1",
-        Description = "Manages health plan member data (subscribers and dependents) populated by X12 834 Enrollment transactions"
+        Description = "Manages health plan member data (subscribers and dependents) populated by X12 834 Enrollment transactions. Surfaces FHIR R4 Patient projection."
     });
 });
 
-// Database Configuration
+// ── Database Configuration ───────────────────────────────────────────
 var mongoConnectionString = builder.Configuration["MongoDb:ConnectionString"];
+var eventsContainerName = builder.Configuration["CosmosDb:EventsContainerName"] ?? "member-events";
+var eventsCollectionName = builder.Configuration["MongoDb:EventsCollectionName"] ?? "member-events";
 
 if (!string.IsNullOrEmpty(mongoConnectionString))
 {
-    // MongoDB Registration
-    builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(sp => 
-    {
-        return new MongoDB.Driver.MongoClient(mongoConnectionString);
-    });
-    
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(_ =>
+        new MongoDB.Driver.MongoClient(mongoConnectionString));
+
     builder.Services.AddScoped<MongoDB.Driver.IMongoDatabase>(sp =>
     {
         var client = sp.GetRequiredService<MongoDB.Driver.IMongoClient>();
@@ -40,19 +41,22 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     });
 
     builder.Services.AddScoped<IMemberRepository, MemberRepositoryMongo>();
+    builder.Services.AddScoped<IMemberEventRepository>(sp =>
+        new MemberEventRepositoryMongo(
+            sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
+            eventsCollectionName));
     Console.WriteLine("Using MongoDB database provider");
 }
 else
 {
-    // Cosmos DB client (singleton)
     builder.Services.AddSingleton<CosmosClient>(sp =>
     {
         var configuration = sp.GetRequiredService<IConfiguration>();
-        var endpoint = configuration["CosmosDb:Endpoint"] 
+        var endpoint = configuration["CosmosDb:Endpoint"]
             ?? throw new InvalidOperationException("CosmosDb:Endpoint configuration missing");
-        var key = configuration["CosmosDb:Key"] 
+        var key = configuration["CosmosDb:Key"]
             ?? throw new InvalidOperationException("CosmosDb:Key configuration missing");
-        
+
         return new CosmosClient(endpoint, key, new CosmosClientOptions
         {
             SerializerOptions = new CosmosSerializationOptions
@@ -62,7 +66,6 @@ else
         });
     });
 
-    // Register repositories
     builder.Services.AddScoped<IMemberRepository>(sp =>
     {
         var cosmosClient = sp.GetRequiredService<CosmosClient>();
@@ -70,8 +73,58 @@ else
         var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
         return new MemberRepository(cosmosClient, databaseName);
     });
-    Console.WriteLine("Using Cosmos DB database provider");
+
+    builder.Services.AddScoped<IMemberEventRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new MemberEventRepository(cosmosClient, databaseName, eventsContainerName);
+    });
+
+    Console.WriteLine($"Using Cosmos DB database provider (events container: {eventsContainerName})");
 }
+
+// ── Member Service internals ─────────────────────────────────────────
+builder.Services.AddScoped<IMemberEventPublisher, CosmosMemberEventPublisher>();
+builder.Services.AddSingleton<IFhirPatientProjector, FhirPatientProjector>();
+
+// Identifier encryption. Real KV-backed encryptor when a data-key secret name is
+// configured; otherwise fall through to the no-op shim (dev only).
+var encryptionKeySecretName = builder.Configuration["Member:IdentifierEncryption:KeySecretName"];
+if (!string.IsNullOrWhiteSpace(encryptionKeySecretName))
+{
+    builder.Services.AddSingleton<IIdentifierEncryptor>(sp =>
+        new KeyVaultIdentifierEncryptor(
+            sp.GetRequiredService<ISecretProvider>(),
+            sp.GetRequiredService<ILogger<KeyVaultIdentifierEncryptor>>(),
+            encryptionKeySecretName));
+}
+else
+{
+    if (!builder.Environment.IsDevelopment())
+    {
+        // Fail loudly in non-dev rather than silently passing PII through plaintext.
+        throw new InvalidOperationException(
+            "Member:IdentifierEncryption:KeySecretName must be configured in non-development environments.");
+    }
+    builder.Services.AddSingleton<IIdentifierEncryptor, NoOpIdentifierEncryptor>();
+    Console.WriteLine("[dev] IIdentifierEncryptor = NoOp (PII stored plaintext). Configure Member:IdentifierEncryption:KeySecretName to enable.");
+}
+
+// ── Downstream typed clients ─────────────────────────────────────────
+builder.Services.Configure<DownstreamOptions>(builder.Configuration.GetSection("Downstream"));
+
+var coverageBaseUrl = builder.Configuration["Downstream:CoverageService:BaseUrl"];
+var enrollmentBaseUrl = builder.Configuration["Downstream:EnrollmentImportService:BaseUrl"];
+var accumulatorBaseUrl = builder.Configuration["Downstream:AccumulatorService:BaseUrl"];
+
+RegisterDownstream<ICoverageServiceClient, HttpCoverageServiceClient, FakeCoverageServiceClient>(
+    builder, coverageBaseUrl);
+RegisterDownstream<IEnrollmentImportServiceClient, HttpEnrollmentImportServiceClient, FakeEnrollmentImportServiceClient>(
+    builder, enrollmentBaseUrl);
+RegisterDownstream<IAccumulatorServiceClient, HttpAccumulatorServiceClient, FakeAccumulatorServiceClient>(
+    builder, accumulatorBaseUrl);
 
 builder.Services.AddCors(options =>
 {
@@ -106,3 +159,40 @@ app.MapControllers();
 app.MapChoHealthChecks();
 
 app.Run();
+
+// Required so WebApplicationFactory<Program> works in the test project.
+public partial class Program { }
+
+// ── Helpers ──────────────────────────────────────────────────────────
+static void RegisterDownstream<TInterface, THttpClient, TFakeClient>(
+    WebApplicationBuilder builder,
+    string? baseUrl)
+    where TInterface : class
+    where THttpClient : class, TInterface
+    where TFakeClient : class, TInterface
+{
+    if (!string.IsNullOrWhiteSpace(baseUrl))
+    {
+        builder.Services.AddHttpClient<TInterface, THttpClient>(c =>
+        {
+            c.BaseAddress = new Uri(baseUrl);
+            c.Timeout = TimeSpan.FromSeconds(10);
+        });
+    }
+    else if (builder.Environment.IsDevelopment())
+    {
+        builder.Services.AddSingleton<TInterface, TFakeClient>();
+        Console.WriteLine($"[dev] Registered {typeof(TFakeClient).Name} for {typeof(TInterface).Name} (no downstream URL configured).");
+    }
+    else
+    {
+        // Production: register the Http client with no base URL. The client will
+        // throw DownstreamUnavailableException on every call, and controllers map
+        // that to a 503 ProblemDetails. Keeps the service bootable so other
+        // endpoints remain available.
+        builder.Services.AddHttpClient<TInterface, THttpClient>(c =>
+        {
+            c.Timeout = TimeSpan.FromSeconds(10);
+        });
+    }
+}

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -1,9 +1,11 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
+using MemberService.HostedServices;
 using MemberService.Middleware;
 using MemberService.Repositories;
 using MemberService.Services;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -33,18 +35,28 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(_ =>
         new MongoDB.Driver.MongoClient(mongoConnectionString));
 
-    builder.Services.AddScoped<MongoDB.Driver.IMongoDatabase>(sp =>
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoDatabase>(sp =>
     {
         var client = sp.GetRequiredService<MongoDB.Driver.IMongoClient>();
         var databaseName = builder.Configuration["MongoDb:DatabaseName"] ?? "CloudHealthOffice";
         return client.GetDatabase(databaseName);
     });
 
-    builder.Services.AddScoped<IMemberRepository, MemberRepositoryMongo>();
-    builder.Services.AddScoped<IMemberEventRepository>(sp =>
+    // Repositories are constructed without I/O side effects; indexes are provisioned
+    // by the hosted services below, which lets us register these as singletons.
+    builder.Services.AddSingleton<IMemberRepository, MemberRepositoryMongo>();
+    builder.Services.AddSingleton<IMemberEventRepository>(sp =>
         new MemberEventRepositoryMongo(
             sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
             eventsCollectionName));
+
+    builder.Services.AddHostedService<MemberIndexInitializer>();
+    builder.Services.AddSingleton<IHostedService>(sp =>
+        new MemberEventIndexInitializer(
+            sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
+            eventsCollectionName,
+            sp.GetRequiredService<ILogger<MemberEventIndexInitializer>>()));
+
     Console.WriteLine("Using MongoDB database provider");
 }
 else
@@ -79,7 +91,11 @@ else
         var cosmosClient = sp.GetRequiredService<CosmosClient>();
         var configuration = sp.GetRequiredService<IConfiguration>();
         var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
-        return new MemberEventRepository(cosmosClient, databaseName, eventsContainerName);
+        return new MemberEventRepository(
+            cosmosClient,
+            databaseName,
+            eventsContainerName,
+            sp.GetRequiredService<ILogger<MemberEventRepository>>());
     });
 
     Console.WriteLine($"Using Cosmos DB database provider (events container: {eventsContainerName})");
@@ -110,6 +126,31 @@ else
     }
     builder.Services.AddSingleton<IIdentifierEncryptor, NoOpIdentifierEncryptor>();
     Console.WriteLine("[dev] IIdentifierEncryptor = NoOp (PII stored plaintext). Configure Member:IdentifierEncryption:KeySecretName to enable.");
+}
+
+// Identifier fingerprinting (HMAC-SHA256 keyed by a DISTINCT KV secret from the
+// encryption key). Used to dedupe PII identifiers without comparing ciphertexts
+// (which differ by AES-GCM nonce even for identical plaintext).
+var fingerprintKeySecretName =
+    builder.Configuration["Encryption:IdentifierFingerprintKeySecret"]
+    ?? builder.Configuration["Member:IdentifierFingerprint:KeySecretName"];
+if (!string.IsNullOrWhiteSpace(fingerprintKeySecretName))
+{
+    builder.Services.AddSingleton<IIdentifierFingerprinter>(sp =>
+        new HmacSha256IdentifierFingerprinter(
+            sp.GetRequiredService<ISecretProvider>(),
+            sp.GetRequiredService<ILogger<HmacSha256IdentifierFingerprinter>>(),
+            fingerprintKeySecretName));
+}
+else
+{
+    if (!builder.Environment.IsDevelopment())
+    {
+        throw new InvalidOperationException(
+            "Encryption:IdentifierFingerprintKeySecret must be configured in non-development environments.");
+    }
+    builder.Services.AddSingleton<IIdentifierFingerprinter, NoOpIdentifierFingerprinter>();
+    Console.WriteLine("[dev] IIdentifierFingerprinter = NoOp (plain SHA-256). Configure Encryption:IdentifierFingerprintKeySecret to enable.");
 }
 
 // ── Downstream typed clients ─────────────────────────────────────────

--- a/src/services/member-service/Repositories/IMemberEventRepository.cs
+++ b/src/services/member-service/Repositories/IMemberEventRepository.cs
@@ -1,0 +1,46 @@
+using MemberService.Models;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Append-only store for member events.
+///
+/// Writes are idempotent keyed on <c>(TenantId, MemberId, EventId)</c>. A repeated
+/// <see cref="AppendAsync(MemberEvent, CancellationToken)"/> with the same
+/// <see cref="MemberEvent.EventId"/> is a no-op that returns the previously-stored event.
+///
+/// Reads return events for a single member ordered by <see cref="MemberEvent.Version"/>.
+/// </summary>
+public interface IMemberEventRepository
+{
+    /// <summary>
+    /// Append an event. If an event with the same <c>(TenantId, MemberId, EventId)</c>
+    /// already exists, returns the existing event without writing a new document
+    /// (<c>Appended=false</c>).
+    /// </summary>
+    Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default);
+
+    /// <summary>
+    /// List events for a member, ordered by <see cref="MemberEvent.Version"/> ascending.
+    /// </summary>
+    Task<IReadOnlyList<MemberEvent>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetch a single event by <c>EventId</c>, scoped by <c>(TenantId, MemberId)</c>.
+    /// </summary>
+    Task<MemberEvent?> GetByIdAsync(
+        string tenantId,
+        string memberId,
+        string eventId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Return the next version number to use for the given member (max+1, or 1 if none).
+    /// </summary>
+    Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default);
+}
+
+public readonly record struct AppendResult(MemberEvent Event, bool Appended);

--- a/src/services/member-service/Repositories/MemberEventRepository.cs
+++ b/src/services/member-service/Repositories/MemberEventRepository.cs
@@ -1,21 +1,43 @@
 using System.Net;
 using MemberService.Models;
+using MemberService.Services;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
 
 namespace MemberService.Repositories;
 
 /// <summary>
 /// Cosmos DB repository for <see cref="MemberEvent"/>.
-/// Container is provisioned with PK path <c>/partitionKey</c> so per-member streams
-/// remain co-located for Change Feed consumers.
+///
+/// The container MUST be provisioned with:
+///   - Partition key path: <c>/partitionKey</c> (format <c>{tenantId}:{memberId}</c>).
+///   - Unique key policy with path <c>/version</c>. This enforces
+///     uniqueness of <c>(partitionKey, version)</c> so concurrent writers
+///     conflict at the index level, not silently overlap.
+///
+/// See <c>scripts/cosmos/provision-member-events.sh</c>.
 /// </summary>
 public class MemberEventRepository : IMemberEventRepository
 {
-    private readonly Container _container;
+    /// <summary>
+    /// Cosmos sub-status for a unique-key constraint violation on a secondary
+    /// unique-key policy path. An HTTP 409 with this sub-status means a
+    /// concurrent writer already claimed this version slot; the publisher
+    /// should refetch the next version and retry.
+    /// </summary>
+    public const int UniqueKeyViolationSubStatus = 1009;
 
-    public MemberEventRepository(CosmosClient cosmosClient, string databaseName, string containerName)
+    private readonly Container _container;
+    private readonly ILogger<MemberEventRepository>? _logger;
+
+    public MemberEventRepository(
+        CosmosClient cosmosClient,
+        string databaseName,
+        string containerName,
+        ILogger<MemberEventRepository>? logger = null)
     {
         _container = cosmosClient.GetDatabase(databaseName).GetContainer(containerName);
+        _logger = logger;
     }
 
     public async Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)
@@ -32,6 +54,27 @@ public class MemberEventRepository : IMemberEventRepository
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
         {
+            // Two distinct causes of 409 on this container:
+            //   - SubStatus 0: document id collision → client retried with same EventId
+            //     (the id is EventId). Idempotent no-op; return the existing event.
+            //   - SubStatus 1009: unique-key-policy violation on /version → a concurrent
+            //     writer took our version slot. Surface as Appended=false with Event=null
+            //     so the publisher recomputes Version and retries.
+            //   - Any other non-zero sub-status: log and treat as id-collision (idempotent)
+            //     to stay safe, but the log entry lets us notice if Cosmos ever introduces
+            //     a new sub-status we haven't considered.
+            if (ex.SubStatusCode == UniqueKeyViolationSubStatus)
+            {
+                return new AppendResult(evt, Appended: false);
+            }
+
+            if (ex.SubStatusCode != 0)
+            {
+                _logger?.LogWarning(ex,
+                    "Unexpected Cosmos 409 SubStatus {SubStatus} on member-events append for {PartitionKey} v{Version}. Treating as idempotent no-op.",
+                    ex.SubStatusCode, evt.PartitionKey, evt.Version);
+            }
+
             var existing = await GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
             return new AppendResult(existing ?? evt, Appended: false);
         }

--- a/src/services/member-service/Repositories/MemberEventRepository.cs
+++ b/src/services/member-service/Repositories/MemberEventRepository.cs
@@ -72,7 +72,7 @@ public class MemberEventRepository : IMemberEventRepository
             {
                 _logger?.LogWarning(ex,
                     "Unexpected Cosmos 409 SubStatus {SubStatus} on member-events append for {PartitionKey} v{Version}. Treating as idempotent no-op.",
-                    ex.SubStatusCode, evt.PartitionKey, evt.Version);
+                    ex.SubStatusCode, SanitizeForLog(evt.PartitionKey), evt.Version);
             }
 
             var existing = await GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
@@ -151,4 +151,7 @@ public class MemberEventRepository : IMemberEventRepository
         if (string.IsNullOrEmpty(evt.PartitionKey))
             evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
     }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 }

--- a/src/services/member-service/Repositories/MemberEventRepository.cs
+++ b/src/services/member-service/Repositories/MemberEventRepository.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using MemberService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Cosmos DB repository for <see cref="MemberEvent"/>.
+/// Container is provisioned with PK path <c>/partitionKey</c> so per-member streams
+/// remain co-located for Change Feed consumers.
+/// </summary>
+public class MemberEventRepository : IMemberEventRepository
+{
+    private readonly Container _container;
+
+    public MemberEventRepository(CosmosClient cosmosClient, string databaseName, string containerName)
+    {
+        _container = cosmosClient.GetDatabase(databaseName).GetContainer(containerName);
+    }
+
+    public async Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)
+    {
+        NormalizeEnvelope(evt);
+
+        try
+        {
+            var response = await _container.CreateItemAsync(
+                evt,
+                new PartitionKey(evt.PartitionKey),
+                cancellationToken: ct);
+            return new AppendResult(response.Resource, Appended: true);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            var existing = await GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+            return new AppendResult(existing ?? evt, Appended: false);
+        }
+    }
+
+    public async Task<IReadOnlyList<MemberEvent>> ListByMemberAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var partitionKey = MemberEvent.BuildPartitionKey(tenantId, memberId);
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.partitionKey = @pk ORDER BY c.version ASC")
+            .WithParameter("@pk", partitionKey);
+
+        var iterator = _container.GetItemQueryIterator<MemberEvent>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) });
+
+        var results = new List<MemberEvent>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    public async Task<MemberEvent?> GetByIdAsync(
+        string tenantId, string memberId, string eventId, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _container.ReadItemAsync<MemberEvent>(
+                eventId,
+                new PartitionKey(MemberEvent.BuildPartitionKey(tenantId, memberId)),
+                cancellationToken: ct);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<int> GetNextVersionAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var partitionKey = MemberEvent.BuildPartitionKey(tenantId, memberId);
+        var query = new QueryDefinition(
+            "SELECT VALUE MAX(c.version) FROM c WHERE c.partitionKey = @pk")
+            .WithParameter("@pk", partitionKey);
+
+        var iterator = _container.GetItemQueryIterator<int?>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) });
+
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            var max = page.FirstOrDefault();
+            return (max ?? 0) + 1;
+        }
+        return 1;
+    }
+
+    private static void NormalizeEnvelope(MemberEvent evt)
+    {
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EventId is required (client-supplied idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
+            throw new ArgumentException("TenantId and MemberId are required");
+
+        if (string.IsNullOrEmpty(evt.Id))
+            evt.Id = evt.EventId;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+    }
+}

--- a/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
@@ -4,8 +4,10 @@ using MongoDB.Driver;
 namespace MemberService.Repositories;
 
 /// <summary>
-/// MongoDB repository for <see cref="MemberEvent"/>. Enforces idempotency via a
-/// unique compound index on <c>(TenantId, MemberId, EventId)</c>.
+/// MongoDB repository for <see cref="MemberEvent"/>. Idempotency and ordering
+/// are enforced by unique compound indexes created at startup by
+/// <c>MemberEventIndexInitializer</c> (not here — keeping construction
+/// side-effect free so the repository can be registered as a singleton).
 /// </summary>
 public class MemberEventRepositoryMongo : IMemberEventRepository
 {
@@ -14,22 +16,6 @@ public class MemberEventRepositoryMongo : IMemberEventRepository
     public MemberEventRepositoryMongo(IMongoDatabase database, string collectionName = "member-events")
     {
         _collection = database.GetCollection<MemberEvent>(collectionName);
-
-        var idemKeys = Builders<MemberEvent>.IndexKeys
-            .Ascending(x => x.TenantId)
-            .Ascending(x => x.MemberId)
-            .Ascending(x => x.EventId);
-        _collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
-            idemKeys,
-            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_event" }));
-
-        var orderKeys = Builders<MemberEvent>.IndexKeys
-            .Ascending(x => x.TenantId)
-            .Ascending(x => x.MemberId)
-            .Ascending(x => x.Version);
-        _collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
-            orderKeys,
-            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_version" }));
     }
 
     public async Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)

--- a/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
@@ -1,0 +1,94 @@
+using MemberService.Models;
+using MongoDB.Driver;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// MongoDB repository for <see cref="MemberEvent"/>. Enforces idempotency via a
+/// unique compound index on <c>(TenantId, MemberId, EventId)</c>.
+/// </summary>
+public class MemberEventRepositoryMongo : IMemberEventRepository
+{
+    private readonly IMongoCollection<MemberEvent> _collection;
+
+    public MemberEventRepositoryMongo(IMongoDatabase database, string collectionName = "member-events")
+    {
+        _collection = database.GetCollection<MemberEvent>(collectionName);
+
+        var idemKeys = Builders<MemberEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.MemberId)
+            .Ascending(x => x.EventId);
+        _collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
+            idemKeys,
+            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_event" }));
+
+        var orderKeys = Builders<MemberEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.MemberId)
+            .Ascending(x => x.Version);
+        _collection.Indexes.CreateOne(new CreateIndexModel<MemberEvent>(
+            orderKeys,
+            new CreateIndexOptions { Unique = true, Name = "ux_tenant_member_version" }));
+    }
+
+    public async Task<AppendResult> AppendAsync(MemberEvent evt, CancellationToken ct = default)
+    {
+        NormalizeEnvelope(evt);
+
+        try
+        {
+            await _collection.InsertOneAsync(evt, cancellationToken: ct);
+            return new AppendResult(evt, Appended: true);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            var existing = await GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+            return new AppendResult(existing ?? evt, Appended: false);
+        }
+    }
+
+    public async Task<IReadOnlyList<MemberEvent>> ListByMemberAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var filter = Builders<MemberEvent>.Filter.Eq(x => x.TenantId, tenantId) &
+                     Builders<MemberEvent>.Filter.Eq(x => x.MemberId, memberId);
+        return await _collection.Find(filter)
+            .SortBy(x => x.Version)
+            .ToListAsync(ct);
+    }
+
+    public async Task<MemberEvent?> GetByIdAsync(
+        string tenantId, string memberId, string eventId, CancellationToken ct = default)
+    {
+        var filter = Builders<MemberEvent>.Filter.Eq(x => x.TenantId, tenantId) &
+                     Builders<MemberEvent>.Filter.Eq(x => x.MemberId, memberId) &
+                     Builders<MemberEvent>.Filter.Eq(x => x.EventId, eventId);
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<int> GetNextVersionAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var filter = Builders<MemberEvent>.Filter.Eq(x => x.TenantId, tenantId) &
+                     Builders<MemberEvent>.Filter.Eq(x => x.MemberId, memberId);
+        var last = await _collection.Find(filter)
+            .SortByDescending(x => x.Version)
+            .Limit(1)
+            .FirstOrDefaultAsync(ct);
+        return (last?.Version ?? 0) + 1;
+    }
+
+    private static void NormalizeEnvelope(MemberEvent evt)
+    {
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EventId is required (client-supplied idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
+            throw new ArgumentException("TenantId and MemberId are required");
+
+        if (string.IsNullOrEmpty(evt.Id))
+            evt.Id = evt.EventId;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+    }
+}

--- a/src/services/member-service/Repositories/MemberRepository.cs
+++ b/src/services/member-service/Repositories/MemberRepository.cs
@@ -209,6 +209,32 @@ public class MemberRepository : IMemberRepository
         var member = await GetByMemberIdAsync(tenantId, memberId);
         return member != null;
     }
+
+    public async Task<Member?> GetByIdentifierAsync(string tenantId, string system, string value)
+    {
+        var query = new QueryDefinition(@"
+            SELECT TOP 1 * FROM c
+            WHERE c.tenantId = @tenantId
+              AND EXISTS(
+                SELECT VALUE i FROM i IN c.identifiers
+                WHERE i.system = @system AND i.value = @value
+              )")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@system", system)
+            .WithParameter("@value", value);
+
+        var iterator = _container.GetItemQueryIterator<Member>(query, requestOptions: new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(tenantId)
+        });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            return response.FirstOrDefault();
+        }
+        return null;
+    }
 }
 
 /// <summary>
@@ -233,4 +259,10 @@ public interface IMemberRepository
     Task<Member> UpdateAsync(Member member);
     Task DeleteAsync(string tenantId, string id);
     Task<bool> ExistsAsync(string tenantId, string memberId);
+
+    /// <summary>
+    /// Find a member by typed identifier (system + value). Used for idempotent member
+    /// creation and portal lookups.
+    /// </summary>
+    Task<Member?> GetByIdentifierAsync(string tenantId, string system, string value);
 }

--- a/src/services/member-service/Repositories/MemberRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberRepositoryMongo.cs
@@ -16,16 +16,14 @@ public class MemberRepositoryMongo : IMemberRepository
 {
     private readonly IMongoCollection<Member> _collection;
 
+    /// <summary>
+    /// Constructs the repository. Index creation is handled at startup by
+    /// <c>MemberIndexInitializer</c> so the repository can be registered as
+    /// a singleton and constructed without I/O side effects.
+    /// </summary>
     public MemberRepositoryMongo(IMongoDatabase database)
     {
         _collection = database.GetCollection<Member>("Members");
-        
-        // Ensure indexes (fire and forget generally, or on startup)
-        var indexKeys = Builders<Member>.IndexKeys
-            .Ascending(x => x.TenantId)
-            .Ascending(x => x.MemberId);
-        var indexModel = new CreateIndexModel<Member>(indexKeys);
-        _collection.Indexes.CreateOne(indexModel);
     }
 
     public async Task<Member?> GetByIdAsync(string tenantId, string id)

--- a/src/services/member-service/Repositories/MemberRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberRepositoryMongo.cs
@@ -141,9 +141,20 @@ public class MemberRepositoryMongo : IMemberRepository
 
     public async Task<bool> ExistsAsync(string tenantId, string memberId)
     {
-        var filter = Builders<Member>.Filter.Eq(x => x.MemberId, memberId) & 
+        var filter = Builders<Member>.Filter.Eq(x => x.MemberId, memberId) &
                      Builders<Member>.Filter.Eq(x => x.TenantId, tenantId);
-                     
+
         return await _collection.Find(filter).AnyAsync();
+    }
+
+    public async Task<Member?> GetByIdentifierAsync(string tenantId, string system, string value)
+    {
+        var filter = Builders<Member>.Filter.Eq(x => x.TenantId, tenantId) &
+                     Builders<Member>.Filter.ElemMatch(
+                         x => x.Identifiers,
+                         Builders<MemberIdentifier>.Filter.Eq(i => i.System, system) &
+                         Builders<MemberIdentifier>.Filter.Eq(i => i.Value, value));
+
+        return await _collection.Find(filter).FirstOrDefaultAsync();
     }
 }

--- a/src/services/member-service/Services/ConcurrencyException.cs
+++ b/src/services/member-service/Services/ConcurrencyException.cs
@@ -1,0 +1,20 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Thrown when the event publisher exhausts its version-conflict retries.
+/// Callers may treat this as a transient failure (retry at request level).
+/// </summary>
+public sealed class ConcurrencyException : Exception
+{
+    public string TenantId { get; }
+    public string MemberId { get; }
+    public int Attempts { get; }
+
+    public ConcurrencyException(string tenantId, string memberId, int attempts, Exception? inner = null)
+        : base($"Concurrent version conflicts for {tenantId}:{memberId} after {attempts} attempts.", inner)
+    {
+        TenantId = tenantId;
+        MemberId = memberId;
+        Attempts = attempts;
+    }
+}

--- a/src/services/member-service/Services/CosmosMemberEventPublisher.cs
+++ b/src/services/member-service/Services/CosmosMemberEventPublisher.cs
@@ -1,0 +1,69 @@
+using MemberService.Models;
+using MemberService.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Default <see cref="IMemberEventPublisher"/>. Writes events to the append-only
+/// Cosmos/Mongo stream via <see cref="IMemberEventRepository"/>. Concurrent writers
+/// are retried on version conflict.
+/// </summary>
+public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
+{
+    private readonly IMemberEventRepository _repository;
+    private readonly ILogger<CosmosMemberEventPublisher> _logger;
+    private const int MaxVersionRetries = 5;
+
+    public CosmosMemberEventPublisher(
+        IMemberEventRepository repository,
+        ILogger<CosmosMemberEventPublisher> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<MemberEvent> PublishAsync(MemberEvent evt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("MemberEvent.EventId is required (client-supplied idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
+            throw new ArgumentException("MemberEvent must have TenantId and MemberId");
+
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+        if (string.IsNullOrEmpty(evt.Id)) evt.Id = evt.EventId;
+        if (evt.SchemaVersion <= 0) evt.SchemaVersion = 1;
+
+        // If a prior write with this EventId already exists, short-circuit and return it.
+        var existing = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+        if (existing != null)
+        {
+            _logger.LogDebug("MemberEvent {EventId} already present for {Tenant}:{Member} (idempotent no-op)",
+                evt.EventId, evt.TenantId, evt.MemberId);
+            return existing;
+        }
+
+        for (int attempt = 1; attempt <= MaxVersionRetries; attempt++)
+        {
+            evt.Version = await _repository.GetNextVersionAsync(evt.TenantId, evt.MemberId, ct);
+            var result = await _repository.AppendAsync(evt, ct);
+            if (result.Appended) return result.Event;
+
+            // Duplicate-key: either same EventId raced us, or a concurrent writer took our version slot.
+            var refetch = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+            if (refetch != null) return refetch;
+
+            _logger.LogWarning(
+                "MemberEvent version conflict for {Tenant}:{Member} v{Version}; retry {Attempt}/{Max}",
+                evt.TenantId, evt.MemberId, evt.Version, attempt, MaxVersionRetries);
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to append MemberEvent after {MaxVersionRetries} version-retry attempts " +
+            $"for {evt.TenantId}:{evt.MemberId}");
+    }
+}

--- a/src/services/member-service/Services/CosmosMemberEventPublisher.cs
+++ b/src/services/member-service/Services/CosmosMemberEventPublisher.cs
@@ -6,14 +6,24 @@ namespace MemberService.Services;
 
 /// <summary>
 /// Default <see cref="IMemberEventPublisher"/>. Writes events to the append-only
-/// Cosmos/Mongo stream via <see cref="IMemberEventRepository"/>. Concurrent writers
-/// are retried on version conflict.
+/// Cosmos/Mongo stream via <see cref="IMemberEventRepository"/>.
+///
+/// Concurrency: repositories surface a version conflict as
+/// <see cref="AppendResult.Appended"/> <c>false</c> with no existing event.
+/// The publisher retries up to <see cref="MaxVersionRetries"/> with exponential
+/// backoff capped at 250 ms before surfacing a <see cref="ConcurrencyException"/>.
+///
+/// Idempotency: if a caller retries with the same <see cref="MemberEvent.EventId"/>,
+/// the repository returns <c>Appended=false</c> with the existing event and the
+/// publisher short-circuits.
 /// </summary>
 public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
 {
+    private const int MaxVersionRetries = 5;
+    private static readonly int[] BackoffMs = { 2, 5, 25, 100, 250 };
+
     private readonly IMemberEventRepository _repository;
     private readonly ILogger<CosmosMemberEventPublisher> _logger;
-    private const int MaxVersionRetries = 5;
 
     public CosmosMemberEventPublisher(
         IMemberEventRepository repository,
@@ -38,32 +48,41 @@ public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
         if (string.IsNullOrEmpty(evt.Id)) evt.Id = evt.EventId;
         if (evt.SchemaVersion <= 0) evt.SchemaVersion = 1;
 
-        // If a prior write with this EventId already exists, short-circuit and return it.
+        // Short-circuit: if a prior write with this EventId exists, return it.
         var existing = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
         if (existing != null)
         {
-            _logger.LogDebug("MemberEvent {EventId} already present for {Tenant}:{Member} (idempotent no-op)",
+            _logger.LogDebug(
+                "MemberEvent {EventId} already present for {Tenant}:{Member} (idempotent no-op)",
                 evt.EventId, evt.TenantId, evt.MemberId);
             return existing;
         }
 
-        for (int attempt = 1; attempt <= MaxVersionRetries; attempt++)
+        for (int attempt = 0; attempt < MaxVersionRetries; attempt++)
         {
             evt.Version = await _repository.GetNextVersionAsync(evt.TenantId, evt.MemberId, ct);
             var result = await _repository.AppendAsync(evt, ct);
             if (result.Appended) return result.Event;
 
-            // Duplicate-key: either same EventId raced us, or a concurrent writer took our version slot.
+            // Appended=false has two causes:
+            //   1. Same EventId already exists → the repository returns it as result.Event.
+            //      Short-circuit with the existing row.
+            //   2. Version slot taken by a concurrent writer (unique-key violation) →
+            //      result.Event is the envelope we just tried. Re-fetch by EventId to
+            //      disambiguate, then either return the existing or retry with a new version.
             var refetch = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
             if (refetch != null) return refetch;
 
             _logger.LogWarning(
-                "MemberEvent version conflict for {Tenant}:{Member} v{Version}; retry {Attempt}/{Max}",
-                evt.TenantId, evt.MemberId, evt.Version, attempt, MaxVersionRetries);
+                "MemberEvent version {Version} conflict for {Tenant}:{Member}; retry {Attempt}/{Max}",
+                evt.Version, evt.TenantId, evt.MemberId, attempt + 1, MaxVersionRetries);
+
+            if (attempt + 1 < MaxVersionRetries)
+            {
+                await Task.Delay(BackoffMs[attempt], ct);
+            }
         }
 
-        throw new InvalidOperationException(
-            $"Failed to append MemberEvent after {MaxVersionRetries} version-retry attempts " +
-            $"for {evt.TenantId}:{evt.MemberId}");
+        throw new ConcurrencyException(evt.TenantId, evt.MemberId, MaxVersionRetries);
     }
 }

--- a/src/services/member-service/Services/CosmosMemberEventPublisher.cs
+++ b/src/services/member-service/Services/CosmosMemberEventPublisher.cs
@@ -54,7 +54,7 @@ public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
         {
             _logger.LogDebug(
                 "MemberEvent {EventId} already present for {Tenant}:{Member} (idempotent no-op)",
-                evt.EventId, evt.TenantId, evt.MemberId);
+                SanitizeForLog(evt.EventId), SanitizeForLog(evt.TenantId), SanitizeForLog(evt.MemberId));
             return existing;
         }
 
@@ -75,7 +75,7 @@ public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
 
             _logger.LogWarning(
                 "MemberEvent version {Version} conflict for {Tenant}:{Member}; retry {Attempt}/{Max}",
-                evt.Version, evt.TenantId, evt.MemberId, attempt + 1, MaxVersionRetries);
+                evt.Version, SanitizeForLog(evt.TenantId), SanitizeForLog(evt.MemberId), attempt + 1, MaxVersionRetries);
 
             if (attempt + 1 < MaxVersionRetries)
             {
@@ -85,4 +85,7 @@ public sealed class CosmosMemberEventPublisher : IMemberEventPublisher
 
         throw new ConcurrencyException(evt.TenantId, evt.MemberId, MaxVersionRetries);
     }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 }

--- a/src/services/member-service/Services/DownstreamOptions.cs
+++ b/src/services/member-service/Services/DownstreamOptions.cs
@@ -1,0 +1,18 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Bound from configuration section <c>Downstream</c>. All base URLs are optional; when
+/// unset, the corresponding endpoints return 503 Service Unavailable with a RFC 7807
+/// problem-detail.
+/// </summary>
+public class DownstreamOptions
+{
+    public DownstreamService? CoverageService { get; set; }
+    public DownstreamService? EnrollmentImportService { get; set; }
+    public DownstreamService? AccumulatorService { get; set; }
+}
+
+public class DownstreamService
+{
+    public string? BaseUrl { get; set; }
+}

--- a/src/services/member-service/Services/DownstreamUnavailableException.cs
+++ b/src/services/member-service/Services/DownstreamUnavailableException.cs
@@ -1,0 +1,18 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Thrown by downstream clients when the remote service is unconfigured or unreachable.
+/// Controllers convert these to RFC 7807 ProblemDetails with status 503.
+/// </summary>
+public sealed class DownstreamUnavailableException : Exception
+{
+    public string ServiceName { get; }
+    public string? Detail { get; }
+
+    public DownstreamUnavailableException(string serviceName, string? detail = null, Exception? inner = null)
+        : base($"Downstream service '{serviceName}' is unavailable.", inner)
+    {
+        ServiceName = serviceName;
+        Detail = detail;
+    }
+}

--- a/src/services/member-service/Services/FakeDownstreamClients.cs
+++ b/src/services/member-service/Services/FakeDownstreamClients.cs
@@ -1,0 +1,90 @@
+using MemberService.Controllers;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Dev-only stand-ins for downstream services. Registered ONLY when
+/// <c>IHostEnvironment.IsDevelopment()</c> is true AND the corresponding
+/// downstream base URL is not configured. Never use in production — production
+/// must fail loudly with 503 when a downstream is misconfigured.
+/// </summary>
+public sealed class FakeCoverageServiceClient : ICoverageServiceClient
+{
+    public Task<MemberPcpResponse> GetPcpAsync(string tenantId, string memberId, CancellationToken ct = default)
+        => Task.FromResult(new MemberPcpResponse
+        {
+            ProviderId = "dev-prov-001",
+            ProviderName = "Dr. Dev Fixture, MD",
+            NPI = "1234567890",
+            Specialty = "Internal Medicine",
+            NetworkStatus = "In-Network",
+            AssignedDate = DateTime.UtcNow.AddMonths(-6),
+            PracticeName = "Dev Fixture Clinic",
+            Phone = "555-555-0100"
+        });
+
+    public Task<MemberPcpResponse> AssignPcpAsync(
+        string tenantId, string memberId, AssignPcpRequest request, CancellationToken ct = default)
+        => Task.FromResult(new MemberPcpResponse
+        {
+            ProviderId = request.ProviderId,
+            ProviderName = "Dr. Dev Fixture, MD",
+            NPI = "1234567890",
+            Specialty = "Internal Medicine",
+            NetworkStatus = "In-Network",
+            AssignedDate = request.EffectiveDate
+        });
+
+    public Task<IReadOnlyList<CoverageHistoryEvent>> GetCoverageHistoryAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<CoverageHistoryEvent>>(new List<CoverageHistoryEvent>
+        {
+            new()
+            {
+                EventDate = DateTime.UtcNow.AddMonths(-6),
+                EventType = "Enrolled",
+                Description = "Initial enrollment (dev fixture)",
+                ChangedBy = "dev-fixture"
+            }
+        });
+
+    public Task TerminateCoverageAsync(
+        string tenantId, string memberId, TerminateMemberRequest request, CancellationToken ct = default)
+        => Task.CompletedTask;
+}
+
+public sealed class FakeEnrollmentImportServiceClient : IEnrollmentImportServiceClient
+{
+    public Task<IReadOnlyList<Enrollment834Record>> Get834TransactionsAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<Enrollment834Record>>(new List<Enrollment834Record>
+        {
+            new()
+            {
+                TransactionId = "DEV-TXN-001",
+                BatchId = "DEV-BATCH-001",
+                MemberId = memberId,
+                MemberName = "Dev Fixture",
+                MaintenanceTypeCode = "021",
+                TransactionDate = DateTime.UtcNow.AddMonths(-6),
+                Status = "Accepted"
+            }
+        });
+}
+
+public sealed class FakeAccumulatorServiceClient : IAccumulatorServiceClient
+{
+    public Task<MemberAccumulatorsResponse> GetAccumulatorsAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+        => Task.FromResult(new MemberAccumulatorsResponse
+        {
+            IndividualDeductibleUsed = 0m,
+            IndividualDeductibleLimit = 2000m,
+            FamilyDeductibleUsed = 0m,
+            FamilyDeductibleLimit = 6000m,
+            IndividualOopUsed = 0m,
+            IndividualOopLimit = 8150m,
+            FamilyOopUsed = 0m,
+            FamilyOopLimit = 16300m
+        });
+}

--- a/src/services/member-service/Services/FhirExtensionBuilder.cs
+++ b/src/services/member-service/Services/FhirExtensionBuilder.cs
@@ -1,0 +1,88 @@
+using System.Text.Json.Nodes;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Small helper for assembling FHIR extension nodes. Keeps US Core
+/// race/ethnicity/genderIdentity/birthSex wiring DRY.
+/// </summary>
+internal static class FhirExtensionBuilder
+{
+    public const string UsCoreRace = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+    public const string UsCoreEthnicity = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity";
+    public const string UsCoreBirthSex = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex";
+    public const string UsCoreGenderIdentity = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity";
+
+    public static JsonObject Coding(string system, string code, string? display = null)
+    {
+        var coding = new JsonObject
+        {
+            ["system"] = system,
+            ["code"] = code
+        };
+        if (!string.IsNullOrEmpty(display)) coding["display"] = display;
+        return coding;
+    }
+
+    public static JsonObject ExtensionString(string url, string value) => new()
+    {
+        ["url"] = url,
+        ["valueString"] = value
+    };
+
+    public static JsonObject ExtensionCoding(string url, JsonObject coding) => new()
+    {
+        ["url"] = url,
+        ["valueCoding"] = coding
+    };
+
+    public static JsonObject ExtensionCodeableConcept(string url, JsonObject codeableConcept) => new()
+    {
+        ["url"] = url,
+        ["valueCodeableConcept"] = codeableConcept
+    };
+
+    /// <summary>
+    /// Build a US Core race/ethnicity extension composite:
+    /// ombCategory (0..1 for ethnicity, 0..5 for race) + detailed (0..*) + text (1..1).
+    /// </summary>
+    public static JsonObject? BuildRaceExtension(
+        Models.CodedConcept? omb,
+        IReadOnlyList<Models.CodedConcept> detail,
+        string? text)
+    {
+        if (omb == null && detail.Count == 0 && string.IsNullOrEmpty(text)) return null;
+
+        var extensions = new JsonArray();
+        if (omb != null)
+        {
+            extensions.Add(ExtensionCoding(
+                "ombCategory",
+                Coding(omb.System, omb.Code, omb.Display)));
+        }
+        foreach (var d in detail)
+        {
+            extensions.Add(ExtensionCoding(
+                "detailed",
+                Coding(d.System, d.Code, d.Display)));
+        }
+        extensions.Add(ExtensionString("text", text ?? omb?.Display ?? "Unknown"));
+
+        return new JsonObject
+        {
+            ["url"] = UsCoreRace,
+            ["extension"] = extensions
+        };
+    }
+
+    public static JsonObject? BuildEthnicityExtension(
+        Models.CodedConcept? omb,
+        IReadOnlyList<Models.CodedConcept> detail,
+        string? text)
+    {
+        var ext = BuildRaceExtension(omb, detail, text);
+        if (ext == null) return null;
+        ext["url"] = UsCoreEthnicity;
+        return ext;
+    }
+}

--- a/src/services/member-service/Services/FhirPatientProjector.cs
+++ b/src/services/member-service/Services/FhirPatientProjector.cs
@@ -1,0 +1,217 @@
+using System.Text.Json.Nodes;
+using MemberService.Models;
+using static MemberService.Services.FhirExtensionBuilder;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Hand-built FHIR R4 Patient projector. Populates:
+///   - identifier[] (MemberId + typed identifiers; PII values are redacted unless a
+///     caller-supplied <see cref="IIdentifierEncryptor"/> decrypts them upstream)
+///   - name, telecom, address, gender, birthDate, deceased[x]
+///   - communication (preferred language + additional languages)
+///   - maritalStatus
+///   - US Core extensions: us-core-race, us-core-ethnicity, us-core-birthsex,
+///     us-core-genderIdentity
+/// </summary>
+public sealed class FhirPatientProjector : IFhirPatientProjector
+{
+    public JsonObject Project(Member member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        var patient = new JsonObject
+        {
+            ["resourceType"] = "Patient",
+            ["id"] = member.Id,
+            ["active"] = member.Status == EnrollmentStatus.Active
+        };
+
+        // ── Extensions (US Core) ─────────────────────────────────────
+        var extensions = new JsonArray();
+        var raceExt = BuildRaceExtension(member.Race, member.RaceDetail, member.Race?.Display);
+        if (raceExt != null) extensions.Add(raceExt);
+
+        var ethExt = BuildEthnicityExtension(member.Ethnicity, member.EthnicityDetail, member.Ethnicity?.Display);
+        if (ethExt != null) extensions.Add(ethExt);
+
+        if (!string.IsNullOrEmpty(member.BirthSex))
+        {
+            extensions.Add(new JsonObject
+            {
+                ["url"] = UsCoreBirthSex,
+                ["valueCode"] = member.BirthSex
+            });
+        }
+
+        if (member.GenderIdentity != null)
+        {
+            extensions.Add(ExtensionCodeableConcept(
+                UsCoreGenderIdentity,
+                new JsonObject
+                {
+                    ["coding"] = new JsonArray(Coding(
+                        member.GenderIdentity.System,
+                        member.GenderIdentity.Code,
+                        member.GenderIdentity.Display))
+                }));
+        }
+
+        if (!string.IsNullOrEmpty(member.Pronouns))
+        {
+            extensions.Add(ExtensionString(
+                "http://hl7.org/fhir/StructureDefinition/individual-pronouns",
+                member.Pronouns));
+        }
+
+        if (extensions.Count > 0) patient["extension"] = extensions;
+
+        // ── Identifiers ──────────────────────────────────────────────
+        var identifiers = new JsonArray
+        {
+            new JsonObject
+            {
+                ["use"] = "official",
+                ["system"] = FhirIdentifierSystems.MemberId,
+                ["value"] = member.MemberId
+            }
+        };
+        foreach (var ident in member.Identifiers)
+        {
+            if (string.IsNullOrEmpty(ident.Value)) continue;
+
+            // Never emit ciphertext. If the stored value is encrypted and no
+            // upstream decryption was done, redact to avoid leaking envelope bytes.
+            var value = ident.IsEncrypted ? "[REDACTED]" : ident.Value;
+
+            var node = new JsonObject
+            {
+                ["use"] = string.IsNullOrEmpty(ident.Use) ? "official" : ident.Use,
+                ["system"] = ident.System,
+                ["value"] = value
+            };
+            if (ident.PeriodStart.HasValue || ident.PeriodEnd.HasValue)
+            {
+                var period = new JsonObject();
+                if (ident.PeriodStart.HasValue) period["start"] = ident.PeriodStart.Value.ToString("o");
+                if (ident.PeriodEnd.HasValue) period["end"] = ident.PeriodEnd.Value.ToString("o");
+                node["period"] = period;
+            }
+            if (!string.IsNullOrEmpty(ident.Assigner))
+            {
+                node["assigner"] = new JsonObject { ["display"] = ident.Assigner };
+            }
+            identifiers.Add(node);
+        }
+        patient["identifier"] = identifiers;
+
+        // ── Name ─────────────────────────────────────────────────────
+        var givenNames = new JsonArray { member.FirstName };
+        if (!string.IsNullOrEmpty(member.MiddleName)) givenNames.Add(member.MiddleName);
+        patient["name"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["use"] = "official",
+                ["family"] = member.LastName,
+                ["given"] = givenNames
+            }
+        };
+
+        // ── Telecom ──────────────────────────────────────────────────
+        var telecom = new JsonArray();
+        if (!string.IsNullOrEmpty(member.Phone))
+            telecom.Add(new JsonObject { ["system"] = "phone", ["value"] = member.Phone, ["use"] = "home" });
+        if (!string.IsNullOrEmpty(member.Email))
+            telecom.Add(new JsonObject { ["system"] = "email", ["value"] = member.Email });
+        if (telecom.Count > 0) patient["telecom"] = telecom;
+
+        // ── Gender / BirthDate ───────────────────────────────────────
+        patient["gender"] = MapGender(member.Gender);
+        patient["birthDate"] = member.DateOfBirth.ToString("yyyy-MM-dd");
+
+        // ── Deceased ─────────────────────────────────────────────────
+        if (member.DeceasedDate.HasValue)
+        {
+            patient["deceasedDateTime"] = member.DeceasedDate.Value.ToString("o");
+        }
+        else if (member.Deceased)
+        {
+            patient["deceasedBoolean"] = true;
+        }
+
+        // ── Address ──────────────────────────────────────────────────
+        if (HasAddress(member))
+        {
+            var address = new JsonObject { ["use"] = "home" };
+            if (!string.IsNullOrEmpty(member.Address))
+                address["line"] = new JsonArray { member.Address };
+            if (!string.IsNullOrEmpty(member.City)) address["city"] = member.City;
+            if (!string.IsNullOrEmpty(member.State)) address["state"] = member.State;
+            if (!string.IsNullOrEmpty(member.ZipCode)) address["postalCode"] = member.ZipCode;
+            patient["address"] = new JsonArray { address };
+        }
+
+        // ── Marital Status ───────────────────────────────────────────
+        if (member.MaritalStatus != null)
+        {
+            patient["maritalStatus"] = new JsonObject
+            {
+                ["coding"] = new JsonArray(Coding(
+                    member.MaritalStatus.System,
+                    member.MaritalStatus.Code,
+                    member.MaritalStatus.Display))
+            };
+        }
+
+        // ── Communication ────────────────────────────────────────────
+        var communications = new JsonArray();
+        if (!string.IsNullOrEmpty(member.PreferredLanguage))
+        {
+            communications.Add(new JsonObject
+            {
+                ["language"] = new JsonObject
+                {
+                    ["coding"] = new JsonArray(Coding(
+                        "urn:ietf:bcp:47", member.PreferredLanguage, member.PreferredLanguage))
+                },
+                ["preferred"] = true
+            });
+        }
+        foreach (var lang in member.Languages)
+        {
+            if (string.IsNullOrEmpty(lang)) continue;
+            if (string.Equals(lang, member.PreferredLanguage, StringComparison.OrdinalIgnoreCase)) continue;
+            communications.Add(new JsonObject
+            {
+                ["language"] = new JsonObject
+                {
+                    ["coding"] = new JsonArray(Coding("urn:ietf:bcp:47", lang, lang))
+                },
+                ["preferred"] = false
+            });
+        }
+        if (communications.Count > 0) patient["communication"] = communications;
+
+        // ── Meta ─────────────────────────────────────────────────────
+        patient["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = member.LastUpdatedDate.ToString("o"),
+            ["profile"] = new JsonArray("http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient")
+        };
+
+        return patient;
+    }
+
+    private static string MapGender(string? g) => g?.ToUpperInvariant() switch
+    {
+        "M" => "male",
+        "F" => "female",
+        "U" => "unknown",
+        _ => "unknown"
+    };
+
+    private static bool HasAddress(Member m) =>
+        !string.IsNullOrEmpty(m.Address) || !string.IsNullOrEmpty(m.City) ||
+        !string.IsNullOrEmpty(m.State) || !string.IsNullOrEmpty(m.ZipCode);
+}

--- a/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
@@ -1,0 +1,79 @@
+using System.Security.Cryptography;
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// HMAC-SHA256 fingerprinter keyed by a secret fetched from the configured
+/// <see cref="ISecretProvider"/>. Fingerprint key MUST be distinct from the
+/// AES-GCM encryption key so rotation does not leak plaintext identifiers.
+/// </summary>
+public sealed class HmacSha256IdentifierFingerprinter : IIdentifierFingerprinter
+{
+    private readonly ISecretProvider _secrets;
+    private readonly ILogger<HmacSha256IdentifierFingerprinter> _logger;
+    private readonly string _keySecretName;
+
+    private byte[]? _cachedKey;
+    private readonly SemaphoreSlim _keyLock = new(1, 1);
+
+    public HmacSha256IdentifierFingerprinter(
+        ISecretProvider secrets,
+        ILogger<HmacSha256IdentifierFingerprinter> logger,
+        string keySecretName)
+    {
+        _secrets = secrets;
+        _logger = logger;
+        _keySecretName = string.IsNullOrWhiteSpace(keySecretName)
+            ? throw new ArgumentException("keySecretName is required", nameof(keySecretName))
+            : keySecretName;
+    }
+
+    public bool IsEnabled => true;
+
+    public async Task<string> FingerprintAsync(string normalizedPlaintext, CancellationToken ct = default)
+    {
+        var key = await GetKeyAsync(ct);
+        var data = Encoding.UTF8.GetBytes(normalizedPlaintext ?? string.Empty);
+        var hash = HMACSHA256.HashData(key, data);
+        return Convert.ToHexString(hash);
+    }
+
+    private async Task<byte[]> GetKeyAsync(CancellationToken ct)
+    {
+        if (_cachedKey != null) return _cachedKey;
+
+        await _keyLock.WaitAsync(ct);
+        try
+        {
+            if (_cachedKey != null) return _cachedKey;
+
+            var raw = await _secrets.GetSecretAsync(_keySecretName, ct)
+                ?? throw new InvalidOperationException(
+                    $"Identifier fingerprint HMAC key '{_keySecretName}' not found in secret provider.");
+
+            byte[] keyBytes;
+            try
+            {
+                keyBytes = Convert.FromBase64String(raw);
+            }
+            catch (FormatException)
+            {
+                keyBytes = Encoding.UTF8.GetBytes(raw);
+            }
+
+            if (keyBytes.Length < 32)
+                throw new InvalidOperationException(
+                    $"Identifier fingerprint HMAC key must be at least 32 bytes; got {keyBytes.Length}.");
+
+            _cachedKey = keyBytes;
+            return keyBytes;
+        }
+        finally
+        {
+            _keyLock.Release();
+        }
+    }
+}

--- a/src/services/member-service/Services/HttpAccumulatorServiceClient.cs
+++ b/src/services/member-service/Services/HttpAccumulatorServiceClient.cs
@@ -1,0 +1,42 @@
+using System.Net.Http.Json;
+using MemberService.Controllers;
+using Microsoft.Extensions.Options;
+
+namespace MemberService.Services;
+
+public sealed class HttpAccumulatorServiceClient : IAccumulatorServiceClient
+{
+    private readonly HttpClient _http;
+    private readonly DownstreamService? _options;
+    private const string ServiceName = "accumulator-service";
+
+    public HttpAccumulatorServiceClient(HttpClient http, IOptions<DownstreamOptions> options)
+    {
+        _http = http;
+        _options = options.Value.AccumulatorService;
+    }
+
+    public async Task<MemberAccumulatorsResponse> GetAccumulatorsAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options?.BaseUrl))
+            throw new DownstreamUnavailableException(
+                ServiceName,
+                "Configure Downstream:AccumulatorService:BaseUrl to enable accumulator lookup.");
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"/api/v1/members/{Uri.EscapeDataString(memberId)}/accumulators");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<MemberAccumulatorsResponse>(cancellationToken: ct)
+                ?? throw new DownstreamUnavailableException(ServiceName, "Empty response body");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+}

--- a/src/services/member-service/Services/HttpCoverageServiceClient.cs
+++ b/src/services/member-service/Services/HttpCoverageServiceClient.cs
@@ -32,7 +32,7 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
     public async Task<MemberPcpResponse> GetPcpAsync(string tenantId, string memberId, CancellationToken ct = default)
     {
         EnsureConfigured();
-        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/pcp");
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/pcp");
         req.Headers.Add("X-Tenant-ID", tenantId);
         try
         {
@@ -51,7 +51,7 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         string tenantId, string memberId, AssignPcpRequest request, CancellationToken ct = default)
     {
         EnsureConfigured();
-        var req = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/pcp")
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/pcp")
         {
             Content = JsonContent.Create(request)
         };
@@ -73,7 +73,7 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         string tenantId, string memberId, CancellationToken ct = default)
     {
         EnsureConfigured();
-        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/history");
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/history");
         req.Headers.Add("X-Tenant-ID", tenantId);
         try
         {
@@ -92,7 +92,7 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         string tenantId, string memberId, TerminateMemberRequest request, CancellationToken ct = default)
     {
         EnsureConfigured();
-        var req = new HttpRequestMessage(HttpMethod.Post, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/terminate")
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/terminate")
         {
             Content = JsonContent.Create(request)
         };

--- a/src/services/member-service/Services/HttpCoverageServiceClient.cs
+++ b/src/services/member-service/Services/HttpCoverageServiceClient.cs
@@ -1,0 +1,110 @@
+using System.Net.Http.Json;
+using MemberService.Controllers;
+using Microsoft.Extensions.Options;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// <see cref="ICoverageServiceClient"/> backed by a configured HttpClient.
+/// When <c>Downstream:CoverageService:BaseUrl</c> is not set, every call throws
+/// <see cref="DownstreamUnavailableException"/> so the controller returns 503.
+/// </summary>
+public sealed class HttpCoverageServiceClient : ICoverageServiceClient
+{
+    private readonly HttpClient _http;
+    private readonly DownstreamService? _options;
+    private const string ServiceName = "coverage-service";
+
+    public HttpCoverageServiceClient(HttpClient http, IOptions<DownstreamOptions> options)
+    {
+        _http = http;
+        _options = options.Value.CoverageService;
+    }
+
+    private void EnsureConfigured()
+    {
+        if (string.IsNullOrWhiteSpace(_options?.BaseUrl))
+            throw new DownstreamUnavailableException(
+                ServiceName,
+                "Configure Downstream:CoverageService:BaseUrl to enable coverage integrations.");
+    }
+
+    public async Task<MemberPcpResponse> GetPcpAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        EnsureConfigured();
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/pcp");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<MemberPcpResponse>(cancellationToken: ct)
+                ?? throw new DownstreamUnavailableException(ServiceName, "Empty response body");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+
+    public async Task<MemberPcpResponse> AssignPcpAsync(
+        string tenantId, string memberId, AssignPcpRequest request, CancellationToken ct = default)
+    {
+        EnsureConfigured();
+        var req = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/pcp")
+        {
+            Content = JsonContent.Create(request)
+        };
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<MemberPcpResponse>(cancellationToken: ct)
+                ?? throw new DownstreamUnavailableException(ServiceName, "Empty response body");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+
+    public async Task<IReadOnlyList<CoverageHistoryEvent>> GetCoverageHistoryAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        EnsureConfigured();
+        var req = new HttpRequestMessage(HttpMethod.Get, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/history");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<List<CoverageHistoryEvent>>(cancellationToken: ct)
+                ?? new List<CoverageHistoryEvent>();
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+
+    public async Task TerminateCoverageAsync(
+        string tenantId, string memberId, TerminateMemberRequest request, CancellationToken ct = default)
+    {
+        EnsureConfigured();
+        var req = new HttpRequestMessage(HttpMethod.Post, $"/api/v1/coverage/members/{Uri.EscapeDataString(memberId)}/terminate")
+        {
+            Content = JsonContent.Create(request)
+        };
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+}

--- a/src/services/member-service/Services/HttpEnrollmentImportServiceClient.cs
+++ b/src/services/member-service/Services/HttpEnrollmentImportServiceClient.cs
@@ -1,0 +1,42 @@
+using System.Net.Http.Json;
+using MemberService.Controllers;
+using Microsoft.Extensions.Options;
+
+namespace MemberService.Services;
+
+public sealed class HttpEnrollmentImportServiceClient : IEnrollmentImportServiceClient
+{
+    private readonly HttpClient _http;
+    private readonly DownstreamService? _options;
+    private const string ServiceName = "enrollment-import-service";
+
+    public HttpEnrollmentImportServiceClient(HttpClient http, IOptions<DownstreamOptions> options)
+    {
+        _http = http;
+        _options = options.Value.EnrollmentImportService;
+    }
+
+    public async Task<IReadOnlyList<Enrollment834Record>> Get834TransactionsAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options?.BaseUrl))
+            throw new DownstreamUnavailableException(
+                ServiceName,
+                "Configure Downstream:EnrollmentImportService:BaseUrl to enable 834 history.");
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"/api/v1/enrollment/transactions?memberId={Uri.EscapeDataString(memberId)}");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<List<Enrollment834Record>>(cancellationToken: ct)
+                ?? new List<Enrollment834Record>();
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+}

--- a/src/services/member-service/Services/ICoverageServiceClient.cs
+++ b/src/services/member-service/Services/ICoverageServiceClient.cs
@@ -1,0 +1,47 @@
+using MemberService.Controllers;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Typed client for the coverage-service. PCP lookup/assignment and coverage history
+/// are authoritative in coverage-service — this client is how member-service delegates.
+/// </summary>
+public interface ICoverageServiceClient
+{
+    Task<MemberPcpResponse> GetPcpAsync(string tenantId, string memberId, CancellationToken ct = default);
+
+    Task<MemberPcpResponse> AssignPcpAsync(
+        string tenantId,
+        string memberId,
+        AssignPcpRequest request,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<CoverageHistoryEvent>> GetCoverageHistoryAsync(
+        string tenantId,
+        string memberId,
+        CancellationToken ct = default);
+
+    Task TerminateCoverageAsync(
+        string tenantId,
+        string memberId,
+        TerminateMemberRequest request,
+        CancellationToken ct = default);
+}
+
+/// <summary>Typed client for the enrollment-import-service (834 transaction history).</summary>
+public interface IEnrollmentImportServiceClient
+{
+    Task<IReadOnlyList<Enrollment834Record>> Get834TransactionsAsync(
+        string tenantId,
+        string memberId,
+        CancellationToken ct = default);
+}
+
+/// <summary>Typed client for the accumulator service (deductible + OOP balances).</summary>
+public interface IAccumulatorServiceClient
+{
+    Task<MemberAccumulatorsResponse> GetAccumulatorsAsync(
+        string tenantId,
+        string memberId,
+        CancellationToken ct = default);
+}

--- a/src/services/member-service/Services/IFhirPatientProjector.cs
+++ b/src/services/member-service/Services/IFhirPatientProjector.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Nodes;
+using MemberService.Models;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Projects a <see cref="Member"/> into a FHIR R4 Patient resource (as a
+/// <see cref="JsonObject"/>). Hand-built to avoid the Hl7.Fhir.R4 transitive
+/// dep graph and keep serialization deterministic for tests.
+/// </summary>
+public interface IFhirPatientProjector
+{
+    JsonObject Project(Member member);
+}

--- a/src/services/member-service/Services/IIdentifierEncryptor.cs
+++ b/src/services/member-service/Services/IIdentifierEncryptor.cs
@@ -1,0 +1,17 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Field-level encryption for PII identifiers (SSN, MBI, Medicaid IDs).
+/// Implementations back the data key with Azure Key Vault via <see cref="CloudHealthOffice.Infrastructure.Configuration.ISecretProvider"/>.
+/// </summary>
+public interface IIdentifierEncryptor
+{
+    /// <summary>True when the impl performs real encryption (false = no-op dev shim).</summary>
+    bool IsEnabled { get; }
+
+    /// <summary>Encrypt plaintext. Returns ciphertext (opaque string). Null/empty in = null/empty out.</summary>
+    Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default);
+
+    /// <summary>Decrypt ciphertext produced by <see cref="EncryptAsync"/>.</summary>
+    Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default);
+}

--- a/src/services/member-service/Services/IIdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/IIdentifierFingerprinter.cs
@@ -1,0 +1,19 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Deterministic fingerprint for PII identifier values. Used ONLY for
+/// duplicate detection — never for lookup beyond equality comparison, never
+/// reversed. Implementations must use a KV-backed HMAC key that is DISTINCT
+/// from the AES-GCM encryption key so the two secrets can rotate independently.
+/// </summary>
+public interface IIdentifierFingerprinter
+{
+    /// <summary>True when the implementation performs real HMAC (false = dev no-op).</summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Returns a stable fingerprint for the given already-normalized plaintext.
+    /// Same input → same output (for the lifetime of the HMAC key).
+    /// </summary>
+    Task<string> FingerprintAsync(string normalizedPlaintext, CancellationToken ct = default);
+}

--- a/src/services/member-service/Services/IMemberEventPublisher.cs
+++ b/src/services/member-service/Services/IMemberEventPublisher.cs
@@ -1,0 +1,24 @@
+using MemberService.Models;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Publishes <see cref="MemberEvent"/>s. Authoritative store in this PR is the Cosmos
+/// <c>member-events</c> container (<see cref="CosmosMemberEventPublisher"/>). Downstream
+/// fan-out (bus publishers) can be layered via a decorator/composite without touching
+/// call sites.
+///
+/// Payload rules:
+///   - <see cref="MemberEventType.MemberCreated"/> MUST contain the full member snapshot.
+///   - All other events SHOULD contain a diff of changed fields.
+/// </summary>
+public interface IMemberEventPublisher
+{
+    /// <summary>
+    /// Append an event. Idempotent on <see cref="MemberEvent.EventId"/>; callers
+    /// may safely retry. Populates <see cref="MemberEvent.Version"/>,
+    /// <see cref="MemberEvent.PartitionKey"/>, and <see cref="MemberEvent.OccurredAt"/>
+    /// if not set.
+    /// </summary>
+    Task<MemberEvent> PublishAsync(MemberEvent evt, CancellationToken ct = default);
+}

--- a/src/services/member-service/Services/IdentifierNormalization.cs
+++ b/src/services/member-service/Services/IdentifierNormalization.cs
@@ -1,0 +1,37 @@
+using System.Text;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// PII identifier normalization used before fingerprint hashing and duplicate
+/// detection. Strips dashes, spaces, parentheses, dots, slashes; uppercases.
+/// Intentionally lossy — callers still persist the original plaintext
+/// (encrypted) in <c>MemberIdentifier.Value</c>; this is only for dedupe.
+/// </summary>
+public static class IdentifierNormalization
+{
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '-':
+                case ' ':
+                case '(':
+                case ')':
+                case '.':
+                case '/':
+                case '_':
+                    continue;
+                default:
+                    sb.Append(char.ToUpperInvariant(ch));
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
+++ b/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
@@ -1,0 +1,152 @@
+using System.Security.Cryptography;
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// AES-256-GCM identifier encryptor. The data encryption key is fetched from the
+/// configured secret provider (Azure Key Vault in prod) — no key material is
+/// maintained in this process. Reuses the existing <see cref="ISecretProvider"/>
+/// pattern rather than adding another crypto layer.
+///
+/// Ciphertext format (base64url of):
+///   [1 byte version = 0x01][12 bytes IV][16 bytes tag][ciphertext bytes]
+/// </summary>
+public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
+{
+    private const byte Version = 0x01;
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+
+    private readonly ISecretProvider _secrets;
+    private readonly ILogger<KeyVaultIdentifierEncryptor> _logger;
+    private readonly string _keySecretName;
+
+    private byte[]? _cachedKey;
+    private readonly SemaphoreSlim _keyLock = new(1, 1);
+
+    public KeyVaultIdentifierEncryptor(
+        ISecretProvider secrets,
+        ILogger<KeyVaultIdentifierEncryptor> logger,
+        string keySecretName)
+    {
+        _secrets = secrets;
+        _logger = logger;
+        _keySecretName = string.IsNullOrWhiteSpace(keySecretName)
+            ? throw new ArgumentException("keySecretName is required", nameof(keySecretName))
+            : keySecretName;
+    }
+
+    public bool IsEnabled => true;
+
+    public async Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return plaintext;
+
+        var key = await GetKeyAsync(ct);
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var cipherBytes = new byte[plainBytes.Length];
+        var tag = new byte[TagSize];
+
+        using var gcm = new AesGcm(key, TagSize);
+        gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+
+        var envelope = new byte[1 + NonceSize + TagSize + cipherBytes.Length];
+        envelope[0] = Version;
+        Buffer.BlockCopy(nonce, 0, envelope, 1, NonceSize);
+        Buffer.BlockCopy(tag, 0, envelope, 1 + NonceSize, TagSize);
+        Buffer.BlockCopy(cipherBytes, 0, envelope, 1 + NonceSize + TagSize, cipherBytes.Length);
+
+        return Base64UrlEncode(envelope);
+    }
+
+    public async Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(ciphertext)) return ciphertext;
+
+        byte[] envelope;
+        try
+        {
+            envelope = Base64UrlDecode(ciphertext);
+        }
+        catch (FormatException)
+        {
+            _logger.LogWarning("Identifier ciphertext is not valid base64url");
+            throw;
+        }
+
+        if (envelope.Length < 1 + NonceSize + TagSize)
+            throw new CryptographicException("Envelope too short");
+        if (envelope[0] != Version)
+            throw new CryptographicException($"Unsupported envelope version 0x{envelope[0]:X2}");
+
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipherLen = envelope.Length - 1 - NonceSize - TagSize;
+        var cipherBytes = new byte[cipherLen];
+        Buffer.BlockCopy(envelope, 1, nonce, 0, NonceSize);
+        Buffer.BlockCopy(envelope, 1 + NonceSize, tag, 0, TagSize);
+        Buffer.BlockCopy(envelope, 1 + NonceSize + TagSize, cipherBytes, 0, cipherLen);
+
+        var key = await GetKeyAsync(ct);
+        var plainBytes = new byte[cipherLen];
+        using var gcm = new AesGcm(key, TagSize);
+        gcm.Decrypt(nonce, cipherBytes, tag, plainBytes);
+        return Encoding.UTF8.GetString(plainBytes);
+    }
+
+    private async Task<byte[]> GetKeyAsync(CancellationToken ct)
+    {
+        if (_cachedKey != null) return _cachedKey;
+
+        await _keyLock.WaitAsync(ct);
+        try
+        {
+            if (_cachedKey != null) return _cachedKey;
+
+            var raw = await _secrets.GetSecretAsync(_keySecretName, ct)
+                ?? throw new InvalidOperationException(
+                    $"Identifier encryption key '{_keySecretName}' not found in secret provider. " +
+                    "Provision a 32-byte key in Key Vault under this name.");
+
+            byte[] keyBytes;
+            try
+            {
+                keyBytes = Convert.FromBase64String(raw);
+            }
+            catch (FormatException)
+            {
+                keyBytes = Encoding.UTF8.GetBytes(raw);
+            }
+
+            if (keyBytes.Length != 32)
+                throw new InvalidOperationException(
+                    $"Identifier encryption key must be 32 bytes (AES-256); got {keyBytes.Length}.");
+
+            _cachedKey = keyBytes;
+            return keyBytes;
+        }
+        finally
+        {
+            _keyLock.Release();
+        }
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string s)
+    {
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+
+}

--- a/src/services/member-service/Services/NoOpIdentifierEncryptor.cs
+++ b/src/services/member-service/Services/NoOpIdentifierEncryptor.cs
@@ -1,0 +1,16 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// No-op identifier encryptor for dev / test environments with no Key Vault.
+/// Passes values through unchanged. Never register in production.
+/// </summary>
+public sealed class NoOpIdentifierEncryptor : IIdentifierEncryptor
+{
+    public bool IsEnabled => false;
+
+    public Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+        => Task.FromResult(plaintext);
+
+    public Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+        => Task.FromResult(ciphertext);
+}

--- a/src/services/member-service/Services/NoOpIdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/NoOpIdentifierFingerprinter.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Dev-only fingerprinter. Returns a plain SHA-256 hash (no keyed HMAC).
+/// Dedupe still works; cryptographic guarantees do not. Never register in prod.
+/// </summary>
+public sealed class NoOpIdentifierFingerprinter : IIdentifierFingerprinter
+{
+    public bool IsEnabled => false;
+
+    public Task<string> FingerprintAsync(string normalizedPlaintext, CancellationToken ct = default)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPlaintext ?? string.Empty));
+        return Task.FromResult(Convert.ToHexString(bytes));
+    }
+}

--- a/src/services/member-service/appsettings.json
+++ b/src/services/member-service/appsettings.json
@@ -9,5 +9,23 @@
   "Authentication": {
     "Authority": "https://yourtenant.b2clogin.com/yourtenant.onmicrosoft.com/v2.0/",
     "Audience": "api://member-service"
+  },
+  "CosmosDb": {
+    "DatabaseName": "CloudHealthOffice",
+    "EventsContainerName": "member-events"
+  },
+  "MongoDb": {
+    "DatabaseName": "CloudHealthOffice",
+    "EventsCollectionName": "member-events"
+  },
+  "Member": {
+    "IdentifierEncryption": {
+      "KeySecretName": ""
+    }
+  },
+  "Downstream": {
+    "CoverageService": { "BaseUrl": "" },
+    "EnrollmentImportService": { "BaseUrl": "" },
+    "AccumulatorService": { "BaseUrl": "" }
   }
 }

--- a/src/services/member-service/appsettings.json
+++ b/src/services/member-service/appsettings.json
@@ -23,6 +23,9 @@
       "KeySecretName": ""
     }
   },
+  "Encryption": {
+    "IdentifierFingerprintKeySecret": ""
+  },
   "Downstream": {
     "CoverageService": { "BaseUrl": "" },
     "EnrollmentImportService": { "BaseUrl": "" },

--- a/src/services/member-service/member-service.csproj
+++ b/src/services/member-service/member-service.csproj
@@ -17,6 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Allow the test project to access internal types (e.g., FhirExtensionBuilder). -->
+    <InternalsVisibleTo Include="MemberService.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />


### PR DESCRIPTION
Extend Member to a FHIR R4 Patient operational projection with typed
identifiers, append-only event stream, and typed downstream clients.

Models
- Identifiers[], PreferredLanguage/Languages, Race/Ethnicity (OMB + detail),
  GenderIdentity, Pronouns, MaritalStatus, Deceased(+Date), BirthSex,
  CommunicationPreferences[]
- MemberEvent envelope with Version (per-aggregate sequence), SchemaVersion,
  EventId (client-supplied idempotency key), PartitionKey (tenantId:memberId).
  Dual-serialized Payload for Cosmos (JsonObject) and Mongo (string).

Persistence
- IMemberEventRepository with Cosmos + Mongo impls (unique index on
  tenantId/memberId/eventId and /version). Decorator-friendly publisher
  CosmosMemberEventPublisher so a future ServiceBusEventPublisher can be
  layered without touching call sites. Cosmos member-events container
  provisioned with /partitionKey PK and a uniqueKeyPolicy on /version.
- IMemberRepository.GetByIdentifierAsync on both backends.
- Mongo index creation moved to `MemberEventIndexInitializer` /
  `MemberIndexInitializer` hosted services; repositories are singletons.

FHIR
- FhirPatientProjector (hand-built JsonObject, no Hl7.Fhir.R4 dep) with
  FhirExtensionBuilder helper for US Core race/ethnicity/birthSex/
  genderIdentity. FhirIdentifierSystems centralises system URIs
  (us-ssn, us-mbi, us-medicaid, urn:cho:{member-id,portal-id,exchange-id},
  urn:cho:legacy:{slug}).

Controllers
- MembersController TODOs closed: Create/Update/Terminate emit events,
  CheckEligibility evaluates real dates/status, CoverageHistory/
  834Transactions/Accumulators/Pcp proxy to downstream services.
- Sub-events (AddressChanged) use deterministic `{parentEventId}:address`
  ids so retried updates stay idempotent.
- New GET /{id}/fhir (application/fhir+json) and GET /{id}/events endpoints.
- IdentifiersController: GET/POST/DELETE typed identifiers with PII
  redaction; PII dedupe uses HMAC-SHA256 `ValueFingerprint` of normalized
  plaintext so same-plaintext adds across different AES-GCM nonces
  collide at 409.

Security
- IIdentifierEncryptor (AES-256-GCM) backed by ISecretProvider for SSN/MBI/
  Medicaid values.
- IIdentifierFingerprinter (HMAC-SHA256) keyed by a **distinct** KV secret
  (`Encryption:IdentifierFingerprintKeySecret`) so encryption and
  fingerprint keys rotate independently.
- Program.cs throws at startup in non-dev when either KV secret is
  unconfigured (no silent plaintext, no collision-hash fallback).

Downstream integration
- Typed HTTP clients for coverage/enrollment/accumulator with 503
  RFC 7807 ProblemDetails when Downstream:{Service}:BaseUrl is unset.
  Fake clients registered only when IsDevelopment() and no base URL.
  Never used in production.
- Coverage-service gains `GET/PUT /coverage/member/{memberId}/pcp` and
  `POST /coverage/member/{memberId}/terminate` (paths match the existing
  singular `/member/` convention).
- Enrollment-import-service gains `GET /enrollment/transactions` backed
  by a new `EnrollmentTransaction` collection written per 834 row.

Tests
- Unit tests for models, encryptor (incl. tampered-ciphertext), repositories
  (idempotency, ordering, tenant isolation), publisher (version increment,
  idempotent, **version conflict retry**), FHIR projector (US Core
  extensions, deceased variants, identifier redaction, minimal-member
  smoke), controllers (all former TODO paths + 503 downstream handling),
  identifiers controller.
- New **PII dedupe tests** prove same-plaintext SSN across different AES
  nonces collides, and that `123-45-6789` / `123456789` / `123 45 6789`
  all match.
- New **AddressChanged idempotency test** verifies retried updates with
  the same EventId yield exactly one MemberUpdated + one AddressChanged.
- New **DownstreamRouteContractTests** enumerates the coverage-service
  and enrollment-import-service route tables via WebApplicationFactory
  and asserts every path baked into HttpCoverageServiceClient /
  HttpEnrollmentImportServiceClient maps to a registered endpoint —
  catches the pluralization class of regression that triggered this PR's
  review at build/test time.
- New test projects: `CoverageService.Tests` and
  `EnrollmentImportService.Tests`, mirroring the MemberService.Tests
  package set exactly and wired into cloudhealthoffice-main.sln.
- Integration test via WebApplicationFactory: create → FHIR → events
  round-trip.

Docs
- docs/architecture/member-foundation.md with component diagram, event
  schema, API contract table, 503 contract, encryption flow, Cosmos
  provisioning (with inline `az` sample), and PII dedupe / fingerprint
  rotation model.
- scripts/cosmos/provision-member-events.sh.
- scripts/smoke/member-foundation-smoke.sh.

---

## Review Fixes (commit c706804)

All 6 findings from the Copilot review (PR #650) resolved in a single
additive commit on top of 00f6ea2 — no force-push.

| # | Finding | Fix |
|---|---|---|
| 1 | [Cosmos version race](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605873) | `member-events` container provisioned with `uniqueKeyPolicy` on `/version`; `MemberEventRepository` handles 409 SubStatus 1009 → version retry with exponential backoff (5 tries, then `ConcurrencyException`). Unexpected non-zero sub-statuses are logged for telemetry. |
| 2 | [Mongo index creation in ctor](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605886) | Indexes moved to `MemberEventIndexInitializer` / `MemberIndexInitializer` hosted services; repositories registered as singletons. |
| 3 | [AddressChanged idempotency](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605903) | Sub-events use deterministic `{parentEventId}:address`. Termination and PCP primary events accept caller-supplied EventId via request body. |
| 4 | [Coverage-service URL mismatch](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605912) | Client paths aligned to singular `/member/`; coverage-service gains GET/PUT `/pcp` and POST `/terminate` endpoints (with TODO pointer to roadmap 5.7 Phase 2 for effective-dated PCP history). |
| 5 | [Enrollment-import-service endpoint missing](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605928) | New `GET /api/v1/enrollment/transactions` + `EnrollmentTransaction` persistence wired into the import path. |
| 6 | [PII fingerprint-based dedupe](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097605942) | HMAC-SHA256 fingerprint of normalized plaintext stored on `MemberIdentifier.ValueFingerprint`; dedupe compares fingerprints, not ciphertexts. Separate KV secret from the AES key. |

**Scope bump:** `DownstreamRouteContractTests` added — enumerates remote
route tables at test time and asserts each embedded path exists. Catches
this exact class of bug before it ships.

## Follow-ups (not in scope for this PR)

- CodeQL "log entries created from user input" findings on
  `CosmosMemberEventPublisher.cs` (threads
  [r3097603461](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097603461),
  [r3097603466](https://github.com/aurelianware/cloudhealthoffice/pull/650#discussion_r3097603466))
  — structured logger parameters already use placeholders, but tenantId /
  memberId / version flow in from user input and should be sanitized for
  CRLF before logging. Tracked as a separate hardening pass so the PR #650
  fix scope stays contained.

https://claude.ai/code/session_01DpZsFucfm5wdfYk4q21xh6