### PR TITLE
feat(enrollment-import-service): append-only EnrollmentEvent stream + manual enrollment (5.6)

### DIFF
--- a/scripts/cosmos/provision-enrollment-events.sh
+++ b/scripts/cosmos/provision-enrollment-events.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Provisions the Cosmos SQL container backing the enrollment-events stream.
+#
+# Requirements:
+#   - Partition key path: /partitionKey (format "{tenantId}:{memberId}")
+#   - Unique key policy on path /version → enforces at-most-one document per
+#     (partitionKey, version) tuple so concurrent writers collide at index
+#     time. EnrollmentEventRepository converts the 409/1009 result into a
+#     version retry in EnrollmentEventPublisher.
+#
+# Unique key policies are IMMUTABLE after container creation. Migrating an
+# existing container requires: create new container with the policy → dual-
+# write or copy documents → swap reads → delete old container. In dev/staging
+# a drop-and-recreate is acceptable.
+#
+# Usage:
+#   scripts/cosmos/provision-enrollment-events.sh \
+#     --account my-cosmos \
+#     --resource-group rg-cho \
+#     --database CloudHealthOffice \
+#     [--container enrollment-events] \
+#     [--throughput 400]
+#
+# Prereqs: Azure CLI logged in, cosmosdb-preview extension if needed.
+
+set -euo pipefail
+
+CONTAINER="enrollment-events"
+THROUGHPUT=400
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --account)        ACCOUNT="$2"; shift 2 ;;
+    --resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+    --database)       DATABASE="$2"; shift 2 ;;
+    --container)      CONTAINER="$2"; shift 2 ;;
+    --throughput)     THROUGHPUT="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${ACCOUNT:?--account is required}"
+: "${RESOURCE_GROUP:?--resource-group is required}"
+: "${DATABASE:?--database is required}"
+
+echo "==> Creating Cosmos SQL container '${CONTAINER}' on '${ACCOUNT}/${DATABASE}'"
+
+az cosmosdb sql container create \
+  --account-name "${ACCOUNT}" \
+  --resource-group "${RESOURCE_GROUP}" \
+  --database-name "${DATABASE}" \
+  --name "${CONTAINER}" \
+  --partition-key-path "/partitionKey" \
+  --unique-key-policy '{"uniqueKeys":[{"paths":["/version"]}]}' \
+  --throughput "${THROUGHPUT}"
+
+echo "OK: ${CONTAINER} created with unique-key policy on /version"

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -548,52 +548,117 @@
                     </div>
                 </MudTabPanel>
 
-                <!-- Enrollment History Tab -->
+                <!-- Enrollment History Tab — backed by the per-member EnrollmentEvent stream -->
                 <MudTabPanel Text="Enrollment History" Icon="@Icons.Material.Filled.Timeline">
                     <div>
-                        @if (_loadingHistory)
+                        <MudGrid Class="mb-3">
+                            <MudItem xs="12" md="4">
+                                <MudSelect T="string" Label="Event type" Dense="true" Variant="Variant.Outlined"
+                                           Value="@_eventTypeFilter" ValueChanged="OnEventTypeChanged" Clearable="true">
+                                    <MudSelectItem T="string" Value="@(string.Empty)">All</MudSelectItem>
+                                    @foreach (var t in EnrollmentEventTypes)
+                                    {
+                                        <MudSelectItem T="string" Value="@t">@t</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                            <MudItem xs="6" md="4">
+                                <MudDatePicker Label="From" Date="_eventFromFilter" DateChanged="OnEventFromChanged"
+                                               Variant="Variant.Outlined" Clearable="true" />
+                            </MudItem>
+                            <MudItem xs="6" md="4">
+                                <MudDatePicker Label="To" Date="_eventToFilter" DateChanged="OnEventToChanged"
+                                               Variant="Variant.Outlined" Clearable="true" />
+                            </MudItem>
+                        </MudGrid>
+
+                        @if (_loadingEvents)
                         {
                             <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-4" />
                         }
-                        else if (_coverageHistory.Any())
+                        else if (_enrollmentEvents.Any())
                         {
-                            <MudTimeline TimelinePosition="TimelinePosition.Start">
-                                @foreach (var evt in _coverageHistory.OrderByDescending(e => e.EventDate))
+                            <MudExpansionPanels MultiExpansion="true" Dense="true">
+                                @foreach (var evt in _enrollmentEvents)
                                 {
-                                    <MudTimelineItem Color="@GetEventColor(evt.EventType)" Size="Size.Small">
-                                        <ItemContent>
-                                            <MudCard Elevation="1" Class="mb-1" Style="border: 1px solid rgba(0,255,255,0.1);">
-                                                <MudCardContent Class="py-2">
-                                                    <div class="d-flex justify-space-between align-center">
-                                                        <MudText Typo="Typo.body1" Style="font-weight: 500;">@evt.Description</MudText>
-                                                        <MudChip T="string" Size="Size.Small" Color="@GetEventColor(evt.EventType)">@evt.EventType</MudChip>
-                                                    </div>
-                                                    <MudText Typo="Typo.body2" Color="Color.Secondary">
-                                                        @evt.EventDate.ToString("MMM dd, yyyy") @if (!string.IsNullOrEmpty(evt.ChangedBy)) { <text>— @evt.ChangedBy</text> }
+                                    <MudExpansionPanel>
+                                        <TitleContent>
+                                            <div class="d-flex align-center" style="width:100%;">
+                                                <MudChip T="string" Size="Size.Small"
+                                                         Color="@GetEventColor(evt.EventType)" Class="mr-2">
+                                                    @evt.EventType
+                                                </MudChip>
+                                                <MudText Typo="Typo.body2" Style="font-weight:500;">
+                                                    @(evt.EventDate?.ToString("MMM dd, yyyy") ?? evt.OccurredAt.ToString("MMM dd, yyyy HH:mm"))
+                                                </MudText>
+                                                <MudSpacer />
+                                                <MudText Typo="Typo.caption" Color="Color.Secondary"
+                                                         Style="font-family: monospace;">
+                                                    v@(evt.Version) · @(evt.Source ?? "edi834")
+                                                </MudText>
+                                            </div>
+                                        </TitleContent>
+                                        <ChildContent>
+                                            <MudGrid>
+                                                <MudItem xs="6" md="3">
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Maintenance type</MudText>
+                                                    <MudText Typo="Typo.body2">@(evt.MaintenanceType ?? "—")</MudText>
+                                                </MudItem>
+                                                <MudItem xs="6" md="3">
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Maintenance reason</MudText>
+                                                    <MudText Typo="Typo.body2">@(evt.MaintenanceReason ?? "—")</MudText>
+                                                </MudItem>
+                                                <MudItem xs="6" md="3">
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Batch ID</MudText>
+                                                    <MudText Typo="Typo.body2" Style="font-family: monospace;">
+                                                        @(evt.SourceBatchId ?? "—")
                                                     </MudText>
-                                                    @if (!string.IsNullOrEmpty(evt.OldValue) || !string.IsNullOrEmpty(evt.NewValue))
-                                                    {
-                                                        <div class="mt-1">
-                                                            @if (!string.IsNullOrEmpty(evt.OldValue))
-                                                            {
-                                                                <MudText Typo="Typo.caption" Color="Color.Secondary">From: @evt.OldValue</MudText>
-                                                            }
-                                                            @if (!string.IsNullOrEmpty(evt.NewValue))
-                                                            {
-                                                                <MudText Typo="Typo.caption" Color="Color.Primary">To: @evt.NewValue</MudText>
-                                                            }
-                                                        </div>
-                                                    }
-                                                </MudCardContent>
-                                            </MudCard>
-                                        </ItemContent>
-                                    </MudTimelineItem>
+                                                </MudItem>
+                                                <MudItem xs="6" md="3">
+                                                    <MudText Typo="Typo.caption" Color="Color.Secondary">Transaction ID</MudText>
+                                                    <MudText Typo="Typo.body2" Style="font-family: monospace;">
+                                                        @(evt.TransactionId ?? "—")
+                                                    </MudText>
+                                                </MudItem>
+                                                @if (evt.RetroEffectiveDate.HasValue)
+                                                {
+                                                    <MudItem xs="12">
+                                                        <MudAlert Severity="Severity.Warning" Dense="true">
+                                                            Retro-adjusted to @evt.RetroEffectiveDate.Value.ToString("MMM dd, yyyy")
+                                                        </MudAlert>
+                                                    </MudItem>
+                                                }
+                                                @if (!string.IsNullOrWhiteSpace(evt.RawSegment))
+                                                {
+                                                    <MudItem xs="12">
+                                                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mb-1">
+                                                            Raw 834 / manual snippet
+                                                        </MudText>
+                                                        <pre style="white-space: pre-wrap; word-break: break-word;
+                                                                    background: rgba(0,0,0,0.4); padding: 8px;
+                                                                    border-radius: 4px; font-size: 0.75rem; max-height: 240px;
+                                                                    overflow: auto;">@evt.RawSegment</pre>
+                                                    </MudItem>
+                                                }
+                                            </MudGrid>
+                                        </ChildContent>
+                                    </MudExpansionPanel>
                                 }
-                            </MudTimeline>
+                            </MudExpansionPanels>
+
+                            @if (!string.IsNullOrEmpty(_eventsContinuationToken))
+                            {
+                                <div class="d-flex justify-center mt-3">
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Primary"
+                                               OnClick="LoadMoreEventsAsync">
+                                        Load more
+                                    </MudButton>
+                                </div>
+                            }
                         }
                         else
                         {
-                            <MudAlert Severity="Severity.Info">No enrollment history available.</MudAlert>
+                            <MudAlert Severity="Severity.Info">No enrollment events found for the selected filters.</MudAlert>
                         }
                     </div>
                 </MudTabPanel>
@@ -762,16 +827,28 @@
     private MemberPcp? _pcp;
     private List<CoverageHistoryEvent> _coverageHistory = new();
     private List<Enrollment834Record> _transactions834 = new();
+    private List<CloudHealthOffice.Portal.Services.EnrollmentEvent> _enrollmentEvents = new();
+    private string? _eventsContinuationToken;
+    private string _eventTypeFilter = string.Empty;
+    private DateTime? _eventFromFilter;
+    private DateTime? _eventToFilter;
     private MemberAccumulators? _accumulators;
     private MemberBenefitView? _benefitView;
     private string? _selectedBenefitPlanId;
     private string? _benefitsError;
+
+    private static readonly string[] EnrollmentEventTypes =
+    {
+        "Enrolled", "Terminated", "PlanChanged", "AddressChanged", "PcpChanged",
+        "SepTriggered", "CobraElected", "CobraTerminated", "RetroAdjusted", "ReinstatementApproved"
+    };
 
     private bool _loading = true;
     private bool _loadingCoverage = true;
     private bool _loadingPcp = false;
     private bool _loadingHistory = false;
     private bool _loading834 = false;
+    private bool _loadingEvents = false;
     private bool _loadingAccumulators = false;
     private bool _loadingBenefits = false;
     private bool _loadingFamily = false;
@@ -837,8 +914,64 @@
         _ = LoadPcpAsync();
         _ = LoadHistoryAsync();
         _ = Load834Async();
+        _ = LoadEnrollmentEventsAsync(reset: true);
         _ = LoadBenefitsForActiveCoverageAsync();
         _ = LoadFamilyAsync();
+    }
+
+    private async Task LoadEnrollmentEventsAsync(bool reset)
+    {
+        _loadingEvents = true;
+        if (reset)
+        {
+            _enrollmentEvents = new();
+            _eventsContinuationToken = null;
+        }
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var page = await MemberService.GetEnrollmentEventsAsync(
+                MemberId,
+                new EnrollmentEventFilter(
+                    Type: string.IsNullOrWhiteSpace(_eventTypeFilter) ? null : _eventTypeFilter,
+                    From: _eventFromFilter?.ToUniversalTime(),
+                    To: _eventToFilter?.ToUniversalTime(),
+                    Limit: 50,
+                    ContinuationToken: reset ? null : _eventsContinuationToken));
+
+            _enrollmentEvents.AddRange(page.Items);
+            _eventsContinuationToken = page.ContinuationToken;
+        }
+        catch
+        {
+            if (reset) _enrollmentEvents = new();
+        }
+        finally
+        {
+            _loadingEvents = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private Task LoadMoreEventsAsync() => LoadEnrollmentEventsAsync(reset: false);
+
+    private Task OnEventTypeChanged(string value)
+    {
+        _eventTypeFilter = value ?? string.Empty;
+        return LoadEnrollmentEventsAsync(reset: true);
+    }
+
+    private Task OnEventFromChanged(DateTime? value)
+    {
+        _eventFromFilter = value;
+        return LoadEnrollmentEventsAsync(reset: true);
+    }
+
+    private Task OnEventToChanged(DateTime? value)
+    {
+        _eventToFilter = value;
+        return LoadEnrollmentEventsAsync(reset: true);
     }
 
     private async Task LoadFamilyAsync()
@@ -1040,10 +1173,18 @@
         eventType switch
         {
             "Enrolled" => Color.Success,
+            "ReinstatementApproved" => Color.Success,
             "Reinstated" => Color.Success,
+            "PlanChanged" => Color.Info,
             "PlanChange" => Color.Info,
+            "PcpChanged" => Color.Primary,
             "PcpChange" => Color.Primary,
+            "AddressChanged" => Color.Tertiary,
+            "SepTriggered" => Color.Warning,
+            "CobraElected" => Color.Warning,
+            "CobraTerminated" => Color.Error,
             "Terminated" => Color.Error,
+            "RetroAdjusted" => Color.Warning,
             _ => Color.Default
         };
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -935,8 +935,13 @@
                 MemberId,
                 new EnrollmentEventFilter(
                     Type: string.IsNullOrWhiteSpace(_eventTypeFilter) ? null : _eventTypeFilter,
-                    From: _eventFromFilter?.ToUniversalTime(),
-                    To: _eventToFilter?.ToUniversalTime(),
+                    // MudDatePicker hands back midnight with DateTimeKind.Unspecified —
+                    // ToUniversalTime() on that would silently shift the intended date
+                    // by the local offset. Instead, treat the picker date as a calendar
+                    // day and extend the window to inclusive end-of-day on the To side
+                    // so events later the same day aren't excluded.
+                    From: NormalizeFilterFromUtc(_eventFromFilter),
+                    To: NormalizeFilterToUtc(_eventToFilter),
                     Limit: 50,
                     ContinuationToken: reset ? null : _eventsContinuationToken));
 
