### PR TITLE
feat(member-service): graduate SubscriberMemberId to symmetric FamilyRelationship graph (5.5)

### DIFF
--- a/docs/migrations/family-relationships-backfill.md
+++ b/docs/migrations/family-relationships-backfill.md
@@ -1,0 +1,136 @@
+# Family Relationships Backfill Runbook
+
+**Change:** graduates `Member.SubscriberMemberId` (a single-valued FK) to a
+symmetric `FamilyRelationship` edge table. Legacy field is marked `[Obsolete]`
+and derived from the graph on read.
+
+---
+
+## 1. Pre-flight
+
+Run these read-only counts in the target environment before starting:
+
+```bash
+# Count members that have a subscriber FK (candidates for backfill)
+mongosh "$MONGO_URI" --eval '
+  db.Members.countDocuments({
+    tenantId: "<TENANT_ID>",
+    subscriberMemberId: { $exists: true, $ne: null }
+  })
+'
+
+# Count relationships already in the graph (should be 0 pre-migration)
+mongosh "$MONGO_URI" --eval '
+  db.FamilyRelationships.countDocuments({ tenantId: "<TENANT_ID>" })
+'
+```
+
+Verify the deployment requirement for MongoDB transactions (used by the symmetric-pair
+writer): the Mongo cluster must be a **replica set**. Standalone Mongo will reject
+the transactions with a clear error rather than silently breaking the symmetric
+invariant. On Cosmos DB, symmetric pairs use `TransactionalBatch` within the
+`/tenantId` partition — no additional configuration required.
+
+## 2. Deploy
+
+1. Deploy member-service with this change set. The service will:
+   - Accept writes to the new `FamilyRelationshipsController` endpoints.
+   - Auto-create a relationship pair whenever a dependent is created via
+     `POST /api/v1/members` with `SubscriberMemberId` set (the shim).
+   - Continue writing `Member.SubscriberMemberId` on legacy write paths.
+   - Start deriving `Member.SubscriberMemberId` from the graph on reads where the
+     graph is populated; falls back to the stored legacy value otherwise.
+
+2. Verify the startup log shows:
+   ```
+   FamilyRelationship indexes ensured.
+   ```
+
+## 3. Backfill
+
+Run per tenant. The tool is resumable — if the process is killed it picks up
+where it left off on the next run.
+
+```bash
+# Dry-run first (no writes) to see the edge list
+dotnet run --project tools/FamilyRelationshipsBackfill -- \
+  --tenant <TENANT_ID> --dry-run
+
+# For real
+dotnet run --project tools/FamilyRelationshipsBackfill -- \
+  --tenant <TENANT_ID> --batch 500
+```
+
+Configuration is read from `tools/FamilyRelationshipsBackfill/appsettings.json`
+and/or env vars:
+
+- `MongoDb__ConnectionString` (required)
+- `MongoDb__DatabaseName` (default `CloudHealthOffice`)
+
+Progress is written to a `BackfillJobs` collection, one row per tenant. To
+re-run from scratch for a tenant:
+
+```bash
+dotnet run --project tools/FamilyRelationshipsBackfill -- \
+  --tenant <TENANT_ID> --reset
+```
+
+### Idempotency
+
+The tool calls `FamilyRelationshipService.CreateAsync`, which rejects duplicate
+active pairs. Re-running the backfill is safe:
+
+- Missing pairs get created.
+- Pairs that already exist (from shim auto-creation on new writes, or a prior
+  backfill run) are counted as `alreadyLinked` and skipped.
+
+## 4. Verification
+
+After the run completes for a tenant, verify the invariants:
+
+```javascript
+// Expected: (count of non-subscriber members with SubscriberMemberId) * 2
+//   (one forward + one inverse row per legacy edge)
+db.FamilyRelationships.countDocuments({ tenantId: "<TENANT_ID>" });
+
+// Every pair must have exactly 2 rows (symmetric-graph invariant)
+db.FamilyRelationships.aggregate([
+  { $match: { tenantId: "<TENANT_ID>" } },
+  { $group: { _id: "$pairId", rows: { $sum: 1 } } },
+  { $match: { rows: { $ne: 2 } } },
+]); // expected: empty cursor
+
+// Each pair must be same-tenant (Phase 1 constraint)
+db.FamilyRelationships.aggregate([
+  { $group: { _id: "$pairId", tenants: { $addToSet: "$tenantId" } } },
+  { $match: { tenants: { $not: { $size: 1 } } } },
+]); // expected: empty cursor
+```
+
+## 5. Rollback
+
+Safe rollback: the `Members` collection is untouched by the backfill — only the
+new `FamilyRelationships` collection is written.
+
+```javascript
+db.FamilyRelationships.deleteMany({ tenantId: "<TENANT_ID>" });
+db.BackfillJobs.deleteMany({ tenantId: "<TENANT_ID>" });
+```
+
+The member-service will continue to honor the legacy `SubscriberMemberId` field
+as the source of truth after rollback; graph-derivation degrades gracefully to
+returning `null` and the stored field value is used.
+
+## 6. Known phase-1 constraints
+
+- **Same-tenant only.** Cross-tenant family relationships (dual-coverage spouses
+  on different employer plans at the same payer) are rejected. These are
+  deferred to a later phase with a dedicated architecture doc.
+- **Soft-delete only.** `DELETE /{relId}` soft-deletes within 24h of creation
+  for data-entry errors. Normal wind-down is `POST /{relId}/end`. Hard delete
+  is not exposed — claims, authorizations, and QMCSO records depend on historical
+  edges remaining retrievable for audit.
+- **Legacy FK still written.** The 834 enrollment path still writes
+  `Member.SubscriberMemberId`; the shim mirrors it onto the graph. Once the
+  enrollment-import-service migrates to the new API (separate PR), the legacy
+  FK can be dropped.

--- a/src/portal/CloudHealthOffice.Portal/Pages/AddDependentDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/AddDependentDialog.razor
@@ -1,0 +1,160 @@
+@using CloudHealthOffice.Portal.Services
+@inject IFamilyRelationshipService FamilyRelationshipService
+@inject ISnackbar Snackbar
+
+<MudDialog Style="min-width: 680px;">
+    <DialogContent>
+        <MudStepper @bind-ActiveIndex="_step" Color="Color.Primary">
+            <MudStep Title="Dependent info">
+                <MudGrid>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Member.MemberId" Label="Dependent Member ID" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudDatePicker @bind-Date="_effectiveDate" Label="Effective Date" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Member.FirstName" Label="First Name" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Member.LastName" Label="Last Name" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="4">
+                        <MudDatePicker @bind-Date="_dob" Label="Date of Birth" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="4">
+                        <MudSelect T="string" Label="Gender" @bind-Value="_payload.Member.Gender">
+                            <MudSelectItem Value="@("M")">Male</MudSelectItem>
+                            <MudSelectItem Value="@("F")">Female</MudSelectItem>
+                            <MudSelectItem Value="@("U")">Unknown</MudSelectItem>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" md="4">
+                        <MudTextField @bind-Value="_payload.Member.SSN" Label="SSN (optional)" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Member.Email" Label="Email" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Member.Phone" Label="Phone" />
+                    </MudItem>
+                </MudGrid>
+            </MudStep>
+
+            <MudStep Title="Relationship">
+                <MudGrid>
+                    <MudItem xs="12" md="6">
+                        <MudSelect T="string" Label="Relationship" @bind-Value="_payload.Relationship.RelationshipCode" Required="true">
+                            <MudSelectItem Value="@("19")">Child</MudSelectItem>
+                            <MudSelectItem Value="@("01")">Spouse</MudSelectItem>
+                            <MudSelectItem Value="@("53")">Life Partner / Domestic Partner</MudSelectItem>
+                            <MudSelectItem Value="@("17")">Stepchild</MudSelectItem>
+                            <MudSelectItem Value="@("10")">Foster Child</MudSelectItem>
+                            <MudSelectItem Value="@("22")">Handicapped Dependent</MudSelectItem>
+                            <MudSelectItem Value="@("29")">Significant Other</MudSelectItem>
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudDatePicker @bind-Date="_relStartDate" Label="Relationship Start" Required="true" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudCheckBox T="bool" @bind-Value="_payload.Relationship.IsCustodial" Label="Custodial (minor / QMCSO)" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField @bind-Value="_payload.Relationship.QmcsoReference" Label="QMCSO Reference (optional)" />
+                    </MudItem>
+                </MudGrid>
+            </MudStep>
+
+            <MudStep Title="Confirm">
+                <MudText Typo="Typo.body2" Class="mb-3">Review before creating:</MudText>
+                <MudList T="string" Dense="true">
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.Badge">Member ID: <b>@_payload.Member.MemberId</b></MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.Person">@_payload.Member.FirstName @_payload.Member.LastName</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.Cake">DOB: @(_dob?.ToString("MM/dd/yyyy") ?? "—")</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.Link">Relationship: @_payload.Relationship.RelationshipCode @(_payload.Relationship.IsCustodial ? "(custodial)" : "")</MudListItem>
+                    <MudListItem T="string" Icon="@Icons.Material.Filled.CalendarToday">Effective: @(_effectiveDate?.ToString("MM/dd/yyyy") ?? "—")</MudListItem>
+                </MudList>
+                @if (_error != null)
+                {
+                    <MudAlert Severity="Severity.Error" Class="mt-3">@_error</MudAlert>
+                }
+            </MudStep>
+        </MudStepper>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Disabled="_submitting">Cancel</MudButton>
+        @if (_step > 0)
+        {
+            <MudButton OnClick="Back" Disabled="_submitting">Back</MudButton>
+        }
+        @if (_step < 2)
+        {
+            <MudButton Color="Color.Primary" OnClick="Next" Disabled="@(!CanAdvance())">Next</MudButton>
+        }
+        else
+        {
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="_submitting">
+                @(_submitting ? "Creating..." : "Create")
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] public string SubscriberMemberId { get; set; } = string.Empty;
+
+    private int _step = 0;
+    private bool _submitting = false;
+    private string? _error;
+
+    private DateTime? _dob;
+    private DateTime? _effectiveDate = DateTime.Today;
+    private DateTime? _relStartDate = DateTime.Today;
+
+    private readonly AddDependentPayload _payload = new()
+    {
+        Relationship = new AddDependentRelationship { RelationshipCode = "19" },
+    };
+
+    private bool CanAdvance() => _step switch
+    {
+        0 => !string.IsNullOrWhiteSpace(_payload.Member.MemberId)
+             && !string.IsNullOrWhiteSpace(_payload.Member.FirstName)
+             && !string.IsNullOrWhiteSpace(_payload.Member.LastName)
+             && _dob.HasValue
+             && _effectiveDate.HasValue,
+        1 => !string.IsNullOrWhiteSpace(_payload.Relationship.RelationshipCode)
+             && _relStartDate.HasValue,
+        _ => false,
+    };
+
+    private void Next() { if (CanAdvance()) _step++; }
+    private void Back() { if (_step > 0) _step--; }
+    private void Cancel() => MudDialog.Cancel();
+
+    private async Task Submit()
+    {
+        _error = null;
+        _submitting = true;
+        try
+        {
+            _payload.Member.DateOfBirth = _dob!.Value;
+            _payload.Member.EffectiveDate = _effectiveDate!.Value;
+            _payload.Relationship.StartDate = _relStartDate!.Value;
+
+            await FamilyRelationshipService.AddDependentAsync(SubscriberMemberId, _payload);
+            MudDialog.Close(DialogResult.Ok(true));
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _submitting = false;
+        }
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/AddDependentDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/AddDependentDialog.razor
@@ -4,83 +4,89 @@
 
 <MudDialog Style="min-width: 680px;">
     <DialogContent>
-        <MudStepper @bind-ActiveIndex="_step" Color="Color.Primary">
-            <MudStep Title="Dependent info">
-                <MudGrid>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Member.MemberId" Label="Dependent Member ID" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudDatePicker @bind-Date="_effectiveDate" Label="Effective Date" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Member.FirstName" Label="First Name" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Member.LastName" Label="Last Name" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="4">
-                        <MudDatePicker @bind-Date="_dob" Label="Date of Birth" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="4">
-                        <MudSelect T="string" Label="Gender" @bind-Value="_payload.Member.Gender">
-                            <MudSelectItem Value="@("M")">Male</MudSelectItem>
-                            <MudSelectItem Value="@("F")">Female</MudSelectItem>
-                            <MudSelectItem Value="@("U")">Unknown</MudSelectItem>
-                        </MudSelect>
-                    </MudItem>
-                    <MudItem xs="12" md="4">
-                        <MudTextField @bind-Value="_payload.Member.SSN" Label="SSN (optional)" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Member.Email" Label="Email" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Member.Phone" Label="Phone" />
-                    </MudItem>
-                </MudGrid>
-            </MudStep>
+        <MudText Typo="Typo.subtitle2" Color="Color.Secondary" Class="mb-3">
+            Step @(_step + 1) of 3 — @StepTitle
+        </MudText>
+        <MudProgressLinear Color="Color.Primary" Value="@(((_step + 1) * 100.0) / 3.0)" Class="mb-4" />
 
-            <MudStep Title="Relationship">
-                <MudGrid>
-                    <MudItem xs="12" md="6">
-                        <MudSelect T="string" Label="Relationship" @bind-Value="_payload.Relationship.RelationshipCode" Required="true">
-                            <MudSelectItem Value="@("19")">Child</MudSelectItem>
-                            <MudSelectItem Value="@("01")">Spouse</MudSelectItem>
-                            <MudSelectItem Value="@("53")">Life Partner / Domestic Partner</MudSelectItem>
-                            <MudSelectItem Value="@("17")">Stepchild</MudSelectItem>
-                            <MudSelectItem Value="@("10")">Foster Child</MudSelectItem>
-                            <MudSelectItem Value="@("22")">Handicapped Dependent</MudSelectItem>
-                            <MudSelectItem Value="@("29")">Significant Other</MudSelectItem>
-                        </MudSelect>
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudDatePicker @bind-Date="_relStartDate" Label="Relationship Start" Required="true" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudCheckBox T="bool" @bind-Value="_payload.Relationship.IsCustodial" Label="Custodial (minor / QMCSO)" />
-                    </MudItem>
-                    <MudItem xs="12" md="6">
-                        <MudTextField @bind-Value="_payload.Relationship.QmcsoReference" Label="QMCSO Reference (optional)" />
-                    </MudItem>
-                </MudGrid>
-            </MudStep>
-
-            <MudStep Title="Confirm">
-                <MudText Typo="Typo.body2" Class="mb-3">Review before creating:</MudText>
-                <MudList T="string" Dense="true">
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Badge">Member ID: <b>@_payload.Member.MemberId</b></MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Person">@_payload.Member.FirstName @_payload.Member.LastName</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Cake">DOB: @(_dob?.ToString("MM/dd/yyyy") ?? "—")</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.Link">Relationship: @_payload.Relationship.RelationshipCode @(_payload.Relationship.IsCustodial ? "(custodial)" : "")</MudListItem>
-                    <MudListItem T="string" Icon="@Icons.Material.Filled.CalendarToday">Effective: @(_effectiveDate?.ToString("MM/dd/yyyy") ?? "—")</MudListItem>
-                </MudList>
-                @if (_error != null)
-                {
-                    <MudAlert Severity="Severity.Error" Class="mt-3">@_error</MudAlert>
-                }
-            </MudStep>
-        </MudStepper>
+        @if (_step == 0)
+        {
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Member.MemberId" Label="Dependent Member ID" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudDatePicker @bind-Date="_effectiveDate" Label="Effective Date" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Member.FirstName" Label="First Name" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Member.LastName" Label="Last Name" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudDatePicker @bind-Date="_dob" Label="Date of Birth" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudSelect T="string" Label="Gender" @bind-Value="_payload.Member.Gender">
+                        <MudSelectItem Value="@("M")">Male</MudSelectItem>
+                        <MudSelectItem Value="@("F")">Female</MudSelectItem>
+                        <MudSelectItem Value="@("U")">Unknown</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" md="4">
+                    <MudTextField @bind-Value="_payload.Member.SSN" Label="SSN (optional)" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Member.Email" Label="Email" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Member.Phone" Label="Phone" />
+                </MudItem>
+            </MudGrid>
+        }
+        else if (_step == 1)
+        {
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudSelect T="string" Label="Relationship" @bind-Value="_payload.Relationship.RelationshipCode" Required="true">
+                        <MudSelectItem Value="@("19")">Child</MudSelectItem>
+                        <MudSelectItem Value="@("01")">Spouse</MudSelectItem>
+                        <MudSelectItem Value="@("53")">Life Partner / Domestic Partner</MudSelectItem>
+                        <MudSelectItem Value="@("17")">Stepchild</MudSelectItem>
+                        <MudSelectItem Value="@("10")">Foster Child</MudSelectItem>
+                        <MudSelectItem Value="@("22")">Handicapped Dependent</MudSelectItem>
+                        <MudSelectItem Value="@("29")">Significant Other</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudDatePicker @bind-Date="_relStartDate" Label="Relationship Start" Required="true" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudCheckBox T="bool" @bind-Checked="_payload.Relationship.IsCustodial" Label="Custodial (minor / QMCSO)" />
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTextField @bind-Value="_payload.Relationship.QmcsoReference" Label="QMCSO Reference (optional)" />
+                </MudItem>
+            </MudGrid>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2" Class="mb-3">Review before creating:</MudText>
+            <MudSimpleTable Dense="true" Hover="true" Elevation="0">
+                <tbody>
+                    <tr><td>Member ID</td><td><b>@_payload.Member.MemberId</b></td></tr>
+                    <tr><td>Name</td><td>@_payload.Member.FirstName @_payload.Member.LastName</td></tr>
+                    <tr><td>Date of Birth</td><td>@(_dob?.ToString("MM/dd/yyyy") ?? "—")</td></tr>
+                    <tr><td>Relationship</td><td>@_payload.Relationship.RelationshipCode @(_payload.Relationship.IsCustodial ? "(custodial)" : "")</td></tr>
+                    <tr><td>Effective</td><td>@(_effectiveDate?.ToString("MM/dd/yyyy") ?? "—")</td></tr>
+                </tbody>
+            </MudSimpleTable>
+            @if (_error != null)
+            {
+                <MudAlert Severity="Severity.Error" Class="mt-3">@_error</MudAlert>
+            }
+        }
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Cancel" Disabled="_submitting">Cancel</MudButton>
@@ -117,6 +123,13 @@
     private readonly AddDependentPayload _payload = new()
     {
         Relationship = new AddDependentRelationship { RelationshipCode = "19" },
+    };
+
+    private string StepTitle => _step switch
+    {
+        0 => "Dependent info",
+        1 => "Relationship",
+        _ => "Confirm",
     };
 
     private bool CanAdvance() => _step switch

--- a/src/portal/CloudHealthOffice.Portal/Pages/FamilyRelationshipTable.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/FamilyRelationshipTable.razor
@@ -1,0 +1,60 @@
+@using CloudHealthOffice.Portal.Services
+
+<MudSimpleTable Dense="true" Hover="true" Elevation="1">
+    <thead>
+        <tr>
+            <th>Member ID</th>
+            <th>Relationship</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Custodial</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var row in Rows)
+        {
+            <tr>
+                <td>
+                    <span style="font-family: monospace;">@row.RelatedMemberId</span>
+                </td>
+                <td>
+                    <MudChip T="string" Size="Size.Small" Color="Color.Info">@LabelFor(row.RelationshipCode)</MudChip>
+                    @if (row.IsCustodial)
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Warning">Custodial</MudChip>
+                    }
+                </td>
+                <td>@row.StartDate.ToString("MM/dd/yyyy")</td>
+                <td>@(row.EndDate?.ToString("MM/dd/yyyy") ?? "—")</td>
+                <td>@(row.IsCustodial ? "Yes" : "")</td>
+                <td>
+                    @if (row.EndDate == null && row.DeletedAt == null && OnEnd.HasDelegate)
+                    {
+                        <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Error"
+                                   OnClick="@(() => OnEnd.InvokeAsync(row))">End</MudButton>
+                    }
+                </td>
+            </tr>
+        }
+    </tbody>
+</MudSimpleTable>
+
+@code {
+    [Parameter] public List<FamilyRelationshipRow> Rows { get; set; } = new();
+    [Parameter] public EventCallback<FamilyRelationshipRow> OnEnd { get; set; }
+
+    private static string LabelFor(string code) => code switch
+    {
+        "18" => "Self",
+        "01" => "Spouse",
+        "19" => "Child",
+        "53" => "Life Partner",
+        "17" => "Stepchild",
+        "10" => "Foster Child",
+        "G8" => "Parent / Other",
+        "22" => "Handicapped Dep.",
+        "29" => "Significant Other",
+        _ => code,
+    };
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -3,6 +3,7 @@
 @inject IMemberService MemberService
 @inject ICoverageService CoverageService
 @inject IBenefitPlanService BenefitPlanService
+@inject IFamilyRelationshipService FamilyRelationshipService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
@@ -680,6 +681,63 @@
                         }
                     </div>
                 </MudTabPanel>
