### PR TITLE
feat(coverage-service): PCP assignment validation + history + CareTeam (5.7)

### DIFF
--- a/docs/architecture/pcp-assignment.md
+++ b/docs/architecture/pcp-assignment.md
@@ -1,0 +1,220 @@
+# PCP Assignment
+
+Roadmap reference: 5.7 Phase 1.
+
+## Service choice
+
+PCP assignment lives in **coverage-service**, with member-service acting as a
+thin proxy to keep portal calls on a single boundary.
+
+Why coverage-service:
+
+- Coverage already owns the `PcpNpi`, `PcpName`, `PcpAssignmentDate`,
+  `PcpAssignmentMethod`, and `PreviousPcpNpi` fields used by eligibility,
+  capitation, and downstream claims.
+- Coverage has the `(Member -> Sponsor -> Plan -> LineOfBusiness)` linkage
+  that PCP validation needs (network match by plan + LOB).
+- The capitation panel-roster endpoint (`GET /by-pcp/{npi}`) already lives
+  here; reusing it as the panel-count source avoids a second authoritative
+  store.
+- Multi-tenant partitioning keys are the same shape as the existing
+  Coverage container (`tenantId` partition key).
+
+Why not member-service:
+
+- member-service is a Patient projector and identity store, not a benefits
+  store. Putting plan/LOB-aware validation there would duplicate state.
+- Network/panel checks need to call provider-service either way; the round
+  trip is the same from either service.
+
+## Data model
+
+### `PcpAssignment` (new collection)
+
+Effective-dated history. One row per assignment change. The current
+assignment for a member is the row with `EndDate == null`.
+
+| field                       | notes                                                   |
+| --------------------------- | ------------------------------------------------------- |
+| `tenantId`                  | partition key                                           |
+| `id`                        | document id                                             |
+| `memberId`                  |                                                         |
+| `coverageId`                | which Coverage this assignment was attached to          |
+| `providerId`                | provider-service opaque id (best-effort)                |
+| `providerNpi`               | 10-digit NPI; the stable external id                    |
+| `providerName`              | denormalized for display / FHIR                         |
+| `effectiveDate`             |                                                         |
+| `endDate`                   | null = current; stamped when superseded                 |
+| `assignmentReason`          | free-text                                               |
+| `assignmentSource`          | `MemberChoice \| AutoAssigned \| AdminAssigned`         |
+| `networkStatusAtAssignment` | snapshot — see "Snapshot semantics" below               |
+| `assignedBy`                | actor (user / system principal)                         |
+| `createdDate`               |                                                         |
+
+The denormalized `Coverage.Pcp*` fields stay — they are the read-path for
+eligibility (270/271) and capitation roster joins. `PcpAssignment` is the
+write log + audit log. Both update inside the same `AssignAsync` call.
+
+### Snapshot semantics: `NetworkStatusAtAssignment`
+
+This is the network status that was true **at the moment the assignment was
+written**. It is never updated. If a provider later terminates their
+network participation, the historical row still reads `InNetwork`, because
+that is what was true the day the assignment was made. The audit trail
+needs that property to be useful.
+
+For live UI status, always re-fetch via provider-service. Do not surface
+`networkStatusAtAssignment` as the live network indicator anywhere. The
+field name is verbose on purpose; do not abbreviate it to `NetworkStatus`
+in any DTO that escapes the history shape.
+
+## Validation ladder
+
+`PcpAssignmentService.AssignAsync` runs a deterministic, fail-fast
+validation ladder. The first failure is what gets returned, logged, and
+metric'd. The order of these checks is **API contract** — portal switches
+on `code` and picks remediation flows. Reordering or renaming requires a
+coordinated portal release.
+
+| order | code                       | trigger                                                     |
+| ----: | -------------------------- | ----------------------------------------------------------- |
+|     0 | `NO_ACTIVE_COVERAGE`       | preflight; member has no active coverage on the date        |
+|     0 | `INVALID_NPI`              | preflight; npi not 10 digits                                |
+|     1 | `PROVIDER_NOT_FOUND`       | provider-service lookup returns null                        |
+|     2 | `PROVIDER_INACTIVE`        | `Provider.Status != Active`                                 |
+|     3 | `PROVIDER_NOT_CREDENTIALED`| `CredentialingStatus != Approved`                           |
+|     4 | `NO_NETWORK_PARTICIPATION` | no active participation matching coverage's plan+LOB        |
+|     5 | `NOT_ACCEPTING_PATIENTS`   | `PanelAccepted == false` (override) or `AcceptingNewPatients == false` |
+|     6 | `LOB_NOT_ACCEPTED`         | LOB not in `AcceptedLobs` (when set)                        |
+|     7 | `AGE_OUT_OF_RANGE`         | member age outside `Min/MaxAcceptedAgeYears`                |
+|     8 | `PANEL_FULL`               | live panel count `>=` `PanelLimit`                          |
+
+Codes 0 and the rest of the ladder are emitted as 400 ProblemDetails-shaped
+`PcpValidationError { code, field, message, severity }`. The exception is
+`NO_ACTIVE_COVERAGE`, which is a 404 because there is no resource to attach
+the assignment to.
+
+## Panel race
+
+Step 8 reads the current panel count via `IPanelCounter`, then the service
+writes the assignment row. Between those two operations, another assignment
+can land and both can pass the limit check.
+
+**Phase 1 (this PR): accept the race.** Panel limits in practice carry
+slack — a provider with a 1,000 limit is not going to crash at 1,001. We
+ship the validation as racy, document it here, and add a stub
+`PcpPanelReconciliationJob` that scans for over-limit panels per tenant and
+logs a warning. The reconciliation job has no scheduler bound to it in this
+PR — the goal of the stub is to make the observability path exist before
+the race actually bites.
+
+**Phase 2: per-provider distributed lock.** Acquire a Redis lock on
+`pcp-assignment:{tenantId}:{npi}` before the capacity check and hold it
+through the write. Tracked under Addendum A.7.2 (Redis primitives).
+`TODO(addendum-a)` markers are in the code at the panel-check site and on
+the reconciliation stub.
+
+**Not chosen: optimistic ETag on the panel counter.** Most correct (no
+race, no waiting for a lock) but requires capitation-service to expose a
+versioned counter. Revisit if the lock approach becomes painful.
+
+## CareTeam
+
+`ICareTeamProjector` projects an aggregate of `CareTeamMember` entries
+into a FHIR R4 CareTeam aligned to the US Core 6.1 CareTeam profile.
+
+```csharp
+JsonObject Project(string memberId, Coverage? coverage, IEnumerable<CareTeamMember> members);
+```
+
+`CareTeamMember { Role, PractitionerNpi, DisplayName, EffectiveDate, EndDate, Source }`
+is decoupled from `PcpAssignment` so future sources (specialists, care
+managers, behavioral health) populate the same projector without taking a
+dependency on the PCP types.
+
+Today only the PCP source is wired (`CareTeamMember.FromPcp`). The
+projector intentionally emits no placeholder participants; an empty member
+list yields a `proposed` status CareTeam with no `participant[]` entries.
+
+`status` mapping:
+
+- `inactive` if the underlying coverage is `Terminated`, or every
+  participant has been ended.
+- `proposed` if there are no participants.
+- `active` otherwise.
+
+`participant[].role` uses the FHIR `practitioner-role` CodeSystem (`doctor`
+for PCP/Specialist, `ict` for care manager). `participant[].member` is a
+`Practitioner` Reference shaped as an identifier-only Reference using the
+NPI system `http://hl7.org/fhir/sid/us-npi`, since coverage-service does
+not own logical Practitioner ids.
+
+## Provider-service contract changes
+
+`Provider.NetworkParticipation` gains five fields to gate PCP validation:
+
+| field                  | semantics                                                         |
+| ---------------------- | ----------------------------------------------------------------- |
+| `PanelLimit`           | max members assignable to this participation; null = unlimited    |
+| `PanelAccepted`        | overrides `AcceptingNewPatients` for PCP only; null = inherit     |
+| `AcceptedLobs`         | LOBs accepted as PCP; empty = accept any LOB on the participation |
+| `MinAcceptedAgeYears`  | minimum member age; null = no floor                               |
+| `MaxAcceptedAgeYears`  | maximum member age; null = no ceiling                             |
+
+### Migration plan
+
+- **Schema**: pure additions on an embedded sub-document. No DDL needed for
+  Cosmos / Mongo; existing documents read back with `null` for new fields.
+- **Backfill**: `null` is treated as legacy unconstrained — panel open,
+  any LOB the participation already covers, no age limits. This preserves
+  current behavior for every participation that was loaded before this
+  migration.
+- **Forward writes**: every write path that emits a `NetworkParticipation`
+  needs to populate these fields going forward:
+  - `ProvidersController.AddNetworkParticipation` (existing endpoint —
+    accepts whatever the caller sends; needs the portal Provider edit dialog
+    updated to capture these inputs).
+  - any bulk-import / CAQH-sync path that materializes participations.
+  - future `CreateEditProviderDialog.razor` edits.
+
+  `TODO(provider-service)` markers are in `Provider.NetworkParticipation`
+  for the next person on that surface.
+- **Backfill window**: network ops can run a one-time backfill once the
+  fields land. Until then, every Phase-1 PCP assignment behaves as if the
+  participation has unlimited panel and accepts the member's LOB and age —
+  i.e., it gates only on credentialing, network participation, and
+  `AcceptingNewPatients`. That is the same effective contract we shipped
+  pre-5.7, so no regressions.
+
+## Member-service ↔ coverage-service contract
+
+`PUT /api/v1/members/{id}/pcp` now propagates 400 from coverage-service
+verbatim. The `HttpCoverageServiceClient.AssignPcpAsync` call returns an
+`AssignPcpOutcome` instead of throwing on 400 — the validation error body
+travels through to the portal so it can localize off `code`.
+
+503 / connectivity issues continue to throw `DownstreamUnavailableException`
+and surface as `503` ProblemDetails on the member-service edge.
+
+New endpoint `GET /api/v1/members/{id}/pcp/history` proxies through to the
+coverage-service `member/{id}/pcp/history` endpoint.
+
+## Portal
+
+- `PcpSearchDialog.razor` replaces `AssignPcpDialog.razor`. Each row in
+  the provider table renders a Network chip and a Panel chip. Live panel
+  capacity is a Phase-2 enhancement once provider-service exposes panel
+  counts on `ProviderListItem` — a tooltip on the chip notes this.
+- The PCP tab in `MemberDetailsDialog.razor` now shows an "Assignment
+  History" subsection backed by the new history endpoint, with a column
+  for `NetworkStatusAtAssignment` (rendered as a chip and labeled
+  "Network @ Assignment" so it does not get confused with live status).
+
+## FHIR
+
+- `Patient.generalPractitioner[]` is emitted by `FhirPatientProjector.Project`
+  when the caller passes a `MemberPcpResponse`. `MembersController.GetFhirPatient`
+  fetches the current PCP best-effort and forwards it in. Failures degrade
+  silently — the resource omits the optional rather than 503'ing the read.
+- `GET /api/v1/coverage/member/{id}/care-team` returns a US Core CareTeam
+  resource. Today it has at most one PCP participant.

--- a/docs/architecture/pcp-assignment.md
+++ b/docs/architecture/pcp-assignment.md
@@ -208,7 +208,7 @@ coverage-service `member/{id}/pcp/history` endpoint.
 - The PCP tab in `MemberDetailsDialog.razor` now shows an "Assignment
   History" subsection backed by the new history endpoint, with a column
   for `NetworkStatusAtAssignment` (rendered as a chip and labeled
-  "Network @ Assignment" so it does not get confused with live status).
+  "Network at Assignment" so it does not get confused with live status).
 
 ## FHIR
 

--- a/src/portal/CloudHealthOffice.Portal/Dialogs/PcpSearchDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Dialogs/PcpSearchDialog.razor
@@ -7,7 +7,7 @@
     <TitleContent>
         <MudText Typo="Typo.h6">
             <MudIcon Icon="@Icons.Material.Filled.LocalHospital" Class="mr-2" Style="vertical-align: middle;" />
-            Assign Primary Care Physician
+            Search and Assign Primary Care Physician
         </MudText>
     </TitleContent>
     <DialogContent>
@@ -15,7 +15,8 @@
         {
             <MudAlert Severity="Severity.Info" Class="mb-4" Dense="true">
                 Current PCP: <strong>@_currentPcp.ProviderName</strong> (@_currentPcp.Specialty) —
-                <MudChip T="string" Size="Size.Small" Color="@(_currentPcp.NetworkStatus == "In-Network" ? Color.Success : Color.Warning)">
+                <MudChip T="string" Size="Size.Small"
+                         Color="@(_currentPcp.NetworkStatus == "In-Network" ? Color.Success : Color.Warning)">
                     @_currentPcp.NetworkStatus
                 </MudChip>
             </MudAlert>
@@ -63,21 +64,22 @@
                       SelectedItemChanged="OnProviderSelected"
                       T="ProviderListItem">
                 <HeaderContent>
-                    <MudTh>Provider Name</MudTh>
+                    <MudTh>Provider</MudTh>
                     <MudTh>NPI</MudTh>
                     <MudTh>Specialty</MudTh>
                     <MudTh>Location</MudTh>
                     <MudTh>Network</MudTh>
-                    <MudTh>Credentialing</MudTh>
+                    <MudTh>Panel</MudTh>
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd DataLabel="Provider Name">
+                    <MudTd DataLabel="Provider">
                         <div class="d-flex align-center gap-2">
                             @if (_selectedProvider?.ProviderId == context.ProviderId)
                             {
                                 <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" />
                             }
-                            <MudText Typo="Typo.body2" Style="@("font-weight: " + (_selectedProvider?.ProviderId == context.ProviderId ? "bold" : "normal"))">
+                            <MudText Typo="Typo.body2"
+                                     Style="@("font-weight: " + (_selectedProvider?.ProviderId == context.ProviderId ? "bold" : "normal"))">
                                 @context.Name
                             </MudText>
                         </div>
@@ -89,15 +91,21 @@
                     <MudTd DataLabel="Location">@context.City, @context.State</MudTd>
                     <MudTd DataLabel="Network">
                         <MudChip T="string" Size="Size.Small"
-                                 Color="@(context.NetworkStatus == "In-Network" ? Color.Success : context.NetworkStatus == "Pending" ? Color.Warning : Color.Error)">
+                                 Color="@NetworkStatusColor(context.NetworkStatus)">
                             @context.NetworkStatus
                         </MudChip>
                     </MudTd>
-                    <MudTd DataLabel="Credentialing">
-                        <MudChip T="string" Size="Size.Small"
-                                 Color="@(context.CredentialingStatus == "Active" ? Color.Success : context.CredentialingStatus == "Pending" ? Color.Warning : Color.Error)">
-                            @context.CredentialingStatus
-                        </MudChip>
+                    <MudTd DataLabel="Panel">
+                        @* Panel availability is sourced from provider-service NetworkParticipation
+                           (PanelLimit + PanelAccepted). Until provider-service exposes a roll-up
+                           field on ProviderListItem we surface the AcceptingNewPatients heuristic
+                           that already drives the row, plus a tooltip explaining the limitation. *@
+                        <MudTooltip Text="Live panel capacity will appear here once provider-service exposes panel counts on the directory list. See docs/architecture/pcp-assignment.md.">
+                            <MudChip T="string" Size="Size.Small"
+                                     Color="@PanelChipColor(context)">
+                                @PanelChipLabel(context)
+                            </MudChip>
+                        </MudTooltip>
                     </MudTd>
                 </RowTemplate>
             </MudTable>
@@ -123,12 +131,26 @@
                                    HelperText="Date when PCP assignment takes effect" />
                 </MudItem>
                 <MudItem xs="12" md="6">
+                    <MudSelect @bind-Value="_source" Label="Assignment Source" Variant="Variant.Outlined">
+                        <MudSelectItem Value="@("MemberChoice")">Member choice</MudSelectItem>
+                        <MudSelectItem Value="@("AdminAssigned")">Admin assigned</MudSelectItem>
+                        <MudSelectItem Value="@("AutoAssigned")">Auto assigned</MudSelectItem>
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12">
                     <MudTextField @bind-Value="_reason"
                                   Label="Reason for Change (optional)"
                                   Variant="Variant.Outlined"
                                   HelperText="e.g., Member request, provider left network" />
                 </MudItem>
             </MudGrid>
+        }
+
+        @if (_validationError != null)
+        {
+            <MudAlert Severity="Severity.Error" Class="mt-4" Variant="Variant.Outlined">
+                <strong>@_validationError.Code</strong>: @_validationError.Message
+            </MudAlert>
         }
     </DialogContent>
     <DialogActions>
@@ -150,15 +172,13 @@
     [CascadingParameter]
     MudDialogInstance MudDialog { get; set; } = null!;
 
-    [Parameter]
-    public string MemberId { get; set; } = string.Empty;
-
-    [Parameter]
-    public MemberPcp? CurrentPcp { get; set; }
+    [Parameter] public string MemberId { get; set; } = string.Empty;
+    [Parameter] public MemberPcp? CurrentPcp { get; set; }
 
     private MemberPcp? _currentPcp;
     private string _searchTerm = string.Empty;
     private string _specialtyFilter = string.Empty;
+    private string _source = "MemberChoice";
     private List<ProviderListItem> _providers = new();
     private ProviderListItem? _selectedProvider;
     private DateTime? _effectiveDate = DateTime.Today;
@@ -166,6 +186,7 @@
     private bool _searching = false;
     private bool _assigning = false;
     private bool _hasSearched = false;