@@ -955,6 +960,16 @@
     }
 
     private Task LoadMoreEventsAsync() => LoadEnrollmentEventsAsync(reset: false);
+
+    private static DateTime? NormalizeFilterFromUtc(DateTime? picked) =>
+        picked.HasValue
+            ? DateTime.SpecifyKind(picked.Value.Date, DateTimeKind.Utc)
+            : null;
+
+    private static DateTime? NormalizeFilterToUtc(DateTime? picked) =>
+        picked.HasValue
+            ? DateTime.SpecifyKind(picked.Value.Date.AddDays(1).AddTicks(-1), DateTimeKind.Utc)
+            : null;
 
     private Task OnEventTypeChanged(string value)
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -28,6 +28,9 @@ public interface IMemberService
     Task AssignPcpAsync(AssignPcpRequest request);
     Task<List<CoverageHistoryEvent>> GetCoverageHistoryAsync(string memberId);
     Task<List<Enrollment834Record>> GetMember834TransactionsAsync(string memberId);
+    Task<EnrollmentEventPage> GetEnrollmentEventsAsync(
+        string memberId,
+        EnrollmentEventFilter filter);
     Task TerminateEnrollmentAsync(TerminateEnrollmentRequest request);
     Task<MemberAccumulators> GetAccumulatorsAsync(string memberId);
 }
@@ -1274,6 +1277,45 @@ public class Enrollment834Record
     public List<string> Errors { get; set; } = new();
     public string? RawSegmentPreview { get; set; }
 }
+
+/// <summary>
+/// Portal projection of enrollment-import-service's <c>EnrollmentEvent</c>. Surfaced via
+/// the member-service proxy at GET /members/{id}/enrollment-events so consent /
+/// audit / tenant filtering happens on the same boundary as every other member read.
+/// </summary>
+public class EnrollmentEvent
+{
+    public string EventId { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public DateTime OccurredAt { get; set; }
+    public DateTime? EventDate { get; set; }
+    public DateTime? RetroEffectiveDate { get; set; }
+    public string? SourceBatchId { get; set; }
+    public string? TransactionId { get; set; }
+    public string? MaintenanceType { get; set; }
+    public string? MaintenanceReason { get; set; }
+    public string? Source { get; set; }
+
+    /// <summary>Raw JSON payload (changed fields, plan ids, etc.). Rendered as-is for now.</summary>
+    public System.Text.Json.JsonElement? Payload { get; set; }
+
+    /// <summary>Raw 834 (or manual JSON) snippet captured at write time, for audit display.</summary>
+    public string? RawSegment { get; set; }
+}
+
+public class EnrollmentEventPage
+{
+    public List<EnrollmentEvent> Items { get; set; } = new();
+    public string? ContinuationToken { get; set; }
+}
+
+public sealed record EnrollmentEventFilter(
+    string? Type = null,
+    DateTime? From = null,
+    DateTime? To = null,
+    int Limit = 50,
+    string? ContinuationToken = null);
 
 public class AssignPcpRequest
 {

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -269,6 +269,29 @@ public class MemberService : IMemberService
         }
     }
 