+
+                <!-- Family Tab -->
+                <MudTabPanel Text="Family" Icon="@Icons.Material.Filled.FamilyRestroom">
+                    <div>
+                        <div class="d-flex align-center mb-3">
+                            <MudText Typo="Typo.subtitle1" Style="font-weight: 600;">
+                                <MudIcon Icon="@Icons.Material.Filled.Groups" Size="Size.Small" Class="mr-1" />
+                                Family Relationships
+                            </MudText>
+                            <MudSpacer />
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                       StartIcon="@Icons.Material.Filled.PersonAdd"
+                                       OnClick="OpenAddDependentDialog">
+                                Add Dependent
+                            </MudButton>
+                        </div>
+
+                        @if (_loadingFamily)
+                        {
+                            <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-4" />
+                        }
+                        else
+                        {
+                            @if (_subscriberRows.Any())
+                            {
+                                <MudExpansionPanels MultiExpansion="true" Class="mb-2">
+                                    <MudExpansionPanel Text="Subscriber" IsInitiallyExpanded="true">
+                                        <FamilyRelationshipTable Rows="_subscriberRows" OnEnd="EndRelationshipAsync" />
+                                    </MudExpansionPanel>
+                                </MudExpansionPanels>
+                            }
+
+                            @if (_dependentRows.Any())
+                            {
+                                <MudExpansionPanels MultiExpansion="true" Class="mb-2">
+                                    <MudExpansionPanel Text="@($"Dependents ({_dependentRows.Count})")" IsInitiallyExpanded="true">
+                                        <FamilyRelationshipTable Rows="_dependentRows" OnEnd="EndRelationshipAsync" />
+                                    </MudExpansionPanel>
+                                </MudExpansionPanels>
+                            }
+
+                            @if (_otherRows.Any())
+                            {
+                                <MudExpansionPanels MultiExpansion="true" Class="mb-2">
+                                    <MudExpansionPanel Text="@($"Other ({_otherRows.Count})")">
+                                        <FamilyRelationshipTable Rows="_otherRows" OnEnd="EndRelationshipAsync" />
+                                    </MudExpansionPanel>
+                                </MudExpansionPanels>
+                            }
+
+                            @if (!_subscriberRows.Any() && !_dependentRows.Any() && !_otherRows.Any())
+                            {
+                                <MudAlert Severity="Severity.Info">No family relationships recorded for this member.</MudAlert>
+                            }
+                        }
+                    </div>
+                </MudTabPanel>
             </MudTabs>
         }
         else
@@ -716,8 +774,16 @@
     private bool _loading834 = false;
     private bool _loadingAccumulators = false;
     private bool _loadingBenefits = false;
+    private bool _loadingFamily = false;
     private int _activeTab = 0;
     private string? _serviceError;
+
+    private List<FamilyRelationshipRow> _subscriberRows = new();
+    private List<FamilyRelationshipRow> _dependentRows = new();
+    private List<FamilyRelationshipRow> _otherRows = new();
+
+    // X12 INS02 codes meaning "the counterparty is this member's subscriber"
+    private static readonly HashSet<string> DependentToSubscriberCodes = new() { "19", "17", "10", "01", "53", "22", "29" };
 
     private MudTabPanel? _pcpTab;
     private MudTable<Enrollment834Record>? _834Table;
@@ -769,6 +835,66 @@
         _ = LoadHistoryAsync();
         _ = Load834Async();
         _ = LoadBenefitsForActiveCoverageAsync();
+        _ = LoadFamilyAsync();
+    }
+
+    private async Task LoadFamilyAsync()
+    {
+        _loadingFamily = true;
+        try
+        {
+            var rows = await FamilyRelationshipService.ListForMemberAsync(MemberId);
+
+            // Bucket rows into subscriber / dependents / other based on INS02 direction.
+            // Each row is already subject-perspective (SubjectMemberId == this member).
+            _subscriberRows = rows.Where(r => DependentToSubscriberCodes.Contains(r.RelationshipCode)).ToList();
+            _dependentRows  = rows.Where(r => r.RelationshipCode == "G8").ToList();
+            _otherRows      = rows.Except(_subscriberRows).Except(_dependentRows).ToList();
+        }
+        catch (ServiceUnavailableException) { ResetFamily(); }
+        catch { ResetFamily(); }
+        finally
+        {
+            _loadingFamily = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void ResetFamily()
+    {
+        _subscriberRows = new();
+        _dependentRows = new();
+        _otherRows = new();
+    }
+
+    private async Task EndRelationshipAsync(FamilyRelationshipRow row)
+    {
+        try
+        {
+            await FamilyRelationshipService.EndRelationshipAsync(MemberId, row.Id);
+            Snackbar.Add("Relationship ended.", Severity.Success);
+            await LoadFamilyAsync();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to end relationship: {ex.Message}", Severity.Error);
+        }
+    }
+
+    private async Task OpenAddDependentDialog()
+    {
+        var parameters = new DialogParameters
+        {
+            [nameof(AddDependentDialog.SubscriberMemberId)] = MemberId,
+        };
+        var options = new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<AddDependentDialog>("Add Dependent", parameters, options);
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            Snackbar.Add("Dependent added.", Severity.Success);
+            await LoadFamilyAsync();
+        }
     }
 
     private async Task LoadBenefitsForActiveCoverageAsync()

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -782,8 +782,11 @@
     private List<FamilyRelationshipRow> _dependentRows = new();
     private List<FamilyRelationshipRow> _otherRows = new();
 
-    // X12 INS02 codes meaning "the counterparty is this member's subscriber"
-    private static readonly HashSet<string> DependentToSubscriberCodes = new() { "19", "17", "10", "01", "53", "22", "29" };
+    // Codes whose inverse is "G8" (Parent / Other) — these are the true
+    // directional dependent→subscriber edges. Self-inverse codes like "01"
+    // (Spouse), "53" (Life Partner), "22" (Handicapped Dep.), "29" (Significant
+    // Other) are symmetric and don't identify a subscriber; they land in "Other".
+    private static readonly HashSet<string> DependentToSubscriberCodes = new() { "19", "17", "10" };
 
     private MudTabPanel? _pcpTab;
     private MudTable<Enrollment834Record>? _834Table;

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -226,6 +226,7 @@ builder.Services.AddScoped<IUserContextService, UserContextService>();
 
 // Register microservice clients
 builder.Services.AddScoped<IMemberService, MemberService>();
+builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService>();
 builder.Services.AddScoped<ICoverageService, CoverageService>();
 builder.Services.AddScoped<IClaimsService, ClaimsService>();
 builder.Services.AddScoped<IEligibilityService, EligibilityService>();

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -77,6 +77,65 @@ public interface ICoverageService
     Task<List<Coverage>> GetCoverageByMemberIdAsync(string memberId);
 }
 
+public interface IFamilyRelationshipService
+{
+    Task<List<FamilyRelationshipRow>> ListForMemberAsync(string memberId);
+    Task<FamilyRelationshipRow?> AddDependentAsync(string subscriberMemberId, AddDependentPayload payload);
+    Task EndRelationshipAsync(string memberId, string relationshipId, DateTime? endDate = null);
+    Task<FamilyRelationshipRow?> UpdateRelationshipAsync(string memberId, string relationshipId, UpdateRelationshipPayload payload);
+    Task SoftDeleteAsync(string memberId, string relationshipId, string reason);
+}
+
+public class FamilyRelationshipRow
+{
+    public string Id { get; set; } = string.Empty;
+    public string SubjectMemberId { get; set; } = string.Empty;
+    public string RelatedMemberId { get; set; } = string.Empty;
+    public string RelationshipCode { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+    public DateTime? DeletedAt { get; set; }
+}
+
+public class AddDependentPayload
+{
+    public AddDependentMember Member { get; set; } = new();
+    public AddDependentRelationship Relationship { get; set; } = new();
+}
+
+public class AddDependentMember
+{
+    public string MemberId { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string? MiddleName { get; set; }
+    public DateTime DateOfBirth { get; set; }
+    public string? Gender { get; set; }
+    public string? SSN { get; set; }
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public DateTime EffectiveDate { get; set; }
+}
+
+public class AddDependentRelationship
+{
+    public string RelationshipCode { get; set; } = "19";
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+}
+
+public class UpdateRelationshipPayload
+{
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool? IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+}
+
 public interface IAuthorizationService
 {
     Task<List<AuthorizationSummary>> GetAuthorizationsAsync(string? memberId = null);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -3368,14 +3368,24 @@ public class FamilyRelationshipService : IFamilyRelationshipService
                 var body = await response.Content.ReadAsStringAsync();
                 throw new InvalidOperationException($"Add dependent failed ({(int)response.StatusCode}): {body}");
             }
-            // The API returns {member, subscriberMemberId} — we don't need the full body in the portal
-            return null;
+
+            // Server returns { member, subscriberMemberId, relationship }. Surface the
+            // relationship row so callers can link into the new edge without a re-fetch.
+            var parsed = await response.Content.ReadFromJsonAsync<AddDependentApiResponse>(
+                new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            return parsed?.Relationship;
         }
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
             throw new ServiceUnavailableException("Member Service", ex);
         }
+    }
+
+    private class AddDependentApiResponse
+    {
+        public FamilyRelationshipRow? Relationship { get; set; }
+        public string SubscriberMemberId { get; set; } = string.Empty;
     }
 
     public async Task EndRelationshipAsync(string memberId, string relationshipId, DateTime? endDate = null)

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -3325,3 +3325,111 @@ public class TerminologyServiceImpl : ITerminologyService
         catch (HttpRequestException ex) { _logger.LogError(ex, "Terminology Service unavailable"); throw new ServiceUnavailableException("Terminology Service", ex); }
     }
 }
+
+public class FamilyRelationshipService : IFamilyRelationshipService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<FamilyRelationshipService> _logger;
+
+    public FamilyRelationshipService(HttpClient httpClient, IConfiguration configuration, ILogger<FamilyRelationshipService> logger)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    private string BaseUrl => _configuration["Services:MemberService"] ?? string.Empty;
+
+    public async Task<List<FamilyRelationshipRow>> ListForMemberAsync(string memberId)
+    {
+        try
+        {
+            var payload = await _httpClient.GetFromJsonAsync<FamilyRelationshipListResponse>(
+                $"{BaseUrl}/members/{Uri.EscapeDataString(memberId)}/relationships");
+            return payload?.Relationships ?? new List<FamilyRelationshipRow>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<FamilyRelationshipRow?> AddDependentAsync(string subscriberMemberId, AddDependentPayload payload)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{BaseUrl}/members/{Uri.EscapeDataString(subscriberMemberId)}/dependents",
+                payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                throw new InvalidOperationException($"Add dependent failed ({(int)response.StatusCode}): {body}");
+            }
+            // The API returns {member, subscriberMemberId} — we don't need the full body in the portal
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task EndRelationshipAsync(string memberId, string relationshipId, DateTime? endDate = null)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{BaseUrl}/members/{Uri.EscapeDataString(memberId)}/relationships/{Uri.EscapeDataString(relationshipId)}/end",
+                new { endDate });
+            response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<FamilyRelationshipRow?> UpdateRelationshipAsync(string memberId, string relationshipId, UpdateRelationshipPayload payload)
+    {
+        try
+        {
+            var response = await _httpClient.PutAsJsonAsync(
+                $"{BaseUrl}/members/{Uri.EscapeDataString(memberId)}/relationships/{Uri.EscapeDataString(relationshipId)}",
+                payload);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<FamilyRelationshipRow>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task SoftDeleteAsync(string memberId, string relationshipId, string reason)
+    {
+        try
+        {
+            var url = $"{BaseUrl}/members/{Uri.EscapeDataString(memberId)}/relationships/{Uri.EscapeDataString(relationshipId)}?reason={Uri.EscapeDataString(reason)}";
+            var response = await _httpClient.DeleteAsync(url);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    private class FamilyRelationshipListResponse
+    {
+        public string MemberId { get; set; } = string.Empty;
+        public List<FamilyRelationshipRow> Relationships { get; set; } = new();
+        public int TotalCount { get; set; }
+    }
+}

--- a/src/services/member-service/Controllers/FamilyRelationshipsController.cs
+++ b/src/services/member-service/Controllers/FamilyRelationshipsController.cs
@@ -53,7 +53,9 @@ public class FamilyRelationshipsController : ControllerBase
         CancellationToken ct = default)
     {
         var member = await _memberRepo.GetByMemberIdAsync(TenantId, memberId);
-        if (member == null) return NotFound();
+        // Hide drafts from the relationships endpoint the same way MembersController.GetMember
+        // hides them — a draft Member's edges shouldn't be enumerable until the wizard commits.
+        if (member == null || member.IsDraft) return NotFound();
 
         var rows = await _service.ListForMemberAsync(TenantId, memberId, includeDeleted, ct);
 
@@ -155,9 +157,16 @@ public class FamilyRelationshipsController : ControllerBase
     }
 
     /// <summary>
-    /// Soft-delete (admin-only, data-entry error correction within 24h).
-    /// Hard delete is intentionally not exposed — the relationship may be referenced
-    /// by downstream claims, authorizations, and audit records.
+    /// Soft-delete (data-entry error correction within 24h). Hard delete is
+    /// intentionally not exposed — the relationship may be referenced by downstream
+    /// claims, authorizations, and audit records.
+    ///
+    /// Authorization: this endpoint is intended to be gated to admin actors at the
+    /// API gateway / ingress (no controller-level policy is defined because the
+    /// service stack does not configure <c>AddAuthorization</c> here; policies live
+    /// at the gateway). The 24h creation-window guard inside
+    /// <c>FamilyRelationshipService.SoftDeleteAsync</c> is defense-in-depth but not
+    /// a substitute for the gateway policy.
     /// </summary>
     [HttpDelete("{relId}")]
     [ProducesResponseType(typeof(FamilyRelationship), 200)]
@@ -264,9 +273,10 @@ public class FamilyRelationshipsController : ControllerBase
 
         await _memberRepo.CreateAsync(dependent);
 
+        FamilyRelationship createdRelationship;
         try
         {
-            await _service.CreateAsync(TenantId, new CreateFamilyRelationshipRequest
+            createdRelationship = await _service.CreateAsync(TenantId, new CreateFamilyRelationshipRequest
             {
                 SubjectMemberId = dependent.MemberId,
                 RelatedMemberId = memberId,
@@ -304,12 +314,20 @@ public class FamilyRelationshipsController : ControllerBase
                 ["memberId"] = dependent.MemberId,
                 ["subscriberMemberId"] = memberId,
                 ["relationshipCode"] = request.Relationship.RelationshipCode,
+                ["relationshipId"] = createdRelationship.Id,
             },
         }, ct);
 
+        // Location points at the created relationship row, not the Member. A GET on
+        // api/v1/members/{depMemberId}/relationships/{relId} will resolve it.
         return CreatedAtAction(nameof(Get),
-            new { memberId = dependent.MemberId, relId = dependent.Id },
-            new AddDependentResponse { Member = dependent, SubscriberMemberId = memberId });
+            new { memberId = dependent.MemberId, relId = createdRelationship.Id },
+            new AddDependentResponse
+            {
+                Member = dependent,
+                SubscriberMemberId = memberId,
+                Relationship = createdRelationship,
+            });
     }
 }
 
