### PR TITLE
feat(accumulator-service): add plan-year accumulators service + claim event wiring (5.4)

### DIFF
--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -185,6 +185,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoverageService.Tests", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EnrollmentImportService.Tests", "src\services\enrollment-import-service\EnrollmentImportService.Tests\EnrollmentImportService.Tests.csproj", "{E1F2A3B4-C5D6-4E7F-8A9B-0C1D2E3F4A5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "accumulator-service", "src\services\accumulator-service\accumulator-service.csproj", "{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.AccumulatorService.Tests", "tests\CloudHealthOffice.AccumulatorService.Tests\CloudHealthOffice.AccumulatorService.Tests.csproj", "{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1047,6 +1051,30 @@ Global
 		{63F7AAFC-0279-4537-AD38-5D188D73739C}.Release|x64.Build.0 = Release|Any CPU
 		{63F7AAFC-0279-4537-AD38-5D188D73739C}.Release|x86.ActiveCfg = Release|Any CPU
 		{63F7AAFC-0279-4537-AD38-5D188D73739C}.Release|x86.Build.0 = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|x64.Build.0 = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Debug|x86.Build.0 = Debug|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|x64.ActiveCfg = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|x64.Build.0 = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1C2D3E4-F5A6-4B7C-8D9E-0F1A2B3C4D5E}.Release|x86.Build.0 = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Debug|x86.Build.0 = Debug|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|x64.Build.0 = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2D3E4F5-A6B7-4C8D-9E0F-1A2B3C4D5E6F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -525,5 +525,26 @@ services:
         condition: service_healthy
     profiles: [core]
 
+  # Member plan-year accumulators. Subscribes to claims.finalized.v1 and applies
+  # per-member deductible / OOP / per-service updates; idempotent on (tenantId, claimId).
+  # Manual adjustments audited via AccumulatorEvent + accumulators.adjusted.v1.
+  accumulator-service:
+    build:
+      context: .
+      dockerfile: src/services/accumulator-service/Dockerfile
+    ports:
+      - "5029:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - MongoDb__ConnectionString=mongodb://mongo:27017
+      - MongoDb__DatabaseName=AccumulatorDB
+      - Kafka__BootstrapServers=kafka:9092
+      - Kafka__ClientId=accumulator-service
+      - Kafka__ClaimFinalized__GroupId=accumulator-service.claims-finalized
+    depends_on:
+      mongo:
+        condition: service_healthy
+    profiles: [core]
+
 volumes:
   mongo_data:

--- a/docs/architecture/accumulator-service.md
+++ b/docs/architecture/accumulator-service.md
@@ -1,0 +1,152 @@
+# Accumulator Service
+
+Tracks per-member plan-year accumulators: individual & family deductibles,
+out-of-pocket maxima, and per-benefit-category usage. Driven by finalized
+claim events and manual operator adjustments; read by the portal
+(Accumulators tab) via member-service.
+
+## Responsibilities
+
+1. Project `ClaimFinalizedEvent`s onto a per-(tenant, member, plan-year)
+   `AccumulatorSnapshot`.
+2. Serve point-in-time reads (`GET /api/v1/accumulators/{memberId}`) and
+   history (`/history`).
+3. Record authorized manual adjustments with full audit trail.
+4. Emit `AccumulatorAdjustedEvent` so downstream analytics / audit
+   projectors see every mutation.
+
+## Data model
+
+### `AccumulatorSnapshot`
+
+Current-state read model. One per `(tenantId, memberId, planYearStart)`.
+Document id is deterministic: `{tenantId}:{memberId}:{yyyyMMdd}` so a retro
+claim can resolve its target without a separate lookup.
+
+Fields: individual / family deductible & OOP (used + limit),
+`ServiceAccumulators[]` per benefit category, `Version` (monotonic), and
+timestamps.
+
+### `AccumulatorEvent`
+
+Append-only event stream. This is the source of truth for audit and for
+rebuilding the snapshot by replay. Unique constraints:
+
+- `(tenantId, eventId)` — wire-level dedup.
+- `(tenantId, aggregateId, version)` — strict ordering per snapshot.
+
+Event types: `ClaimApplied`, `ManualAdjustment`, `OrphanSkipped`,
+`DuplicateSkipped`.
+
+### `ProcessedClaim`
+
+Idempotency marker keyed by `(tenantId, claimId)`. Upsert-then-check on a
+unique index makes duplicate detection race-free. Stores `ProcessedAt` and
+`ResultingEventId` so a support engineer debugging a duplicate-claim
+question can see exactly when and by which event the claim was applied.
+
+## Event contract: `ClaimFinalizedEvent`
+
+Internal CHO event, **not** a FHIR ExplanationOfBenefit. EOB is a
+query-time projection surfaced by claims-service for Patient Access /
+Payer-to-Payer (Phase 3); coupling an internal event to FHIR versioning
+cadence is a footgun. Carry exactly what accumulator aggregation needs,
+flat:
+
+- Envelope: `EventId` (GUID), `EventSchemaVersion` (int), `EventType`,
+  `OccurredAt`.
+- Identity: `TenantId`, `ClaimId`, `ClaimNumber`, `MemberId`.
+- Time: `ServiceDate` (for plan-year selection), `AdjudicationTimestamp`
+  (when the decision was made), `PlanYearStart` / `PlanYearEnd`
+  (producer-asserted; optional).
+- Amounts (claim-level sums): `DeductibleApplied`, `CoinsuranceApplied`,
+  `CopayApplied`, `OopApplied`, `PlanPaid`, `MemberResponsibility`.
+- Flags: `IsFamilyAggregate`, `BenefitCategory`, `FinalStatus`.
+- `LineItems[]` — per-line applied amounts. Populated when a single claim
+  spans multiple benefit categories. Most claims have one line.
+
+Idempotency is keyed by `(TenantId, ClaimId)` — not `EventId` — because
+re-finalization of the same claim must be deduped even across event-id
+regenerations (e.g. producer restart replays).
+
+## Snapshot selection (retro claims)
+
+Snapshot selection uses **ServiceDate**, not `AdjudicationTimestamp` or
+"today". A claim finalized today for a service date six months ago lands
+in the plan year that contained the service date. This is asserted by
+`AccumulatorServiceTests.Apply_RetroClaim_TargetsPriorYearSnapshotNotCurrent`.
+
+## Orphan handling
+
+When `ClaimFinalizedEvent.ServiceDate` does not map to any known
+plan-year snapshot (e.g. predates earliest coverage):
+
+- Log a structured warning with `{ClaimId, TenantId, MemberId, ServiceDate}`.
+- Emit `OrphanAccumulatorClaimEvent` to `accumulators.orphan.v1`.
+- Mark the `ProcessedClaim` with `Outcome = OrphanSkipped`.
+- Do **not** silently drop, and do **not** crash — this is a data-quality
+  alert condition that operational tooling should surface.
+
+## HTTP surface
+
+- `GET /api/v1/accumulators/{memberId}?asOfDate=YYYY-MM-DD` — canonical
+  read. Returns a zero-state response (not 404) when no snapshot exists,
+  so the portal renders cleanly for new members.
+- `GET /api/v1/accumulators/{memberId}/history` — full snapshot list
+  across plan years plus the most recent 200 events.
+- `POST /api/v1/accumulators/{memberId}/adjust` — manual adjustment.
+  Requires `ActorId` and `Reason`; both are written to the audit event.
+- `GET /api/v1/members/{memberId}/accumulators` — compat alias for the
+  member-service client. **TODO(deprecate-members-accumulators-alias)**:
+  retire alongside the `/api/v1/plans` pattern retired in PR #652.
+
+Every request must carry `X-Tenant-ID`. Missing header → 400.
+
+## Messaging
+
+Currently Kafka via `Confluent.Kafka`, consistent with claims-service:
+
+- Consumer: `claims.finalized.v1` (group
+  `accumulator-service.claims-finalized`,
+  `EnableAutoCommit=false`, commit only on terminal outcome).
+- Producer: `accumulators.adjusted.v1`, `accumulators.orphan.v1`.
+
+**TODO(addendum-a)**: evaluate migration to the Service Bus-backed
+`IMessageBus` abstraction at the Phase 1 / Phase 2 boundary. Claims
+events have pub-sub fan-out characteristics (accumulators, risk
+adjustment, analytics, condition-service), so Kafka may be the right
+choice once formalized — that decision is explicitly out of scope for
+this PR.
+
+## Multi-tenancy
+
+Every collection / container is partition-keyed on `tenantId`.
+Repositories never issue a query without a `tenantId` predicate. The
+shared `TenantMiddleware` (see
+`CloudHealthOffice.Infrastructure.Middleware`) resolves the tenant from
+JWT claims first, `X-Tenant-ID` header second, `tenantId` query
+parameter as a dev-only fallback.
+
+## Configuration
+
+| Setting | Purpose |
+| --- | --- |
+| `MongoDb:ConnectionString` | Primary storage. Mongo path when set. |
+| `CosmosDb:ConnectionString` | Fallback storage. Cosmos path when Mongo is unset. |
+| `Kafka:BootstrapServers` | Kafka brokers. Consumer + publisher disable gracefully when unset. |
+| `Kafka:ClaimFinalized:GroupId` | Consumer group for claims.finalized.v1. |
+
+`member-service` must have `Downstream:AccumulatorService:BaseUrl`
+configured outside Development — an unset value is a **startup error**,
+not a lazy 503 at call time (per PR #650 convention).
+
+## Testing
+
+- `AccumulatorServiceTests` — unit tests for apply, idempotency, retro,
+  orphan, family aggregate, multi-line attribution, manual adjustment,
+  tenant isolation.
+- `AccumulatorsControllerTests` — integration tests via
+  `WebApplicationFactory<Program>`, with in-memory substitutions for the
+  repository / processed-claim store / event publisher.
+
+No external infrastructure required to run either suite.

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/MemberServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/MemberServiceTests.cs
@@ -397,19 +397,31 @@ public class MemberServiceTests
     {
         var json = JsonSerializer.Serialize(new
         {
+            memberId = "MBR-42",
+            planYearStart = "2026-01-01",
+            planYearEnd = "2026-12-31",
             individualDeductibleUsed = 500m, individualDeductibleLimit = 2000m,
             familyDeductibleUsed = 1200m, familyDeductibleLimit = 4000m,
             individualOopUsed = 1500m, individualOopLimit = 6000m,
             familyOopUsed = 3000m, familyOopLimit = 12000m,
             serviceAccumulators = new[]
             {
-                new { serviceType = "Physical Therapy", used = 8, limit = 20, unitType = "visits" }
+                new { benefitCategory = "Physical Therapy", used = 8m, limit = 20m, unit = "Visits" }
             },
             recentActivity = new[]
             {
-                new { claimId = "CLM-500", serviceDate = "2026-02-15",
-                      deductibleApplied = 100m, copayApplied = 25m,
-                      coinsuranceApplied = 30m, planPaid = 345m }
+                new {
+                    eventId = "evt-1",
+                    eventType = "ClaimApplied",
+                    sourceReference = "CLM-500",
+                    occurredAt = "2026-02-15",
+                    deductibleDelta = 100m,
+                    oopDelta = 155m,
+                    familyDeductibleDelta = 0m,
+                    familyOopDelta = 0m,
+                    reason = (string?)null,
+                    actorId = "system"
+                }
             }
         }, JsonOpts);
 
@@ -421,13 +433,13 @@ public class MemberServiceTests
         result.IndividualDeductibleLimit.Should().Be(2000m);
         result.FamilyOopLimit.Should().Be(12000m);
         result.ServiceAccumulators.Should().ContainSingle();
-        result.ServiceAccumulators[0].ServiceType.Should().Be("Physical Therapy");
-        result.ServiceAccumulators[0].Used.Should().Be(8);
-        result.ServiceAccumulators[0].Limit.Should().Be(20);
+        result.ServiceAccumulators[0].BenefitCategory.Should().Be("Physical Therapy");
+        result.ServiceAccumulators[0].Used.Should().Be(8m);
+        result.ServiceAccumulators[0].Limit.Should().Be(20m);
         result.RecentActivity.Should().ContainSingle();
-        result.RecentActivity[0].ClaimId.Should().Be("CLM-500");
-        result.RecentActivity[0].DeductibleApplied.Should().Be(100m);
-        result.RecentActivity[0].PlanPaid.Should().Be(345m);
+        result.RecentActivity[0].SourceReference.Should().Be("CLM-500");
+        result.RecentActivity[0].DeductibleDelta.Should().Be(100m);
+        result.RecentActivity[0].OopDelta.Should().Be(155m);
     }
 
     // ── CoverageHistoryEvent – remaining properties ────────────────────────────

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -181,10 +181,10 @@
                                         @foreach (var svc in _accumulators.ServiceAccumulators)
                                         {
                                             <tr>
-                                                <td>@svc.ServiceType</td>
-                                                <td>@svc.Used @svc.UnitType</td>
-                                                <td>@svc.Limit @svc.UnitType</td>
-                                                <td>@(svc.Limit - svc.Used) @svc.UnitType</td>
+                                                <td>@svc.BenefitCategory</td>
+                                                <td>@svc.Used @svc.Unit</td>
+                                                <td>@svc.Limit @svc.Unit</td>
+                                                <td>@(svc.Limit - svc.Used) @svc.Unit</td>
                                                 <td style="min-width: 150px;">
                                                     <MudProgressLinear Value="@GetPercent(svc.Used, svc.Limit)"
                                                                        Color="@GetAccumColor(svc.Used, svc.Limit)"
@@ -206,25 +206,32 @@
                                     <thead>
                                         <tr>
                                             <th>Date</th>
-                                            <th>Claim ID</th>
-                                            <th style="text-align: right;">Deductible</th>
-                                            <th style="text-align: right;">Copay</th>
-                                            <th style="text-align: right;">Coinsurance</th>
-                                            <th style="text-align: right;">Plan Paid</th>
+                                            <th>Event</th>
+                                            <th>Source</th>
+                                            <th style="text-align: right;">Deductible Δ</th>
+                                            <th style="text-align: right;">OOP Δ</th>
+                                            <th>Actor</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         @foreach (var act in _accumulators.RecentActivity)
                                         {
                                             <tr>
-                                                <td>@act.ServiceDate.ToString("MM/dd/yyyy")</td>
+                                                <td>@act.OccurredAt.ToString("MM/dd/yyyy")</td>
+                                                <td>@act.EventType</td>
                                                 <td>
-                                                    <MudLink Href="@($"/claims/{act.ClaimId}")" Typo="Typo.body2" Style="font-family: monospace;">@act.ClaimId</MudLink>
+                                                    @if (act.EventType == "ClaimApplied" && !string.IsNullOrEmpty(act.SourceReference))
+                                                    {
+                                                        <MudLink Href="@($"/claims/{act.SourceReference}")" Typo="Typo.body2" Style="font-family: monospace;">@act.SourceReference</MudLink>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span style="font-family: monospace;">@act.SourceReference</span>
+                                                    }
                                                 </td>
-                                                <td style="text-align: right;">@act.DeductibleApplied.ToString("C")</td>
-                                                <td style="text-align: right;">@act.CopayApplied.ToString("C")</td>
-                                                <td style="text-align: right;">@act.CoinsuranceApplied.ToString("C")</td>
-                                                <td style="text-align: right;">@act.PlanPaid.ToString("C")</td>
+                                                <td style="text-align: right;">@act.DeductibleDelta.ToString("C")</td>
+                                                <td style="text-align: right;">@act.OopDelta.ToString("C")</td>
+                                                <td>@act.ActorId</td>
                                             </tr>
                                         }
                                     </tbody>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -34,6 +34,10 @@ public interface IMemberService
 
 public class MemberAccumulators
 {
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
     public decimal IndividualDeductibleUsed { get; set; }
     public decimal IndividualDeductibleLimit { get; set; }
     public decimal FamilyDeductibleUsed { get; set; }
@@ -48,20 +52,24 @@ public class MemberAccumulators
 
 public class ServiceAccumulator
 {
-    public string ServiceType { get; set; } = string.Empty;
-    public int Used { get; set; }
-    public int Limit { get; set; }
-    public string UnitType { get; set; } = "visits";
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal Used { get; set; }
+    public decimal Limit { get; set; }
+    public string Unit { get; set; } = "USD";
 }
 
 public class AccumulatorActivity
 {
-    public string ClaimId { get; set; } = string.Empty;
-    public DateTime ServiceDate { get; set; }
-    public decimal DeductibleApplied { get; set; }
-    public decimal CopayApplied { get; set; }
-    public decimal CoinsuranceApplied { get; set; }
-    public decimal PlanPaid { get; set; }
+    public string EventId { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public string? SourceReference { get; set; }
+    public DateTime OccurredAt { get; set; }
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+    public string? Reason { get; set; }
+    public string ActorId { get; set; } = "system";
 }
 
 public interface ICoverageService

--- a/src/services/accumulator-service/Controllers/AccumulatorsController.cs
+++ b/src/services/accumulator-service/Controllers/AccumulatorsController.cs
@@ -1,0 +1,92 @@
+using AccumulatorService.Models;
+using AccumulatorService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AccumulatorService.Controllers;
+
+/// <summary>
+/// HTTP surface for accumulator queries and manual adjustments.
+///
+/// Two route roots are exposed:
+///   - /api/v1/accumulators/{memberId}                  — canonical per spec
+///   - /api/v1/members/{memberId}/accumulators          — compat alias for member-service
+///
+/// TODO(deprecate-members-accumulators-alias): the /members/{memberId}/accumulators
+/// alias is a transitional shape so member-service's existing HttpAccumulatorServiceClient
+/// keeps working. Track deprecation alongside the /api/v1/plans pattern retired in PR #652.
+/// </summary>
+[ApiController]
+public class AccumulatorsController : ControllerBase
+{
+    public string TenantId { get; set; } = string.Empty;
+
+    private readonly IAccumulatorService _svc;
+    private readonly ILogger<AccumulatorsController> _logger;
+
+    public AccumulatorsController(IAccumulatorService svc, ILogger<AccumulatorsController> logger)
+    {
+        _svc = svc;
+        _logger = logger;
+    }
+
+    // ── canonical routes ────────────────────────────────────────────────
+
+    [HttpGet("api/v1/accumulators/{memberId}")]
+    [ProducesResponseType(typeof(AccumulatorResponse), 200)]
+    [ProducesResponseType(404)]
+    public Task<IActionResult> Get(string memberId, [FromQuery] DateTime? asOfDate, CancellationToken ct)
+        => GetCore(memberId, asOfDate, ct);
+
+    [HttpGet("api/v1/accumulators/{memberId}/history")]
+    [ProducesResponseType(typeof(AccumulatorHistoryResponse), 200)]
+    public async Task<IActionResult> GetHistory(string memberId, CancellationToken ct)
+    {
+        var h = await _svc.GetHistoryAsync(TenantId, memberId, ct);
+        return Ok(h);
+    }
+
+    [HttpPost("api/v1/accumulators/{memberId}/adjust")]
+    [ProducesResponseType(typeof(AccumulatorAdjustmentResponse), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> Adjust(string memberId, [FromBody] AccumulatorAdjustmentRequest request, CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+        if (request.PlanYearStart > request.PlanYearEnd)
+            return BadRequest("PlanYearStart must be <= PlanYearEnd");
+        if (string.IsNullOrWhiteSpace(request.Reason))
+            return BadRequest("Reason is required for manual adjustment");
+
+        var result = await _svc.AdjustAsync(TenantId, memberId, request, ct);
+        _logger.LogInformation(
+            "Accumulator adjusted: tenant={TenantId} member={MemberId} adjustmentId={AdjustmentId} actor={ActorId}",
+            TenantId, memberId, result.AdjustmentId, request.ActorId);
+        return Ok(result);
+    }
+
+    // ── compat alias for member-service ─────────────────────────────────
+
+    [HttpGet("api/v1/members/{memberId}/accumulators")]
+    [ProducesResponseType(typeof(AccumulatorResponse), 200)]
+    [ProducesResponseType(404)]
+    public Task<IActionResult> GetForMember(string memberId, [FromQuery] DateTime? asOfDate, CancellationToken ct)
+        => GetCore(memberId, asOfDate, ct);
+
+    // ── shared ──────────────────────────────────────────────────────────
+
+    private async Task<IActionResult> GetCore(string memberId, DateTime? asOfDate, CancellationToken ct)
+    {
+        var result = await _svc.GetAsync(TenantId, memberId, asOfDate, ct);
+        if (result is null)
+        {
+            // No snapshot exists yet (new member or no claims in the requested plan year).
+            // Return an empty zero-state rather than 404 so the portal renders clean.
+            return Ok(new AccumulatorResponse
+            {
+                MemberId = memberId,
+                PlanYearStart = asOfDate.HasValue ? new DateTime(asOfDate.Value.Year, 1, 1) : new DateTime(DateTime.UtcNow.Year, 1, 1),
+                PlanYearEnd = asOfDate.HasValue ? new DateTime(asOfDate.Value.Year, 12, 31) : new DateTime(DateTime.UtcNow.Year, 12, 31)
+            });
+        }
+        return Ok(result);
+    }
+}

--- a/src/services/accumulator-service/Controllers/AccumulatorsController.cs
+++ b/src/services/accumulator-service/Controllers/AccumulatorsController.cs
@@ -33,7 +33,6 @@ public class AccumulatorsController : ControllerBase
 
     [HttpGet("api/v1/accumulators/{memberId}")]
     [ProducesResponseType(typeof(AccumulatorResponse), 200)]
-    [ProducesResponseType(404)]
     public Task<IActionResult> Get(string memberId, [FromQuery] DateTime? asOfDate, CancellationToken ct)
         => GetCore(memberId, asOfDate, ct);
 
@@ -59,7 +58,10 @@ public class AccumulatorsController : ControllerBase
         var result = await _svc.AdjustAsync(TenantId, memberId, request, ct);
         _logger.LogInformation(
             "Accumulator adjusted: tenant={TenantId} member={MemberId} adjustmentId={AdjustmentId} actor={ActorId}",
-            TenantId, memberId, result.AdjustmentId, request.ActorId);
+            SanitizeForLog(TenantId),
+            SanitizeForLog(memberId),
+            SanitizeForLog(result.AdjustmentId),
+            SanitizeForLog(request.ActorId));
         return Ok(result);
     }
 
@@ -67,7 +69,6 @@ public class AccumulatorsController : ControllerBase
 
     [HttpGet("api/v1/members/{memberId}/accumulators")]
     [ProducesResponseType(typeof(AccumulatorResponse), 200)]
-    [ProducesResponseType(404)]
     public Task<IActionResult> GetForMember(string memberId, [FromQuery] DateTime? asOfDate, CancellationToken ct)
         => GetCore(memberId, asOfDate, ct);
 
@@ -88,5 +89,11 @@ public class AccumulatorsController : ControllerBase
             });
         }
         return Ok(result);
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 }

--- a/src/services/accumulator-service/Dockerfile
+++ b/src/services/accumulator-service/Dockerfile
@@ -1,0 +1,36 @@
+ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+
+COPY src/services/accumulator-service/accumulator-service.csproj src/services/accumulator-service/
+COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/
+RUN dotnet restore src/services/accumulator-service/accumulator-service.csproj
+
+COPY src/services/accumulator-service/ src/services/accumulator-service/
+COPY src/services/shared/CloudHealthOffice.Infrastructure/ src/services/shared/CloudHealthOffice.Infrastructure/
+COPY src/services/shared/CloudHealthOffice.Events/ src/services/shared/CloudHealthOffice.Events/
+RUN dotnet build src/services/accumulator-service/accumulator-service.csproj -c Release --no-restore
+
+FROM build AS publish
+RUN dotnet publish src/services/accumulator-service/accumulator-service.csproj -c Release -o /app/publish /p:UseAppHost=false --no-restore --no-build
+
+FROM ${REGISTRY}/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=publish /app/publish .
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/health/live || exit 1
+
+ENTRYPOINT ["dotnet", "accumulator-service.dll"]

--- a/src/services/accumulator-service/Middleware/TenantMiddleware.cs
+++ b/src/services/accumulator-service/Middleware/TenantMiddleware.cs
@@ -1,0 +1,80 @@
+namespace AccumulatorService.Middleware;
+
+/// <summary>
+/// Tenant isolation middleware. Every request must carry X-Tenant-ID (or a
+/// tenantId query parameter as a dev convenience); missing tenant → 400. Writes
+/// the resolved tenant to HttpContext.Items["TenantId"] for the action filter.
+/// Health-check paths bypass.
+/// </summary>
+public class TenantMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<TenantMiddleware> _logger;
+
+    public TenantMiddleware(RequestDelegate next, ILogger<TenantMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (IsBypassPath(context.Request.Path))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (context.Request.Headers.TryGetValue("X-Tenant-ID", out var tenantId))
+        {
+            context.Items["TenantId"] = tenantId.ToString();
+        }
+        else if (context.Request.Query.TryGetValue("tenantId", out var queryTenantId))
+        {
+            context.Items["TenantId"] = queryTenantId.ToString();
+        }
+        else
+        {
+            _logger.LogWarning("No tenant ID found in request to {Path}", SanitizeForLog(context.Request.Path));
+            context.Response.StatusCode = 400;
+            await context.Response.WriteAsync("Tenant ID is required");
+            return;
+        }
+
+        await _next(context);
+    }
+
+    private static bool IsBypassPath(PathString path) =>
+        path.StartsWithSegments("/health") ||
+        path.StartsWithSegments("/ready") ||
+        path.StartsWithSegments("/live") ||
+        path.StartsWithSegments("/swagger");
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}
+
+public static class TenantMiddlewareExtensions
+{
+    public static IApplicationBuilder UseTenantMiddleware(this IApplicationBuilder builder) =>
+        builder.UseMiddleware<TenantMiddleware>();
+}
+
+public class TenantActionFilter : Microsoft.AspNetCore.Mvc.Filters.IActionFilter
+{
+    public void OnActionExecuting(Microsoft.AspNetCore.Mvc.Filters.ActionExecutingContext context)
+    {
+        var tenantId = context.HttpContext.Items["TenantId"]?.ToString();
+        if (string.IsNullOrEmpty(tenantId)) return;
+
+        if (context.Controller is Controllers.AccumulatorsController c)
+        {
+            c.TenantId = tenantId;
+        }
+    }
+
+    public void OnActionExecuted(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext context) { }
+}