+    public async Task<EnrollmentEventPage> GetEnrollmentEventsAsync(string memberId, EnrollmentEventFilter filter)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        var qs = new List<string> { $"limit={Math.Clamp(filter.Limit, 1, 200)}" };
+        if (!string.IsNullOrWhiteSpace(filter.Type)) qs.Add($"type={Uri.EscapeDataString(filter.Type)}");
+        if (filter.From.HasValue) qs.Add($"from={Uri.EscapeDataString(filter.From.Value.ToString("o"))}");
+        if (filter.To.HasValue) qs.Add($"to={Uri.EscapeDataString(filter.To.Value.ToString("o"))}");
+        if (!string.IsNullOrWhiteSpace(filter.ContinuationToken))
+            qs.Add($"continuationToken={Uri.EscapeDataString(filter.ContinuationToken)}");
+
+        try
+        {
+            var url = $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/enrollment-events?{string.Join("&", qs)}";
+            var page = await _httpClient.GetFromJsonAsync<EnrollmentEventPage>(url);
+            return page ?? new EnrollmentEventPage();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
     public async Task TerminateEnrollmentAsync(TerminateEnrollmentRequest request)
     {
         var baseUrl = _configuration["Services:MemberService"];

--- a/src/services/enrollment-import-service/Controllers/EnrollmentEventsController.cs
+++ b/src/services/enrollment-import-service/Controllers/EnrollmentEventsController.cs
@@ -1,0 +1,66 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnrollmentImportService.Controllers;
+
+/// <summary>
+/// Read-side API for the per-member enrollment-event stream.
+/// </summary>
+[ApiController]
+[Route("api/v1/members")]
+public class EnrollmentEventsController : ControllerBase
+{
+    private readonly IEnrollmentEventRepository _repository;
+
+    public EnrollmentEventsController(IEnrollmentEventRepository repository)
+    {
+        _repository = repository;
+    }
+
+    /// <summary>
+    /// List enrollment events for a member, newest first. Optionally filter by
+    /// <paramref name="type"/> (enum name or numeric value) and an occurredAt window.
+    /// Returns a continuation token for paging through large histories.
+    /// </summary>
+    [HttpGet("{memberId}/enrollment-events")]
+    [ProducesResponseType(typeof(EnrollmentEventListResponse), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> List(
+        string memberId,
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId,
+        [FromQuery] string? type = null,
+        [FromQuery] DateTime? from = null,
+        [FromQuery] DateTime? to = null,
+        [FromQuery] int limit = 50,
+        [FromQuery] string? continuationToken = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = "X-Tenant-ID header is required" });
+        if (string.IsNullOrWhiteSpace(memberId))
+            return BadRequest(new { error = "memberId is required" });
+
+        EnrollmentEventType? typeFilter = null;
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            if (!Enum.TryParse<EnrollmentEventType>(type, ignoreCase: true, out var parsed))
+                return BadRequest(new { error = $"Unknown event type '{type}'" });
+            typeFilter = parsed;
+        }
+
+        var query = new EnrollmentEventQuery(
+            EventType: typeFilter,
+            FromUtc: from,
+            ToUtc: to,
+            Limit: Math.Clamp(limit, 1, 200),
+            ContinuationToken: continuationToken);
+
+        var page = await _repository.ListByMemberAsync(tenantId, memberId, query, ct);
+        return Ok(new EnrollmentEventListResponse(page.Items, page.ContinuationToken));
+    }
+}
+
+public sealed record EnrollmentEventListResponse(
+    IReadOnlyList<EnrollmentEvent> Items,
+    string? ContinuationToken);

--- a/src/services/enrollment-import-service/Controllers/ManualEnrollmentController.cs
+++ b/src/services/enrollment-import-service/Controllers/ManualEnrollmentController.cs
@@ -1,0 +1,93 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnrollmentImportService.Controllers;
+
+/// <summary>
+/// Manual enrollment entry. Validates with the same <see cref="IEnrollmentValidator"/> as
+/// the 834 ingestion path and emits an equivalent <see cref="EnrollmentEvent"/> so manual
+/// and 834 events are interchangeable downstream.
+///
+/// Idempotency: callers may supply <see cref="MemberEnrollment.EventId"/> in the body to
+/// guarantee retry-safety. If omitted, a fresh GUID is generated per submission and only
+/// exact-collision dedup applies.
+/// </summary>
+[ApiController]
+[Route("api/v1/enrollments")]
+public class ManualEnrollmentController : ControllerBase
+{
+    private readonly IEnrollmentImportService _importService;
+    private readonly IEnrollmentValidator _validator;
+    private readonly ILogger<ManualEnrollmentController> _logger;
+
+    public ManualEnrollmentController(
+        IEnrollmentImportService importService,
+        IEnrollmentValidator validator,
+        ILogger<ManualEnrollmentController> logger)
+    {
+        _importService = importService;
+        _validator = validator;
+        _logger = logger;
+    }
+
+    [HttpPost("manual")]
+    [ProducesResponseType(typeof(ImportResult), 200)]
+    [ProducesResponseType(typeof(ValidationProblemDetails), 400)]
+    public async Task<IActionResult> CreateManual(
+        [FromBody] MemberEnrollment enrollment,
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId,
+        [FromHeader(Name = "X-Actor-ID")] string? actorId = null)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest(new { error = "X-Tenant-ID header is required" });
+
+        var validation = _validator.Validate(enrollment);
+        if (!validation.IsValid)
+        {
+            // Map structured errors to a field-keyed ValidationProblemDetails.
+            // Multiple errors per field are merged into the same key.
+            var grouped = validation.Errors
+                .GroupBy(e => e.Field)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Select(e => $"[{e.Code}] {e.Message}").ToArray());
+
+            var problem = new ValidationProblemDetails(grouped)
+            {
+                Title = "Manual enrollment validation failed",
+                Status = StatusCodes.Status400BadRequest
+            };
+            return BadRequest(problem);
+        }
+
+        // Caller-supplied EventId guarantees retry-safety. We default a GUID here so the
+        // downstream publisher always sees a non-null id.
+        enrollment.EventId ??= Guid.NewGuid().ToString("N");
+
+        var batchId = $"MANUAL-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
+        var batch = new Enrollment834
+        {
+            FileName = $"manual:{actorId ?? "unknown"}",
+            ParsedAt = DateTime.UtcNow,
+            TransactionCount = 1,
+            BatchId = batchId,
+            ManualSource = true,
+            Enrollments = new List<MemberEnrollment> { enrollment }
+        };
+
+        _logger.LogInformation(
+            "Manual enrollment for tenant {TenantId} subscriber {SubscriberId} type {Type} actor {Actor} eventId {EventId}",
+            Sanitize(tenantId),
+            Sanitize(enrollment.SubscriberId),
+            Sanitize(enrollment.MaintenanceType),
+            Sanitize(actorId),
+            Sanitize(enrollment.EventId));
+
+        var result = await _importService.ImportEnrollmentAsync(batch, tenantId);
+        return Ok(result);
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/EnrollmentEventsControllerTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/EnrollmentEventsControllerTests.cs
@@ -1,0 +1,90 @@
+using EnrollmentImportService.Controllers;
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Repositories;
+using EnrollmentImportService.Tests.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace EnrollmentImportService.Tests.Controllers;
+
+public class EnrollmentEventsControllerTests
+{
+    private static (EnrollmentEventsController ctl, InMemoryEnrollmentEventRepository repo) Build()
+    {
+        var repo = new InMemoryEnrollmentEventRepository();
+        var ctl = new EnrollmentEventsController(repo);
+        return (ctl, repo);
+    }
+
+    private static EnrollmentEvent Make(
+        string memberId, EnrollmentEventType type, int version, DateTime occurredAt) => new()
+    {
+        TenantId = "t1",
+        MemberId = memberId,
+        EventId = $"e-{memberId}-{version}",
+        EventType = type,
+        Version = version,
+        OccurredAt = occurredAt,
+        SourceBatchId = "B-1",
+        TransactionId = $"T-{version}",
+        MaintenanceType = "021"
+    };
+
+    [Fact]
+    public async Task List_ReturnsEvents_NewestFirst()
+    {
+        var (ctl, repo) = Build();
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.Enrolled, 1, DateTime.UtcNow.AddDays(-2)));
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.PlanChanged, 2, DateTime.UtcNow.AddDays(-1)));
+
+        var resp = await ctl.List("M-1", "t1");
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var page = ok.Value.Should().BeOfType<EnrollmentEventListResponse>().Subject;
+        page.Items.Should().HaveCount(2);
+        page.Items[0].Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task List_FiltersByType()
+    {
+        var (ctl, repo) = Build();
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.Enrolled, 1, DateTime.UtcNow));
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.PlanChanged, 2, DateTime.UtcNow));
+
+        var resp = await ctl.List("M-1", "t1", type: "PlanChanged");
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var page = ok.Value.Should().BeOfType<EnrollmentEventListResponse>().Subject;
+        page.Items.Should().ContainSingle();
+        page.Items[0].EventType.Should().Be(EnrollmentEventType.PlanChanged);
+    }
+
+    [Fact]
+    public async Task List_UnknownType_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        var resp = await ctl.List("M-1", "t1", type: "Bogus");
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task List_MissingTenant_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        var resp = await ctl.List("M-1", tenantId: "");
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task List_FiltersByDateWindow()
+    {
+        var (ctl, repo) = Build();
+        var now = DateTime.UtcNow;
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.Enrolled, 1, now.AddDays(-10)));
+        await repo.AppendAsync(Make("M-1", EnrollmentEventType.PlanChanged, 2, now.AddDays(-1)));
+
+        var resp = await ctl.List("M-1", "t1", from: now.AddDays(-5));
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var page = ok.Value.Should().BeOfType<EnrollmentEventListResponse>().Subject;
+        page.Items.Should().ContainSingle();
+        page.Items[0].Version.Should().Be(2);
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/ManualEnrollmentControllerTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/ManualEnrollmentControllerTests.cs
@@ -1,0 +1,81 @@
+using EnrollmentImportService.Controllers;
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace EnrollmentImportService.Tests.Controllers;
+
+public class ManualEnrollmentControllerTests
+{
+    private static (ManualEnrollmentController ctl, Mock<IEnrollmentImportService> svc) Build()
+    {
+        var svc = new Mock<IEnrollmentImportService>();
+        svc.Setup(s => s.ImportEnrollmentAsync(It.IsAny<Enrollment834>(), It.IsAny<string>()))
+            .ReturnsAsync(new ImportResult { BatchId = "B-1", SuccessCount = 1 });
+        var ctl = new ManualEnrollmentController(
+            svc.Object,
+            new EnrollmentValidator(),
+            NullLogger<ManualEnrollmentController>.Instance);
+        return (ctl, svc);
+    }
+
+    private static MemberEnrollment Valid() => new()
+    {
+        SubscriberId = "M-001",
+        MaintenanceType = "021",
+        BenefitStatus = "A",
+        Relationship = "18",
+        EnrollmentDate = "2026-01-01",
+        Demographics = new Demographics { FirstName = "Jane", LastName = "Doe" }
+    };
+
+    [Fact]
+    public async Task CreateManual_ValidPayload_DefaultsEventId_AndImports()
+    {
+        var (ctl, svc) = Build();
+        var resp = await ctl.CreateManual(Valid(), "t1", "actor1");
+
+        resp.Should().BeOfType<OkObjectResult>();
+        svc.Verify(s => s.ImportEnrollmentAsync(
+            It.Is<Enrollment834>(b =>
+                b.ManualSource &&
+                b.Enrollments.Count == 1 &&
+                !string.IsNullOrEmpty(b.Enrollments[0].EventId)),
+            "t1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateManual_PreservesSuppliedEventId_ForRetrySafety()
+    {
+        var (ctl, svc) = Build();
+        var enrollment = Valid();
+        enrollment.EventId = "client-supplied-key";
+
+        await ctl.CreateManual(enrollment, "t1");
+
+        svc.Verify(s => s.ImportEnrollmentAsync(
+            It.Is<Enrollment834>(b => b.Enrollments[0].EventId == "client-supplied-key"),
+            "t1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateManual_MissingTenant_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        var resp = await ctl.CreateManual(Valid(), tenantId: "");
+        resp.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateManual_InvalidPayload_ReturnsValidationProblemWithFieldKeys()
+    {
+        var (ctl, _) = Build();
+        var resp = await ctl.CreateManual(new MemberEnrollment(), "t1");
+        var bad = resp.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problem = bad.Value.Should().BeOfType<ValidationProblemDetails>().Subject;
+        problem.Errors.Keys.Should().Contain("subscriberId");
+        problem.Errors.Keys.Should().Contain("maintenanceType");
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentEventPublisherTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentEventPublisherTests.cs
@@ -1,0 +1,77 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EnrollmentImportService.Tests.Services;
+
+public class EnrollmentEventPublisherTests
+{
+    private static EnrollmentEventPublisher Build(out InMemoryEnrollmentEventRepository repo)
+    {
+        repo = new InMemoryEnrollmentEventRepository();
+        return new EnrollmentEventPublisher(repo, NullLogger<EnrollmentEventPublisher>.Instance);
+    }
+
+    private static EnrollmentEvent Sample(string eventId = "e1") => new()
+    {
+        TenantId = "t1",
+        MemberId = "M-001",
+        EventId = eventId,
+        EventType = EnrollmentEventType.Enrolled,
+        OccurredAt = DateTime.UtcNow,
+        Source = "edi834"
+    };
+
+    [Fact]
+    public async Task PublishAsync_AssignsVersion_AndStoresEvent()
+    {
+        var publisher = Build(out var repo);
+        var stored = await publisher.PublishAsync(Sample());
+
+        stored.Version.Should().Be(1);
+        stored.PartitionKey.Should().Be("t1:M-001");
+        repo.AllEvents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task PublishAsync_SameEventId_IsIdempotent()
+    {
+        var publisher = Build(out var repo);
+        var first = await publisher.PublishAsync(Sample("dup"));
+        var second = await publisher.PublishAsync(Sample("dup"));
+
+        second.Version.Should().Be(first.Version);
+        repo.AllEvents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task PublishAsync_RetriesOnVersionConflict_AndSucceeds()
+    {
+        var publisher = Build(out var repo);
+        repo.VersionConflictsToInject = 1;
+
+        var stored = await publisher.PublishAsync(Sample("retry-e1"));
+        stored.Version.Should().Be(1);
+        repo.AllEvents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ExhaustsRetries_ThrowsConcurrencyException()
+    {
+        var publisher = Build(out var repo);
+        repo.VersionConflictsToInject = 100;
+
+        Func<Task> act = async () => await publisher.PublishAsync(Sample("never"));
+        await act.Should().ThrowAsync<EnrollmentConcurrencyException>();
+    }
+
+    [Fact]
+    public async Task PublishAsync_MissingEventId_Throws()
+    {
+        var publisher = Build(out _);
+        var bad = Sample();
+        bad.EventId = string.Empty;
+        Func<Task> act = async () => await publisher.PublishAsync(bad);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -3,11 +3,17 @@ using EnrollmentImportService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
+// The production class and the root namespace share a name (`EnrollmentImportService`),
+// which makes `EnrollmentImportService.Services.EnrollmentImportService.Foo(...)` ambiguous
+// in expression position from inside `EnrollmentImportService.Tests.*`. This alias pins
+// the static-call target to the class and keeps the tests readable.
+using ImportSvc = EnrollmentImportService.Services.EnrollmentImportService;
+
 namespace EnrollmentImportService.Tests.Services;
 
 public class EnrollmentImportServiceTests
 {
-    private static (EnrollmentImportService.Services.EnrollmentImportService svc,
+    private static (ImportSvc svc,
         InMemoryEnrollmentEventRepository events,
         Mock<IEnrollmentRepository> repo)
         Build()
@@ -30,9 +36,9 @@ public class EnrollmentImportServiceTests
         var publisher = new EnrollmentEventPublisher(events, NullLogger<EnrollmentEventPublisher>.Instance);
         var validator = new EnrollmentValidator();
 
-        var svc = new EnrollmentImportService.Services.EnrollmentImportService(
+        var svc = new ImportSvc(
             repo.Object, txns.Object, publisher, validator,
-            NullLogger<EnrollmentImportService.Services.EnrollmentImportService>.Instance);
+            NullLogger<ImportSvc>.Instance);
         return (svc, events, repo);
     }
 
@@ -177,7 +183,7 @@ public class EnrollmentImportServiceTests
         e.MaintenanceType = "024";
         e.BenefitStatus = "C";
         e.TerminationDate = "2026-04-01";
-        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+        ImportSvc.ClassifyEvent(e)
             .Should().Be(EnrollmentEventType.CobraTerminated);
     }
 
@@ -187,7 +193,7 @@ public class EnrollmentImportServiceTests
         var e = NewSubscriber("M-1");
         e.MaintenanceType = "021";
         e.BenefitStatus = "C";
-        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+        ImportSvc.ClassifyEvent(e)
             .Should().Be(EnrollmentEventType.CobraElected);
     }
 
@@ -196,7 +202,7 @@ public class EnrollmentImportServiceTests
     {
         var e = NewSubscriber("M-1");
         e.MaintenanceType = "025";
-        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+        ImportSvc.ClassifyEvent(e)
             .Should().Be(EnrollmentEventType.ReinstatementApproved);
     }
 }

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -1,0 +1,202 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace EnrollmentImportService.Tests.Services;
+
+public class EnrollmentImportServiceTests
+{
+    private static (EnrollmentImportService.Services.EnrollmentImportService svc,
+        InMemoryEnrollmentEventRepository events,
+        Mock<IEnrollmentRepository> repo)
+        Build()
+    {
+        var repo = new Mock<IEnrollmentRepository>();
+        // Subscriber-id queries return null so the import takes the "create new" path.
+        repo.Setup(r => r.GetMemberBySubscriberIdAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((Member?)null);
+        repo.Setup(r => r.GetMemberByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((Member?)null);
+        repo.Setup(r => r.CreateMemberAsync(It.IsAny<Member>())).ReturnsAsync((Member m) => m);
+        repo.Setup(r => r.UpdateMemberAsync(It.IsAny<Member>())).ReturnsAsync((Member m) => m);
+        repo.Setup(r => r.CreateCoverageAsync(It.IsAny<Coverage>())).ReturnsAsync((Coverage c) => c);
+
+        var txns = new Mock<IEnrollmentTransactionRepository>();
+        txns.Setup(t => t.CreateAsync(It.IsAny<EnrollmentTransaction>()))
+            .ReturnsAsync((EnrollmentTransaction t) => t);
+
+        var events = new InMemoryEnrollmentEventRepository();
+        var publisher = new EnrollmentEventPublisher(events, NullLogger<EnrollmentEventPublisher>.Instance);
+        var validator = new EnrollmentValidator();
+
+        var svc = new EnrollmentImportService.Services.EnrollmentImportService(
+            repo.Object, txns.Object, publisher, validator,
+            NullLogger<EnrollmentImportService.Services.EnrollmentImportService>.Instance);
+        return (svc, events, repo);
+    }
+
+    private static MemberEnrollment NewSubscriber(string subscriberId) => new()
+    {
+        SubscriberId = subscriberId,
+        MaintenanceType = "021",
+        BenefitStatus = "A",
+        Relationship = "18",
+        EnrollmentDate = "2026-01-01",
+        Demographics = new Demographics { FirstName = "Jane", LastName = "Doe" }
+    };
+
+    [Fact]
+    public async Task Import_EmitsOneEvent_PerAcceptedTransaction()
+    {
+        var (svc, events, _) = Build();
+
+        var batch = new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-1",
+            Enrollments = new()
+            {
+                NewSubscriber("M-001"),
+                NewSubscriber("M-002")
+            }
+        };
+        var result = await svc.ImportEnrollmentAsync(batch, "t1");
+
+        result.SuccessCount.Should().Be(2);
+        events.AllEvents.Should().HaveCount(2);
+        events.AllEvents.Select(e => e.MemberId).Should().BeEquivalentTo(new[] { "M-001", "M-002" });
+    }
+
+    [Fact]
+    public async Task Import_RejectedValidation_DoesNotEmitEvent()
+    {
+        var (svc, events, _) = Build();
+
+        var bad = new MemberEnrollment(); // no required fields
+        var batch = new Enrollment834
+        {
+            FileName = "bad.834",
+            BatchId = "B-bad",
+            Enrollments = new() { bad }
+        };
+        var result = await svc.ImportEnrollmentAsync(batch, "t1");
+
+        result.FailedCount.Should().Be(1);
+        events.AllEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Import_ReplayingSameBatch_ProducesNoDuplicateEvents()
+    {
+        var (svc, events, _) = Build();
+
+        var batch = new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-replay",
+            Enrollments = new() { NewSubscriber("M-replay") }
+        };
+
+        await svc.ImportEnrollmentAsync(batch, "t1");
+        await svc.ImportEnrollmentAsync(batch, "t1");
+
+        events.AllEvents.Should().HaveCount(1);
+        events.AllEvents[0].EventId.Should().StartWith("834-B-replay:");
+    }
+
+    [Fact]
+    public async Task Import_ManualSource_UsesManualPrefix_AndDoesNotAccidentallyDedupe()
+    {
+        var (svc, events, _) = Build();
+
+        // Two manual enrollments for the same subscriber but with distinct EventIds —
+        // each should produce a separate event even if the synthesized batch ids
+        // happened to collide, because the prefix makes them disjoint and the per-event
+        // EventId differs.
+        var e1 = NewSubscriber("M-manual");
+        e1.EventId = "evt-A";
+        var e2 = NewSubscriber("M-manual");
+        e2.EventId = "evt-B";
+
+        await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "manual:user1",
+            BatchId = "MANUAL-1",
+            ManualSource = true,
+            Enrollments = new() { e1 }
+        }, "t1");
+
+        // Second submission shouldn't have a colliding M-manual address with an existing
+        // member, so set MaintenanceType=001 to take the update path.
+        e2.MaintenanceType = "001";
+        e2.EnrollmentDate = "2026-02-01";
+        await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "manual:user1",
+            BatchId = "MANUAL-1", // intentionally identical
+            ManualSource = true,
+            Enrollments = new() { e2 }
+        }, "t1");
+
+        events.AllEvents.Should().HaveCount(2);
+        events.AllEvents.All(e => e.EventId.StartsWith("manual-")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Import_ManualSource_SameRequestEventId_IsIdempotent()
+    {
+        var (svc, events, _) = Build();
+
+        var e1 = NewSubscriber("M-idem");
+        e1.EventId = "stable-key";
+
+        await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "manual",
+            BatchId = "MANUAL-A",
+            ManualSource = true,
+            Enrollments = new() { e1 }
+        }, "t1");
+
+        await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "manual",
+            BatchId = "MANUAL-B", // different batch id
+            ManualSource = true,
+            Enrollments = new() { e1 }
+        }, "t1");
+
+        events.AllEvents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ClassifyEvent_TerminationWithCobra_IsCobraTerminated()
+    {
+        var e = NewSubscriber("M-1");
+        e.MaintenanceType = "024";
+        e.BenefitStatus = "C";
+        e.TerminationDate = "2026-04-01";
+        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+            .Should().Be(EnrollmentEventType.CobraTerminated);
+    }
+
+    [Fact]
+    public void ClassifyEvent_AdditionWithCobra_IsCobraElected()
+    {
+        var e = NewSubscriber("M-1");
+        e.MaintenanceType = "021";
+        e.BenefitStatus = "C";
+        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+            .Should().Be(EnrollmentEventType.CobraElected);
+    }
+
+    [Fact]
+    public void ClassifyEvent_Reinstatement_IsReinstatementApproved()
+    {
+        var e = NewSubscriber("M-1");
+        e.MaintenanceType = "025";
+        EnrollmentImportService.Services.EnrollmentImportService.ClassifyEvent(e)
+            .Should().Be(EnrollmentEventType.ReinstatementApproved);
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -3,9 +3,9 @@ using EnrollmentImportService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
-// Classification is tested via the dedicated EnrollmentEventClassifier helper so we
-// avoid the "production class shares a name with the root namespace" resolution bug —
-// see EnrollmentEventClassifier for the full rationale.
+// Classification is tested via the dedicated EnrollmentEventClassifier helper to avoid
+// the name-shadowing issue between the root namespace and the production import-service
+// class — see EnrollmentEventClassifier's XML doc for the full rationale.
 using ImportSvc = EnrollmentImportService.Services.EnrollmentImportService;
 
 namespace EnrollmentImportService.Tests.Services;

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -3,10 +3,9 @@ using EnrollmentImportService.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
-// The production class and the root namespace share a name (`EnrollmentImportService`),
-// which makes `EnrollmentImportService.Services.EnrollmentImportService.Foo(...)` ambiguous
-// in expression position from inside `EnrollmentImportService.Tests.*`. This alias pins
-// the static-call target to the class and keeps the tests readable.
+// Classification is tested via the dedicated EnrollmentEventClassifier helper so we
+// avoid the "production class shares a name with the root namespace" resolution bug —
+// see EnrollmentEventClassifier for the full rationale.
 using ImportSvc = EnrollmentImportService.Services.EnrollmentImportService;
 
 namespace EnrollmentImportService.Tests.Services;
@@ -183,7 +182,7 @@ public class EnrollmentImportServiceTests
         e.MaintenanceType = "024";
         e.BenefitStatus = "C";
         e.TerminationDate = "2026-04-01";
-        ImportSvc.ClassifyEvent(e)
+        EnrollmentEventClassifier.Classify(e)
             .Should().Be(EnrollmentEventType.CobraTerminated);
     }
 
@@ -193,7 +192,7 @@ public class EnrollmentImportServiceTests
         var e = NewSubscriber("M-1");
         e.MaintenanceType = "021";
         e.BenefitStatus = "C";
-        ImportSvc.ClassifyEvent(e)
+        EnrollmentEventClassifier.Classify(e)
             .Should().Be(EnrollmentEventType.CobraElected);
     }
 
@@ -202,7 +201,7 @@ public class EnrollmentImportServiceTests
     {
         var e = NewSubscriber("M-1");
         e.MaintenanceType = "025";
-        ImportSvc.ClassifyEvent(e)
+        EnrollmentEventClassifier.Classify(e)
             .Should().Be(EnrollmentEventType.ReinstatementApproved);
     }
 }

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentValidatorTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentValidatorTests.cs
@@ -1,0 +1,78 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+
+namespace EnrollmentImportService.Tests.Services;
+
+public class EnrollmentValidatorTests
+{
+    private static MemberEnrollment Valid() => new()
+    {
+        MaintenanceType = "021",
+        BenefitStatus = "A",
+        Relationship = "18",
+        SubscriberId = "M-001",
+        EnrollmentDate = "2026-01-01",
+        Demographics = new Demographics { FirstName = "Jane", LastName = "Doe" }
+    };
+
+    [Fact]
+    public void Validate_HappyPath_IsValid()
+    {
+        var result = new EnrollmentValidator().Validate(Valid());
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_MissingFields_ReportsStructuredErrors()
+    {
+        var bad = new MemberEnrollment();
+        var result = new EnrollmentValidator().Validate(bad);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Select(e => e.Code).Should().Contain(new[]
+        {
+            "maintenanceType.required",
+            "benefitStatus.required",
+            "relationship.required",
+            "subscriberId.required",
+            "demographics.required"
+        });
+        result.Errors.Should().OnlyContain(e => !string.IsNullOrEmpty(e.Field));
+    }
+
+    [Fact]
+    public void Validate_TerminationWithoutDate_Fails()
+    {
+        var e = Valid();
+        e.MaintenanceType = "024";
+        e.EnrollmentDate = null;
+        e.TerminationDate = null;
+        var result = new EnrollmentValidator().Validate(e);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.Code == "terminationDate.requiredForTermination");
+    }
+
+    [Fact]
+    public void Validate_AdditionWithoutDateOrCoverage_Fails()
+    {
+        var e = Valid();
+        e.MaintenanceType = "021";
+        e.EnrollmentDate = null;
+        e.Coverage = new();
+        var result = new EnrollmentValidator().Validate(e);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(x => x.Code == "enrollmentDate.requiredForAddition");
+    }
+
+    [Fact]
+    public void Validate_UnsupportedMaintenanceType_Fails()
+    {
+        var e = Valid();
+        e.MaintenanceType = "999";
+        var result = new EnrollmentValidator().Validate(e);
+        result.Errors.Should().Contain(x => x.Code == "maintenanceType.unsupported");
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/InMemoryEnrollmentEventRepository.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/InMemoryEnrollmentEventRepository.cs
@@ -1,0 +1,115 @@
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Repositories;
+
+namespace EnrollmentImportService.Tests.Services;
+
+/// <summary>
+/// Test double for <see cref="IEnrollmentEventRepository"/>. Models the same uniqueness
+/// rules as Cosmos (unique on EventId per partition; unique on Version per partition) so
+/// publisher tests exercise realistic conflict paths.
+/// </summary>
+internal sealed class InMemoryEnrollmentEventRepository : IEnrollmentEventRepository
+{
+    private readonly object _lock = new();
+    private readonly List<EnrollmentEvent> _events = new();
+    public int VersionConflictsToInject { get; set; }
+
+    public IReadOnlyList<EnrollmentEvent> AllEvents
+    {
+        get { lock (_lock) return _events.ToArray(); }
+    }
+
+    public Task<EnrollmentEventAppendResult> AppendAsync(EnrollmentEvent evt, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            if (VersionConflictsToInject > 0)
+            {
+                VersionConflictsToInject--;
+                return Task.FromResult(new EnrollmentEventAppendResult(evt, Appended: false));
+            }
+
+            var existingById = _events.FirstOrDefault(e =>
+                e.TenantId == evt.TenantId && e.MemberId == evt.MemberId && e.EventId == evt.EventId);
+            if (existingById != null)
+                return Task.FromResult(new EnrollmentEventAppendResult(existingById, Appended: false));
+
+            var versionTaken = _events.Any(e =>
+                e.TenantId == evt.TenantId && e.MemberId == evt.MemberId && e.Version == evt.Version);
+            if (versionTaken)
+                return Task.FromResult(new EnrollmentEventAppendResult(evt, Appended: false));
+
+            _events.Add(Clone(evt));
+            return Task.FromResult(new EnrollmentEventAppendResult(Clone(evt), Appended: true));
+        }
+    }
+
+    public Task<EnrollmentEventPage> ListByMemberAsync(
+        string tenantId, string memberId, EnrollmentEventQuery query, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            IEnumerable<EnrollmentEvent> q = _events
+                .Where(e => e.TenantId == tenantId && e.MemberId == memberId);
+            if (query.EventType.HasValue)
+                q = q.Where(e => e.EventType == query.EventType.Value);
+            if (query.FromUtc.HasValue)
+                q = q.Where(e => e.OccurredAt >= query.FromUtc.Value);
+            if (query.ToUtc.HasValue)
+                q = q.Where(e => e.OccurredAt <= query.ToUtc.Value);
+
+            var items = q.OrderByDescending(e => e.Version)
+                .Take(query.Limit)
+                .Select(Clone)
+                .ToList();
+            return Task.FromResult(new EnrollmentEventPage(items, ContinuationToken: null));
+        }
+    }
+
+    public Task<EnrollmentEvent?> GetByIdAsync(
+        string tenantId, string memberId, string eventId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var hit = _events.FirstOrDefault(e =>
+                e.TenantId == tenantId && e.MemberId == memberId && e.EventId == eventId);
+            return Task.FromResult(hit == null ? null : Clone(hit));
+        }
+    }
+
+    public Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        lock (_lock)
+        {
+            var max = _events
+                .Where(e => e.TenantId == tenantId && e.MemberId == memberId)
+                .Select(e => (int?)e.Version)
+                .Max() ?? 0;
+            return Task.FromResult(max + 1);
+        }
+    }
+
+    private static EnrollmentEvent Clone(EnrollmentEvent src) => new()
+    {
+        Id = src.Id,
+        PartitionKey = src.PartitionKey,
+        TenantId = src.TenantId,
+        MemberId = src.MemberId,
+        EventId = src.EventId,
+        EventType = src.EventType,
+        Version = src.Version,
+        SchemaVersion = src.SchemaVersion,
+        OccurredAt = src.OccurredAt,
+        EventDate = src.EventDate,
+        RetroEffectiveDate = src.RetroEffectiveDate,
+        SourceBatchId = src.SourceBatchId,
+        TransactionId = src.TransactionId,
+        MaintenanceType = src.MaintenanceType,
+        MaintenanceReason = src.MaintenanceReason,
+        Source = src.Source,
+        ActorId = src.ActorId,
+        CorrelationId = src.CorrelationId,
+        Payload = src.Payload?.DeepClone() as System.Text.Json.Nodes.JsonObject,
+        RawSegment = src.RawSegment
+    };
+}

--- a/src/services/enrollment-import-service/Models/Enrollment.cs
+++ b/src/services/enrollment-import-service/Models/Enrollment.cs
@@ -9,15 +9,26 @@ public class Enrollment834
 {
     [JsonPropertyName("fileName")]
     public string FileName { get; set; } = string.Empty;
-    
+
     [JsonPropertyName("parsedAt")]
     public DateTime ParsedAt { get; set; }
-    
+
     [JsonPropertyName("transactionCount")]
     public int TransactionCount { get; set; }
-    
+
     [JsonPropertyName("enrollments")]
     public List<MemberEnrollment> Enrollments { get; set; } = new();
+
+    /// <summary>
+    /// Optional caller-supplied batch id. When set, replays of the same batch produce
+    /// deterministic event ids and de-duplicate at the event store.
+    /// </summary>
+    [JsonPropertyName("batchId")]
+    public string? BatchId { get; set; }
+
+    /// <summary>True when this batch came from a manual entry endpoint, not an 834 file.</summary>
+    [JsonPropertyName("manualSource")]
+    public bool ManualSource { get; set; }
 }
 
 public class MemberEnrollment
@@ -63,6 +74,21 @@ public class MemberEnrollment
     
     [JsonPropertyName("dependents")]
     public List<Dependent> Dependents { get; set; } = new();
+
+    /// <summary>
+    /// Optional caller-supplied transaction id (834 BGN02 or manual). When omitted the
+    /// import service derives a deterministic id from <c>(BatchId, SubscriberId)</c>.
+    /// </summary>
+    [JsonPropertyName("transactionId")]
+    public string? TransactionId { get; set; }
+
+    /// <summary>
+    /// For manual-source enrollments only: the client-supplied idempotency key for the
+    /// resulting <see cref="EnrollmentEvent"/>. Ignored when <see cref="Enrollment834.ManualSource"/>
+    /// is false. Defaults to a fresh GUID at the controller boundary.
+    /// </summary>
+    [JsonPropertyName("eventId")]
+    public string? EventId { get; set; }
 }
 
 public class Demographics

--- a/src/services/enrollment-import-service/Models/EnrollmentEvent.cs
+++ b/src/services/enrollment-import-service/Models/EnrollmentEvent.cs
@@ -1,0 +1,142 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace EnrollmentImportService.Models;
+
+/// <summary>
+/// Append-only event record for the enrollment-events stream.
+///
+/// Idempotency: the writer supplies <see cref="EventId"/>; the repository rejects duplicates
+/// keyed on <c>(TenantId, MemberId, EventId)</c>. For 834 ingestion the EventId is derived
+/// from <c>(BatchId, TransactionId, MemberId)</c> so replaying a batch yields zero new events.
+///
+/// Ordering: <see cref="Version"/> is monotonically increasing per (TenantId, MemberId).
+/// Concurrent writers conflict on the unique-key policy on <c>/version</c>; the publisher
+/// re-fetches the next version and retries.
+///
+/// Partition: Cosmos container <c>enrollment-events</c> uses partition key
+/// <c>{tenantId}:{memberId}</c> so per-member change-feed consumers read in order.
+/// </summary>
+public class EnrollmentEvent
+{
+    [Required]
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [Required]
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    [JsonPropertyName("tenantId")]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    [JsonPropertyName("memberId")]
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>Client-supplied idempotency key, unique within (TenantId, MemberId).</summary>
+    [Required]
+    [JsonPropertyName("eventId")]
+    public string EventId { get; set; } = string.Empty;
+
+    [Required]
+    [JsonPropertyName("eventType")]
+    public EnrollmentEventType EventType { get; set; }
+
+    [Required]
+    [JsonPropertyName("version")]
+    public int Version { get; set; }
+
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>Wall-clock time the event was recorded.</summary>
+    [JsonPropertyName("occurredAt")]
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Business-effective date for the change (e.g. termination effective date).</summary>
+    [JsonPropertyName("eventDate")]
+    public DateTime? EventDate { get; set; }
+
+    /// <summary>
+    /// For retro adjustments only: the date the change is back-dated to. Always emitted
+    /// as a separate field from <see cref="EventDate"/> so reconciliations can distinguish
+    /// "when it was effective" (eventDate) from "when we acted" (occurredAt).
+    /// </summary>
+    [JsonPropertyName("retroEffectiveDate")]
+    public DateTime? RetroEffectiveDate { get; set; }
+
+    /// <summary>Originating 834 batch id, or "manual:{guid}" for manually-entered events.</summary>
+    [JsonPropertyName("sourceBatchId")]
+    public string? SourceBatchId { get; set; }
+
+    /// <summary>The 834 BGN02 transaction id, or null for manual.</summary>
+    [JsonPropertyName("transactionId")]
+    public string? TransactionId { get; set; }
+
+    /// <summary>834 INS03 maintenance type code (021/001/024/030/etc.).</summary>
+    [JsonPropertyName("maintenanceType")]
+    public string? MaintenanceType { get; set; }
+
+    /// <summary>834 INS04 maintenance reason code (e.g. EC, 41).</summary>
+    [JsonPropertyName("maintenanceReason")]
+    public string? MaintenanceReason { get; set; }
+
+    [JsonPropertyName("source")]
+    public string Source { get; set; } = "edi834";
+
+    [JsonPropertyName("actorId")]
+    public string? ActorId { get; set; }
+
+    [JsonPropertyName("correlationId")]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>Event-specific payload (changed fields, plan ids, addresses, etc.).</summary>
+    [JsonPropertyName("payload")]
+    public JsonObject? Payload { get; set; }
+
+    /// <summary>
+    /// Raw 834 snippet (or JSON form of the manual request) for audit / display.
+    /// Truncated to keep documents under Cosmos's 2MB limit.
+    /// </summary>
+    [JsonPropertyName("rawSegment")]
+    public string? RawSegment { get; set; }
+
+    public static string BuildPartitionKey(string tenantId, string memberId) =>
+        $"{tenantId}:{memberId}";
+
+    /// <summary>
+    /// EventId for an 834-ingested event. Prefix is fixed (<c>"834-"</c>) so it can never
+    /// collide with manual EventIds even if an operator picks the same suffix.
+    /// </summary>
+    public static string BuildIngestEventId(string batchId, string transactionId, string memberId) =>
+        $"834-{batchId}:{transactionId}:{memberId}";
+
+    /// <summary>
+    /// EventId for a manually-entered event. <paramref name="requestEventId"/> is the
+    /// caller-supplied idempotency key (a fresh GUID if the caller didn't provide one).
+    /// The prefix (<c>"manual-"</c>) prevents cross-path collisions with 834-derived ids.
+    /// </summary>
+    public static string BuildManualEventId(string requestEventId, string memberId) =>
+        $"manual-{requestEventId}:{memberId}";
+}
+
+/// <summary>
+/// Event types covered by the enrollment stream. Keep numeric values stable — they are
+/// persisted in Cosmos.
+/// </summary>
+public enum EnrollmentEventType
+{
+    Enrolled = 1,
+    Terminated = 2,
+    PlanChanged = 3,
+    AddressChanged = 4,
+    PcpChanged = 5,
+    SepTriggered = 6,
+    CobraElected = 7,
+    CobraTerminated = 8,
+    RetroAdjusted = 9,
+    ReinstatementApproved = 10
+}

--- a/src/services/enrollment-import-service/Models/EnrollmentEvent.cs
+++ b/src/services/enrollment-import-service/Models/EnrollmentEvent.cs
@@ -68,11 +68,24 @@ public class EnrollmentEvent
     [JsonPropertyName("retroEffectiveDate")]
     public DateTime? RetroEffectiveDate { get; set; }
 
-    /// <summary>Originating 834 batch id, or "manual:{guid}" for manually-entered events.</summary>
+    /// <summary>
+    /// Originating batch id. For 834 ingestion this is the caller-supplied
+    /// <see cref="Enrollment834.BatchId"/> or a generated <c>BATCH-&lt;ts&gt;-&lt;guid&gt;</c>.
+    /// For manual submissions the controller synthesises <c>MANUAL-&lt;ts&gt;-&lt;guid&gt;</c>.
+    /// It is NOT the source of idempotency on the manual path — see <see cref="EventId"/>
+    /// and <see cref="BuildManualEventId"/>.
+    /// </summary>
     [JsonPropertyName("sourceBatchId")]
     public string? SourceBatchId { get; set; }
 
-    /// <summary>The 834 BGN02 transaction id, or null for manual.</summary>
+    /// <summary>
+    /// Per-transaction identifier. For 834 ingestion this is the 834 BGN02 when the
+    /// caller supplies one, or the service-derived <c>{batchId}-{position}-{subscriberId}</c>
+    /// otherwise. For manual submissions the service sets it to a synthesised id that
+    /// lets transaction-log queries still group by batch; the per-event idempotency key
+    /// on the manual path is the caller-supplied <c>EventId</c> (see
+    /// <see cref="BuildManualEventId"/>), not this field.
+    /// </summary>
     [JsonPropertyName("transactionId")]
     public string? TransactionId { get; set; }
 

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -11,7 +11,15 @@ builder.Services.AddSecretProvider(builder.Configuration);
 builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
 
 // Add services
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(o =>
+    {
+        // Emit enums as their member names (e.g. "Enrolled") so portal + member-service
+        // DTOs that model EnrollmentEventType as a string can round-trip without a
+        // custom converter on every consumer.
+        o.JsonSerializerOptions.Converters.Add(
+            new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -1,4 +1,5 @@
 using EnrollmentImportService;
+using EnrollmentImportService.Repositories;
 using EnrollmentImportService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
@@ -32,6 +33,9 @@ builder.Services.AddSingleton<CosmosClient>(sp =>
 // Repositories and services
 builder.Services.AddScoped<IEnrollmentRepository, EnrollmentRepository>();
 builder.Services.AddScoped<IEnrollmentTransactionRepository, EnrollmentTransactionRepository>();
+builder.Services.AddScoped<IEnrollmentEventRepository, EnrollmentEventRepository>();
+builder.Services.AddScoped<IEnrollmentEventPublisher, EnrollmentEventPublisher>();
+builder.Services.AddSingleton<IEnrollmentValidator, EnrollmentValidator>();
 builder.Services.AddScoped<IEnrollmentImportService, EnrollmentImportService.Services.EnrollmentImportService>();
 
 // Health checks (MongoDB or Cosmos DB)

--- a/src/services/enrollment-import-service/Repositories/EnrollmentEventRepository.cs
+++ b/src/services/enrollment-import-service/Repositories/EnrollmentEventRepository.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using EnrollmentImportService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace EnrollmentImportService.Repositories;
+
+/// <summary>
+/// Cosmos DB repository for <see cref="EnrollmentEvent"/>.
+///
+/// Container provisioning:
+///   - Partition key path: <c>/partitionKey</c> (format <c>{tenantId}:{memberId}</c>).
+///   - Unique-key policy: <c>/version</c> — concurrent writers collide at the index
+///     instead of silently overlapping.
+/// </summary>
+public class EnrollmentEventRepository : IEnrollmentEventRepository
+{
+    /// <summary>Cosmos sub-status for a unique-key constraint violation.</summary>
+    public const int UniqueKeyViolationSubStatus = 1009;
+
+    private readonly CosmosClient _cosmosClient;
+    private readonly IConfiguration _config;
+    private readonly ILogger<EnrollmentEventRepository>? _logger;
+
+    public EnrollmentEventRepository(
+        CosmosClient cosmosClient,
+        IConfiguration config,
+        ILogger<EnrollmentEventRepository>? logger = null)
+    {
+        _cosmosClient = cosmosClient;
+        _config = config;
+        _logger = logger;
+    }
+
+    private Container Container => _cosmosClient.GetContainer(
+        _config["CosmosDb:DatabaseName"] ?? "CloudHealthOffice",
+        _config["CosmosDb:EnrollmentEventsContainerName"] ?? "enrollment-events");
+
+    public async Task<EnrollmentEventAppendResult> AppendAsync(EnrollmentEvent evt, CancellationToken ct = default)
+    {
+        Normalize(evt);
+
+        try
+        {
+            var response = await Container.CreateItemAsync(
+                evt,
+                new PartitionKey(evt.PartitionKey),
+                cancellationToken: ct);
+            return new EnrollmentEventAppendResult(response.Resource, Appended: true);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            if (ex.SubStatusCode == UniqueKeyViolationSubStatus)
+            {
+                return new EnrollmentEventAppendResult(evt, Appended: false);
+            }
+
+            if (ex.SubStatusCode != 0)
+            {
+                _logger?.LogWarning(ex,
+                    "Unexpected Cosmos 409 SubStatus {SubStatus} on enrollment-events append for {PartitionKey} v{Version}. Treating as idempotent no-op.",
+                    ex.SubStatusCode, SanitizeForLog(evt.PartitionKey), evt.Version);
+            }
+
+            var existing = await GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+            return new EnrollmentEventAppendResult(existing ?? evt, Appended: false);
+        }
+    }
+
+    public async Task<EnrollmentEventPage> ListByMemberAsync(
+        string tenantId, string memberId, EnrollmentEventQuery query, CancellationToken ct = default)
+    {
+        var partitionKey = EnrollmentEvent.BuildPartitionKey(tenantId, memberId);
+
+        var sql = "SELECT * FROM c WHERE c.partitionKey = @pk";
+        if (query.EventType.HasValue) sql += " AND c.eventType = @type";
+        if (query.FromUtc.HasValue) sql += " AND c.occurredAt >= @from";
+        if (query.ToUtc.HasValue) sql += " AND c.occurredAt <= @to";
+        sql += " ORDER BY c.version DESC";
+
+        var def = new QueryDefinition(sql).WithParameter("@pk", partitionKey);
+        if (query.EventType.HasValue) def = def.WithParameter("@type", (int)query.EventType.Value);
+        if (query.FromUtc.HasValue) def = def.WithParameter("@from", query.FromUtc.Value);
+        if (query.ToUtc.HasValue) def = def.WithParameter("@to", query.ToUtc.Value);
+
+        var iterator = Container.GetItemQueryIterator<EnrollmentEvent>(
+            def,
+            continuationToken: query.ContinuationToken,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(partitionKey),
+                MaxItemCount = Math.Clamp(query.Limit, 1, 500)
+            });
+
+        if (!iterator.HasMoreResults)
+            return new EnrollmentEventPage(Array.Empty<EnrollmentEvent>(), null);
+
+        var page = await iterator.ReadNextAsync(ct);
+        return new EnrollmentEventPage(page.ToList(), page.ContinuationToken);
+    }
+
+    public async Task<EnrollmentEvent?> GetByIdAsync(
+        string tenantId, string memberId, string eventId, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await Container.ReadItemAsync<EnrollmentEvent>(
+                eventId,
+                new PartitionKey(EnrollmentEvent.BuildPartitionKey(tenantId, memberId)),
+                cancellationToken: ct);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var partitionKey = EnrollmentEvent.BuildPartitionKey(tenantId, memberId);
+        var query = new QueryDefinition(
+            "SELECT VALUE MAX(c.version) FROM c WHERE c.partitionKey = @pk")
+            .WithParameter("@pk", partitionKey);
+
+        var iterator = Container.GetItemQueryIterator<int?>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) });
+
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            var max = page.FirstOrDefault();
+            return (max ?? 0) + 1;
+        }
+        return 1;
+    }
+
+    private static void Normalize(EnrollmentEvent evt)
+    {
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EventId is required (idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
+            throw new ArgumentException("TenantId and MemberId are required");
+
+        if (string.IsNullOrEmpty(evt.Id)) evt.Id = evt.EventId;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = EnrollmentEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/enrollment-import-service/Repositories/IEnrollmentEventRepository.cs
+++ b/src/services/enrollment-import-service/Repositories/IEnrollmentEventRepository.cs
@@ -1,0 +1,51 @@
+using EnrollmentImportService.Models;
+
+namespace EnrollmentImportService.Repositories;
+
+/// <summary>
+/// Append-only store for <see cref="EnrollmentEvent"/>.
+///
+/// Writes are idempotent keyed on <c>(TenantId, MemberId, EventId)</c>. Repeated calls with
+/// the same EventId return the existing event (<c>Appended=false</c>) without writing a
+/// new document.
+/// </summary>
+public interface IEnrollmentEventRepository
+{
+    /// <summary>
+    /// Append an event. Returns <c>Appended=false</c> with the existing event for an
+    /// EventId collision, or <c>Appended=false</c> with the in-memory envelope (no Event)
+    /// when a concurrent writer claimed our version slot.
+    /// </summary>
+    Task<EnrollmentEventAppendResult> AppendAsync(EnrollmentEvent evt, CancellationToken ct = default);
+
+    /// <summary>
+    /// List events for a member, ordered by <see cref="EnrollmentEvent.Version"/> ascending,
+    /// optionally filtered by event type and/or occurredAt window.
+    /// </summary>
+    Task<EnrollmentEventPage> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        EnrollmentEventQuery query,
+        CancellationToken ct = default);
+
+    Task<EnrollmentEvent?> GetByIdAsync(
+        string tenantId,
+        string memberId,
+        string eventId,
+        CancellationToken ct = default);
+
+    Task<int> GetNextVersionAsync(string tenantId, string memberId, CancellationToken ct = default);
+}
+
+public readonly record struct EnrollmentEventAppendResult(EnrollmentEvent Event, bool Appended);
+
+public sealed record EnrollmentEventQuery(
+    EnrollmentEventType? EventType = null,
+    DateTime? FromUtc = null,
+    DateTime? ToUtc = null,
+    int Limit = 100,
+    string? ContinuationToken = null);
+
+public sealed record EnrollmentEventPage(
+    IReadOnlyList<EnrollmentEvent> Items,
+    string? ContinuationToken);

--- a/src/services/enrollment-import-service/Repositories/IEnrollmentEventRepository.cs
+++ b/src/services/enrollment-import-service/Repositories/IEnrollmentEventRepository.cs
@@ -19,8 +19,10 @@ public interface IEnrollmentEventRepository
     Task<EnrollmentEventAppendResult> AppendAsync(EnrollmentEvent evt, CancellationToken ct = default);
 
     /// <summary>
-    /// List events for a member, ordered by <see cref="EnrollmentEvent.Version"/> ascending,
-    /// optionally filtered by event type and/or occurredAt window.
+    /// List events for a member, ordered by <see cref="EnrollmentEvent.Version"/>
+    /// <b>descending</b> (newest first) — this is what the controller + portal
+    /// timeline consume. Optionally filtered by event type and/or occurredAt window.
+    /// Callers that need chronological replay should reverse the page.
     /// </summary>
     Task<EnrollmentEventPage> ListByMemberAsync(
         string tenantId,

--- a/src/services/enrollment-import-service/Services/EnrollmentEventClassifier.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentEventClassifier.cs
@@ -1,0 +1,48 @@
+using EnrollmentImportService.Models;
+
+namespace EnrollmentImportService.Services;
+
+/// <summary>
+/// Derives <see cref="EnrollmentEventType"/> from an 834 <see cref="MemberEnrollment"/>
+/// segment. Pulled out of the import service so it can be unit-tested without dragging in
+/// the full repository/publisher graph — and so the call site doesn't collide with the
+/// name-shadowing between the root namespace and the production import-service class.
+/// </summary>
+public static class EnrollmentEventClassifier
+{
+    public static EnrollmentEventType Classify(MemberEnrollment e)
+    {
+        // Order matters: most specific reasons first.
+        if (e.MaintenanceType == "024")
+        {
+            return e.BenefitStatus == "C" || e.MaintenanceReason == "EC"
+                ? EnrollmentEventType.CobraTerminated
+                : EnrollmentEventType.Terminated;
+        }
+
+        if (e.MaintenanceType == "025")
+            return EnrollmentEventType.ReinstatementApproved;
+
+        if (e.BenefitStatus == "C" && e.MaintenanceType == "021")
+            return EnrollmentEventType.CobraElected;
+
+        if (e.MaintenanceReason is "EC" or "37")
+            return EnrollmentEventType.SepTriggered;
+
+        if (e.MaintenanceType == "021")
+            return EnrollmentEventType.Enrolled;
+
+        // 001 = Change. AddressChanged wins when a demographics delta is present; any
+        // other change (plan, dates, group info) is surfaced as PlanChanged. The schema
+        // keeps the enum stable so callers can widen later without breaking stored events.
+        if (HasAddressChange(e)) return EnrollmentEventType.AddressChanged;
+        return EnrollmentEventType.PlanChanged;
+    }
+
+    private static bool HasAddressChange(MemberEnrollment e) =>
+        e.Demographics != null
+        && (!string.IsNullOrWhiteSpace(e.Demographics.Address1)
+            || !string.IsNullOrWhiteSpace(e.Demographics.City)
+            || !string.IsNullOrWhiteSpace(e.Demographics.State)
+            || !string.IsNullOrWhiteSpace(e.Demographics.Zip));
+}

--- a/src/services/enrollment-import-service/Services/EnrollmentEventClassifier.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentEventClassifier.cs
@@ -32,9 +32,10 @@ public static class EnrollmentEventClassifier
         if (e.MaintenanceType == "021")
             return EnrollmentEventType.Enrolled;
 
-        // 001 = Change. AddressChanged wins when a demographics delta is present; any
-        // other change (plan, dates, group info) is surfaced as PlanChanged. The schema
-        // keeps the enum stable so callers can widen later without breaking stored events.
+        // Fallback for all other maintenance types (commonly 001 = Change).
+        // AddressChanged wins when a demographics delta is present; any other change
+        // (plan, dates, group info) is surfaced as PlanChanged. The schema keeps the
+        // enum stable so callers can widen later without breaking stored events.
         if (HasAddressChange(e)) return EnrollmentEventType.AddressChanged;
         return EnrollmentEventType.PlanChanged;
     }

--- a/src/services/enrollment-import-service/Services/EnrollmentEventPublisher.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentEventPublisher.cs
@@ -1,0 +1,137 @@
+using System.Diagnostics.Metrics;
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Repositories;
+
+namespace EnrollmentImportService.Services;
+
+public interface IEnrollmentEventPublisher
+{
+    Task<EnrollmentEvent> PublishAsync(EnrollmentEvent evt, CancellationToken ct = default);
+}
+
+public sealed class EnrollmentConcurrencyException : Exception
+{
+    public EnrollmentConcurrencyException(string tenantId, string memberId, int attempts)
+        : base($"Failed to append enrollment event for {tenantId}:{memberId} after {attempts} version-conflict retries.")
+    {
+        TenantId = tenantId;
+        MemberId = memberId;
+        Attempts = attempts;
+    }
+
+    public string TenantId { get; }
+    public string MemberId { get; }
+    public int Attempts { get; }
+}
+
+/// <summary>
+/// Default <see cref="IEnrollmentEventPublisher"/>. Mirrors
+/// <c>CosmosMemberEventPublisher</c>: idempotent on EventId, retries up to
+/// <see cref="MaxVersionRetries"/> on version conflict with bounded backoff.
+///
+/// Replay observability: every dedup short-circuit (caller re-submitted an EventId we
+/// already stored) increments <c>enrollment_event_replay_total</c> and emits a structured
+/// log line including the original event's <c>OccurredAt</c>. Silent dedup is correct
+/// behavior but invisible operations hide real problems — when this counter spikes,
+/// someone re-played an 834 (intentional reprocessing or pipeline duplicate delivery).
+/// </summary>
+public sealed class EnrollmentEventPublisher : IEnrollmentEventPublisher
+{
+    private const int MaxVersionRetries = 5;
+    private static readonly int[] BackoffMs = { 2, 5, 25, 100, 250 };
+
+    public const string MeterName = "EnrollmentImportService";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    /// <summary>
+    /// Counter incremented every time the publisher dedupes an event because an entry
+    /// with the same EventId already exists. Tagged with <c>tenantId</c>,
+    /// <c>eventType</c>, <c>source</c> (834|manual).
+    /// </summary>
+    public static readonly Counter<long> ReplayCounter =
+        Meter.CreateCounter<long>(
+            "enrollment_event_replay_total",
+            unit: "{events}",
+            description: "Number of enrollment events deduped on replay (existing EventId).");
+
+    private readonly IEnrollmentEventRepository _repository;
+    private readonly ILogger<EnrollmentEventPublisher> _logger;
+
+    public EnrollmentEventPublisher(
+        IEnrollmentEventRepository repository,
+        ILogger<EnrollmentEventPublisher> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<EnrollmentEvent> PublishAsync(EnrollmentEvent evt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EnrollmentEvent.EventId is required (idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
+            throw new ArgumentException("EnrollmentEvent must have TenantId and MemberId");
+
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = EnrollmentEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
+        if (string.IsNullOrEmpty(evt.Id)) evt.Id = evt.EventId;
+        if (evt.SchemaVersion <= 0) evt.SchemaVersion = 1;
+
+        var existing = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+        if (existing != null)
+        {
+            RecordReplay(existing, "preflight");
+            return existing;
+        }
+
+        for (int attempt = 0; attempt < MaxVersionRetries; attempt++)
+        {
+            evt.Version = await _repository.GetNextVersionAsync(evt.TenantId, evt.MemberId, ct);
+            var result = await _repository.AppendAsync(evt, ct);
+            if (result.Appended) return result.Event;
+
+            // Either a same-EventId race (refetch returns it) or a version-slot collision
+            // (refetch returns null; recompute version and retry).
+            var refetch = await _repository.GetByIdAsync(evt.TenantId, evt.MemberId, evt.EventId, ct);
+            if (refetch != null)
+            {
+                RecordReplay(refetch, "race");
+                return refetch;
+            }
+
+            _logger.LogWarning(
+                "EnrollmentEvent version {Version} conflict for {Tenant}:{Member}; retry {Attempt}/{Max}",
+                evt.Version, Sanitize(evt.TenantId), Sanitize(evt.MemberId), attempt + 1, MaxVersionRetries);
+
+            if (attempt + 1 < MaxVersionRetries)
+                await Task.Delay(BackoffMs[attempt], ct);
+        }
+
+        throw new EnrollmentConcurrencyException(evt.TenantId, evt.MemberId, MaxVersionRetries);
+    }
+
+    private void RecordReplay(EnrollmentEvent existing, string detection)
+    {
+        ReplayCounter.Add(1,
+            new KeyValuePair<string, object?>("tenantId", Sanitize(existing.TenantId)),
+            new KeyValuePair<string, object?>("eventType", existing.EventType.ToString()),
+            new KeyValuePair<string, object?>("source", existing.Source ?? "unknown"));
+
+        // Debug-level so it doesn't flood production logs but is grep-able when triaging.
+        _logger.LogDebug(
+            "EnrollmentEvent replay deduped: eventId={EventId} tenant={Tenant} member={Member} type={Type} originallyOccurredAt={OccurredAt:o} detection={Detection}",
+            Sanitize(existing.EventId),
+            Sanitize(existing.TenantId),
+            Sanitize(existing.MemberId),
+            existing.EventType,
+            existing.OccurredAt,
+            detection);
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -117,7 +117,7 @@ public class EnrollmentImportService : IEnrollmentImportService
         var memberId = memberEnrollment.SubscriberId ?? string.Empty;
         if (string.IsNullOrEmpty(memberId)) return;
 
-        var eventType = ClassifyEvent(memberEnrollment);
+        var eventType = EnrollmentEventClassifier.Classify(memberEnrollment);
         var eventDate = ParseDate(
             memberEnrollment.MaintenanceType == "024"
                 ? memberEnrollment.TerminationDate
@@ -189,44 +189,6 @@ public class EnrollmentImportService : IEnrollmentImportService
                 SanitizeForLog(tenantId), SanitizeForLog(memberId), SanitizeForLog(batchId));
         }
     }
-
-    internal static EnrollmentEventType ClassifyEvent(MemberEnrollment e)
-    {
-        // Order matters: most specific reasons first.
-        if (e.MaintenanceType == "024")
-        {
-            return e.BenefitStatus == "C" || e.MaintenanceReason == "EC"
-                ? EnrollmentEventType.CobraTerminated
-                : EnrollmentEventType.Terminated;
-        }
-
-        if (e.MaintenanceType == "025")
-            return EnrollmentEventType.ReinstatementApproved;
-
-        if (e.BenefitStatus == "C" && e.MaintenanceType == "021")
-            return EnrollmentEventType.CobraElected;
-
-        if (e.MaintenanceReason is "EC" or "37")
-            return EnrollmentEventType.SepTriggered;
-
-        if (e.MaintenanceType == "021")
-            return EnrollmentEventType.Enrolled;
-
-        // 001 = Change. AddressChanged wins when a demographics delta is present; any
-        // other change (plan, dates, group info) is surfaced as PlanChanged. We don't
-        // have a stronger signal from the 834 payload to split this further, and the
-        // schema keeps the enum stable so callers can widen later without breaking
-        // stored events.
-        if (HasAddressChange(e)) return EnrollmentEventType.AddressChanged;
-        return EnrollmentEventType.PlanChanged;
-    }
-
-    private static bool HasAddressChange(MemberEnrollment e) =>
-        e.Demographics != null
-        && (!string.IsNullOrWhiteSpace(e.Demographics.Address1)
-            || !string.IsNullOrWhiteSpace(e.Demographics.City)
-            || !string.IsNullOrWhiteSpace(e.Demographics.State)
-            || !string.IsNullOrWhiteSpace(e.Demographics.Zip));
 
     private static bool IsRetro(MemberEnrollment e, DateTime? eventDate) =>
         eventDate.HasValue && eventDate.Value.Date < DateTime.UtcNow.Date.AddDays(-30);

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -52,8 +52,9 @@ public class EnrollmentImportService : IEnrollmentImportService
             ? enrollment.BatchId
             : $"BATCH-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
 
-        foreach (var memberEnrollment in enrollment.Enrollments)
+        for (int i = 0; i < enrollment.Enrollments.Count; i++)
         {
+            var memberEnrollment = enrollment.Enrollments[i];
             var txnStatus = "Accepted";
             var validation = _validator.Validate(memberEnrollment);
             if (!validation.IsValid)
@@ -72,10 +73,13 @@ public class EnrollmentImportService : IEnrollmentImportService
             }
 
             // Deterministic transaction id keyed on batch + position + subscriber so that
-            // replays of an identical batch produce identical EventIds.
+            // (a) replays of an identical batch produce identical EventIds, and
+            // (b) multiple enrollments for the same subscriber within one batch (e.g.
+            //     two separate life events on the same day) do NOT collapse to the
+            //     same id. The position is 0-based and stable within a batch.
             var transactionId = !string.IsNullOrEmpty(memberEnrollment.TransactionId)
                 ? memberEnrollment.TransactionId
-                : $"{batchId}-{memberEnrollment.SubscriberId ?? "ANON"}";
+                : $"{batchId}-{i:D4}-{memberEnrollment.SubscriberId ?? "ANON"}";
 
             try
             {
@@ -208,9 +212,12 @@ public class EnrollmentImportService : IEnrollmentImportService
         if (e.MaintenanceType == "021")
             return EnrollmentEventType.Enrolled;
 
-        // 001 = Change. Distinguish by the most material change first.
+        // 001 = Change. AddressChanged wins when a demographics delta is present; any
+        // other change (plan, dates, group info) is surfaced as PlanChanged. We don't
+        // have a stronger signal from the 834 payload to split this further, and the
+        // schema keeps the enum stable so callers can widen later without breaking
+        // stored events.
         if (HasAddressChange(e)) return EnrollmentEventType.AddressChanged;
-        if (HasPlanChange(e)) return EnrollmentEventType.PlanChanged;
         return EnrollmentEventType.PlanChanged;
     }
 
@@ -220,9 +227,6 @@ public class EnrollmentImportService : IEnrollmentImportService
             || !string.IsNullOrWhiteSpace(e.Demographics.City)
             || !string.IsNullOrWhiteSpace(e.Demographics.State)
             || !string.IsNullOrWhiteSpace(e.Demographics.Zip));
-
-    private static bool HasPlanChange(MemberEnrollment e) =>
-        e.Coverage != null && e.Coverage.Count > 0;
 
     private static bool IsRetro(MemberEnrollment e, DateTime? eventDate) =>
         eventDate.HasValue && eventDate.Value.Date < DateTime.UtcNow.Date.AddDays(-30);

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using EnrollmentImportService.Models;
+using EnrollmentImportService.Repositories;
 
 namespace EnrollmentImportService.Services;
 
@@ -9,17 +12,29 @@ public interface IEnrollmentImportService
 
 public class EnrollmentImportService : IEnrollmentImportService
 {
+    private static readonly JsonSerializerOptions RawSegmentJsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
     private readonly IEnrollmentRepository _repository;
     private readonly IEnrollmentTransactionRepository _transactions;
+    private readonly IEnrollmentEventPublisher _eventPublisher;
+    private readonly IEnrollmentValidator _validator;
     private readonly ILogger<EnrollmentImportService> _logger;
 
     public EnrollmentImportService(
         IEnrollmentRepository repository,
         IEnrollmentTransactionRepository transactions,
+        IEnrollmentEventPublisher eventPublisher,
+        IEnrollmentValidator validator,
         ILogger<EnrollmentImportService> logger)
     {
         _repository = repository;
         _transactions = transactions;
+        _eventPublisher = eventPublisher;
+        _validator = validator;
         _logger = logger;
     }
 
@@ -31,14 +46,41 @@ public class EnrollmentImportService : IEnrollmentImportService
             StartedAt = DateTime.UtcNow
         };
 
-        var batchId = $"BATCH-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
+        // Stable batch id when a caller pre-supplies it (manual enrollment, replay tests),
+        // otherwise generate. A stable batchId keeps replay event-ids deterministic.
+        var batchId = !string.IsNullOrEmpty(enrollment.BatchId)
+            ? enrollment.BatchId
+            : $"BATCH-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid():N}".Substring(0, 40);
 
         foreach (var memberEnrollment in enrollment.Enrollments)
         {
             var txnStatus = "Accepted";
+            var validation = _validator.Validate(memberEnrollment);
+            if (!validation.IsValid)
+            {
+                var flat = string.Join("; ", validation.ToFlatStrings());
+                _logger.LogWarning(
+                    "Validation failed for subscriber {SubscriberId}: {Errors}",
+                    SanitizeForLog(memberEnrollment.SubscriberId), flat);
+                result.Errors.AddRange(
+                    validation.Errors.Select(e =>
+                        $"Subscriber {memberEnrollment.SubscriberId}: [{e.Code}] {e.Field} — {e.Message}"));
+                result.FailedCount++;
+                txnStatus = "Rejected";
+                await RecordTransactionAsync(tenantId, batchId, enrollment, memberEnrollment, txnStatus);
+                continue;
+            }
+
+            // Deterministic transaction id keyed on batch + position + subscriber so that
+            // replays of an identical batch produce identical EventIds.
+            var transactionId = !string.IsNullOrEmpty(memberEnrollment.TransactionId)
+                ? memberEnrollment.TransactionId
+                : $"{batchId}-{memberEnrollment.SubscriberId ?? "ANON"}";
+
             try
             {
                 await ProcessMemberEnrollmentAsync(memberEnrollment, tenantId, result);
+                await PublishEnrollmentEventAsync(tenantId, batchId, transactionId, enrollment, memberEnrollment);
             }
             catch (Exception ex)
             {
@@ -53,11 +95,154 @@ public class EnrollmentImportService : IEnrollmentImportService
         }
 
         result.CompletedAt = DateTime.UtcNow;
+        result.BatchId = batchId;
         _logger.LogInformation(
             "Import completed: {SuccessCount} success, {FailedCount} failed, {SkippedCount} skipped",
             result.SuccessCount, result.FailedCount, result.SkippedCount);
 
         return result;
+    }
+
+    private async Task PublishEnrollmentEventAsync(
+        string tenantId,
+        string batchId,
+        string transactionId,
+        Enrollment834 batch,
+        MemberEnrollment memberEnrollment)
+    {
+        var memberId = memberEnrollment.SubscriberId ?? string.Empty;
+        if (string.IsNullOrEmpty(memberId)) return;
+
+        var eventType = ClassifyEvent(memberEnrollment);
+        var eventDate = ParseDate(
+            memberEnrollment.MaintenanceType == "024"
+                ? memberEnrollment.TerminationDate
+                : memberEnrollment.EnrollmentDate);
+
+        var retroEffectiveDate = IsRetro(memberEnrollment, eventDate)
+            ? eventDate
+            : (DateTime?)null;
+
+        var payload = new JsonObject
+        {
+            ["benefitStatus"] = memberEnrollment.BenefitStatus,
+            ["relationship"] = memberEnrollment.Relationship,
+            ["groupNumber"] = memberEnrollment.GroupNumber,
+            ["enrollmentDate"] = memberEnrollment.EnrollmentDate,
+            ["terminationDate"] = memberEnrollment.TerminationDate,
+            ["coverageCount"] = memberEnrollment.Coverage?.Count ?? 0,
+            ["dependentCount"] = memberEnrollment.Dependents?.Count ?? 0
+        };
+
+        var rawSegment = SerializeRawSegment(memberEnrollment);
+
+        // EventId construction differs by source so 834 replays are deterministic
+        // (idempotent dedup) while back-to-back manual POSTs from the same batch wrapper
+        // never accidentally collide. Manual callers either supply their own EventId for
+        // retry safety or get a fresh GUID per POST.
+        string eventId;
+        if (batch.ManualSource)
+        {
+            var requestEventId = string.IsNullOrWhiteSpace(memberEnrollment.EventId)
+                ? Guid.NewGuid().ToString("N")
+                : memberEnrollment.EventId;
+            eventId = EnrollmentEvent.BuildManualEventId(requestEventId, memberId);
+        }
+        else
+        {
+            eventId = EnrollmentEvent.BuildIngestEventId(batchId, transactionId, memberId);
+        }
+
+        var evt = new EnrollmentEvent
+        {
+            TenantId = tenantId,
+            MemberId = memberId,
+            EventId = eventId,
+            EventType = eventType,
+            OccurredAt = DateTime.UtcNow,
+            EventDate = eventDate,
+            RetroEffectiveDate = retroEffectiveDate,
+            SourceBatchId = batchId,
+            TransactionId = transactionId,
+            MaintenanceType = memberEnrollment.MaintenanceType,
+            MaintenanceReason = memberEnrollment.MaintenanceReason,
+            Source = batch.ManualSource ? "manual" : "edi834",
+            CorrelationId = batch.FileName,
+            Payload = payload,
+            RawSegment = rawSegment
+        };
+
+        try
+        {
+            await _eventPublisher.PublishAsync(evt);
+        }
+        catch (Exception ex)
+        {
+            // Event publication is not allowed to break the import — the transaction log
+            // still records the txn. Surface as a warning so it shows up in dashboards.
+            _logger.LogWarning(ex,
+                "Failed to publish EnrollmentEvent for {Tenant}:{Member} batch {BatchId}",
+                SanitizeForLog(tenantId), SanitizeForLog(memberId), SanitizeForLog(batchId));
+        }
+    }
+
+    internal static EnrollmentEventType ClassifyEvent(MemberEnrollment e)
+    {
+        // Order matters: most specific reasons first.
+        if (e.MaintenanceType == "024")
+        {
+            return e.BenefitStatus == "C" || e.MaintenanceReason == "EC"
+                ? EnrollmentEventType.CobraTerminated
+                : EnrollmentEventType.Terminated;
+        }
+
+        if (e.MaintenanceType == "025")
+            return EnrollmentEventType.ReinstatementApproved;
+
+        if (e.BenefitStatus == "C" && e.MaintenanceType == "021")
+            return EnrollmentEventType.CobraElected;
+
+        if (e.MaintenanceReason is "EC" or "37")
+            return EnrollmentEventType.SepTriggered;
+
+        if (e.MaintenanceType == "021")
+            return EnrollmentEventType.Enrolled;
+
+        // 001 = Change. Distinguish by the most material change first.
+        if (HasAddressChange(e)) return EnrollmentEventType.AddressChanged;
+        if (HasPlanChange(e)) return EnrollmentEventType.PlanChanged;
+        return EnrollmentEventType.PlanChanged;
+    }
+
+    private static bool HasAddressChange(MemberEnrollment e) =>
+        e.Demographics != null
+        && (!string.IsNullOrWhiteSpace(e.Demographics.Address1)
+            || !string.IsNullOrWhiteSpace(e.Demographics.City)
+            || !string.IsNullOrWhiteSpace(e.Demographics.State)
+            || !string.IsNullOrWhiteSpace(e.Demographics.Zip));
+
+    private static bool HasPlanChange(MemberEnrollment e) =>
+        e.Coverage != null && e.Coverage.Count > 0;
+
+    private static bool IsRetro(MemberEnrollment e, DateTime? eventDate) =>
+        eventDate.HasValue && eventDate.Value.Date < DateTime.UtcNow.Date.AddDays(-30);
+
+    private static string SerializeRawSegment(MemberEnrollment e)
+    {
+        // PHI lives in here (names, addresses, optionally SSN). Persistence relies on
+        // container-level encryption-at-rest — do NOT also re-encrypt at the field level.
+        // Telemetry exporters that read this field MUST scrub it the same way they scrub
+        // span attributes.
+        try
+        {
+            var raw = JsonSerializer.Serialize(e, RawSegmentJsonOptions);
+            // Cap raw snippet so we don't blow Cosmos's 2MB doc limit on huge dependents.
+            return raw.Length > 8000 ? raw.Substring(0, 8000) : raw;
+        }
+        catch
+        {
+            return string.Empty;
+        }
     }
 
     private async Task RecordTransactionAsync(
@@ -396,6 +581,7 @@ public class EnrollmentImportService : IEnrollmentImportService
 public class ImportResult
 {
     public string FileName { get; set; } = string.Empty;
+    public string BatchId { get; set; } = string.Empty;
     public DateTime StartedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
     public int SuccessCount { get; set; }

--- a/src/services/enrollment-import-service/Services/EnrollmentValidator.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentValidator.cs
@@ -4,7 +4,7 @@ namespace EnrollmentImportService.Services;
 
 public interface IEnrollmentValidator
 {
-    EnrollmentValidationResult Validate(MemberEnrollment enrollment);
+    EnrollmentValidationResult Validate(MemberEnrollment? enrollment);
 }
 
 /// <summary>
@@ -57,7 +57,7 @@ public sealed class EnrollmentValidator : IEnrollmentValidator
         "A", "C", "T"
     };
 
-    public EnrollmentValidationResult Validate(MemberEnrollment enrollment)
+    public EnrollmentValidationResult Validate(MemberEnrollment? enrollment)
     {
         if (enrollment is null)
         {

--- a/src/services/enrollment-import-service/Services/EnrollmentValidator.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentValidator.cs
@@ -1,0 +1,126 @@
+using EnrollmentImportService.Models;
+
+namespace EnrollmentImportService.Services;
+
+public interface IEnrollmentValidator
+{
+    EnrollmentValidationResult Validate(MemberEnrollment enrollment);
+}
+
+/// <summary>
+/// Structured validation error. <see cref="Field"/> uses dot-notation paths so callers
+/// can map errors to field-keyed envelopes (e.g. <c>ValidationProblemDetails</c>).
+/// <see cref="Code"/> is a stable machine-readable identifier; <see cref="Message"/>
+/// is human-facing.
+/// </summary>
+public sealed record EnrollmentValidationError(string Field, string Code, string Message);
+
+public sealed record EnrollmentValidationResult(bool IsValid, IReadOnlyList<EnrollmentValidationError> Errors)
+{
+    public static EnrollmentValidationResult Ok() =>
+        new(true, Array.Empty<EnrollmentValidationError>());
+
+    public static EnrollmentValidationResult Fail(IEnumerable<EnrollmentValidationError> errors) =>
+        new(false, errors.ToList());
+
+    /// <summary>Convenience for log lines and free-text envelopes.</summary>
+    public IEnumerable<string> ToFlatStrings() =>
+        Errors.Select(e => $"{e.Field}: {e.Message}");
+}
+
+/// <summary>
+/// Shared validation for both 834-ingested and manually-entered enrollments. Keeping this
+/// in one place ensures the manual API rejects exactly what the 834 pipeline would reject.
+///
+/// Errors are returned as structured <see cref="EnrollmentValidationError"/>s with field
+/// paths and stable codes so callers can build their own error envelopes
+/// (ValidationProblemDetails, audit log, RFC7807, etc.) without parsing free text.
+/// </summary>
+public sealed class EnrollmentValidator : IEnrollmentValidator
+{
+    private static readonly HashSet<string> AllowedMaintenance = new(StringComparer.Ordinal)
+    {
+        "001", // Change
+        "021", // Addition
+        "024", // Termination
+        "025", // Reinstatement
+        "030"  // Audit/Compare
+    };
+
+    private static readonly HashSet<string> AllowedRelationship = new(StringComparer.Ordinal)
+    {
+        "18", "01", "19", "G8", "17", "10"
+    };
+
+    private static readonly HashSet<string> AllowedBenefitStatus = new(StringComparer.Ordinal)
+    {
+        "A", "C", "T"
+    };
+
+    public EnrollmentValidationResult Validate(MemberEnrollment enrollment)
+    {
+        if (enrollment is null)
+        {
+            return EnrollmentValidationResult.Fail(new[]
+            {
+                new EnrollmentValidationError("$", "enrollment.required", "enrollment payload is required")
+            });
+        }
+
+        var errors = new List<EnrollmentValidationError>();
+
+        if (string.IsNullOrWhiteSpace(enrollment.MaintenanceType))
+            errors.Add(new("maintenanceType", "maintenanceType.required",
+                "maintenanceType is required (021/001/024/025/030)"));
+        else if (!AllowedMaintenance.Contains(enrollment.MaintenanceType))
+            errors.Add(new("maintenanceType", "maintenanceType.unsupported",
+                $"maintenanceType '{enrollment.MaintenanceType}' is not supported"));
+
+        if (string.IsNullOrWhiteSpace(enrollment.BenefitStatus))
+            errors.Add(new("benefitStatus", "benefitStatus.required",
+                "benefitStatus is required (A/C/T)"));
+        else if (!AllowedBenefitStatus.Contains(enrollment.BenefitStatus))
+            errors.Add(new("benefitStatus", "benefitStatus.unsupported",
+                $"benefitStatus '{enrollment.BenefitStatus}' is not supported"));
+
+        if (string.IsNullOrWhiteSpace(enrollment.Relationship))
+            errors.Add(new("relationship", "relationship.required",
+                "relationship is required (18/01/19/...)"));
+        else if (!AllowedRelationship.Contains(enrollment.Relationship))
+            errors.Add(new("relationship", "relationship.unsupported",
+                $"relationship '{enrollment.Relationship}' is not supported"));
+
+        if (string.IsNullOrWhiteSpace(enrollment.SubscriberId))
+            errors.Add(new("subscriberId", "subscriberId.required", "subscriberId is required"));
+
+        if (enrollment.Demographics == null)
+        {
+            errors.Add(new("demographics", "demographics.required", "demographics is required"));
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(enrollment.Demographics.FirstName))
+                errors.Add(new("demographics.firstName", "demographics.firstName.required",
+                    "demographics.firstName is required"));
+            if (string.IsNullOrWhiteSpace(enrollment.Demographics.LastName))
+                errors.Add(new("demographics.lastName", "demographics.lastName.required",
+                    "demographics.lastName is required"));
+        }
+
+        if (enrollment.MaintenanceType == "024" && string.IsNullOrWhiteSpace(enrollment.TerminationDate))
+            errors.Add(new("terminationDate", "terminationDate.requiredForTermination",
+                "terminationDate is required for maintenanceType=024"));
+
+        if (enrollment.MaintenanceType == "021"
+            && string.IsNullOrWhiteSpace(enrollment.EnrollmentDate)
+            && (enrollment.Coverage == null || enrollment.Coverage.Count == 0))
+        {
+            errors.Add(new("enrollmentDate", "enrollmentDate.requiredForAddition",
+                "enrollmentDate or coverage[] is required for maintenanceType=021"));
+        }
+
+        return errors.Count == 0
+            ? EnrollmentValidationResult.Ok()
+            : EnrollmentValidationResult.Fail(errors);
+    }
+}

--- a/src/services/enrollment-import-service/appsettings.json
+++ b/src/services/enrollment-import-service/appsettings.json
@@ -11,7 +11,9 @@
     "DatabaseName": "CloudHealthOffice",
     "MembersContainerName": "Members",
     "CoverageContainerName": "Coverage",
-    "SponsorsContainerName": "Sponsors"
+    "SponsorsContainerName": "Sponsors",
+    "TransactionsContainerName": "enrollment-transactions",
+    "EnrollmentEventsContainerName": "enrollment-events"
   },
   "AllowedHosts": "*"
 }

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -604,6 +604,39 @@ public class MembersController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// List per-member enrollment events. Proxies through to enrollment-import-service so
+    /// consent scope, audit logging, tenant context, and rate limiting all live on this
+    /// member-service boundary instead of being duplicated at every portal client.
+    /// </summary>
+    [HttpGet("{memberId}/enrollment-events")]
+    [ProducesResponseType(typeof(EnrollmentEventListResponse), 200)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetEnrollmentEvents(
+        [FromRoute] string memberId,
+        [FromQuery] string? type = null,
+        [FromQuery] DateTime? from = null,
+        [FromQuery] DateTime? to = null,
+        [FromQuery] int limit = 50,
+        [FromQuery] string? continuationToken = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(memberId))
+            return BadRequest(new { error = "memberId is required" });
+
+        try
+        {
+            var page = await _enrollment.GetEnrollmentEventsAsync(
+                TenantId, memberId, type, from, to, Math.Clamp(limit, 1, 200), continuationToken, ct);
+            return Ok(page);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
+    }
+
     [HttpGet("{memberId}/accumulators")]
     [ProducesResponseType(typeof(MemberAccumulatorsResponse), 200)]
     [ProducesResponseType(503)]
@@ -782,6 +815,34 @@ public class Enrollment834Record
     public string MaintenanceTypeCode { get; set; } = string.Empty;
     public DateTime TransactionDate { get; set; }
     public string Status { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Member-service projection of an enrollment-import-service event. Mirrors the
+/// downstream document shape so the portal does not need to know about the underlying
+/// service. Consent / audit / tenant filtering happen on this boundary.
+/// </summary>
+public class EnrollmentEventRecord
+{
+    public string EventId { get; set; } = string.Empty;
+    public string EventType { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public DateTime OccurredAt { get; set; }
+    public DateTime? EventDate { get; set; }
+    public DateTime? RetroEffectiveDate { get; set; }
+    public string? SourceBatchId { get; set; }
+    public string? TransactionId { get; set; }
+    public string? MaintenanceType { get; set; }
+    public string? MaintenanceReason { get; set; }
+    public string? Source { get; set; }
+    public System.Text.Json.Nodes.JsonObject? Payload { get; set; }
+    public string? RawSegment { get; set; }
+}
+
+public class EnrollmentEventListResponse
+{
+    public List<EnrollmentEventRecord> Items { get; set; } = new();
+    public string? ContinuationToken { get; set; }
 }
 
 public class MemberAccumulatorsResponse

--- a/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
@@ -268,6 +268,38 @@ public class MembersControllerTests
     }
 
     [Fact]
+    public async Task GetEnrollmentEvents_ProxiesToDownstream()
+    {
+        var (ctl, _, _, _, enrollment, _) = Build();
+        enrollment.Setup(e => e.GetEnrollmentEventsAsync(
+                Tenant, "M-001", null, null, null, 50, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EnrollmentEventListResponse
+            {
+                Items = new()
+                {
+                    new EnrollmentEventRecord { EventId = "e1", EventType = "Enrolled", Version = 1 }
+                }
+            });
+
+        var resp = await ctl.GetEnrollmentEvents("M-001", null, null, null, 50, null, CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var page = ok.Value.Should().BeOfType<EnrollmentEventListResponse>().Subject;
+        page.Items.Should().ContainSingle().Which.EventId.Should().Be("e1");
+    }
+
+    [Fact]
+    public async Task GetEnrollmentEvents_WhenDownstreamDown_Returns503()
+    {
+        var (ctl, _, _, _, enrollment, _) = Build();
+        enrollment.Setup(e => e.GetEnrollmentEventsAsync(
+                Tenant, "M-001", null, null, null, 50, null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DownstreamUnavailableException("enrollment-import-service"));
+
+        var resp = await ctl.GetEnrollmentEvents("M-001", null, null, null, 50, null, CancellationToken.None);
+        ((ObjectResult)resp).StatusCode.Should().Be(503);
+    }
+
+    [Fact]
     public async Task GetAccumulators_WhenUnavailable_Returns503()
     {
         var (ctl, _, _, _, _, accu) = Build();

--- a/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
@@ -64,10 +64,13 @@ public class DownstreamRouteContractTests
             {
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(services);
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
+                RemoveAll<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(services);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(
                     new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>().Object);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
                     new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
+                services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(
+                    new Mock<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>().Object);
             });
         }
 
@@ -110,7 +113,16 @@ public class DownstreamRouteContractTests
         using var factory = new EnrollmentFactory();
         var endpoints = GetRegisteredPatterns(factory.Services);
 
-        AssertRouteRegistered(endpoints, "GET", "api/v1/enrollment/transactions");
+        var expected = new (string Verb, string PathTemplate)[]
+        {
+            ("GET", "api/v1/enrollment/transactions"),
+            ("GET", "api/v1/members/{memberId}/enrollment-events"),
+        };
+
+        foreach (var (verb, template) in expected)
+        {
+            AssertRouteRegistered(endpoints, verb, template);
+        }
     }
 
     private static List<(string Verb, string Pattern)> GetRegisteredPatterns(IServiceProvider sp)

--- a/src/services/member-service/Services/FakeDownstreamClients.cs
+++ b/src/services/member-service/Services/FakeDownstreamClients.cs
@@ -70,6 +70,35 @@ public sealed class FakeEnrollmentImportServiceClient : IEnrollmentImportService
                 Status = "Accepted"
             }
         });
+
+    public Task<EnrollmentEventListResponse> GetEnrollmentEventsAsync(
+        string tenantId,
+        string memberId,
+        string? type = null,
+        DateTime? from = null,
+        DateTime? to = null,
+        int limit = 50,
+        string? continuationToken = null,
+        CancellationToken ct = default)
+        => Task.FromResult(new EnrollmentEventListResponse
+        {
+            Items = new List<EnrollmentEventRecord>
+            {
+                new()
+                {
+                    EventId = "834-DEV-BATCH-001:DEV-TXN-001:" + memberId,
+                    EventType = "Enrolled",
+                    Version = 1,
+                    OccurredAt = DateTime.UtcNow.AddMonths(-6),
+                    EventDate = DateTime.UtcNow.AddMonths(-6),
+                    SourceBatchId = "DEV-BATCH-001",
+                    TransactionId = "DEV-TXN-001",
+                    MaintenanceType = "021",
+                    Source = "edi834"
+                }
+            },
+            ContinuationToken = null
+        });
 }
 
 public sealed class FakeAccumulatorServiceClient : IAccumulatorServiceClient

--- a/src/services/member-service/Services/HttpEnrollmentImportServiceClient.cs
+++ b/src/services/member-service/Services/HttpEnrollmentImportServiceClient.cs
@@ -39,4 +39,43 @@ public sealed class HttpEnrollmentImportServiceClient : IEnrollmentImportService
             throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
         }
     }
+
+    public async Task<EnrollmentEventListResponse> GetEnrollmentEventsAsync(
+        string tenantId,
+        string memberId,
+        string? type = null,
+        DateTime? from = null,
+        DateTime? to = null,
+        int limit = 50,
+        string? continuationToken = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options?.BaseUrl))
+            throw new DownstreamUnavailableException(
+                ServiceName,
+                "Configure Downstream:EnrollmentImportService:BaseUrl to enable enrollment events.");
+
+        var qs = new List<string> { $"limit={Math.Clamp(limit, 1, 200)}" };
+        if (!string.IsNullOrWhiteSpace(type)) qs.Add($"type={Uri.EscapeDataString(type)}");
+        if (from.HasValue) qs.Add($"from={Uri.EscapeDataString(from.Value.ToString("o"))}");
+        if (to.HasValue) qs.Add($"to={Uri.EscapeDataString(to.Value.ToString("o"))}");
+        if (!string.IsNullOrWhiteSpace(continuationToken))
+            qs.Add($"continuationToken={Uri.EscapeDataString(continuationToken)}");
+
+        var req = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/v1/members/{Uri.EscapeDataString(memberId)}/enrollment-events?{string.Join("&", qs)}");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<EnrollmentEventListResponse>(cancellationToken: ct)
+                ?? new EnrollmentEventListResponse();
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
 }