@@ -371,6 +389,7 @@ public class AddDependentResponse
 {
     public Member Member { get; set; } = new();
     public string SubscriberMemberId { get; set; } = string.Empty;
+    public FamilyRelationship? Relationship { get; set; }
 }
 
 #endregion

--- a/src/services/member-service/Controllers/FamilyRelationshipsController.cs
+++ b/src/services/member-service/Controllers/FamilyRelationshipsController.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Middleware;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MemberService.Controllers;
+
+/// <summary>
+/// Family relationships for a member. Graduates the legacy
+/// <c>Member.SubscriberMemberId</c> FK model to a symmetric
+/// <see cref="FamilyRelationship"/> graph.
+/// </summary>
+[ApiController]
+[Route("api/v1/members/{memberId}/relationships")]
+public class FamilyRelationshipsController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IFamilyRelationshipService _service;
+    private readonly IMemberRepository _memberRepo;
+    private readonly IMemberEventPublisher _eventPublisher;
+    private readonly IIdentifierEncryptor _encryptor;
+
+    public FamilyRelationshipsController(
+        IFamilyRelationshipService service,
+        IMemberRepository memberRepo,
+        IMemberEventPublisher eventPublisher,
+        IIdentifierEncryptor encryptor)
+    {
+        _service = service;
+        _memberRepo = memberRepo;
+        _eventPublisher = eventPublisher;
+        _encryptor = encryptor;
+    }
+
+    // ── Read ────────────────────────────────────────────────────────────
+
+    /// <summary>List active relationships touching <paramref name="memberId"/>.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(FamilyRelationshipListResponse), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> List(
+        [FromRoute] string memberId,
+        [FromQuery] bool includeDeleted = false,
+        CancellationToken ct = default)
+    {
+        var member = await _memberRepo.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var rows = await _service.ListForMemberAsync(TenantId, memberId, includeDeleted, ct);
+
+        // Only surface the edges where this member is the subject — each pair has two
+        // rows and we don't want to return them twice.
+        var mine = rows.Where(r => r.SubjectMemberId == memberId).ToList();
+        return Ok(new FamilyRelationshipListResponse
+        {
+            MemberId = memberId,
+            Relationships = mine,
+            TotalCount = mine.Count,
+        });
+    }
+
+    [HttpGet("{relId}")]
+    [ProducesResponseType(typeof(FamilyRelationship), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> Get([FromRoute] string memberId, [FromRoute] string relId, CancellationToken ct)
+    {
+        var row = await _service.GetByIdAsync(TenantId, relId, ct);
+        if (row == null || (row.SubjectMemberId != memberId && row.RelatedMemberId != memberId))
+            return NotFound();
+        return Ok(row);
+    }
+
+    // ── Create / update / end ────────────────────────────────────────────
+
+    [HttpPost]
+    [ProducesResponseType(typeof(FamilyRelationship), 201)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> Create(
+        [FromRoute] string memberId,
+        [FromBody] CreateFamilyRelationshipRequest request,
+        CancellationToken ct)
+    {
+        if (request == null) return BadRequest("Body is required.");
+        // Force the URL's memberId to be the subject; ignore any mismatched body value
+        // to avoid confusing URL vs body ownership.
+        request.SubjectMemberId = memberId;
+        try
+        {
+            var created = await _service.CreateAsync(TenantId, request, User.Identity?.Name, ct);
+            return CreatedAtAction(nameof(Get), new { memberId, relId = created.Id }, created);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{relId}")]
+    [ProducesResponseType(typeof(FamilyRelationship), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> Update(
+        [FromRoute] string memberId,
+        [FromRoute] string relId,
+        [FromBody] UpdateFamilyRelationshipRequest request,
+        CancellationToken ct)
+    {
+        var row = await _service.GetByIdAsync(TenantId, relId, ct);
+        if (row == null || (row.SubjectMemberId != memberId && row.RelatedMemberId != memberId))
+            return NotFound();
+        try
+        {
+            var updated = await _service.UpdateAsync(TenantId, relId, request, User.Identity?.Name, ct);
+            return Ok(updated);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>End a relationship (normal wind-down).</summary>
+    [HttpPost("{relId}/end")]
+    [ProducesResponseType(typeof(FamilyRelationship), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> End(
+        [FromRoute] string memberId,
+        [FromRoute] string relId,
+        [FromBody] EndRelationshipRequest? request,
+        CancellationToken ct)
+    {
+        var row = await _service.GetByIdAsync(TenantId, relId, ct);
+        if (row == null || (row.SubjectMemberId != memberId && row.RelatedMemberId != memberId))
+            return NotFound();
+        try
+        {
+            var endDate = request?.EndDate ?? DateTime.UtcNow;
+            var updated = await _service.EndAsync(TenantId, relId, endDate, User.Identity?.Name, ct);
+            return Ok(updated);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Soft-delete (admin-only, data-entry error correction within 24h).
+    /// Hard delete is intentionally not exposed — the relationship may be referenced
+    /// by downstream claims, authorizations, and audit records.
+    /// </summary>
+    [HttpDelete("{relId}")]
+    [ProducesResponseType(typeof(FamilyRelationship), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> SoftDelete(
+        [FromRoute] string memberId,
+        [FromRoute] string relId,
+        [FromQuery] string reason,
+        CancellationToken ct)
+    {
+        var row = await _service.GetByIdAsync(TenantId, relId, ct);
+        if (row == null || (row.SubjectMemberId != memberId && row.RelatedMemberId != memberId))
+            return NotFound();
+        try
+        {
+            var updated = await _service.SoftDeleteAsync(TenantId, relId, reason, User.Identity?.Name, ct: ct);
+            return Ok(updated);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    // ── Add-Dependent wizard ────────────────────────────────────────────
+
+    /// <summary>
+    /// Two-step (but externally atomic-feeling) Add Dependent: creates a new Member in
+    /// <c>IsDraft=true</c> state, then creates the symmetric relationship pair, then
+    /// promotes the draft (<c>IsDraft=false</c>).
+    ///
+    /// If the relationship create fails, the Member is left as a draft — drafts are
+    /// invisible to normal queries and a reconciler sweeps them after their TTL.
+    /// (Outbox-pattern dispatch will replace this once the member-event consumer
+    /// pipeline is in place; see architectural notes in docs/migrations/...)
+    /// </summary>
+    [HttpPost("/api/v1/members/{memberId}/dependents")]
+    [ProducesResponseType(typeof(AddDependentResponse), 201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> AddDependent(
+        [FromRoute] string memberId,
+        [FromBody] AddDependentRequest request,
+        CancellationToken ct)
+    {
+        if (request == null || request.Member == null || request.Relationship == null)
+            return BadRequest("Both member and relationship payloads are required.");
+
+        var subscriber = await _memberRepo.GetByMemberIdAsync(TenantId, memberId);
+        if (subscriber == null) return NotFound($"Subscriber '{memberId}' not found.");
+
+        // Fail fast on an invalid relationship code before touching the Member store.
+        if (!FamilyRelationshipCodes.IsValid(request.Relationship.RelationshipCode))
+            return BadRequest(new { error = $"Unknown relationshipCode '{request.Relationship.RelationshipCode}'." });
+
+        var existing = await _memberRepo.GetByMemberIdAsync(TenantId, request.Member.MemberId);
+        if (existing != null)
+            return Conflict(new { memberId = request.Member.MemberId, message = "MemberId already exists in this tenant." });
+
+        var identifiers = new List<MemberIdentifier>();
+        if (!string.IsNullOrEmpty(request.Member.SSN))
+        {
+            var cipher = await _encryptor.EncryptAsync(request.Member.SSN, ct);
+            identifiers.Add(new MemberIdentifier
+            {
+                Type = MemberIdentifierType.SSN,
+                System = FhirIdentifierSystems.SSN,
+                Value = cipher ?? string.Empty,
+                IsEncrypted = _encryptor.IsEnabled,
+            });
+        }
+
+        var dependent = new Member
+        {
+            TenantId = TenantId,
+            MemberId = request.Member.MemberId,
+            SSN = _encryptor.IsEnabled ? null : request.Member.SSN,
+            GroupNumber = request.Member.GroupNumber ?? subscriber.GroupNumber,
+            IsSubscriber = false,
+#pragma warning disable CS0618 // back-compat: derived on read after migration
+            SubscriberMemberId = memberId,
+            RelationshipCode = request.Relationship.RelationshipCode,
+#pragma warning restore CS0618
+            FirstName = request.Member.FirstName,
+            LastName = request.Member.LastName,
+            MiddleName = request.Member.MiddleName,
+            DateOfBirth = request.Member.DateOfBirth,
+            Gender = request.Member.Gender,
+            Address = request.Member.Address ?? subscriber.Address,
+            City = request.Member.City ?? subscriber.City,
+            State = request.Member.State ?? subscriber.State,
+            ZipCode = request.Member.ZipCode ?? subscriber.ZipCode,
+            Phone = request.Member.Phone,
+            Email = request.Member.Email,
+            EffectiveDate = request.Member.EffectiveDate,
+            TerminationDate = request.Member.TerminationDate,
+            Status = EnrollmentStatus.Pending,
+            LineOfBusiness = subscriber.LineOfBusiness,
+            Identifiers = identifiers,
+            IsDraft = true,
+            CreatedBy = User.Identity?.Name ?? "portal",
+        };
+
+        await _memberRepo.CreateAsync(dependent);
+
+        try
+        {
+            await _service.CreateAsync(TenantId, new CreateFamilyRelationshipRequest
+            {
+                SubjectMemberId = dependent.MemberId,
+                RelatedMemberId = memberId,
+                RelationshipCode = request.Relationship.RelationshipCode,
+                StartDate = request.Relationship.StartDate == default
+                    ? request.Member.EffectiveDate
+                    : request.Relationship.StartDate,
+                EndDate = request.Relationship.EndDate,
+                IsCustodial = request.Relationship.IsCustodial,
+                QmcsoReference = request.Relationship.QmcsoReference,
+            }, User.Identity?.Name, ct);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            // Leave the Member as a draft — the reconciler will purge it after TTL.
+            // Returning 400 lets the portal surface a specific error to the user.
+            return BadRequest(new { error = ex.Message, memberId = dependent.MemberId, draft = true });
+        }
+
+        dependent.IsDraft = false;
+        dependent.LastUpdatedDate = DateTime.UtcNow;
+        await _memberRepo.UpdateAsync(dependent);
+
+        await _eventPublisher.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = dependent.MemberId,
+            EventId = request.EventId ?? Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberCreated,
+            ActorId = User.Identity?.Name,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["source"] = "AddDependent",
+                ["memberId"] = dependent.MemberId,
+                ["subscriberMemberId"] = memberId,
+                ["relationshipCode"] = request.Relationship.RelationshipCode,
+            },
+        }, ct);
+
+        return CreatedAtAction(nameof(Get),
+            new { memberId = dependent.MemberId, relId = dependent.Id },
+            new AddDependentResponse { Member = dependent, SubscriberMemberId = memberId });
+    }
+}
+
+#region Request / response models
+
+public class FamilyRelationshipListResponse
+{
+    public string MemberId { get; set; } = string.Empty;
+    public List<FamilyRelationship> Relationships { get; set; } = new();
+    public int TotalCount { get; set; }
+}
+
+public class EndRelationshipRequest
+{
+    public DateTime? EndDate { get; set; }
+}
+
+public class AddDependentRequest
+{
+    [Required]
+    public AddDependentMember Member { get; set; } = new();
+
+    [Required]
+    public AddDependentRelationship Relationship { get; set; } = new();
+
+    public string? EventId { get; set; }
+}
+
+public class AddDependentMember
+{
+    [Required] public string MemberId { get; set; } = string.Empty;
+    [Required] public string FirstName { get; set; } = string.Empty;
+    [Required] public string LastName { get; set; } = string.Empty;
+    public string? MiddleName { get; set; }
+    [Required] public DateTime DateOfBirth { get; set; }
+    public string? Gender { get; set; }
+    public string? SSN { get; set; }
+    public string? GroupNumber { get; set; }
+    public string? Address { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+    public string? ZipCode { get; set; }
+    public string? Phone { get; set; }
+    public string? Email { get; set; }
+    [Required] public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+}
+
+public class AddDependentRelationship
+{
+    [Required] public string RelationshipCode { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+}
+
+public class AddDependentResponse
+{
+    public Member Member { get; set; } = new();
+    public string SubscriberMemberId { get; set; } = string.Empty;
+}
+
+#endregion

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -32,6 +32,8 @@ public class MembersController : ControllerBase
     private readonly ICoverageServiceClient _coverage;
     private readonly IEnrollmentImportServiceClient _enrollment;
     private readonly IAccumulatorServiceClient _accumulators;
+    private readonly IRelationshipShim? _relationshipShim;
+    private readonly IFamilyRelationshipService? _familyRelationships;
 
     public MembersController(
         IMemberRepository memberRepository,
@@ -41,7 +43,9 @@ public class MembersController : ControllerBase
         IIdentifierEncryptor encryptor,
         ICoverageServiceClient coverage,
         IEnrollmentImportServiceClient enrollment,
-        IAccumulatorServiceClient accumulators)
+        IAccumulatorServiceClient accumulators,
+        IRelationshipShim? relationshipShim = null,
+        IFamilyRelationshipService? familyRelationships = null)
     {
         _memberRepository = memberRepository;
         _eventPublisher = eventPublisher;
@@ -51,6 +55,8 @@ public class MembersController : ControllerBase
         _coverage = coverage;
         _enrollment = enrollment;
         _accumulators = accumulators;
+        _relationshipShim = relationshipShim;
+        _familyRelationships = familyRelationships;
     }
 
     // ── Search / read ────────────────────────────────────────────────
@@ -119,7 +125,35 @@ public class MembersController : ControllerBase
     {
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
+        if (member.IsDraft) return NotFound();
+        await HydrateSubscriberFromGraphAsync(member, HttpContext.RequestAborted);
         return Ok(member);
+    }
+
+    /// <summary>
+    /// Overwrite the legacy <see cref="Member.SubscriberMemberId"/> from the active
+    /// <see cref="FamilyRelationship"/> graph when one is registered. Non-throwing: if
+    /// derivation fails or returns null, the stored legacy value remains.
+    /// </summary>
+    private async Task HydrateSubscriberFromGraphAsync(Member member, CancellationToken ct)
+    {
+        if (_familyRelationships == null) return;
+        if (member.IsSubscriber) return;
+        try
+        {
+            var derived = await _familyRelationships.DeriveSubscriberMemberIdAsync(TenantId, member.MemberId, ct);
+            if (!string.IsNullOrEmpty(derived))
+            {
+#pragma warning disable CS0618
+                member.SubscriberMemberId = derived;
+#pragma warning restore CS0618
+            }
+        }
+        catch
+        {
+            // Derivation is a read-side best-effort. Never let graph errors break
+            // the member GET — the legacy field still holds the 834-written value.
+        }
     }
 
     // ── Create / update / terminate ──────────────────────────────────
@@ -159,6 +193,7 @@ public class MembersController : ControllerBase
             });
         }
 
+#pragma warning disable CS0618 // write-back to legacy FK preserves 834-shaped payloads; graph is authoritative going forward
         var member = new Member
         {
             TenantId = TenantId,
@@ -194,8 +229,16 @@ public class MembersController : ControllerBase
             LastUpdatedDate = DateTime.UtcNow,
             CreatedBy = User.Identity?.Name ?? "System"
         };
+#pragma warning restore CS0618
 
         await _memberRepository.CreateAsync(member);
+
+        // Shim the legacy FK onto the relationship graph for dependents. No-op when
+        // the shim isn't registered (tests) or the member is a subscriber.
+        if (_relationshipShim != null)
+        {
+            await _relationshipShim.EnsureRelationshipAsync(member, User.Identity?.Name, ct);
+        }
 
         var eventId = !string.IsNullOrEmpty(request.EventId)
             ? request.EventId
@@ -374,7 +417,7 @@ public class MembersController : ControllerBase
     public async Task<IActionResult> GetDependents([FromRoute] string memberId)
     {
         var dependents = await _memberRepository.GetDependentsAsync(TenantId, memberId);
-        return Ok(dependents);
+        return Ok(dependents.Where(d => !d.IsDraft).ToList());
     }
 
     // ── Eligibility ──────────────────────────────────────────────────
@@ -590,7 +633,9 @@ public class MembersController : ControllerBase
         ["tenantId"] = member.TenantId,
         ["groupNumber"] = member.GroupNumber,
         ["isSubscriber"] = member.IsSubscriber,
+#pragma warning disable CS0618
         ["subscriberMemberId"] = member.SubscriberMemberId,
+#pragma warning restore CS0618
         ["firstName"] = member.FirstName,
         ["lastName"] = member.LastName,
         ["middleName"] = member.MiddleName,

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -34,6 +34,7 @@ public class MembersController : ControllerBase
     private readonly IAccumulatorServiceClient _accumulators;
     private readonly IRelationshipShim? _relationshipShim;
     private readonly IFamilyRelationshipService? _familyRelationships;
+    private readonly ILogger<MembersController>? _logger;
 
     public MembersController(
         IMemberRepository memberRepository,
@@ -45,7 +46,8 @@ public class MembersController : ControllerBase
         IEnrollmentImportServiceClient enrollment,
         IAccumulatorServiceClient accumulators,
         IRelationshipShim? relationshipShim = null,
-        IFamilyRelationshipService? familyRelationships = null)
+        IFamilyRelationshipService? familyRelationships = null,
+        ILogger<MembersController>? logger = null)
     {
         _memberRepository = memberRepository;
         _eventPublisher = eventPublisher;
@@ -57,6 +59,7 @@ public class MembersController : ControllerBase
         _accumulators = accumulators;
         _relationshipShim = relationshipShim;
         _familyRelationships = familyRelationships;
+        _logger = logger;
     }
 
     // ── Search / read ────────────────────────────────────────────────
@@ -78,6 +81,8 @@ public class MembersController : ControllerBase
         if (!string.IsNullOrEmpty(memberId))
         {
             var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+            // Drafts are hidden from standard search paths (parity with GetMember).
+            if (member != null && member.IsDraft) member = null;
             return Ok(new MemberListResponse
             {
                 Members = member != null ? new List<Member> { member } : new List<Member>(),
@@ -90,7 +95,7 @@ public class MembersController : ControllerBase
             TenantId, groupNumber, lastName, dateOfBirth,
             activeOnly, subscribersOnly, pageSize, continuationToken);
 
-        var list = items.ToList();
+        var list = items.Where(m => !m.IsDraft).ToList();
         return Ok(new MemberListResponse
         {
             Members = list,
@@ -108,7 +113,7 @@ public class MembersController : ControllerBase
             return await SearchMembers(pageSize: 20);
 
         var byId = await _memberRepository.GetByMemberIdAsync(TenantId, q);
-        if (byId != null)
+        if (byId != null && !byId.IsDraft)
             return Ok(new List<Member> { byId });
 
         return await SearchMembers(
@@ -149,10 +154,14 @@ public class MembersController : ControllerBase
 #pragma warning restore CS0618
             }
         }
-        catch
+        catch (Exception ex)
         {
-            // Derivation is a read-side best-effort. Never let graph errors break
-            // the member GET — the legacy field still holds the 834-written value.
+            // Best-effort on the read path — the legacy field still holds the last 834
+            // value, so the GET doesn't need to fail. Log so operators can see when the
+            // graph is unavailable for a given tenant instead of silently falling through.
+            _logger?.LogWarning(ex,
+                "Best-effort SubscriberMemberId derivation failed for tenant {TenantId} member {MemberId}; returning legacy field.",
+                TenantId, member.MemberId);
         }
     }
 

--- a/src/services/member-service/HostedServices/FamilyRelationshipIndexInitializer.cs
+++ b/src/services/member-service/HostedServices/FamilyRelationshipIndexInitializer.cs
@@ -1,0 +1,65 @@
+using MemberService.Models;
+using MemberService.Repositories;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace MemberService.HostedServices;
+
+/// <summary>
+/// Provisions MongoDB indexes on the <c>FamilyRelationships</c> collection at startup.
+/// Matches the pattern of <see cref="MemberIndexInitializer"/>: idempotent, runs once,
+/// keeps repository construction side-effect free.
+/// </summary>
+public sealed class FamilyRelationshipIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly ILogger<FamilyRelationshipIndexInitializer> _logger;
+
+    public FamilyRelationshipIndexInitializer(
+        IMongoDatabase db,
+        ILogger<FamilyRelationshipIndexInitializer> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<FamilyRelationship>(
+            FamilyRelationshipRepositoryMongo.CollectionName);
+
+        // Supports ListBySubjectAsync (portal Family tab, shim idempotency check).
+        var subjectKeys = Builders<FamilyRelationship>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.SubjectMemberId)
+            .Ascending(x => x.EndDate);
+        collection.Indexes.CreateOne(new CreateIndexModel<FamilyRelationship>(
+            subjectKeys,
+            new CreateIndexOptions { Name = "ix_tenant_subject_enddate" }),
+            cancellationToken: cancellationToken);
+
+        // Supports GetPairAsync (update/end/delete paths).
+        var pairKeys = Builders<FamilyRelationship>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.PairId);
+        collection.Indexes.CreateOne(new CreateIndexModel<FamilyRelationship>(
+            pairKeys,
+            new CreateIndexOptions { Name = "ix_tenant_pair" }),
+            cancellationToken: cancellationToken);
+
+        // Supports ListTouchingAsync (graph derivation, portal reads).
+        var relatedKeys = Builders<FamilyRelationship>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.RelatedMemberId);
+        collection.Indexes.CreateOne(new CreateIndexModel<FamilyRelationship>(
+            relatedKeys,
+            new CreateIndexOptions { Name = "ix_tenant_related" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("FamilyRelationship indexes ensured.");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/FamilyRelationshipsControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/FamilyRelationshipsControllerTests.cs
@@ -1,0 +1,205 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Controllers;
+
+public class FamilyRelationshipsControllerTests
+{
+    private const string Tenant = "tenant-t1";
+
+    private static (FamilyRelationshipsController ctl,
+                    InMemoryMemberRepository members,
+                    InMemoryFamilyRelationshipRepository rels,
+                    FamilyRelationshipService svc,
+                    InMemoryMemberEventRepository events) Build()
+    {
+        var members = new InMemoryMemberRepository();
+        var rels = new InMemoryFamilyRelationshipRepository();
+        var svc = new FamilyRelationshipService(rels, members);
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var enc = new NoOpIdentifierEncryptor();
+        var ctl = new FamilyRelationshipsController(svc, members, publisher, enc);
+
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, members, rels, svc, events);
+    }
+
+    private static Member Sub(string id = "SUB-1") => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        MemberId = id,
+        GroupNumber = "GRP",
+        IsSubscriber = true,
+        FirstName = "Alice",
+        LastName = "Example",
+        DateOfBirth = new DateTime(1980, 1, 1),
+        EffectiveDate = new DateTime(2024, 1, 1),
+    };
+
+    private static Member Dep(string id, string sub) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        MemberId = id,
+        GroupNumber = "GRP",
+        IsSubscriber = false,
+        FirstName = "Junior",
+        LastName = "Example",
+        DateOfBirth = new DateTime(2015, 1, 1),
+        EffectiveDate = new DateTime(2024, 1, 1),
+    };
+
+    [Fact]
+    public async Task Create_ReturnsCreatedAndPersistsPair()
+    {
+        var (ctl, members, rels, _, _) = Build();
+        await members.CreateAsync(Sub("SUB-1"));
+        await members.CreateAsync(Dep("DEP-1", "SUB-1"));
+
+        var resp = await ctl.Create("DEP-1", new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = "DEP-1",
+            RelatedMemberId = "SUB-1",
+            RelationshipCode = "19",
+            StartDate = new DateTime(2024, 1, 1),
+        }, CancellationToken.None);
+
+        resp.Should().BeOfType<CreatedAtActionResult>();
+        rels.Rows.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Create_InvalidCode_ReturnsBadRequest()
+    {
+        var (ctl, members, _, _, _) = Build();
+        await members.CreateAsync(Sub());
+        await members.CreateAsync(Dep("DEP-1", "SUB-1"));
+
+        var resp = await ctl.Create("DEP-1", new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = "DEP-1",
+            RelatedMemberId = "SUB-1",
+            RelationshipCode = "ZZ",
+            StartDate = new DateTime(2024, 1, 1),
+        }, CancellationToken.None);
+
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task End_MarksPairEnded()
+    {
+        var (ctl, members, rels, svc, _) = Build();
+        await members.CreateAsync(Sub());
+        await members.CreateAsync(Dep("DEP-1", "SUB-1"));
+        var forward = await svc.CreateAsync(Tenant, new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = "DEP-1",
+            RelatedMemberId = "SUB-1",
+            RelationshipCode = "19",
+            StartDate = new DateTime(2024, 1, 1),
+        }, "tester");
+
+        var resp = await ctl.End("DEP-1", forward.Id,
+            new EndRelationshipRequest { EndDate = new DateTime(2025, 6, 30) },
+            CancellationToken.None);
+
+        resp.Should().BeOfType<OkObjectResult>();
+        rels.Rows.Where(r => r.PairId == forward.PairId)
+            .Should().OnlyContain(r => r.EndDate == new DateTime(2025, 6, 30));
+    }
+
+    [Fact]
+    public async Task List_ReturnsOnlySubjectPerspectiveRows()
+    {
+        var (ctl, members, _, svc, _) = Build();
+        await members.CreateAsync(Sub());
+        await members.CreateAsync(Dep("DEP-1", "SUB-1"));
+        await svc.CreateAsync(Tenant, new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = "DEP-1",
+            RelatedMemberId = "SUB-1",
+            RelationshipCode = "19",
+            StartDate = new DateTime(2024, 1, 1),
+        }, "tester");
+
+        var resp = await ctl.List("DEP-1", includeDeleted: false, CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<FamilyRelationshipListResponse>().Subject;
+
+        body.Relationships.Should().ContainSingle();
+        body.Relationships[0].SubjectMemberId.Should().Be("DEP-1");
+    }
+
+    [Fact]
+    public async Task AddDependent_CreatesMemberAndPairAtomically()
+    {
+        var (ctl, members, rels, _, _) = Build();
+        await members.CreateAsync(Sub("SUB-1"));
+
+        var resp = await ctl.AddDependent("SUB-1", new AddDependentRequest
+        {
+            Member = new AddDependentMember
+            {
+                MemberId = "DEP-NEW",
+                FirstName = "Baby",
+                LastName = "Example",
+                DateOfBirth = new DateTime(2024, 3, 1),
+                EffectiveDate = new DateTime(2024, 4, 1),
+            },
+            Relationship = new AddDependentRelationship
+            {
+                RelationshipCode = "19",
+                StartDate = new DateTime(2024, 4, 1),
+                IsCustodial = true,
+            },
+        }, CancellationToken.None);
+
+        resp.Should().BeOfType<CreatedAtActionResult>();
+        members.Members.Should().ContainSingle(m => m.MemberId == "DEP-NEW" && !m.IsDraft);
+        rels.Rows.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AddDependent_InvalidRelationship_LeavesDraftMember_ReturnsBadRequest()
+    {
+        // Simulate the second write failing: we pass a code that passes the initial
+        // validity check but collides with an existing active pair. Create one first.
+        var (ctl, members, rels, svc, _) = Build();
+        await members.CreateAsync(Sub("SUB-1"));
+        var existingDep = Dep("DEP-EXIST", "SUB-1");
+        await members.CreateAsync(existingDep);
+        await svc.CreateAsync(Tenant, new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = "DEP-EXIST",
+            RelatedMemberId = "SUB-1",
+            RelationshipCode = "19",
+            StartDate = new DateTime(2024, 1, 1),
+        }, "tester");
+
+        // Now try to add a second "DEP-EXIST" member — MemberId conflict rejected early.
+        var resp = await ctl.AddDependent("SUB-1", new AddDependentRequest
+        {
+            Member = new AddDependentMember
+            {
+                MemberId = "DEP-EXIST",
+                FirstName = "Dup",
+                LastName = "Example",
+                DateOfBirth = new DateTime(2024, 3, 1),
+                EffectiveDate = new DateTime(2024, 4, 1),
+            },
+            Relationship = new AddDependentRelationship { RelationshipCode = "19", StartDate = new DateTime(2024, 4, 1) },
+        }, CancellationToken.None);
+
+        resp.Should().BeOfType<ConflictObjectResult>();
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryFamilyRelationshipRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryFamilyRelationshipRepository.cs
@@ -1,0 +1,106 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>
+/// In-memory fake for <see cref="IFamilyRelationshipRepository"/>. Emulates the
+/// same-tenant / symmetric-pair invariants enforced by the Cosmos and Mongo impls
+/// so service-layer tests can exercise the full behavior contract.
+/// </summary>
+public sealed class InMemoryFamilyRelationshipRepository : IFamilyRelationshipRepository
+{
+    public List<FamilyRelationship> Rows { get; } = new();
+
+    /// <summary>If true, the next paired write throws after the first row is inserted —
+    /// used to assert the atomic-pair contract.</summary>
+    public bool SimulatePairTornWrite { get; set; }
+
+    public Task CreatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        if (forward.TenantId != inverse.TenantId)
+            throw new InvalidOperationException("Pair rows must share TenantId.");
+
+        if (SimulatePairTornWrite)
+        {
+            // Write only the forward row, then throw. Tests assert the repo rolls back.
+            throw new InvalidOperationException("Simulated transactional failure.");
+        }
+
+        Rows.Add(Clone(forward));
+        Rows.Add(Clone(inverse));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        if (forward.TenantId != inverse.TenantId)
+            throw new InvalidOperationException("Pair rows must share TenantId.");
+
+        Replace(forward);
+        Replace(inverse);
+        return Task.CompletedTask;
+    }
+
+    public Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+        => Task.FromResult<FamilyRelationship?>(
+            Rows.FirstOrDefault(r => r.TenantId == tenantId && r.Id == id));
+
+    public Task<List<FamilyRelationship>> GetPairAsync(string tenantId, string pairId, CancellationToken ct = default)
+        => Task.FromResult(Rows
+            .Where(r => r.TenantId == tenantId && r.PairId == pairId)
+            .ToList());
+
+    public Task<List<FamilyRelationship>> ListBySubjectAsync(
+        string tenantId, string subjectMemberId, bool includeDeleted = false, CancellationToken ct = default)
+        => Task.FromResult(Rows
+            .Where(r => r.TenantId == tenantId && r.SubjectMemberId == subjectMemberId)
+            .Where(r => includeDeleted || r.DeletedAt == null)
+            .ToList());
+
+    public Task<List<FamilyRelationship>> ListTouchingAsync(
+        string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default)
+        => Task.FromResult(Rows
+            .Where(r => r.TenantId == tenantId &&
+                        (r.SubjectMemberId == memberId || r.RelatedMemberId == memberId))
+            .Where(r => includeDeleted || r.DeletedAt == null)
+            .ToList());
+
+    public Task<FamilyRelationship?> FindActivePairAsync(
+        string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
+        => Task.FromResult<FamilyRelationship?>(
+            Rows.FirstOrDefault(r =>
+                r.TenantId == tenantId &&
+                r.SubjectMemberId == subjectMemberId &&
+                r.RelatedMemberId == relatedMemberId &&
+                r.DeletedAt == null &&
+                r.EndDate == null));
+
+    private void Replace(FamilyRelationship row)
+    {
+        var idx = Rows.FindIndex(r => r.TenantId == row.TenantId && r.Id == row.Id);
+        if (idx < 0) Rows.Add(Clone(row));
+        else Rows[idx] = Clone(row);
+    }
+
+    private static FamilyRelationship Clone(FamilyRelationship r) => new()
+    {
+        Id = r.Id,
+        TenantId = r.TenantId,
+        SubjectMemberId = r.SubjectMemberId,
+        RelatedMemberId = r.RelatedMemberId,
+        RelationshipCode = r.RelationshipCode,
+        PairId = r.PairId,
+        StartDate = r.StartDate,
+        EndDate = r.EndDate,
+        IsCustodial = r.IsCustodial,
+        QmcsoReference = r.QmcsoReference,
+        CreatedDate = r.CreatedDate,
+        CreatedBy = r.CreatedBy,
+        UpdatedDate = r.UpdatedDate,
+        UpdatedBy = r.UpdatedBy,
+        DeletedAt = r.DeletedAt,
+        DeletedBy = r.DeletedBy,
+        DeletedReason = r.DeletedReason,
+    };
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryFamilyRelationshipRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryFamilyRelationshipRepository.cs
@@ -23,7 +23,12 @@ public sealed class InMemoryFamilyRelationshipRepository : IFamilyRelationshipRe
 
         if (SimulatePairTornWrite)
         {
-            // Write only the forward row, then throw. Tests assert the repo rolls back.
+            // Write only the forward row, then throw. Tests assert the service /
+            // higher-level caller's expectation that a torn write is observable via
+            // the rogue row being left behind — i.e., the repo itself is NOT atomic
+            // when this flag is set. Use this to exercise failure-path code paths
+            // that should clean up or surface the inconsistency.
+            Rows.Add(Clone(forward));
             throw new InvalidOperationException("Simulated transactional failure.");
         }
 
@@ -68,13 +73,17 @@ public sealed class InMemoryFamilyRelationshipRepository : IFamilyRelationshipRe
 
     public Task<FamilyRelationship?> FindActivePairAsync(
         string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
-        => Task.FromResult<FamilyRelationship?>(
+    {
+        // Match production semantics: a future EndDate is still "active".
+        var now = DateTime.UtcNow;
+        return Task.FromResult<FamilyRelationship?>(
             Rows.FirstOrDefault(r =>
                 r.TenantId == tenantId &&
                 r.SubjectMemberId == subjectMemberId &&
                 r.RelatedMemberId == relatedMemberId &&
                 r.DeletedAt == null &&
-                r.EndDate == null));
+                (r.EndDate == null || r.EndDate > now)));
+    }
 
     private void Replace(FamilyRelationship row)
     {

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberRepository.cs
@@ -34,9 +34,11 @@ public sealed class InMemoryMemberRepository : IMemberRepository
     }
 
     public Task<List<Member>> GetDependentsAsync(string tenantId, string subscriberMemberId)
+#pragma warning disable CS0618
         => Task.FromResult(Members
             .Where(m => m.TenantId == tenantId && m.SubscriberMemberId == subscriberMemberId && !m.IsSubscriber)
             .ToList());
+#pragma warning restore CS0618
 
     public Task<int> GetCountByGroupAsync(string tenantId, string groupNumber)
         => Task.FromResult(Members.Count(m => m.TenantId == tenantId && m.GroupNumber == groupNumber));

--- a/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/MemberFhirSmokeTests.cs
@@ -46,25 +46,32 @@ public class MemberFhirSmokeTests : IClassFixture<MemberFhirSmokeTests.Factory>
             {
                 RemoveAll<IMemberRepository>(services);
                 RemoveAll<IMemberEventRepository>(services);
+                RemoveAll<IFamilyRelationshipRepository>(services);
                 RemoveAll<MongoDB.Driver.IMongoClient>(services);
                 RemoveAll<MongoDB.Driver.IMongoDatabase>(services);
 
                 // Remove the Mongo index initializers that would try to connect to the
                 // fake MongoDB host at startup. Don't use RemoveAll<IHostedService>() as
                 // that would also remove the Kestrel host service and prevent the test
-                // server from starting.
+                // server from starting. RemoveAll checks both ServiceType and
+                // ImplementationType so it catches both factory-less AddHostedService<T>
+                // registrations and explicit factory-style AddSingleton<IHostedService>
+                // registrations.
                 RemoveAll<MemberEventIndexInitializer>(services);
                 RemoveAll<MemberIndexInitializer>(services);
+                RemoveAll<FamilyRelationshipIndexInitializer>(services);
 
                 services.AddSingleton<IMemberRepository>(MemberRepo);
                 services.AddSingleton<IMemberEventRepository>(EventRepo);
+                services.AddSingleton<IFamilyRelationshipRepository>(new InMemoryFamilyRelationshipRepository());
             });
             return base.CreateHost(builder);
         }
 
         private static void RemoveAll<T>(IServiceCollection services)
         {
-            var toRemove = services.Where(d => d.ServiceType == typeof(T)).ToList();
+            var toRemove = services.Where(d =>
+                d.ServiceType == typeof(T) || d.ImplementationType == typeof(T)).ToList();
             foreach (var d in toRemove) services.Remove(d);
         }
     }

--- a/src/services/member-service/MemberService.Tests/Services/FamilyRelationshipServiceTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FamilyRelationshipServiceTests.cs
@@ -1,0 +1,202 @@
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+
+namespace MemberService.Tests.Services;
+
+public class FamilyRelationshipServiceTests
+{
+    private const string Tenant = "tenant-t1";
+    private const string OtherTenant = "tenant-t2";
+
+    private static (FamilyRelationshipService svc,
+                    InMemoryMemberRepository members,
+                    InMemoryFamilyRelationshipRepository rels) Build()
+    {
+        var members = new InMemoryMemberRepository();
+        var rels = new InMemoryFamilyRelationshipRepository();
+        var svc = new FamilyRelationshipService(rels, members);
+        return (svc, members, rels);
+    }
+
+    private static Member Make(string memberId, string tenant = Tenant, bool isSubscriber = true)
+        => new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = tenant,
+            MemberId = memberId,
+            GroupNumber = "GRP",
+            IsSubscriber = isSubscriber,
+            FirstName = "F",
+            LastName = "L",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            EffectiveDate = new DateTime(2024, 1, 1),
+        };
+
+    private static CreateFamilyRelationshipRequest Req(string subject, string related, string code = "19")
+        => new()
+        {
+            SubjectMemberId = subject,
+            RelatedMemberId = related,
+            RelationshipCode = code,
+            StartDate = new DateTime(2024, 1, 1),
+        };
+
+    [Fact]
+    public async Task Create_WritesSymmetricPair_WithSharedPairId()
+    {
+        var (svc, members, rels) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+
+        var forward = await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        rels.Rows.Should().HaveCount(2);
+        var pair = rels.Rows.Where(r => r.PairId == forward.PairId).ToList();
+        pair.Should().HaveCount(2);
+        pair.Select(r => r.SubjectMemberId).Should().BeEquivalentTo(new[] { "DEP-1", "SUB-1" });
+        pair.Select(r => r.RelationshipCode).Should().BeEquivalentTo(new[] { "19", "G8" });
+    }
+
+    [Fact]
+    public async Task Create_UnknownRelationshipCode_Rejected()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+
+        var act = () => svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "ZZ"), "tester");
+        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
+            .WithMessage("*Unknown relationshipCode*");
+    }
+
+    [Fact]
+    public async Task Create_SelfRelationship_Rejected()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("M-1"));
+
+        var act = () => svc.CreateAsync(Tenant, Req("M-1", "M-1", "18"), "tester");
+        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
+            .WithMessage("*cannot have a relationship to themselves*");
+    }
+
+    [Fact]
+    public async Task Create_DuplicateActivePair_Rejected()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+
+        await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        var act = () => svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
+            .WithMessage("*already exists*");
+    }
+
+    [Fact]
+    public async Task Create_CrossTenant_Rejected()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1", tenant: Tenant));
+        await members.CreateAsync(Make("DEP-1", tenant: OtherTenant, isSubscriber: false));
+
+        // Subject in Tenant, but related member only exists in OtherTenant → lookup fails.
+        var act = () => svc.CreateAsync(Tenant, Req("SUB-1", "DEP-1", "G8"), "tester");
+        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
+            .WithMessage("*not found in tenant*");
+    }
+
+    [Fact]
+    public async Task End_SetsEndDateOnBothRowsOfPair()
+    {
+        var (svc, members, rels) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+        var forward = await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        var ended = await svc.EndAsync(Tenant, forward.Id, new DateTime(2025, 6, 30), "tester");
+
+        ended.EndDate.Should().Be(new DateTime(2025, 6, 30));
+        rels.Rows.Where(r => r.PairId == forward.PairId)
+            .Should().OnlyContain(r => r.EndDate == new DateTime(2025, 6, 30));
+    }
+
+    [Fact]
+    public async Task SoftDelete_WithinWindow_MarksBothRowsDeleted()
+    {
+        var (svc, members, rels) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+        var forward = await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        var deleted = await svc.SoftDeleteAsync(Tenant, forward.Id, "wrong code", "admin");
+
+        deleted.DeletedAt.Should().NotBeNull();
+        rels.Rows.Where(r => r.PairId == forward.PairId)
+            .Should().OnlyContain(r => r.DeletedAt != null && r.DeletedBy == "admin");
+    }
+
+    [Fact]
+    public async Task SoftDelete_OutsideWindow_Rejected()
+    {
+        var (svc, members, rels) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+        var forward = await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        // Age out the pair.
+        foreach (var r in rels.Rows.Where(r => r.PairId == forward.PairId))
+        {
+            r.CreatedDate = DateTime.UtcNow.AddDays(-3);
+        }
+
+        var act = () => svc.SoftDeleteAsync(Tenant, forward.Id, "too late", "admin");
+        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
+            .WithMessage("*only permitted within*");
+    }
+
+    [Fact]
+    public async Task Derivation_ReturnsSubscriberMemberId_FromActiveEdge()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+        await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+
+        var derived = await svc.DeriveSubscriberMemberIdAsync(Tenant, "DEP-1");
+        derived.Should().Be("SUB-1");
+    }
+
+    [Fact]
+    public async Task Derivation_IgnoresEndedRelationships()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+        var forward = await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+        await svc.EndAsync(Tenant, forward.Id, DateTime.UtcNow.AddDays(-1), "tester");
+
+        var derived = await svc.DeriveSubscriberMemberIdAsync(Tenant, "DEP-1");
+        derived.Should().BeNull();
+    }
+
+    [Fact]
+    public void RelationshipCodes_IsValid_RejectsUnknown()
+    {
+        FamilyRelationshipCodes.IsValid("19").Should().BeTrue();
+        FamilyRelationshipCodes.IsValid("01").Should().BeTrue();
+        FamilyRelationshipCodes.IsValid(null).Should().BeFalse();
+        FamilyRelationshipCodes.IsValid("").Should().BeFalse();
+        FamilyRelationshipCodes.IsValid("ZZ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void InverseCode_Child_MapsToParent()
+    {
+        FamilyRelationshipCodes.Invert("19").Should().Be("G8");
+        FamilyRelationshipCodes.Invert("G8").Should().Be("19");
+        FamilyRelationshipCodes.Invert("01").Should().Be("01"); // spouse self-inverse
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/FamilyRelationshipServiceTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FamilyRelationshipServiceTests.cs
@@ -90,9 +90,26 @@ public class FamilyRelationshipServiceTests
 
         await svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
 
+        // Typed exception so shim / backfill idempotency paths don't rely on
+        // brittle error-message matching.
         var act = () => svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
-        await act.Should().ThrowAsync<FamilyRelationshipValidationException>()
-            .WithMessage("*already exists*");
+        await act.Should().ThrowAsync<DuplicateFamilyRelationshipException>();
+    }
+
+    [Fact]
+    public async Task Create_Rejects_SecondActivePair_EvenWithFutureEndDate()
+    {
+        var (svc, members, _) = Build();
+        await members.CreateAsync(Make("SUB-1"));
+        await members.CreateAsync(Make("DEP-1", isSubscriber: false));
+
+        // First pair has a future EndDate — still "active" per model.IsActive.
+        var req = Req("DEP-1", "SUB-1", "19");
+        req.EndDate = DateTime.UtcNow.AddYears(5);
+        await svc.CreateAsync(Tenant, req, "tester");
+
+        var act = () => svc.CreateAsync(Tenant, Req("DEP-1", "SUB-1", "19"), "tester");
+        await act.Should().ThrowAsync<DuplicateFamilyRelationshipException>();
     }
 
     [Fact]

--- a/src/services/member-service/MemberService.Tests/Services/RelationshipShimTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/RelationshipShimTests.cs
@@ -1,0 +1,120 @@
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+public class RelationshipShimTests
+{
+    private const string Tenant = "tenant-t1";
+
+    private static (RelationshipShim shim,
+                    FamilyRelationshipService svc,
+                    InMemoryMemberRepository members,
+                    InMemoryFamilyRelationshipRepository rels) Build()
+    {
+        var members = new InMemoryMemberRepository();
+        var rels = new InMemoryFamilyRelationshipRepository();
+        var svc = new FamilyRelationshipService(rels, members);
+        var shim = new RelationshipShim(svc, NullLogger<RelationshipShim>.Instance);
+        return (shim, svc, members, rels);
+    }
+
+    private static Member MakeDep(string id, string sub, string code = "19") => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        MemberId = id,
+        GroupNumber = "GRP",
+        IsSubscriber = false,
+#pragma warning disable CS0618 // legacy fields — the shim's entire job is to bridge these
+        SubscriberMemberId = sub,
+        RelationshipCode = code,
+#pragma warning restore CS0618
+        FirstName = "F",
+        LastName = "L",
+        DateOfBirth = new DateTime(2010, 1, 1),
+        EffectiveDate = new DateTime(2024, 1, 1),
+    };
+
+    private static Member MakeSub(string id) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        MemberId = id,
+        GroupNumber = "GRP",
+        IsSubscriber = true,
+        FirstName = "S",
+        LastName = "L",
+        DateOfBirth = new DateTime(1980, 1, 1),
+        EffectiveDate = new DateTime(2024, 1, 1),
+    };
+
+    [Fact]
+    public async Task ShimCreatesSymmetricPair_OnDependentWithSubscriberFk()
+    {
+        var (shim, _, members, rels) = Build();
+        await members.CreateAsync(MakeSub("SUB-1"));
+        var dep = MakeDep("DEP-1", "SUB-1");
+        await members.CreateAsync(dep);
+
+        await shim.EnsureRelationshipAsync(dep, actor: "834-import");
+
+        rels.Rows.Should().HaveCount(2);
+        rels.Rows.Should().Contain(r => r.SubjectMemberId == "DEP-1" && r.RelatedMemberId == "SUB-1" && r.RelationshipCode == "19");
+        rels.Rows.Should().Contain(r => r.SubjectMemberId == "SUB-1" && r.RelatedMemberId == "DEP-1" && r.RelationshipCode == "G8");
+    }
+
+    [Fact]
+    public async Task ShimIsIdempotent_AcrossRepeatedCalls()
+    {
+        var (shim, _, members, rels) = Build();
+        await members.CreateAsync(MakeSub("SUB-1"));
+        var dep = MakeDep("DEP-1", "SUB-1");
+        await members.CreateAsync(dep);
+
+        await shim.EnsureRelationshipAsync(dep, actor: "834-import");
+        await shim.EnsureRelationshipAsync(dep, actor: "834-import");
+        await shim.EnsureRelationshipAsync(dep, actor: "834-import");
+
+        // Still exactly one pair (2 rows) after three runs — replayed 834 batches don't duplicate.
+        rels.Rows.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ShimSkips_WhenSubscriberFkMissing()
+    {
+        var (shim, _, members, rels) = Build();
+        var dep = MakeDep("DEP-1", sub: "");
+        await members.CreateAsync(dep);
+
+        await shim.EnsureRelationshipAsync(dep, actor: "834-import");
+        rels.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ShimSkips_WhenMemberIsSubscriber()
+    {
+        var (shim, _, members, rels) = Build();
+        var sub = MakeSub("SUB-1");
+        await members.CreateAsync(sub);
+
+        await shim.EnsureRelationshipAsync(sub, actor: "834-import");
+        rels.Rows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ShimSwallows_WhenSubscriberNotFoundInTenant()
+    {
+        // Shim must not block a legitimate 834 write if the graph side fails — it
+        // logs and returns. The backfill tool reconciles later.
+        var (shim, _, members, rels) = Build();
+        var dep = MakeDep("DEP-ORPHAN", "SUB-DOES-NOT-EXIST");
+        await members.CreateAsync(dep);
+
+        var act = () => shim.EnsureRelationshipAsync(dep, actor: "834-import");
+        await act.Should().NotThrowAsync();
+        rels.Rows.Should().BeEmpty();
+    }
+}

--- a/src/services/member-service/Models/FamilyRelationship.cs
+++ b/src/services/member-service/Models/FamilyRelationship.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// Symmetric family-relationship edge. Every logical relationship is persisted as
+/// two rows (A→B and B→A) written atomically so the graph is always symmetric.
+///
+/// Replaces <see cref="Member.SubscriberMemberId"/> as the source of truth for
+/// subscriber/dependent structure. Legacy <c>SubscriberMemberId</c> is derived
+/// from this graph on read for back-compat (see migration runbook at
+/// <c>docs/migrations/family-relationships-backfill.md</c>).
+///
+/// Soft-delete only: use <c>EndDate</c> for normal wind-down; <c>DeletedAt</c>
+/// for rare data-entry error corrections. Hard delete is not permitted — audit,
+/// claims, authorizations and QMCSO references depend on historical rows
+/// remaining retrievable.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class FamilyRelationship
+{
+    /// <summary>Cosmos document id / Mongo _id.</summary>
+    [Required]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Partition key. Both sides of a symmetric pair share the same tenant, so the two
+    /// rows live in the same Cosmos partition and can be written in a TransactionalBatch.
+    /// </summary>
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>The member this edge belongs to (the "from" side).</summary>
+    [Required]
+    [StringLength(50)]
+    public string SubjectMemberId { get; set; } = string.Empty;
+
+    /// <summary>The member at the other end of the edge (the "to" side).</summary>
+    [Required]
+    [StringLength(50)]
+    public string RelatedMemberId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// X12 INS02 code describing how <see cref="RelatedMemberId"/> relates to
+    /// <see cref="SubjectMemberId"/> (e.g., "19" when subject's child is related).
+    /// See <see cref="RelationshipCodes"/>.
+    /// </summary>
+    [Required]
+    [StringLength(4)]
+    public string RelationshipCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Transaction id that links the two symmetric rows (A→B and B→A) written together.
+    /// Used to find the counterpart when ending, editing, or deleting.
+    /// </summary>
+    [Required]
+    [StringLength(64)]
+    public string PairId { get; set; } = string.Empty;
+
+    [Required]
+    public DateTime StartDate { get; set; }
+
+    /// <summary>Null for active relationships. Setting this is the normal wind-down path.</summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>True when the relationship carries custodial responsibility (minors, QMCSO).</summary>
+    public bool IsCustodial { get; set; }
+
+    /// <summary>QMCSO case reference for court-ordered medical coverage of minors.</summary>
+    [StringLength(128)]
+    public string? QmcsoReference { get; set; }
+
+    [Required]
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
+    public DateTime? UpdatedDate { get; set; }
+
+    [StringLength(200)]
+    public string? UpdatedBy { get; set; }
+
+    // ── Soft-delete (rare; admin-only; reserved for data-entry errors) ───
+
+    public DateTime? DeletedAt { get; set; }
+
+    [StringLength(200)]
+    public string? DeletedBy { get; set; }
+
+    [StringLength(500)]
+    public string? DeletedReason { get; set; }
+
+    /// <summary>True when this row has been soft-deleted. Repositories filter it out by default.</summary>
+    [BsonIgnore]
+    public bool IsDeleted => DeletedAt.HasValue;
+
+    /// <summary>True when this row is currently active (no EndDate, not soft-deleted).</summary>
+    [BsonIgnore]
+    public bool IsActive => !DeletedAt.HasValue && (EndDate == null || EndDate > DateTime.UtcNow);
+}
+
+/// <summary>
+/// Known-good X12 INS02 relationship codes and inverse-relationship table.
+///
+/// Validator exists at the service boundary (see <c>FamilyRelationshipService</c>).
+/// Unknown codes from imports are stored as-is on legacy <c>Member.RelationshipCode</c>;
+/// the validator only runs on portal/API writes.
+/// </summary>
+public static class FamilyRelationshipCodes
+{
+    /// <summary>
+    /// Inverse-relationship map. Child → Parent, Parent → Child, etc. Codes that are
+    /// self-inverse (Spouse ↔ Spouse, Life Partner ↔ Life Partner) map to themselves.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> Inverses = new Dictionary<string, string>
+    {
+        ["18"] = "18",   // Self ↔ Self (only valid when subject == related — rejected by validator)
+        ["01"] = "01",   // Spouse ↔ Spouse
+        ["19"] = "G8",   // Child → Parent
+        ["G8"] = "19",   // Parent → Child (INS02 "Other" repurposed as parent — see note)
+        ["53"] = "53",   // Life Partner ↔ Life Partner
+        ["17"] = "G8",   // Stepchild → Stepparent
+        ["10"] = "G8",   // Foster child → Foster parent
+        ["20"] = "20",   // Employee ↔ Employer-sponsored (rare)
+        ["22"] = "22",   // Handicapped dependent → guardian (self-inverse for symmetry)
+        ["29"] = "29",   // Significant other
+    };
+
+    /// <summary>Full set of codes accepted at the API boundary.</summary>
+    public static readonly IReadOnlySet<string> Known = new HashSet<string>(Inverses.Keys);
+
+    public static bool IsValid(string? code) =>
+        !string.IsNullOrWhiteSpace(code) && Known.Contains(code);
+
+    /// <summary>
+    /// Returns the inverse code for the B→A row of a symmetric pair, or <c>null</c>
+    /// if <paramref name="code"/> is unknown. Writers must reject unknown codes at
+    /// the service boundary — we do not invent inverses.
+    /// </summary>
+    public static string? Invert(string code) =>
+        Inverses.TryGetValue(code, out var inverse) ? inverse : null;
+}

--- a/src/services/member-service/Models/Member.cs
+++ b/src/services/member-service/Models/Member.cs
@@ -51,8 +51,16 @@ public class Member
     public bool IsSubscriber { get; set; }
 
     /// <summary>
-    /// For dependents: link to subscriber's MemberId
+    /// For dependents: link to subscriber's MemberId.
     /// </summary>
+    /// <remarks>
+    /// Legacy FK, retained for back-compat with callers that read the Member directly.
+    /// On read, <see cref="MembersController"/> overwrites this from the active
+    /// <c>FamilyRelationship</c> graph (see docs/migrations/family-relationships-backfill.md).
+    /// Slated for removal in a future major version — new write paths should create a
+    /// <c>FamilyRelationship</c> instead of setting this field.
+    /// </remarks>
+    [Obsolete("Derived from FamilyRelationship graph on read. New writes must go through FamilyRelationshipService. See docs/migrations/family-relationships-backfill.md.", error: false)]
     [StringLength(50)]
     public string? SubscriberMemberId { get; set; }
 
@@ -283,6 +291,14 @@ public class Member
     /// Communication channel preferences (opt-in, windows, per-channel language override).
     /// </summary>
     public List<CommunicationPreference> CommunicationPreferences { get; set; } = new();
+
+    /// <summary>
+    /// True while the Member is in a partially-constructed state (e.g., Add-Dependent
+    /// wizard has created the Member but not yet created its <c>FamilyRelationship</c>).
+    /// Drafts are hidden from standard search/read paths. A background reconciler
+    /// promotes or purges drafts after a TTL. See <c>FamilyRelationshipsController.AddDependent</c>.
+    /// </summary>
+    public bool IsDraft { get; set; }
 }
 
 /// <summary>

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -49,8 +49,10 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
         new MemberEventRepositoryMongo(
             sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
             eventsCollectionName));
+    builder.Services.AddSingleton<IFamilyRelationshipRepository, FamilyRelationshipRepositoryMongo>();
 
     builder.Services.AddHostedService<MemberIndexInitializer>();
+    builder.Services.AddHostedService<FamilyRelationshipIndexInitializer>();
     builder.Services.AddSingleton<IHostedService>(sp =>
         new MemberEventIndexInitializer(
             sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
@@ -98,12 +100,22 @@ else
             sp.GetRequiredService<ILogger<MemberEventRepository>>());
     });
 
+    builder.Services.AddScoped<IFamilyRelationshipRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new FamilyRelationshipRepository(cosmosClient, databaseName);
+    });
+
     Console.WriteLine($"Using Cosmos DB database provider (events container: {eventsContainerName})");
 }
 
 // ── Member Service internals ─────────────────────────────────────────
 builder.Services.AddScoped<IMemberEventPublisher, CosmosMemberEventPublisher>();
 builder.Services.AddSingleton<IFhirPatientProjector, FhirPatientProjector>();
+builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService>();
+builder.Services.AddScoped<IRelationshipShim, RelationshipShim>();
 
 // Identifier encryption. Real KV-backed encryptor when a data-key secret name is
 // configured; otherwise fall through to the no-op shim (dev only).

--- a/src/services/member-service/Repositories/FamilyRelationshipRepository.cs
+++ b/src/services/member-service/Repositories/FamilyRelationshipRepository.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Cosmos DB repository for <see cref="FamilyRelationship"/>. Uses <c>TransactionalBatch</c>
+/// for symmetric-pair writes — both rows share <c>tenantId</c> so they live in the same
+/// partition, which is a precondition for batch atomicity in Cosmos.
+/// </summary>
+public class FamilyRelationshipRepository : IFamilyRelationshipRepository
+{
+    private readonly Container _container;
+    public const string ContainerName = "FamilyRelationships";
+    public const string PartitionKeyPath = "/tenantId";
+
+    public FamilyRelationshipRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        var database = cosmosClient.GetDatabase(databaseName);
+        _container = database.GetContainer(ContainerName);
+    }
+
+    public async Task CreatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        EnsureSameTenant(forward, inverse);
+        var batch = _container.CreateTransactionalBatch(new PartitionKey(forward.TenantId))
+            .CreateItem(forward)
+            .CreateItem(inverse);
+
+        using var response = await batch.ExecuteAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CosmosException(
+                $"Symmetric-pair create failed (pairId={forward.PairId}): {response.ErrorMessage}",
+                response.StatusCode, 0, response.ActivityId, response.RequestCharge);
+        }
+    }
+
+    public async Task UpdatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        EnsureSameTenant(forward, inverse);
+        var batch = _container.CreateTransactionalBatch(new PartitionKey(forward.TenantId))
+            .ReplaceItem(forward.Id, forward)
+            .ReplaceItem(inverse.Id, inverse);
+
+        using var response = await batch.ExecuteAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CosmosException(
+                $"Symmetric-pair update failed (pairId={forward.PairId}): {response.ErrorMessage}",
+                response.StatusCode, 0, response.ActivityId, response.RequestCharge);
+        }
+    }
+
+    public async Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _container.ReadItemAsync<FamilyRelationship>(
+                id, new PartitionKey(tenantId), cancellationToken: ct);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<List<FamilyRelationship>> GetPairAsync(string tenantId, string pairId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.tenantId = @t AND c.pairId = @p")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@p", pairId);
+
+        return await QueryAllAsync(query, tenantId, ct);
+    }
+
+    public async Task<List<FamilyRelationship>> ListBySubjectAsync(
+        string tenantId, string subjectMemberId, bool includeDeleted = false, CancellationToken ct = default)
+    {
+        var queryText = "SELECT * FROM c WHERE c.tenantId = @t AND c.subjectMemberId = @s";
+        if (!includeDeleted) queryText += " AND NOT IS_DEFINED(c.deletedAt)";
+        var query = new QueryDefinition(queryText)
+            .WithParameter("@t", tenantId)
+            .WithParameter("@s", subjectMemberId);
+
+        return await QueryAllAsync(query, tenantId, ct);
+    }
+
+    public async Task<List<FamilyRelationship>> ListTouchingAsync(
+        string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default)
+    {
+        var queryText = "SELECT * FROM c WHERE c.tenantId = @t AND (c.subjectMemberId = @m OR c.relatedMemberId = @m)";
+        if (!includeDeleted) queryText += " AND NOT IS_DEFINED(c.deletedAt)";
+        var query = new QueryDefinition(queryText)
+            .WithParameter("@t", tenantId)
+            .WithParameter("@m", memberId);
+
+        return await QueryAllAsync(query, tenantId, ct);
+    }
+
+    public async Task<FamilyRelationship?> FindActivePairAsync(
+        string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(@"
+                SELECT TOP 1 * FROM c
+                WHERE c.tenantId = @t
+                  AND c.subjectMemberId = @s
+                  AND c.relatedMemberId = @r
+                  AND NOT IS_DEFINED(c.deletedAt)
+                  AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@s", subjectMemberId)
+            .WithParameter("@r", relatedMemberId);
+
+        var results = await QueryAllAsync(query, tenantId, ct);
+        return results.FirstOrDefault();
+    }
+
+    private async Task<List<FamilyRelationship>> QueryAllAsync(QueryDefinition query, string tenantId, CancellationToken ct)
+    {
+        var iterator = _container.GetItemQueryIterator<FamilyRelationship>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<FamilyRelationship>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    private static void EnsureSameTenant(FamilyRelationship a, FamilyRelationship b)
+    {
+        if (!string.Equals(a.TenantId, b.TenantId, StringComparison.Ordinal))
+        {
+            // Guard against a coding mistake in the service layer. Symmetric-pair
+            // atomicity relies on both rows sharing the same Cosmos partition key.
+            throw new InvalidOperationException(
+                "FamilyRelationship pair rows must share the same TenantId. " +
+                "Cross-tenant relationships are not supported in this phase.");
+        }
+    }
+}

--- a/src/services/member-service/Repositories/FamilyRelationshipRepository.cs
+++ b/src/services/member-service/Repositories/FamilyRelationshipRepository.cs
@@ -85,7 +85,10 @@ public class FamilyRelationshipRepository : IFamilyRelationshipRepository
         string tenantId, string subjectMemberId, bool includeDeleted = false, CancellationToken ct = default)
     {
         var queryText = "SELECT * FROM c WHERE c.tenantId = @t AND c.subjectMemberId = @s";
-        if (!includeDeleted) queryText += " AND NOT IS_DEFINED(c.deletedAt)";
+        // System.Text.Json emits missing-nullable as `null`, not as an absent property,
+        // so a strict `NOT IS_DEFINED` filter would hide every non-deleted row. Allow
+        // both cases: the property is missing OR explicitly null.
+        if (!includeDeleted) queryText += " AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)";
         var query = new QueryDefinition(queryText)
             .WithParameter("@t", tenantId)
             .WithParameter("@s", subjectMemberId);
@@ -97,7 +100,10 @@ public class FamilyRelationshipRepository : IFamilyRelationshipRepository
         string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default)
     {
         var queryText = "SELECT * FROM c WHERE c.tenantId = @t AND (c.subjectMemberId = @m OR c.relatedMemberId = @m)";
-        if (!includeDeleted) queryText += " AND NOT IS_DEFINED(c.deletedAt)";
+        // System.Text.Json emits missing-nullable as `null`, not as an absent property,
+        // so a strict `NOT IS_DEFINED` filter would hide every non-deleted row. Allow
+        // both cases: the property is missing OR explicitly null.
+        if (!includeDeleted) queryText += " AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)";
         var query = new QueryDefinition(queryText)
             .WithParameter("@t", tenantId)
             .WithParameter("@m", memberId);
@@ -108,16 +114,20 @@ public class FamilyRelationshipRepository : IFamilyRelationshipRepository
     public async Task<FamilyRelationship?> FindActivePairAsync(
         string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
     {
+        // Active = not soft-deleted AND (no end date OR end date is in the future).
+        // Matches FamilyRelationship.IsActive and DeriveSubscriberMemberIdAsync —
+        // an EndDate in the future must still block duplicate creates.
         var query = new QueryDefinition(@"
                 SELECT TOP 1 * FROM c
                 WHERE c.tenantId = @t
                   AND c.subjectMemberId = @s
                   AND c.relatedMemberId = @r
-                  AND NOT IS_DEFINED(c.deletedAt)
-                  AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+                  AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)
+                  AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null OR c.endDate > @now)")
             .WithParameter("@t", tenantId)
             .WithParameter("@s", subjectMemberId)
-            .WithParameter("@r", relatedMemberId);
+            .WithParameter("@r", relatedMemberId)
+            .WithParameter("@now", DateTime.UtcNow);
 
         var results = await QueryAllAsync(query, tenantId, ct);
         return results.FirstOrDefault();

--- a/src/services/member-service/Repositories/FamilyRelationshipRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/FamilyRelationshipRepositoryMongo.cs
@@ -113,12 +113,15 @@ public class FamilyRelationshipRepositoryMongo : IFamilyRelationshipRepository
     public async Task<FamilyRelationship?> FindActivePairAsync(
         string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
     {
+        // Active = not soft-deleted AND (no end date OR end date is still in the future).
+        // Matches FamilyRelationship.IsActive; a future EndDate must still block duplicates.
+        var now = DateTime.UtcNow;
         var fb = Builders<FamilyRelationship>.Filter;
         var f = fb.Eq(x => x.TenantId, tenantId) &
                 fb.Eq(x => x.SubjectMemberId, subjectMemberId) &
                 fb.Eq(x => x.RelatedMemberId, relatedMemberId) &
                 fb.Eq(x => x.DeletedAt, (DateTime?)null) &
-                fb.Eq(x => x.EndDate, (DateTime?)null);
+                (fb.Eq(x => x.EndDate, (DateTime?)null) | fb.Gt(x => x.EndDate, now));
         return await _collection.Find(f).FirstOrDefaultAsync(ct);
     }
 }

--- a/src/services/member-service/Repositories/FamilyRelationshipRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/FamilyRelationshipRepositoryMongo.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MongoDB.Driver;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// MongoDB repository for <see cref="FamilyRelationship"/>. Uses multi-document
+/// transactions (replica set required) to make symmetric-pair writes atomic.
+///
+/// Deployment requirement: MongoDB must run as a replica set. Transactions degrade
+/// gracefully with a helpful error on standalone deployments — the service refuses
+/// to persist a partial pair rather than silently breaking the symmetric invariant.
+/// See <c>docs/migrations/family-relationships-backfill.md</c> for the Mongo
+/// deployment requirement.
+/// </summary>
+public class FamilyRelationshipRepositoryMongo : IFamilyRelationshipRepository
+{
+    private readonly IMongoClient _client;
+    private readonly IMongoCollection<FamilyRelationship> _collection;
+    public const string CollectionName = "FamilyRelationships";
+
+    public FamilyRelationshipRepositoryMongo(IMongoClient client, IMongoDatabase database)
+    {
+        _client = client;
+        _collection = database.GetCollection<FamilyRelationship>(CollectionName);
+    }
+
+    public async Task CreatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        if (forward.TenantId != inverse.TenantId)
+            throw new InvalidOperationException("Pair rows must share TenantId.");
+
+        using var session = await _client.StartSessionAsync(cancellationToken: ct);
+        session.StartTransaction();
+        try
+        {
+            await _collection.InsertManyAsync(session, new[] { forward, inverse }, cancellationToken: ct);
+            await session.CommitTransactionAsync(ct);
+        }
+        catch
+        {
+            await session.AbortTransactionAsync(ct);
+            throw;
+        }
+    }
+
+    public async Task UpdatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default)
+    {
+        if (forward.TenantId != inverse.TenantId)
+            throw new InvalidOperationException("Pair rows must share TenantId.");
+
+        using var session = await _client.StartSessionAsync(cancellationToken: ct);
+        session.StartTransaction();
+        try
+        {
+            await _collection.ReplaceOneAsync(session,
+                Builders<FamilyRelationship>.Filter.Eq(x => x.Id, forward.Id) &
+                Builders<FamilyRelationship>.Filter.Eq(x => x.TenantId, forward.TenantId),
+                forward, cancellationToken: ct);
+            await _collection.ReplaceOneAsync(session,
+                Builders<FamilyRelationship>.Filter.Eq(x => x.Id, inverse.Id) &
+                Builders<FamilyRelationship>.Filter.Eq(x => x.TenantId, inverse.TenantId),
+                inverse, cancellationToken: ct);
+            await session.CommitTransactionAsync(ct);
+        }
+        catch
+        {
+            await session.AbortTransactionAsync(ct);
+            throw;
+        }
+    }
+
+    public async Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        var filter = Builders<FamilyRelationship>.Filter.Eq(x => x.Id, id) &
+                     Builders<FamilyRelationship>.Filter.Eq(x => x.TenantId, tenantId);
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<List<FamilyRelationship>> GetPairAsync(string tenantId, string pairId, CancellationToken ct = default)
+    {
+        var filter = Builders<FamilyRelationship>.Filter.Eq(x => x.TenantId, tenantId) &
+                     Builders<FamilyRelationship>.Filter.Eq(x => x.PairId, pairId);
+        return await _collection.Find(filter).ToListAsync(ct);
+    }
+
+    public async Task<List<FamilyRelationship>> ListBySubjectAsync(
+        string tenantId, string subjectMemberId, bool includeDeleted = false, CancellationToken ct = default)
+    {
+        var f = Builders<FamilyRelationship>.Filter.Eq(x => x.TenantId, tenantId) &
+                Builders<FamilyRelationship>.Filter.Eq(x => x.SubjectMemberId, subjectMemberId);
+        if (!includeDeleted)
+            f &= Builders<FamilyRelationship>.Filter.Eq(x => x.DeletedAt, (DateTime?)null);
+        return await _collection.Find(f).ToListAsync(ct);
+    }
+
+    public async Task<List<FamilyRelationship>> ListTouchingAsync(
+        string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default)
+    {
+        var fb = Builders<FamilyRelationship>.Filter;
+        var f = fb.Eq(x => x.TenantId, tenantId) &
+                (fb.Eq(x => x.SubjectMemberId, memberId) | fb.Eq(x => x.RelatedMemberId, memberId));
+        if (!includeDeleted)
+            f &= fb.Eq(x => x.DeletedAt, (DateTime?)null);
+        return await _collection.Find(f).ToListAsync(ct);
+    }
+
+    public async Task<FamilyRelationship?> FindActivePairAsync(
+        string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default)
+    {
+        var fb = Builders<FamilyRelationship>.Filter;
+        var f = fb.Eq(x => x.TenantId, tenantId) &
+                fb.Eq(x => x.SubjectMemberId, subjectMemberId) &
+                fb.Eq(x => x.RelatedMemberId, relatedMemberId) &
+                fb.Eq(x => x.DeletedAt, (DateTime?)null) &
+                fb.Eq(x => x.EndDate, (DateTime?)null);
+        return await _collection.Find(f).FirstOrDefaultAsync(ct);
+    }
+}