--- a/src/services/accumulator-service/Models/AccumulatorAdjustment.cs
+++ b/src/services/accumulator-service/Models/AccumulatorAdjustment.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace AccumulatorService.Models;
+
+/// <summary>
+/// Request body for POST /api/v1/accumulators/{memberId}/adjust. Manual overrides
+/// by an authorized operator (e.g., to reflect an out-of-system payment or correct
+/// a miskeyed claim). Every adjustment produces an AccumulatorEvent with EventType
+/// = ManualAdjustment and an AccumulatorAdjustedEvent on the bus.
+/// </summary>
+public class AccumulatorAdjustmentRequest
+{
+    [Required]
+    public DateTime PlanYearStart { get; set; }
+
+    [Required]
+    public DateTime PlanYearEnd { get; set; }
+
+    /// <summary>Operator performing the adjustment. Required for audit.</summary>
+    [Required]
+    [StringLength(200)]
+    public string ActorId { get; set; } = string.Empty;
+
+    /// <summary>Free-text justification. Required for audit.</summary>
+    [Required]
+    [StringLength(2000, MinimumLength = 4)]
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>Signed deltas. Negative values reduce counters (e.g. reversing a posted claim).</summary>
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+
+    public List<ServiceAccumulatorAdjustment> ServiceDeltas { get; set; } = new();
+
+    /// <summary>Optional. When provided, the adjustment is idempotent against this key.</summary>
+    [StringLength(200)]
+    public string? AdjustmentId { get; set; }
+}
+
+public class ServiceAccumulatorAdjustment
+{
+    [Required]
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal UsedDelta { get; set; }
+    public string Unit { get; set; } = "USD";
+}
+
+public class AccumulatorAdjustmentResponse
+{
+    public string AdjustmentId { get; set; } = string.Empty;
+    public AccumulatorSnapshot Snapshot { get; set; } = new();
+}

--- a/src/services/accumulator-service/Models/AccumulatorApiModels.cs
+++ b/src/services/accumulator-service/Models/AccumulatorApiModels.cs
@@ -1,0 +1,68 @@
+namespace AccumulatorService.Models;
+
+/// <summary>
+/// Projection shape returned by GET /api/v1/accumulators/{memberId} and the
+/// member-service compat route. Mirrors MemberAccumulatorsResponse in member-service
+/// (and MemberAccumulators in the portal) so the proxy is a pass-through, not a
+/// re-shape. Typed lists intentionally — <c>List&lt;object&gt;</c> was a smell that
+/// kept the portal blind to the real shape.
+/// </summary>
+public class AccumulatorResponse
+{
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
+    public decimal IndividualDeductibleUsed { get; set; }
+    public decimal IndividualDeductibleLimit { get; set; }
+    public decimal FamilyDeductibleUsed { get; set; }
+    public decimal FamilyDeductibleLimit { get; set; }
+    public decimal IndividualOopUsed { get; set; }
+    public decimal IndividualOopLimit { get; set; }
+    public decimal FamilyOopUsed { get; set; }
+    public decimal FamilyOopLimit { get; set; }
+
+    public List<ServiceAccumulatorDto> ServiceAccumulators { get; set; } = new();
+    public List<AccumulatorActivityDto> RecentActivity { get; set; } = new();
+}
+
+public class ServiceAccumulatorDto
+{
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal Used { get; set; }
+    public decimal Limit { get; set; }
+    public string Unit { get; set; } = "USD";
+}
+
+public class AccumulatorActivityDto
+{
+    public string EventId { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public string? SourceReference { get; set; }
+    public DateTime OccurredAt { get; set; }
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+    public string? Reason { get; set; }
+    public string ActorId { get; set; } = "system";
+}
+
+public class AccumulatorHistoryResponse
+{
+    public string MemberId { get; set; } = string.Empty;
+    public List<AccumulatorSnapshotSummary> Snapshots { get; set; } = new();
+    public List<AccumulatorActivityDto> Events { get; set; } = new();
+}
+
+public class AccumulatorSnapshotSummary
+{
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+    public decimal IndividualDeductibleUsed { get; set; }
+    public decimal IndividualDeductibleLimit { get; set; }
+    public decimal IndividualOopUsed { get; set; }
+    public decimal IndividualOopLimit { get; set; }
+    public long Version { get; set; }
+    public DateTime LastUpdatedDate { get; set; }
+}

--- a/src/services/accumulator-service/Models/AccumulatorEvent.cs
+++ b/src/services/accumulator-service/Models/AccumulatorEvent.cs
@@ -1,0 +1,94 @@
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace AccumulatorService.Models;
+
+/// <summary>
+/// Append-only event-store row for accumulator mutations. Mirrors the pattern used
+/// by member-service's MemberEvent stream so audit reconstruction is uniform across
+/// services. Snapshot is a projection over these rows.
+///
+/// Unique constraints enforced at the persistence layer:
+///   (tenantId, eventId)                        — wire-level de-dup
+///   (tenantId, aggregateId, version)           — strict ordering per snapshot
+/// </summary>
+[BsonIgnoreExtraElements]
+public class AccumulatorEvent
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Partition key. Also the MongoDB _id for lookups.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Per-event id — matches the inbound event's EventId for ClaimApplied, fresh GUID for manual events.</summary>
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Snapshot this event mutated. Matches AccumulatorSnapshot.Id.</summary>
+    public string AggregateId { get; set; } = string.Empty;
+
+    /// <summary>Snapshot version this event produced (post-write).</summary>
+    public long Version { get; set; }
+
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
+    /// <summary>ClaimApplied | ManualAdjustment | OrphanSkipped | DuplicateSkipped.</summary>
+    public string EventType { get; set; } = string.Empty;
+
+    /// <summary>ClaimId for ClaimApplied/OrphanSkipped/DuplicateSkipped; AdjustmentId for ManualAdjustment.</summary>
+    public string? SourceReference { get; set; }
+
+    public string ActorId { get; set; } = "system";
+    public string? Reason { get; set; }
+
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+
+    public List<ServiceAccumulatorDeltaRow> ServiceDeltas { get; set; } = new();
+
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Non-null only for event rows that originated from a ClaimFinalizedEvent.
+    /// Used together with a unique index on (tenantId, sourceClaimId) to enforce
+    /// idempotent application of the same claim across replayed messages.
+    /// </summary>
+    public string? SourceClaimId { get; set; }
+}
+
+public class ServiceAccumulatorDeltaRow
+{
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal UsedDelta { get; set; }
+    public string Unit { get; set; } = "USD";
+}
+
+/// <summary>
+/// Persisted idempotency marker for ClaimFinalized consumption. The pair
+/// (TenantId, ClaimId) is the idempotency key — re-finalization of the same
+/// claim must be deduped even across event-id regenerations.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class ProcessedClaim
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+    public string ClaimId { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp the claim was applied; lets debugging trace "when did this get counted".</summary>
+    public DateTime ProcessedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>AccumulatorEvent.Id that recorded the apply. Null for OrphanSkipped markers.</summary>
+    public string? ResultingEventId { get; set; }
+
+    /// <summary>Applied | OrphanSkipped.</summary>
+    public string Outcome { get; set; } = "Applied";
+
+    public static string BuildId(string tenantId, string claimId) => $"{tenantId}:{claimId}";
+}

--- a/src/services/accumulator-service/Models/AccumulatorEvent.cs
+++ b/src/services/accumulator-service/Models/AccumulatorEvent.cs
@@ -18,7 +18,12 @@ public class AccumulatorEvent
     [JsonPropertyName("id")]
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
-    /// <summary>Partition key. Also the MongoDB _id for lookups.</summary>
+    /// <summary>
+    /// Partition key. Every query must include it; uniqueness is enforced on
+    /// <c>(TenantId, EventId)</c> and <c>(TenantId, AggregateId, Version)</c>.
+    /// The document id in Mongo is the GUID in <see cref="Id"/>; in Cosmos the
+    /// partition key is TenantId and the id is also <see cref="Id"/>.
+    /// </summary>
     public string TenantId { get; set; } = string.Empty;
 
     /// <summary>Per-event id — matches the inbound event's EventId for ClaimApplied, fresh GUID for manual events.</summary>
@@ -54,8 +59,11 @@ public class AccumulatorEvent
 
     /// <summary>
     /// Non-null only for event rows that originated from a ClaimFinalizedEvent.
-    /// Used together with a unique index on (tenantId, sourceClaimId) to enforce
-    /// idempotent application of the same claim across replayed messages.
+    /// Claim-level idempotency is enforced at the <see cref="ProcessedClaim"/>
+    /// store (unique on <c>(TenantId, ClaimId)</c>), not by a secondary index on
+    /// this column — the processed-claim marker is the single source of truth
+    /// so one claim can legitimately produce multiple event rows (e.g. a future
+    /// reversal). This field exists for audit / debugging queries.
     /// </summary>
     public string? SourceClaimId { get; set; }
 }

--- a/src/services/accumulator-service/Models/AccumulatorSnapshot.cs
+++ b/src/services/accumulator-service/Models/AccumulatorSnapshot.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace AccumulatorService.Models;
+
+/// <summary>
+/// Aggregated plan-year accumulator state for a member. One snapshot per
+/// (tenantId, memberId, planYearStart). Updated by ClaimFinalized events and
+/// manual adjustments; served by GET /api/v1/accumulators/{memberId}.
+///
+/// The snapshot is the current-state projection. The source of truth for the
+/// numbers is <see cref="AccumulatorEvent"/> — snapshot can be rebuilt by replay.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class AccumulatorSnapshot
+{
+    /// <summary>
+    /// Document id: "{tenantId}:{memberId}:{planYearStart:yyyyMMdd}". Chosen so
+    /// that retro claims for a prior plan year deterministically target the right
+    /// snapshot without a lookup step.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    public string MemberId { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime PlanYearStart { get; set; }
+
+    [Required]
+    public DateTime PlanYearEnd { get; set; }
+
+    public decimal IndividualDeductibleUsed { get; set; }
+    public decimal IndividualDeductibleLimit { get; set; }
+    public decimal FamilyDeductibleUsed { get; set; }
+    public decimal FamilyDeductibleLimit { get; set; }
+    public decimal IndividualOopUsed { get; set; }
+    public decimal IndividualOopLimit { get; set; }
+    public decimal FamilyOopUsed { get; set; }
+    public decimal FamilyOopLimit { get; set; }
+
+    public List<ServiceAccumulator> ServiceAccumulators { get; set; } = new();
+
+    /// <summary>Monotonic version counter. Incremented on every write; used for optimistic concurrency.</summary>
+    public long Version { get; set; }
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+    public DateTime LastUpdatedDate { get; set; } = DateTime.UtcNow;
+
+    public static string BuildId(string tenantId, string memberId, DateTime planYearStart) =>
+        $"{tenantId}:{memberId}:{planYearStart:yyyyMMdd}";
+}
+
+public class ServiceAccumulator
+{
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal Used { get; set; }
+    public decimal Limit { get; set; }
+
+    /// <summary>USD | Visits | Days | Units.</summary>
+    public string Unit { get; set; } = "USD";
+}