+    private PcpValidationProblem? _validationError;
 
     protected override void OnInitialized()
     {
@@ -185,9 +206,8 @@
         {
             _providers = await ProviderService.SearchProvidersAsync(
                 specialty: string.IsNullOrEmpty(_specialtyFilter) ? null : _specialtyFilter,
-                networkStatus: "In-Network",
+                networkStatus: null,
                 searchTerm: string.IsNullOrEmpty(_searchTerm) ? null : _searchTerm);
-            // Filter to individual providers (PCPs are individual practitioners)
             _providers = _providers.Where(p => p.PracticeType == "Individual" || p.PracticeType == "").ToList();
         }
         catch (Exception ex)
@@ -204,23 +224,34 @@
     private void OnProviderSelected(ProviderListItem provider)
     {
         _selectedProvider = _selectedProvider?.ProviderId == provider.ProviderId ? null : provider;
+        _validationError = null;
     }
 
     private async Task AssignPcp()
     {
         if (_selectedProvider == null || !_effectiveDate.HasValue) return;
         _assigning = true;
+        _validationError = null;
         try
         {
-            await MemberService.AssignPcpAsync(new AssignPcpRequest
+            var outcome = await MemberService.AssignPcpAsync(new AssignPcpRequest
             {
                 MemberId = MemberId,
                 ProviderId = _selectedProvider.ProviderId,
+                ProviderNpi = _selectedProvider.NPI,
                 EffectiveDate = _effectiveDate.Value,
-                Reason = string.IsNullOrWhiteSpace(_reason) ? null : _reason
+                Reason = string.IsNullOrWhiteSpace(_reason) ? null : _reason,
+                AssignmentSource = _source
             });
 
-            var newPcp = new MemberPcp
+            if (!outcome.IsSuccess)
+            {
+                _validationError = outcome.ValidationError;
+                Snackbar.Add($"PCP assignment rejected: {outcome.ValidationError?.Message}", Severity.Warning);
+                return;
+            }
+
+            var newPcp = outcome.Pcp ?? new MemberPcp
             {
                 ProviderId = _selectedProvider.ProviderId,
                 ProviderName = _selectedProvider.Name,
@@ -245,4 +276,17 @@
     }
 
     private void Cancel() => MudDialog.Cancel();
+
+    private static Color NetworkStatusColor(string status) => status switch
+    {
+        "In-Network" => Color.Success,
+        "Pending" => Color.Warning,
+        _ => Color.Error
+    };
+
+    private static Color PanelChipColor(ProviderListItem p) =>
+        p.CredentialingStatus == "Active" ? Color.Success : Color.Warning;
+
+    private static string PanelChipLabel(ProviderListItem p) =>
+        p.CredentialingStatus == "Active" ? "Open" : "Pending";
 }

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -545,6 +545,48 @@
                                 Assign PCP
                             </MudButton>
                         }
+
+                        <MudDivider Class="my-4" />
+                        <MudText Typo="Typo.subtitle1" Class="mb-2">
+                            <MudIcon Icon="@Icons.Material.Filled.History" Class="mr-1" Size="Size.Small" />
+                            Assignment History
+                        </MudText>
+                        @if (_loadingPcpHistory)
+                        {
+                            <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-2" />
+                        }
+                        else if (_pcpHistory.Count == 0)
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Secondary">No prior PCP assignments recorded.</MudText>
+                        }
+                        else
+                        {
+                            <MudTable Items="_pcpHistory" Dense="true" Hover="true" T="PcpAssignmentHistoryItem">
+                                <HeaderContent>
+                                    <MudTh>Provider</MudTh>
+                                    <MudTh>NPI</MudTh>
+                                    <MudTh>Effective</MudTh>
+                                    <MudTh>End</MudTh>
+                                    <MudTh>Source</MudTh>
+                                    <MudTh>Network @ Assignment</MudTh>
+                                    <MudTh>Reason</MudTh>
+                                </HeaderContent>
+                                <RowTemplate>
+                                    <MudTd DataLabel="Provider">@(string.IsNullOrEmpty(context.ProviderName) ? context.ProviderNpi : context.ProviderName)</MudTd>
+                                    <MudTd DataLabel="NPI"><span style="font-family: monospace;">@context.ProviderNpi</span></MudTd>
+                                    <MudTd DataLabel="Effective">@context.EffectiveDate.ToString("MM/dd/yyyy")</MudTd>
+                                    <MudTd DataLabel="End">@(context.EndDate.HasValue ? context.EndDate.Value.ToString("MM/dd/yyyy") : "—")</MudTd>
+                                    <MudTd DataLabel="Source">
+                                        <MudChip T="string" Size="Size.Small">@context.AssignmentSource</MudChip>
+                                    </MudTd>
+                                    <MudTd DataLabel="Network @ Assignment">
+                                        @* Snapshot value — never updated. Live status is fetched separately. *@
+                                        <MudChip T="string" Size="Size.Small">@context.NetworkStatusAtAssignment</MudChip>
+                                    </MudTd>
+                                    <MudTd DataLabel="Reason">@(context.AssignmentReason ?? "—")</MudTd>
+                                </RowTemplate>
+                            </MudTable>
+                        }
                     </div>
                 </MudTabPanel>
 
@@ -825,6 +867,8 @@
     private MemberDetails? _member;
     private List<Coverage> _coverages = new();
     private MemberPcp? _pcp;
+    private List<PcpAssignmentHistoryItem> _pcpHistory = new();
+    private bool _loadingPcpHistory;
     private List<CoverageHistoryEvent> _coverageHistory = new();
     private List<Enrollment834Record> _transactions834 = new();
     private List<CloudHealthOffice.Portal.Services.EnrollmentEvent> _enrollmentEvents = new();
@@ -1084,6 +1128,7 @@
     private async Task LoadPcpAsync()
     {
         _loadingPcp = true;
+        _loadingPcpHistory = true;
         try
         {
             _pcp = await MemberService.GetMemberPcpAsync(MemberId);
@@ -1092,6 +1137,17 @@
         finally
         {
             _loadingPcp = false;
+            await InvokeAsync(StateHasChanged);
+        }
+
+        try
+        {
+            _pcpHistory = await MemberService.GetMemberPcpHistoryAsync(MemberId);
+        }
+        catch { _pcpHistory = new(); }
+        finally
+        {
+            _loadingPcpHistory = false;
             await InvokeAsync(StateHasChanged);
         }
     }
@@ -1130,15 +1186,17 @@
     {
         var parameters = new DialogParameters
         {
-            [nameof(AssignPcpDialog.MemberId)] = MemberId,
-            [nameof(AssignPcpDialog.CurrentPcp)] = _pcp
+            [nameof(PcpSearchDialog.MemberId)] = MemberId,
+            [nameof(PcpSearchDialog.CurrentPcp)] = _pcp
         };
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true };
-        var dialog = await DialogService.ShowAsync<AssignPcpDialog>("Assign PCP", parameters, options);
+        var dialog = await DialogService.ShowAsync<PcpSearchDialog>("Assign PCP", parameters, options);
         var result = await dialog.Result;
         if (!result.Canceled && result.Data is MemberPcp newPcp)
         {
             _pcp = newPcp;
+            // Refresh history so the just-closed prior assignment row appears.
+            _ = LoadPcpAsync();
             StateHasChanged();
         }
     }

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -1196,8 +1196,9 @@
         {
             _pcp = newPcp;
             // Refresh history so the just-closed prior assignment row appears.
-            _ = LoadPcpAsync();
-            StateHasChanged();
+            // Awaited rather than fire-and-forget: fire-and-forget swallows
+            // exceptions and can StateHasChanged after dialog disposal.
+            await LoadPcpAsync();
         }
     }
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -568,7 +568,7 @@
                                     <MudTh>Effective</MudTh>
                                     <MudTh>End</MudTh>
                                     <MudTh>Source</MudTh>
-                                    <MudTh>Network @ Assignment</MudTh>
+                                    <MudTh>Network at Assignment</MudTh>
                                     <MudTh>Reason</MudTh>
                                 </HeaderContent>
                                 <RowTemplate>
@@ -579,7 +579,7 @@
                                     <MudTd DataLabel="Source">
                                         <MudChip T="string" Size="Size.Small">@context.AssignmentSource</MudChip>
                                     </MudTd>
-                                    <MudTd DataLabel="Network @ Assignment">
+                                    <MudTd DataLabel="Network at Assignment">
                                         @* Snapshot value — never updated. Live status is fetched separately. *@
                                         <MudChip T="string" Size="Size.Small">@context.NetworkStatusAtAssignment</MudChip>
                                     </MudTd>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -25,7 +25,15 @@ public interface IMemberService
     Task<List<MemberSummary>> SearchMembersAsync(string searchTerm);
     Task<MemberDetails?> GetMemberByIdAsync(string memberId);
     Task<MemberPcp?> GetMemberPcpAsync(string memberId);