--- a/src/services/member-service/Repositories/IFamilyRelationshipRepository.cs
+++ b/src/services/member-service/Repositories/IFamilyRelationshipRepository.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Persistence contract for <see cref="FamilyRelationship"/>. Writes are atomic
+/// symmetric pairs (A→B and B→A persisted together under a shared <c>PairId</c>).
+///
+/// Read methods exclude soft-deleted rows by default. Pass <c>includeDeleted=true</c>
+/// to surface them for audit/admin reads.
+/// </summary>
+public interface IFamilyRelationshipRepository
+{
+    /// <summary>
+    /// Atomically persist the forward and inverse rows of a symmetric relationship.
+    /// Cosmos uses <c>TransactionalBatch</c> (both rows share <c>tenantId</c>); Mongo
+    /// uses a session with a transaction.
+    /// </summary>
+    Task CreatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically replace both rows of a pair (shared PairId). Caller is responsible
+    /// for preserving symmetry — service layer enforces this.
+    /// </summary>
+    Task UpdatePairAsync(FamilyRelationship forward, FamilyRelationship inverse, CancellationToken ct = default);
+
+    Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default);
+
+    /// <summary>Returns all rows with the given PairId (normally exactly two).</summary>
+    Task<List<FamilyRelationship>> GetPairAsync(string tenantId, string pairId, CancellationToken ct = default);
+
+    /// <summary>
+    /// All relationships where <paramref name="subjectMemberId"/> is the subject
+    /// (the "from" side of the edge). Excludes soft-deleted unless requested.
+    /// </summary>
+    Task<List<FamilyRelationship>> ListBySubjectAsync(
+        string tenantId, string subjectMemberId, bool includeDeleted = false, CancellationToken ct = default);
+
+    /// <summary>
+    /// All relationships touching <paramref name="memberId"/> on either side
+    /// (subject OR related). Used for the portal Family tab and graph derivation.
+    /// </summary>
+    Task<List<FamilyRelationship>> ListTouchingAsync(
+        string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up an active (not ended, not deleted) relationship between two members. Used for
+    /// duplicate-pair rejection on create.
+    /// </summary>
+    Task<FamilyRelationship?> FindActivePairAsync(
+        string tenantId, string subjectMemberId, string relatedMemberId, CancellationToken ct = default);
+}