--- a/src/services/accumulator-service/Program.cs
+++ b/src/services/accumulator-service/Program.cs
@@ -1,0 +1,99 @@
+using AccumulatorService.Middleware;
+using AccumulatorService.Repositories;
+using AccumulatorService.Services;
+using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.HealthChecks;
+using Microsoft.Azure.Cosmos;
+using MongoDB.Driver;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSecretProvider(builder.Configuration);
+builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
+
+builder.Services.AddControllers(options =>
+{
+    options.Filters.Add<TenantActionFilter>();
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Title = "Cloud Health Office - Accumulator Service API",
+        Version = "v1",
+        Description = "Member plan-year accumulators (deductible / OOP / per-service). Snapshots driven by ClaimFinalized events and manual adjustments."
+    });
+});
+
+// ── Database ─────────────────────────────────────────────────────────
+// Mirrors eligibility-service's auto-detect pattern: Mongo if configured, else Cosmos.
+var mongoConnection = builder.Configuration["MongoDb:ConnectionString"];
+if (!string.IsNullOrWhiteSpace(mongoConnection))
+{
+    builder.Services.AddSingleton<IMongoClient>(_ => new MongoClient(mongoConnection));
+    builder.Services.AddScoped(sp =>
+    {
+        var client = sp.GetRequiredService<IMongoClient>();
+        var dbName = builder.Configuration["MongoDb:DatabaseName"] ?? "AccumulatorDB";
+        return client.GetDatabase(dbName);
+    });
+    builder.Services.AddScoped<IAccumulatorRepository, AccumulatorRepositoryMongo>();
+    builder.Services.AddScoped<IProcessedClaimStore, ProcessedClaimStoreMongo>();
+    Console.WriteLine("Using MongoDB database provider");
+}
+else
+{
+    var cosmosConnection = builder.Configuration["CosmosDb:ConnectionString"]
+        ?? throw new InvalidOperationException("Database connection not configured: set MongoDb:ConnectionString or CosmosDb:ConnectionString");
+
+    builder.Services.AddSingleton(_ => new CosmosClient(cosmosConnection, new CosmosClientOptions
+    {
+        SerializerOptions = new CosmosSerializationOptions
+        {
+            PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+        }
+    }));
+    builder.Services.AddScoped<IAccumulatorRepository, AccumulatorRepositoryCosmos>();
+    builder.Services.AddScoped<IProcessedClaimStore, ProcessedClaimStoreCosmos>();
+}
+
+// ── Domain service ───────────────────────────────────────────────────
+builder.Services.AddScoped<IAccumulatorService, AccumulatorService.Services.AccumulatorService>();
+
+// ── Kafka publisher + consumer ───────────────────────────────────────
+// Publisher registered as singleton IHostedService so StartAsync builds the
+// producer during app startup. Graceful degrade to no-op if Kafka is unavailable.
+builder.Services.AddSingleton<KafkaAccumulatorEventPublisher>();
+builder.Services.AddSingleton<IAccumulatorEventPublisher>(sp => sp.GetRequiredService<KafkaAccumulatorEventPublisher>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<KafkaAccumulatorEventPublisher>());
+builder.Services.AddHostedService<ClaimFinalizedConsumer>();
+
+builder.Services.AddCors(o => o.AddPolicy("AllowAll", p => p.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
+
+builder.Services.AddChoHealthChecks(options =>
+{
+    options.MongoDbConnectionString = builder.Configuration["MongoDb:ConnectionString"];
+    options.CosmosDbConnectionString = builder.Configuration["CosmosDb:ConnectionString"];
+    options.CosmosDbEndpoint = builder.Configuration["CosmosDb:Endpoint"];
+    options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Accumulator Service API v1"));
+}
+
+app.UseCors("AllowAll");
+app.UseTenantMiddleware();
+app.UseAuthorization();
+app.MapControllers();
+app.MapChoHealthChecks();
+
+app.Run();
+
+public partial class Program { }

--- a/src/services/accumulator-service/Repositories/AccumulatorRepositoryCosmos.cs
+++ b/src/services/accumulator-service/Repositories/AccumulatorRepositoryCosmos.cs
@@ -1,0 +1,154 @@
+using AccumulatorService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace AccumulatorService.Repositories;
+
+public class AccumulatorRepositoryCosmos : IAccumulatorRepository
+{
+    private readonly Container _snapshots;
+    private readonly Container _events;
+
+    public AccumulatorRepositoryCosmos(CosmosClient client)
+    {
+        var db = client.GetDatabase("CloudHealthOffice");
+        _snapshots = db.GetContainer("AccumulatorSnapshots");
+        _events = db.GetContainer("AccumulatorEvents");
+    }
+
+    public async Task<AccumulatorSnapshot?> GetSnapshotAsync(string tenantId, string memberId, DateTime planYearStart, CancellationToken ct = default)
+    {
+        var id = AccumulatorSnapshot.BuildId(tenantId, memberId, planYearStart);
+        try
+        {
+            var resp = await _snapshots.ReadItemAsync<AccumulatorSnapshot>(id, new PartitionKey(tenantId), cancellationToken: ct);
+            return resp.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<AccumulatorSnapshot?> GetSnapshotByAsOfDateAsync(string tenantId, string memberId, DateTime asOfDate, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                @"SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId
+                  AND c.planYearStart <= @asOf AND c.planYearEnd >= @asOf")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId)
+            .WithParameter("@asOf", asOfDate);
+
+        using var iter = _snapshots.GetItemQueryIterator<AccumulatorSnapshot>(query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iter.HasMoreResults)
+        {
+            var page = await iter.ReadNextAsync(ct);
+            return page.FirstOrDefault();
+        }
+        return null;
+    }
+
+    public async Task<IReadOnlyList<AccumulatorSnapshot>> GetSnapshotsAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId ORDER BY c.planYearStart DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+        var results = new List<AccumulatorSnapshot>();
+        using var iter = _snapshots.GetItemQueryIterator<AccumulatorSnapshot>(query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        while (iter.HasMoreResults)
+        {
+            var page = await iter.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    public async Task UpsertSnapshotAsync(AccumulatorSnapshot snapshot, CancellationToken ct = default)
+    {
+        snapshot.LastUpdatedDate = DateTime.UtcNow;
+        await _snapshots.UpsertItemAsync(snapshot, new PartitionKey(snapshot.TenantId), cancellationToken: ct);
+    }
+
+    public async Task AppendEventAsync(AccumulatorEvent evt, CancellationToken ct = default)
+    {
+        await _events.CreateItemAsync(evt, new PartitionKey(evt.TenantId), cancellationToken: ct);
+    }
+
+    public async Task<IReadOnlyList<AccumulatorEvent>> GetEventsAsync(string tenantId, string memberId, int take = 100, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                @"SELECT TOP @take * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId
+                  ORDER BY c.occurredAt DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId)
+            .WithParameter("@take", take);
+        var results = new List<AccumulatorEvent>();
+        using var iter = _events.GetItemQueryIterator<AccumulatorEvent>(query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        while (iter.HasMoreResults)
+        {
+            var page = await iter.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+}
+
+public class ProcessedClaimStoreCosmos : IProcessedClaimStore
+{
+    private readonly Container _col;
+
+    public ProcessedClaimStoreCosmos(CosmosClient client)
+    {
+        var db = client.GetDatabase("CloudHealthOffice");
+        _col = db.GetContainer("AccumulatorProcessedClaims");
+    }
+
+    public async Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var marker = new ProcessedClaim
+        {
+            Id = ProcessedClaim.BuildId(tenantId, claimId),
+            TenantId = tenantId,
+            ClaimId = claimId,
+            ProcessedAt = DateTime.UtcNow,
+            Outcome = "Pending"
+        };
+        try
+        {
+            await _col.CreateItemAsync(marker, new PartitionKey(tenantId), cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            return false;
+        }
+    }
+
+    public async Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default)
+    {
+        var id = ProcessedClaim.BuildId(tenantId, claimId);
+        var existing = await GetAsync(tenantId, claimId, ct);
+        if (existing is null) return;
+        existing.ResultingEventId = resultingEventId;
+        existing.Outcome = outcome;
+        existing.ProcessedAt = DateTime.UtcNow;
+        await _col.UpsertItemAsync(existing, new PartitionKey(tenantId), cancellationToken: ct);
+    }
+
+    public async Task<ProcessedClaim?> GetAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var id = ProcessedClaim.BuildId(tenantId, claimId);
+        try
+        {
+            var resp = await _col.ReadItemAsync<ProcessedClaim>(id, new PartitionKey(tenantId), cancellationToken: ct);
+            return resp.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}

--- a/src/services/accumulator-service/Repositories/AccumulatorRepositoryCosmos.cs
+++ b/src/services/accumulator-service/Repositories/AccumulatorRepositoryCosmos.cs
@@ -94,6 +94,23 @@ public class AccumulatorRepositoryCosmos : IAccumulatorRepository
         }
         return results;
     }
+
+    public async Task<AccumulatorEvent?> GetManualAdjustmentAsync(string tenantId, string adjustmentId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                @"SELECT TOP 1 * FROM c WHERE c.tenantId = @tenantId
+                  AND c.eventType = 'ManualAdjustment' AND c.sourceReference = @adjustmentId")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@adjustmentId", adjustmentId);
+        using var iter = _events.GetItemQueryIterator<AccumulatorEvent>(query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iter.HasMoreResults)
+        {
+            var page = await iter.ReadNextAsync(ct);
+            return page.FirstOrDefault();
+        }
+        return null;
+    }
 }
 
 public class ProcessedClaimStoreCosmos : IProcessedClaimStore
@@ -106,7 +123,7 @@ public class ProcessedClaimStoreCosmos : IProcessedClaimStore
         _col = db.GetContainer("AccumulatorProcessedClaims");
     }
 
-    public async Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    public async Task<BeginClaimOutcome> TryBeginAsync(string tenantId, string claimId, CancellationToken ct = default)
     {
         var marker = new ProcessedClaim
         {
@@ -119,11 +136,18 @@ public class ProcessedClaimStoreCosmos : IProcessedClaimStore
         try
         {
             await _col.CreateItemAsync(marker, new PartitionKey(tenantId), cancellationToken: ct);
-            return true;
+            return BeginClaimOutcome.Proceed;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
         {
-            return false;
+            // See Mongo implementation: Pending marker means a prior attempt
+            // crashed mid-flight and this call should retry the apply, not skip.
+            var existing = await GetAsync(tenantId, claimId, ct);
+            if (existing is null || string.Equals(existing.Outcome, "Pending", StringComparison.Ordinal))
+            {
+                return BeginClaimOutcome.Proceed;
+            }
+            return BeginClaimOutcome.AlreadyApplied;
         }
     }
 

--- a/src/services/accumulator-service/Repositories/AccumulatorRepositoryMongo.cs
+++ b/src/services/accumulator-service/Repositories/AccumulatorRepositoryMongo.cs
@@ -96,6 +96,15 @@ public class AccumulatorRepositoryMongo : IAccumulatorRepository
             .Limit(take)
             .ToListAsync(ct);
     }
+
+    public async Task<AccumulatorEvent?> GetManualAdjustmentAsync(string tenantId, string adjustmentId, CancellationToken ct = default)
+    {
+        var filter = Builders<AccumulatorEvent>.Filter.And(
+            Builders<AccumulatorEvent>.Filter.Eq(e => e.TenantId, tenantId),
+            Builders<AccumulatorEvent>.Filter.Eq(e => e.EventType, "ManualAdjustment"),
+            Builders<AccumulatorEvent>.Filter.Eq(e => e.SourceReference, adjustmentId));
+        return await _events.Find(filter).FirstOrDefaultAsync(ct);
+    }
 }
 
 public class ProcessedClaimStoreMongo : IProcessedClaimStore
@@ -111,7 +120,7 @@ public class ProcessedClaimStoreMongo : IProcessedClaimStore
             new CreateIndexOptions { Unique = true }));
     }
 
-    public async Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    public async Task<BeginClaimOutcome> TryBeginAsync(string tenantId, string claimId, CancellationToken ct = default)
     {
         var id = ProcessedClaim.BuildId(tenantId, claimId);
         var marker = new ProcessedClaim
@@ -125,11 +134,19 @@ public class ProcessedClaimStoreMongo : IProcessedClaimStore
         try
         {
             await _col.InsertOneAsync(marker, cancellationToken: ct);
-            return true;
+            return BeginClaimOutcome.Proceed;
         }
         catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
-            return false;
+            // Marker already exists. Only treat as duplicate if a prior attempt
+            // reached a terminal outcome; Pending means an earlier attempt crashed
+            // mid-flight and the caller may retry.
+            var existing = await GetAsync(tenantId, claimId, ct);
+            if (existing is null || string.Equals(existing.Outcome, "Pending", StringComparison.Ordinal))
+            {
+                return BeginClaimOutcome.Proceed;
+            }
+            return BeginClaimOutcome.AlreadyApplied;
         }
     }
 

--- a/src/services/accumulator-service/Repositories/AccumulatorRepositoryMongo.cs
+++ b/src/services/accumulator-service/Repositories/AccumulatorRepositoryMongo.cs
@@ -1,0 +1,157 @@
+using AccumulatorService.Models;
+using MongoDB.Driver;
+
+namespace AccumulatorService.Repositories;
+
+public class AccumulatorRepositoryMongo : IAccumulatorRepository
+{
+    private readonly IMongoCollection<AccumulatorSnapshot> _snapshots;
+    private readonly IMongoCollection<AccumulatorEvent> _events;
+
+    public AccumulatorRepositoryMongo(IMongoDatabase database)
+    {
+        _snapshots = database.GetCollection<AccumulatorSnapshot>("AccumulatorSnapshots");
+        _events = database.GetCollection<AccumulatorEvent>("AccumulatorEvents");
+        EnsureIndexes();
+    }
+
+    private void EnsureIndexes()
+    {
+        var snapKeys = Builders<AccumulatorSnapshot>.IndexKeys;
+        _snapshots.Indexes.CreateMany(new[]
+        {
+            new CreateIndexModel<AccumulatorSnapshot>(
+                snapKeys.Ascending(s => s.TenantId).Ascending(s => s.MemberId).Descending(s => s.PlanYearStart)),
+            new CreateIndexModel<AccumulatorSnapshot>(
+                snapKeys.Ascending(s => s.TenantId).Ascending(s => s.Id),
+                new CreateIndexOptions { Unique = true })
+        });
+
+        var evtKeys = Builders<AccumulatorEvent>.IndexKeys;
+        _events.Indexes.CreateMany(new[]
+        {
+            // Wire-level de-dup. (tenantId, eventId) must be globally unique.
+            new CreateIndexModel<AccumulatorEvent>(
+                evtKeys.Ascending(e => e.TenantId).Ascending(e => e.EventId),
+                new CreateIndexOptions { Unique = true }),
+            // Per-aggregate ordering. (tenantId, aggregateId, version) must be unique.
+            new CreateIndexModel<AccumulatorEvent>(
+                evtKeys.Ascending(e => e.TenantId).Ascending(e => e.AggregateId).Ascending(e => e.Version),
+                new CreateIndexOptions { Unique = true }),
+            new CreateIndexModel<AccumulatorEvent>(
+                evtKeys.Ascending(e => e.TenantId).Ascending(e => e.MemberId).Descending(e => e.OccurredAt))
+        });
+    }
+
+    public async Task<AccumulatorSnapshot?> GetSnapshotAsync(string tenantId, string memberId, DateTime planYearStart, CancellationToken ct = default)
+    {
+        var id = AccumulatorSnapshot.BuildId(tenantId, memberId, planYearStart);
+        var filter = Builders<AccumulatorSnapshot>.Filter.And(
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.TenantId, tenantId),
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.Id, id));
+        return await _snapshots.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<AccumulatorSnapshot?> GetSnapshotByAsOfDateAsync(string tenantId, string memberId, DateTime asOfDate, CancellationToken ct = default)
+    {
+        var filter = Builders<AccumulatorSnapshot>.Filter.And(
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.TenantId, tenantId),
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.MemberId, memberId),
+            Builders<AccumulatorSnapshot>.Filter.Lte(s => s.PlanYearStart, asOfDate),
+            Builders<AccumulatorSnapshot>.Filter.Gte(s => s.PlanYearEnd, asOfDate));
+        return await _snapshots.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<AccumulatorSnapshot>> GetSnapshotsAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var filter = Builders<AccumulatorSnapshot>.Filter.And(
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.TenantId, tenantId),
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.MemberId, memberId));
+        return await _snapshots.Find(filter)
+            .SortByDescending(s => s.PlanYearStart)
+            .ToListAsync(ct);
+    }
+
+    public async Task UpsertSnapshotAsync(AccumulatorSnapshot snapshot, CancellationToken ct = default)
+    {
+        snapshot.LastUpdatedDate = DateTime.UtcNow;
+        var filter = Builders<AccumulatorSnapshot>.Filter.And(
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.TenantId, snapshot.TenantId),
+            Builders<AccumulatorSnapshot>.Filter.Eq(s => s.Id, snapshot.Id));
+        await _snapshots.ReplaceOneAsync(filter, snapshot, new ReplaceOptions { IsUpsert = true }, ct);
+    }
+
+    public async Task AppendEventAsync(AccumulatorEvent evt, CancellationToken ct = default)
+    {
+        await _events.InsertOneAsync(evt, cancellationToken: ct);
+    }
+
+    public async Task<IReadOnlyList<AccumulatorEvent>> GetEventsAsync(string tenantId, string memberId, int take = 100, CancellationToken ct = default)
+    {
+        var filter = Builders<AccumulatorEvent>.Filter.And(
+            Builders<AccumulatorEvent>.Filter.Eq(e => e.TenantId, tenantId),
+            Builders<AccumulatorEvent>.Filter.Eq(e => e.MemberId, memberId));
+        return await _events.Find(filter)
+            .SortByDescending(e => e.OccurredAt)
+            .Limit(take)
+            .ToListAsync(ct);
+    }
+}
+
+public class ProcessedClaimStoreMongo : IProcessedClaimStore
+{
+    private readonly IMongoCollection<ProcessedClaim> _col;
+
+    public ProcessedClaimStoreMongo(IMongoDatabase database)
+    {
+        _col = database.GetCollection<ProcessedClaim>("AccumulatorProcessedClaims");
+        var keys = Builders<ProcessedClaim>.IndexKeys;
+        _col.Indexes.CreateOne(new CreateIndexModel<ProcessedClaim>(
+            keys.Ascending(p => p.TenantId).Ascending(p => p.ClaimId),
+            new CreateIndexOptions { Unique = true }));
+    }
+
+    public async Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var id = ProcessedClaim.BuildId(tenantId, claimId);
+        var marker = new ProcessedClaim
+        {
+            Id = id,
+            TenantId = tenantId,
+            ClaimId = claimId,
+            ProcessedAt = DateTime.UtcNow,
+            Outcome = "Pending"
+        };
+        try
+        {
+            await _col.InsertOneAsync(marker, cancellationToken: ct);
+            return true;
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default)
+    {
+        var id = ProcessedClaim.BuildId(tenantId, claimId);
+        var filter = Builders<ProcessedClaim>.Filter.And(
+            Builders<ProcessedClaim>.Filter.Eq(p => p.TenantId, tenantId),
+            Builders<ProcessedClaim>.Filter.Eq(p => p.Id, id));
+        var update = Builders<ProcessedClaim>.Update
+            .Set(p => p.ResultingEventId, resultingEventId)
+            .Set(p => p.Outcome, outcome)
+            .Set(p => p.ProcessedAt, DateTime.UtcNow);
+        await _col.UpdateOneAsync(filter, update, cancellationToken: ct);
+    }
+
+    public async Task<ProcessedClaim?> GetAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var id = ProcessedClaim.BuildId(tenantId, claimId);
+        var filter = Builders<ProcessedClaim>.Filter.And(
+            Builders<ProcessedClaim>.Filter.Eq(p => p.TenantId, tenantId),
+            Builders<ProcessedClaim>.Filter.Eq(p => p.Id, id));
+        return await _col.Find(filter).FirstOrDefaultAsync(ct);
+    }
+}