--- a/src/services/member-service/Services/ICoverageServiceClient.cs
+++ b/src/services/member-service/Services/ICoverageServiceClient.cs
@@ -28,12 +28,26 @@ public interface ICoverageServiceClient
         CancellationToken ct = default);
 }
 
-/// <summary>Typed client for the enrollment-import-service (834 transaction history).</summary>
+/// <summary>Typed client for the enrollment-import-service (834 transaction history + event stream).</summary>
 public interface IEnrollmentImportServiceClient
 {
     Task<IReadOnlyList<Enrollment834Record>> Get834TransactionsAsync(
         string tenantId,
         string memberId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// List enrollment events for a member, newest first. Optional filters apply at the
+    /// downstream service. Continuation token is opaque and round-trips to the caller.
+    /// </summary>
+    Task<EnrollmentEventListResponse> GetEnrollmentEventsAsync(
+        string tenantId,
+        string memberId,
+        string? type = null,
+        DateTime? from = null,
+        DateTime? to = null,
+        int limit = 50,
+        string? continuationToken = null,
         CancellationToken ct = default);
 }
 


### PR DESCRIPTION
Adds a per-member append-only event stream backing 834 ingestion and a new manual
enrollment API. Mirrors the member-events publisher pattern from PR #650.

- EnrollmentEvent model + Cosmos repository (partition key tenantId:memberId,
  unique-key on /version) with a provisioning script.
- EnrollmentEventPublisher: idempotent on EventId, retries on version conflict,
  emits enrollment_event_replay_total metric + structured debug log on every
  short-circuit so silent dedup is observable in telemetry.
- EnrollmentValidator extracted as a shared layer; returns structured errors
  with field paths + stable codes so 834 and manual paths share the same rules.
- EnrollmentImportService emits one event per accepted transaction. Deterministic
  EventIds make 834 replay idempotent: "834-{batchId}:{transactionId}:{memberId}".
- Manual events use a distinct prefix "manual-{requestEventId}:{memberId}" so
  back-to-back POSTs never accidentally dedupe; callers may supply EventId in
  the body for retry-safety, otherwise a fresh GUID is generated per POST.
- New controllers: POST /api/v1/enrollments/manual (validation identical to
  834) and GET /api/v1/members/{memberId}/enrollment-events (paginated,
  filterable by type and date window).
- Member-service exposes GET /api/v1/members/{memberId}/enrollment-events as a
  proxy to enrollment-import-service so portal traffic flows through the same
  consent / audit / tenant boundary as every other member-scoped read.
- Portal Enrollment History tab now consumes the stream via member-service:
  expandable rows surface maintenance codes, batch/transaction ids, retro
  effective date, and the raw 834 (or manual JSON) snippet captured at write.
- Tests cover validator field paths, publisher idempotency + retry, import
  emit-one-per-txn, replay-no-dupes, manual prefix isolation, member-service
  proxy happy path + 503.