--- a/src/services/member-service/Services/FamilyRelationshipService.cs
+++ b/src/services/member-service/Services/FamilyRelationshipService.cs
@@ -67,7 +67,7 @@ public class FamilyRelationshipService : IFamilyRelationshipService
         // parallel active pairs, which would break "active" derivation downstream.
         var existing = await _repo.FindActivePairAsync(tenantId, req.SubjectMemberId, req.RelatedMemberId, ct);
         if (existing != null)
-            throw new FamilyRelationshipValidationException(
+            throw new DuplicateFamilyRelationshipException(
                 $"An active relationship already exists between '{req.SubjectMemberId}' and '{req.RelatedMemberId}'.");
 
         if (req.EndDate.HasValue && req.EndDate.Value < req.StartDate)

--- a/src/services/member-service/Services/FamilyRelationshipService.cs
+++ b/src/services/member-service/Services/FamilyRelationshipService.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Enforces the invariants of the family-relationship graph:
+///
+///  1. Symmetric graph — every write produces both A→B and B→A rows under a shared
+///     <c>PairId</c>, via a transactional repository method.
+///  2. Same-tenant — cross-tenant relationships are rejected in this phase.
+///     (Deferred to a future phase that handles dual-coverage spouses on different
+///     employer plans at the same payer.)
+///  3. Code validation — relationship codes are validated at the service boundary
+///     against <see cref="FamilyRelationshipCodes"/>. Unknown codes are rejected.
+///  4. Soft-delete only — normal wind-down is end-dating; hard delete never occurs.
+/// </summary>
+public class FamilyRelationshipService : IFamilyRelationshipService
+{
+    /// <summary>Subset of X12 INS02 codes that indicate "dependent → subscriber".</summary>
+    private static readonly HashSet<string> DependentToSubscriberCodes = new() { "19", "17", "10", "01", "53", "22", "29" };
+
+    private readonly IFamilyRelationshipRepository _repo;
+    private readonly IMemberRepository _memberRepo;
+
+    public FamilyRelationshipService(IFamilyRelationshipRepository repo, IMemberRepository memberRepo)
+    {
+        _repo = repo;
+        _memberRepo = memberRepo;
+    }
+
+    public async Task<FamilyRelationship> CreateAsync(
+        string tenantId, CreateFamilyRelationshipRequest req, string? actor, CancellationToken ct = default)
+    {
+        if (req == null) throw new ArgumentNullException(nameof(req));
+
+        if (string.IsNullOrWhiteSpace(req.SubjectMemberId) || string.IsNullOrWhiteSpace(req.RelatedMemberId))
+            throw new FamilyRelationshipValidationException("subjectMemberId and relatedMemberId are required.");
+
+        if (string.Equals(req.SubjectMemberId, req.RelatedMemberId, StringComparison.Ordinal))
+            throw new FamilyRelationshipValidationException("A member cannot have a relationship to themselves.");
+
+        if (!FamilyRelationshipCodes.IsValid(req.RelationshipCode))
+            throw new FamilyRelationshipValidationException(
+                $"Unknown relationshipCode '{req.RelationshipCode}'. See X12 INS02.");
+
+        var inverseCode = FamilyRelationshipCodes.Invert(req.RelationshipCode)
+            ?? throw new FamilyRelationshipValidationException(
+                $"No inverse mapping for relationshipCode '{req.RelationshipCode}'.");
+
+        // Same-tenant constraint: member lookups below run scoped to tenantId. If either
+        // member is absent in this tenant, we treat it as a not-found.
+        var subject = await _memberRepo.GetByMemberIdAsync(tenantId, req.SubjectMemberId);
+        if (subject == null)
+            throw new FamilyRelationshipValidationException($"Subject '{req.SubjectMemberId}' not found in tenant.");
+
+        var related = await _memberRepo.GetByMemberIdAsync(tenantId, req.RelatedMemberId);
+        if (related == null)
+            throw new FamilyRelationshipValidationException($"Related member '{req.RelatedMemberId}' not found in tenant.");
+
+        // Duplicate-active guard: surface a clear error rather than producing two
+        // parallel active pairs, which would break "active" derivation downstream.
+        var existing = await _repo.FindActivePairAsync(tenantId, req.SubjectMemberId, req.RelatedMemberId, ct);
+        if (existing != null)
+            throw new FamilyRelationshipValidationException(
+                $"An active relationship already exists between '{req.SubjectMemberId}' and '{req.RelatedMemberId}'.");
+
+        if (req.EndDate.HasValue && req.EndDate.Value < req.StartDate)
+            throw new FamilyRelationshipValidationException("endDate must be on or after startDate.");
+
+        var pairId = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow;
+
+        var forward = new FamilyRelationship
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = tenantId,
+            SubjectMemberId = req.SubjectMemberId,
+            RelatedMemberId = req.RelatedMemberId,
+            RelationshipCode = req.RelationshipCode,
+            PairId = pairId,
+            StartDate = req.StartDate,
+            EndDate = req.EndDate,
+            IsCustodial = req.IsCustodial,
+            QmcsoReference = req.QmcsoReference,
+            CreatedDate = now,
+            CreatedBy = actor,
+        };
+
+        var inverse = new FamilyRelationship
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = tenantId,
+            SubjectMemberId = req.RelatedMemberId,
+            RelatedMemberId = req.SubjectMemberId,
+            RelationshipCode = inverseCode,
+            PairId = pairId,
+            StartDate = req.StartDate,
+            EndDate = req.EndDate,
+            IsCustodial = req.IsCustodial,
+            QmcsoReference = req.QmcsoReference,
+            CreatedDate = now,
+            CreatedBy = actor,
+        };
+
+        await _repo.CreatePairAsync(forward, inverse, ct);
+        return forward;
+    }
+
+    public async Task<FamilyRelationship> UpdateAsync(
+        string tenantId, string id, UpdateFamilyRelationshipRequest req, string? actor, CancellationToken ct = default)
+    {
+        var (forward, inverse) = await LoadPairOrThrowAsync(tenantId, id, ct);
+
+        if (req.StartDate.HasValue)
+        {
+            forward.StartDate = req.StartDate.Value;
+            inverse.StartDate = req.StartDate.Value;
+        }
+        if (req.EndDate.HasValue)
+        {
+            if (req.EndDate.Value < (req.StartDate ?? forward.StartDate))
+                throw new FamilyRelationshipValidationException("endDate must be on or after startDate.");
+            forward.EndDate = req.EndDate.Value;
+            inverse.EndDate = req.EndDate.Value;
+        }
+        if (req.IsCustodial.HasValue)
+        {
+            forward.IsCustodial = req.IsCustodial.Value;
+            inverse.IsCustodial = req.IsCustodial.Value;
+        }
+        if (req.QmcsoReference != null)
+        {
+            forward.QmcsoReference = req.QmcsoReference;
+            inverse.QmcsoReference = req.QmcsoReference;
+        }
+
+        StampUpdate(forward, actor);
+        StampUpdate(inverse, actor);
+        await _repo.UpdatePairAsync(forward, inverse, ct);
+        return forward;
+    }
+
+    public async Task<FamilyRelationship> EndAsync(
+        string tenantId, string id, DateTime endDate, string? actor, CancellationToken ct = default)
+    {
+        var (forward, inverse) = await LoadPairOrThrowAsync(tenantId, id, ct);
+
+        if (endDate < forward.StartDate)
+            throw new FamilyRelationshipValidationException("endDate must be on or after startDate.");
+
+        forward.EndDate = endDate;
+        inverse.EndDate = endDate;
+        StampUpdate(forward, actor);
+        StampUpdate(inverse, actor);
+        await _repo.UpdatePairAsync(forward, inverse, ct);
+        return forward;
+    }
+
+    public async Task<FamilyRelationship> SoftDeleteAsync(
+        string tenantId, string id, string reason, string? actor,
+        TimeSpan? maxAge = null, CancellationToken ct = default)
+    {
+        var (forward, inverse) = await LoadPairOrThrowAsync(tenantId, id, ct);
+
+        var window = maxAge ?? TimeSpan.FromHours(24);
+        if (DateTime.UtcNow - forward.CreatedDate > window)
+            throw new FamilyRelationshipValidationException(
+                $"Soft-delete is only permitted within {window.TotalHours:F0}h of creation. " +
+                "Use POST /{id}/end to wind the relationship down instead.");
+
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new FamilyRelationshipValidationException("deletedReason is required.");
+
+        var now = DateTime.UtcNow;
+        foreach (var row in new[] { forward, inverse })
+        {
+            row.DeletedAt = now;
+            row.DeletedBy = actor;
+            row.DeletedReason = reason;
+            StampUpdate(row, actor);
+        }
+        await _repo.UpdatePairAsync(forward, inverse, ct);
+        return forward;
+    }
+
+    public Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default) =>
+        _repo.GetByIdAsync(tenantId, id, ct);
+
+    public Task<List<FamilyRelationship>> ListForMemberAsync(
+        string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default) =>
+        _repo.ListTouchingAsync(tenantId, memberId, includeDeleted, ct);
+
+    public async Task<string?> DeriveSubscriberMemberIdAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var edges = await _repo.ListBySubjectAsync(tenantId, memberId, includeDeleted: false, ct);
+        var now = DateTime.UtcNow;
+
+        // An active edge where the subject (memberId) stands in a "dependent-like"
+        // role toward the counterparty. Picks the earliest-start relationship to
+        // keep derivation stable across reads.
+        var candidate = edges
+            .Where(e => e.EndDate == null || e.EndDate > now)
+            .Where(e => DependentToSubscriberCodes.Contains(e.RelationshipCode))
+            .OrderBy(e => e.StartDate)
+            .FirstOrDefault();
+
+        return candidate?.RelatedMemberId;
+    }
+
+    private async Task<(FamilyRelationship Forward, FamilyRelationship Inverse)> LoadPairOrThrowAsync(
+        string tenantId, string id, CancellationToken ct)
+    {
+        var anchor = await _repo.GetByIdAsync(tenantId, id, ct)
+            ?? throw new FamilyRelationshipValidationException($"Relationship '{id}' not found.");
+        var rows = await _repo.GetPairAsync(tenantId, anchor.PairId, ct);
+        if (rows.Count != 2)
+            throw new InvalidOperationException(
+                $"Pair {anchor.PairId} has {rows.Count} rows — expected 2. Graph invariant violated.");
+
+        var forward = rows.FirstOrDefault(r => r.Id == anchor.Id) ?? rows[0];
+        var inverse = rows.FirstOrDefault(r => r.Id != anchor.Id) ?? rows[1];
+        return (forward, inverse);
+    }
+
+    private static void StampUpdate(FamilyRelationship row, string? actor)
+    {
+        row.UpdatedDate = DateTime.UtcNow;
+        row.UpdatedBy = actor;
+    }
+}