--- a/src/services/accumulator-service/Repositories/IAccumulatorRepository.cs
+++ b/src/services/accumulator-service/Repositories/IAccumulatorRepository.cs
@@ -1,0 +1,44 @@
+using AccumulatorService.Models;
+
+namespace AccumulatorService.Repositories;
+
+/// <summary>
+/// Persistence boundary for accumulator state. Split into two repositories by
+/// aggregate (Snapshot vs Event) so the event stream can grow independently of
+/// the snapshot read model. Both implementations (Mongo, Cosmos) partition by
+/// tenantId.
+/// </summary>
+public interface IAccumulatorRepository
+{
+    Task<AccumulatorSnapshot?> GetSnapshotAsync(string tenantId, string memberId, DateTime planYearStart, CancellationToken ct = default);
+
+    /// <summary>Snapshot covering the given as-of date, by plan year. Returns null when no matching snapshot exists.</summary>
+    Task<AccumulatorSnapshot?> GetSnapshotByAsOfDateAsync(string tenantId, string memberId, DateTime asOfDate, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccumulatorSnapshot>> GetSnapshotsAsync(string tenantId, string memberId, CancellationToken ct = default);
+
+    Task UpsertSnapshotAsync(AccumulatorSnapshot snapshot, CancellationToken ct = default);
+
+    Task AppendEventAsync(AccumulatorEvent evt, CancellationToken ct = default);
+
+    Task<IReadOnlyList<AccumulatorEvent>> GetEventsAsync(string tenantId, string memberId, int take = 100, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Idempotency store for ClaimFinalized processing. Upsert-then-check on the
+/// unique (tenantId, claimId) key — duplicate-claim detection is race-free.
+/// </summary>
+public interface IProcessedClaimStore
+{
+    /// <summary>
+    /// Attempt to mark a claim as processed. Returns true when the marker was
+    /// newly inserted (apply should proceed); false when the claim was already
+    /// applied (consumer should skip). ResultingEventId is populated later by
+    /// <see cref="CompleteAsync"/>.
+    /// </summary>
+    Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default);
+
+    Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default);
+
+    Task<ProcessedClaim?> GetAsync(string tenantId, string claimId, CancellationToken ct = default);
+}

--- a/src/services/accumulator-service/Repositories/IAccumulatorRepository.cs
+++ b/src/services/accumulator-service/Repositories/IAccumulatorRepository.cs
@@ -22,23 +22,44 @@ public interface IAccumulatorRepository
     Task AppendEventAsync(AccumulatorEvent evt, CancellationToken ct = default);
 
     Task<IReadOnlyList<AccumulatorEvent>> GetEventsAsync(string tenantId, string memberId, int take = 100, CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up a prior <c>ManualAdjustment</c> event by its caller-supplied
+    /// <c>AdjustmentId</c>. Used by <c>AdjustAsync</c> to make client-provided
+    /// adjustment ids idempotent: a retry returns the existing snapshot rather
+    /// than attempting a second apply that would 500 on the unique index.
+    /// Returns null when no prior adjustment exists.
+    /// </summary>
+    Task<AccumulatorEvent?> GetManualAdjustmentAsync(string tenantId, string adjustmentId, CancellationToken ct = default);
 }
 
 /// <summary>
-/// Idempotency store for ClaimFinalized processing. Upsert-then-check on the
-/// unique (tenantId, claimId) key — duplicate-claim detection is race-free.
+/// Two-phase idempotency store for ClaimFinalized processing. A claim goes
+/// Pending → Applied | OrphanSkipped. The lease-style design means a failure
+/// between the begin-marker insert and the final CompleteAsync (DB or Kafka
+/// hiccup) does NOT permanently mark the claim deduped — the next redelivery
+/// sees a Pending marker and re-enters the apply path. Only a terminal
+/// (Applied / OrphanSkipped) marker causes a skip.
 /// </summary>
 public interface IProcessedClaimStore
 {
     /// <summary>
-    /// Attempt to mark a claim as processed. Returns true when the marker was
-    /// newly inserted (apply should proceed); false when the claim was already
-    /// applied (consumer should skip). ResultingEventId is populated later by
-    /// <see cref="CompleteAsync"/>.
+    /// Outcome of attempting to begin processing a claim.
+    ///
+    /// <list type="bullet">
+    ///   <item><description><c>Proceed</c>: caller owns the lease and should apply. Either the marker did not exist or an earlier attempt crashed before completing — the existing Pending row is treated as available for retry.</description></item>
+    ///   <item><description><c>AlreadyApplied</c>: a prior call completed successfully. Caller must skip.</description></item>
+    /// </list>
     /// </summary>
-    Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default);
+    Task<BeginClaimOutcome> TryBeginAsync(string tenantId, string claimId, CancellationToken ct = default);
 
     Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default);
 
     Task<ProcessedClaim?> GetAsync(string tenantId, string claimId, CancellationToken ct = default);
+}
+
+public enum BeginClaimOutcome
+{
+    Proceed,
+    AlreadyApplied
 }