-    Task AssignPcpAsync(AssignPcpRequest request);
+
+    /// <summary>
+    /// Assign a PCP. Returns a populated <see cref="PcpAssignmentOutcome"/> — on
+    /// validation failure (400), <see cref="PcpAssignmentOutcome.ValidationError"/>
+    /// is set with the structured error code from coverage-service.
+    /// </summary>
+    Task<PcpAssignmentOutcome> AssignPcpAsync(AssignPcpRequest request);
+
+    Task<List<PcpAssignmentHistoryItem>> GetMemberPcpHistoryAsync(string memberId);
     Task<List<CoverageHistoryEvent>> GetCoverageHistoryAsync(string memberId);
     Task<List<Enrollment834Record>> GetMember834TransactionsAsync(string memberId);
     Task<EnrollmentEventPage> GetEnrollmentEventsAsync(
@@ -1321,8 +1329,49 @@ public class AssignPcpRequest
 {
     public string MemberId { get; set; } = string.Empty;
     public string ProviderId { get; set; } = string.Empty;
+    public string? ProviderNpi { get; set; }
     public DateTime EffectiveDate { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>MemberChoice (default), AutoAssigned, or AdminAssigned.</summary>
+    public string? AssignmentSource { get; set; }
+}
+
+public class PcpAssignmentOutcome
+{
+    public MemberPcp? Pcp { get; set; }
+    public PcpValidationProblem? ValidationError { get; set; }
+    public bool IsSuccess => Pcp != null;
+}
+
+/// <summary>
+/// Mirror of coverage-service's <c>PcpValidationError</c>. <see cref="Code"/>
+/// values are stable — see docs/architecture/pcp-assignment.md "Validation
+/// ladder" for the canonical list.
+/// </summary>
+public class PcpValidationProblem
+{
+    public string Code { get; set; } = string.Empty;
+    public string Field { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string Severity { get; set; } = "Error";
+}
+
+public class PcpAssignmentHistoryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string CoverageId { get; set; } = string.Empty;
+    public string ProviderNpi { get; set; } = string.Empty;
+    public string? ProviderId { get; set; }
+    public string? ProviderName { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? AssignmentReason { get; set; }
+    public string AssignmentSource { get; set; } = "MemberChoice";
+    public string NetworkStatusAtAssignment { get; set; } = "Unknown";
+    public string? AssignedBy { get; set; }
+    public DateTime CreatedDate { get; set; }
 }
 
 public class TerminateEnrollmentRequest

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -232,7 +232,13 @@ public class MemberService : IMemberService
             var response = await _httpClient.PutAsJsonAsync($"{baseUrl}/members/{request.MemberId}/pcp", request);
             if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
             {
-                var problem = await response.Content.ReadFromJsonAsync<PcpValidationProblem>();
+                PcpValidationProblem? problem = null;
+                try
+                {
+                    problem = await response.Content.ReadFromJsonAsync<PcpValidationProblem>();
+                }
+                catch (JsonException) { /* malformed body → fall through to default */ }
+
                 return new PcpAssignmentOutcome
                 {
                     ValidationError = problem ?? new PcpValidationProblem
@@ -244,9 +250,22 @@ public class MemberService : IMemberService
             }
             response.EnsureSuccessStatusCode();
             var pcp = await response.Content.ReadFromJsonAsync<MemberPcp>();
+            if (pcp is null)
+            {
+                // 2xx with empty/invalid body is a contract break — surface as
+                // unavailable so the UI gets a deterministic failure path
+                // rather than a warning with an empty message.
+                throw new ServiceUnavailableException("Member Service",
+                    new HttpRequestException("Member Service returned an empty PCP assignment response."));
+            }
             return new PcpAssignmentOutcome { Pcp = pcp };
         }
         catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+        catch (JsonException ex)
         {
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
             throw new ServiceUnavailableException("Member Service", ex);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -224,13 +224,43 @@ public class MemberService : IMemberService
         }
     }
 
-    public async Task AssignPcpAsync(AssignPcpRequest request)
+    public async Task<PcpAssignmentOutcome> AssignPcpAsync(AssignPcpRequest request)
     {
         var baseUrl = _configuration["Services:MemberService"];
         try
         {
             var response = await _httpClient.PutAsJsonAsync($"{baseUrl}/members/{request.MemberId}/pcp", request);
+            if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                var problem = await response.Content.ReadFromJsonAsync<PcpValidationProblem>();
+                return new PcpAssignmentOutcome
+                {
+                    ValidationError = problem ?? new PcpValidationProblem
+                    {
+                        Code = "VALIDATION_FAILED",
+                        Message = "PCP assignment was rejected."
+                    }
+                };
+            }
             response.EnsureSuccessStatusCode();
+            var pcp = await response.Content.ReadFromJsonAsync<MemberPcp>();
+            return new PcpAssignmentOutcome { Pcp = pcp };
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<List<PcpAssignmentHistoryItem>> GetMemberPcpHistoryAsync(string memberId)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        try
+        {
+            var history = await _httpClient.GetFromJsonAsync<List<PcpAssignmentHistoryItem>>(
+                $"{baseUrl}/members/{memberId}/pcp/history");
+            return history ?? new List<PcpAssignmentHistoryItem>();
         }
         catch (HttpRequestException ex)
         {

--- a/src/services/coverage-service/Controllers/CoverageController.cs
+++ b/src/services/coverage-service/Controllers/CoverageController.cs
@@ -2,10 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 using CoverageService.Middleware;
 using CoverageService.Models;
 using CoverageService.Repositories;
+using CoverageService.Services;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CoverageService.Controllers;
@@ -20,14 +22,22 @@ namespace CoverageService.Controllers;
 public class CoverageController : ControllerBase
 {
     private readonly ICoverageRepository _coverageRepository;
+    private readonly IPcpAssignmentService? _pcpService;
+    private readonly ICareTeamProjector? _careTeamProjector;
     private readonly ILogger<CoverageController> _logger;
 
     // Tenant context from middleware
     private string TenantId => HttpContext.GetTenantId();
 
-    public CoverageController(ICoverageRepository coverageRepository, ILogger<CoverageController> logger)
+    public CoverageController(
+        ICoverageRepository coverageRepository,
+        ILogger<CoverageController> logger,
+        IPcpAssignmentService? pcpService = null,
+        ICareTeamProjector? careTeamProjector = null)
     {
         _coverageRepository = coverageRepository;
+        _pcpService = pcpService;
+        _careTeamProjector = careTeamProjector;
         _logger = logger;
     }
 
@@ -391,66 +401,116 @@ public class CoverageController : ControllerBase
     }
 
     /// <summary>
-    /// Assign or change the member's PCP. Writes <c>PcpNpi</c> + <c>PcpAssignmentDate</c>
-    /// on all active coverages for the member and moves the prior <c>PcpNpi</c> into
-    /// <c>PreviousPcpNpi</c>.
-    ///
-    /// TODO(roadmap 5.7 Phase 2): track PCP changes in a dedicated
-    /// <c>PcpAssignmentHistory</c> collection with effective-dated rows rather than
-    /// overwriting. Leaving the overwrite pattern in place for PR #650 per scope.
+    /// Assign or change the member's PCP. Validation is performed by
+    /// <see cref="IPcpAssignmentService"/> in a fail-fast ordered ladder; the
+    /// first failure is returned as 400 with a structured
+    /// <see cref="PcpValidationError"/> body so the portal can localize and
+    /// pick a remediation flow off <c>code</c>.
     /// </summary>
     [HttpPut("member/{memberId}/pcp")]
     [ProducesResponseType(typeof(MemberPcpResponse), 200)]
-    [ProducesResponseType(400)]
+    [ProducesResponseType(typeof(PcpValidationError), 400)]
     [ProducesResponseType(404)]
+    [ProducesResponseType(503)]
     public async Task<IActionResult> AssignMemberPcp(
         [FromRoute] string memberId,
-        [FromBody] AssignPcpBody request)
+        [FromBody] AssignPcpBody request,
+        CancellationToken ct)
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        if (string.IsNullOrWhiteSpace(request.ProviderId) && string.IsNullOrWhiteSpace(request.ProviderNpi))
-            return BadRequest(new { Message = "providerId or providerNpi is required" });
-
-        var npi = request.ProviderNpi ?? request.ProviderId;
-        if (npi.Length != 10 || !npi.All(char.IsDigit))
-            return BadRequest(new { Message = "providerNpi must be exactly 10 digits" });
-
-        var checkDate = request.EffectiveDate == default ? DateTime.UtcNow.Date : request.EffectiveDate;
-        var active = (await _coverageRepository.GetActiveCoverageByMemberIdAsync(
-            TenantId, memberId, checkDate)).ToList();
-
-        if (active.Count == 0)
+        if (_pcpService == null)
         {
-            return NotFound(new
-            {
-                MemberId = memberId,
-                Message = "No active coverage for member; cannot assign PCP."
-            });
+            return StatusCode(503, new { Message = "PCP assignment service not configured." });
         }
 
-        foreach (var coverage in active)
+        var npi = request.ProviderNpi ?? request.ProviderId ?? string.Empty;
+        var cmd = new AssignPcpCommand
         {
-            if (!string.IsNullOrEmpty(coverage.PcpNpi) && coverage.PcpNpi != npi)
-                coverage.PreviousPcpNpi = coverage.PcpNpi;
-            coverage.PcpNpi = npi;
-            coverage.PcpName = request.ProviderName;
-            coverage.PcpAssignmentDate = checkDate;
-            coverage.PcpAssignmentMethod = PcpAssignmentMethod.MemberSelected;
-            coverage.LastUpdatedDate = DateTime.UtcNow;
-            coverage.LastUpdatedBy = User.Identity?.Name ?? "member-service";
-            await _coverageRepository.UpdateAsync(coverage);
+            ProviderNpi = npi,
+            ProviderId = request.ProviderId,
+            EffectiveDate = request.EffectiveDate,
+            Reason = request.Reason,
+            Source = ParseSource(request.AssignmentSource),
+            MemberDateOfBirth = request.MemberDateOfBirth,
+            AssignedBy = User.Identity?.Name ?? "member-service"
+        };
+
+        var result = await _pcpService.AssignAsync(TenantId, memberId, cmd, ct);
+        if (!result.IsSuccess)
+        {
+            var err = result.Error!;
+            // NoActiveCoverage is the one preflight failure that's a 404 (the
+            // member has no coverage to attach a PCP to). Everything else is a
+            // 400 on the assignment request.
+            if (err.Code == PcpValidationCodes.NoActiveCoverage)
+                return NotFound(err);
+            return BadRequest(err);
         }
 
+        var assignment = result.Assignment!;
         return Ok(new MemberPcpResponse
         {
-            ProviderId = npi,
-            ProviderName = request.ProviderName ?? string.Empty,
-            NPI = npi,
-            AssignedDate = checkDate,
-            NetworkStatus = "In-Network"
+            ProviderId = assignment.ProviderId ?? assignment.ProviderNpi,
+            ProviderName = assignment.ProviderName ?? string.Empty,
+            NPI = assignment.ProviderNpi,
+            AssignedDate = assignment.EffectiveDate,
+            NetworkStatus = assignment.NetworkStatusAtAssignment
         });
     }
+
+    /// <summary>
+    /// Full PCP assignment history for a member, newest first. The currently-open
+    /// row (EndDate = null) is what <c>GetMemberPcp</c> reflects; older rows are
+    /// closed by EndDate when superseded.
+    /// </summary>
+    [HttpGet("member/{memberId}/pcp/history")]
+    [ProducesResponseType(typeof(IReadOnlyList<PcpAssignment>), 200)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetMemberPcpHistory([FromRoute] string memberId, CancellationToken ct)
+    {
+        if (_pcpService == null) return StatusCode(503, new { Message = "PCP assignment service not configured." });
+        var history = await _pcpService.GetHistoryAsync(TenantId, memberId, ct);
+        return Ok(history);
+    }
+
+    /// <summary>
+    /// FHIR R4 CareTeam projection for a member. Today only the PCP role is
+    /// populated; specialist / care-manager participants will be added by
+    /// roadmap 5.7 Phase 2 work without changing the projector's contract.
+    /// </summary>
+    [HttpGet("member/{memberId}/care-team")]
+    [Produces("application/fhir+json", "application/json")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetMemberCareTeam([FromRoute] string memberId, CancellationToken ct)
+    {
+        if (_pcpService == null || _careTeamProjector == null)
+            return StatusCode(503, new { Message = "Care team projector not configured." });
+
+        var current = await _pcpService.GetCurrentAsync(TenantId, memberId, ct);
+        var coverages = await _coverageRepository.GetActiveCoverageByMemberIdAsync(TenantId, memberId, DateTime.UtcNow);
+        var primaryCoverage = coverages.OrderBy(c => (int)c.LineOfBusiness).FirstOrDefault();
+
+        var members = current != null
+            ? new[] { CareTeamMember.FromPcp(current) }
+            : Array.Empty<CareTeamMember>();
+
+        var resource = _careTeamProjector.Project(memberId, primaryCoverage, members);
+        return new ContentResult
+        {
+            ContentType = "application/fhir+json",
+            Content = resource.ToJsonString(),
+            StatusCode = 200
+        };
+    }
+
+    private static PcpAssignmentSource ParseSource(string? raw) => raw switch
+    {
+        "AutoAssigned" => PcpAssignmentSource.AutoAssigned,
+        "AdminAssigned" => PcpAssignmentSource.AdminAssigned,
+        _ => PcpAssignmentSource.MemberChoice
+    };
 
     /// <summary>
     /// Terminate all active coverages for a member.
@@ -513,6 +573,19 @@ public class AssignPcpBody
     public string? ProviderName { get; set; }
     public DateTime EffectiveDate { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>
+    /// Origin of the assignment. Accepted values: <c>MemberChoice</c> (default),
+    /// <c>AutoAssigned</c>, <c>AdminAssigned</c>. See <see cref="PcpAssignmentSource"/>.
+    /// </summary>
+    public string? AssignmentSource { get; set; }
+
+    /// <summary>
+    /// Optional member DOB so the assignment service can enforce age-range
+    /// participations (pediatric vs adult). When omitted the AGE_OUT_OF_RANGE
+    /// check is skipped — caller is responsible for enforcing if needed.
+    /// </summary>
+    public DateTime? MemberDateOfBirth { get; set; }
 }
 
 public class MemberPcpResponse

--- a/src/services/coverage-service/Controllers/CoverageController.cs
+++ b/src/services/coverage-service/Controllers/CoverageController.cs
@@ -455,8 +455,25 @@ public class CoverageController : ControllerBase
             ProviderName = assignment.ProviderName ?? string.Empty,
             NPI = assignment.ProviderNpi,
             AssignedDate = assignment.EffectiveDate,
-            NetworkStatus = assignment.NetworkStatusAtAssignment
+            // Wire the display-shaped network status ("In-Network" / "Out-of-Network")
+            // — NOT the raw snapshot ("Tier1") which lives on the history row. The
+            // portal colors off this value and assignment is only allowed when the
+            // provider has an active participation, so success implies In-Network.
+            NetworkStatus = ToDisplayNetworkStatus(assignment.NetworkStatusAtAssignment)
         });
+    }
+
+    private static string ToDisplayNetworkStatus(string? snapshot)
+    {
+        if (string.IsNullOrWhiteSpace(snapshot)) return "In-Network";
+        if (snapshot.Equals("Out-of-Network", StringComparison.OrdinalIgnoreCase)
+            || snapshot.Equals("OutOfNetwork", StringComparison.OrdinalIgnoreCase)
+            || snapshot.Equals("OON", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Out-of-Network";
+        }
+        // Tier1/Tier2/Tier3 + anything else from an active participation ⇒ In-Network
+        return "In-Network";
     }
 
     /// <summary>
@@ -465,13 +482,13 @@ public class CoverageController : ControllerBase
     /// closed by EndDate when superseded.
     /// </summary>
     [HttpGet("member/{memberId}/pcp/history")]
-    [ProducesResponseType(typeof(IReadOnlyList<PcpAssignment>), 200)]
+    [ProducesResponseType(typeof(IReadOnlyList<PcpAssignmentHistoryResponse>), 200)]
     [ProducesResponseType(503)]
     public async Task<IActionResult> GetMemberPcpHistory([FromRoute] string memberId, CancellationToken ct)
     {
         if (_pcpService == null) return StatusCode(503, new { Message = "PCP assignment service not configured." });
         var history = await _pcpService.GetHistoryAsync(TenantId, memberId, ct);
-        return Ok(history);
+        return Ok(history.Select(PcpAssignmentHistoryResponse.From).ToList());
     }
 
     /// <summary>
@@ -489,8 +506,17 @@ public class CoverageController : ControllerBase
             return StatusCode(503, new { Message = "Care team projector not configured." });
 
         var current = await _pcpService.GetCurrentAsync(TenantId, memberId, ct);
-        var coverages = await _coverageRepository.GetActiveCoverageByMemberIdAsync(TenantId, memberId, DateTime.UtcNow);
-        var primaryCoverage = coverages.OrderBy(c => (int)c.LineOfBusiness).FirstOrDefault();
+
+        // CareTeam.status depends on the underlying coverage's lifecycle, including
+        // termination — so we read coverage HISTORY here (includes terminated rows)
+        // rather than active-only, otherwise the "inactive" branch in
+        // CareTeamProjector.MapStatus is unreachable for terminated members.
+        var history = await _coverageRepository.GetCoverageHistoryAsync(TenantId, memberId, includeTerminated: true);
+        var primaryCoverage = history
+            .Where(c => c.InsuranceLineCode == InsuranceLineCodes.Health)
+            .OrderByDescending(c => c.EffectiveDate)
+            .FirstOrDefault()
+            ?? history.OrderByDescending(c => c.EffectiveDate).FirstOrDefault();
 
         var members = current != null
             ? new[] { CareTeamMember.FromPcp(current) }
@@ -598,6 +624,47 @@ public class MemberPcpResponse
     public DateTime AssignedDate { get; set; }
     public string? PracticeName { get; set; }
     public string? Phone { get; set; }
+}
+
+/// <summary>
+/// Wire-shaped projection of <see cref="PcpAssignment"/> for the history endpoint.
+/// Keeping a dedicated DTO (instead of returning the model directly) pins the
+/// on-wire shape: every enum is a string, internal fields (tenantId) are dropped,
+/// and downstream clients can rely on this contract across coverage-service
+/// refactors.
+/// </summary>
+public class PcpAssignmentHistoryResponse
+{
+    public string Id { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string CoverageId { get; set; } = string.Empty;
+    public string ProviderNpi { get; set; } = string.Empty;
+    public string? ProviderId { get; set; }
+    public string? ProviderName { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? AssignmentReason { get; set; }
+    public string AssignmentSource { get; set; } = "MemberChoice";
+    public string NetworkStatusAtAssignment { get; set; } = "Unknown";
+    public string? AssignedBy { get; set; }
+    public DateTime CreatedDate { get; set; }
+
+    public static PcpAssignmentHistoryResponse From(PcpAssignment a) => new()
+    {
+        Id = a.Id,
+        MemberId = a.MemberId,
+        CoverageId = a.CoverageId,
+        ProviderNpi = a.ProviderNpi,
+        ProviderId = a.ProviderId,
+        ProviderName = a.ProviderName,
+        EffectiveDate = a.EffectiveDate,
+        EndDate = a.EndDate,
+        AssignmentReason = a.AssignmentReason,
+        AssignmentSource = a.AssignmentSource.ToString(),
+        NetworkStatusAtAssignment = a.NetworkStatusAtAssignment,
+        AssignedBy = a.AssignedBy,
+        CreatedDate = a.CreatedDate
+    };
 }
 
 public class TerminateMemberCoverageBody

--- a/src/services/coverage-service/CoverageService.Tests/Controllers/CoverageMemberEndpointsTests.cs
+++ b/src/services/coverage-service/CoverageService.Tests/Controllers/CoverageMemberEndpointsTests.cs
@@ -1,6 +1,7 @@
 using CoverageService.Controllers;
 using CoverageService.Models;
 using CoverageService.Repositories;
+using CoverageService.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,14 +13,20 @@ public class CoverageMemberEndpointsTests
 {
     private const string Tenant = "t1";
 
-    private static (CoverageController ctl, Mock<ICoverageRepository> repo) Build()
+    private static (CoverageController ctl, Mock<ICoverageRepository> repo, Mock<IPcpAssignmentService> pcp) Build()
     {
         var repo = new Mock<ICoverageRepository>();
-        var ctl = new CoverageController(repo.Object, NullLogger<CoverageController>.Instance);
+        var pcp = new Mock<IPcpAssignmentService>();
+        var careTeam = new Mock<ICareTeamProjector>();
+        var ctl = new CoverageController(
+            repo.Object,
+            NullLogger<CoverageController>.Instance,
+            pcp.Object,
+            careTeam.Object);
         var http = new DefaultHttpContext();
         http.Items["TenantId"] = Tenant;
         ctl.ControllerContext = new ControllerContext { HttpContext = http };
-        return (ctl, repo);
+        return (ctl, repo, pcp);
     }
 
     private static Coverage ActiveCoverage(string memberId, string? pcpNpi = null) => new()
@@ -37,7 +44,7 @@ public class CoverageMemberEndpointsTests
     [Fact]
     public async Task GetMemberPcp_WithAssignment_ReturnsPcp()
     {
-        var (ctl, repo) = Build();
+        var (ctl, repo, _) = Build();
         repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
             .ReturnsAsync(new List<Coverage> { ActiveCoverage("M1", "1234567890") });
 
@@ -50,7 +57,7 @@ public class CoverageMemberEndpointsTests
     [Fact]
     public async Task GetMemberPcp_NoActiveCoverage_Returns404()
     {
-        var (ctl, repo) = Build();
+        var (ctl, repo, _) = Build();
         repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
             .ReturnsAsync(new List<Coverage>());
 
@@ -60,7 +67,7 @@ public class CoverageMemberEndpointsTests
     [Fact]
     public async Task GetMemberPcp_ActiveCoverageWithoutPcp_Returns404()
     {
-        var (ctl, repo) = Build();
+        var (ctl, repo, _) = Build();
         repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
             .ReturnsAsync(new List<Coverage> { ActiveCoverage("M1") });
 
@@ -68,48 +75,66 @@ public class CoverageMemberEndpointsTests
     }
 
     [Fact]
-    public async Task AssignMemberPcp_ValidNpi_WritesAndMovesPrior()
+    public async Task AssignMemberPcp_DelegatesToServiceAndReturnsOk()
     {
-        var (ctl, repo) = Build();
-        var existing = ActiveCoverage("M1", "9999999999");
-        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
-            .ReturnsAsync(new List<Coverage> { existing });
-        repo.Setup(r => r.UpdateAsync(It.IsAny<Coverage>()))
-            .ReturnsAsync((Coverage c) => c);
+        var (ctl, _, pcp) = Build();
+        pcp.Setup(p => p.AssignAsync(Tenant, "M1", It.IsAny<AssignPcpCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PcpAssignmentResult.Ok(new PcpAssignment
+            {
+                TenantId = Tenant,
+                MemberId = "M1",
+                CoverageId = "cov1",
+                ProviderNpi = "1234567890",
+                ProviderName = "Dr. Test",
+                EffectiveDate = DateTime.UtcNow.Date,
+                NetworkStatusAtAssignment = "InNetwork"
+            }));
 
         var resp = await ctl.AssignMemberPcp("M1",
-            new AssignPcpBody { ProviderNpi = "1234567890", EffectiveDate = DateTime.UtcNow.Date });
+            new AssignPcpBody { ProviderNpi = "1234567890", EffectiveDate = DateTime.UtcNow.Date },
+            CancellationToken.None);
 
-        resp.Should().BeOfType<OkObjectResult>();
-        existing.PcpNpi.Should().Be("1234567890");
-        existing.PreviousPcpNpi.Should().Be("9999999999");
-        repo.Verify(r => r.UpdateAsync(It.IsAny<Coverage>()), Times.Once);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberPcpResponse>().Subject;
+        body.NPI.Should().Be("1234567890");
     }
 
     [Fact]
-    public async Task AssignMemberPcp_InvalidNpi_ReturnsBadRequest()
+    public async Task AssignMemberPcp_ValidationFailure_ReturnsBadRequestWithError()
     {
-        var (ctl, _) = Build();
-        var resp = await ctl.AssignMemberPcp("M1", new AssignPcpBody { ProviderNpi = "bad" });
-        resp.Should().BeOfType<BadRequestObjectResult>();
+        var (ctl, _, pcp) = Build();
+        pcp.Setup(p => p.AssignAsync(Tenant, "M1", It.IsAny<AssignPcpCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PcpAssignmentResult.Fail(new PcpValidationError(
+                PcpValidationCodes.PanelFull, "providerNpi", "Provider panel is full (1000 / 1000).")));
+
+        var resp = await ctl.AssignMemberPcp("M1",
+            new AssignPcpBody { ProviderNpi = "1234567890", EffectiveDate = DateTime.UtcNow.Date },
+            CancellationToken.None);
+
+        var bad = resp.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var body = bad.Value.Should().BeOfType<PcpValidationError>().Subject;
+        body.Code.Should().Be(PcpValidationCodes.PanelFull);
     }
 
     [Fact]
     public async Task AssignMemberPcp_NoActiveCoverage_Returns404()
     {
-        var (ctl, repo) = Build();
-        repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
-            .ReturnsAsync(new List<Coverage>());
+        var (ctl, _, pcp) = Build();
+        pcp.Setup(p => p.AssignAsync(Tenant, "M1", It.IsAny<AssignPcpCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PcpAssignmentResult.Fail(new PcpValidationError(
+                PcpValidationCodes.NoActiveCoverage, "memberId", "No active coverage.")));
 
         var resp = await ctl.AssignMemberPcp("M1",
-            new AssignPcpBody { ProviderNpi = "1234567890" });
+            new AssignPcpBody { ProviderNpi = "1234567890" },
+            CancellationToken.None);
+
         resp.Should().BeOfType<NotFoundObjectResult>();
     }
 
     [Fact]
     public async Task TerminateMemberCoverage_ActiveCoverages_MarksTerminated()
     {
-        var (ctl, repo) = Build();
+        var (ctl, repo, _) = Build();
         var c1 = ActiveCoverage("M1");
         var c2 = ActiveCoverage("M1");
         repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
@@ -130,7 +155,7 @@ public class CoverageMemberEndpointsTests
     [Fact]
     public async Task TerminateMemberCoverage_NoActiveCoverage_Returns404()
     {
-        var (ctl, repo) = Build();
+        var (ctl, repo, _) = Build();
         repo.Setup(r => r.GetActiveCoverageByMemberIdAsync(Tenant, "M1", It.IsAny<DateTime>(), null))
             .ReturnsAsync(new List<Coverage>());
 

--- a/src/services/coverage-service/CoverageService.Tests/Services/CareTeamProjectorTests.cs
+++ b/src/services/coverage-service/CoverageService.Tests/Services/CareTeamProjectorTests.cs
@@ -1,0 +1,71 @@
+using CoverageService.Models;
+using CoverageService.Services;
+
+namespace CoverageService.Tests.Services;
+
+public class CareTeamProjectorTests
+{
+    private readonly CareTeamProjector _projector = new();
+
+    [Fact]
+    public void Project_WithPcpOnly_EmitsSingleParticipant()
+    {
+        var resource = _projector.Project(
+            "M-001",
+            new Coverage { Status = CoverageStatus.Active, LineOfBusiness = LineOfBusiness.Commercial },
+            new[]
+            {
+                new CareTeamMember
+                {
+                    Role = CareTeamRole.PrimaryCareProvider,
+                    PractitionerNpi = "1234567890",
+                    DisplayName = "Dr. Test",
+                    EffectiveDate = new DateTime(2025, 1, 1)
+                }
+            });
+
+        resource["resourceType"]!.GetValue<string>().Should().Be("CareTeam");
+        resource["status"]!.GetValue<string>().Should().Be("active");
+        resource["subject"]!["reference"]!.GetValue<string>().Should().Be("Patient/M-001");
+        var participants = resource["participant"]!.AsArray();
+        participants.Count.Should().Be(1);
+        participants[0]!["member"]!["identifier"]!["value"]!.GetValue<string>().Should().Be("1234567890");
+    }
+
+    [Fact]
+    public void Project_NoMembers_EmitsProposedStatusAndNoParticipants()
+    {
+        var resource = _projector.Project("M-001", null, Array.Empty<CareTeamMember>());
+
+        resource["status"]!.GetValue<string>().Should().Be("proposed");
+        resource.ContainsKey("participant").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Project_TerminatedCoverage_EmitsInactive()
+    {
+        var resource = _projector.Project(
+            "M-001",
+            new Coverage { Status = CoverageStatus.Terminated },
+            new[]
+            {
+                new CareTeamMember
+                {
+                    Role = CareTeamRole.PrimaryCareProvider,
+                    PractitionerNpi = "1234567890",
+                    DisplayName = "Dr. Test",
+                    EffectiveDate = new DateTime(2025, 1, 1)
+                }
+            });
+
+        resource["status"]!.GetValue<string>().Should().Be("inactive");
+    }
+
+    [Fact]
+    public void Project_AlignsToUsCoreProfile()
+    {
+        var resource = _projector.Project("M-001", null, Array.Empty<CareTeamMember>());
+        var profiles = resource["meta"]!["profile"]!.AsArray();
+        profiles.Should().Contain(p => p!.GetValue<string>() == "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam");
+    }
+}

--- a/src/services/coverage-service/CoverageService.Tests/Services/PcpAssignmentServiceTests.cs
+++ b/src/services/coverage-service/CoverageService.Tests/Services/PcpAssignmentServiceTests.cs
@@ -1,0 +1,233 @@
+using CoverageService.Models;
+using CoverageService.Repositories;
+using CoverageService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CoverageService.Tests.Services;
+
+/// <summary>
+/// Validation-ladder coverage for PcpAssignmentService. Each test pins the
+/// fail-fast contract: setting up state where multiple checks would fail and
+/// asserting only the earliest one is returned.
+/// </summary>
+public class PcpAssignmentServiceTests
+{
+    private const string Tenant = "t1";
+    private const string Member = "M1";
+    private const string Npi = "1234567890";
+
+    private static (PcpAssignmentService svc,
+                    Mock<ICoverageRepository> coverage,
+                    Mock<IPcpAssignmentRepository> assignments,
+                    Mock<IProviderServiceClient> providers,
+                    Mock<IPanelCounter> panel) Build()
+    {
+        var coverage = new Mock<ICoverageRepository>();
+        var assignments = new Mock<IPcpAssignmentRepository>();
+        var providers = new Mock<IProviderServiceClient>();
+        var panel = new Mock<IPanelCounter>();
+
+        // Default repository wiring: one active medical coverage on Plan-A (Commercial).
+        coverage.Setup(c => c.GetActiveCoverageByMemberIdAsync(Tenant, Member, It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage>
+            {
+                new()
+                {
+                    TenantId = Tenant,
+                    Id = "cov-1",
+                    MemberId = Member,
+                    GroupNumber = "G",
+                    PlanId = "Plan-A",
+                    LineOfBusiness = LineOfBusiness.Commercial,
+                    EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+                    Status = CoverageStatus.Active
+                }
+            });
+        coverage.Setup(c => c.UpdateAsync(It.IsAny<Coverage>())).ReturnsAsync((Coverage c) => c);
+        assignments.Setup(a => a.AddAsync(It.IsAny<PcpAssignment>())).ReturnsAsync((PcpAssignment a) => a);
+        assignments.Setup(a => a.EndOpenAssignmentsAsync(Tenant, Member, It.IsAny<DateTime>())).ReturnsAsync(0);
+
+        var svc = new PcpAssignmentService(
+            coverage.Object,
+            assignments.Object,
+            providers.Object,
+            panel.Object,
+            NullLogger<PcpAssignmentService>.Instance);
+
+        return (svc, coverage, assignments, providers, panel);
+    }
+
+    private static AssignPcpCommand Cmd(DateTime? dob = null) => new()
+    {
+        ProviderNpi = Npi,
+        EffectiveDate = DateTime.UtcNow.Date,
+        Source = PcpAssignmentSource.MemberChoice,
+        MemberDateOfBirth = dob
+    };
+
+    private static ProviderDto HappyProvider(int? panelLimit = null, int? minAge = null, int? maxAge = null)
+    {
+        var part = new NetworkParticipationDto
+        {
+            PlanId = "Plan-A",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.AddYears(-1),
+            AcceptingNewPatients = true,
+            PanelLimit = panelLimit,
+            MinAcceptedAgeYears = minAge,
+            MaxAcceptedAgeYears = maxAge
+        };
+        return new ProviderDto
+        {
+            Id = "prov-1",
+            NPI = Npi,
+            FullName = "Dr. Test",
+            Status = ProviderStatusDto.Active,
+            CredentialingStatus = CredentialingStatusDto.Approved,
+            AcceptingNewPatients = true,
+            NetworkParticipations = new List<NetworkParticipationDto> { part }
+        };
+    }
+
+    [Fact]
+    public async Task ProviderNotFound_FailsFirst()
+    {
+        var (svc, _, _, providers, _) = Build();
+        providers.Setup(p => p.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync((ProviderDto?)null);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.IsSuccess.Should().BeFalse();
+        result.Error!.Code.Should().Be(PcpValidationCodes.ProviderNotFound);
+    }
+
+    [Fact]
+    public async Task ProviderInactive_FailsBeforeCredentialing()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider();
+        p.Status = ProviderStatusDto.Terminated;
+        p.CredentialingStatus = CredentialingStatusDto.Pending; // would also fail
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.ProviderInactive);
+    }
+
+    [Fact]
+    public async Task NotCredentialed_FailsBeforeNetwork()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider();
+        p.CredentialingStatus = CredentialingStatusDto.Pending;
+        p.NetworkParticipations.Clear(); // would also fail NoNetworkParticipation
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.ProviderNotCredentialed);
+    }
+
+    [Fact]
+    public async Task NoMatchingNetworkParticipation_Fails()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider();
+        p.NetworkParticipations[0].LineOfBusiness = LineOfBusiness.Medicare; // member is Commercial
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.NoNetworkParticipation);
+    }
+
+    [Fact]
+    public async Task PanelClosed_Fails()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider();
+        p.NetworkParticipations[0].PanelAccepted = false;
+        p.NetworkParticipations[0].AcceptingNewPatients = true; // panel-specific override
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.NotAcceptingPatients);
+    }
+
+    [Fact]
+    public async Task LobNotAccepted_FailsBeforeAge()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider(minAge: 100); // age would also fail
+        p.NetworkParticipations[0].AcceptedLobs = new List<LineOfBusiness> { LineOfBusiness.Medicaid };
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd(dob: new DateTime(1990, 1, 1)));
+        result.Error!.Code.Should().Be(PcpValidationCodes.LobNotAccepted);
+    }
+
+    [Fact]
+    public async Task Pediatric_RejectsAdult()
+    {
+        var (svc, _, _, providers, _) = Build();
+        var p = HappyProvider(maxAge: 21);
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd(dob: new DateTime(1980, 1, 1)));
+        result.Error!.Code.Should().Be(PcpValidationCodes.AgeOutOfRange);
+    }
+
+    [Fact]
+    public async Task PanelFull_FailsLast()
+    {
+        var (svc, _, _, providers, panel) = Build();
+        var p = HappyProvider(panelLimit: 1000);
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+        panel.Setup(x => x.CurrentPanelCountAsync(Tenant, Npi, It.IsAny<CancellationToken>())).ReturnsAsync(1000);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.PanelFull);
+    }
+
+    [Fact]
+    public async Task HappyPath_WritesAssignment_ClosesPrior_UpdatesCoverage()
+    {
+        var (svc, coverage, assignments, providers, panel) = Build();
+        var p = HappyProvider(panelLimit: 100);
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(p);
+        panel.Setup(x => x.CurrentPanelCountAsync(Tenant, Npi, It.IsAny<CancellationToken>())).ReturnsAsync(50);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd(dob: new DateTime(1980, 1, 1)));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Assignment!.ProviderNpi.Should().Be(Npi);
+        result.Assignment.NetworkStatusAtAssignment.Should().NotBeNullOrEmpty();
+        assignments.Verify(a => a.EndOpenAssignmentsAsync(Tenant, Member, It.IsAny<DateTime>()), Times.Once);
+        assignments.Verify(a => a.AddAsync(It.IsAny<PcpAssignment>()), Times.Once);
+        coverage.Verify(c => c.UpdateAsync(It.IsAny<Coverage>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task NoActiveCoverage_FailsBeforeProviderLookup()
+    {
+        var (svc, coverage, _, providers, _) = Build();
+        coverage.Setup(c => c.GetActiveCoverageByMemberIdAsync(Tenant, Member, It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage>());
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+        result.Error!.Code.Should().Be(PcpValidationCodes.NoActiveCoverage);
+        providers.Verify(p => p.GetByNpiAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvalidNpi_FailsBeforeProviderLookup()
+    {
+        var (svc, _, _, providers, _) = Build();
+
+        var result = await svc.AssignAsync(Tenant, Member, new AssignPcpCommand
+        {
+            ProviderNpi = "abc",
+            EffectiveDate = DateTime.UtcNow.Date
+        });
+        result.Error!.Code.Should().Be(PcpValidationCodes.InvalidNpi);
+        providers.Verify(p => p.GetByNpiAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/services/coverage-service/CoverageService.Tests/Services/PcpAssignmentServiceTests.cs
+++ b/src/services/coverage-service/CoverageService.Tests/Services/PcpAssignmentServiceTests.cs
@@ -230,4 +230,121 @@ public class PcpAssignmentServiceTests
         result.Error!.Code.Should().Be(PcpValidationCodes.InvalidNpi);
         providers.Verify(p => p.GetByNpiAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    // ── PR #656 cleanup: denormalization scope + AdminAssigned mapping ──
+
+    [Fact]
+    public async Task HealthAndDentalCoverage_DenormStampsHealthRowOnly()
+    {
+        var coverageRepo = new Mock<ICoverageRepository>();
+        var assignments = new Mock<IPcpAssignmentRepository>();
+        var providers = new Mock<IProviderServiceClient>();
+        var panel = new Mock<IPanelCounter>();
+
+        var health = new Coverage
+        {
+            TenantId = Tenant,
+            Id = "cov-health",
+            MemberId = Member,
+            GroupNumber = "G",
+            PlanId = "Plan-A",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            InsuranceLineCode = InsuranceLineCodes.Health,
+            EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+            Status = CoverageStatus.Active
+        };
+        var dental = new Coverage
+        {
+            TenantId = Tenant,
+            Id = "cov-dental",
+            MemberId = Member,
+            GroupNumber = "G",
+            PlanId = "Plan-A",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            InsuranceLineCode = InsuranceLineCodes.Dental,
+            EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+            Status = CoverageStatus.Active
+        };
+
+        coverageRepo.Setup(c => c.GetActiveCoverageByMemberIdAsync(Tenant, Member, It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { health, dental });
+        coverageRepo.Setup(c => c.UpdateAsync(It.IsAny<Coverage>())).ReturnsAsync((Coverage c) => c);
+        assignments.Setup(a => a.AddAsync(It.IsAny<PcpAssignment>())).ReturnsAsync((PcpAssignment a) => a);
+        assignments.Setup(a => a.EndOpenAssignmentsAsync(Tenant, Member, It.IsAny<DateTime>())).ReturnsAsync(0);
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(HappyProvider());
+
+        var svc = new PcpAssignmentService(
+            coverageRepo.Object, assignments.Object, providers.Object, panel.Object,
+            NullLogger<PcpAssignmentService>.Instance);
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+
+        result.IsSuccess.Should().BeTrue();
+        health.PcpNpi.Should().Be(Npi);
+        health.PcpName.Should().NotBeNullOrEmpty();
+        dental.PcpNpi.Should().BeNull("dental coverage must never be stamped with a PCP");
+        dental.PcpName.Should().BeNull();
+        coverageRepo.Verify(c => c.UpdateAsync(It.Is<Coverage>(x => x.Id == "cov-health")), Times.Once);
+        coverageRepo.Verify(c => c.UpdateAsync(It.Is<Coverage>(x => x.Id == "cov-dental")), Times.Never);
+    }
+
+    [Fact]
+    public async Task NoHealthCodedCoverage_LegacyFallbackStampsActive()
+    {
+        // Coverage with null InsuranceLineCode (loaded before the field was
+        // populated). The medical-only filter returns zero targets, so the
+        // service falls back to stamping the active row — preserving legacy
+        // behavior for tenants that haven't backfilled InsuranceLineCode.
+        var (svc, coverage, _, providers, _) = Build();
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(HappyProvider());
+
+        var result = await svc.AssignAsync(Tenant, Member, Cmd());
+
+        result.IsSuccess.Should().BeTrue();
+        coverage.Verify(c => c.UpdateAsync(It.IsAny<Coverage>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AdminAssignedSource_MapsToAdministrativeMethod()
+    {
+        var coverageRepo = new Mock<ICoverageRepository>();
+        var assignments = new Mock<IPcpAssignmentRepository>();
+        var providers = new Mock<IProviderServiceClient>();
+        var panel = new Mock<IPanelCounter>();
+
+        var health = new Coverage
+        {
+            TenantId = Tenant,
+            Id = "cov-health",
+            MemberId = Member,
+            GroupNumber = "G",
+            PlanId = "Plan-A",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            InsuranceLineCode = InsuranceLineCodes.Health,
+            EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+            Status = CoverageStatus.Active
+        };
+        coverageRepo.Setup(c => c.GetActiveCoverageByMemberIdAsync(Tenant, Member, It.IsAny<DateTime>(), null))
+            .ReturnsAsync(new List<Coverage> { health });
+        coverageRepo.Setup(c => c.UpdateAsync(It.IsAny<Coverage>())).ReturnsAsync((Coverage c) => c);
+        assignments.Setup(a => a.AddAsync(It.IsAny<PcpAssignment>())).ReturnsAsync((PcpAssignment a) => a);
+        assignments.Setup(a => a.EndOpenAssignmentsAsync(Tenant, Member, It.IsAny<DateTime>())).ReturnsAsync(0);
+        providers.Setup(x => x.GetByNpiAsync(Npi, It.IsAny<CancellationToken>())).ReturnsAsync(HappyProvider());
+
+        var svc = new PcpAssignmentService(
+            coverageRepo.Object, assignments.Object, providers.Object, panel.Object,
+            NullLogger<PcpAssignmentService>.Instance);
+
+        var cmd = new AssignPcpCommand
+        {
+            ProviderNpi = Npi,
+            EffectiveDate = DateTime.UtcNow.Date,
+            Source = PcpAssignmentSource.AdminAssigned
+        };
+
+        var result = await svc.AssignAsync(Tenant, Member, cmd);
+
+        result.IsSuccess.Should().BeTrue();
+        health.PcpAssignmentMethod.Should().Be(PcpAssignmentMethod.Administrative);
+    }
 }

--- a/src/services/coverage-service/Models/Coverage.cs
+++ b/src/services/coverage-service/Models/Coverage.cs
@@ -348,5 +348,13 @@ public enum PcpAssignmentMethod
     /// <summary>
     /// Plan-level default PCP assignment
     /// </summary>
-    PlanDefault = 3
+    PlanDefault = 3,
+
+    /// <summary>
+    /// Admin / back-office override (CSR, network ops). Distinct from
+    /// <see cref="MemberSelected"/> for reporting — did the member choose or
+    /// did an admin override? — and mirrors
+    /// <c>PcpAssignmentSource.AdminAssigned</c> on the history row.
+    /// </summary>
+    Administrative = 4
 }

--- a/src/services/coverage-service/Models/PcpAssignment.cs
+++ b/src/services/coverage-service/Models/PcpAssignment.cs
@@ -1,0 +1,98 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace CoverageService.Models;
+
+/// <summary>
+/// Immutable history row for a member's Primary Care Provider assignment.
+/// A new row is written on every assignment; the prior open row is closed by
+/// stamping <see cref="EndDate"/>. Current PCP = the row with null <see cref="EndDate"/>.
+///
+/// Denormalized <c>Coverage.PcpNpi / PcpName / PcpAssignmentDate / PreviousPcpNpi</c>
+/// remain for fast read paths (eligibility, capitation roster) but this collection
+/// is the source of truth for history / audit / FHIR CareTeam projection.
+/// </summary>
+public class PcpAssignment
+{
+    /// <summary>Multi-tenant partition key.</summary>
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Document id.</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Member this assignment belongs to.</summary>
+    [Required]
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Coverage record this assignment was written against. Kept for audit — if the
+    /// member has multiple active coverages (e.g., Medical + Dental), each gets
+    /// its own history row so termination of one coverage doesn't orphan the other.
+    /// </summary>
+    [Required]
+    public string CoverageId { get; set; } = string.Empty;
+
+    /// <summary>Provider-service record id (opaque).</summary>
+    public string? ProviderId { get; set; }
+
+    /// <summary>National Provider Identifier (10 digits). The stable external id.</summary>
+    [Required]
+    [StringLength(10, MinimumLength = 10)]
+    public string ProviderNpi { get; set; } = string.Empty;
+
+    /// <summary>Denormalized provider display name, captured at assignment time.</summary>
+    public string? ProviderName { get; set; }
+
+    /// <summary>When this assignment becomes effective.</summary>
+    [Required]
+    public DateTime EffectiveDate { get; set; }
+
+    /// <summary>
+    /// When this assignment was closed (i.e. a newer assignment took over or the
+    /// member terminated). Null = currently active.
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>Human-readable reason for this change, if supplied.</summary>
+    [StringLength(500)]
+    public string? AssignmentReason { get; set; }
+
+    /// <summary>Who / what initiated the change.</summary>
+    [Required]
+    public PcpAssignmentSource AssignmentSource { get; set; } = PcpAssignmentSource.MemberChoice;
+
+    /// <summary>
+    /// Network-status snapshot captured at assignment time. Never updated.
+    ///
+    /// If the provider later terminates their network participation, this field
+    /// still reflects the status that was true when the assignment was written —
+    /// that's the point of an audit trail. For live UI status, always fetch via
+    /// provider-service; do NOT treat this value as current.
+    /// </summary>
+    [Required]
+    public string NetworkStatusAtAssignment { get; set; } = "Unknown";
+
+    /// <summary>Audit: user/system that created the assignment.</summary>
+    [StringLength(200)]
+    public string? AssignedBy { get; set; }
+
+    /// <summary>Audit: creation timestamp.</summary>
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Origin of a PCP assignment. Drives downstream reporting (auto-assignment rate,
+/// member-choice rate) and regulatory reporting for Medicaid/Medicare.
+/// </summary>
+public enum PcpAssignmentSource
+{
+    /// <summary>Member actively chose the PCP (portal, phone, paper form).</summary>
+    MemberChoice = 1,
+
+    /// <summary>System auto-assigned (geo-match, round-robin, plan default).</summary>
+    AutoAssigned = 2,
+
+    /// <summary>Admin / back-office override (CSR, network ops).</summary>
+    AdminAssigned = 3
+}

--- a/src/services/coverage-service/Models/PcpAssignment.cs
+++ b/src/services/coverage-service/Models/PcpAssignment.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace CoverageService.Models;
 
@@ -84,7 +85,12 @@ public class PcpAssignment
 /// <summary>
 /// Origin of a PCP assignment. Drives downstream reporting (auto-assignment rate,
 /// member-choice rate) and regulatory reporting for Medicaid/Medicare.
+///
+/// Serialized as a string on the wire — member-service and the portal
+/// deserialize into string-typed DTOs, and the value is part of the PCP
+/// history API contract. Do not remove the converter.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PcpAssignmentSource
 {
     /// <summary>Member actively chose the PCP (portal, phone, paper form).</summary>

--- a/src/services/coverage-service/Models/PcpValidationError.cs
+++ b/src/services/coverage-service/Models/PcpValidationError.cs
@@ -1,0 +1,56 @@
+namespace CoverageService.Models;
+
+/// <summary>
+/// Structured validation failure emitted by <c>PcpAssignmentService</c>. The
+/// <see cref="Code"/> values are an API contract — the portal localizes off them
+/// and picks the remediation path (search again, escalate to ops, etc.). Do not
+/// rename without coordinating a portal release.
+/// </summary>
+public sealed class PcpValidationError
+{
+    public PcpValidationError(string code, string field, string message, PcpValidationSeverity severity = PcpValidationSeverity.Error)
+    {
+        Code = code;
+        Field = field;
+        Message = message;
+        Severity = severity;
+    }
+
+    /// <summary>Machine-readable error code (see <see cref="PcpValidationCodes"/>).</summary>
+    public string Code { get; }
+
+    /// <summary>Field the error is attached to (providerNpi, memberId, panel, etc.).</summary>
+    public string Field { get; }
+
+    /// <summary>Human-readable explanation — displayed as fallback if portal has no localization.</summary>
+    public string Message { get; }
+
+    /// <summary>Severity. Today all validation errors are <see cref="PcpValidationSeverity.Error"/>; Warning reserved for future soft-fails.</summary>
+    public PcpValidationSeverity Severity { get; }
+}
+
+public enum PcpValidationSeverity
+{
+    Warning = 0,
+    Error = 1
+}
+
+/// <summary>
+/// Stable string codes for PCP validation failures. Ordered here in the same
+/// fail-fast order <c>PcpAssignmentService</c> evaluates them.
+/// </summary>
+public static class PcpValidationCodes
+{
+    public const string ProviderNotFound = "PROVIDER_NOT_FOUND";
+    public const string ProviderInactive = "PROVIDER_INACTIVE";
+    public const string ProviderNotCredentialed = "PROVIDER_NOT_CREDENTIALED";
+    public const string NoNetworkParticipation = "NO_NETWORK_PARTICIPATION";
+    public const string NotAcceptingPatients = "NOT_ACCEPTING_PATIENTS";
+    public const string LobNotAccepted = "LOB_NOT_ACCEPTED";
+    public const string AgeOutOfRange = "AGE_OUT_OF_RANGE";
+    public const string PanelFull = "PANEL_FULL";
+
+    // Preflight (not part of the ordered ladder):
+    public const string NoActiveCoverage = "NO_ACTIVE_COVERAGE";
+    public const string InvalidNpi = "INVALID_NPI";
+}

--- a/src/services/coverage-service/Models/PcpValidationError.cs
+++ b/src/services/coverage-service/Models/PcpValidationError.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace CoverageService.Models;
 
 /// <summary>
@@ -29,6 +31,11 @@ public sealed class PcpValidationError
     public PcpValidationSeverity Severity { get; }
 }
 
+/// <summary>
+/// Severity of a PCP validation failure. Serialized as a string on the wire —
+/// downstream clients (member-service + portal) expect "Error"/"Warning".
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PcpValidationSeverity
 {
     Warning = 0,

--- a/src/services/coverage-service/Program.cs
+++ b/src/services/coverage-service/Program.cs
@@ -92,12 +92,17 @@ builder.Services.AddHttpClient<IProviderServiceClient, HttpProviderServiceClient
 });
 builder.Services.AddHttpClient<IPanelCounter, HttpPanelCounter>((sp, client) =>
 {
-    // Panel counter hits the local /by-pcp endpoint by default — for cross-service
-    // capitation deployments, point this at capitation-service.
+    // Panel counter reads the capitation-style /by-pcp roster. Prefer the
+    // capitation-service URL when set; fall back to the coverage-service URL
+    // (since coverage itself exposes /by-pcp). If neither is configured, leave
+    // BaseAddress null — HttpPanelCounter short-circuits to 0 in that case so
+    // panel-limit checks degrade gracefully rather than gating every assignment.
     var baseUrl = builder.Configuration["Downstream:CapitationService:BaseUrl"]
-                 ?? builder.Configuration["Downstream:CoverageService:BaseUrl"]
-                 ?? "http://localhost";
-    client.BaseAddress = new Uri(baseUrl);
+                 ?? builder.Configuration["Downstream:CoverageService:BaseUrl"];
+    if (!string.IsNullOrWhiteSpace(baseUrl))
+    {
+        client.BaseAddress = new Uri(baseUrl);
+    }
 });
 builder.Services.AddScoped<IPcpAssignmentService, PcpAssignmentService>();
 builder.Services.AddSingleton<ICareTeamProjector, CareTeamProjector>();

--- a/src/services/coverage-service/Program.cs
+++ b/src/services/coverage-service/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Cosmos;
 using CoverageService.Middleware;
 using CoverageService.Repositories;
+using CoverageService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 
@@ -40,6 +41,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     });
 
     builder.Services.AddScoped<ICoverageRepository, CoverageRepositoryMongo>();
+    builder.Services.AddScoped<IPcpAssignmentRepository, PcpAssignmentRepositoryMongo>();
     Console.WriteLine("Using MongoDB database provider");
 }
 else
@@ -68,7 +70,38 @@ else
         var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
         return new CoverageRepository(cosmosClient, databaseName);
     });
+
+    builder.Services.AddScoped<IPcpAssignmentRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new PcpAssignmentRepository(cosmosClient, databaseName);
+    });
 }
+
+// PCP assignment + provider client + care team projector
+builder.Services.Configure<ProviderServiceOptions>(opts =>
+{
+    opts.BaseUrl = builder.Configuration["Downstream:ProviderService:BaseUrl"];
+});
+builder.Services.AddHttpClient<IProviderServiceClient, HttpProviderServiceClient>((sp, client) =>
+{
+    var baseUrl = builder.Configuration["Downstream:ProviderService:BaseUrl"];
+    if (!string.IsNullOrWhiteSpace(baseUrl)) client.BaseAddress = new Uri(baseUrl);
+});
+builder.Services.AddHttpClient<IPanelCounter, HttpPanelCounter>((sp, client) =>
+{
+    // Panel counter hits the local /by-pcp endpoint by default — for cross-service
+    // capitation deployments, point this at capitation-service.
+    var baseUrl = builder.Configuration["Downstream:CapitationService:BaseUrl"]
+                 ?? builder.Configuration["Downstream:CoverageService:BaseUrl"]
+                 ?? "http://localhost";
+    client.BaseAddress = new Uri(baseUrl);
+});
+builder.Services.AddScoped<IPcpAssignmentService, PcpAssignmentService>();
+builder.Services.AddSingleton<ICareTeamProjector, CareTeamProjector>();
+builder.Services.AddScoped<PcpPanelReconciliationJob>();
 
 builder.Services.AddCors(options =>
 {

--- a/src/services/coverage-service/Repositories/PcpAssignmentRepository.cs
+++ b/src/services/coverage-service/Repositories/PcpAssignmentRepository.cs
@@ -59,7 +59,7 @@ public sealed class PcpAssignmentRepository : IPcpAssignmentRepository
     public async Task<int> EndOpenAssignmentsAsync(string tenantId, string memberId, DateTime endDate)
     {
         var query = new QueryDefinition(
-                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR IS_NULL(c.endDate))")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@memberId", memberId);
 
@@ -83,7 +83,7 @@ public sealed class PcpAssignmentRepository : IPcpAssignmentRepository
     public async Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId)
     {
         var query = new QueryDefinition(
-                "SELECT TOP 1 * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null) ORDER BY c.effectiveDate DESC")
+                "SELECT TOP 1 * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR IS_NULL(c.endDate)) ORDER BY c.effectiveDate DESC")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@memberId", memberId);
 
@@ -121,7 +121,7 @@ public sealed class PcpAssignmentRepository : IPcpAssignmentRepository
     public async Task<int> CountOpenByNpiAsync(string tenantId, string providerNpi)
     {
         var query = new QueryDefinition(
-                "SELECT VALUE COUNT(1) FROM c WHERE c.tenantId = @tenantId AND c.providerNpi = @npi AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+                "SELECT VALUE COUNT(1) FROM c WHERE c.tenantId = @tenantId AND c.providerNpi = @npi AND (NOT IS_DEFINED(c.endDate) OR IS_NULL(c.endDate))")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@npi", providerNpi);
 

--- a/src/services/coverage-service/Repositories/PcpAssignmentRepository.cs
+++ b/src/services/coverage-service/Repositories/PcpAssignmentRepository.cs
@@ -1,0 +1,219 @@
+using CoverageService.Models;
+using Microsoft.Azure.Cosmos;
+using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoverageService.Repositories;
+
+/// <summary>
+/// Effective-dated history of PCP assignments. One row per change — prior rows
+/// are closed (EndDate stamped), they are never mutated otherwise. Current
+/// assignment = the row for a (tenantId, memberId) where EndDate is null.
+/// </summary>
+public interface IPcpAssignmentRepository
+{
+    /// <summary>Append a new assignment row.</summary>
+    Task<PcpAssignment> AddAsync(PcpAssignment assignment);
+
+    /// <summary>
+    /// Close any currently-open assignment(s) for a member by stamping <paramref name="endDate"/>.
+    /// Multiple open rows are possible in theory (one per coverage) but in practice
+    /// we key on memberId for simplicity — callers that need per-coverage termination
+    /// should filter in memory.
+    /// </summary>
+    Task<int> EndOpenAssignmentsAsync(string tenantId, string memberId, DateTime endDate);
+
+    /// <summary>Current (open) assignment for a member, if any.</summary>
+    Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId);
+
+    /// <summary>Full history, newest first.</summary>
+    Task<IReadOnlyList<PcpAssignment>> GetHistoryAsync(string tenantId, string memberId);
+
+    /// <summary>Count of currently-open assignments to a given NPI. Used by panel reconciliation.</summary>
+    Task<int> CountOpenByNpiAsync(string tenantId, string providerNpi);
+}
+
+/// <summary>
+/// Cosmos DB implementation of <see cref="IPcpAssignmentRepository"/>. Partition key = tenantId.
+/// </summary>
+public sealed class PcpAssignmentRepository : IPcpAssignmentRepository
+{
+    private readonly Container _container;
+    private const string ContainerName = "PcpAssignments";
+
+    public PcpAssignmentRepository(CosmosClient client, string databaseName)
+    {
+        _container = client.GetDatabase(databaseName).GetContainer(ContainerName);
+    }
+
+    public async Task<PcpAssignment> AddAsync(PcpAssignment assignment)
+    {
+        assignment.CreatedDate = DateTime.UtcNow;
+        var response = await _container.CreateItemAsync(assignment, new PartitionKey(assignment.TenantId));
+        return response.Resource;
+    }
+
+    public async Task<int> EndOpenAssignmentsAsync(string tenantId, string memberId, DateTime endDate)
+    {
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+
+        var iterator = _container.GetItemQueryIterator<PcpAssignment>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var closed = 0;
+        while (iterator.HasMoreResults)
+        {
+            foreach (var open in await iterator.ReadNextAsync())
+            {
+                open.EndDate = endDate;
+                await _container.ReplaceItemAsync(open, open.Id, new PartitionKey(tenantId));
+                closed++;
+            }
+        }
+        return closed;
+    }
+
+    public async Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId)
+    {
+        var query = new QueryDefinition(
+                "SELECT TOP 1 * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null) ORDER BY c.effectiveDate DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+
+        var iterator = _container.GetItemQueryIterator<PcpAssignment>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            return page.FirstOrDefault();
+        }
+        return null;
+    }
+
+    public async Task<IReadOnlyList<PcpAssignment>> GetHistoryAsync(string tenantId, string memberId)
+    {
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId ORDER BY c.effectiveDate DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+
+        var iterator = _container.GetItemQueryIterator<PcpAssignment>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<PcpAssignment>();
+        while (iterator.HasMoreResults)
+        {
+            results.AddRange(await iterator.ReadNextAsync());
+        }
+        return results;
+    }
+
+    public async Task<int> CountOpenByNpiAsync(string tenantId, string providerNpi)
+    {
+        var query = new QueryDefinition(
+                "SELECT VALUE COUNT(1) FROM c WHERE c.tenantId = @tenantId AND c.providerNpi = @npi AND (NOT IS_DEFINED(c.endDate) OR c.endDate = null)")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@npi", providerNpi);
+
+        var iterator = _container.GetItemQueryIterator<int>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            return response.FirstOrDefault();
+        }
+        return 0;
+    }
+}
+
+/// <summary>
+/// MongoDB implementation of <see cref="IPcpAssignmentRepository"/>.
+/// </summary>
+public sealed class PcpAssignmentRepositoryMongo : IPcpAssignmentRepository
+{
+    private readonly IMongoCollection<PcpAssignment> _collection;
+    private const string CollectionName = "PcpAssignments";
+
+    public PcpAssignmentRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<PcpAssignment>(CollectionName);
+
+        var keys = Builders<PcpAssignment>.IndexKeys;
+        _collection.Indexes.CreateMany(new[]
+        {
+            new CreateIndexModel<PcpAssignment>(keys.Ascending(x => x.TenantId).Ascending(x => x.MemberId).Ascending(x => x.EndDate)),
+            new CreateIndexModel<PcpAssignment>(keys.Ascending(x => x.TenantId).Ascending(x => x.ProviderNpi).Ascending(x => x.EndDate)),
+            new CreateIndexModel<PcpAssignment>(keys.Ascending(x => x.TenantId).Ascending(x => x.MemberId).Descending(x => x.EffectiveDate))
+        });
+    }
+
+    public async Task<PcpAssignment> AddAsync(PcpAssignment assignment)
+    {
+        assignment.CreatedDate = DateTime.UtcNow;
+        if (string.IsNullOrEmpty(assignment.Id))
+            assignment.Id = Guid.NewGuid().ToString();
+        await _collection.InsertOneAsync(assignment);
+        return assignment;
+    }
+
+    public async Task<int> EndOpenAssignmentsAsync(string tenantId, string memberId, DateTime endDate)
+    {
+        var b = Builders<PcpAssignment>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.MemberId, memberId),
+            b.Eq(x => x.EndDate, null));
+
+        var update = Builders<PcpAssignment>.Update.Set(x => x.EndDate, endDate);
+        var result = await _collection.UpdateManyAsync(filter, update);
+        return (int)result.ModifiedCount;
+    }
+
+    public async Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId)
+    {
+        var b = Builders<PcpAssignment>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.MemberId, memberId),
+            b.Eq(x => x.EndDate, null));
+
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.EffectiveDate)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<IReadOnlyList<PcpAssignment>> GetHistoryAsync(string tenantId, string memberId)
+    {
+        var b = Builders<PcpAssignment>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.MemberId, memberId));
+
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.EffectiveDate)
+            .ToListAsync();
+    }
+
+    public async Task<int> CountOpenByNpiAsync(string tenantId, string providerNpi)
+    {
+        var b = Builders<PcpAssignment>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderNpi, providerNpi),
+            b.Eq(x => x.EndDate, null));
+
+        return (int)await _collection.CountDocumentsAsync(filter);
+    }
+}