--- a/src/services/member-service/Services/IFamilyRelationshipService.cs
+++ b/src/services/member-service/Services/IFamilyRelationshipService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Service-layer API for the family-relationship graph. Enforces symmetric writes,
+/// validates relationship codes at the trust boundary, guards same-tenant
+/// constraint, and runs soft-delete semantics.
+/// </summary>
+public interface IFamilyRelationshipService
+{
+    /// <summary>
+    /// Create a symmetric relationship between <paramref name="request.SubjectMemberId"/>
+    /// and <paramref name="request.RelatedMemberId"/>. Returns the forward row; caller can
+    /// fetch the pair via <see cref="GetPairAsync"/> if needed.
+    /// </summary>
+    Task<FamilyRelationship> CreateAsync(string tenantId, CreateFamilyRelationshipRequest request, string? actor, CancellationToken ct = default);
+
+    /// <summary>Edit non-identity fields (dates, custodial flag, QMCSO reference) on a pair.</summary>
+    Task<FamilyRelationship> UpdateAsync(string tenantId, string id, UpdateFamilyRelationshipRequest request, string? actor, CancellationToken ct = default);
+
+    /// <summary>End-date a relationship (normal wind-down). Updates both rows of the pair.</summary>
+    Task<FamilyRelationship> EndAsync(string tenantId, string id, DateTime endDate, string? actor, CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-delete (data-entry error correction). Requires actor to be an admin and the row
+    /// to have been created within <paramref name="maxAge"/> (default: 24h). Never purges.
+    /// </summary>
+    Task<FamilyRelationship> SoftDeleteAsync(string tenantId, string id, string reason, string? actor, TimeSpan? maxAge = null, CancellationToken ct = default);
+
+    Task<FamilyRelationship?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default);
+
+    /// <summary>All relationships touching a member, grouped for the portal Family tab.</summary>
+    Task<List<FamilyRelationship>> ListForMemberAsync(string tenantId, string memberId, bool includeDeleted = false, CancellationToken ct = default);
+
+    /// <summary>
+    /// Derive the legacy <see cref="Member.SubscriberMemberId"/> value for a dependent
+    /// from the active relationship graph. Returns null when no subscriber relationship
+    /// (code "19"/"17"/"10" — dependent → subscriber) exists. Used by read paths to
+    /// keep the obsolete field populated for back-compat.
+    /// </summary>
+    Task<string?> DeriveSubscriberMemberIdAsync(string tenantId, string memberId, CancellationToken ct = default);
+}
+
+public class CreateFamilyRelationshipRequest
+{
+    public string SubjectMemberId { get; set; } = string.Empty;
+    public string RelatedMemberId { get; set; } = string.Empty;
+    /// <summary>X12 INS02 code. Validated against <see cref="FamilyRelationshipCodes"/>.</summary>
+    public string RelationshipCode { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+}
+
+public class UpdateFamilyRelationshipRequest
+{
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public bool? IsCustodial { get; set; }
+    public string? QmcsoReference { get; set; }
+}
+
+/// <summary>
+/// Thrown when a relationship write violates an invariant (symmetric-graph, same-tenant,
+/// duplicate-active, invalid code, member-not-found). Mapped to 400 in the controller.
+/// </summary>
+public class FamilyRelationshipValidationException : Exception
+{
+    public FamilyRelationshipValidationException(string message) : base(message) { }
+}

--- a/src/services/member-service/Services/IFamilyRelationshipService.cs
+++ b/src/services/member-service/Services/IFamilyRelationshipService.cs
@@ -27,8 +27,10 @@ public interface IFamilyRelationshipService
     Task<FamilyRelationship> EndAsync(string tenantId, string id, DateTime endDate, string? actor, CancellationToken ct = default);
 
     /// <summary>
-    /// Soft-delete (data-entry error correction). Requires actor to be an admin and the row
-    /// to have been created within <paramref name="maxAge"/> (default: 24h). Never purges.
+    /// Soft-delete (data-entry error correction). Row must have been created within
+    /// <paramref name="maxAge"/> (default: 24h). Never purges. Authorization of the
+    /// acting user is the caller's responsibility — enforce it at the controller /
+    /// API boundary, not here.
     /// </summary>
     Task<FamilyRelationship> SoftDeleteAsync(string tenantId, string id, string reason, string? actor, TimeSpan? maxAge = null, CancellationToken ct = default);
 
@@ -68,9 +70,22 @@ public class UpdateFamilyRelationshipRequest
 
 /// <summary>
 /// Thrown when a relationship write violates an invariant (symmetric-graph, same-tenant,
-/// duplicate-active, invalid code, member-not-found). Mapped to 400 in the controller.
+/// invalid code, member-not-found). Mapped to 400 in the controller. See
+/// <see cref="DuplicateFamilyRelationshipException"/> for the duplicate-active-pair case
+/// — callers that need to no-op on re-runs (the shim, the backfill) catch that subtype
+/// rather than inspecting error-message text.
 /// </summary>
 public class FamilyRelationshipValidationException : Exception
 {
     public FamilyRelationshipValidationException(string message) : base(message) { }
+}
+
+/// <summary>
+/// Thrown when a create would produce a second active pair between two members. Distinct
+/// type so idempotent callers (shim / backfill) can reliably detect it without
+/// message-matching.
+/// </summary>
+public class DuplicateFamilyRelationshipException : FamilyRelationshipValidationException
+{
+    public DuplicateFamilyRelationshipException(string message) : base(message) { }
 }

--- a/src/services/member-service/Services/RelationshipShim.cs
+++ b/src/services/member-service/Services/RelationshipShim.cs
@@ -72,20 +72,38 @@ public sealed class RelationshipShim : IRelationshipShim
         {
             await _service.CreateAsync(dependent.TenantId, req, actor ?? "834-import", ct);
         }
-        catch (FamilyRelationshipValidationException ex) when (
-            ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+        catch (DuplicateFamilyRelationshipException)
         {
+            // Idempotent re-run: the active pair is already in place.
             _logger.LogDebug(
                 "RelationshipShim no-op: pair already exists for {Dependent} → {Subscriber}",
-                dependent.MemberId, legacySubscriberId);
+                SanitizeForLog(dependent.MemberId), SanitizeForLog(legacySubscriberId));
         }
         catch (FamilyRelationshipValidationException ex)
         {
             // Log and swallow — the shim must never block a legitimate 834 write.
             // Graph-model completeness can be reconciled by the backfill tool.
             _logger.LogWarning(ex,
-                "RelationshipShim: skipped edge for {Dependent} → {Subscriber}: {Reason}",
-                dependent.MemberId, legacySubscriberId, ex.Message);
+                "RelationshipShim: skipped edge for {Dependent} → {Subscriber}",
+                SanitizeForLog(dependent.MemberId), SanitizeForLog(legacySubscriberId));
         }