--- a/src/services/accumulator-service/Services/AccumulatorService.cs
+++ b/src/services/accumulator-service/Services/AccumulatorService.cs
@@ -1,0 +1,402 @@
+using AccumulatorService.Models;
+using AccumulatorService.Repositories;
+using CloudHealthOffice.Events;
+
+namespace AccumulatorService.Services;
+
+/// <summary>
+/// Accumulator domain service. Owns two mutations:
+///
+///   1. <see cref="ApplyClaimFinalizedAsync"/> — idempotent, driven by Kafka.
+///      Selects the snapshot by ServiceDate's plan year (NOT today's date) so a
+///      retro-finalized claim from six months ago lands in the correct prior-year
+///      bucket. If no snapshot covers the service date, emits an
+///      OrphanAccumulatorClaim signal and skips — data-quality alert, not silent drop.
+///
+///   2. <see cref="AdjustAsync"/> — manual override by an authorized operator.
+///      Every adjustment writes an AccumulatorEvent (audit) and publishes an
+///      AccumulatorAdjustedEvent.
+///
+/// Snapshot mutations go through the event store: append the event first, then
+/// project to the snapshot. Snapshot Version is bumped in lockstep with
+/// AccumulatorEvent.Version so the two stay consistent under replay.
+/// </summary>
+public class AccumulatorService : IAccumulatorService
+{
+    private readonly IAccumulatorRepository _repo;
+    private readonly IProcessedClaimStore _processed;
+    private readonly IAccumulatorEventPublisher _publisher;
+    private readonly ILogger<AccumulatorService> _logger;
+
+    public AccumulatorService(
+        IAccumulatorRepository repo,
+        IProcessedClaimStore processed,
+        IAccumulatorEventPublisher publisher,
+        ILogger<AccumulatorService> logger)
+    {
+        _repo = repo;
+        _processed = processed;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    public async Task<AccumulatorResponse?> GetAsync(string tenantId, string memberId, DateTime? asOfDate, CancellationToken ct = default)
+    {
+        var target = asOfDate ?? DateTime.UtcNow.Date;
+        var snapshot = await _repo.GetSnapshotByAsOfDateAsync(tenantId, memberId, target, ct);
+        if (snapshot is null) return null;
+
+        var recent = await _repo.GetEventsAsync(tenantId, memberId, take: 20, ct);
+        return ToResponse(snapshot, recent);
+    }
+
+    public async Task<AccumulatorHistoryResponse> GetHistoryAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var snapshots = await _repo.GetSnapshotsAsync(tenantId, memberId, ct);
+        var events = await _repo.GetEventsAsync(tenantId, memberId, take: 200, ct);
+        return new AccumulatorHistoryResponse
+        {
+            MemberId = memberId,
+            Snapshots = snapshots.Select(s => new AccumulatorSnapshotSummary
+            {
+                PlanYearStart = s.PlanYearStart,
+                PlanYearEnd = s.PlanYearEnd,
+                IndividualDeductibleUsed = s.IndividualDeductibleUsed,
+                IndividualDeductibleLimit = s.IndividualDeductibleLimit,
+                IndividualOopUsed = s.IndividualOopUsed,
+                IndividualOopLimit = s.IndividualOopLimit,
+                Version = s.Version,
+                LastUpdatedDate = s.LastUpdatedDate
+            }).ToList(),
+            Events = events.Select(ToActivity).ToList()
+        };
+    }
+
+    public async Task<ApplyResult> ApplyClaimFinalizedAsync(ClaimFinalizedEvent evt, CancellationToken ct = default)
+    {
+        // Idempotency — upsert-then-check on (tenantId, claimId). The same claimId
+        // is the dedupe key even across regenerated EventIds (re-finalization of
+        // the same claim must not double-count).
+        var claimed = await _processed.TryClaimAsync(evt.TenantId, evt.ClaimId, ct);
+        if (!claimed)
+        {
+            _logger.LogInformation(
+                "ClaimFinalizedEvent for claim {ClaimId} tenant {TenantId} is a duplicate; skipping",
+                SanitizeForLog(evt.ClaimId), SanitizeForLog(evt.TenantId));
+            return new ApplyResult(ApplyOutcome.Duplicate, null, null, "DuplicateClaim");
+        }
+
+        // Select snapshot by ServiceDate, not AdjudicationTimestamp or today.
+        // A claim finalized today for a service date six months ago belongs in the
+        // plan year that contained the service date.
+        var snapshot = await ResolveSnapshotAsync(evt, ct);
+        if (snapshot is null)
+        {
+            _logger.LogWarning(
+                "Orphan claim: ServiceDate {ServiceDate} does not map to any known plan-year snapshot for member {MemberId} tenant {TenantId}. ClaimId={ClaimId}",
+                evt.ServiceDate, SanitizeForLog(evt.MemberId), SanitizeForLog(evt.TenantId), SanitizeForLog(evt.ClaimId));
+
+            await _publisher.PublishOrphanAsync(new OrphanAccumulatorClaimEvent
+            {
+                TenantId = evt.TenantId,
+                MemberId = evt.MemberId,
+                ClaimId = evt.ClaimId,
+                ClaimNumber = evt.ClaimNumber,
+                ServiceDate = evt.ServiceDate,
+                Reason = "No AccumulatorSnapshot matches ServiceDate plan year"
+            }, ct);
+
+            await _processed.CompleteAsync(evt.TenantId, evt.ClaimId, resultingEventId: string.Empty, outcome: "OrphanSkipped", ct);
+            return new ApplyResult(ApplyOutcome.Orphan, null, null, "OrphanServiceDate");
+        }
+
+        var (deductibleDelta, oopDelta, serviceDeltas) = ComputeDeltas(evt);
+        var familyDeductibleDelta = evt.IsFamilyAggregate ? deductibleDelta : 0m;
+        var familyOopDelta = evt.IsFamilyAggregate ? oopDelta : 0m;
+
+        snapshot.IndividualDeductibleUsed = Clamp(snapshot.IndividualDeductibleUsed + deductibleDelta, snapshot.IndividualDeductibleLimit);
+        snapshot.IndividualOopUsed = Clamp(snapshot.IndividualOopUsed + oopDelta, snapshot.IndividualOopLimit);
+        snapshot.FamilyDeductibleUsed = Clamp(snapshot.FamilyDeductibleUsed + familyDeductibleDelta, snapshot.FamilyDeductibleLimit);
+        snapshot.FamilyOopUsed = Clamp(snapshot.FamilyOopUsed + familyOopDelta, snapshot.FamilyOopLimit);
+        ApplyServiceDeltas(snapshot, serviceDeltas);
+        snapshot.Version += 1;
+
+        var auditEvent = new AccumulatorEvent
+        {
+            TenantId = evt.TenantId,
+            EventId = evt.EventId, // preserve wire id for de-dup
+            AggregateId = snapshot.Id,
+            Version = snapshot.Version,
+            MemberId = evt.MemberId,
+            PlanYearStart = snapshot.PlanYearStart,
+            PlanYearEnd = snapshot.PlanYearEnd,
+            EventType = "ClaimApplied",
+            SourceReference = evt.ClaimId,
+            SourceClaimId = evt.ClaimId,
+            ActorId = "system",
+            DeductibleDelta = deductibleDelta,
+            OopDelta = oopDelta,
+            FamilyDeductibleDelta = familyDeductibleDelta,
+            FamilyOopDelta = familyOopDelta,
+            ServiceDeltas = serviceDeltas.Select(d => new ServiceAccumulatorDeltaRow
+            {
+                BenefitCategory = d.BenefitCategory,
+                UsedDelta = d.UsedDelta,
+                Unit = d.Unit
+            }).ToList(),
+            OccurredAt = evt.OccurredAt.UtcDateTime
+        };
+
+        await _repo.AppendEventAsync(auditEvent, ct);
+        await _repo.UpsertSnapshotAsync(snapshot, ct);
+        await _processed.CompleteAsync(evt.TenantId, evt.ClaimId, auditEvent.Id, "Applied", ct);
+
+        await _publisher.PublishAdjustedAsync(new AccumulatorAdjustedEvent
+        {
+            TenantId = evt.TenantId,
+            MemberId = evt.MemberId,
+            PlanYearStart = snapshot.PlanYearStart,
+            PlanYearEnd = snapshot.PlanYearEnd,
+            AdjustmentSource = "ClaimApplied",
+            SourceReference = evt.ClaimId,
+            ActorId = "system",
+            DeductibleDelta = deductibleDelta,
+            OopDelta = oopDelta,
+            FamilyDeductibleDelta = familyDeductibleDelta,
+            FamilyOopDelta = familyOopDelta,
+            ServiceDeltas = serviceDeltas
+        }, ct);
+
+        return new ApplyResult(ApplyOutcome.Applied, snapshot, auditEvent.Id, null);
+    }
+
+    public async Task<AccumulatorAdjustmentResponse> AdjustAsync(string tenantId, string memberId, AccumulatorAdjustmentRequest request, CancellationToken ct = default)
+    {
+        var snapshot = await _repo.GetSnapshotAsync(tenantId, memberId, request.PlanYearStart, ct)
+            ?? new AccumulatorSnapshot
+            {
+                Id = AccumulatorSnapshot.BuildId(tenantId, memberId, request.PlanYearStart),
+                TenantId = tenantId,
+                MemberId = memberId,
+                PlanYearStart = request.PlanYearStart,
+                PlanYearEnd = request.PlanYearEnd
+            };
+
+        snapshot.IndividualDeductibleUsed = Math.Max(0m, snapshot.IndividualDeductibleUsed + request.DeductibleDelta);
+        snapshot.IndividualOopUsed = Math.Max(0m, snapshot.IndividualOopUsed + request.OopDelta);
+        snapshot.FamilyDeductibleUsed = Math.Max(0m, snapshot.FamilyDeductibleUsed + request.FamilyDeductibleDelta);
+        snapshot.FamilyOopUsed = Math.Max(0m, snapshot.FamilyOopUsed + request.FamilyOopDelta);
+
+        foreach (var s in request.ServiceDeltas)
+        {
+            ApplyOneServiceDelta(snapshot, s.BenefitCategory, s.UsedDelta, s.Unit);
+        }
+        snapshot.Version += 1;
+
+        var adjustmentId = request.AdjustmentId ?? Guid.NewGuid().ToString();
+        var auditEvent = new AccumulatorEvent
+        {
+            TenantId = tenantId,
+            EventId = adjustmentId,
+            AggregateId = snapshot.Id,
+            Version = snapshot.Version,
+            MemberId = memberId,
+            PlanYearStart = snapshot.PlanYearStart,
+            PlanYearEnd = snapshot.PlanYearEnd,
+            EventType = "ManualAdjustment",
+            SourceReference = adjustmentId,
+            ActorId = request.ActorId,
+            Reason = request.Reason,
+            DeductibleDelta = request.DeductibleDelta,
+            OopDelta = request.OopDelta,
+            FamilyDeductibleDelta = request.FamilyDeductibleDelta,
+            FamilyOopDelta = request.FamilyOopDelta,
+            ServiceDeltas = request.ServiceDeltas.Select(d => new ServiceAccumulatorDeltaRow
+            {
+                BenefitCategory = d.BenefitCategory,
+                UsedDelta = d.UsedDelta,
+                Unit = d.Unit
+            }).ToList()
+        };
+
+        await _repo.AppendEventAsync(auditEvent, ct);
+        await _repo.UpsertSnapshotAsync(snapshot, ct);
+
+        await _publisher.PublishAdjustedAsync(new AccumulatorAdjustedEvent
+        {
+            TenantId = tenantId,
+            MemberId = memberId,
+            PlanYearStart = snapshot.PlanYearStart,
+            PlanYearEnd = snapshot.PlanYearEnd,
+            AdjustmentSource = "ManualAdjustment",
+            SourceReference = adjustmentId,
+            ActorId = request.ActorId,
+            Reason = request.Reason,
+            DeductibleDelta = request.DeductibleDelta,
+            OopDelta = request.OopDelta,
+            FamilyDeductibleDelta = request.FamilyDeductibleDelta,
+            FamilyOopDelta = request.FamilyOopDelta,
+            ServiceDeltas = request.ServiceDeltas.Select(d => new ServiceAccumulatorDelta
+            {
+                BenefitCategory = d.BenefitCategory,
+                UsedDelta = d.UsedDelta,
+                Unit = d.Unit
+            }).ToList()
+        }, ct);
+
+        return new AccumulatorAdjustmentResponse { AdjustmentId = adjustmentId, Snapshot = snapshot };
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private async Task<AccumulatorSnapshot?> ResolveSnapshotAsync(ClaimFinalizedEvent evt, CancellationToken ct)
+    {
+        // Prefer the snapshot that explicitly covers the service date; fall back to
+        // one keyed by the event's PlanYearStart if both exist (producer may have
+        // pre-resolved the plan year).
+        var byServiceDate = await _repo.GetSnapshotByAsOfDateAsync(evt.TenantId, evt.MemberId, evt.ServiceDate, ct);
+        if (byServiceDate is not null) return byServiceDate;
+
+        if (evt.PlanYearStart != default)
+        {
+            var byKey = await _repo.GetSnapshotAsync(evt.TenantId, evt.MemberId, evt.PlanYearStart, ct);
+            if (byKey is not null) return byKey;
+
+            // Producer-asserted plan year but no snapshot yet — create an empty
+            // snapshot to hold the amounts rather than dropping them as orphan.
+            // Limits default to zero; benefit-plan-service will hydrate limits
+            // later via a separate workflow.
+            if (evt.PlanYearStart <= evt.ServiceDate && evt.PlanYearEnd >= evt.ServiceDate)
+            {
+                var fresh = new AccumulatorSnapshot
+                {
+                    Id = AccumulatorSnapshot.BuildId(evt.TenantId, evt.MemberId, evt.PlanYearStart),
+                    TenantId = evt.TenantId,
+                    MemberId = evt.MemberId,
+                    PlanYearStart = evt.PlanYearStart,
+                    PlanYearEnd = evt.PlanYearEnd
+                };
+                return fresh;
+            }
+        }
+
+        return null;
+    }
+
+    private static (decimal deductible, decimal oop, List<ServiceAccumulatorDelta> services) ComputeDeltas(ClaimFinalizedEvent evt)
+    {
+        // Prefer per-line amounts when present — they let us attribute to multiple
+        // benefit categories from a single claim. Fall back to claim-level when
+        // the producer didn't populate lines.
+        if (evt.LineItems.Count > 0)
+        {
+            var deductible = evt.LineItems.Sum(l => l.DeductibleApplied);
+            var oop = evt.LineItems.Sum(l => l.OopApplied);
+            var services = evt.LineItems
+                .GroupBy(l => string.IsNullOrWhiteSpace(l.BenefitCategory) ? evt.BenefitCategory : l.BenefitCategory)
+                .Where(g => !string.IsNullOrWhiteSpace(g.Key))
+                .Select(g => new ServiceAccumulatorDelta
+                {
+                    BenefitCategory = g.Key,
+                    UsedDelta = g.Sum(l => l.DeductibleApplied + l.CoinsuranceApplied + l.CopayApplied),
+                    Unit = "USD"
+                })
+                .ToList();
+            return (deductible, oop, services);
+        }
+
+        var categoryRollup = new List<ServiceAccumulatorDelta>();
+        if (!string.IsNullOrWhiteSpace(evt.BenefitCategory))
+        {
+            categoryRollup.Add(new ServiceAccumulatorDelta
+            {
+                BenefitCategory = evt.BenefitCategory,
+                UsedDelta = evt.DeductibleApplied + evt.CoinsuranceApplied + evt.CopayApplied,
+                Unit = "USD"
+            });
+        }
+        return (evt.DeductibleApplied, evt.OopApplied, categoryRollup);
+    }
+
+    private static void ApplyServiceDeltas(AccumulatorSnapshot snapshot, List<ServiceAccumulatorDelta> deltas)
+    {
+        foreach (var d in deltas)
+        {
+            ApplyOneServiceDelta(snapshot, d.BenefitCategory, d.UsedDelta, d.Unit);
+        }
+    }
+
+    private static void ApplyOneServiceDelta(AccumulatorSnapshot snapshot, string category, decimal used, string unit)
+    {
+        if (string.IsNullOrWhiteSpace(category)) return;
+        var existing = snapshot.ServiceAccumulators.FirstOrDefault(s =>
+            string.Equals(s.BenefitCategory, category, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+        {
+            snapshot.ServiceAccumulators.Add(new ServiceAccumulator
+            {
+                BenefitCategory = category,
+                Used = Math.Max(0m, used),
+                Unit = unit
+            });
+            return;
+        }
+        existing.Used = Math.Max(0m, existing.Used + used);
+    }
+
+    /// <summary>
+    /// OOP/deductible counters are always ≥ 0 and, when a limit is set, ≤ the limit.
+    /// Exceeding the limit is a legitimate edge (retro-finalize + coverage change),
+    /// so we cap rather than reject. Anything truly anomalous surfaces in the event
+    /// stream at full fidelity — the snapshot is a projection, the event store is truth.
+    /// </summary>
+    private static decimal Clamp(decimal value, decimal limit)
+    {
+        if (value < 0m) return 0m;
+        if (limit > 0m && value > limit) return limit;
+        return value;
+    }
+
+    private static AccumulatorResponse ToResponse(AccumulatorSnapshot s, IReadOnlyList<AccumulatorEvent> recent) => new()
+    {
+        MemberId = s.MemberId,
+        PlanYearStart = s.PlanYearStart,
+        PlanYearEnd = s.PlanYearEnd,
+        IndividualDeductibleUsed = s.IndividualDeductibleUsed,
+        IndividualDeductibleLimit = s.IndividualDeductibleLimit,
+        FamilyDeductibleUsed = s.FamilyDeductibleUsed,
+        FamilyDeductibleLimit = s.FamilyDeductibleLimit,
+        IndividualOopUsed = s.IndividualOopUsed,
+        IndividualOopLimit = s.IndividualOopLimit,
+        FamilyOopUsed = s.FamilyOopUsed,
+        FamilyOopLimit = s.FamilyOopLimit,
+        ServiceAccumulators = s.ServiceAccumulators.Select(a => new ServiceAccumulatorDto
+        {
+            BenefitCategory = a.BenefitCategory,
+            Used = a.Used,
+            Limit = a.Limit,
+            Unit = a.Unit
+        }).ToList(),
+        RecentActivity = recent.Select(ToActivity).ToList()
+    };
+
+    private static AccumulatorActivityDto ToActivity(AccumulatorEvent e) => new()
+    {
+        EventId = e.EventId,
+        EventType = e.EventType,
+        SourceReference = e.SourceReference,
+        OccurredAt = e.OccurredAt,
+        DeductibleDelta = e.DeductibleDelta,
+        OopDelta = e.OopDelta,
+        FamilyDeductibleDelta = e.FamilyDeductibleDelta,
+        FamilyOopDelta = e.FamilyOopDelta,
+        Reason = e.Reason,
+        ActorId = e.ActorId
+    };
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/accumulator-service/Services/AccumulatorService.cs
+++ b/src/services/accumulator-service/Services/AccumulatorService.cs
@@ -74,14 +74,16 @@ public class AccumulatorService : IAccumulatorService
 
     public async Task<ApplyResult> ApplyClaimFinalizedAsync(ClaimFinalizedEvent evt, CancellationToken ct = default)
     {
-        // Idempotency — upsert-then-check on (tenantId, claimId). The same claimId
-        // is the dedupe key even across regenerated EventIds (re-finalization of
-        // the same claim must not double-count).
-        var claimed = await _processed.TryClaimAsync(evt.TenantId, evt.ClaimId, ct);
-        if (!claimed)
+        // Two-phase idempotency — (tenantId, claimId) is the dedupe key even across
+        // regenerated EventIds (re-finalization must not double-count). A Pending
+        // marker from a crashed prior attempt does NOT block retry: TryBeginAsync
+        // returns Proceed in that case so we don't permanently skip on transient
+        // failures between the begin-marker and the final CompleteAsync.
+        var begin = await _processed.TryBeginAsync(evt.TenantId, evt.ClaimId, ct);
+        if (begin == BeginClaimOutcome.AlreadyApplied)
         {
             _logger.LogInformation(
-                "ClaimFinalizedEvent for claim {ClaimId} tenant {TenantId} is a duplicate; skipping",
+                "ClaimFinalizedEvent for claim {ClaimId} tenant {TenantId} already applied; skipping",
                 SanitizeForLog(evt.ClaimId), SanitizeForLog(evt.TenantId));
             return new ApplyResult(ApplyOutcome.Duplicate, null, null, "DuplicateClaim");
         }
@@ -121,10 +123,13 @@ public class AccumulatorService : IAccumulatorService
         ApplyServiceDeltas(snapshot, serviceDeltas);
         snapshot.Version += 1;
 
+        // Fresh EventId per attempt so a retry (Pending-marker replay) does not
+        // collide on the unique (tenantId, eventId) index. Wire-level dedup is
+        // ProcessedClaim's job, not this event row's.
         var auditEvent = new AccumulatorEvent
         {
             TenantId = evt.TenantId,
-            EventId = evt.EventId, // preserve wire id for de-dup
+            EventId = Guid.NewGuid().ToString(),
             AggregateId = snapshot.Id,
             Version = snapshot.Version,
             MemberId = evt.MemberId,
@@ -172,6 +177,31 @@ public class AccumulatorService : IAccumulatorService
 
     public async Task<AccumulatorAdjustmentResponse> AdjustAsync(string tenantId, string memberId, AccumulatorAdjustmentRequest request, CancellationToken ct = default)
     {
+        // Idempotent replay on client-supplied AdjustmentId: if we've seen this
+        // adjustmentId before, return the existing snapshot rather than applying
+        // the delta again. Before this check the duplicate index violation would
+        // surface as a 500 from the event append.
+        if (!string.IsNullOrWhiteSpace(request.AdjustmentId))
+        {
+            var prior = await _repo.GetManualAdjustmentAsync(tenantId, request.AdjustmentId, ct);
+            if (prior is not null)
+            {
+                var existing = await _repo.GetSnapshotAsync(tenantId, memberId, request.PlanYearStart, ct);
+                return new AccumulatorAdjustmentResponse
+                {
+                    AdjustmentId = request.AdjustmentId,
+                    Snapshot = existing ?? new AccumulatorSnapshot
+                    {
+                        Id = AccumulatorSnapshot.BuildId(tenantId, memberId, request.PlanYearStart),
+                        TenantId = tenantId,
+                        MemberId = memberId,
+                        PlanYearStart = request.PlanYearStart,
+                        PlanYearEnd = request.PlanYearEnd
+                    }
+                };
+            }
+        }
+
         var snapshot = await _repo.GetSnapshotAsync(tenantId, memberId, request.PlanYearStart, ct)
             ?? new AccumulatorSnapshot
             {
@@ -197,7 +227,9 @@ public class AccumulatorService : IAccumulatorService
         var auditEvent = new AccumulatorEvent
         {
             TenantId = tenantId,
-            EventId = adjustmentId,
+            // Fresh wire-level EventId; duplicate AdjustmentId handled above by
+            // GetManualAdjustmentAsync lookup keyed on SourceReference.
+            EventId = Guid.NewGuid().ToString(),
             AggregateId = snapshot.Id,
             Version = snapshot.Version,
             MemberId = memberId,

--- a/src/services/accumulator-service/Services/ClaimFinalizedConsumer.cs
+++ b/src/services/accumulator-service/Services/ClaimFinalizedConsumer.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using CloudHealthOffice.Events;
+using Confluent.Kafka;
+
+namespace AccumulatorService.Services;
+
+/// <summary>
+/// BackgroundService subscriber for claims.finalized.v1. For each message:
+///   - deserialize → ClaimFinalizedEvent
+///   - delegate to IAccumulatorService.ApplyClaimFinalizedAsync (idempotent)
+///   - commit offset only on a terminal outcome (Applied | Duplicate | Orphan)
+///
+/// Commit strategy is EnableAutoCommit=false with explicit StoreOffset so
+/// transient failures (DB hiccup) get a re-delivery rather than a silent skip.
+///
+/// TODO(addendum-a): this Kafka subscriber may migrate to the Service Bus-backed
+/// IMessageBus at the Phase 1/2 boundary. Current Kafka wiring matches claims-service
+/// for consistency; migration decision is explicitly out of scope for this PR.
+/// </summary>
+public class ClaimFinalizedConsumer : BackgroundService
+{
+    public const string Topic = "claims.finalized.v1";
+
+    private readonly IServiceProvider _services;
+    private readonly IConfiguration _config;
+    private readonly ILogger<ClaimFinalizedConsumer> _logger;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public ClaimFinalizedConsumer(IServiceProvider services, IConfiguration config, ILogger<ClaimFinalizedConsumer> logger)
+    {
+        _services = services;
+        _config = config;
+        _logger = logger;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var bootstrap = _config["Kafka:BootstrapServers"];
+        if (string.IsNullOrWhiteSpace(bootstrap))
+        {
+            _logger.LogWarning("Kafka:BootstrapServers not configured — ClaimFinalized consumer disabled");
+            return Task.CompletedTask;
+        }
+
+        // Run on a background thread so the synchronous Consume loop doesn't block
+        // the host startup path.
+        return Task.Run(() => RunLoop(bootstrap!, stoppingToken), stoppingToken);
+    }
+
+    private void RunLoop(string bootstrap, CancellationToken stoppingToken)
+    {
+        var cfg = new ConsumerConfig
+        {
+            BootstrapServers = bootstrap,
+            GroupId = _config["Kafka:ClaimFinalized:GroupId"] ?? "accumulator-service.claims-finalized",
+            ClientId = _config["Kafka:ClientId"] ?? "accumulator-service",
+            EnableAutoCommit = false,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnablePartitionEof = false
+        };
+
+        var sasl = _config["Kafka:SaslUsername"];
+        if (!string.IsNullOrWhiteSpace(sasl))
+        {
+            cfg.SaslUsername = sasl;
+            cfg.SaslPassword = _config["Kafka:SaslPassword"];
+            cfg.SaslMechanism = SaslMechanism.ScramSha512;
+            cfg.SecurityProtocol = SecurityProtocol.SaslSsl;
+        }
+
+        using var consumer = new ConsumerBuilder<string, string>(cfg)
+            .SetErrorHandler((_, e) => _logger.LogError("Kafka consumer error: {Reason}", e.Reason))
+            .Build();
+
+        try
+        {
+            consumer.Subscribe(Topic);
+            _logger.LogInformation("ClaimFinalized consumer subscribed to {Topic}", Topic);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                ConsumeResult<string, string>? result;
+                try
+                {
+                    result = consumer.Consume(TimeSpan.FromSeconds(1));
+                }
+                catch (ConsumeException ex)
+                {
+                    _logger.LogError(ex, "Consume error: {Reason}", ex.Error.Reason);
+                    continue;
+                }
+                if (result?.Message is null) continue;
+
+                try
+                {
+                    ProcessAsync(result.Message.Value, stoppingToken).GetAwaiter().GetResult();
+                    consumer.StoreOffset(result);
+                    consumer.Commit(result);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to process ClaimFinalizedEvent at {Topic}:{Partition}:{Offset} — message will be redelivered",
+                        result.Topic, result.Partition.Value, result.Offset.Value);
+                    // No offset commit → Kafka redelivers on next poll/assignment.
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on shutdown.
+        }
+        finally
+        {
+            try { consumer.Close(); } catch { /* best-effort */ }
+        }
+    }
+
+    private async Task ProcessAsync(string payload, CancellationToken ct)
+    {
+        var evt = JsonSerializer.Deserialize<ClaimFinalizedEvent>(payload, JsonOptions);
+        if (evt is null || string.IsNullOrWhiteSpace(evt.ClaimId) || string.IsNullOrWhiteSpace(evt.TenantId))
+        {
+            _logger.LogWarning("Ignoring ClaimFinalized message with missing required fields");
+            return;
+        }
+
+        using var scope = _services.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<IAccumulatorService>();
+        var outcome = await svc.ApplyClaimFinalizedAsync(evt, ct);
+        _logger.LogInformation(
+            "ClaimFinalized processed: claim={ClaimId} tenant={TenantId} outcome={Outcome}",
+            evt.ClaimId, evt.TenantId, outcome.Outcome);
+    }
+}

--- a/src/services/accumulator-service/Services/IAccumulatorEventPublisher.cs
+++ b/src/services/accumulator-service/Services/IAccumulatorEventPublisher.cs
@@ -1,0 +1,19 @@
+using CloudHealthOffice.Events;
+
+namespace AccumulatorService.Services;
+
+/// <summary>
+/// Publishes outbound accumulator events to Kafka.
+///
+/// TODO(addendum-a): claims-service → accumulator-service is currently Kafka via
+/// Confluent.Kafka, consistent with the rest of the claims pipeline. When the
+/// Phase 1/2 boundary brings the IMessageBus abstraction (Service Bus-backed) this
+/// flow is a candidate for evaluation — though claim events are pub-sub fan-out
+/// (accumulators, risk adjustment, analytics, condition-service) and Kafka may
+/// remain the right choice once formalized. Not a problem for this PR.
+/// </summary>
+public interface IAccumulatorEventPublisher
+{
+    Task PublishAdjustedAsync(AccumulatorAdjustedEvent evt, CancellationToken ct = default);
+    Task PublishOrphanAsync(OrphanAccumulatorClaimEvent evt, CancellationToken ct = default);
+}

--- a/src/services/accumulator-service/Services/IAccumulatorService.cs
+++ b/src/services/accumulator-service/Services/IAccumulatorService.cs
@@ -1,0 +1,30 @@
+using AccumulatorService.Models;
+using CloudHealthOffice.Events;
+
+namespace AccumulatorService.Services;
+
+/// <summary>
+/// Apply result for ClaimFinalized processing. Encodes the three possible
+/// outcomes — applied, duplicate (idempotent skip), orphan (no matching plan-year
+/// snapshot could be resolved) — without exceptions, so the Kafka consumer can
+/// log/metric each case.
+/// </summary>
+public enum ApplyOutcome
+{
+    Applied,
+    Duplicate,
+    Orphan
+}
+
+public record ApplyResult(ApplyOutcome Outcome, AccumulatorSnapshot? Snapshot, string? EventId, string? Reason);
+
+public interface IAccumulatorService
+{
+    Task<AccumulatorResponse?> GetAsync(string tenantId, string memberId, DateTime? asOfDate, CancellationToken ct = default);
+
+    Task<AccumulatorHistoryResponse> GetHistoryAsync(string tenantId, string memberId, CancellationToken ct = default);
+
+    Task<ApplyResult> ApplyClaimFinalizedAsync(ClaimFinalizedEvent evt, CancellationToken ct = default);
+
+    Task<AccumulatorAdjustmentResponse> AdjustAsync(string tenantId, string memberId, AccumulatorAdjustmentRequest request, CancellationToken ct = default);
+}

--- a/src/services/accumulator-service/Services/KafkaAccumulatorEventPublisher.cs
+++ b/src/services/accumulator-service/Services/KafkaAccumulatorEventPublisher.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using System.Text.Json;
+using CloudHealthOffice.Events;
+using Confluent.Kafka;
+
+namespace AccumulatorService.Services;
+
+public class KafkaAccumulatorEventPublisher : IAccumulatorEventPublisher, IHostedService, IAsyncDisposable
+{
+    public const string AdjustedTopic = "accumulators.adjusted.v1";
+    public const string OrphanTopic = "accumulators.orphan.v1";
+
+    private readonly ILogger<KafkaAccumulatorEventPublisher> _logger;
+    private readonly IConfiguration _config;
+    private IProducer<string, string>? _producer;
+    private bool _available;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public KafkaAccumulatorEventPublisher(ILogger<KafkaAccumulatorEventPublisher> logger, IConfiguration config)
+    {
+        _logger = logger;
+        _config = config;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var bootstrap = _config["Kafka:BootstrapServers"];
+        if (string.IsNullOrWhiteSpace(bootstrap))
+        {
+            _logger.LogWarning("Kafka:BootstrapServers not configured — accumulator publisher disabled");
+            return Task.CompletedTask;
+        }
+
+        var cfg = new ProducerConfig
+        {
+            BootstrapServers = bootstrap,
+            ClientId = _config["Kafka:ClientId"] ?? "accumulator-service",
+            MessageTimeoutMs = 10_000,
+            RequestTimeoutMs = 10_000,
+            EnableIdempotence = true
+        };
+
+        var sasl = _config["Kafka:SaslUsername"];
+        if (!string.IsNullOrWhiteSpace(sasl))
+        {
+            cfg.SaslUsername = sasl;
+            cfg.SaslPassword = _config["Kafka:SaslPassword"];
+            cfg.SaslMechanism = SaslMechanism.ScramSha512;
+            cfg.SecurityProtocol = SecurityProtocol.SaslSsl;
+        }
+
+        try
+        {
+            _producer = new ProducerBuilder<string, string>(cfg).Build();
+            _available = true;
+            _logger.LogInformation("Accumulator event publisher connected to Kafka at {Servers}", bootstrap);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Kafka producer init failed — accumulator event publisher running in degraded mode");
+            _available = false;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        try { _producer?.Flush(TimeSpan.FromSeconds(5)); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Error flushing producer on shutdown"); }
+        _producer?.Dispose();
+        _producer = null;
+        _available = false;
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAdjustedAsync(AccumulatorAdjustedEvent evt, CancellationToken ct = default)
+        => PublishAsync(AdjustedTopic, $"{evt.TenantId}:{evt.MemberId}", evt, evt.EventType, evt.EventSchemaVersion, evt.TenantId, ct);
+
+    public Task PublishOrphanAsync(OrphanAccumulatorClaimEvent evt, CancellationToken ct = default)
+        => PublishAsync(OrphanTopic, $"{evt.TenantId}:{evt.ClaimId}", evt, evt.EventType, evt.EventSchemaVersion, evt.TenantId, ct);
+
+    private async Task PublishAsync<T>(string topic, string key, T payload, string eventType, int schemaVersion, string tenantId, CancellationToken ct)
+    {
+        if (!_available || _producer is null)
+        {
+            _logger.LogDebug("Kafka unavailable; skipping {EventType} publish", eventType);
+            return;
+        }
+
+        var message = new Message<string, string>
+        {
+            Key = key,
+            Value = JsonSerializer.Serialize(payload, JsonOptions),
+            Headers = new Headers
+            {
+                { "tenant-id", Encoding.UTF8.GetBytes(tenantId) },
+                { "event-type", Encoding.UTF8.GetBytes(eventType) },
+                { "event-schema-version", Encoding.UTF8.GetBytes(schemaVersion.ToString()) }
+            }
+        };
+
+        try
+        {
+            await _producer.ProduceAsync(topic, message, ct);
+        }
+        catch (ProduceException<string, string> ex)
+        {
+            _logger.LogError(ex, "Failed to publish {EventType} to {Topic}: {Reason}", eventType, topic, ex.Error.Reason);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error publishing {EventType}", eventType);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/services/accumulator-service/accumulator-service.csproj
+++ b/src/services/accumulator-service/accumulator-service.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/services/accumulator-service/accumulator-service.csproj
+++ b/src/services/accumulator-service/accumulator-service.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>AccumulatorService</RootNamespace>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
+    <ProjectReference Include="..\shared\CloudHealthOffice.Events\CloudHealthOffice.Events.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/services/accumulator-service/appsettings.Development.json
+++ b/src/services/accumulator-service/appsettings.Development.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  },
+  "MongoDb": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "AccumulatorDB"
+  },
+  "Kafka": {
+    "BootstrapServers": "localhost:9092"
+  }
+}

--- a/src/services/accumulator-service/appsettings.json
+++ b/src/services/accumulator-service/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "MongoDb": {
+    "ConnectionString": "",
+    "DatabaseName": "AccumulatorDB"
+  },
+  "CosmosDb": {
+    "ConnectionString": "",
+    "Endpoint": "",
+    "Key": ""
+  },
+  "Kafka": {
+    "BootstrapServers": "",
+    "ClientId": "accumulator-service",
+    "ClaimFinalized": {
+      "GroupId": "accumulator-service.claims-finalized"
+    }
+  }
+}

--- a/src/services/accumulator-service/k8s/accumulator-service-deployment.yaml
+++ b/src/services/accumulator-service/k8s/accumulator-service-deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: accumulator-service-config
+  namespace: cloudhealthoffice
+data:
+  ASPNETCORE_ENVIRONMENT: "Production"
+  MongoDb__DatabaseName: "AccumulatorDB"
+  Kafka__ClientId: "accumulator-service"
+  Kafka__ClaimFinalized__GroupId: "accumulator-service.claims-finalized"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accumulator-service
+  namespace: cloudhealthoffice
+  labels:
+    app: accumulator-service
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: accumulator-service
+  template:
+    metadata:
+      labels:
+        app: accumulator-service
+        tier: backend
+    spec:
+      containers:
+      - name: accumulator-service
+        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-accumulator-service:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: accumulator-service-config
+              key: ASPNETCORE_ENVIRONMENT
+        - name: MongoDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: database-secret
+              key: connectionString
+        - name: MongoDb__DatabaseName
+          valueFrom:
+            configMapKeyRef:
+              name: accumulator-service-config
+              key: MongoDb__DatabaseName
+        - name: Kafka__BootstrapServers
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: bootstrapServers
+              optional: true
+        - name: Kafka__SaslUsername
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: saslUsername
+              optional: true
+        - name: Kafka__SaslPassword
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: saslPassword
+              optional: true
+        - name: Kafka__ClientId
+          valueFrom:
+            configMapKeyRef:
+              name: accumulator-service-config
+              key: Kafka__ClientId
+        - name: Kafka__ClaimFinalized__GroupId
+          valueFrom:
+            configMapKeyRef:
+              name: accumulator-service-config
+              key: Kafka__ClaimFinalized__GroupId
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: accumulator-service
+  namespace: cloudhealthoffice
+  labels:
+    app: accumulator-service
+spec:
+  type: ClusterIP
+  selector:
+    app: accumulator-service
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -688,7 +688,13 @@ public class ClaimsController : ControllerBase
         claim.Status = ClaimStatus.Voided;
         claim.LastUpdatedDate = DateTime.UtcNow;
 
-        await _claimRepository.UpdateAsync(claim);
+        var updated = await _claimRepository.UpdateAsync(claim);
+
+        // Voided is a terminal status — downstream consumers (accumulators,
+        // analytics) need the reversal signal just as they do for paid/denied
+        // transitions. Without this publish a void initiated via DELETE silently
+        // diverges from voids reached through the status-update endpoint.
+        await _eventPublisher.PublishClaimFinalizedAsync(updated, GetTenantId());
 
         return NoContent();
     }

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -251,8 +251,20 @@ public class ClaimsController : ControllerBase
             await _eventPublisher.PublishClaimPendedAsync(updated, GetTenantId());
         }
 
+        if (IsTerminalStatus(updated.Status))
+        {
+            await _eventPublisher.PublishClaimFinalizedAsync(updated, GetTenantId());
+        }
+
         return Ok(updated);
     }
+
+    private static bool IsTerminalStatus(ClaimStatus status) =>
+        status is ClaimStatus.Paid
+            or ClaimStatus.Approved
+            or ClaimStatus.PartiallyPaid
+            or ClaimStatus.Denied
+            or ClaimStatus.Voided;
 
     /// <summary>
     /// Pend a claim with structured pend details and emit a ClaimPendedEvent.
@@ -350,6 +362,12 @@ public class ClaimsController : ControllerBase
         }
 
         var updated = await _claimRepository.UpdateAsync(claim);
+
+        if (IsTerminalStatus(updated.Status))
+        {
+            await _eventPublisher.PublishClaimFinalizedAsync(updated, GetTenantId());
+        }
+
         return Ok(updated);
     }
 
@@ -584,6 +602,12 @@ public class ClaimsController : ControllerBase
         claim.AdjudicationResult.PayerPayment = remittance.PaymentAmount;
 
         var updated = await _claimRepository.UpdateAsync(claim);
+
+        if (IsTerminalStatus(updated.Status))
+        {
+            await _eventPublisher.PublishClaimFinalizedAsync(updated, GetTenantId());
+        }
+
         return Ok(updated);
     }
 

--- a/src/services/claims-service/Services/ClaimEventPublisher.cs
+++ b/src/services/claims-service/Services/ClaimEventPublisher.cs
@@ -21,11 +21,20 @@ public interface IClaimEventPublisher
     /// source of truth, not the event stream).
     /// </summary>
     Task PublishClaimPendedAsync(Claim claim, string tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Emit a ClaimFinalizedEvent when a claim reaches a terminal adjudication
+    /// state (Approved, Paid, PartiallyPaid, Denied). Consumed by accumulator-service
+    /// (member deductible/OOP projection) and downstream analytics. Same degraded-mode
+    /// semantics as PublishClaimPendedAsync — claim DB is truth, event is a notification.
+    /// </summary>
+    Task PublishClaimFinalizedAsync(Claim claim, string tenantId, CancellationToken ct = default);
 }
 
 public class ClaimEventPublisher : IClaimEventPublisher, IHostedService, IAsyncDisposable
 {
     public const string ClaimPendedTopic = "claims.pended.v1";
+    public const string ClaimFinalizedTopic = "claims.finalized.v1";
 
     private readonly ILogger<ClaimEventPublisher> _logger;
     private readonly IConfiguration _configuration;
@@ -153,6 +162,96 @@ public class ClaimEventPublisher : IClaimEventPublisher, IHostedService, IAsyncD
         {
             _logger.LogError(ex, "Unexpected error publishing ClaimPendedEvent for claim {ClaimId}", claim.Id);
         }
+    }
+
+    public async Task PublishClaimFinalizedAsync(Claim claim, string tenantId, CancellationToken ct = default)
+    {
+        if (!_available || _producer == null)
+        {
+            _logger.LogDebug("Kafka producer unavailable; skipping ClaimFinalizedEvent for claim {ClaimId}", claim.Id);
+            return;
+        }
+
+        var evt = BuildFinalizedEvent(claim, tenantId);
+
+        var message = new Message<string, string>
+        {
+            Key = claim.Id,
+            Value = JsonSerializer.Serialize(evt, JsonOptions),
+            Headers = new Headers
+            {
+                { "tenant-id", Encoding.UTF8.GetBytes(tenantId) },
+                { "event-type", Encoding.UTF8.GetBytes(evt.EventType) },
+                { "event-schema-version", Encoding.UTF8.GetBytes(evt.EventSchemaVersion.ToString()) }
+            }
+        };
+
+        try
+        {
+            await _producer.ProduceAsync(ClaimFinalizedTopic, message, ct);
+            _logger.LogInformation("Published ClaimFinalizedEvent for claim {ClaimId} ({Status}) to {Topic}",
+                claim.Id, claim.Status, ClaimFinalizedTopic);
+        }
+        catch (ProduceException<string, string> ex)
+        {
+            _logger.LogError(ex, "Failed to publish ClaimFinalizedEvent for claim {ClaimId}: {Reason}",
+                claim.Id, ex.Error.Reason);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error publishing ClaimFinalizedEvent for claim {ClaimId}", claim.Id);
+        }
+    }
+
+    private static ClaimFinalizedEvent BuildFinalizedEvent(Claim claim, string tenantId)
+    {
+        var adj = claim.AdjudicationResult;
+        var lines = claim.ClaimLines.Select(l => new ClaimFinalizedLineItem
+        {
+            LineNumber = l.LineNumber,
+            BenefitCategory = l.RevenueCode ?? l.PlaceOfServiceCode ?? string.Empty,
+            ServiceCode = l.ProcedureCode,
+            DeductibleApplied = l.AdjudicationResult?.AdjustmentReasons
+                .Where(r => r.ReasonCode == "1").Sum(r => r.Amount) ?? 0m,
+            CoinsuranceApplied = l.AdjudicationResult?.AdjustmentReasons
+                .Where(r => r.ReasonCode == "2").Sum(r => r.Amount) ?? 0m,
+            CopayApplied = l.AdjudicationResult?.AdjustmentReasons
+                .Where(r => r.ReasonCode == "3").Sum(r => r.Amount) ?? 0m,
+            OopApplied = (l.AdjudicationResult?.PatientResponsibility) ?? 0m,
+            PlanPaid = l.AdjudicationResult?.PaidAmount ?? 0m,
+            MemberResponsibility = l.AdjudicationResult?.PatientResponsibility ?? 0m
+        }).ToList();
+
+        var status = claim.Status switch
+        {
+            ClaimStatus.Paid or ClaimStatus.Approved or ClaimStatus.PartiallyPaid => "Paid",
+            ClaimStatus.Denied => "Denied",
+            ClaimStatus.Voided => "Reversed",
+            _ => claim.Status.ToString()
+        };
+
+        // Family-aggregate determination requires benefit-plan context the claim does
+        // not carry. Default false here; accumulator-service applies individual-only
+        // unless the producer (or a future plan-enrichment step) sets this flag.
+        return new ClaimFinalizedEvent
+        {
+            TenantId = tenantId,
+            ClaimId = claim.Id,
+            ClaimNumber = claim.ClaimNumber,
+            MemberId = claim.MemberId,
+            ServiceDate = claim.ServiceDateFrom,
+            AdjudicationTimestamp = claim.AdjudicatedDate ?? DateTimeOffset.UtcNow,
+            FinalStatus = status,
+            BenefitCategory = claim.PlaceOfServiceCode ?? string.Empty,
+            IsFamilyAggregate = false,
+            DeductibleApplied = adj?.DeductibleAmount ?? 0m,
+            CoinsuranceApplied = adj?.CoinsuranceAmount ?? 0m,
+            CopayApplied = adj?.CopayAmount ?? 0m,
+            OopApplied = adj?.PatientResponsibility ?? 0m,
+            PlanPaid = adj?.PayerPayment ?? 0m,
+            MemberResponsibility = adj?.PatientResponsibility ?? 0m,
+            LineItems = lines
+        };
     }
 
     public async ValueTask DisposeAsync()

--- a/src/services/claims-service/Services/ClaimEventPublisher.cs
+++ b/src/services/claims-service/Services/ClaimEventPublisher.cs
@@ -230,6 +230,17 @@ public class ClaimEventPublisher : IClaimEventPublisher, IHostedService, IAsyncD
             _ => claim.Status.ToString()
         };
 
+        // Plan-year boundaries: claims-service does not own the plan calendar, so
+        // we default to the calendar year containing ServiceDate. benefit-plan-service
+        // overrides this downstream when a non-calendar plan year applies. Populating
+        // these fields (even as a best-effort default) is what keeps
+        // accumulator-service's ResolveSnapshotAsync off the orphan path when no
+        // snapshot is pre-seeded; without them every first-ever finalize would be
+        // treated as orphaned.
+        var serviceDate = claim.ServiceDateFrom;
+        var planYearStart = new DateTime(serviceDate.Year, 1, 1);
+        var planYearEnd = new DateTime(serviceDate.Year, 12, 31);
+
         // Family-aggregate determination requires benefit-plan context the claim does
         // not carry. Default false here; accumulator-service applies individual-only
         // unless the producer (or a future plan-enrichment step) sets this flag.
@@ -239,7 +250,9 @@ public class ClaimEventPublisher : IClaimEventPublisher, IHostedService, IAsyncD
             ClaimId = claim.Id,
             ClaimNumber = claim.ClaimNumber,
             MemberId = claim.MemberId,
-            ServiceDate = claim.ServiceDateFrom,
+            PlanYearStart = planYearStart,
+            PlanYearEnd = planYearEnd,
+            ServiceDate = serviceDate,
             AdjudicationTimestamp = claim.AdjudicatedDate ?? DateTimeOffset.UtcNow,
             FinalStatus = status,
             BenefitCategory = claim.PlaceOfServiceCode ?? string.Empty,

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -732,6 +732,10 @@ public class Enrollment834Record
 
 public class MemberAccumulatorsResponse
 {
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
     public decimal IndividualDeductibleUsed { get; set; }
     public decimal IndividualDeductibleLimit { get; set; }
     public decimal FamilyDeductibleUsed { get; set; }
@@ -740,8 +744,31 @@ public class MemberAccumulatorsResponse
     public decimal IndividualOopLimit { get; set; }
     public decimal FamilyOopUsed { get; set; }
     public decimal FamilyOopLimit { get; set; }
-    public List<object> ServiceAccumulators { get; set; } = new();
-    public List<object> RecentActivity { get; set; } = new();
+
+    public List<MemberServiceAccumulator> ServiceAccumulators { get; set; } = new();
+    public List<MemberAccumulatorActivity> RecentActivity { get; set; } = new();
+}
+
+public class MemberServiceAccumulator
+{
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal Used { get; set; }
+    public decimal Limit { get; set; }
+    public string Unit { get; set; } = "USD";
+}
+
+public class MemberAccumulatorActivity
+{
+    public string EventId { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public string? SourceReference { get; set; }
+    public DateTime OccurredAt { get; set; }
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+    public string? Reason { get; set; }
+    public string ActorId { get; set; } = "system";
 }
 
 public class AssignPcpRequest

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -164,6 +164,14 @@ RegisterDownstream<ICoverageServiceClient, HttpCoverageServiceClient, FakeCovera
     builder, coverageBaseUrl);
 RegisterDownstream<IEnrollmentImportServiceClient, HttpEnrollmentImportServiceClient, FakeEnrollmentImportServiceClient>(
     builder, enrollmentBaseUrl);
+// Production must have accumulator-service configured — no silent fallback to a
+// fake projection. Per PR #650 review: fakes are dev-only, and an unset downstream
+// in a non-development environment is a startup error, not a lazy 503 at call time.
+if (!builder.Environment.IsDevelopment() && string.IsNullOrWhiteSpace(accumulatorBaseUrl))
+{
+    throw new InvalidOperationException(
+        "Downstream:AccumulatorService:BaseUrl must be configured outside Development.");
+}
 RegisterDownstream<IAccumulatorServiceClient, HttpAccumulatorServiceClient, FakeAccumulatorServiceClient>(
     builder, accumulatorBaseUrl);
 

--- a/src/services/member-service/Services/FakeDownstreamClients.cs
+++ b/src/services/member-service/Services/FakeDownstreamClients.cs
@@ -78,6 +78,9 @@ public sealed class FakeAccumulatorServiceClient : IAccumulatorServiceClient
         string tenantId, string memberId, CancellationToken ct = default)
         => Task.FromResult(new MemberAccumulatorsResponse
         {
+            MemberId = memberId,
+            PlanYearStart = new DateTime(DateTime.UtcNow.Year, 1, 1),
+            PlanYearEnd = new DateTime(DateTime.UtcNow.Year, 12, 31),
             IndividualDeductibleUsed = 0m,
             IndividualDeductibleLimit = 2000m,
             FamilyDeductibleUsed = 0m,

--- a/src/services/shared/CloudHealthOffice.Events/AccumulatorAdjustedEvent.cs
+++ b/src/services/shared/CloudHealthOffice.Events/AccumulatorAdjustedEvent.cs
@@ -1,0 +1,68 @@
+namespace CloudHealthOffice.Events;
+
+/// <summary>
+/// Event payload for accumulators.adjusted.v1. Emitted by accumulator-service when
+/// a snapshot is modified — either by a finalized claim application or by a manual
+/// operator override. Consumers: audit log projector, downstream analytics.
+/// </summary>
+public class AccumulatorAdjustedEvent
+{
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+    public string EventType { get; set; } = "accumulator.adjusted";
+    public int EventSchemaVersion { get; set; } = 1;
+    public DateTimeOffset OccurredAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public string TenantId { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
+    /// <summary>ClaimApplied | ManualAdjustment | OrphanSkipped | Reversal.</summary>
+    public string AdjustmentSource { get; set; } = string.Empty;
+
+    /// <summary>ClaimId for ClaimApplied/Reversal; AdjustmentId for ManualAdjustment.</summary>
+    public string? SourceReference { get; set; }
+
+    /// <summary>User or system principal that performed the change.</summary>
+    public string ActorId { get; set; } = "system";
+
+    /// <summary>Free-text reason required for manual adjustments.</summary>
+    public string? Reason { get; set; }
+
+    /// <summary>Signed deltas applied to each counter. Negative for reversals.</summary>
+    public decimal DeductibleDelta { get; set; }
+    public decimal OopDelta { get; set; }
+    public decimal FamilyDeductibleDelta { get; set; }
+    public decimal FamilyOopDelta { get; set; }
+
+    /// <summary>Per-service-category deltas, if any.</summary>
+    public List<ServiceAccumulatorDelta> ServiceDeltas { get; set; } = new();
+}
+
+public class ServiceAccumulatorDelta
+{
+    public string BenefitCategory { get; set; } = string.Empty;
+    public decimal UsedDelta { get; set; }
+    public string Unit { get; set; } = "USD";
+}
+
+/// <summary>
+/// Event payload for accumulators.orphan.v1. Emitted when a ClaimFinalizedEvent
+/// arrives with a ServiceDate that does not map to any known plan-year snapshot
+/// for the member (e.g. predates earliest coverage). This is a data-quality alert,
+/// not a silent drop — downstream ops tooling should surface these for review.
+/// </summary>
+public class OrphanAccumulatorClaimEvent
+{
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+    public string EventType { get; set; } = "accumulator.orphan";
+    public int EventSchemaVersion { get; set; } = 1;
+    public DateTimeOffset OccurredAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public string TenantId { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string ClaimId { get; set; } = string.Empty;
+    public string ClaimNumber { get; set; } = string.Empty;
+    public DateTime ServiceDate { get; set; }
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/services/shared/CloudHealthOffice.Events/ClaimFinalizedEvent.cs
+++ b/src/services/shared/CloudHealthOffice.Events/ClaimFinalizedEvent.cs
@@ -1,0 +1,77 @@
+namespace CloudHealthOffice.Events;
+
+/// <summary>
+/// Event payload for claims.finalized.v1. Emitted by claims-service when a claim
+/// reaches a terminal adjudication state (paid, denied, or reversed). Consumed by
+/// accumulator-service to update member deductible/OOP counters and by downstream
+/// analytics/risk consumers.
+///
+/// This is an INTERNAL CHO event, not a FHIR ExplanationOfBenefit. EOB is a
+/// query-time projection exposed by claims-service for Patient Access / Payer-to-Payer
+/// surfaces (Phase 3); coupling this event to the FHIR spec's versioning cadence would
+/// be a footgun. Carry only what accumulator aggregation needs, flat.
+/// </summary>
+public class ClaimFinalizedEvent
+{
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+    public string EventType { get; set; } = "claim.finalized";
+    public int EventSchemaVersion { get; set; } = 1;
+    public DateTimeOffset OccurredAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public string TenantId { get; set; } = string.Empty;
+    public string ClaimId { get; set; } = string.Empty;
+    public string ClaimNumber { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>Plan year boundaries that govern which AccumulatorSnapshot to update.</summary>
+    public DateTime PlanYearStart { get; set; }
+    public DateTime PlanYearEnd { get; set; }
+
+    /// <summary>Service date drives plan-year selection for retro claims.</summary>
+    public DateTime ServiceDate { get; set; }
+
+    /// <summary>When adjudication decided the amounts; distinct from ServiceDate.</summary>
+    public DateTimeOffset AdjudicationTimestamp { get; set; }
+
+    /// <summary>Terminal status: Paid | Denied | Reversed.</summary>
+    public string FinalStatus { get; set; } = "Paid";
+
+    /// <summary>
+    /// Primary benefit category for the whole claim (e.g. "PrimaryCare", "Lab", "ER").
+    /// Line-level categories live on <see cref="LineItems"/>; this is a convenience
+    /// rollup for single-category claims.
+    /// </summary>
+    public string BenefitCategory { get; set; } = string.Empty;
+
+    /// <summary>True when the amounts below contribute to the family aggregate in addition to individual.</summary>
+    public bool IsFamilyAggregate { get; set; }
+
+    // Claim-level applied amounts. For multi-line claims these are the sums of
+    // LineItems[*]. Consumers MAY prefer LineItems for category-aware aggregation
+    // and MUST use claim-level values when LineItems is empty.
+    public decimal DeductibleApplied { get; set; }
+    public decimal CoinsuranceApplied { get; set; }
+    public decimal CopayApplied { get; set; }
+    public decimal OopApplied { get; set; }
+    public decimal PlanPaid { get; set; }
+    public decimal MemberResponsibility { get; set; }
+
+    /// <summary>
+    /// Per-line applied amounts. Populated when a single claim spans multiple
+    /// benefit categories (e.g. PCP visit + lab draw). Most claims have one line.
+    /// </summary>
+    public List<ClaimFinalizedLineItem> LineItems { get; set; } = new();
+}
+
+public class ClaimFinalizedLineItem
+{
+    public int LineNumber { get; set; }
+    public string BenefitCategory { get; set; } = string.Empty;
+    public string ServiceCode { get; set; } = string.Empty;
+    public decimal DeductibleApplied { get; set; }
+    public decimal CoinsuranceApplied { get; set; }
+    public decimal CopayApplied { get; set; }
+    public decimal OopApplied { get; set; }
+    public decimal PlanPaid { get; set; }
+    public decimal MemberResponsibility { get; set; }
+}

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorServiceTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorServiceTests.cs
@@ -1,0 +1,269 @@
+using AccumulatorService.Models;
+using AccumulatorService.Services;
+using CloudHealthOffice.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.AccumulatorService.Tests;
+
+/// <summary>
+/// Behavior of the accumulator domain service. Covers:
+///   - Apply path: sums deltas into the correct snapshot
+///   - Idempotency: replay of the same ClaimFinalizedEvent does not double-count
+///   - Retro adjustment: a prior-year service date targets the prior-year snapshot
+///   - Orphan: unknown plan year emits OrphanAccumulatorClaimEvent and skips
+///   - Manual adjustment: produces audit event + AccumulatorAdjusted publish
+///   - Family aggregate flag
+///   - Multi-line per-category attribution
+/// </summary>
+public class AccumulatorServiceTests
+{
+    private const string Tenant = "t1";
+    private const string Member = "m-100";
+
+    private static global::AccumulatorService.Services.AccumulatorService BuildSut(
+        out InMemoryAccumulatorRepository repo,
+        out InMemoryProcessedClaimStore processed,
+        out RecordingPublisher publisher)
+    {
+        repo = new InMemoryAccumulatorRepository();
+        processed = new InMemoryProcessedClaimStore();
+        publisher = new RecordingPublisher();
+        return new global::AccumulatorService.Services.AccumulatorService(
+            repo, processed, publisher,
+            NullLogger<global::AccumulatorService.Services.AccumulatorService>.Instance);
+    }
+
+    private static AccumulatorSnapshot SeedSnapshot(InMemoryAccumulatorRepository repo, int year, decimal dedLimit = 2000m, decimal oopLimit = 8000m)
+    {
+        var start = new DateTime(year, 1, 1);
+        var end = new DateTime(year, 12, 31);
+        var s = new AccumulatorSnapshot
+        {
+            Id = AccumulatorSnapshot.BuildId(Tenant, Member, start),
+            TenantId = Tenant,
+            MemberId = Member,
+            PlanYearStart = start,
+            PlanYearEnd = end,
+            IndividualDeductibleLimit = dedLimit,
+            IndividualOopLimit = oopLimit,
+            FamilyDeductibleLimit = dedLimit * 3,
+            FamilyOopLimit = oopLimit * 2
+        };
+        repo.Seed(s);
+        return s;
+    }
+
+    private static ClaimFinalizedEvent MakeClaim(
+        string claimId,
+        DateTime serviceDate,
+        decimal deductible,
+        decimal coinsurance = 0m,
+        decimal copay = 0m,
+        decimal oop = 0m,
+        bool familyAggregate = false,
+        string category = "PrimaryCare",
+        List<ClaimFinalizedLineItem>? lines = null) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        ClaimId = claimId,
+        ClaimNumber = claimId,
+        MemberId = Member,
+        ServiceDate = serviceDate,
+        AdjudicationTimestamp = DateTimeOffset.UtcNow,
+        BenefitCategory = category,
+        IsFamilyAggregate = familyAggregate,
+        DeductibleApplied = deductible,
+        CoinsuranceApplied = coinsurance,
+        CopayApplied = copay,
+        OopApplied = oop == 0m ? deductible + coinsurance + copay : oop,
+        PlanPaid = 0m,
+        MemberResponsibility = deductible + coinsurance + copay,
+        LineItems = lines ?? new()
+    };
+
+    [Fact]
+    public async Task Apply_UpdatesCorrectSnapshotAndAuditEvent()
+    {
+        var sut = BuildSut(out var repo, out var processed, out var pub);
+        SeedSnapshot(repo, 2026);
+
+        var evt = MakeClaim("CLM-1", new DateTime(2026, 3, 15), deductible: 150m, coinsurance: 50m, oop: 200m);
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Applied, result.Outcome);
+        Assert.NotNull(result.Snapshot);
+        Assert.Equal(150m, result.Snapshot!.IndividualDeductibleUsed);
+        Assert.Equal(200m, result.Snapshot.IndividualOopUsed);
+        Assert.Equal(1, result.Snapshot.Version);
+
+        Assert.Single(repo.Events);
+        var audit = repo.Events[0];
+        Assert.Equal("ClaimApplied", audit.EventType);
+        Assert.Equal("CLM-1", audit.SourceClaimId);
+        Assert.Equal(evt.EventId, audit.EventId);
+        Assert.Equal(audit.Version, result.Snapshot.Version);
+
+        Assert.Single(pub.Adjusted);
+        Assert.Equal("ClaimApplied", pub.Adjusted[0].AdjustmentSource);
+    }
+
+    [Fact]
+    public async Task Apply_IsIdempotent_SecondReplayReturnsDuplicate()
+    {
+        var sut = BuildSut(out var repo, out var processed, out var pub);
+        SeedSnapshot(repo, 2026);
+
+        var evt = MakeClaim("CLM-DUP", new DateTime(2026, 3, 15), deductible: 100m);
+        var first = await sut.ApplyClaimFinalizedAsync(evt);
+
+        // Regenerate a fresh EventId on the replay — dedup is keyed by ClaimId, not EventId.
+        var replay = MakeClaim("CLM-DUP", new DateTime(2026, 3, 15), deductible: 100m);
+        var second = await sut.ApplyClaimFinalizedAsync(replay);
+
+        Assert.Equal(ApplyOutcome.Applied, first.Outcome);
+        Assert.Equal(ApplyOutcome.Duplicate, second.Outcome);
+
+        var snap = await repo.GetSnapshotAsync(Tenant, Member, new DateTime(2026, 1, 1));
+        Assert.Equal(100m, snap!.IndividualDeductibleUsed); // not 200
+        Assert.Single(repo.Events);
+
+        var marker = await processed.GetAsync(Tenant, "CLM-DUP");
+        Assert.NotNull(marker);
+        Assert.Equal("Applied", marker!.Outcome);
+        Assert.False(string.IsNullOrWhiteSpace(marker.ResultingEventId));
+    }
+
+    [Fact]
+    public async Task Apply_RetroClaim_TargetsPriorYearSnapshotNotCurrent()
+    {
+        var sut = BuildSut(out var repo, out _, out _);
+        var priorYear = SeedSnapshot(repo, 2025);
+        var currentYear = SeedSnapshot(repo, 2026);
+
+        // Finalized today, but service rendered in the prior plan year.
+        var evt = MakeClaim("CLM-RETRO", new DateTime(2025, 11, 20), deductible: 300m);
+        evt.AdjudicationTimestamp = DateTimeOffset.UtcNow;
+
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Applied, result.Outcome);
+        var prior = await repo.GetSnapshotAsync(Tenant, Member, priorYear.PlanYearStart);
+        var current = await repo.GetSnapshotAsync(Tenant, Member, currentYear.PlanYearStart);
+        Assert.Equal(300m, prior!.IndividualDeductibleUsed);
+        Assert.Equal(0m, current!.IndividualDeductibleUsed);
+    }
+
+    [Fact]
+    public async Task Apply_OrphanServiceDate_EmitsOrphanEventAndSkips()
+    {
+        var sut = BuildSut(out var repo, out var processed, out var pub);
+        SeedSnapshot(repo, 2026);
+
+        // Service date predates any known snapshot and the event does not carry
+        // a producer-asserted plan year that would cover it.
+        var evt = MakeClaim("CLM-ORPHAN", new DateTime(2022, 4, 1), deductible: 250m);
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Orphan, result.Outcome);
+        Assert.Empty(repo.Events);
+        Assert.Single(pub.Orphans);
+        Assert.Equal("CLM-ORPHAN", pub.Orphans[0].ClaimId);
+
+        var marker = await processed.GetAsync(Tenant, "CLM-ORPHAN");
+        Assert.Equal("OrphanSkipped", marker!.Outcome);
+    }
+
+    [Fact]
+    public async Task Apply_FamilyAggregate_UpdatesFamilyCountersToo()
+    {
+        var sut = BuildSut(out var repo, out _, out _);
+        SeedSnapshot(repo, 2026);
+
+        var evt = MakeClaim("CLM-FAM", new DateTime(2026, 2, 10), deductible: 500m, oop: 500m, familyAggregate: true);
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Applied, result.Outcome);
+        Assert.Equal(500m, result.Snapshot!.IndividualDeductibleUsed);
+        Assert.Equal(500m, result.Snapshot.FamilyDeductibleUsed);
+        Assert.Equal(500m, result.Snapshot.FamilyOopUsed);
+    }
+
+    [Fact]
+    public async Task Apply_MultiLineClaim_AttributesPerCategory()
+    {
+        var sut = BuildSut(out var repo, out _, out _);
+        SeedSnapshot(repo, 2026);
+
+        var evt = MakeClaim("CLM-MULTI", new DateTime(2026, 4, 1), deductible: 0m, category: "PrimaryCare", lines: new List<ClaimFinalizedLineItem>
+        {
+            new() { LineNumber = 1, BenefitCategory = "PrimaryCare", ServiceCode = "99213", CopayApplied = 25m, OopApplied = 25m },
+            new() { LineNumber = 2, BenefitCategory = "Lab", ServiceCode = "80053", CoinsuranceApplied = 12m, OopApplied = 12m }
+        });
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Applied, result.Outcome);
+        var snap = result.Snapshot!;
+        Assert.Equal(37m, snap.IndividualOopUsed);
+        Assert.Equal(2, snap.ServiceAccumulators.Count);
+        Assert.Contains(snap.ServiceAccumulators, s => s.BenefitCategory == "PrimaryCare" && s.Used == 25m);
+        Assert.Contains(snap.ServiceAccumulators, s => s.BenefitCategory == "Lab" && s.Used == 12m);
+    }
+
+    [Fact]
+    public async Task Adjust_ManualAdjustment_RecordsAuditAndPublishes()
+    {
+        var sut = BuildSut(out var repo, out _, out var pub);
+        SeedSnapshot(repo, 2026);
+
+        var req = new AccumulatorAdjustmentRequest
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            ActorId = "ops-user@cho",
+            Reason = "Correct mis-keyed claim CLM-99 (applied under wrong member)",
+            DeductibleDelta = -100m,
+            OopDelta = -100m
+        };
+        var result = await sut.AdjustAsync(Tenant, Member, req);
+
+        Assert.False(string.IsNullOrWhiteSpace(result.AdjustmentId));
+        Assert.Equal(0m, result.Snapshot.IndividualDeductibleUsed); // floored at 0
+
+        var audit = repo.Events.Single();
+        Assert.Equal("ManualAdjustment", audit.EventType);
+        Assert.Equal("ops-user@cho", audit.ActorId);
+        Assert.Equal(req.Reason, audit.Reason);
+
+        var adjusted = pub.Adjusted.Single();
+        Assert.Equal("ManualAdjustment", adjusted.AdjustmentSource);
+        Assert.Equal(req.Reason, adjusted.Reason);
+    }
+
+    [Fact]
+    public async Task TenantIsolation_ClaimForOneTenantDoesNotTouchAnother()
+    {
+        var sut = BuildSut(out var repo, out _, out _);
+        SeedSnapshot(repo, 2026);
+
+        // Seed a snapshot under a different tenant id with the same member id to
+        // verify partition isolation.
+        repo.Seed(new AccumulatorSnapshot
+        {
+            Id = AccumulatorSnapshot.BuildId("other-tenant", Member, new DateTime(2026, 1, 1)),
+            TenantId = "other-tenant",
+            MemberId = Member,
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            IndividualDeductibleLimit = 2000m
+        });
+
+        var evt = MakeClaim("CLM-TENANT", new DateTime(2026, 5, 5), deductible: 400m);
+        await sut.ApplyClaimFinalizedAsync(evt);
+
+        var mine = await repo.GetSnapshotAsync(Tenant, Member, new DateTime(2026, 1, 1));
+        var other = await repo.GetSnapshotAsync("other-tenant", Member, new DateTime(2026, 1, 1));
+        Assert.Equal(400m, mine!.IndividualDeductibleUsed);
+        Assert.Equal(0m, other!.IndividualDeductibleUsed);
+    }
+}

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorServiceTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorServiceTests.cs
@@ -101,7 +101,9 @@ public class AccumulatorServiceTests
         var audit = repo.Events[0];
         Assert.Equal("ClaimApplied", audit.EventType);
         Assert.Equal("CLM-1", audit.SourceClaimId);
-        Assert.Equal(evt.EventId, audit.EventId);
+        // Audit row gets a fresh EventId per attempt (not the wire id) so a retry
+        // after a transient failure doesn't collide on (tenantId, eventId).
+        Assert.False(string.IsNullOrWhiteSpace(audit.EventId));
         Assert.Equal(audit.Version, result.Snapshot.Version);
 
         Assert.Single(pub.Adjusted);
@@ -208,6 +210,57 @@ public class AccumulatorServiceTests
         Assert.Equal(2, snap.ServiceAccumulators.Count);
         Assert.Contains(snap.ServiceAccumulators, s => s.BenefitCategory == "PrimaryCare" && s.Used == 25m);
         Assert.Contains(snap.ServiceAccumulators, s => s.BenefitCategory == "Lab" && s.Used == 12m);
+    }
+
+    [Fact]
+    public async Task Apply_PendingMarkerFromPriorCrash_IsRetriedNotSkipped()
+    {
+        // Simulate: a prior attempt inserted the Pending marker but crashed before
+        // CompleteAsync. The next delivery must re-enter the apply path, not treat
+        // the claim as already applied.
+        var sut = BuildSut(out var repo, out var processed, out _);
+        SeedSnapshot(repo, 2026);
+
+        // Pre-seed a Pending marker as if a crash occurred.
+        await processed.TryBeginAsync("t1", "CLM-CRASH");
+        var marker = await processed.GetAsync("t1", "CLM-CRASH");
+        Assert.Equal("Pending", marker!.Outcome);
+
+        var evt = MakeClaim("CLM-CRASH", new DateTime(2026, 6, 1), deductible: 120m);
+        var result = await sut.ApplyClaimFinalizedAsync(evt);
+
+        Assert.Equal(ApplyOutcome.Applied, result.Outcome);
+        var snap = await repo.GetSnapshotAsync("t1", "m-100", new DateTime(2026, 1, 1));
+        Assert.Equal(120m, snap!.IndividualDeductibleUsed);
+
+        var final = await processed.GetAsync("t1", "CLM-CRASH");
+        Assert.Equal("Applied", final!.Outcome);
+    }
+
+    [Fact]
+    public async Task Adjust_SameAdjustmentId_IsIdempotentAndReturnsExistingSnapshot()
+    {
+        var sut = BuildSut(out var repo, out _, out var pub);
+        SeedSnapshot(repo, 2026);
+
+        var req = new AccumulatorAdjustmentRequest
+        {
+            AdjustmentId = "adj-42",
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            ActorId = "ops-user@cho",
+            Reason = "Out-of-system payment posted manually",
+            DeductibleDelta = 200m
+        };
+        var first = await sut.AdjustAsync("t1", "m-100", req);
+        var second = await sut.AdjustAsync("t1", "m-100", req);
+
+        Assert.Equal("adj-42", first.AdjustmentId);
+        Assert.Equal("adj-42", second.AdjustmentId);
+        Assert.Equal(first.Snapshot.Version, second.Snapshot.Version);
+        Assert.Equal(200m, second.Snapshot.IndividualDeductibleUsed);
+        Assert.Single(repo.Events); // only one ManualAdjustment row
+        Assert.Single(pub.Adjusted); // only one publish
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorsControllerTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorsControllerTests.cs
@@ -5,6 +5,8 @@ using AccumulatorService.Repositories;
 using AccumulatorService.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CloudHealthOffice.AccumulatorService.Tests;
@@ -27,9 +29,11 @@ public class AccumulatorsControllerTests : IClassFixture<AccumulatorsControllerT
     }
 
     [Fact]
-    public async Task Health_ReturnsOk()
+    public async Task Health_LivenessReturnsOk()
     {
-        var resp = await _client.GetAsync("/health");
+        // /health/live skips DB probes; /health aggregates the mongodb check which
+        // would dial a nonexistent server in the hermetic test harness.
+        var resp = await _client.GetAsync("/health/live");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorsControllerTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/AccumulatorsControllerTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Json;
+using AccumulatorService.Models;
+using AccumulatorService.Repositories;
+using AccumulatorService.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CloudHealthOffice.AccumulatorService.Tests;
+
+/// <summary>
+/// Integration tests for AccumulatorsController via WebApplicationFactory.
+/// Mongo/Cosmos/Kafka are replaced with in-memory fixtures so the test run is
+/// hermetic — no external infra required.
+/// </summary>
+public class AccumulatorsControllerTests : IClassFixture<AccumulatorsControllerTests.Factory>
+{
+    private readonly Factory _factory;
+    private readonly HttpClient _client;
+
+    public AccumulatorsControllerTests(Factory f)
+    {
+        _factory = f;
+        _client = f.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+    }
+
+    [Fact]
+    public async Task Health_ReturnsOk()
+    {
+        var resp = await _client.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithNoSnapshot_ReturnsZeroStateNot404()
+    {
+        var resp = await _client.GetAsync("/api/v1/accumulators/unknown-member");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadFromJsonAsync<AccumulatorResponse>();
+        Assert.NotNull(body);
+        Assert.Equal(0m, body!.IndividualDeductibleUsed);
+    }
+
+    [Fact]
+    public async Task MissingTenant_Returns400()
+    {
+        using var naked = _factory.CreateClient();
+        var resp = await naked.GetAsync("/api/v1/accumulators/m-1");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task CompatAlias_ReturnsSameShapeAsCanonical()
+    {
+        var canonical = await _client.GetAsync("/api/v1/accumulators/m-42");
+        var alias = await _client.GetAsync("/api/v1/members/m-42/accumulators");
+        Assert.Equal(HttpStatusCode.OK, canonical.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, alias.StatusCode);
+
+        var a = await canonical.Content.ReadFromJsonAsync<AccumulatorResponse>();
+        var b = await alias.Content.ReadFromJsonAsync<AccumulatorResponse>();
+        Assert.Equal(a!.MemberId, b!.MemberId);
+        Assert.Equal(a.IndividualDeductibleLimit, b.IndividualDeductibleLimit);
+    }
+
+    [Fact]
+    public async Task Adjust_RequiresReason()
+    {
+        var req = new AccumulatorAdjustmentRequest
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            ActorId = "op-1",
+            Reason = "", // invalid
+            DeductibleDelta = -10m
+        };
+        var resp = await _client.PostAsJsonAsync("/api/v1/accumulators/m-1/adjust", req);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    public class Factory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                // Provide a dummy Mongo connection so Program.cs takes the Mongo branch
+                // (the other branch throws when both stores are unset). The actual Mongo
+                // client is never dialed — we remove the IAccumulatorRepository registration
+                // before any request runs and replace it with the in-memory fake.
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["MongoDb:ConnectionString"] = "mongodb://localhost:27017",
+                    ["MongoDb:DatabaseName"] = "AccumulatorTests",
+                    ["Kafka:BootstrapServers"] = ""
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                foreach (var t in new[]
+                {
+                    typeof(IAccumulatorRepository),
+                    typeof(IProcessedClaimStore),
+                    typeof(IAccumulatorEventPublisher)
+                })
+                {
+                    var descriptors = services.Where(d => d.ServiceType == t).ToList();
+                    foreach (var d in descriptors) services.Remove(d);
+                }
+
+                // Remove DB client registrations that would try to connect.
+                var toDrop = services.Where(d =>
+                    d.ServiceType.FullName?.Contains("Mongo") == true ||
+                    d.ServiceType.FullName?.Contains("Cosmos") == true).ToList();
+                foreach (var d in toDrop) services.Remove(d);
+
+                services.AddSingleton<IAccumulatorRepository, InMemoryAccumulatorRepository>();
+                services.AddSingleton<IProcessedClaimStore, InMemoryProcessedClaimStore>();
+                services.AddSingleton<IAccumulatorEventPublisher, RecordingPublisher>();
+                services.AddScoped<IAccumulatorService, global::AccumulatorService.Services.AccumulatorService>();
+            });
+        }
+    }
+}

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/CloudHealthOffice.AccumulatorService.Tests.csproj
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/CloudHealthOffice.AccumulatorService.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\services\accumulator-service\accumulator-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Events\CloudHealthOffice.Events.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
@@ -67,16 +67,31 @@ public class InMemoryAccumulatorRepository : IAccumulatorRepository
             .ToList();
         return Task.FromResult(result);
     }