--- a/src/services/coverage-service/Services/CareTeamProjector.cs
+++ b/src/services/coverage-service/Services/CareTeamProjector.cs
@@ -1,0 +1,179 @@
+using CoverageService.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace CoverageService.Services;
+
+/// <summary>
+/// Projects an aggregate of <see cref="CareTeamMember"/> entries (PCP today;
+/// specialists, care managers, value-based partners later) into a FHIR R4
+/// CareTeam resource aligned to the US Core 6.1 CareTeam profile.
+///
+/// Design notes for the next person to extend this:
+/// <list type="bullet">
+///   <item>Each member becomes one <c>participant[]</c> entry with its own
+///         <c>role</c>, <c>member</c> Practitioner reference, and <c>period</c>.</item>
+///   <item>The projector itself does NOT know about specialists vs care
+///         managers — it just renders whatever <see cref="CareTeamMember"/>s it
+///         is handed. Source services decide whose roles to include.</item>
+///   <item>No empty placeholders are emitted. If only PCP is supplied the
+///         resulting CareTeam has exactly one participant.</item>
+/// </list>
+/// </summary>
+public interface ICareTeamProjector
+{
+    JsonObject Project(string memberId, Coverage? coverage, IEnumerable<CareTeamMember> members);
+}
+
+/// <summary>
+/// Input row for <see cref="ICareTeamProjector"/>. Decoupled from
+/// <see cref="PcpAssignment"/> so future sources (care management service,
+/// specialist referrals, embedded behavioral health) can populate the same
+/// projector without taking a dependency on the PCP types.
+/// </summary>
+public sealed class CareTeamMember
+{
+    public CareTeamRole Role { get; init; }
+    public string PractitionerNpi { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public DateTime EffectiveDate { get; init; }
+    public DateTime? EndDate { get; init; }
+
+    /// <summary>
+    /// Source of this care-team entry — used downstream to attribute the row
+    /// (e.g., "pcp-assignment-service", "care-management-service"). Free-form on
+    /// purpose; source services should pick a stable string.
+    /// </summary>
+    public string Source { get; init; } = string.Empty;
+
+    public static CareTeamMember FromPcp(PcpAssignment a) => new()
+    {
+        Role = CareTeamRole.PrimaryCareProvider,
+        PractitionerNpi = a.ProviderNpi,
+        DisplayName = a.ProviderName ?? a.ProviderNpi,
+        EffectiveDate = a.EffectiveDate,
+        EndDate = a.EndDate,
+        Source = "pcp-assignment-service"
+    };
+}
+
+/// <summary>
+/// Care-team roles we know how to render today. Add new values as new sources
+/// land — keep the enum stable; the int values are persisted nowhere.
+/// </summary>
+public enum CareTeamRole
+{
+    PrimaryCareProvider = 1,
+    Specialist = 2,
+    CareManager = 3,
+    BehavioralHealth = 4
+}
+
+public sealed class CareTeamProjector : ICareTeamProjector
+{
+    // Practitioner role codes (FHIR + US Core care-team-member role).
+    private const string PractitionerRoleSystem = "http://terminology.hl7.org/CodeSystem/practitioner-role";
+    private const string NpiSystem = "http://hl7.org/fhir/sid/us-npi";
+    private const string UsCoreCareTeamProfile = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam";
+
+    public JsonObject Project(string memberId, Coverage? coverage, IEnumerable<CareTeamMember> members)
+    {
+        ArgumentNullException.ThrowIfNull(memberId);
+        ArgumentNullException.ThrowIfNull(members);
+
+        var memberList = members.ToList();
+
+        var careTeam = new JsonObject
+        {
+            ["resourceType"] = "CareTeam",
+            ["id"] = $"care-team-{memberId}",
+            ["status"] = MapStatus(coverage, memberList),
+            ["subject"] = new JsonObject
+            {
+                ["reference"] = $"Patient/{memberId}"
+            },
+            ["meta"] = new JsonObject
+            {
+                ["profile"] = new JsonArray(UsCoreCareTeamProfile)
+            }
+        };
+
+        if (memberList.Count > 0)
+        {
+            var earliest = memberList.Min(m => m.EffectiveDate);
+            var latestEnd = memberList.All(m => m.EndDate.HasValue)
+                ? memberList.Max(m => m.EndDate!.Value)
+                : (DateTime?)null;
+
+            var period = new JsonObject { ["start"] = earliest.ToString("o") };
+            if (latestEnd.HasValue) period["end"] = latestEnd.Value.ToString("o");
+            careTeam["period"] = period;
+        }
+
+        if (memberList.Count > 0)
+        {
+            var participants = new JsonArray();
+            foreach (var m in memberList)
+            {
+                participants.Add(BuildParticipant(m));
+            }
+            careTeam["participant"] = participants;
+        }
+
+        return careTeam;
+    }
+
+    private static JsonObject BuildParticipant(CareTeamMember m)
+    {
+        var (code, display) = MapRole(m.Role);
+
+        var participant = new JsonObject
+        {
+            ["role"] = new JsonArray(new JsonObject
+            {
+                ["coding"] = new JsonArray(new JsonObject
+                {
+                    ["system"] = PractitionerRoleSystem,
+                    ["code"] = code,
+                    ["display"] = display
+                })
+            }),
+            ["member"] = new JsonObject
+            {
+                ["type"] = "Practitioner",
+                ["identifier"] = new JsonObject
+                {
+                    ["system"] = NpiSystem,
+                    ["value"] = m.PractitionerNpi
+                },
+                ["display"] = m.DisplayName
+            }
+        };
+
+        var period = new JsonObject { ["start"] = m.EffectiveDate.ToString("o") };
+        if (m.EndDate.HasValue) period["end"] = m.EndDate.Value.ToString("o");
+        participant["period"] = period;
+
+        return participant;
+    }
+
+    private static string MapStatus(Coverage? coverage, IReadOnlyList<CareTeamMember> members)
+    {
+        if (coverage != null && coverage.Status == CoverageStatus.Terminated) return "inactive";
+        if (members.Count == 0) return "proposed";
+        // If every participant has been ended, the team is inactive.
+        if (members.All(m => m.EndDate.HasValue && m.EndDate.Value <= DateTime.UtcNow)) return "inactive";
+        return "active";
+    }
+
+    private static (string code, string display) MapRole(CareTeamRole role) => role switch
+    {
+        CareTeamRole.PrimaryCareProvider => ("doctor", "Primary Care Provider"),
+        CareTeamRole.Specialist => ("doctor", "Specialist"),
+        CareTeamRole.CareManager => ("ict", "Care Manager"),
+        CareTeamRole.BehavioralHealth => ("doctor", "Behavioral Health"),
+        _ => ("doctor", role.ToString())
+    };
+}

--- a/src/services/coverage-service/Services/HttpProviderServiceClient.cs
+++ b/src/services/coverage-service/Services/HttpProviderServiceClient.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace CoverageService.Services;
+
+public sealed class ProviderServiceOptions
+{
+    public string? BaseUrl { get; set; }
+}
+
+/// <summary>
+/// HTTP-backed <see cref="IProviderServiceClient"/>. When BaseUrl is unset
+/// (typical for local dev / tests) <see cref="GetByNpiAsync"/> returns null —
+/// validation will then fail with PROVIDER_NOT_FOUND, which is the right
+/// failure mode in a half-configured environment.
+/// </summary>
+public sealed class HttpProviderServiceClient : IProviderServiceClient
+{
+    private readonly HttpClient _http;
+    private readonly ProviderServiceOptions _options;
+
+    public HttpProviderServiceClient(HttpClient http, IOptions<ProviderServiceOptions> options)
+    {
+        _http = http;
+        _options = options.Value;
+    }
+
+    public async Task<ProviderDto?> GetByNpiAsync(string npi, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.BaseUrl)) return null;
+
+        try
+        {
+            var resp = await _http.GetAsync($"/api/Providers/npi/{Uri.EscapeDataString(npi)}", ct);
+            if (resp.StatusCode == HttpStatusCode.NotFound) return null;
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<ProviderDto>(cancellationToken: ct);
+        }
+        catch (HttpRequestException)
+        {
+            // Network blip / provider-service down — treated as "not found" so
+            // assignment fails with PROVIDER_NOT_FOUND rather than 503-ing the
+            // member-service caller. Operators see this in provider-service health.
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// HTTP-backed <see cref="IPanelCounter"/>. Reads the capitation-service-style
+/// roster endpoint already exposed by coverage-service itself
+/// (GET /api/v1/coverage/by-pcp/{npi}) — but only counts active rows, which is
+/// the same population panel limits gate against.
+/// </summary>
+public sealed class HttpPanelCounter : IPanelCounter
+{
+    private readonly HttpClient _http;
+    private readonly ProviderServiceOptions _options;
+
+    public HttpPanelCounter(HttpClient http, IOptions<ProviderServiceOptions> options)
+    {
+        _http = http;
+        _options = options.Value;
+    }
+
+    public async Task<int> CurrentPanelCountAsync(string tenantId, string providerNpi, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(_options.BaseUrl)) return 0;
+
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get,
+                $"/api/v1/coverage/by-pcp/{Uri.EscapeDataString(providerNpi)}?status=1");
+            req.Headers.Add("X-Tenant-ID", tenantId);
+            using var resp = await _http.SendAsync(req, ct);
+            if (!resp.IsSuccessStatusCode) return 0;
+            var rows = await resp.Content.ReadFromJsonAsync<List<Models.Coverage>>(cancellationToken: ct);
+            return rows?.Count ?? 0;
+        }
+        catch (HttpRequestException)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/services/coverage-service/Services/HttpProviderServiceClient.cs
+++ b/src/services/coverage-service/Services/HttpProviderServiceClient.cs
@@ -56,21 +56,26 @@ public sealed class HttpProviderServiceClient : IProviderServiceClient
 /// roster endpoint already exposed by coverage-service itself
 /// (GET /api/v1/coverage/by-pcp/{npi}) — but only counts active rows, which is
 /// the same population panel limits gate against.
+///
+/// Enabled/disabled via <see cref="HttpClient.BaseAddress"/>: when the endpoint
+/// URL is not configured in Program.cs we leave BaseAddress null and this
+/// counter short-circuits to 0. That is deliberately decoupled from
+/// <see cref="ProviderServiceOptions"/>, which belongs to
+/// <see cref="HttpProviderServiceClient"/> only — the counter hits a different
+/// service (capitation / coverage) and must not inherit provider-service config.
 /// </summary>
 public sealed class HttpPanelCounter : IPanelCounter
 {
     private readonly HttpClient _http;
-    private readonly ProviderServiceOptions _options;
 
-    public HttpPanelCounter(HttpClient http, IOptions<ProviderServiceOptions> options)
+    public HttpPanelCounter(HttpClient http)
     {
         _http = http;
-        _options = options.Value;
     }
 
     public async Task<int> CurrentPanelCountAsync(string tenantId, string providerNpi, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(_options.BaseUrl)) return 0;
+        if (_http.BaseAddress is null) return 0;
 
         try
         {

--- a/src/services/coverage-service/Services/IProviderServiceClient.cs
+++ b/src/services/coverage-service/Services/IProviderServiceClient.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoverageService.Services;
+
+/// <summary>
+/// Typed client into provider-service. coverage-service consults this for PCP
+/// validation — provider record, network participations, panel limits.
+///
+/// DTO shape mirrors provider-service's <c>Provider</c> closely enough for our
+/// uses without taking a project reference. Fields we don't need (bank account,
+/// hospital affiliations, etc.) are intentionally omitted.
+/// </summary>
+public interface IProviderServiceClient
+{
+    /// <summary>Look up a provider by NPI. Returns null on 404.</summary>
+    Task<ProviderDto?> GetByNpiAsync(string npi, CancellationToken ct = default);
+}
+
+/// <summary>
+/// In-process panel counter. Production binding hits capitation-service
+/// <c>GET /api/coverage/by-pcp/{npi}</c> count; tests bind a fake.
+/// </summary>
+public interface IPanelCounter
+{
+    /// <summary>
+    /// Current count of members assigned to this NPI. Inherently racy; see
+    /// <c>docs/architecture/pcp-assignment.md</c> "Panel race" section.
+    /// </summary>
+    Task<int> CurrentPanelCountAsync(string tenantId, string providerNpi, CancellationToken ct = default);
+}
+
+public sealed class ProviderDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string NPI { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public string PrimarySpecialty { get; set; } = string.Empty;
+    public ProviderStatusDto Status { get; set; } = ProviderStatusDto.Active;
+    public CredentialingStatusDto CredentialingStatus { get; set; } = CredentialingStatusDto.Pending;
+    public bool AcceptingNewPatients { get; set; } = true;
+    public List<NetworkParticipationDto> NetworkParticipations { get; set; } = new();
+}
+
+public sealed class NetworkParticipationDto
+{
+    public string? PlanId { get; set; }
+    public Models.LineOfBusiness LineOfBusiness { get; set; }
+    public string NetworkTier { get; set; } = "Tier1";
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+    public bool AcceptingNewPatients { get; set; } = true;
+    public int? PanelLimit { get; set; }
+    public bool? PanelAccepted { get; set; }
+    public List<Models.LineOfBusiness> AcceptedLobs { get; set; } = new();
+    public int? MinAcceptedAgeYears { get; set; }
+    public int? MaxAcceptedAgeYears { get; set; }
+}
+
+public enum ProviderStatusDto
+{
+    Active = 1,
+    Inactive = 2,
+    Terminated = 3,
+    Pending = 4
+}
+
+public enum CredentialingStatusDto
+{
+    Pending = 1,
+    Approved = 2,
+    Denied = 3,
+    Expired = 4,
+    Suspended = 5
+}

--- a/src/services/coverage-service/Services/PcpAssignmentService.cs
+++ b/src/services/coverage-service/Services/PcpAssignmentService.cs
@@ -1,0 +1,262 @@
+using CoverageService.Models;
+using CoverageService.Repositories;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoverageService.Services;
+
+/// <summary>
+/// Result of an assignment attempt. Either <see cref="Assignment"/> is populated
+/// (success) or <see cref="Error"/> is (validation failure).
+/// </summary>
+public sealed class PcpAssignmentResult
+{
+    public PcpAssignment? Assignment { get; init; }
+    public PcpValidationError? Error { get; init; }
+    public bool IsSuccess => Assignment != null;
+
+    public static PcpAssignmentResult Ok(PcpAssignment assignment) => new() { Assignment = assignment };
+    public static PcpAssignmentResult Fail(PcpValidationError error) => new() { Error = error };
+}
+
+public interface IPcpAssignmentService
+{
+    Task<PcpAssignmentResult> AssignAsync(string tenantId, string memberId, AssignPcpCommand cmd, CancellationToken ct = default);
+    Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId, CancellationToken ct = default);
+    Task<IReadOnlyList<PcpAssignment>> GetHistoryAsync(string tenantId, string memberId, CancellationToken ct = default);
+}
+
+public sealed class AssignPcpCommand
+{
+    public string ProviderNpi { get; set; } = string.Empty;
+    public string? ProviderId { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public string? Reason { get; set; }
+    public PcpAssignmentSource Source { get; set; } = PcpAssignmentSource.MemberChoice;
+    public DateTime? MemberDateOfBirth { get; set; }
+    public string? AssignedBy { get; set; }
+}
+
+/// <summary>
+/// PCP assignment with a fail-fast validation ladder. The order of checks is the
+/// API contract — the first failure is what gets returned to the caller, logged,
+/// and metric'd, so callers can build deterministic remediation flows.
+///
+/// On success: closes the prior open assignment row (stamps EndDate), writes a
+/// new <see cref="PcpAssignment"/>, and updates the denormalized PCP fields on
+/// every active <see cref="Coverage"/> for the member.
+/// </summary>
+public sealed class PcpAssignmentService : IPcpAssignmentService
+{
+    private readonly ICoverageRepository _coverage;
+    private readonly IPcpAssignmentRepository _assignments;
+    private readonly IProviderServiceClient _providers;
+    private readonly IPanelCounter _panel;
+    private readonly ILogger<PcpAssignmentService> _logger;
+
+    public PcpAssignmentService(
+        ICoverageRepository coverage,
+        IPcpAssignmentRepository assignments,
+        IProviderServiceClient providers,
+        IPanelCounter panel,
+        ILogger<PcpAssignmentService> logger)
+    {
+        _coverage = coverage;
+        _assignments = assignments;
+        _providers = providers;
+        _panel = panel;
+        _logger = logger;
+    }
+
+    public Task<PcpAssignment?> GetCurrentAsync(string tenantId, string memberId, CancellationToken ct = default)
+        => _assignments.GetCurrentAsync(tenantId, memberId);
+
+    public Task<IReadOnlyList<PcpAssignment>> GetHistoryAsync(string tenantId, string memberId, CancellationToken ct = default)
+        => _assignments.GetHistoryAsync(tenantId, memberId);
+
+    public async Task<PcpAssignmentResult> AssignAsync(
+        string tenantId, string memberId, AssignPcpCommand cmd, CancellationToken ct = default)
+    {
+        // Pre-flight: needs to come before the validation ladder because without
+        // active coverage there's nothing to attach the assignment to.
+        var effective = cmd.EffectiveDate == default ? DateTime.UtcNow.Date : cmd.EffectiveDate.Date;
+        var coverages = await _coverage.GetActiveCoverageByMemberIdAsync(tenantId, memberId, effective);
+        if (coverages.Count == 0)
+        {
+            return PcpAssignmentResult.Fail(new PcpValidationError(
+                PcpValidationCodes.NoActiveCoverage, "memberId",
+                "No active coverage for member on the requested effective date."));
+        }
+
+        if (string.IsNullOrWhiteSpace(cmd.ProviderNpi) || cmd.ProviderNpi.Length != 10 || !cmd.ProviderNpi.All(char.IsDigit))
+        {
+            return PcpAssignmentResult.Fail(new PcpValidationError(
+                PcpValidationCodes.InvalidNpi, "providerNpi",
+                "providerNpi must be exactly 10 digits."));
+        }
+
+        // Pick the canonical coverage to validate against — if a member has
+        // multiple active coverages (e.g., Medical + Dental), the medical one
+        // (LineOfBusiness != Dental) drives PCP rules.
+        var primary = coverages.OrderBy(c => (int)c.LineOfBusiness).First();
+
+        // ── Validation ladder ─────────────────────────────────────────────
+        // Order matters; first failure wins. Do NOT reorder without a portal+API
+        // changelog entry — error codes are an integration contract.
+
+        var provider = await _providers.GetByNpiAsync(cmd.ProviderNpi, ct);
+        if (provider == null)
+        {
+            return Fail(PcpValidationCodes.ProviderNotFound, "providerNpi",
+                $"Provider with NPI {cmd.ProviderNpi} not found in directory.");
+        }
+
+        if (provider.Status != ProviderStatusDto.Active)
+        {
+            return Fail(PcpValidationCodes.ProviderInactive, "providerNpi",
+                $"Provider is {provider.Status}; only Active providers may be assigned as PCP.");
+        }
+
+        if (provider.CredentialingStatus != CredentialingStatusDto.Approved)
+        {
+            return Fail(PcpValidationCodes.ProviderNotCredentialed, "providerNpi",
+                $"Provider credentialing is {provider.CredentialingStatus}; must be Approved.");
+        }
+
+        var participation = SelectParticipation(provider, primary, effective);
+        if (participation == null)
+        {
+            return Fail(PcpValidationCodes.NoNetworkParticipation, "providerNpi",
+                $"Provider has no active network participation for plan {primary.PlanId} / LOB {primary.LineOfBusiness}.");
+        }
+
+        // PanelAccepted overrides the broader AcceptingNewPatients flag — a
+        // provider may be open to referrals but closed to new PCP assignments.
+        var panelAccepted = participation.PanelAccepted ?? participation.AcceptingNewPatients;
+        if (!panelAccepted)
+        {
+            return Fail(PcpValidationCodes.NotAcceptingPatients, "providerNpi",
+                "Provider is not currently accepting new PCP patients on this participation.");
+        }
+
+        if (participation.AcceptedLobs.Count > 0 && !participation.AcceptedLobs.Contains(primary.LineOfBusiness))
+        {
+            return Fail(PcpValidationCodes.LobNotAccepted, "providerNpi",
+                $"Provider does not accept LOB {primary.LineOfBusiness} as PCP on this participation.");
+        }
+
+        if (cmd.MemberDateOfBirth.HasValue)
+        {
+            var ageYears = AgeInYears(cmd.MemberDateOfBirth.Value, effective);
+            if (participation.MinAcceptedAgeYears.HasValue && ageYears < participation.MinAcceptedAgeYears.Value)
+            {
+                return Fail(PcpValidationCodes.AgeOutOfRange, "memberId",
+                    $"Member age {ageYears} below provider's minimum accepted age {participation.MinAcceptedAgeYears.Value}.");
+            }
+            if (participation.MaxAcceptedAgeYears.HasValue && ageYears > participation.MaxAcceptedAgeYears.Value)
+            {
+                return Fail(PcpValidationCodes.AgeOutOfRange, "memberId",
+                    $"Member age {ageYears} above provider's maximum accepted age {participation.MaxAcceptedAgeYears.Value}.");
+            }
+        }
+
+        if (participation.PanelLimit.HasValue)
+        {
+            // Inherently racy — between this read and the AddAsync below, another
+            // assignment can land. Documented in docs/architecture/pcp-assignment.md
+            // "Panel race" — Phase 1 accepts the slack, nightly reconciliation
+            // (PcpPanelReconciliationJob) flags over-limit panels. Phase 2 will move
+            // to a Redis lock per (tenantId, npi) — see Addendum A.7.2.
+            // TODO(addendum-a): replace with TryAcquireAsync(npi) -> ITransientLock.
+            var current = await _panel.CurrentPanelCountAsync(tenantId, cmd.ProviderNpi, ct);
+            if (current >= participation.PanelLimit.Value)
+            {
+                return Fail(PcpValidationCodes.PanelFull, "providerNpi",
+                    $"Provider panel is full ({current} / {participation.PanelLimit.Value}).");
+            }
+        }
+
+        // ── Validation passed; persist ────────────────────────────────────
+
+        var networkStatus = string.IsNullOrEmpty(participation.NetworkTier)
+            ? "InNetwork"
+            : participation.NetworkTier;
+
+        // Close any open prior row(s). EndDate = effective so the audit trail
+        // shows continuity (no gap between assignments).
+        await _assignments.EndOpenAssignmentsAsync(tenantId, memberId, effective);
+
+        var assignment = await _assignments.AddAsync(new PcpAssignment
+        {
+            TenantId = tenantId,
+            MemberId = memberId,
+            CoverageId = primary.Id,
+            ProviderId = cmd.ProviderId ?? provider.Id,
+            ProviderNpi = cmd.ProviderNpi,
+            ProviderName = provider.FullName,
+            EffectiveDate = effective,
+            EndDate = null,
+            AssignmentReason = cmd.Reason,
+            AssignmentSource = cmd.Source,
+            NetworkStatusAtAssignment = networkStatus,
+            AssignedBy = cmd.AssignedBy
+        });
+
+        // Update denormalized PCP fields on every active coverage (read-path
+        // optimization preserved from the prior implementation).
+        foreach (var cov in coverages)
+        {
+            if (!string.IsNullOrEmpty(cov.PcpNpi) && cov.PcpNpi != cmd.ProviderNpi)
+            {
+                cov.PreviousPcpNpi = cov.PcpNpi;
+            }
+            cov.PcpNpi = cmd.ProviderNpi;
+            cov.PcpName = provider.FullName;
+            cov.PcpAssignmentDate = effective;
+            cov.PcpAssignmentMethod = cmd.Source switch
+            {
+                PcpAssignmentSource.MemberChoice => PcpAssignmentMethod.MemberSelected,
+                PcpAssignmentSource.AutoAssigned => PcpAssignmentMethod.AutoAssigned,
+                PcpAssignmentSource.AdminAssigned => PcpAssignmentMethod.MemberSelected,
+                _ => PcpAssignmentMethod.MemberSelected
+            };
+            cov.LastUpdatedDate = DateTime.UtcNow;
+            cov.LastUpdatedBy = cmd.AssignedBy ?? "pcp-assignment-service";
+            await _coverage.UpdateAsync(cov);
+        }
+
+        _logger.LogInformation(
+            "PCP assigned tenant={TenantId} member={MemberId} npi={Npi} source={Source}",
+            tenantId, memberId, cmd.ProviderNpi, cmd.Source);
+
+        return PcpAssignmentResult.Ok(assignment);
+    }
+
+    private static NetworkParticipationDto? SelectParticipation(ProviderDto provider, Coverage coverage, DateTime asOf)
+    {
+        return provider.NetworkParticipations
+            .Where(np => (np.PlanId == null || np.PlanId == coverage.PlanId)
+                         && np.LineOfBusiness == coverage.LineOfBusiness
+                         && np.EffectiveDate.Date <= asOf
+                         && (np.TerminationDate == null || np.TerminationDate.Value.Date >= asOf))
+            .OrderBy(np => np.NetworkTier) // Tier1 wins
+            .FirstOrDefault();
+    }
+
+    private static int AgeInYears(DateTime dob, DateTime asOf)
+    {
+        var age = asOf.Year - dob.Year;
+        if (asOf < dob.AddYears(age)) age--;
+        return age;
+    }
+
+    private PcpAssignmentResult Fail(string code, string field, string message)
+    {
+        _logger.LogInformation("PCP validation failed code={Code} field={Field}", code, field);
+        return PcpAssignmentResult.Fail(new PcpValidationError(code, field, message));
+    }
+}

--- a/src/services/coverage-service/Services/PcpAssignmentService.cs
+++ b/src/services/coverage-service/Services/PcpAssignmentService.cs
@@ -213,9 +213,29 @@ public sealed class PcpAssignmentService : IPcpAssignmentService
             AssignedBy = cmd.AssignedBy
         });
 
-        // Update denormalized PCP fields on every active coverage (read-path
-        // optimization preserved from the prior implementation).
-        foreach (var cov in coverages)
+        // Update denormalized PCP fields only on PCP-eligible medical coverage
+        // rows. Dental / Vision / Life / etc. rows never carry a PCP — stamping
+        // them produces nonsense for downstream readers. This mirrors the
+        // validation-side filter above (primary = Health-coded row). See PR #656
+        // cleanup pass.
+        //
+        // Legacy fallback: rows loaded before InsuranceLineCode was required may
+        // have a null/empty line code. When no Health row exists, stamp all
+        // active rows as before so existing tenants don't regress silently.
+        var denormTargets = coverages
+            .Where(c => c.InsuranceLineCode == InsuranceLineCodes.Health)
+            .ToList();
+        if (denormTargets.Count == 0) denormTargets = coverages.ToList();
+
+        var method = cmd.Source switch
+        {
+            PcpAssignmentSource.MemberChoice => PcpAssignmentMethod.MemberSelected,
+            PcpAssignmentSource.AutoAssigned => PcpAssignmentMethod.AutoAssigned,
+            PcpAssignmentSource.AdminAssigned => PcpAssignmentMethod.Administrative,
+            _ => PcpAssignmentMethod.MemberSelected
+        };
+
+        foreach (var cov in denormTargets)
         {
             if (!string.IsNullOrEmpty(cov.PcpNpi) && cov.PcpNpi != cmd.ProviderNpi)
             {
@@ -224,13 +244,7 @@ public sealed class PcpAssignmentService : IPcpAssignmentService
             cov.PcpNpi = cmd.ProviderNpi;
             cov.PcpName = provider.FullName;
             cov.PcpAssignmentDate = effective;
-            cov.PcpAssignmentMethod = cmd.Source switch
-            {
-                PcpAssignmentSource.MemberChoice => PcpAssignmentMethod.MemberSelected,
-                PcpAssignmentSource.AutoAssigned => PcpAssignmentMethod.AutoAssigned,
-                PcpAssignmentSource.AdminAssigned => PcpAssignmentMethod.MemberSelected,
-                _ => PcpAssignmentMethod.MemberSelected
-            };
+            cov.PcpAssignmentMethod = method;
             cov.LastUpdatedDate = DateTime.UtcNow;
             cov.LastUpdatedBy = cmd.AssignedBy ?? "pcp-assignment-service";
             await _coverage.UpdateAsync(cov);

--- a/src/services/coverage-service/Services/PcpAssignmentService.cs
+++ b/src/services/coverage-service/Services/PcpAssignmentService.cs
@@ -100,9 +100,16 @@ public sealed class PcpAssignmentService : IPcpAssignmentService
         }
 
         // Pick the canonical coverage to validate against — if a member has
-        // multiple active coverages (e.g., Medical + Dental), the medical one
-        // (LineOfBusiness != Dental) drives PCP rules.
-        var primary = coverages.OrderBy(c => (int)c.LineOfBusiness).First();
+        // multiple active coverages (e.g., Medical + Dental), the Health line
+        // drives PCP rules. `LineOfBusiness` is Commercial/Medicare/etc., it
+        // does NOT distinguish Health from Dental; the discriminator lives on
+        // `InsuranceLineCode` (HLT/DEN/VIS/LIF). Fall back to LOB ordering only
+        // when no Health-coded row exists (legacy data).
+        var primary = coverages
+            .Where(c => c.InsuranceLineCode == InsuranceLineCodes.Health)
+            .OrderBy(c => (int)c.LineOfBusiness)
+            .FirstOrDefault()
+            ?? coverages.OrderBy(c => (int)c.LineOfBusiness).First();
 
         // ── Validation ladder ─────────────────────────────────────────────
         // Order matters; first failure wins. Do NOT reorder without a portal+API
@@ -231,9 +238,15 @@ public sealed class PcpAssignmentService : IPcpAssignmentService
 
         _logger.LogInformation(
             "PCP assigned tenant={TenantId} member={MemberId} npi={Npi} source={Source}",
-            tenantId, memberId, cmd.ProviderNpi, cmd.Source);
+            Sanitize(tenantId), Sanitize(memberId), Sanitize(cmd.ProviderNpi), cmd.Source);
 
         return PcpAssignmentResult.Ok(assignment);
+    }
+
+    private static string Sanitize(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
     private static NetworkParticipationDto? SelectParticipation(ProviderDto provider, Coverage coverage, DateTime asOf)

--- a/src/services/coverage-service/Services/PcpPanelReconciliationJob.cs
+++ b/src/services/coverage-service/Services/PcpPanelReconciliationJob.cs
@@ -1,0 +1,72 @@
+using CoverageService.Repositories;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoverageService.Services;
+
+/// <summary>
+/// Stub of the nightly panel reconciliation. Counts open assignments per (tenant,
+/// NPI) and logs anything that exceeds the provider's <c>PanelLimit</c>.
+///
+/// This intentionally has no scheduler bound to it yet — the goal of the stub is
+/// to make the observability path exist before the panel race actually bites.
+/// Wiring it to a hosted background service / Azure Function trigger is tracked
+/// under roadmap 5.7 Phase 2 alongside the Redis-lock work
+/// (see docs/architecture/pcp-assignment.md "Panel race").
+///
+/// TODO(addendum-a): trigger from a HostedService cron and emit a metric per
+/// over-limit panel so on-call can alert on sustained overage.
+/// </summary>
+public sealed class PcpPanelReconciliationJob
+{
+    private readonly IPcpAssignmentRepository _assignments;
+    private readonly IProviderServiceClient _providers;
+    private readonly ILogger<PcpPanelReconciliationJob> _logger;
+
+    public PcpPanelReconciliationJob(
+        IPcpAssignmentRepository assignments,
+        IProviderServiceClient providers,
+        ILogger<PcpPanelReconciliationJob> logger)
+    {
+        _assignments = assignments;
+        _providers = providers;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the list of (npi, currentCount, limit) tuples that exceed their
+    /// configured limit. Caller is responsible for emitting metrics or paging.
+    /// </summary>
+    public async Task<IReadOnlyList<PanelOverageReport>> ScanAsync(
+        string tenantId, IEnumerable<string> npisToCheck, CancellationToken ct = default)
+    {
+        var report = new List<PanelOverageReport>();
+        foreach (var npi in npisToCheck)
+        {
+            var provider = await _providers.GetByNpiAsync(npi, ct);
+            if (provider == null) continue;
+
+            var count = await _assignments.CountOpenByNpiAsync(tenantId, npi);
+
+            // Check every participation — if any has a limit and we're over it, flag.
+            foreach (var part in provider.NetworkParticipations)
+            {
+                if (!part.PanelLimit.HasValue) continue;
+                if (count > part.PanelLimit.Value)
+                {
+                    var entry = new PanelOverageReport(npi, count, part.PanelLimit.Value, part.LineOfBusiness.ToString());
+                    report.Add(entry);
+                    _logger.LogWarning(
+                        "PCP panel over-limit tenant={TenantId} npi={Npi} count={Count} limit={Limit} lob={Lob}",
+                        tenantId, npi, count, part.PanelLimit.Value, part.LineOfBusiness);
+                }
+            }
+        }
+        return report;
+    }
+}
+
+public sealed record PanelOverageReport(string Npi, int CurrentCount, int Limit, string Lob);

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -493,7 +493,7 @@ public class MembersController : ControllerBase
         }
         catch (DownstreamUnavailableException ex)
         {
-            _logger?.LogDebug(ex, "PCP lookup unavailable while projecting FHIR Patient for {MemberId}; emitting without generalPractitioner.", memberId);
+            _logger?.LogDebug(ex, "PCP lookup unavailable while projecting FHIR Patient for {MemberId}; emitting without generalPractitioner.", SanitizeForLog(memberId));
         }
 
         var patient = _fhirProjector.Project(member, pcp);
@@ -709,6 +709,12 @@ public class MembersController : ControllerBase
     }
 
     // ── Helpers ──────────────────────────────────────────────────────
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
 
     private IActionResult DownstreamUnavailable(DownstreamUnavailableException ex)
     {

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -482,7 +482,21 @@ public class MembersController : ControllerBase
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
-        var patient = _fhirProjector.Project(member);
+        // Best-effort PCP fetch so Patient.generalPractitioner is populated when
+        // available. Failures (downstream unavailable, no PCP yet) silently
+        // degrade to a Patient resource without generalPractitioner — that's
+        // valid US Core; we don't 503 the FHIR read for a missing optional.
+        MemberPcpResponse? pcp = null;
+        try
+        {
+            pcp = await _coverage.GetPcpAsync(TenantId, memberId, HttpContext.RequestAborted);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            _logger?.LogDebug(ex, "PCP lookup unavailable while projecting FHIR Patient for {MemberId}; emitting without generalPractitioner.", memberId);
+        }
+
+        var patient = _fhirProjector.Project(member, pcp);
         return new ContentResult
         {
             ContentType = "application/fhir+json",
@@ -529,7 +543,8 @@ public class MembersController : ControllerBase
     }
 
     [HttpPut("{memberId}/pcp")]
-    [ProducesResponseType(200)]
+    [ProducesResponseType(typeof(MemberPcpResponse), 200)]
+    [ProducesResponseType(typeof(PcpValidationProblem), 400)]
     [ProducesResponseType(404)]
     [ProducesResponseType(503)]
     public async Task<IActionResult> AssignPcp(
@@ -540,15 +555,28 @@ public class MembersController : ControllerBase
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
-        MemberPcpResponse result;
+        // Forward the member's DOB so coverage-service can enforce age-range
+        // panels (pediatric vs adult) without an extra round-trip.
+        if (request.MemberDateOfBirth == null) request.MemberDateOfBirth = member.DateOfBirth;
+
+        AssignPcpOutcome outcome;
         try
         {
-            result = await _coverage.AssignPcpAsync(TenantId, memberId, request, ct);
+            outcome = await _coverage.AssignPcpAsync(TenantId, memberId, request, ct);
         }
         catch (DownstreamUnavailableException ex)
         {
             return DownstreamUnavailable(ex);
         }
+
+        // Validation rejection — surface the structured error verbatim so the
+        // portal can localize off the code. Do NOT publish a PcpChanged event.
+        if (!outcome.IsSuccess)
+        {
+            return BadRequest(outcome.ValidationError);
+        }
+
+        var result = outcome.Pcp!;
 
         // PUT /pcp is its own primary event — not a sub-event of an UpdateMember
         // call — so its EventId comes from the request body (caller-supplied
@@ -564,12 +592,39 @@ public class MembersController : ControllerBase
             Payload = new JsonObject
             {
                 ["providerId"] = request.ProviderId,
+                ["providerNpi"] = request.ProviderNpi,
                 ["effectiveDate"] = request.EffectiveDate.ToString("o"),
-                ["reason"] = request.Reason
+                ["reason"] = request.Reason,
+                ["assignmentSource"] = request.AssignmentSource
             }
         }, ct);
 
         return Ok(result);