+    }
+
+    /// <summary>
+    /// Strip control characters (including CR/LF) from user-controlled values before
+    /// they enter a log message. Prevents log-forging / log-injection per CodeQL rule
+    /// cs/log-forging. MemberId and SubscriberMemberId originate from X12 payloads
+    /// processed upstream — never trust them verbatim in logs.
+    /// </summary>
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var buffer = new System.Text.StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            buffer.Append(char.IsControl(ch) ? '_' : ch);
+        }
+        if (buffer.Length > 128) buffer.Length = 128;
+        return buffer.ToString();
     }
 }

--- a/src/services/member-service/Services/RelationshipShim.cs
+++ b/src/services/member-service/Services/RelationshipShim.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using Microsoft.Extensions.Logging;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Bridges legacy <c>Member.SubscriberMemberId</c> / <c>Member.RelationshipCode</c> writes
+/// (from the 834 enrollment-import path) onto the new symmetric-graph model, creating a
+/// <see cref="FamilyRelationship"/> pair when a dependent is written.
+///
+/// <para>
+/// <b>Idempotency:</b> calling <see cref="EnsureRelationshipAsync"/> repeatedly for the same
+/// (subscriber, dependent) pair is a no-op once the active pair exists. Safe to re-run
+/// against the same member (e.g. replayed 834 batches, backfill dry-runs).
+/// </para>
+///
+/// <para>
+/// <b>Same-tenant only:</b> the shim silently skips relationships where the subscriber
+/// lookup returns null in the dependent's tenant. That is the correct behavior for 834
+/// imports, which always enroll both parties in the same tenant.
+/// </para>
+/// </summary>
+public interface IRelationshipShim
+{
+    /// <summary>
+    /// Create (or no-op) the symmetric relationship pair implied by a legacy
+    /// <c>Member.SubscriberMemberId</c> / <c>Member.RelationshipCode</c> write.
+    /// </summary>
+    Task EnsureRelationshipAsync(Member dependent, string? actor, CancellationToken ct = default);
+}
+
+public sealed class RelationshipShim : IRelationshipShim
+{
+    private readonly IFamilyRelationshipService _service;
+    private readonly ILogger<RelationshipShim> _logger;
+
+    public RelationshipShim(IFamilyRelationshipService service, ILogger<RelationshipShim> logger)
+    {
+        _service = service;
+        _logger = logger;
+    }
+
+    public async Task EnsureRelationshipAsync(Member dependent, string? actor, CancellationToken ct = default)
+    {
+        if (dependent == null) throw new ArgumentNullException(nameof(dependent));
+
+        if (dependent.IsSubscriber) return;
+#pragma warning disable CS0618 // The shim's entire purpose is to migrate the obsolete FK to the graph.
+        var legacySubscriberId = dependent.SubscriberMemberId;
+        if (string.IsNullOrWhiteSpace(legacySubscriberId)) return;
+
+        var code = !string.IsNullOrWhiteSpace(dependent.RelationshipCode) &&
+                   FamilyRelationshipCodes.IsValid(dependent.RelationshipCode!)
+            ? dependent.RelationshipCode!
+            : RelationshipCodes.Child;
+#pragma warning restore CS0618
+
+        var req = new CreateFamilyRelationshipRequest
+        {
+            SubjectMemberId = dependent.MemberId,
+            RelatedMemberId = legacySubscriberId!,
+            RelationshipCode = code,
+            StartDate = dependent.EffectiveDate == default ? DateTime.UtcNow : dependent.EffectiveDate,
+            EndDate = dependent.TerminationDate,
+            IsCustodial = false,
+        };
+
+        try
+        {
+            await _service.CreateAsync(dependent.TenantId, req, actor ?? "834-import", ct);
+        }
+        catch (FamilyRelationshipValidationException ex) when (
+            ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "RelationshipShim no-op: pair already exists for {Dependent} → {Subscriber}",
+                dependent.MemberId, legacySubscriberId);
+        }
+        catch (FamilyRelationshipValidationException ex)
+        {
+            // Log and swallow — the shim must never block a legitimate 834 write.
+            // Graph-model completeness can be reconciled by the backfill tool.
+            _logger.LogWarning(ex,
+                "RelationshipShim: skipped edge for {Dependent} → {Subscriber}: {Reason}",
+                dependent.MemberId, legacySubscriberId, ex.Message);
+        }
+    }
+}

--- a/tests/CloudHealthOffice.BenefitPlanService.Tests/CloudHealthOffice.BenefitPlanService.Tests.csproj
+++ b/tests/CloudHealthOffice.BenefitPlanService.Tests/CloudHealthOffice.BenefitPlanService.Tests.csproj
@@ -8,7 +8,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <!--
+      Microsoft.Extensions.Logging.Abstractions is intentionally NOT declared here.
+      The benefit-plan-service ProjectReference brings it in transitively at 8.0.3
+      (via the engine packages). Declaring an older version explicitly here would
+      trigger NU1605 (package downgrade), which the .NET 8 SDK treats as a
+      restore-blocking ERROR — not just a warning. NullLogger<T> usages in the
+      tests pick the package up through the transitive reference.
+    -->
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/tests/CloudHealthOffice.PricingApi.Tests/CloudHealthOffice.PricingApi.Tests.csproj
+++ b/tests/CloudHealthOffice.PricingApi.Tests/CloudHealthOffice.PricingApi.Tests.csproj
@@ -11,7 +11,12 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <!--
+      Microsoft.Extensions.Logging.Abstractions intentionally not declared.
+      The PricingApi ProjectReference brings it in transitively at a newer
+      version; declaring it here triggers NU1605 (downgrade) which the .NET
+      8 SDK treats as a restore-blocking error.
+    -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tools/FamilyRelationshipsBackfill/FamilyRelationshipsBackfill.csproj
+++ b/tools/FamilyRelationshipsBackfill/FamilyRelationshipsBackfill.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>FamilyRelationshipsBackfill</RootNamespace>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\services\member-service\member-service.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/FamilyRelationshipsBackfill/Program.cs
+++ b/tools/FamilyRelationshipsBackfill/Program.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace FamilyRelationshipsBackfill;
+
+/// <summary>
+/// Resumable, idempotent backfill of the FamilyRelationship graph from legacy
+/// Member.SubscriberMemberId values. Runs per-tenant; progress is checkpointed to
+/// a backfill-jobs collection so a crashed run can resume where it left off.
+///
+/// Usage:
+///   dotnet run --project tools/FamilyRelationshipsBackfill -- \
+///     --tenant &lt;TENANT_ID&gt; [--batch 500] [--dry-run] [--reset]
+///
+/// Configuration (via appsettings.json / env vars):
+///   MongoDb:ConnectionString   required
+///   MongoDb:DatabaseName       default CloudHealthOffice
+/// </summary>
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddEnvironmentVariables()
+            .AddCommandLine(args)
+            .Build();
+
+        using var loggerFactory = LoggerFactory.Create(b => b.AddSimpleConsole(o =>
+        {
+            o.SingleLine = true;
+            o.TimestampFormat = "HH:mm:ss ";
+        }));
+        var logger = loggerFactory.CreateLogger("Backfill");
+
+        var tenant = config["tenant"];
+        if (string.IsNullOrWhiteSpace(tenant))
+        {
+            Console.Error.WriteLine("--tenant <TENANT_ID> is required.");
+            return 2;
+        }
+
+        var batchSize = int.TryParse(config["batch"], out var b) ? b : 500;
+        var dryRun = bool.TryParse(config["dry-run"], out var d) && d;
+        var reset = bool.TryParse(config["reset"], out var r) && r;
+
+        var mongoCs = config["MongoDb:ConnectionString"]
+            ?? throw new InvalidOperationException("MongoDb:ConnectionString is required.");
+        var dbName = config["MongoDb:DatabaseName"] ?? "CloudHealthOffice";
+
+        var client = new MongoClient(mongoCs);
+        var db = client.GetDatabase(dbName);
+
+        var memberRepo = new MemberRepositoryMongo(db);
+        var relRepo = new FamilyRelationshipRepositoryMongo(client, db);
+        var service = new FamilyRelationshipService(relRepo, memberRepo);
+
+        // Checkpoint collection — each run stores { tenantId, lastProcessedMemberId, completed }.
+        var jobs = db.GetCollection<BackfillJob>("BackfillJobs");
+        var jobFilter = Builders<BackfillJob>.Filter.Eq(x => x.TenantId, tenant);
+
+        if (reset)
+        {
+            await jobs.DeleteManyAsync(jobFilter);
+            logger.LogInformation("Reset checkpoint for tenant {Tenant}", tenant);
+        }
+
+        var job = await jobs.Find(jobFilter).FirstOrDefaultAsync()
+            ?? new BackfillJob { Id = Guid.NewGuid().ToString(), TenantId = tenant, StartedAt = DateTime.UtcNow };
+
+        if (job.Completed)
+        {
+            logger.LogInformation("Tenant {Tenant} backfill already marked completed; pass --reset to re-run.", tenant);
+            return 0;
+        }
+
+        logger.LogInformation("Backfill starting — tenant={Tenant} batchSize={Batch} dryRun={DryRun} resumeFrom={Resume}",
+            tenant, batchSize, dryRun, job.LastProcessedMemberId ?? "(start)");
+
+        var members = db.GetCollection<Member>("Members");
+
+        var cursorFilter = Builders<Member>.Filter.Eq(m => m.TenantId, tenant);
+        if (!string.IsNullOrEmpty(job.LastProcessedMemberId))
+        {
+            cursorFilter &= Builders<Member>.Filter.Gt(m => m.MemberId, job.LastProcessedMemberId);
+        }
+
+        int created = 0, skippedAlreadyLinked = 0, skippedNoSubscriber = 0, errors = 0;
+
+        while (true)
+        {
+            var page = await members.Find(cursorFilter)
+                .Sort(Builders<Member>.Sort.Ascending(m => m.MemberId))
+                .Limit(batchSize)
+                .ToListAsync();
+            if (page.Count == 0) break;
+
+            foreach (var member in page)
+            {
+                if (member.IsSubscriber)
+                {
+                    job.LastProcessedMemberId = member.MemberId;
+                    continue;
+                }
+
+#pragma warning disable CS0618 // reading obsolete field is the whole point of the backfill
+                var legacySubscriber = member.SubscriberMemberId;
+                var code = string.IsNullOrWhiteSpace(member.RelationshipCode) ? "19" : member.RelationshipCode!;
+#pragma warning restore CS0618
+
+                if (string.IsNullOrWhiteSpace(legacySubscriber))
+                {
+                    skippedNoSubscriber++;
+                    job.LastProcessedMemberId = member.MemberId;
+                    continue;
+                }
+
+                try
+                {
+                    if (!FamilyRelationshipCodes.IsValid(code)) code = "19";
+
+                    var req = new CreateFamilyRelationshipRequest
+                    {
+                        SubjectMemberId = member.MemberId,
+                        RelatedMemberId = legacySubscriber!,
+                        RelationshipCode = code,
+                        StartDate = member.EffectiveDate == default ? member.CreatedDate : member.EffectiveDate,
+                        EndDate = member.TerminationDate,
+                        IsCustodial = false,
+                    };
+
+                    if (dryRun)
+                    {
+                        logger.LogInformation("[dry-run] {Dep} → {Sub} ({Code})",
+                            req.SubjectMemberId, req.RelatedMemberId, req.RelationshipCode);
+                    }
+                    else
+                    {
+                        await service.CreateAsync(tenant, req, "backfill", CancellationToken.None);
+                        created++;
+                    }
+                }
+                catch (FamilyRelationshipValidationException ex) when (ex.Message.Contains("already exists"))
+                {
+                    skippedAlreadyLinked++;
+                }
+                catch (FamilyRelationshipValidationException ex)
+                {
+                    logger.LogWarning("Skipped {Member}: {Reason}", member.MemberId, ex.Message);
+                    errors++;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Unexpected failure on member {Member}; continuing", member.MemberId);
+                    errors++;
+                }
+
+                job.LastProcessedMemberId = member.MemberId;
+            }
+
+            // Checkpoint after every page so a crash preserves progress.
+            job.UpdatedAt = DateTime.UtcNow;
+            await jobs.ReplaceOneAsync(jobFilter, job, new ReplaceOptions { IsUpsert = true });
+
+            logger.LogInformation("Page checkpoint: last={Last} created={Created} existing={Existing} noSub={NoSub} errors={Errors}",
+                job.LastProcessedMemberId, created, skippedAlreadyLinked, skippedNoSubscriber, errors);
+
+            cursorFilter = Builders<Member>.Filter.Eq(m => m.TenantId, tenant)
+                & Builders<Member>.Filter.Gt(m => m.MemberId, job.LastProcessedMemberId!);
+        }
+
+        job.Completed = true;
+        job.CompletedAt = DateTime.UtcNow;
+        await jobs.ReplaceOneAsync(jobFilter, job, new ReplaceOptions { IsUpsert = true });
+
+        logger.LogInformation(
+            "Done. tenant={Tenant} created={Created} alreadyLinked={Existing} noSubscriber={NoSub} errors={Errors} dryRun={DryRun}",
+            tenant, created, skippedAlreadyLinked, skippedNoSubscriber, errors, dryRun);
+
+        return errors == 0 ? 0 : 1;
+    }
+}
+
+public sealed class BackfillJob
+{
+    public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string? LastProcessedMemberId { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public bool Completed { get; set; }
+}

--- a/tools/FamilyRelationshipsBackfill/Program.cs
+++ b/tools/FamilyRelationshipsBackfill/Program.cs
@@ -8,6 +8,7 @@ using MemberService.Repositories;
 using MemberService.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 
 namespace FamilyRelationshipsBackfill;
@@ -75,7 +76,7 @@ public static class Program
         }
 
         var job = await jobs.Find(jobFilter).FirstOrDefaultAsync()
-            ?? new BackfillJob { Id = Guid.NewGuid().ToString(), TenantId = tenant, StartedAt = DateTime.UtcNow };
+            ?? new BackfillJob { TenantId = tenant, StartedAt = DateTime.UtcNow };
 
         if (job.Completed)
         {
@@ -149,8 +150,9 @@ public static class Program
                         created++;
                     }
                 }
-                catch (FamilyRelationshipValidationException ex) when (ex.Message.Contains("already exists"))
+                catch (DuplicateFamilyRelationshipException)
                 {
+                    // Pair is already in place (shim or prior backfill run).
                     skippedAlreadyLinked++;
                 }
                 catch (FamilyRelationshipValidationException ex)
@@ -192,8 +194,14 @@ public static class Program
 
 public sealed class BackfillJob
 {
-    public string Id { get; set; } = string.Empty;
+    /// <summary>
+    /// TenantId IS the document id. That guarantees exactly one checkpoint per tenant
+    /// across concurrent or repeated runs — Mongo rejects a second document with the
+    /// same _id instead of silently creating a parallel checkpoint.
+    /// </summary>
+    [BsonId]
     public string TenantId { get; set; } = string.Empty;
+
     public string? LastProcessedMemberId { get; set; }
     public DateTime StartedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }

--- a/tools/FamilyRelationshipsBackfill/appsettings.json
+++ b/tools/FamilyRelationshipsBackfill/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "MongoDb": {
+    "ConnectionString": "",
+    "DatabaseName": "CloudHealthOffice"
+  }
+}


### PR DESCRIPTION
Adds a FamilyRelationship edge store, service, and controller at
/api/v1/members/{memberId}/relationships, plus an Add-Dependent wizard
endpoint and portal Family tab. Legacy Member.SubscriberMemberId is kept,
marked [Obsolete], and derived from the graph on read for back-compat.

Key design decisions (see commit discussion):
- Soft-delete only (no hard delete): POST /{relId}/end for wind-down,
  DELETE for 24h data-entry error correction. Claims, auths, and QMCSO
  references depend on historical edges remaining retrievable.
- Add-Dependent uses Member.IsDraft flag (not compensating delete) because
  the MemberEvent outbox consumer pipeline isn't ready yet (see PR #650).
  To be replaced by the outbox pattern once the consumer loop is in place.
- RelationshipCode stays a string; FamilyRelationshipCodes.IsValid validator
  runs at the service boundary (same pattern as PR #652 ContentHashSha256).
- Phase-1 same-tenant constraint: Cosmos TransactionalBatch atomicity for
  symmetric pair writes requires both rows share the tenantId partition key.
  Cross-tenant family relationships rejected explicitly.
- Mongo path uses multi-document transactions (replica set requirement
  documented in the migration runbook).
- Enrollment import path is bridged by RelationshipShim — idempotent, swallows
  failures so a 834 write is never blocked by graph-side errors.

Deliverables:
- Model / repo (Cosmos + Mongo) / service / shim / controller
- Portal Family tab with three buckets (subscriber / dependents / other) and
  Add Dependent wizard (3-step MudStepper)
- Resumable backfill console tool at tools/FamilyRelationshipsBackfill/
- Migration runbook at docs/migrations/family-relationships-backfill.md
- Tests: symmetric-pair invariant, duplicate-active guard, cross-tenant
  rejection, soft-delete window, shim idempotency, Add-Dependent conflict

https://claude.ai/code/session_01KD7FoQZbeDJZcSrxHqrB9g