+
+    public Task<AccumulatorEvent?> GetManualAdjustmentAsync(string tenantId, string adjustmentId, CancellationToken ct = default)
+    {
+        var evt = Events.FirstOrDefault(e =>
+            e.TenantId == tenantId &&
+            e.EventType == "ManualAdjustment" &&
+            e.SourceReference == adjustmentId);
+        return Task.FromResult(evt);
+    }
 }
 
 public class InMemoryProcessedClaimStore : IProcessedClaimStore
 {
     private readonly Dictionary<string, ProcessedClaim> _map = new();
 
-    public Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    public Task<BeginClaimOutcome> TryBeginAsync(string tenantId, string claimId, CancellationToken ct = default)
     {
         var key = $"{tenantId}:{claimId}";
-        if (_map.ContainsKey(key)) return Task.FromResult(false);
+        if (_map.TryGetValue(key, out var existing))
+        {
+            // Pending = crashed mid-flight; allow retry.
+            if (string.Equals(existing.Outcome, "Pending", StringComparison.Ordinal))
+                return Task.FromResult(BeginClaimOutcome.Proceed);
+            return Task.FromResult(BeginClaimOutcome.AlreadyApplied);
+        }
         _map[key] = new ProcessedClaim
         {
             Id = key,
@@ -85,7 +100,7 @@ public class InMemoryProcessedClaimStore : IProcessedClaimStore
             ProcessedAt = DateTime.UtcNow,
             Outcome = "Pending"
         };
-        return Task.FromResult(true);
+        return Task.FromResult(BeginClaimOutcome.Proceed);
     }
 
     public Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default)

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
@@ -107,7 +107,7 @@ public class InMemoryProcessedClaimStore : IProcessedClaimStore
     }
 }
 