+    }
+
+    /// <summary>
+    /// Full PCP assignment history for a member, newest first. Proxies through to
+    /// coverage-service so portal / consent / audit stay on the member-service
+    /// boundary.
+    /// </summary>
+    [HttpGet("{memberId}/pcp/history")]
+    [ProducesResponseType(typeof(IReadOnlyList<PcpAssignmentHistoryItem>), 200)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(503)]
+    public async Task<IActionResult> GetMemberPcpHistory([FromRoute] string memberId, CancellationToken ct)
+    {
+        var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        try
+        {
+            var history = await _coverage.GetPcpHistoryAsync(TenantId, memberId, ct);
+            return Ok(history);
+        }
+        catch (DownstreamUnavailableException ex)
+        {
+            return DownstreamUnavailable(ex);
+        }
     }
 
     [HttpGet("{memberId}/coverage-history")]
@@ -893,6 +948,19 @@ public class AssignPcpRequest
     public string? ProviderNpi { get; set; }
     public DateTime EffectiveDate { get; set; }
     public string? Reason { get; set; }
+
+    /// <summary>
+    /// Origin of the assignment: <c>MemberChoice</c> (default), <c>AutoAssigned</c>,
+    /// or <c>AdminAssigned</c>. Forwarded to coverage-service and recorded on the
+    /// PcpAssignment history row + PcpChanged event payload.
+    /// </summary>
+    public string? AssignmentSource { get; set; }
+
+    /// <summary>
+    /// Member DOB forwarded to coverage-service for age-range panel validation.
+    /// Auto-populated from the member record when omitted.
+    /// </summary>
+    public DateTime? MemberDateOfBirth { get; set; }
 
     /// <summary>Optional idempotency key for the PcpChanged event.</summary>
     public string? EventId { get; set; }

--- a/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
@@ -236,7 +236,7 @@ public class MembersControllerTests
         var (ctl, _, events, coverage, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         coverage.Setup(c => c.AssignPcpAsync(Tenant, "M-001", It.IsAny<AssignPcpRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new MemberPcpResponse { ProviderId = "prov-1" });
+            .ReturnsAsync(new AssignPcpOutcome { Pcp = new MemberPcpResponse { ProviderId = "prov-1" } });
 
         var resp = await ctl.AssignPcp("M-001",
             new AssignPcpRequest { ProviderId = "prov-1", EffectiveDate = DateTime.UtcNow },

--- a/src/services/member-service/MemberService.Tests/Services/FhirPatientProjectorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FhirPatientProjectorTests.cs
@@ -169,4 +169,32 @@ public class FhirPatientProjectorTests
         json["resourceType"]!.ToString().Should().Be("Patient");
         json["identifier"]!.AsArray().Should().ContainSingle();
     }
+
+    [Fact]
+    public void Project_WithPcp_EmitsGeneralPractitionerWithNpiIdentifier()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember(), new MemberService.Controllers.MemberPcpResponse
+        {
+            ProviderId = "prov-1",
+            ProviderName = "Dr. Test, MD",
+            NPI = "1234567890",
+            Specialty = "Internal Medicine",
+            NetworkStatus = "In-Network",
+            AssignedDate = DateTime.UtcNow
+        });
+
+        var gp = json["generalPractitioner"]!.AsArray();
+        gp.Count.Should().Be(1);
+        gp[0]!["type"]!.ToString().Should().Be("Practitioner");
+        gp[0]!["identifier"]!["system"]!.ToString().Should().Be("http://hl7.org/fhir/sid/us-npi");
+        gp[0]!["identifier"]!["value"]!.ToString().Should().Be("1234567890");
+        gp[0]!["display"]!.ToString().Should().Be("Dr. Test, MD");
+    }
+
+    [Fact]
+    public void Project_WithoutPcp_OmitsGeneralPractitioner()
+    {
+        var json = new FhirPatientProjector().Project(BuildMember(), null);
+        json.ContainsKey("generalPractitioner").Should().BeFalse();
+    }
 }