-public class RecordingPublisher : AccumulatorService.Services.IAccumulatorEventPublisher
+public class RecordingPublisher : global::AccumulatorService.Services.IAccumulatorEventPublisher
 {
     public readonly List<CloudHealthOffice.Events.AccumulatorAdjustedEvent> Adjusted = new();
     public readonly List<CloudHealthOffice.Events.OrphanAccumulatorClaimEvent> Orphans = new();

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/InMemoryAccumulatorRepository.cs
@@ -1,0 +1,126 @@
+using AccumulatorService.Models;
+using AccumulatorService.Repositories;
+
+namespace CloudHealthOffice.AccumulatorService.Tests;
+
+/// <summary>
+/// In-memory repository for unit tests. Enforces the same invariants as the
+/// real repositories — tenant partitioning, unique (tenantId, eventId), unique
+/// (tenantId, aggregateId, version) — so correctness bugs surface here instead
+/// of waiting for integration runs.
+/// </summary>
+public class InMemoryAccumulatorRepository : IAccumulatorRepository
+{
+    private readonly List<AccumulatorSnapshot> _snapshots = new();
+    public readonly List<AccumulatorEvent> Events = new();
+
+    public void Seed(AccumulatorSnapshot s) => _snapshots.Add(s);
+
+    public Task<AccumulatorSnapshot?> GetSnapshotAsync(string tenantId, string memberId, DateTime planYearStart, CancellationToken ct = default)
+    {
+        var id = AccumulatorSnapshot.BuildId(tenantId, memberId, planYearStart);
+        return Task.FromResult(_snapshots.FirstOrDefault(s => s.TenantId == tenantId && s.Id == id));
+    }
+
+    public Task<AccumulatorSnapshot?> GetSnapshotByAsOfDateAsync(string tenantId, string memberId, DateTime asOfDate, CancellationToken ct = default)
+    {
+        var s = _snapshots.FirstOrDefault(x =>
+            x.TenantId == tenantId &&
+            x.MemberId == memberId &&
+            x.PlanYearStart <= asOfDate &&
+            x.PlanYearEnd >= asOfDate);
+        return Task.FromResult(s);
+    }
+
+    public Task<IReadOnlyList<AccumulatorSnapshot>> GetSnapshotsAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        IReadOnlyList<AccumulatorSnapshot> result = _snapshots
+            .Where(s => s.TenantId == tenantId && s.MemberId == memberId)
+            .OrderByDescending(s => s.PlanYearStart)
+            .ToList();
+        return Task.FromResult(result);
+    }
+
+    public Task UpsertSnapshotAsync(AccumulatorSnapshot snapshot, CancellationToken ct = default)
+    {
+        _snapshots.RemoveAll(s => s.TenantId == snapshot.TenantId && s.Id == snapshot.Id);
+        _snapshots.Add(snapshot);
+        return Task.CompletedTask;
+    }
+
+    public Task AppendEventAsync(AccumulatorEvent evt, CancellationToken ct = default)
+    {
+        if (Events.Any(e => e.TenantId == evt.TenantId && e.EventId == evt.EventId))
+            throw new InvalidOperationException($"Duplicate eventId for tenant {evt.TenantId}");
+        if (Events.Any(e => e.TenantId == evt.TenantId && e.AggregateId == evt.AggregateId && e.Version == evt.Version))
+            throw new InvalidOperationException($"Duplicate (aggregateId, version) for tenant {evt.TenantId}");
+        Events.Add(evt);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<AccumulatorEvent>> GetEventsAsync(string tenantId, string memberId, int take = 100, CancellationToken ct = default)
+    {
+        IReadOnlyList<AccumulatorEvent> result = Events
+            .Where(e => e.TenantId == tenantId && e.MemberId == memberId)
+            .OrderByDescending(e => e.OccurredAt)
+            .Take(take)
+            .ToList();
+        return Task.FromResult(result);
+    }
+}
+
+public class InMemoryProcessedClaimStore : IProcessedClaimStore
+{
+    private readonly Dictionary<string, ProcessedClaim> _map = new();
+
+    public Task<bool> TryClaimAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var key = $"{tenantId}:{claimId}";
+        if (_map.ContainsKey(key)) return Task.FromResult(false);
+        _map[key] = new ProcessedClaim
+        {
+            Id = key,
+            TenantId = tenantId,
+            ClaimId = claimId,
+            ProcessedAt = DateTime.UtcNow,
+            Outcome = "Pending"
+        };
+        return Task.FromResult(true);
+    }
+
+    public Task CompleteAsync(string tenantId, string claimId, string resultingEventId, string outcome, CancellationToken ct = default)
+    {
+        var key = $"{tenantId}:{claimId}";
+        if (_map.TryGetValue(key, out var p))
+        {
+            p.ResultingEventId = resultingEventId;
+            p.Outcome = outcome;
+            p.ProcessedAt = DateTime.UtcNow;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task<ProcessedClaim?> GetAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var key = $"{tenantId}:{claimId}";
+        return Task.FromResult(_map.TryGetValue(key, out var p) ? p : null);
+    }
+}
+
+public class RecordingPublisher : AccumulatorService.Services.IAccumulatorEventPublisher
+{
+    public readonly List<CloudHealthOffice.Events.AccumulatorAdjustedEvent> Adjusted = new();
+    public readonly List<CloudHealthOffice.Events.OrphanAccumulatorClaimEvent> Orphans = new();
+
+    public Task PublishAdjustedAsync(CloudHealthOffice.Events.AccumulatorAdjustedEvent evt, CancellationToken ct = default)
+    {
+        Adjusted.Add(evt);
+        return Task.CompletedTask;
+    }
+
+    public Task PublishOrphanAsync(CloudHealthOffice.Events.OrphanAccumulatorClaimEvent evt, CancellationToken ct = default)
+    {
+        Orphans.Add(evt);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
New service at src/services/accumulator-service owning per-member
(tenantId, memberId, planYearStart) AccumulatorSnapshot, driven by
ClaimFinalized events and manual operator adjustments. Mirrors the
eligibility-service scaffold (Controllers/Services/Repositories/Models,
Mongo+Cosmos auto-detect, X-Tenant-ID middleware, Kafka publisher +
consumer, health checks, Dockerfile, k8s manifest).

Event contract: ClaimFinalizedEvent is a flat, internal CHO event —
explicitly not a FHIR ExplanationOfBenefit — carrying applied amounts,
per-line category attribution, service date, and adjudication
timestamp. Idempotency is keyed by (TenantId, ClaimId) so
re-finalization is deduped even across regenerated EventIds.
AccumulatorAdjustedEvent and OrphanAccumulatorClaimEvent cover manual
adjustments and data-quality alerts.

Retro adjustment: snapshot selection uses ServiceDate's plan year, not
today or AdjudicationTimestamp. Orphan claims (service date predating
known coverage) emit an event and skip — never a silent drop.

Audit: append-only AccumulatorEvent stream mirrors member-service's
MemberEvent pattern. Unique constraints on (tenantId, eventId) and
(tenantId, aggregateId, version). ProcessedClaim markers store
ProcessedAt and ResultingEventId for debuggability.

claims-service now publishes claims.finalized.v1 on terminal status
transitions (adjudication, generic status update, 835 remittance).

member-service proxy tightened: List<object> lists replaced with typed
MemberServiceAccumulator / MemberAccumulatorActivity. Production
startup fails loudly when Downstream:AccumulatorService:BaseUrl is
unset (no silent fallback to fakes). Portal MemberAccumulators aligned
to the same shape; Accumulators tab updated to render the event-stream
activity.

Tests: unit + integration coverage for apply, idempotency,
retro-plan-year selection, orphan handling, family aggregate,
multi-line attribution, manual adjustment audit, and tenant isolation.

TODO(addendum-a) markers on the Kafka consumer + publisher flag the
Phase 1/Phase 2 IMessageBus evaluation.
TODO(deprecate-members-accumulators-alias) on the /members/{id}/accumulators
compat route.

https://claude.ai/code/session_011JmSoXSskioqhbgrbjN9J6