--- a/src/services/member-service/Services/FakeDownstreamClients.cs
+++ b/src/services/member-service/Services/FakeDownstreamClients.cs
@@ -23,16 +23,37 @@ public sealed class FakeCoverageServiceClient : ICoverageServiceClient
             Phone = "555-555-0100"
         });
 
-    public Task<MemberPcpResponse> AssignPcpAsync(
+    public Task<AssignPcpOutcome> AssignPcpAsync(
         string tenantId, string memberId, AssignPcpRequest request, CancellationToken ct = default)
-        => Task.FromResult(new MemberPcpResponse
+        => Task.FromResult(new AssignPcpOutcome
         {
-            ProviderId = request.ProviderId,
-            ProviderName = "Dr. Dev Fixture, MD",
-            NPI = "1234567890",
-            Specialty = "Internal Medicine",
-            NetworkStatus = "In-Network",
-            AssignedDate = request.EffectiveDate
+            Pcp = new MemberPcpResponse
+            {
+                ProviderId = request.ProviderId,
+                ProviderName = "Dr. Dev Fixture, MD",
+                NPI = "1234567890",
+                Specialty = "Internal Medicine",
+                NetworkStatus = "In-Network",
+                AssignedDate = request.EffectiveDate
+            }
+        });
+
+    public Task<IReadOnlyList<PcpAssignmentHistoryItem>> GetPcpHistoryAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<PcpAssignmentHistoryItem>>(new List<PcpAssignmentHistoryItem>
+        {
+            new()
+            {
+                Id = "dev-pcp-history-1",
+                MemberId = memberId,
+                CoverageId = "dev-coverage",
+                ProviderNpi = "1234567890",
+                ProviderName = "Dr. Dev Fixture, MD",
+                EffectiveDate = DateTime.UtcNow.AddMonths(-6),
+                AssignmentSource = "MemberChoice",
+                NetworkStatusAtAssignment = "InNetwork",
+                CreatedDate = DateTime.UtcNow.AddMonths(-6)
+            }
         });
 
     public Task<IReadOnlyList<CoverageHistoryEvent>> GetCoverageHistoryAsync(

--- a/src/services/member-service/Services/FhirPatientProjector.cs
+++ b/src/services/member-service/Services/FhirPatientProjector.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using MemberService.Controllers;
 using MemberService.Models;
 using static MemberService.Services.FhirExtensionBuilder;
 
@@ -16,7 +17,11 @@ namespace MemberService.Services;
 /// </summary>
 public sealed class FhirPatientProjector : IFhirPatientProjector
 {
-    public JsonObject Project(Member member)
+    private const string NpiSystem = "http://hl7.org/fhir/sid/us-npi";
+
+    public JsonObject Project(Member member) => Project(member, null);
+
+    public JsonObject Project(Member member, MemberPcpResponse? pcp)
     {
         ArgumentNullException.ThrowIfNull(member);
 
@@ -192,6 +197,29 @@ public sealed class FhirPatientProjector : IFhirPatientProjector
             });
         }
         if (communications.Count > 0) patient["communication"] = communications;
+
+        // ── General Practitioner (PCP) ───────────────────────────────
+        // Emitted only when caller supplied PCP context — projection should
+        // remain pure (no side-effecting fetches). NPI is the stable external
+        // id, so the reference uses an identifier-shaped Reference; consumers
+        // that have a Practitioner record already can swap it for a logical
+        // Practitioner/{id} reference.
+        if (pcp != null && !string.IsNullOrEmpty(pcp.NPI))
+        {
+            patient["generalPractitioner"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "Practitioner",
+                    ["identifier"] = new JsonObject
+                    {
+                        ["system"] = NpiSystem,
+                        ["value"] = pcp.NPI
+                    },
+                    ["display"] = string.IsNullOrEmpty(pcp.ProviderName) ? pcp.NPI : pcp.ProviderName
+                }
+            };
+        }
 
         // ── Meta ─────────────────────────────────────────────────────
         patient["meta"] = new JsonObject

--- a/src/services/member-service/Services/HttpCoverageServiceClient.cs
+++ b/src/services/member-service/Services/HttpCoverageServiceClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using MemberService.Controllers;
 using Microsoft.Extensions.Options;
 
@@ -64,8 +65,17 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
                 // Coverage-service emits a structured PcpValidationError on 400.
                 // Surface it through AssignPcpOutcome so the controller can
                 // forward it as 400 — do NOT throw, this is a normal validation
-                // outcome, not a downstream failure.
-                var problem = await resp.Content.ReadFromJsonAsync<PcpValidationProblem>(cancellationToken: ct);
+                // outcome, not a downstream failure. If the body is missing or
+                // non-JSON (unexpected) we still degrade to a generic error
+                // rather than raising a 500.
+                PcpValidationProblem? problem = null;
+                try
+                {
+                    problem = await resp.Content.ReadFromJsonAsync<PcpValidationProblem>(cancellationToken: ct);
+                }
+                catch (JsonException) { /* fall through to default */ }
+                catch (NotSupportedException) { /* non-JSON content-type */ }
+
                 return new AssignPcpOutcome
                 {
                     ValidationError = problem ?? new PcpValidationProblem
@@ -82,6 +92,11 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         }
         catch (HttpRequestException ex)
         {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+        catch (JsonException ex)
+        {
+            // Success body that didn't match the expected shape → treat as 503.
             throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
         }
     }
@@ -103,6 +118,12 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         catch (HttpRequestException ex)
         {
             throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+        catch (JsonException ex)
+        {
+            // Coverage-service wire shape drift — better to 503 than to leak a 500.
+            throw new DownstreamUnavailableException(
+                ServiceName, $"PCP history response deserialization failed: {ex.Message}", ex);
         }
     }
 

--- a/src/services/member-service/Services/HttpCoverageServiceClient.cs
+++ b/src/services/member-service/Services/HttpCoverageServiceClient.cs
@@ -47,7 +47,7 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         }
     }
 
-    public async Task<MemberPcpResponse> AssignPcpAsync(
+    public async Task<AssignPcpOutcome> AssignPcpAsync(
         string tenantId, string memberId, AssignPcpRequest request, CancellationToken ct = default)
     {
         EnsureConfigured();
@@ -59,9 +59,46 @@ public sealed class HttpCoverageServiceClient : ICoverageServiceClient
         try
         {
             using var resp = await _http.SendAsync(req, ct);
+            if (resp.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                // Coverage-service emits a structured PcpValidationError on 400.
+                // Surface it through AssignPcpOutcome so the controller can
+                // forward it as 400 — do NOT throw, this is a normal validation
+                // outcome, not a downstream failure.
+                var problem = await resp.Content.ReadFromJsonAsync<PcpValidationProblem>(cancellationToken: ct);
+                return new AssignPcpOutcome
+                {
+                    ValidationError = problem ?? new PcpValidationProblem
+                    {
+                        Code = "VALIDATION_FAILED",
+                        Message = "PCP assignment rejected by coverage-service."
+                    }
+                };
+            }
             resp.EnsureSuccessStatusCode();
-            return await resp.Content.ReadFromJsonAsync<MemberPcpResponse>(cancellationToken: ct)
+            var pcp = await resp.Content.ReadFromJsonAsync<MemberPcpResponse>(cancellationToken: ct)
                 ?? throw new DownstreamUnavailableException(ServiceName, "Empty response body");
+            return new AssignPcpOutcome { Pcp = pcp };
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DownstreamUnavailableException(ServiceName, ex.Message, ex);
+        }
+    }
+
+    public async Task<IReadOnlyList<PcpAssignmentHistoryItem>> GetPcpHistoryAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        EnsureConfigured();
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/pcp/history");
+        req.Headers.Add("X-Tenant-ID", tenantId);
+        try
+        {
+            using var resp = await _http.SendAsync(req, ct);
+            resp.EnsureSuccessStatusCode();
+            return await resp.Content.ReadFromJsonAsync<List<PcpAssignmentHistoryItem>>(cancellationToken: ct)
+                ?? new List<PcpAssignmentHistoryItem>();
         }
         catch (HttpRequestException ex)
         {

--- a/src/services/member-service/Services/ICoverageServiceClient.cs
+++ b/src/services/member-service/Services/ICoverageServiceClient.cs
@@ -10,10 +10,21 @@ public interface ICoverageServiceClient
 {
     Task<MemberPcpResponse> GetPcpAsync(string tenantId, string memberId, CancellationToken ct = default);
 
-    Task<MemberPcpResponse> AssignPcpAsync(
+    /// <summary>
+    /// Assign a PCP. Returns either a populated <see cref="MemberPcpResponse"/> or
+    /// a structured <see cref="PcpValidationProblem"/> when coverage-service rejects
+    /// the assignment with 400. 503/connectivity issues still throw
+    /// <see cref="DownstreamUnavailableException"/>.
+    /// </summary>
+    Task<AssignPcpOutcome> AssignPcpAsync(
         string tenantId,
         string memberId,
         AssignPcpRequest request,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<PcpAssignmentHistoryItem>> GetPcpHistoryAsync(
+        string tenantId,
+        string memberId,
         CancellationToken ct = default);
 
     Task<IReadOnlyList<CoverageHistoryEvent>> GetCoverageHistoryAsync(
@@ -26,6 +37,47 @@ public interface ICoverageServiceClient
         string memberId,
         TerminateMemberRequest request,
         CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of a PCP assignment attempt. Exactly one of <see cref="Pcp"/> /
+/// <see cref="ValidationError"/> is populated.
+/// </summary>
+public sealed class AssignPcpOutcome
+{
+    public MemberPcpResponse? Pcp { get; init; }
+    public PcpValidationProblem? ValidationError { get; init; }
+    public bool IsSuccess => Pcp != null;
+}
+
+/// <summary>
+/// Structured PCP validation failure surfaced from coverage-service. Matches the
+/// error contract documented in docs/architecture/pcp-assignment.md.
+/// </summary>
+public sealed class PcpValidationProblem
+{
+    public string Code { get; set; } = string.Empty;
+    public string Field { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string Severity { get; set; } = "Error";
+}
+
+/// <summary>One row in a member's PCP assignment history (mirror of coverage-service shape).</summary>
+public sealed class PcpAssignmentHistoryItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string CoverageId { get; set; } = string.Empty;
+    public string ProviderNpi { get; set; } = string.Empty;
+    public string? ProviderId { get; set; }
+    public string? ProviderName { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? AssignmentReason { get; set; }
+    public string AssignmentSource { get; set; } = "MemberChoice";
+    public string NetworkStatusAtAssignment { get; set; } = "Unknown";
+    public string? AssignedBy { get; set; }
+    public DateTime CreatedDate { get; set; }
 }
 
 /// <summary>Typed client for the enrollment-import-service (834 transaction history + event stream).</summary>

--- a/src/services/member-service/Services/IFhirPatientProjector.cs
+++ b/src/services/member-service/Services/IFhirPatientProjector.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using MemberService.Controllers;
 using MemberService.Models;
 
 namespace MemberService.Services;
@@ -10,5 +11,16 @@ namespace MemberService.Services;
 /// </summary>
 public interface IFhirPatientProjector
 {
+    /// <summary>
+    /// Project a member without PCP context. Equivalent to <see cref="Project(Member, MemberPcpResponse?)"/>
+    /// with <c>pcp = null</c> — kept for callers that don't have PCP data on hand.
+    /// </summary>
     JsonObject Project(Member member);
+
+    /// <summary>
+    /// Project a member; when <paramref name="pcp"/> is provided, emit
+    /// <c>Patient.generalPractitioner</c>[] with an NPI identifier so consumers
+    /// can navigate to the Practitioner without an extra lookup.
+    /// </summary>
+    JsonObject Project(Member member, MemberPcpResponse? pcp);
 }

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -305,6 +305,51 @@ public class NetworkParticipation
     /// Contracted rates (optional - for fee schedule reference)
     /// </summary>
     public ContractedRates? Rates { get; set; }
+
+    // ── PCP panel controls (roadmap 5.7) ───────────────────────────────
+    //
+    // These gate PCP assignment in coverage-service. Null = legacy / unconstrained:
+    // historical participations loaded before this migration landed default to
+    // "panel open, all LOBs on the participation, no age limits" to preserve
+    // existing behavior until network ops backfills real values.
+    //
+    // TODO(provider-service): populate these on every NetworkParticipation write
+    // (ProvidersController.AddNetworkParticipation, any bulk import path, and
+    // future CreateEditProviderDialog edits). See docs/architecture/pcp-assignment.md.
+
+    /// <summary>
+    /// Maximum number of members that may be assigned to this provider under this
+    /// participation. Null = unlimited / not yet backfilled.
+    /// </summary>
+    public int? PanelLimit { get; set; }
+
+    /// <summary>
+    /// Whether this provider accepts new PCP assignments for this participation.
+    /// Distinct from <see cref="AcceptingNewPatients"/> (any new patient) — a panel
+    /// may be closed to new PCP members while still seeing referrals.
+    /// Null = treated as <see cref="AcceptingNewPatients"/>.
+    /// </summary>
+    public bool? PanelAccepted { get; set; }
+
+    /// <summary>
+    /// LOBs this participation will accept as a PCP (subset of / equal to
+    /// <see cref="LineOfBusiness"/>). Empty = accept any LOB covered by this
+    /// participation. Used by coverage-service to enforce Medicaid/Medicare/etc.
+    /// PCP rules without proliferating separate participations per LOB.
+    /// </summary>
+    public List<LineOfBusiness> AcceptedLobs { get; set; } = new();
+
+    /// <summary>
+    /// Minimum member age (years) accepted on this panel. Null = no floor.
+    /// Example: Internal Medicine participation with MinAcceptedAgeYears=18.
+    /// </summary>
+    public int? MinAcceptedAgeYears { get; set; }
+
+    /// <summary>
+    /// Maximum member age (years) accepted on this panel. Null = no ceiling.
+    /// Example: Pediatrics participation with MaxAcceptedAgeYears=21.
+    /// </summary>
+    public int? MaxAcceptedAgeYears { get; set; }
 }
 
 /// <summary>

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -313,9 +313,15 @@ public class NetworkParticipation
     // "panel open, all LOBs on the participation, no age limits" to preserve
     // existing behavior until network ops backfills real values.
     //
-    // TODO(provider-service): populate these on every NetworkParticipation write
-    // (ProvidersController.AddNetworkParticipation, any bulk import path, and
-    // future CreateEditProviderDialog edits). See docs/architecture/pcp-assignment.md.
+    // TODO(provider-service): populate these on every NetworkParticipation write.
+    // Every path that materializes a NetworkParticipation must set the panel-gating
+    // fields (or leave them null = legacy unconstrained). Current write surfaces:
+    //   - ProvidersController.CreateProvider  — accepts NetworkParticipations in the Provider body
+    //   - ProvidersController.UpdateProvider  — overwrites the whole Provider (including participations)
+    //   - ProvidersController.AddNetworkParticipation — appends a single participation
+    //   - Any bulk import / CAQH-sync path that materializes participations
+    //   - Portal CreateEditProviderDialog edits (once the UI surfaces these fields)
+    // See docs/architecture/pcp-assignment.md "Provider-service contract changes".
 
     /// <summary>
     /// Maximum number of members that may be assigned to this provider under this


### PR DESCRIPTION
Move PCP assignment to coverage-service as the authoritative service for
member-PCP relationships, with member-service proxying. Adds an immutable
PcpAssignment history collection (one row per change, prior rows closed by
EndDate stamp), so the denormalized Coverage.Pcp* fields stay as the
read-path while the new collection is the source of truth for audit and
FHIR projection.

Validation runs as a fail-fast ordered ladder in PcpAssignmentService and
returns a structured PcpValidationError { code, field, message, severity }.
Codes are an API contract — portal localizes off code, picks remediation —
and are documented at docs/architecture/pcp-assignment.md. Order is:
PROVIDER_NOT_FOUND, PROVIDER_INACTIVE, PROVIDER_NOT_CREDENTIALED,
NO_NETWORK_PARTICIPATION, NOT_ACCEPTING_PATIENTS, LOB_NOT_ACCEPTED,
AGE_OUT_OF_RANGE, PANEL_FULL.

Panel capacity check is racy (read-then-write between coverage-service and
the panel counter); Phase 1 accepts the slack and ships PcpPanelReconciliationJob
as a stub for the observability path. Phase 2 will add per-provider Redis
locks under Addendum A.7.2 — TODO markers in the code.

NetworkStatusAtAssignment is a snapshot captured at write time and never
updated; the field is named verbosely on purpose so live UI status doesn't
drift to it. Portal renders it as "Network at Assignment" in the history
table.

CareTeamProjector accepts a generic List<CareTeamMember> input — today
only PCP populates it, but specialists and care managers add new entries
without changing the projector shape. US Core 6.1 CareTeam profile;
empty member list yields a "proposed" status CareTeam with no participants
(no placeholder entries).

Provider.NetworkParticipation gains five PCP-gating fields (PanelLimit,
PanelAccepted, AcceptedLobs, MinAcceptedAgeYears, MaxAcceptedAgeYears).
Null defaults preserve legacy behavior; TODO(provider-service) markers
flag the write paths that need backfilling. Migration plan documented.

FhirPatientProjector emits Patient.generalPractitioner[] when a
MemberPcpResponse is supplied; GetFhirPatient fetches it best-effort and
degrades silently on downstream failure.

Portal: PcpSearchDialog replaces AssignPcpDialog with per-row Network +
Panel chips and structured error display; MemberDetailsDialog PCP tab
gains an Assignment History subsection backed by the new history endpoint.

## Follow-up items (out of scope for this PR)

Grepped coverage-service for other write paths that loop over all active
coverages. Findings, for future maintainers:

- `CoverageController.TerminateMemberCoverage` (line ~555) — loops every
  active row to stamp `Status=Terminated`. **Correct by design**: full
  member disenrollment terminates every LOB. Not a bug.
- `CoverageController.GetMemberPcp` (line ~380) — read path; picks
  `FirstOrDefault(c => !string.IsNullOrEmpty(c.PcpNpi))`. After this PR's
  medical-only denormalization lands, only Health-coded rows carry PcpNpi,
  so the read stays correct without changes. Noted for future maintainers.

No other blind-all-coverages write patterns found. The bug was localized
to PCP denormalization and is fixed in this PR.

https://claude.ai/code/session_016efUox81QrD3U7kaqMT3wT