### PR TITLE
feat(member-service): add member alerts (FHIR Flag) and notes (FHIR Communication) (5.9)

### DIFF
--- a/docs/architecture/member-alerts-notes.md
+++ b/docs/architecture/member-alerts-notes.md
@@ -18,6 +18,9 @@ Adds two member-bound resources to the member-service:
 - `IMemberAlertGuard` enforcing service-layer block rules; wired into
   `MembersController.TerminateMember`.
 - New `MemberEventType` values for create/view audit on both resources.
+- `JsonStringEnumConverter` registered on the MVC pipeline so enum payloads
+  (`alertType`, `severity`, `category`) are sent and received as strings
+  ("LitigationHold", "Critical", "CustomerService") rather than numbers.
 - Portal: persistent `MemberAlertBanner` above member tabs; new `Notes`
   `MudTabPanel` with category filter, paged log, entry form.
 
@@ -83,27 +86,42 @@ mechanism per `member-foundation.md`. Five new event types are emitted:
 View events carry `{ scope, count }` so an auditor can reconstruct what was
 displayed without storing the full payload.
 
+View audit is **best-effort**: `PublishViewedAsync` in both controllers
+catches non-cancellation exceptions so a failing audit sink does not turn
+`GET /alerts` or `GET /notes` into a 5xx. The integrity-critical audit
+events (`*Created` and `MemberAlertEnded`) continue to surface publisher
+failures to the caller.
+
 ## Block rules
 
-Critical alerts can prevent specific actions. The rules table is the single
+Active alerts can prevent specific actions. The rules table is the single
 source of truth in code (`Services/MemberAlertGuard.cs`); changes here MUST
 be mirrored in code, and vice versa.
 
-| Alert (active)      | Severity | Blocks action          | Surfaced as              |
-|---------------------|----------|------------------------|--------------------------|
-| `LitigationHold`    | Critical | `Terminate`, `HardDelete` | `409 ProblemDetails` (`type=member-alert-block`) |
-| `EligibilityDispute`| Warning  | `Terminate`            | `409 ProblemDetails`     |
-| `SecurityFreeze`    | Critical | `UpdatePii`            | `409 ProblemDetails`     |
-| `KnownFraudRisk`    | Critical | `UpdatePii`, `NewEnrollment` | `409 ProblemDetails` |
-| `DoNotContact`      | Warning  | `OutboundCommunication`| `409 ProblemDetails` (enforced by comms-service) |
-| `HighRisk`          | any      | _informational only_   | banner only              |
-| `VIP`               | any      | _informational only_   | banner only              |
-| `CustodyDispute`    | any      | _informational only_   | banner only              |
-| `LanguageRequirement` | any    | _informational only_   | banner only              |
-| `AccessibilityNeed` | any      | _informational only_   | banner only              |
+A rule fires when an alert is (a) active, (b) of the matching type, and
+(c) at severity **≥** `Min severity`. Lowering an alert's severity below the
+threshold effectively informs-only without unblocking the portal hard
+path — operators downgrade rather than end when they want the banner to
+stay visible but want to permit an action.
+
+| Alert type            | Min severity | Blocks action               | Surfaced as                                        |
+|-----------------------|--------------|-----------------------------|----------------------------------------------------|
+| `LitigationHold`      | Critical     | `Terminate`, `HardDelete`   | `409 ProblemDetails` (`type=member-alert-block`)   |
+| `EligibilityDispute`  | Warning      | `Terminate`                 | `409 ProblemDetails`                               |
+| `SecurityFreeze`      | Critical     | `UpdatePii`                 | `409 ProblemDetails`                               |
+| `KnownFraudRisk`      | Critical     | `UpdatePii`, `NewEnrollment`| `409 ProblemDetails`                               |
+| `DoNotContact`        | Warning      | `OutboundCommunication`     | `409 ProblemDetails` (enforced by comms-service)   |
+| `HighRisk`            | —            | _informational only_        | banner only                                        |
+| `VIP`                 | —            | _informational only_        | banner only                                        |
+| `CustodyDispute`      | —            | _informational only_        | banner only                                        |
+| `LanguageRequirement` | —            | _informational only_        | banner only                                        |
+| `AccessibilityNeed`   | —            | _informational only_        | banner only                                        |
 
 Block enforcement is centralised in `IMemberAlertGuard.EvaluateAsync` so
-every action that needs to be guarded asks the same service.
+every action that needs to be guarded asks the same service. The evaluator
+calls `ct.ThrowIfCancellationRequested()` before and after the repository
+lookup so a cancelled caller surfaces as `OperationCanceledException`
+rather than running a wasted query.
 
 In this PR the only wired block is `Terminate` from `MembersController` —
 both the DELETE and POST `/terminate` variants call the guard before
@@ -175,3 +193,7 @@ banner is informational and must not block the dialog from rendering.
 | Note view records audit event                                      | `MemberNotesControllerTests.ListNotes_EmitsViewedAuditEvent`               |
 | FHIR Flag projection returns Bundle of Flag resources              | `MemberAlertsControllerTests.GetFhirFlags_ReturnsBundleWithFhirContentType`, `FhirFlagProjectorTests.ProjectBundle_*` |
 | End-dated LitigationHold no longer blocks termination              | `MembersControllerTests.TerminateMember_EndedLitigationHold_AllowsTermination` |
+| LitigationHold at Warning severity does not block termination      | `MemberAlertGuardTests.Terminate_LitigationHoldAtWarning_DoesNotBlock`      |
+| EligibilityDispute at Warning blocks, at Info does not             | `MemberAlertGuardTests.Terminate_EligibilityDisputeAtWarning_Blocks`, `..._AtInfo_DoesNotBlock` |
+| `EvaluateAsync` honors cancellation                                | `MemberAlertGuardTests.EvaluateAsync_CancelledToken_Throws`                |
+| Audit publisher failure does not fail `GET /alerts`                | `MemberAlertsControllerTests.ListAlerts_AuditPublisherFailure_DoesNotFailRead` |

--- a/docs/architecture/member-alerts-notes.md
+++ b/docs/architecture/member-alerts-notes.md
@@ -1,0 +1,177 @@
+# Member Alerts & Notes (5.9)
+
+Adds two member-bound resources to the member-service:
+
+- **`MemberAlert`** — flags such as Litigation Hold, Custody Dispute, VIP,
+  Do Not Contact. Projects to FHIR R4 `Flag`. End-dated rather than deleted.
+- **`MemberNote`** — free-text notes scoped to a category (CustomerService,
+  CareManagement, Appeals, Billing, Clinical). Projects to FHIR R4
+  `Communication`. Immutable once created.
+
+## Scope of this PR
+
+- `MemberAlert` and `MemberNote` models with their enums.
+- `IMemberAlertRepository` / `IMemberNoteRepository` (Cosmos + Mongo).
+- `MemberAlertsController` at `/api/v1/members/{memberId}/alerts`.
+- `MemberNotesController` at `/api/v1/members/{memberId}/notes`.
+- `IFhirFlagProjector` + endpoint `/api/v1/members/{id}/fhir/Flag?status=active`.
+- `IMemberAlertGuard` enforcing service-layer block rules; wired into
+  `MembersController.TerminateMember`.
+- New `MemberEventType` values for create/view audit on both resources.
+- Portal: persistent `MemberAlertBanner` above member tabs; new `Notes`
+  `MudTabPanel` with category filter, paged log, entry form.
+
+## Why a separate container?
+
+Alerts and notes have very different lifecycles from `Member`:
+
+- Members are updated via 834 ingestion; alerts/notes are operator-driven.
+- Notes can grow unbounded — embedding in `Member` would inflate every
+  member read.
+- Alerts need a query plane to compute the "active" set without rehydrating
+  the member.
+
+Separate containers (`MemberAlerts`, `MemberNotes`) partitioned by
+`/tenantId` keep the read paths additive. Mongo collections share the same
+shape via `MemberAlertRepositoryMongo` / `MemberNoteRepositoryMongo`.
+
+## Lifecycle
+
+### Alerts — end-dated, never deleted
+
+| State           | Definition                                            |
+|-----------------|-------------------------------------------------------|
+| Active          | `StartDate <= now AND (EndDate IS NULL OR EndDate > now)` |
+| Future          | `StartDate > now` (created with a future start)       |
+| Ended (history) | `EndDate <= now`                                      |
+
+`POST /alerts/{id}/end` sets `EndDate` and `EndedBy`. Ending an already-ended
+alert is a no-op (200) — repeated end calls remain idempotent. The delete
+endpoint is intentionally absent.
+
+### Notes — append-only, immutable
+
+The `IMemberNoteRepository` interface exposes only `CreateAsync`,
+`GetByIdAsync`, and `ListByMemberAsync`. There is no Update or Delete
+method. Corrections are written as **new notes** with:
+
+```json
+{
+  "subject": "Correction: prior amount was $42.10, not $4210",
+  "body": "...",
+  "linkedResourceType": "MemberNote",
+  "linkedResourceId": "<original note id>"
+}
+```
+
+A reflection-based contract test in `MemberNotesControllerTests` fails the
+build if anyone later adds an Update or Delete method to the interface.
+
+## Audit
+
+Audit lives on the existing `member-events` stream — that is the audit
+mechanism per `member-foundation.md`. Five new event types are emitted:
+
+| Event                       | Triggered by                               |
+|-----------------------------|--------------------------------------------|
+| `MemberAlertCreated` (6)    | `POST .../alerts`                          |
+| `MemberAlertEnded`   (7)    | `POST .../alerts/{id}/end`                 |
+| `MemberAlertViewed`  (8)    | `GET .../alerts`, `.../alerts/{id}`, `.../fhir/Flag` |
+| `MemberNoteCreated`  (9)    | `POST .../notes`                           |
+| `MemberNoteViewed`   (10)   | `GET .../notes`, `.../notes/{id}`          |
+
+View events carry `{ scope, count }` so an auditor can reconstruct what was
+displayed without storing the full payload.
+
+## Block rules
+
+Critical alerts can prevent specific actions. The rules table is the single
+source of truth in code (`Services/MemberAlertGuard.cs`); changes here MUST
+be mirrored in code, and vice versa.
+
+| Alert (active)      | Severity | Blocks action          | Surfaced as              |
+|---------------------|----------|------------------------|--------------------------|
+| `LitigationHold`    | Critical | `Terminate`, `HardDelete` | `409 ProblemDetails` (`type=member-alert-block`) |
+| `EligibilityDispute`| Warning  | `Terminate`            | `409 ProblemDetails`     |
+| `SecurityFreeze`    | Critical | `UpdatePii`            | `409 ProblemDetails`     |
+| `KnownFraudRisk`    | Critical | `UpdatePii`, `NewEnrollment` | `409 ProblemDetails` |
+| `DoNotContact`      | Warning  | `OutboundCommunication`| `409 ProblemDetails` (enforced by comms-service) |
+| `HighRisk`          | any      | _informational only_   | banner only              |
+| `VIP`               | any      | _informational only_   | banner only              |
+| `CustodyDispute`    | any      | _informational only_   | banner only              |
+| `LanguageRequirement` | any    | _informational only_   | banner only              |
+| `AccessibilityNeed` | any      | _informational only_   | banner only              |
+
+Block enforcement is centralised in `IMemberAlertGuard.EvaluateAsync` so
+every action that needs to be guarded asks the same service.
+
+In this PR the only wired block is `Terminate` from `MembersController` —
+both the DELETE and POST `/terminate` variants call the guard before
+mutating state. The 409 ProblemDetails carries `alertId`, `alertType`,
+`severity`, `action`, and (when set) `requiredAction` so the portal can
+render an actionable error rather than a raw status code.
+
+The other actions (`UpdatePii`, `NewEnrollment`, `OutboundCommunication`,
+`HardDelete`) are reserved on the `MemberAlertAction` enum and ready to be
+plumbed in by their owning endpoints / services in follow-up PRs.
+
+## FHIR Flag projection
+
+`/api/v1/members/{memberId}/fhir/Flag?status=active` returns a `Bundle` of
+US Core `Flag` resources. Mapping (see `Services/FhirFlagProjector.cs`):
+
+| FHIR `Flag` field             | `MemberAlert` source                           |
+|-------------------------------|------------------------------------------------|
+| `id`                          | `Id`                                           |
+| `status`                      | `IsActive() ? "active" : "inactive"`           |
+| `category[].coding[].code`    | severity → `safety` / `admin` / `clinical`     |
+| `code.coding[].code`          | `AlertType` (CHO `CodeSystem/member-alert-type`) |
+| `code.text`                   | `Reason`                                       |
+| `subject.identifier`          | `MemberId` (system: `urn:cho:member-id`)       |
+| `period.start` / `period.end` | `StartDate` / `EndDate`                        |
+| `extension[required-action]`  | `RequiredAction` (CHO StructureDefinition)     |
+| `meta.profile`                | `us-core-flag`                                 |
+
+Severity → `category` mapping uses the standard
+`http://terminology.hl7.org/CodeSystem/flag-category` value set; the alert
+**type** rides on `code` so consumers don't have to inspect category to
+discover what kind of flag it is.
+
+## Portal
+
+### `Shared/MemberAlertBanner.razor`
+
+Persistent banner above the member-detail tabs. Renders **only active**
+alerts as MudAlerts color-coded by severity:
+
+| Severity   | MudBlazor color |
+|------------|------------------|
+| Critical   | `Severity.Error`   |
+| Warning    | `Severity.Warning` |
+| Info       | `Severity.Info`    |
+
+Bubbles `OnAlertCountChanged(int)` so the host can react (badge counts,
+disabling actions). Failures degrade silently to an empty banner — the
+banner is informational and must not block the dialog from rendering.
+
+### `Notes` tab in `MemberDetailsDialog.razor`
+
+- Category filter (`All` + the five categories).
+- Paged log (newest first) with `Load more` continuation.
+- Inline entry form (Category / Subject / Body) — submission triggers a
+  `Snackbar` and reloads the page so the new note appears at the top.
+- Lazy load: notes are fetched on first tab activation, not eagerly with
+  the rest of the dialog.
+
+## Acceptance verification
+
+| Acceptance criterion                                              | Verified by                                                                |
+|-------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| Active alerts render banner; expired don't                        | `MemberAlertsControllerTests.ListAlerts_StatusActive_ExcludesEndDated`     |
+| Block rules enforced (LitigationHold blocks terminate → 409)      | `MembersControllerTests.TerminateMember_*_BlockedByActiveLitigationHold_Returns409` |
+| Note creation records audit event                                  | `MemberNotesControllerTests.CreateNote_PersistsAndEmitsAuditEvent`         |
+| Note is immutable                                                  | `MemberNotesControllerTests.NoteRepository_HasNoUpdateOrDeleteMethod_EnforcesImmutability` |
+| Alert view records audit event                                     | `MemberAlertsControllerTests.ListAlerts_EmitsViewedAuditEvent`             |
+| Note view records audit event                                      | `MemberNotesControllerTests.ListNotes_EmitsViewedAuditEvent`               |
+| FHIR Flag projection returns Bundle of Flag resources              | `MemberAlertsControllerTests.GetFhirFlags_ReturnsBundleWithFhirContentType`, `FhirFlagProjectorTests.ProjectBundle_*` |
+| End-dated LitigationHold no longer blocks termination              | `MembersControllerTests.TerminateMember_EndedLitigationHold_AllowsTermination` |

--- a/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MemberDetailsDialog.razor
@@ -1,9 +1,11 @@
 @using CloudHealthOffice.Portal.Services
 @using CloudHealthOffice.Portal.Formatters
+@using CloudHealthOffice.Portal.Shared
 @inject IMemberService MemberService
 @inject ICoverageService CoverageService
 @inject IBenefitPlanService BenefitPlanService
 @inject IFamilyRelationshipService FamilyRelationshipService
+@inject IMemberNoteService MemberNoteService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject NavigationManager Navigation
@@ -42,6 +44,8 @@
                     View Claims
                 </MudButton>
             </div>
+
+            <MemberAlertBanner MemberId="@MemberId" OnAlertCountChanged="OnAlertCountChanged" />
 
             <MudTabs Elevation="0" ApplyEffectsToContainer="true" PanelClass="pt-4"
                      @bind-ActivePanelIndex="_activeTab">
@@ -845,6 +849,109 @@
                         }
                     </div>
                 </MudTabPanel>
+
+                <!-- Notes Tab -->
+                <MudTabPanel Text="Notes" Icon="@Icons.Material.Filled.Notes" OnClick="@(_ => OnNotesTabActivated())">
+                    <div>
+                        <MudGrid Spacing="2" Class="mb-3">
+                            <MudItem xs="12" md="4">
+                                <MudSelect T="string" Label="Category"
+                                           Value="_noteCategoryFilter"
+                                           ValueChanged="OnNoteCategoryChanged"
+                                           Variant="Variant.Outlined" Dense="true">
+                                    <MudSelectItem Value="@string.Empty">All</MudSelectItem>
+                                    @foreach (var cat in NoteCategories)
+                                    {
+                                        <MudSelectItem Value="@cat">@cat</MudSelectItem>
+                                    }
+                                </MudSelect>
+                            </MudItem>
+                            <MudItem xs="12" md="8" Class="d-flex align-center justify-end">
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                           StartIcon="@Icons.Material.Filled.NoteAdd"
+                                           OnClick="ToggleNoteEntry">
+                                    @(_showNoteEntry ? "Cancel" : "Add Note")
+                                </MudButton>
+                            </MudItem>
+                        </MudGrid>
+
+                        @if (_showNoteEntry)
+                        {
+                            <MudPaper Class="pa-3 mb-3" Elevation="1">
+                                <MudGrid Spacing="2">
+                                    <MudItem xs="12" md="4">
+                                        <MudSelect T="string" Label="Category"
+                                                   @bind-Value="_newNoteCategory"
+                                                   Variant="Variant.Outlined" Dense="true">
+                                            @foreach (var cat in NoteCategories)
+                                            {
+                                                <MudSelectItem Value="@cat">@cat</MudSelectItem>
+                                            }
+                                        </MudSelect>
+                                    </MudItem>
+                                    <MudItem xs="12" md="8">
+                                        <MudTextField @bind-Value="_newNoteSubject"
+                                                      Label="Subject" Variant="Variant.Outlined"
+                                                      MaxLength="200" Required="true" />
+                                    </MudItem>
+                                    <MudItem xs="12">
+                                        <MudTextField @bind-Value="_newNoteBody"
+                                                      Label="Body" Variant="Variant.Outlined"
+                                                      Lines="4" MaxLength="8000" Required="true" />
+                                    </MudItem>
+                                    <MudItem xs="12" Class="d-flex justify-end">
+                                        <MudButton Variant="Variant.Filled" Color="Color.Success"
+                                                   Disabled="@(_savingNote || string.IsNullOrWhiteSpace(_newNoteSubject) || string.IsNullOrWhiteSpace(_newNoteBody))"
+                                                   OnClick="SubmitNoteAsync">
+                                            @(_savingNote ? "Saving…" : "Save Note")
+                                        </MudButton>
+                                    </MudItem>
+                                </MudGrid>
+                            </MudPaper>
+                        }
+
+                        @if (_loadingNotes)
+                        {
+                            <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-2" />
+                        }
+                        else if (!_notes.Any())
+                        {
+                            <MudAlert Severity="Severity.Info">No notes recorded for this member.</MudAlert>
+                        }
+                        else
+                        {
+                            <div class="d-flex flex-column">
+                                @foreach (var note in _notes)
+                                {
+                                    <MudPaper Class="pa-3 mb-2" Elevation="1">
+                                        <div class="d-flex align-center gap-2 mb-1">
+                                            <MudChip T="string" Size="Size.Small" Color="@GetNoteCategoryColor(note.Category)">@note.Category</MudChip>
+                                            <MudText Typo="Typo.subtitle2" Style="font-weight: 600;">@note.Subject</MudText>
+                                            <MudSpacer />
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                                @note.Author · @note.CreatedDate.ToLocalTime().ToString("MM/dd/yyyy HH:mm")
+                                            </MudText>
+                                        </div>
+                                        <MudText Typo="Typo.body2" Style="white-space: pre-wrap;">@note.Body</MudText>
+                                        @if (!string.IsNullOrEmpty(note.LinkedResourceType))
+                                        {
+                                            <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
+                                                Linked: @note.LinkedResourceType / @note.LinkedResourceId
+                                            </MudText>
+                                        }
+                                    </MudPaper>
+                                }
+                            </div>
+
+                            @if (!string.IsNullOrEmpty(_notesContinuationToken))
+                            {
+                                <div class="d-flex justify-center mt-2">
+                                    <MudButton Variant="Variant.Outlined" OnClick="LoadMoreNotesAsync">Load more</MudButton>
+                                </div>
+                            }
+                        }
+                    </div>
+                </MudTabPanel>
             </MudTabs>
         }
         else
@@ -898,6 +1005,27 @@
     private bool _loadingFamily = false;
     private int _activeTab = 0;
     private string? _serviceError;
+
+    // Alerts banner — count is bubbled up so other UI can react (e.g.,
+    // disable terminate when LitigationHold is active). Counted, not enumerated,
+    // because the banner owns the alert content rendering.
+    private int _activeAlertCount;
+
+    // Notes tab state
+    private static readonly string[] NoteCategories =
+    {
+        "CustomerService", "CareManagement", "Appeals", "Billing", "Clinical"
+    };
+    private List<MemberNoteView> _notes = new();
+    private string? _notesContinuationToken;
+    private string _noteCategoryFilter = string.Empty;
+    private bool _loadingNotes;
+    private bool _notesLoadedOnce;
+    private bool _showNoteEntry;
+    private bool _savingNote;
+    private string _newNoteCategory = "CustomerService";
+    private string _newNoteSubject = string.Empty;
+    private string _newNoteBody = string.Empty;
 
     private List<FamilyRelationshipRow> _subscriberRows = new();
     private List<FamilyRelationshipRow> _dependentRows = new();
@@ -1346,4 +1474,113 @@
     }
 
     private void Close() => MudDialog.Close();
+
+    // ── Alerts banner integration ────────────────────────────────────────
+    private Task OnAlertCountChanged(int count)
+    {
+        _activeAlertCount = count;
+        return InvokeAsync(StateHasChanged);
+    }
+
+    // ── Notes tab ────────────────────────────────────────────────────────
+    private async Task OnNotesTabActivated()
+    {
+        if (_notesLoadedOnce) return;
+        _notesLoadedOnce = true;
+        await LoadNotesAsync(reset: true);
+    }
+
+    private async Task OnNoteCategoryChanged(string value)
+    {
+        _noteCategoryFilter = value ?? string.Empty;
+        await LoadNotesAsync(reset: true);
+    }
+
+    private async Task LoadNotesAsync(bool reset)
+    {
+        _loadingNotes = true;
+        if (reset)
+        {
+            _notes = new();
+            _notesContinuationToken = null;
+        }
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            var page = await MemberNoteService.ListAsync(MemberId,
+                new MemberNoteFilter(
+                    Category: string.IsNullOrEmpty(_noteCategoryFilter) ? null : _noteCategoryFilter,
+                    Limit: 20,
+                    ContinuationToken: reset ? null : _notesContinuationToken));
+            _notes.AddRange(page.Items);
+            _notesContinuationToken = page.ContinuationToken;
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to load notes: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _loadingNotes = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private Task LoadMoreNotesAsync() => LoadNotesAsync(reset: false);
+
+    private void ToggleNoteEntry()
+    {
+        _showNoteEntry = !_showNoteEntry;
+        if (!_showNoteEntry)
+        {
+            _newNoteSubject = string.Empty;
+            _newNoteBody = string.Empty;
+            _newNoteCategory = "CustomerService";
+        }
+    }
+
+    private async Task SubmitNoteAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_newNoteSubject) || string.IsNullOrWhiteSpace(_newNoteBody)) return;
+
+        _savingNote = true;
+        StateHasChanged();
+        try
+        {
+            var created = await MemberNoteService.CreateAsync(MemberId, new CreateMemberNotePayload
+            {
+                Category = _newNoteCategory,
+                Subject = _newNoteSubject.Trim(),
+                Body = _newNoteBody.Trim()
+            });
+            if (created != null)
+            {
+                Snackbar.Add("Note added.", Severity.Success);
+                _showNoteEntry = false;
+                _newNoteSubject = string.Empty;
+                _newNoteBody = string.Empty;
+                await LoadNotesAsync(reset: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Failed to save note: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _savingNote = false;
+            StateHasChanged();
+        }
+    }
+
+    private static Color GetNoteCategoryColor(string category) => category switch
+    {
+        "CustomerService" => Color.Primary,
+        "CareManagement" => Color.Success,
+        "Appeals" => Color.Warning,
+        "Billing" => Color.Info,
+        "Clinical" => Color.Tertiary,
+        _ => Color.Default
+    };
 }

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -226,6 +226,8 @@ builder.Services.AddScoped<IUserContextService, UserContextService>();
 
 // Register microservice clients
 builder.Services.AddScoped<IMemberService, MemberService>();
+builder.Services.AddScoped<IMemberAlertService, MemberAlertService>();
+builder.Services.AddScoped<IMemberNoteService, MemberNoteService>();
 builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService>();
 builder.Services.AddScoped<ICoverageService, CoverageService>();
 builder.Services.AddScoped<IClaimsService, ClaimsService>();

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -88,6 +88,81 @@ public interface ICoverageService
     Task<List<Coverage>> GetCoverageByMemberIdAsync(string memberId);
 }
 
+public interface IMemberAlertService
+{
+    Task<List<MemberAlertView>> ListAsync(string memberId, bool activeOnly);
+    Task<MemberAlertView?> CreateAsync(string memberId, CreateMemberAlertPayload payload);
+    Task<MemberAlertView?> EndAsync(string memberId, string alertId);
+}
+
+public interface IMemberNoteService
+{
+    Task<MemberNotePage> ListAsync(string memberId, MemberNoteFilter filter);
+    Task<MemberNoteView?> CreateAsync(string memberId, CreateMemberNotePayload payload);
+}
+
+public class MemberAlertView
+{
+    public string Id { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string AlertType { get; set; } = string.Empty;
+    public string Severity { get; set; } = "Info";
+    public DateTime StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public string? RequiredAction { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+    public string? EndedBy { get; set; }
+
+    public bool IsActive(DateTime? asOf = null)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        return StartDate <= t && (!EndDate.HasValue || EndDate.Value > t);
+    }
+}
+
+public class CreateMemberAlertPayload
+{
+    public string AlertType { get; set; } = string.Empty;
+    public string Severity { get; set; } = "Info";
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public string? RequiredAction { get; set; }
+}
+
+public class MemberNoteView
+{
+    public string Id { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public string Category { get; set; } = "CustomerService";
+    public string Subject { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public DateTime CreatedDate { get; set; }
+    public string? LinkedResourceType { get; set; }
+    public string? LinkedResourceId { get; set; }
+}
+
+public class CreateMemberNotePayload
+{
+    public string Category { get; set; } = "CustomerService";
+    public string Subject { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public string? Author { get; set; }
+    public string? LinkedResourceType { get; set; }
+    public string? LinkedResourceId { get; set; }
+}
+
+public sealed record MemberNoteFilter(string? Category, int Limit, string? ContinuationToken);
+
+public class MemberNotePage
+{
+    public List<MemberNoteView> Items { get; set; } = new();
+    public string? ContinuationToken { get; set; }
+}
+
 public interface IFamilyRelationshipService
 {
     Task<List<FamilyRelationshipRow>> ListForMemberAsync(string memberId);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -372,6 +372,129 @@ public class MemberService : IMemberService
     }
 }
 
+public class MemberAlertService : IMemberAlertService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<MemberAlertService> _logger;
+
+    public MemberAlertService(HttpClient httpClient, IConfiguration configuration, ILogger<MemberAlertService> logger)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<List<MemberAlertView>> ListAsync(string memberId, bool activeOnly)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        var url = $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/alerts";
+        if (activeOnly) url += "?status=active";
+        try
+        {
+            var page = await _httpClient.GetFromJsonAsync<MemberAlertListEnvelope>(url);
+            return page?.Items ?? new List<MemberAlertView>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<MemberAlertView?> CreateAsync(string memberId, CreateMemberAlertPayload payload)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/alerts", payload);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MemberAlertView>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<MemberAlertView?> EndAsync(string memberId, string alertId)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/alerts/{Uri.EscapeDataString(alertId)}/end",
+                new { });
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MemberAlertView>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    private sealed class MemberAlertListEnvelope
+    {
+        public List<MemberAlertView> Items { get; set; } = new();
+    }
+}
+
+public class MemberNoteService : IMemberNoteService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<MemberNoteService> _logger;
+
+    public MemberNoteService(HttpClient httpClient, IConfiguration configuration, ILogger<MemberNoteService> logger)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<MemberNotePage> ListAsync(string memberId, MemberNoteFilter filter)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        var qs = new List<string> { $"pageSize={Math.Clamp(filter.Limit, 1, 100)}" };
+        if (!string.IsNullOrWhiteSpace(filter.Category)) qs.Add($"category={Uri.EscapeDataString(filter.Category)}");
+        if (!string.IsNullOrWhiteSpace(filter.ContinuationToken))
+            qs.Add($"continuationToken={Uri.EscapeDataString(filter.ContinuationToken)}");
+
+        try
+        {
+            var url = $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/notes?{string.Join("&", qs)}";
+            var page = await _httpClient.GetFromJsonAsync<MemberNotePage>(url);
+            return page ?? new MemberNotePage();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+
+    public async Task<MemberNoteView?> CreateAsync(string memberId, CreateMemberNotePayload payload)
+    {
+        var baseUrl = _configuration["Services:MemberService"];
+        try
+        {
+            var response = await _httpClient.PostAsJsonAsync(
+                $"{baseUrl}/members/{Uri.EscapeDataString(memberId)}/notes", payload);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MemberNoteView>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Member Service");
+            throw new ServiceUnavailableException("Member Service", ex);
+        }
+    }
+}
+
 public class CoverageService : ICoverageService
 {
     private readonly HttpClient _httpClient;

--- a/src/portal/CloudHealthOffice.Portal/Shared/MemberAlertBanner.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MemberAlertBanner.razor
@@ -1,0 +1,93 @@
+@using CloudHealthOffice.Portal.Services
+@inject IMemberAlertService MemberAlertService
+
+@if (_loading)
+{
+    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-2" />
+}
+else if (_alerts.Any())
+{
+    <div class="d-flex flex-column gap-2 mb-3">
+        @foreach (var alert in _alerts)
+        {
+            <MudAlert Severity="@MapSeverity(alert.Severity)"
+                      Variant="Variant.Filled"
+                      ContentAlignment="HorizontalAlignment.Left">
+                <MudText Typo="Typo.subtitle2" Style="font-weight: 600;">
+                    @Humanize(alert.AlertType) — @alert.Severity
+                </MudText>
+                <MudText Typo="Typo.body2">@alert.Reason</MudText>
+                @if (!string.IsNullOrEmpty(alert.RequiredAction))
+                {
+                    <MudText Typo="Typo.caption" Style="font-style: italic;">
+                        Required action: @alert.RequiredAction
+                    </MudText>
+                }
+            </MudAlert>
+        }
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>Bubble up the active alert count so the host can drive a tab badge or block buttons.</summary>
+    [Parameter]
+    public EventCallback<int> OnAlertCountChanged { get; set; }
+
+    private List<MemberAlertView> _alerts = new();
+    private bool _loading = true;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (string.IsNullOrEmpty(MemberId)) return;
+        await ReloadAsync();
+    }
+
+    public async Task ReloadAsync()
+    {
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            // activeOnly=true — banner shows only in-effect alerts; expired ones
+            // belong in the (future) full Alerts tab, not in the persistent banner.
+            _alerts = await MemberAlertService.ListAsync(MemberId, activeOnly: true);
+        }
+        catch
+        {
+            // Banner is informational; a service failure should not block the
+            // dialog from rendering. Surface as empty banner.
+            _alerts = new();
+        }
+        finally
+        {
+            _loading = false;
+            await OnAlertCountChanged.InvokeAsync(_alerts.Count);
+            StateHasChanged();
+        }
+    }
+
+    private static Severity MapSeverity(string severity) => severity switch
+    {
+        "Critical" => Severity.Error,
+        "Warning" => Severity.Warning,
+        _ => Severity.Info
+    };
+
+    private static string Humanize(string alertType) => alertType switch
+    {
+        "HighRisk" => "High Risk",
+        "LitigationHold" => "Litigation Hold",
+        "DoNotContact" => "Do Not Contact",
+        "VIP" => "VIP",
+        "CustodyDispute" => "Custody Dispute",
+        "LanguageRequirement" => "Language Requirement",
+        "AccessibilityNeed" => "Accessibility Need",
+        "SecurityFreeze" => "Security Freeze",
+        "KnownFraudRisk" => "Known Fraud Risk",
+        "EligibilityDispute" => "Eligibility Dispute",
+        _ => alertType
+    };
+}

--- a/src/services/member-service/Controllers/MemberAlertsController.cs
+++ b/src/services/member-service/Controllers/MemberAlertsController.cs
@@ -29,16 +29,20 @@ public class MemberAlertsController : ControllerBase
     private readonly IMemberEventPublisher _events;
     private readonly IFhirFlagProjector _flagProjector;
 
+    private readonly ILogger<MemberAlertsController>? _logger;
+
     public MemberAlertsController(
         IMemberRepository members,
         IMemberAlertRepository alerts,
         IMemberEventPublisher events,
-        IFhirFlagProjector flagProjector)
+        IFhirFlagProjector flagProjector,
+        ILogger<MemberAlertsController>? logger = null)
     {
         _members = members;
         _alerts = alerts;
         _events = events;
         _flagProjector = flagProjector;
+        _logger = logger;
     }
 
     /// <summary>List alerts for a member. Set <c>status=active</c> to filter to in-effect alerts.</summary>
@@ -211,23 +215,41 @@ public class MemberAlertsController : ControllerBase
         };
     }
 
-    private Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
+    private async Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
     {
-        // View events are best-effort audit; failures shouldn't fail the read.
-        return _events.PublishAsync(new MemberEvent
+        // Best-effort audit: a failure in the event publisher (downstream
+        // Cosmos/Mongo hiccup, concurrency retries exhausted) must not fail
+        // the read. The tradeoff is a potentially missing audit row; the
+        // repository-level audit on Create/End is the primary integrity
+        // guarantee, so missing Viewed rows degrade rather than break.
+        try
         {
-            TenantId = TenantId,
-            MemberId = memberId,
-            EventId = Guid.NewGuid().ToString(),
-            EventType = MemberEventType.MemberAlertViewed,
-            ActorId = User.Identity?.Name ?? "System",
-            CorrelationId = HttpContext.TraceIdentifier,
-            Payload = new JsonObject
+            await _events.PublishAsync(new MemberEvent
             {
-                ["scope"] = scope,
-                ["count"] = count
-            }
-        }, ct);
+                TenantId = TenantId,
+                MemberId = memberId,
+                EventId = Guid.NewGuid().ToString(),
+                EventType = MemberEventType.MemberAlertViewed,
+                ActorId = User.Identity?.Name ?? "System",
+                CorrelationId = HttpContext.TraceIdentifier,
+                Payload = new JsonObject
+                {
+                    ["scope"] = scope,
+                    ["count"] = count
+                }
+            }, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller cancelled — propagate cleanly.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex,
+                "Best-effort audit for MemberAlertViewed failed for {MemberId} scope={Scope}",
+                memberId, scope);
+        }
     }
 }
 

--- a/src/services/member-service/Controllers/MemberAlertsController.cs
+++ b/src/services/member-service/Controllers/MemberAlertsController.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Middleware;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MemberService.Controllers;
+
+/// <summary>
+/// Member alerts (FHIR Flag) — flags such as LitigationHold, CustodyDispute,
+/// LanguageRequirement, etc. Alerts are end-dated rather than deleted; every
+/// create / view / end emits a <see cref="MemberEvent"/> for audit.
+/// </summary>
+[ApiController]
+[Route("api/v1/members/{memberId}/alerts")]
+public class MemberAlertsController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IMemberRepository _members;
+    private readonly IMemberAlertRepository _alerts;
+    private readonly IMemberEventPublisher _events;
+    private readonly IFhirFlagProjector _flagProjector;
+
+    public MemberAlertsController(
+        IMemberRepository members,
+        IMemberAlertRepository alerts,
+        IMemberEventPublisher events,
+        IFhirFlagProjector flagProjector)
+    {
+        _members = members;
+        _alerts = alerts;
+        _events = events;
+        _flagProjector = flagProjector;
+    }
+
+    /// <summary>List alerts for a member. Set <c>status=active</c> to filter to in-effect alerts.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(MemberAlertListResponse), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> ListAlerts(
+        [FromRoute] string memberId,
+        [FromQuery] string? status = null,
+        CancellationToken ct = default)
+    {
+        var member = await _members.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var activeOnly = string.Equals(status, "active", StringComparison.OrdinalIgnoreCase);
+        var items = await _alerts.ListByMemberAsync(TenantId, memberId, activeOnly);
+
+        await PublishViewedAsync(memberId, scope: activeOnly ? "list:active" : "list:all", count: items.Count, ct);
+
+        return Ok(new MemberAlertListResponse { Items = items.ToList() });
+    }
+
+    /// <summary>Get a single alert by id.</summary>
+    [HttpGet("{alertId}")]
+    [ProducesResponseType(typeof(MemberAlert), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetAlert(
+        [FromRoute] string memberId,
+        [FromRoute] string alertId,
+        CancellationToken ct)
+    {
+        var alert = await _alerts.GetByIdAsync(TenantId, memberId, alertId);
+        if (alert == null) return NotFound();
+
+        await PublishViewedAsync(memberId, scope: $"alert:{alertId}", count: 1, ct);
+        return Ok(alert);
+    }
+
+    /// <summary>Create a new alert.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(MemberAlert), 201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> CreateAlert(
+        [FromRoute] string memberId,
+        [FromBody] CreateMemberAlertRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var member = await _members.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var actor = User.Identity?.Name ?? "System";
+        var alert = new MemberAlert
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            AlertType = request.AlertType,
+            Severity = request.Severity,
+            StartDate = request.StartDate ?? DateTime.UtcNow,
+            EndDate = request.EndDate,
+            Reason = request.Reason,
+            RequiredAction = request.RequiredAction,
+            CreatedBy = actor
+        };
+
+        var created = await _alerts.CreateAsync(alert);
+
+        var eventId = string.IsNullOrEmpty(request.EventId)
+            ? Guid.NewGuid().ToString()
+            : request.EventId;
+
+        await _events.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = eventId,
+            EventType = MemberEventType.MemberAlertCreated,
+            ActorId = actor,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["alertId"] = created.Id,
+                ["alertType"] = created.AlertType.ToString(),
+                ["severity"] = created.Severity.ToString(),
+                ["startDate"] = created.StartDate.ToString("o"),
+                ["endDate"] = created.EndDate?.ToString("o"),
+                ["reason"] = created.Reason,
+                ["requiredAction"] = created.RequiredAction
+            }
+        }, ct);
+
+        return CreatedAtAction(nameof(GetAlert),
+            new { memberId, alertId = created.Id }, created);
+    }
+
+    /// <summary>End-date an alert. Idempotent: ending an already-ended alert is a no-op (200).</summary>
+    [HttpPost("{alertId}/end")]
+    [ProducesResponseType(typeof(MemberAlert), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> EndAlert(
+        [FromRoute] string memberId,
+        [FromRoute] string alertId,
+        [FromBody] EndMemberAlertRequest? request,
+        CancellationToken ct)
+    {
+        var alert = await _alerts.GetByIdAsync(TenantId, memberId, alertId);
+        if (alert == null) return NotFound();
+
+        if (alert.EndDate.HasValue)
+        {
+            // Already ended — idempotent return.
+            return Ok(alert);
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        alert.EndDate = request?.EndDate ?? DateTime.UtcNow;
+        alert.EndedBy = actor;
+
+        var updated = await _alerts.EndAsync(alert);
+
+        var eventId = string.IsNullOrEmpty(request?.EventId)
+            ? Guid.NewGuid().ToString()
+            : request!.EventId;
+
+        await _events.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = eventId,
+            EventType = MemberEventType.MemberAlertEnded,
+            ActorId = actor,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["alertId"] = updated.Id,
+                ["alertType"] = updated.AlertType.ToString(),
+                ["endDate"] = updated.EndDate!.Value.ToString("o")
+            }
+        }, ct);
+
+        return Ok(updated);
+    }
+
+    /// <summary>FHIR Flag projection. <c>?status=active</c> filters to in-effect alerts.</summary>
+    [HttpGet("/api/v1/members/{memberId}/fhir/Flag")]
+    [Produces("application/fhir+json", "application/json")]
+    [ProducesResponseType(200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetFhirFlags(
+        [FromRoute] string memberId,
+        [FromQuery] string? status = null,
+        CancellationToken ct = default)
+    {
+        var member = await _members.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var activeOnly = string.Equals(status, "active", StringComparison.OrdinalIgnoreCase);
+        var items = await _alerts.ListByMemberAsync(TenantId, memberId, activeOnly);
+
+        await PublishViewedAsync(memberId, scope: $"fhir:flag:{(activeOnly ? "active" : "all")}", count: items.Count, ct);
+
+        var bundle = _flagProjector.ProjectBundle(items);
+        return new ContentResult
+        {
+            ContentType = "application/fhir+json",
+            Content = bundle.ToJsonString(),
+            StatusCode = 200
+        };
+    }
+
+    private Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
+    {
+        // View events are best-effort audit; failures shouldn't fail the read.
+        return _events.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberAlertViewed,
+            ActorId = User.Identity?.Name ?? "System",
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["scope"] = scope,
+                ["count"] = count
+            }
+        }, ct);
+    }
+}
+
+public class CreateMemberAlertRequest
+{
+    [Required]
+    public MemberAlertType AlertType { get; set; }
+
+    [Required]
+    public MemberAlertSeverity Severity { get; set; }
+
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+
+    [Required]
+    [StringLength(2000)]
+    public string Reason { get; set; } = string.Empty;
+
+    [StringLength(2000)]
+    public string? RequiredAction { get; set; }
+
+    /// <summary>Optional client-supplied idempotency key for the audit event.</summary>
+    public string? EventId { get; set; }
+}
+
+public class EndMemberAlertRequest
+{
+    /// <summary>End date. Defaults to now.</summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>Optional client-supplied idempotency key for the audit event.</summary>
+    public string? EventId { get; set; }
+}
+
+public class MemberAlertListResponse
+{
+    public List<MemberAlert> Items { get; set; } = new();
+}

--- a/src/services/member-service/Controllers/MemberNotesController.cs
+++ b/src/services/member-service/Controllers/MemberNotesController.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Middleware;
+using MemberService.Models;
+using MemberService.Repositories;
+using MemberService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MemberService.Controllers;
+
+/// <summary>
+/// Member notes (FHIR Communication). Notes are immutable — only Create + Read.
+/// Corrections are new notes that link back to the original via
+/// <see cref="CreateMemberNoteRequest.LinkedResourceType"/> = <c>"MemberNote"</c>.
+/// </summary>
+[ApiController]
+[Route("api/v1/members/{memberId}/notes")]
+public class MemberNotesController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IMemberRepository _members;
+    private readonly IMemberNoteRepository _notes;
+    private readonly IMemberEventPublisher _events;
+
+    public MemberNotesController(
+        IMemberRepository members,
+        IMemberNoteRepository notes,
+        IMemberEventPublisher events)
+    {
+        _members = members;
+        _notes = notes;
+        _events = events;
+    }
+
+    /// <summary>List notes for a member, newest first. Filter by category, paged.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(MemberNoteListResponse), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> ListNotes(
+        [FromRoute] string memberId,
+        [FromQuery] MemberNoteCategory? category = null,
+        [FromQuery][Range(1, 100)] int pageSize = 20,
+        [FromQuery] string? continuationToken = null,
+        CancellationToken ct = default)
+    {
+        var member = await _members.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var (items, token) = await _notes.ListByMemberAsync(
+            TenantId, memberId, category, pageSize, continuationToken);
+
+        await PublishViewedAsync(memberId,
+            scope: category.HasValue ? $"list:{category.Value}" : "list:all",
+            count: items.Count, ct);
+
+        return Ok(new MemberNoteListResponse
+        {
+            Items = new List<MemberNote>(items),
+            ContinuationToken = token
+        });
+    }
+
+    /// <summary>Get a single note by id.</summary>
+    [HttpGet("{noteId}")]
+    [ProducesResponseType(typeof(MemberNote), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetNote(
+        [FromRoute] string memberId,
+        [FromRoute] string noteId,
+        CancellationToken ct)
+    {
+        var note = await _notes.GetByIdAsync(TenantId, memberId, noteId);
+        if (note == null) return NotFound();
+
+        await PublishViewedAsync(memberId, scope: $"note:{noteId}", count: 1, ct);
+        return Ok(note);
+    }
+
+    /// <summary>Create a new note. Notes are immutable once created.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(MemberNote), 201)]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> CreateNote(
+        [FromRoute] string memberId,
+        [FromBody] CreateMemberNoteRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var member = await _members.GetByMemberIdAsync(TenantId, memberId);
+        if (member == null) return NotFound();
+
+        var actor = User.Identity?.Name ?? "System";
+        var note = new MemberNote
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            Category = request.Category,
+            Subject = request.Subject,
+            Body = request.Body,
+            Author = string.IsNullOrEmpty(request.Author) ? actor : request.Author,
+            LinkedResourceType = request.LinkedResourceType,
+            LinkedResourceId = request.LinkedResourceId
+        };
+
+        var created = await _notes.CreateAsync(note);
+
+        var eventId = string.IsNullOrEmpty(request.EventId)
+            ? Guid.NewGuid().ToString()
+            : request.EventId;
+
+        await _events.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = eventId,
+            EventType = MemberEventType.MemberNoteCreated,
+            ActorId = actor,
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["noteId"] = created.Id,
+                ["category"] = created.Category.ToString(),
+                ["subject"] = created.Subject,
+                ["author"] = created.Author,
+                ["linkedResourceType"] = created.LinkedResourceType,
+                ["linkedResourceId"] = created.LinkedResourceId
+            }
+        }, ct);
+
+        return CreatedAtAction(nameof(GetNote),
+            new { memberId, noteId = created.Id }, created);
+    }
+
+    private Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
+    {
+        return _events.PublishAsync(new MemberEvent
+        {
+            TenantId = TenantId,
+            MemberId = memberId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = MemberEventType.MemberNoteViewed,
+            ActorId = User.Identity?.Name ?? "System",
+            CorrelationId = HttpContext.TraceIdentifier,
+            Payload = new JsonObject
+            {
+                ["scope"] = scope,
+                ["count"] = count
+            }
+        }, ct);
+    }
+}
+
+public class CreateMemberNoteRequest
+{
+    [Required]
+    public MemberNoteCategory Category { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Subject { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(8000)]
+    public string Body { get; set; } = string.Empty;
+
+    /// <summary>If omitted, defaults to the authenticated user.</summary>
+    [StringLength(200)]
+    public string? Author { get; set; }
+
+    [StringLength(50)]
+    public string? LinkedResourceType { get; set; }
+
+    [StringLength(100)]
+    public string? LinkedResourceId { get; set; }
+
+    public string? EventId { get; set; }
+}
+
+public class MemberNoteListResponse
+{
+    public List<MemberNote> Items { get; set; } = new();
+    public string? ContinuationToken { get; set; }
+}

--- a/src/services/member-service/Controllers/MemberNotesController.cs
+++ b/src/services/member-service/Controllers/MemberNotesController.cs
@@ -27,14 +27,18 @@ public class MemberNotesController : ControllerBase
     private readonly IMemberNoteRepository _notes;
     private readonly IMemberEventPublisher _events;
 
+    private readonly ILogger<MemberNotesController>? _logger;
+
     public MemberNotesController(
         IMemberRepository members,
         IMemberNoteRepository notes,
-        IMemberEventPublisher events)
+        IMemberEventPublisher events,
+        ILogger<MemberNotesController>? logger = null)
     {
         _members = members;
         _notes = notes;
         _events = events;
+        _logger = logger;
     }
 
     /// <summary>List notes for a member, newest first. Filter by category, paged.</summary>
@@ -138,22 +142,37 @@ public class MemberNotesController : ControllerBase
             new { memberId, noteId = created.Id }, created);
     }
 
-    private Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
+    private async Task PublishViewedAsync(string memberId, string scope, int count, CancellationToken ct)
     {
-        return _events.PublishAsync(new MemberEvent
+        // Best-effort audit; failures must not fail the read. See the
+        // analogous comment on MemberAlertsController.PublishViewedAsync.
+        try
         {
-            TenantId = TenantId,
-            MemberId = memberId,
-            EventId = Guid.NewGuid().ToString(),
-            EventType = MemberEventType.MemberNoteViewed,
-            ActorId = User.Identity?.Name ?? "System",
-            CorrelationId = HttpContext.TraceIdentifier,
-            Payload = new JsonObject
+            await _events.PublishAsync(new MemberEvent
             {
-                ["scope"] = scope,
-                ["count"] = count
-            }
-        }, ct);
+                TenantId = TenantId,
+                MemberId = memberId,
+                EventId = Guid.NewGuid().ToString(),
+                EventType = MemberEventType.MemberNoteViewed,
+                ActorId = User.Identity?.Name ?? "System",
+                CorrelationId = HttpContext.TraceIdentifier,
+                Payload = new JsonObject
+                {
+                    ["scope"] = scope,
+                    ["count"] = count
+                }
+            }, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex,
+                "Best-effort audit for MemberNoteViewed failed for {MemberId} scope={Scope}",
+                memberId, scope);
+        }
     }
 }
 

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -34,6 +34,7 @@ public class MembersController : ControllerBase
     private readonly IAccumulatorServiceClient _accumulators;
     private readonly IRelationshipShim? _relationshipShim;
     private readonly IFamilyRelationshipService? _familyRelationships;
+    private readonly IMemberAlertGuard? _alertGuard;
     private readonly ILogger<MembersController>? _logger;
 
     public MembersController(
@@ -47,6 +48,7 @@ public class MembersController : ControllerBase
         IAccumulatorServiceClient accumulators,
         IRelationshipShim? relationshipShim = null,
         IFamilyRelationshipService? familyRelationships = null,
+        IMemberAlertGuard? alertGuard = null,
         ILogger<MembersController>? logger = null)
     {
         _memberRepository = memberRepository;
@@ -59,6 +61,7 @@ public class MembersController : ControllerBase
         _accumulators = accumulators;
         _relationshipShim = relationshipShim;
         _familyRelationships = familyRelationships;
+        _alertGuard = alertGuard;
         _logger = logger;
     }
 
@@ -345,6 +348,7 @@ public class MembersController : ControllerBase
     [HttpDelete("{memberId}")]
     [ProducesResponseType(204)]
     [ProducesResponseType(404)]
+    [ProducesResponseType(typeof(ProblemDetails), 409)]
     public async Task<IActionResult> TerminateMember(
         [FromRoute] string memberId,
         [FromQuery] DateTime? terminationDate = null,
@@ -355,6 +359,9 @@ public class MembersController : ControllerBase
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
 
+        var block = await EvaluateTerminationGuardAsync(memberId, ct);
+        if (block != null) return AlertBlocked(block);
+
         await TerminateInternal(member, terminationDate ?? DateTime.UtcNow, reasonCode, eventId, ct);
         return NoContent();
     }
@@ -363,6 +370,7 @@ public class MembersController : ControllerBase
     [HttpPost("{memberId}/terminate")]
     [ProducesResponseType(200)]
     [ProducesResponseType(404)]
+    [ProducesResponseType(typeof(ProblemDetails), 409)]
     [ProducesResponseType(503)]
     public async Task<IActionResult> TerminateMember(
         [FromRoute] string memberId,
@@ -371,6 +379,9 @@ public class MembersController : ControllerBase
     {
         var member = await _memberRepository.GetByMemberIdAsync(TenantId, memberId);
         if (member == null) return NotFound();
+
+        var block = await EvaluateTerminationGuardAsync(memberId, ct);
+        if (block != null) return AlertBlocked(block);
 
         await TerminateInternal(member, request.TerminationDate, request.ReasonCode, request.EventId, ct);
 
@@ -384,6 +395,32 @@ public class MembersController : ControllerBase
         }
 
         return Ok(new { memberId, terminationDate = request.TerminationDate, reasonCode = request.ReasonCode });
+    }
+
+    private async Task<MemberAlertBlock?> EvaluateTerminationGuardAsync(string memberId, CancellationToken ct)
+    {
+        if (_alertGuard == null) return null;
+        return await _alertGuard.EvaluateAsync(TenantId, memberId, MemberAlertAction.Terminate, ct);
+    }
+
+    private IActionResult AlertBlocked(MemberAlertBlock block)
+    {
+        var problem = new ProblemDetails
+        {
+            Type = "https://cloudhealthoffice.com/problems/member-alert-block",
+            Title = "Action blocked by active member alert",
+            Status = StatusCodes.Status409Conflict,
+            Detail = block.Reason
+        };
+        problem.Extensions["alertId"] = block.Alert.Id;
+        problem.Extensions["alertType"] = block.Alert.AlertType.ToString();
+        problem.Extensions["severity"] = block.Alert.Severity.ToString();
+        problem.Extensions["action"] = block.Action.ToString();
+        if (!string.IsNullOrEmpty(block.Alert.RequiredAction))
+        {
+            problem.Extensions["requiredAction"] = block.Alert.RequiredAction;
+        }
+        return StatusCode(StatusCodes.Status409Conflict, problem);
     }
 
     private async Task TerminateInternal(

--- a/src/services/member-service/HostedServices/MemberEventIndexInitializer.cs
+++ b/src/services/member-service/HostedServices/MemberEventIndexInitializer.cs
@@ -84,7 +84,27 @@ public sealed class MemberIndexInitializer : IHostedService
             new CreateIndexModel<Member>(keys, new CreateIndexOptions { Name = "ix_tenant_member" }),
             cancellationToken: cancellationToken);
 
-        _logger.LogInformation("Member indexes ensured.");
+        var alerts = _db.GetCollection<MemberAlert>("MemberAlerts");
+        alerts.Indexes.CreateOne(
+            new CreateIndexModel<MemberAlert>(
+                Builders<MemberAlert>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.MemberId)
+                    .Descending(x => x.StartDate),
+                new CreateIndexOptions { Name = "ix_tenant_member_start" }),
+            cancellationToken: cancellationToken);
+
+        var notes = _db.GetCollection<MemberNote>("MemberNotes");
+        notes.Indexes.CreateOne(
+            new CreateIndexModel<MemberNote>(
+                Builders<MemberNote>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.MemberId)
+                    .Descending(x => x.CreatedDate),
+                new CreateIndexOptions { Name = "ix_tenant_member_created" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("Member, MemberAlert, MemberNote indexes ensured.");
         return Task.CompletedTask;
     }
 

--- a/src/services/member-service/MemberService.Tests/Controllers/MemberAlertsControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MemberAlertsControllerTests.cs
@@ -167,6 +167,46 @@ public class MemberAlertsControllerTests
     }
 
     [Fact]
+    public async Task ListAlerts_AuditPublisherFailure_DoesNotFailRead()
+    {
+        // View audit is best-effort. Simulate publisher throwing and verify
+        // the list endpoint still returns 200 with the persisted alerts.
+        var members = new InMemoryMemberRepository();
+        members.Members.Add(new Member
+        {
+            TenantId = Tenant, MemberId = MemberId,
+            FirstName = "A", LastName = "B",
+            DateOfBirth = DateTime.UtcNow.AddYears(-30),
+            EffectiveDate = DateTime.UtcNow.AddYears(-1),
+            GroupNumber = "GRP", IsSubscriber = true
+        });
+        var alerts = new InMemoryMemberAlertRepository();
+        alerts.Alerts.Add(new MemberAlert
+        {
+            TenantId = Tenant, MemberId = MemberId, Id = "a1",
+            AlertType = MemberAlertType.VIP, Severity = MemberAlertSeverity.Info,
+            StartDate = DateTime.UtcNow.AddDays(-1), Reason = "r", CreatedBy = "csr"
+        });
+
+        var throwingPublisher = new Mock<MemberService.Services.IMemberEventPublisher>();
+        throwingPublisher
+            .Setup(p => p.PublishAsync(It.IsAny<MemberEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("downstream audit store unavailable"));
+
+        var ctl = new MemberAlertsController(members, alerts, throwingPublisher.Object,
+            new FhirFlagProjector(), NullLogger<MemberAlertsController>.Instance);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+
+        var resp = await ctl.ListAlerts(MemberId, status: "active", CancellationToken.None);
+
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberAlertListResponse>().Subject;
+        body.Items.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task GetFhirFlags_ReturnsBundleWithFhirContentType()
     {
         var (ctl, _, _, _) = Build();

--- a/src/services/member-service/MemberService.Tests/Controllers/MemberAlertsControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MemberAlertsControllerTests.cs
@@ -1,0 +1,182 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Controllers;
+
+public class MemberAlertsControllerTests
+{
+    private const string Tenant = "tenant-test";
+    private const string MemberId = "M-001";
+
+    private static (MemberAlertsController ctl,
+                    InMemoryMemberRepository members,
+                    InMemoryMemberAlertRepository alerts,
+                    InMemoryMemberEventRepository events) Build()
+    {
+        var members = new InMemoryMemberRepository();
+        members.Members.Add(new Member
+        {
+            TenantId = Tenant,
+            MemberId = MemberId,
+            FirstName = "Alice",
+            LastName = "Example",
+            DateOfBirth = new DateTime(1985, 6, 15),
+            EffectiveDate = new DateTime(2024, 1, 1),
+            GroupNumber = "GRP",
+            IsSubscriber = true
+        });
+        var alerts = new InMemoryMemberAlertRepository();
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+        var projector = new FhirFlagProjector();
+
+        var ctl = new MemberAlertsController(members, alerts, publisher, projector);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, members, alerts, events);
+    }
+
+    private static CreateMemberAlertRequest Req(
+        MemberAlertType type = MemberAlertType.LitigationHold,
+        MemberAlertSeverity severity = MemberAlertSeverity.Critical,
+        DateTime? endDate = null) => new()
+        {
+            AlertType = type,
+            Severity = severity,
+            Reason = "Outside counsel filing pending",
+            RequiredAction = "Route through legal",
+            EndDate = endDate
+        };
+
+    [Fact]
+    public async Task CreateAlert_PersistsAndEmitsAuditEvent()
+    {
+        var (ctl, _, alerts, events) = Build();
+
+        var resp = await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+        resp.Should().BeOfType<CreatedAtActionResult>();
+
+        alerts.Alerts.Should().ContainSingle();
+        var stored = alerts.Alerts[0];
+        stored.AlertType.Should().Be(MemberAlertType.LitigationHold);
+        stored.Severity.Should().Be(MemberAlertSeverity.Critical);
+        stored.EndDate.Should().BeNull();
+        stored.CreatedBy.Should().NotBeNullOrEmpty();
+
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberAlertCreated);
+        var created = events.All.First(e => e.EventType == MemberEventType.MemberAlertCreated);
+        created.Payload!["alertType"]!.ToString().Should().Be("LitigationHold");
+    }
+
+    [Fact]
+    public async Task CreateAlert_UnknownMember_Returns404()
+    {
+        var (ctl, _, _, _) = Build();
+        var resp = await ctl.CreateAlert("NOPE", Req(), CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task ListAlerts_StatusActive_ExcludesEndDated()
+    {
+        var (ctl, _, _, _) = Build();
+        await ctl.CreateAlert(MemberId, Req(MemberAlertType.LitigationHold), CancellationToken.None);
+        await ctl.CreateAlert(MemberId, Req(MemberAlertType.VIP, MemberAlertSeverity.Info,
+            endDate: DateTime.UtcNow.AddDays(-1)), CancellationToken.None);
+
+        var resp = await ctl.ListAlerts(MemberId, status: "active", CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberAlertListResponse>().Subject;
+        body.Items.Should().ContainSingle(a => a.AlertType == MemberAlertType.LitigationHold);
+        body.Items.Should().NotContain(a => a.AlertType == MemberAlertType.VIP);
+    }
+
+    [Fact]
+    public async Task ListAlerts_NoStatus_ReturnsAll()
+    {
+        var (ctl, _, _, _) = Build();
+        await ctl.CreateAlert(MemberId, Req(MemberAlertType.LitigationHold), CancellationToken.None);
+        await ctl.CreateAlert(MemberId, Req(MemberAlertType.VIP, MemberAlertSeverity.Info,
+            endDate: DateTime.UtcNow.AddDays(-1)), CancellationToken.None);
+
+        var resp = await ctl.ListAlerts(MemberId, status: null, CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberAlertListResponse>().Subject;
+        body.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListAlerts_EmitsViewedAuditEvent()
+    {
+        var (ctl, _, _, events) = Build();
+        await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+        var baseline = events.All.Count;
+
+        await ctl.ListAlerts(MemberId, status: "active", CancellationToken.None);
+
+        events.All.Count.Should().BeGreaterThan(baseline);
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberAlertViewed);
+    }
+
+    [Fact]
+    public async Task GetAlert_EmitsViewedAuditEvent()
+    {
+        var (ctl, _, _, events) = Build();
+        var created = (CreatedAtActionResult)await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+        var alert = (MemberAlert)created.Value!;
+
+        await ctl.GetAlert(MemberId, alert.Id, CancellationToken.None);
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberAlertViewed);
+    }
+
+    [Fact]
+    public async Task EndAlert_SetsEndDate_AndEmitsAuditEvent()
+    {
+        var (ctl, _, alerts, events) = Build();
+        var created = (CreatedAtActionResult)await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+        var alert = (MemberAlert)created.Value!;
+
+        var resp = await ctl.EndAlert(MemberId, alert.Id,
+            new EndMemberAlertRequest(), CancellationToken.None);
+        resp.Should().BeOfType<OkObjectResult>();
+
+        alerts.Alerts[0].EndDate.Should().NotBeNull();
+        alerts.Alerts[0].IsActive().Should().BeFalse();
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberAlertEnded);
+    }
+
+    [Fact]
+    public async Task EndAlert_AlreadyEnded_IsIdempotent()
+    {
+        var (ctl, _, alerts, events) = Build();
+        var created = (CreatedAtActionResult)await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+        var alert = (MemberAlert)created.Value!;
+        await ctl.EndAlert(MemberId, alert.Id, new EndMemberAlertRequest(), CancellationToken.None);
+        var endedEventsBefore = events.All.Count(e => e.EventType == MemberEventType.MemberAlertEnded);
+
+        var resp = await ctl.EndAlert(MemberId, alert.Id, new EndMemberAlertRequest(), CancellationToken.None);
+        resp.Should().BeOfType<OkObjectResult>();
+        events.All.Count(e => e.EventType == MemberEventType.MemberAlertEnded)
+            .Should().Be(endedEventsBefore, "second end is a no-op");
+    }
+
+    [Fact]
+    public async Task GetFhirFlags_ReturnsBundleWithFhirContentType()
+    {
+        var (ctl, _, _, _) = Build();
+        await ctl.CreateAlert(MemberId, Req(), CancellationToken.None);
+
+        var resp = await ctl.GetFhirFlags(MemberId, status: "active", CancellationToken.None);
+        var content = resp.Should().BeOfType<ContentResult>().Subject;
+        content.ContentType.Should().Be("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"Bundle\"");
+        content.Content.Should().Contain("\"resourceType\":\"Flag\"");
+        content.Content.Should().Contain("LitigationHold");
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/MemberNotesControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MemberNotesControllerTests.cs
@@ -1,0 +1,171 @@
+using MemberService.Controllers;
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Controllers;
+
+public class MemberNotesControllerTests
+{
+    private const string Tenant = "tenant-test";
+    private const string MemberId = "M-001";
+
+    private static (MemberNotesController ctl,
+                    InMemoryMemberRepository members,
+                    InMemoryMemberNoteRepository notes,
+                    InMemoryMemberEventRepository events) Build()
+    {
+        var members = new InMemoryMemberRepository();
+        members.Members.Add(new Member
+        {
+            TenantId = Tenant,
+            MemberId = MemberId,
+            FirstName = "Alice",
+            LastName = "Example",
+            DateOfBirth = new DateTime(1985, 6, 15),
+            EffectiveDate = new DateTime(2024, 1, 1),
+            GroupNumber = "GRP",
+            IsSubscriber = true
+        });
+        var notes = new InMemoryMemberNoteRepository();
+        var events = new InMemoryMemberEventRepository();
+        var publisher = new CosmosMemberEventPublisher(events, NullLogger<CosmosMemberEventPublisher>.Instance);
+
+        var ctl = new MemberNotesController(members, notes, publisher);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = Tenant;
+        ctl.ControllerContext = new ControllerContext { HttpContext = http };
+        return (ctl, members, notes, events);
+    }
+
+    private static CreateMemberNoteRequest Req(
+        MemberNoteCategory cat = MemberNoteCategory.CustomerService,
+        string subject = "Inbound call",
+        string body = "Member called about EOB",
+        string? linkedType = null,
+        string? linkedId = null) => new()
+        {
+            Category = cat,
+            Subject = subject,
+            Body = body,
+            LinkedResourceType = linkedType,
+            LinkedResourceId = linkedId
+        };
+
+    [Fact]
+    public async Task CreateNote_PersistsAndEmitsAuditEvent()
+    {
+        var (ctl, _, notes, events) = Build();
+
+        var resp = await ctl.CreateNote(MemberId, Req(), CancellationToken.None);
+        resp.Should().BeOfType<CreatedAtActionResult>();
+
+        notes.Notes.Should().ContainSingle();
+        var stored = notes.Notes[0];
+        stored.Category.Should().Be(MemberNoteCategory.CustomerService);
+        stored.Author.Should().NotBeNullOrEmpty();
+
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberNoteCreated);
+    }
+
+    [Fact]
+    public async Task CreateNote_UnknownMember_Returns404()
+    {
+        var (ctl, _, _, _) = Build();
+        var resp = await ctl.CreateNote("NOPE", Req(), CancellationToken.None);
+        resp.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task ListNotes_FilterByCategory_OnlyMatching()
+    {
+        var (ctl, _, _, _) = Build();
+        await ctl.CreateNote(MemberId, Req(MemberNoteCategory.CustomerService), CancellationToken.None);
+        await ctl.CreateNote(MemberId, Req(MemberNoteCategory.Appeals,  "Appeal filed"), CancellationToken.None);
+        await ctl.CreateNote(MemberId, Req(MemberNoteCategory.Billing, "Premium concern"), CancellationToken.None);
+
+        var resp = await ctl.ListNotes(MemberId, category: MemberNoteCategory.Appeals,
+            pageSize: 20, continuationToken: null, ct: CancellationToken.None);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var body = ok.Value.Should().BeOfType<MemberNoteListResponse>().Subject;
+        body.Items.Should().ContainSingle(n => n.Category == MemberNoteCategory.Appeals);
+    }
+
+    [Fact]
+    public async Task ListNotes_NewestFirst()
+    {
+        var (ctl, _, notes, _) = Build();
+        // Insert with explicit dates so the ordering check is deterministic
+        notes.Notes.Add(new MemberNote
+        {
+            TenantId = Tenant, MemberId = MemberId, Id = "n1",
+            Category = MemberNoteCategory.CustomerService, Subject = "old",
+            Body = "old", Author = "csr", CreatedDate = DateTime.UtcNow.AddDays(-2)
+        });
+        notes.Notes.Add(new MemberNote
+        {
+            TenantId = Tenant, MemberId = MemberId, Id = "n2",
+            Category = MemberNoteCategory.CustomerService, Subject = "new",
+            Body = "new", Author = "csr", CreatedDate = DateTime.UtcNow
+        });
+
+        var resp = await ctl.ListNotes(MemberId, null, 20, null, CancellationToken.None);
+        var body = ((OkObjectResult)resp).Value.Should().BeOfType<MemberNoteListResponse>().Subject;
+        body.Items[0].Id.Should().Be("n2");
+    }
+
+    [Fact]
+    public async Task ListNotes_EmitsViewedAuditEvent()
+    {
+        var (ctl, _, _, events) = Build();
+        await ctl.CreateNote(MemberId, Req(), CancellationToken.None);
+        var baseline = events.All.Count;
+
+        await ctl.ListNotes(MemberId, null, 20, null, CancellationToken.None);
+        events.All.Count.Should().BeGreaterThan(baseline);
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberNoteViewed);
+    }
+
+    [Fact]
+    public async Task GetNote_EmitsViewedAuditEvent()
+    {
+        var (ctl, _, _, events) = Build();
+        var created = (CreatedAtActionResult)await ctl.CreateNote(MemberId, Req(), CancellationToken.None);
+        var note = (MemberNote)created.Value!;
+
+        await ctl.GetNote(MemberId, note.Id, CancellationToken.None);
+        events.All.Should().Contain(e => e.EventType == MemberEventType.MemberNoteViewed);
+    }
+
+    [Fact]
+    public void NoteRepository_HasNoUpdateOrDeleteMethod_EnforcesImmutability()
+    {
+        // Reflection-based contract test: catching anyone who later adds an
+        // Update / Delete method that would break the immutability invariant.
+        var iface = typeof(MemberService.Repositories.IMemberNoteRepository);
+        var methodNames = iface.GetMethods().Select(m => m.Name).ToList();
+        methodNames.Should().NotContain("UpdateAsync");
+        methodNames.Should().NotContain("DeleteAsync");
+    }
+
+    [Fact]
+    public async Task CreateNote_AsCorrection_LinksBackToOriginal()
+    {
+        var (ctl, _, notes, _) = Build();
+        var created = (CreatedAtActionResult)await ctl.CreateNote(MemberId,
+            Req(subject: "Original (typo)"), CancellationToken.None);
+        var original = (MemberNote)created.Value!;
+
+        var correction = (CreatedAtActionResult)await ctl.CreateNote(MemberId,
+            Req(subject: "Correction", linkedType: "MemberNote", linkedId: original.Id),
+            CancellationToken.None);
+        var corrNote = (MemberNote)correction.Value!;
+
+        corrNote.LinkedResourceType.Should().Be("MemberNote");
+        corrNote.LinkedResourceId.Should().Be(original.Id);
+        notes.Notes.Should().HaveCount(2, "correction is a new note, not an edit");
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/MembersControllerTests.cs
@@ -18,7 +18,8 @@ public class MembersControllerTests
                     InMemoryMemberEventRepository events,
                     Mock<ICoverageServiceClient> coverage,
                     Mock<IEnrollmentImportServiceClient> enrollment,
-                    Mock<IAccumulatorServiceClient> acc) Build()
+                    Mock<IAccumulatorServiceClient> acc,
+                    InMemoryMemberAlertRepository alerts) Build()
     {
         var repo = new InMemoryMemberRepository();
         var events = new InMemoryMemberEventRepository();
@@ -28,14 +29,17 @@ public class MembersControllerTests
         var coverage = new Mock<ICoverageServiceClient>();
         var enrollment = new Mock<IEnrollmentImportServiceClient>();
         var acc = new Mock<IAccumulatorServiceClient>();
+        var alerts = new InMemoryMemberAlertRepository();
+        var guard = new MemberAlertGuard(alerts);
 
         var ctl = new MembersController(repo, publisher, events, projector, enc,
-            coverage.Object, enrollment.Object, acc.Object);
+            coverage.Object, enrollment.Object, acc.Object,
+            relationshipShim: null, familyRelationships: null, alertGuard: guard);
 
         var http = new DefaultHttpContext();
         http.Items["TenantId"] = Tenant;
         ctl.ControllerContext = new ControllerContext { HttpContext = http };
-        return (ctl, repo, events, coverage, enrollment, acc);
+        return (ctl, repo, events, coverage, enrollment, acc, alerts);
     }
 
     private static CreateMemberRequest CreateReq(string memberId = "M-001") => new()
@@ -58,7 +62,7 @@ public class MembersControllerTests
     [Fact]
     public async Task CreateMember_Persists_AndEmitsMemberCreatedWithSnapshot()
     {
-        var (ctl, repo, events, _, _, _) = Build();
+        var (ctl, repo, events, _, _, _, _) = Build();
         var resp = await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
         resp.Should().BeOfType<CreatedAtActionResult>();
@@ -81,7 +85,7 @@ public class MembersControllerTests
     [Fact]
     public async Task CreateMember_DuplicateMemberId_Returns409()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         var second = await ctl.CreateMember(CreateReq(), CancellationToken.None);
         second.Should().BeOfType<ConflictObjectResult>();
@@ -90,7 +94,7 @@ public class MembersControllerTests
     [Fact]
     public async Task CreateMember_DependentWithUnknownSubscriber_ReturnsBadRequest()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         var req = CreateReq("D-001");
         req.IsSubscriber = false;
         req.SubscriberMemberId = "DOES-NOT-EXIST";
@@ -101,7 +105,7 @@ public class MembersControllerTests
     [Fact]
     public async Task UpdateMember_AddressChange_EmitsAddressChangedAndMemberUpdated()
     {
-        var (ctl, _, events, _, _, _) = Build();
+        var (ctl, _, events, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
         var resp = await ctl.UpdateMember("M-001",
@@ -118,7 +122,7 @@ public class MembersControllerTests
     [Fact]
     public async Task UpdateMember_NoChanges_IsNoOp()
     {
-        var (ctl, repo, events, _, _, _) = Build();
+        var (ctl, repo, events, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         var baselineCount = events.All.Count;
 
@@ -130,7 +134,7 @@ public class MembersControllerTests
     [Fact]
     public async Task UpdateMember_NotFound_Returns404()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         var resp = await ctl.UpdateMember("MISSING", new UpdateMemberRequest { City = "X" }, CancellationToken.None);
         resp.Should().BeOfType<NotFoundResult>();
     }
@@ -138,7 +142,7 @@ public class MembersControllerTests
     [Fact]
     public async Task TerminateMember_Delete_MarksTerminatedAndEmits()
     {
-        var (ctl, repo, events, _, _, _) = Build();
+        var (ctl, repo, events, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
         var resp = await ctl.TerminateMember("M-001",
@@ -155,7 +159,7 @@ public class MembersControllerTests
     [Fact]
     public async Task CheckEligibility_ActiveMember_ReturnsEligible()
     {
-        var (ctl, repo, _, _, _, _) = Build();
+        var (ctl, repo, _, _, _, _, _) = Build();
         var req = CreateReq();
         req.EffectiveDate = DateTime.UtcNow.AddMonths(-1);
         await ctl.CreateMember(req, CancellationToken.None);
@@ -170,7 +174,7 @@ public class MembersControllerTests
     [Fact]
     public async Task CheckEligibility_Terminated_ReturnsNotEligible()
     {
-        var (ctl, repo, _, _, _, _) = Build();
+        var (ctl, repo, _, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         repo.Members[0].Status = EnrollmentStatus.Terminated;
 
@@ -183,14 +187,14 @@ public class MembersControllerTests
     [Fact]
     public async Task CheckEligibility_Missing_Returns404()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         (await ctl.CheckEligibility("nope", null)).Should().BeOfType<NotFoundResult>();
     }
 
     [Fact]
     public async Task GetFhirPatient_ReturnsFhirContentType_And_PatientResource()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
         var resp = await ctl.GetFhirPatient("M-001");
@@ -202,7 +206,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetEvents_ReturnsOrderedStream()
     {
-        var (ctl, _, _, _, _, _) = Build();
+        var (ctl, _, _, _, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         await ctl.UpdateMember("M-001", new UpdateMemberRequest { City = "Houston" }, CancellationToken.None);
 
@@ -216,7 +220,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetMemberPcp_WhenCoverageUnavailable_Returns503ProblemDetails()
     {
-        var (ctl, _, _, coverage, _, _) = Build();
+        var (ctl, _, _, coverage, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
 
         coverage.Setup(c => c.GetPcpAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
@@ -233,7 +237,7 @@ public class MembersControllerTests
     [Fact]
     public async Task AssignPcp_EmitsPcpChangedEvent()
     {
-        var (ctl, _, events, coverage, _, _) = Build();
+        var (ctl, _, events, coverage, _, _, _) = Build();
         await ctl.CreateMember(CreateReq(), CancellationToken.None);
         coverage.Setup(c => c.AssignPcpAsync(Tenant, "M-001", It.IsAny<AssignPcpRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AssignPcpOutcome { Pcp = new MemberPcpResponse { ProviderId = "prov-1" } });
@@ -248,7 +252,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetCoverageHistory_WhenUnavailable_Returns503()
     {
-        var (ctl, _, _, coverage, _, _) = Build();
+        var (ctl, _, _, coverage, _, _, _) = Build();
         coverage.Setup(c => c.GetCoverageHistoryAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DownstreamUnavailableException("coverage-service"));
 
@@ -259,7 +263,7 @@ public class MembersControllerTests
     [Fact]
     public async Task Get834Transactions_WhenUnavailable_Returns503()
     {
-        var (ctl, _, _, _, enrollment, _) = Build();
+        var (ctl, _, _, _, enrollment, _, _) = Build();
         enrollment.Setup(e => e.Get834TransactionsAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DownstreamUnavailableException("enrollment-import-service"));
 
@@ -270,7 +274,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetEnrollmentEvents_ProxiesToDownstream()
     {
-        var (ctl, _, _, _, enrollment, _) = Build();
+        var (ctl, _, _, _, enrollment, _, _) = Build();
         enrollment.Setup(e => e.GetEnrollmentEventsAsync(
                 Tenant, "M-001", null, null, null, 50, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EnrollmentEventListResponse
@@ -290,7 +294,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetEnrollmentEvents_WhenDownstreamDown_Returns503()
     {
-        var (ctl, _, _, _, enrollment, _) = Build();
+        var (ctl, _, _, _, enrollment, _, _) = Build();
         enrollment.Setup(e => e.GetEnrollmentEventsAsync(
                 Tenant, "M-001", null, null, null, 50, null, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DownstreamUnavailableException("enrollment-import-service"));
@@ -302,7 +306,7 @@ public class MembersControllerTests
     [Fact]
     public async Task GetAccumulators_WhenUnavailable_Returns503()
     {
-        var (ctl, _, _, _, _, accu) = Build();
+        var (ctl, _, _, _, _, accu, _) = Build();
         accu.Setup(a => a.GetAccumulatorsAsync(Tenant, "M-001", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DownstreamUnavailableException("accumulator-service"));
 
@@ -311,9 +315,95 @@ public class MembersControllerTests
     }
 
     [Fact]
+    public async Task TerminateMember_Delete_BlockedByActiveLitigationHold_Returns409()
+    {
+        var (ctl, _, _, _, _, _, alerts) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        alerts.Alerts.Add(new MemberAlert
+        {
+            TenantId = Tenant, MemberId = "M-001", Id = Guid.NewGuid().ToString(),
+            AlertType = MemberAlertType.LitigationHold,
+            Severity = MemberAlertSeverity.Critical,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            Reason = "Outside counsel notice 2024-04",
+            RequiredAction = "Route through legal",
+            CreatedBy = "legal-ops"
+        });
+
+        var resp = await ctl.TerminateMember("M-001",
+            terminationDate: DateTime.UtcNow,
+            reasonCode: "25",
+            eventId: null,
+            ct: CancellationToken.None);
+
+        var status = resp.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        var problem = status.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(409);
+        problem.Extensions["alertType"].Should().Be("LitigationHold");
+        problem.Extensions["action"].Should().Be("Terminate");
+    }
+
+    [Fact]
+    public async Task TerminateMember_Body_BlockedByActiveLitigationHold_Returns409()
+    {
+        var (ctl, _, events, _, _, _, alerts) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        alerts.Alerts.Add(new MemberAlert
+        {
+            TenantId = Tenant, MemberId = "M-001", Id = Guid.NewGuid().ToString(),
+            AlertType = MemberAlertType.LitigationHold,
+            Severity = MemberAlertSeverity.Critical,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            Reason = "Hold",
+            CreatedBy = "legal-ops"
+        });
+        var preTerminateEvents = events.All.Count(e => e.EventType == MemberEventType.MemberTerminated);
+
+        var resp = await ctl.TerminateMember("M-001", new TerminateMemberRequest
+        {
+            MemberId = "M-001",
+            TerminationDate = DateTime.UtcNow,
+            ReasonCode = "25"
+        }, CancellationToken.None);
+
+        ((ObjectResult)resp).StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        events.All.Count(e => e.EventType == MemberEventType.MemberTerminated)
+            .Should().Be(preTerminateEvents, "termination must not have been recorded");
+    }
+
+    [Fact]
+    public async Task TerminateMember_EndedLitigationHold_AllowsTermination()
+    {
+        var (ctl, repo, _, _, _, _, alerts) = Build();
+        await ctl.CreateMember(CreateReq(), CancellationToken.None);
+
+        alerts.Alerts.Add(new MemberAlert
+        {
+            TenantId = Tenant, MemberId = "M-001", Id = Guid.NewGuid().ToString(),
+            AlertType = MemberAlertType.LitigationHold,
+            Severity = MemberAlertSeverity.Critical,
+            StartDate = DateTime.UtcNow.AddDays(-10),
+            EndDate = DateTime.UtcNow.AddMinutes(-1),  // already ended
+            Reason = "Hold",
+            CreatedBy = "legal-ops"
+        });
+
+        var resp = await ctl.TerminateMember("M-001",
+            terminationDate: DateTime.UtcNow,
+            reasonCode: "25",
+            eventId: null,
+            ct: CancellationToken.None);
+        resp.Should().BeOfType<NoContentResult>();
+        repo.Members[0].Status.Should().Be(EnrollmentStatus.Terminated);
+    }
+
+    [Fact]
     public async Task GetDependents_ReturnsOnlyNonSubscribersLinked()
     {
-        var (ctl, repo, _, _, _, _) = Build();
+        var (ctl, repo, _, _, _, _, _) = Build();
         var sub = CreateReq("SUB-1");
         await ctl.CreateMember(sub, CancellationToken.None);
 

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberAlertRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberAlertRepository.cs
@@ -1,0 +1,60 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>In-memory <see cref="IMemberAlertRepository"/> for tests.</summary>
+public sealed class InMemoryMemberAlertRepository : IMemberAlertRepository
+{
+    public List<MemberAlert> Alerts { get; } = new();
+    private readonly object _lock = new();
+
+    public Task<MemberAlert> CreateAsync(MemberAlert alert)
+    {
+        lock (_lock)
+        {
+            if (string.IsNullOrEmpty(alert.Id)) alert.Id = Guid.NewGuid().ToString();
+            if (alert.CreatedDate == default) alert.CreatedDate = DateTime.UtcNow;
+            Alerts.Add(alert);
+            return Task.FromResult(alert);
+        }
+    }
+
+    public Task<MemberAlert?> GetByIdAsync(string tenantId, string memberId, string alertId)
+    {
+        lock (_lock)
+        {
+            var hit = Alerts.FirstOrDefault(a =>
+                a.TenantId == tenantId && a.MemberId == memberId && a.Id == alertId);
+            return Task.FromResult<MemberAlert?>(hit);
+        }
+    }
+
+    public Task<IReadOnlyList<MemberAlert>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        bool activeOnly,
+        DateTime? asOf = null)
+    {
+        lock (_lock)
+        {
+            var t = asOf ?? DateTime.UtcNow;
+            var q = Alerts.Where(a => a.TenantId == tenantId && a.MemberId == memberId);
+            if (activeOnly) q = q.Where(a => a.IsActive(t));
+            var list = q.OrderByDescending(a => a.StartDate)
+                        .ThenBy(a => a.AlertType)
+                        .ToList();
+            return Task.FromResult<IReadOnlyList<MemberAlert>>(list);
+        }
+    }
+
+    public Task<MemberAlert> EndAsync(MemberAlert alert)
+    {
+        lock (_lock)
+        {
+            var idx = Alerts.FindIndex(a => a.TenantId == alert.TenantId && a.Id == alert.Id);
+            if (idx >= 0) Alerts[idx] = alert;
+            return Task.FromResult(alert);
+        }
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberNoteRepository.cs
+++ b/src/services/member-service/MemberService.Tests/Fakes/InMemoryMemberNoteRepository.cs
@@ -1,0 +1,58 @@
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Tests.Fakes;
+
+/// <summary>In-memory <see cref="IMemberNoteRepository"/> for tests.</summary>
+public sealed class InMemoryMemberNoteRepository : IMemberNoteRepository
+{
+    public List<MemberNote> Notes { get; } = new();
+    private readonly object _lock = new();
+
+    public Task<MemberNote> CreateAsync(MemberNote note)
+    {
+        lock (_lock)
+        {
+            if (string.IsNullOrEmpty(note.Id)) note.Id = Guid.NewGuid().ToString();
+            if (note.CreatedDate == default) note.CreatedDate = DateTime.UtcNow;
+            Notes.Add(note);
+            return Task.FromResult(note);
+        }
+    }
+
+    public Task<MemberNote?> GetByIdAsync(string tenantId, string memberId, string noteId)
+    {
+        lock (_lock)
+        {
+            var hit = Notes.FirstOrDefault(n =>
+                n.TenantId == tenantId && n.MemberId == memberId && n.Id == noteId);
+            return Task.FromResult<MemberNote?>(hit);
+        }
+    }
+
+    public Task<(IReadOnlyList<MemberNote> Items, string? ContinuationToken)> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        MemberNoteCategory? category,
+        int pageSize,
+        string? continuationToken)
+    {
+        lock (_lock)
+        {
+            int skip = 0;
+            if (!string.IsNullOrEmpty(continuationToken) && int.TryParse(continuationToken, out var parsed))
+                skip = parsed;
+
+            var q = Notes
+                .Where(n => n.TenantId == tenantId && n.MemberId == memberId);
+            if (category.HasValue) q = q.Where(n => n.Category == category.Value);
+
+            var ordered = q.OrderByDescending(n => n.CreatedDate).ToList();
+            var page = ordered.Skip(skip).Take(pageSize).ToList();
+            string? next = (skip + page.Count) < ordered.Count
+                ? (skip + page.Count).ToString()
+                : null;
+            return Task.FromResult<(IReadOnlyList<MemberNote>, string?)>((page, next));
+        }
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/FhirFlagProjectorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FhirFlagProjectorTests.cs
@@ -1,0 +1,98 @@
+using MemberService.Models;
+using MemberService.Services;
+
+namespace MemberService.Tests.Services;
+
+public class FhirFlagProjectorTests
+{
+    private readonly FhirFlagProjector _projector = new();
+
+    private static MemberAlert Alert(
+        MemberAlertType type = MemberAlertType.LitigationHold,
+        MemberAlertSeverity severity = MemberAlertSeverity.Critical,
+        DateTime? endDate = null,
+        string? requiredAction = null) => new()
+        {
+            Id = "alert-1",
+            TenantId = "t",
+            MemberId = "M-1",
+            AlertType = type,
+            Severity = severity,
+            StartDate = DateTime.UtcNow.AddDays(-3),
+            EndDate = endDate,
+            Reason = "test reason",
+            RequiredAction = requiredAction,
+            CreatedBy = "csr"
+        };
+
+    [Fact]
+    public void Project_ActiveAlert_StatusIsActive()
+    {
+        var flag = _projector.Project(Alert());
+        flag["resourceType"]!.ToString().Should().Be("Flag");
+        flag["status"]!.ToString().Should().Be("active");
+    }
+
+    [Fact]
+    public void Project_EndDatedAlert_StatusIsInactive()
+    {
+        var flag = _projector.Project(Alert(endDate: DateTime.UtcNow.AddDays(-1)));
+        flag["status"]!.ToString().Should().Be("inactive");
+    }
+
+    [Fact]
+    public void Project_EmitsCodeWithAlertType()
+    {
+        var flag = _projector.Project(Alert(MemberAlertType.CustodyDispute));
+        flag["code"]!["coding"]![0]!["code"]!.ToString().Should().Be("CustodyDispute");
+        flag["code"]!["coding"]![0]!["display"]!.ToString().Should().Be("Custody Dispute");
+    }
+
+    [Fact]
+    public void Project_EmitsSubjectWithMemberIdentifier()
+    {
+        var flag = _projector.Project(Alert());
+        flag["subject"]!["type"]!.ToString().Should().Be("Patient");
+        flag["subject"]!["identifier"]!["value"]!.ToString().Should().Be("M-1");
+    }
+
+    [Fact]
+    public void Project_RequiredAction_EmittedAsExtension()
+    {
+        var flag = _projector.Project(Alert(requiredAction: "Route through legal"));
+        flag["extension"]![0]!["valueString"]!.ToString().Should().Be("Route through legal");
+    }
+
+    [Fact]
+    public void Project_NoRequiredAction_OmitsExtension()
+    {
+        var flag = _projector.Project(Alert(requiredAction: null));
+        flag["extension"].Should().BeNull();
+    }
+
+    [Fact]
+    public void ProjectBundle_WrapsEntries_AsSearchset()
+    {
+        var bundle = _projector.ProjectBundle(new[]
+        {
+            Alert(MemberAlertType.LitigationHold),
+            Alert(MemberAlertType.VIP)
+        });
+
+        bundle["resourceType"]!.ToString().Should().Be("Bundle");
+        bundle["type"]!.ToString().Should().Be("searchset");
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+        bundle["entry"]!.AsArray().Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void Project_SeverityMapsToCategoryCode()
+    {
+        _projector.Project(Alert(severity: MemberAlertSeverity.Critical))
+            ["category"]![0]!["coding"]![0]!["code"]!.ToString().Should().Be("safety");
+        _projector.Project(Alert(severity: MemberAlertSeverity.Warning))
+            ["category"]![0]!["coding"]![0]!["code"]!.ToString().Should().Be("admin");
+        _projector.Project(Alert(severity: MemberAlertSeverity.Info))
+            ["category"]![0]!["coding"]![0]!["code"]!.ToString().Should().Be("clinical");
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/MemberAlertGuardTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/MemberAlertGuardTests.cs
@@ -1,0 +1,99 @@
+using MemberService.Models;
+using MemberService.Services;
+using MemberService.Tests.Fakes;
+
+namespace MemberService.Tests.Services;
+
+public class MemberAlertGuardTests
+{
+    private const string Tenant = "t";
+    private const string MemberId = "M-1";
+
+    private static (MemberAlertGuard guard, InMemoryMemberAlertRepository repo) Build()
+    {
+        var repo = new InMemoryMemberAlertRepository();
+        return (new MemberAlertGuard(repo), repo);
+    }
+
+    private static MemberAlert Active(MemberAlertType type) => new()
+    {
+        TenantId = Tenant, MemberId = MemberId, Id = Guid.NewGuid().ToString(),
+        AlertType = type, Severity = MemberAlertSeverity.Critical,
+        StartDate = DateTime.UtcNow.AddDays(-1), EndDate = null,
+        Reason = "test", CreatedBy = "csr"
+    };
+
+    [Fact]
+    public async Task Terminate_BlockedBy_LitigationHold()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.LitigationHold));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().NotBeNull();
+        block!.Action.Should().Be(MemberAlertAction.Terminate);
+        block.Alert.AlertType.Should().Be(MemberAlertType.LitigationHold);
+    }
+
+    [Fact]
+    public async Task Terminate_BlockedBy_EligibilityDispute()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.EligibilityDispute));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block!.Alert.AlertType.Should().Be(MemberAlertType.EligibilityDispute);
+    }
+
+    [Fact]
+    public async Task Terminate_NotBlockedBy_VIP()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.VIP));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Terminate_EndDatedLitigationHold_DoesNotBlock()
+    {
+        var (guard, repo) = Build();
+        var ended = Active(MemberAlertType.LitigationHold);
+        ended.EndDate = DateTime.UtcNow.AddMinutes(-1);
+        repo.Alerts.Add(ended);
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdatePii_BlockedBy_SecurityFreeze()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.SecurityFreeze));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.UpdatePii);
+        block!.Alert.AlertType.Should().Be(MemberAlertType.SecurityFreeze);
+    }
+
+    [Fact]
+    public async Task NewEnrollment_BlockedBy_KnownFraudRisk()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.KnownFraudRisk));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.NewEnrollment);
+        block!.Alert.AlertType.Should().Be(MemberAlertType.KnownFraudRisk);
+    }
+
+    [Fact]
+    public async Task OutboundCommunication_BlockedBy_DoNotContact()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.DoNotContact));
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.OutboundCommunication);
+        block!.Alert.AlertType.Should().Be(MemberAlertType.DoNotContact);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/MemberAlertGuardTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/MemberAlertGuardTests.cs
@@ -96,4 +96,69 @@ public class MemberAlertGuardTests
         var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.OutboundCommunication);
         block!.Alert.AlertType.Should().Be(MemberAlertType.DoNotContact);
     }
+
+    [Fact]
+    public async Task Terminate_LitigationHoldAtWarning_DoesNotBlock()
+    {
+        // LitigationHold's minimum severity for Terminate is Critical; a
+        // Warning-severity hold is informational and must not block.
+        var (guard, repo) = Build();
+        var warn = Active(MemberAlertType.LitigationHold);
+        warn.Severity = MemberAlertSeverity.Warning;
+        repo.Alerts.Add(warn);
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Terminate_EligibilityDisputeAtInfo_DoesNotBlock()
+    {
+        // EligibilityDispute's minimum for Terminate is Warning; Info is too low.
+        var (guard, repo) = Build();
+        var info = Active(MemberAlertType.EligibilityDispute);
+        info.Severity = MemberAlertSeverity.Info;
+        repo.Alerts.Add(info);
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Terminate_EligibilityDisputeAtWarning_Blocks()
+    {
+        var (guard, repo) = Build();
+        var warn = Active(MemberAlertType.EligibilityDispute);
+        warn.Severity = MemberAlertSeverity.Warning;
+        repo.Alerts.Add(warn);
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block!.Alert.AlertType.Should().Be(MemberAlertType.EligibilityDispute);
+    }
+
+    [Fact]
+    public async Task Terminate_EligibilityDisputeAtCritical_AlsoBlocks()
+    {
+        // Critical >= Warning, so higher severity also triggers.
+        var (guard, repo) = Build();
+        var crit = Active(MemberAlertType.EligibilityDispute);
+        crit.Severity = MemberAlertSeverity.Critical;
+        repo.Alerts.Add(crit);
+
+        var block = await guard.EvaluateAsync(Tenant, MemberId, MemberAlertAction.Terminate);
+        block.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_CancelledToken_Throws()
+    {
+        var (guard, repo) = Build();
+        repo.Alerts.Add(Active(MemberAlertType.LitigationHold));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await guard.EvaluateAsync(
+            Tenant, MemberId, MemberAlertAction.Terminate, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }

--- a/src/services/member-service/Models/MemberAlert.cs
+++ b/src/services/member-service/Models/MemberAlert.cs
@@ -1,0 +1,106 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// A flag attached to a member that warns or constrains downstream interactions
+/// (litigation hold, custody dispute, accessibility need, fraud risk, etc.).
+/// Projects to FHIR R4 Flag.
+///
+/// Lifecycle: alerts are never deleted. They are created with a <see cref="StartDate"/>
+/// and end-dated by writing <see cref="EndDate"/>. The active set is computed as
+/// <c>StartDate &lt;= now AND (EndDate IS NULL OR EndDate &gt; now)</c>.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class MemberAlert
+{
+    /// <summary>Multi-tenant partition key.</summary>
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Cosmos document id.</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>External member id (matches <see cref="Member.MemberId"/>).</summary>
+    [Required]
+    [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    [Required]
+    public MemberAlertType AlertType { get; set; }
+
+    [Required]
+    public MemberAlertSeverity Severity { get; set; } = MemberAlertSeverity.Info;
+
+    /// <summary>When the alert becomes effective. Defaults to creation time.</summary>
+    [Required]
+    public DateTime StartDate { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// When the alert was end-dated. Null while active. Once set, the alert is no
+    /// longer surfaced as active and downstream block rules stop applying.
+    /// </summary>
+    public DateTime? EndDate { get; set; }
+
+    /// <summary>Free-text reason the alert was raised. Required.</summary>
+    [Required]
+    [StringLength(2000)]
+    public string Reason { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional operator-facing instruction (e.g., "Route all communication
+    /// through legal" or "Confirm CSR speaks Spanish before transferring").
+    /// </summary>
+    [StringLength(2000)]
+    public string? RequiredAction { get; set; }
+
+    /// <summary>User or system that created the alert.</summary>
+    [Required]
+    [StringLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+    /// <summary>User or system that end-dated the alert. Set when <see cref="EndDate"/> is set.</summary>
+    [StringLength(200)]
+    public string? EndedBy { get; set; }
+
+    /// <summary>True when the alert is currently in effect.</summary>
+    public bool IsActive(DateTime? asOf = null)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        return StartDate <= t && (!EndDate.HasValue || EndDate.Value > t);
+    }
+}
+
+/// <summary>
+/// Member alert taxonomy. Each value maps to a FHIR Flag.code coding (see
+/// <see cref="MemberService.Services.FhirFlagProjector"/>).
+/// </summary>
+public enum MemberAlertType
+{
+    HighRisk = 1,
+    LitigationHold = 2,
+    DoNotContact = 3,
+    VIP = 4,
+    CustodyDispute = 5,
+    LanguageRequirement = 6,
+    AccessibilityNeed = 7,
+    SecurityFreeze = 8,
+    KnownFraudRisk = 9,
+    EligibilityDispute = 10
+}
+
+/// <summary>
+/// Severity drives color in the portal banner and the FHIR Flag.category.
+/// Critical alerts may also enforce service-layer block rules
+/// (see <see cref="MemberService.Services.IMemberAlertGuard"/>).
+/// </summary>
+public enum MemberAlertSeverity
+{
+    Info = 1,
+    Warning = 2,
+    Critical = 3
+}

--- a/src/services/member-service/Models/MemberAlert.cs
+++ b/src/services/member-service/Models/MemberAlert.cs
@@ -95,8 +95,11 @@ public enum MemberAlertType
 
 /// <summary>
 /// Severity drives color in the portal banner and the FHIR Flag.category.
-/// Critical alerts may also enforce service-layer block rules
-/// (see <see cref="MemberService.Services.IMemberAlertGuard"/>).
+/// Severity is also compared against a per-rule minimum in
+/// <see cref="MemberService.Services.IMemberAlertGuard"/> — e.g., Terminate
+/// is blocked by a LitigationHold at Critical severity, and by an
+/// EligibilityDispute at Warning or higher. Numeric order is significant:
+/// the evaluator uses <c>severity &gt;= minSeverity</c>.
 /// </summary>
 public enum MemberAlertSeverity
 {

--- a/src/services/member-service/Models/MemberEvent.cs
+++ b/src/services/member-service/Models/MemberEvent.cs
@@ -112,5 +112,16 @@ public enum MemberEventType
     MemberUpdated = 2,
     MemberTerminated = 3,
     AddressChanged = 4,
-    PcpChanged = 5
+    PcpChanged = 5,
+
+    // Alerts (FHIR Flag) — view events provide the access audit trail required
+    // for protected member context like LitigationHold, CustodyDispute, etc.
+    MemberAlertCreated = 6,
+    MemberAlertEnded = 7,
+    MemberAlertViewed = 8,
+
+    // Notes (FHIR Communication) — immutable, audited on read for the same
+    // PHI-access reason as alerts.
+    MemberNoteCreated = 9,
+    MemberNoteViewed = 10
 }

--- a/src/services/member-service/Models/MemberNote.cs
+++ b/src/services/member-service/Models/MemberNote.cs
@@ -1,0 +1,67 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace MemberService.Models;
+
+/// <summary>
+/// A free-text note attached to a member. Notes are append-only — once created
+/// they cannot be edited or deleted. Corrections are written as new notes that
+/// link back to the original via <see cref="LinkedResourceType"/> = <c>"MemberNote"</c>
+/// and <see cref="LinkedResourceId"/> = original note id.
+///
+/// Projects to FHIR R4 Communication.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class MemberNote
+{
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    [Required]
+    public MemberNoteCategory Category { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Subject { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(8000)]
+    public string Body { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(200)]
+    public string Author { get; set; } = string.Empty;
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// FHIR-style link to a related resource. For corrections, set this to
+    /// <c>"MemberNote"</c> and the prior note id. Other valid types include
+    /// <c>"Claim"</c>, <c>"Authorization"</c>, <c>"Appeal"</c>, <c>"Communication"</c>.
+    /// </summary>
+    [StringLength(50)]
+    public string? LinkedResourceType { get; set; }
+
+    [StringLength(100)]
+    public string? LinkedResourceId { get; set; }
+}
+
+/// <summary>
+/// Logical inbox the note belongs to. Drives portal filtering and downstream
+/// routing (e.g. Appeals notes feed the appeals queue).
+/// </summary>
+public enum MemberNoteCategory
+{
+    CustomerService = 1,
+    CareManagement = 2,
+    Appeals = 3,
+    Billing = 4,
+    Clinical = 5
+}

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -50,6 +50,8 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
             sp.GetRequiredService<MongoDB.Driver.IMongoDatabase>(),
             eventsCollectionName));
     builder.Services.AddSingleton<IFamilyRelationshipRepository, FamilyRelationshipRepositoryMongo>();
+    builder.Services.AddSingleton<IMemberAlertRepository, MemberAlertRepositoryMongo>();
+    builder.Services.AddSingleton<IMemberNoteRepository, MemberNoteRepositoryMongo>();
 
     builder.Services.AddHostedService<MemberIndexInitializer>();
     builder.Services.AddHostedService<FamilyRelationshipIndexInitializer>();
@@ -108,14 +110,32 @@ else
         return new FamilyRelationshipRepository(cosmosClient, databaseName);
     });
 
+    builder.Services.AddScoped<IMemberAlertRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new MemberAlertRepository(cosmosClient, databaseName);
+    });
+
+    builder.Services.AddScoped<IMemberNoteRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new MemberNoteRepository(cosmosClient, databaseName);
+    });
+
     Console.WriteLine($"Using Cosmos DB database provider (events container: {eventsContainerName})");
 }
 
 // ── Member Service internals ─────────────────────────────────────────
 builder.Services.AddScoped<IMemberEventPublisher, CosmosMemberEventPublisher>();
 builder.Services.AddSingleton<IFhirPatientProjector, FhirPatientProjector>();
+builder.Services.AddSingleton<IFhirFlagProjector, FhirFlagProjector>();
 builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService>();
 builder.Services.AddScoped<IRelationshipShim, RelationshipShim>();
+builder.Services.AddScoped<IMemberAlertGuard, MemberAlertGuard>();
 
 // Identifier encryption. Real KV-backed encryptor when a data-key secret name is
 // configured; otherwise fall through to the no-op shim (dev only).

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -13,7 +13,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSecretProvider(builder.Configuration);
 builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        // Serialize enums as strings so portal clients can POST / read
+        // "LitigationHold", "CustomerService", etc. Without this the default
+        // numeric serialization would 400 on the string payloads used by
+        // MemberAlertsController / MemberNotesController.
+        options.JsonSerializerOptions.Converters.Add(
+            new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {

--- a/src/services/member-service/Repositories/MemberAlertRepository.cs
+++ b/src/services/member-service/Repositories/MemberAlertRepository.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using MemberService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Cosmos DB repository for <see cref="MemberAlert"/>. Partition key is
+/// <c>/tenantId</c> for multi-tenant isolation. Alerts are never hard-deleted —
+/// the lifecycle is end-dating via <see cref="EndAsync"/>.
+/// </summary>
+public class MemberAlertRepository : IMemberAlertRepository
+{
+    private readonly Container _container;
+    private const string ContainerName = "MemberAlerts";
+
+    public MemberAlertRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        _container = cosmosClient.GetDatabase(databaseName).GetContainer(ContainerName);
+    }
+
+    public async Task<MemberAlert> CreateAsync(MemberAlert alert)
+    {
+        if (string.IsNullOrEmpty(alert.Id)) alert.Id = Guid.NewGuid().ToString();
+        if (alert.CreatedDate == default) alert.CreatedDate = DateTime.UtcNow;
+
+        var response = await _container.CreateItemAsync(alert, new PartitionKey(alert.TenantId));
+        return response.Resource;
+    }
+
+    public async Task<MemberAlert?> GetByIdAsync(string tenantId, string memberId, string alertId)
+    {
+        try
+        {
+            var response = await _container.ReadItemAsync<MemberAlert>(alertId, new PartitionKey(tenantId));
+            var alert = response.Resource;
+            return alert.MemberId == memberId ? alert : null;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<MemberAlert>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        bool activeOnly,
+        DateTime? asOf = null)
+    {
+        var queryText = "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId";
+        var query = new QueryDefinition(queryText)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+
+        var iterator = _container.GetItemQueryIterator<MemberAlert>(query, requestOptions: new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(tenantId)
+        });
+
+        var results = new List<MemberAlert>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            results.AddRange(page);
+        }
+
+        // The "active" predicate is computed in-process so callers and tests
+        // share the same definition (see MemberAlert.IsActive).
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly) results = results.Where(a => a.IsActive(t)).ToList();
+
+        // Stable order: most-recent start first, then by alert type for determinism.
+        return results
+            .OrderByDescending(a => a.StartDate)
+            .ThenBy(a => a.AlertType)
+            .ToList();
+    }
+
+    public async Task<MemberAlert> EndAsync(MemberAlert alert)
+    {
+        var response = await _container.ReplaceItemAsync(alert, alert.Id, new PartitionKey(alert.TenantId));
+        return response.Resource;
+    }
+}
+
+public interface IMemberAlertRepository
+{
+    Task<MemberAlert> CreateAsync(MemberAlert alert);
+    Task<MemberAlert?> GetByIdAsync(string tenantId, string memberId, string alertId);
+
+    /// <summary>
+    /// List alerts for a member. When <paramref name="activeOnly"/> is true, only
+    /// alerts whose effective window contains <paramref name="asOf"/> (default = now)
+    /// are returned.
+    /// </summary>
+    Task<IReadOnlyList<MemberAlert>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        bool activeOnly,
+        DateTime? asOf = null);
+
+    /// <summary>Persist an end-dated alert. Caller must set <see cref="MemberAlert.EndDate"/> and <see cref="MemberAlert.EndedBy"/>.</summary>
+    Task<MemberAlert> EndAsync(MemberAlert alert);
+}

--- a/src/services/member-service/Repositories/MemberAlertRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberAlertRepositoryMongo.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MongoDB.Driver;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IMemberAlertRepository"/>.
+/// </summary>
+public class MemberAlertRepositoryMongo : IMemberAlertRepository
+{
+    private readonly IMongoCollection<MemberAlert> _collection;
+
+    public MemberAlertRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<MemberAlert>("MemberAlerts");
+    }
+
+    public async Task<MemberAlert> CreateAsync(MemberAlert alert)
+    {
+        if (string.IsNullOrEmpty(alert.Id)) alert.Id = Guid.NewGuid().ToString();
+        if (alert.CreatedDate == default) alert.CreatedDate = DateTime.UtcNow;
+        await _collection.InsertOneAsync(alert);
+        return alert;
+    }
+
+    public async Task<MemberAlert?> GetByIdAsync(string tenantId, string memberId, string alertId)
+    {
+        var filter = Builders<MemberAlert>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<MemberAlert>.Filter.Eq(a => a.MemberId, memberId)
+                   & Builders<MemberAlert>.Filter.Eq(a => a.Id, alertId);
+        return await _collection.Find(filter).FirstOrDefaultAsync();
+    }
+
+    public async Task<IReadOnlyList<MemberAlert>> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        bool activeOnly,
+        DateTime? asOf = null)
+    {
+        var filter = Builders<MemberAlert>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<MemberAlert>.Filter.Eq(a => a.MemberId, memberId);
+        var results = await _collection.Find(filter).ToListAsync();
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly) results = results.Where(a => a.IsActive(t)).ToList();
+
+        return results
+            .OrderByDescending(a => a.StartDate)
+            .ThenBy(a => a.AlertType)
+            .ToList();
+    }
+
+    public async Task<MemberAlert> EndAsync(MemberAlert alert)
+    {
+        var filter = Builders<MemberAlert>.Filter.Eq(a => a.TenantId, alert.TenantId)
+                   & Builders<MemberAlert>.Filter.Eq(a => a.Id, alert.Id);
+        await _collection.ReplaceOneAsync(filter, alert);
+        return alert;
+    }
+}

--- a/src/services/member-service/Repositories/MemberNoteRepository.cs
+++ b/src/services/member-service/Repositories/MemberNoteRepository.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using MemberService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// Cosmos DB repository for <see cref="MemberNote"/>. Notes are immutable —
+/// only Create + Read are exposed. Corrections are new notes that link back
+/// to the prior note via <see cref="MemberNote.LinkedResourceId"/>.
+/// </summary>
+public class MemberNoteRepository : IMemberNoteRepository
+{
+    private readonly Container _container;
+    private const string ContainerName = "MemberNotes";
+
+    public MemberNoteRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        _container = cosmosClient.GetDatabase(databaseName).GetContainer(ContainerName);
+    }
+
+    public async Task<MemberNote> CreateAsync(MemberNote note)
+    {
+        if (string.IsNullOrEmpty(note.Id)) note.Id = Guid.NewGuid().ToString();
+        if (note.CreatedDate == default) note.CreatedDate = DateTime.UtcNow;
+
+        var response = await _container.CreateItemAsync(note, new PartitionKey(note.TenantId));
+        return response.Resource;
+    }
+
+    public async Task<MemberNote?> GetByIdAsync(string tenantId, string memberId, string noteId)
+    {
+        try
+        {
+            var response = await _container.ReadItemAsync<MemberNote>(noteId, new PartitionKey(tenantId));
+            var note = response.Resource;
+            return note.MemberId == memberId ? note : null;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<(IReadOnlyList<MemberNote> Items, string? ContinuationToken)> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        MemberNoteCategory? category,
+        int pageSize,
+        string? continuationToken)
+    {
+        var queryText = "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.memberId = @memberId";
+        if (category.HasValue) queryText += " AND c.category = @category";
+        queryText += " ORDER BY c.createdDate DESC";
+
+        var query = new QueryDefinition(queryText)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@memberId", memberId);
+        if (category.HasValue) query = query.WithParameter("@category", (int)category.Value);
+
+        var iterator = _container.GetItemQueryIterator<MemberNote>(
+            query,
+            continuationToken,
+            new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(tenantId),
+                MaxItemCount = pageSize
+            });
+
+        var results = new List<MemberNote>();
+        string? nextToken = null;
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            results.AddRange(response);
+            nextToken = response.ContinuationToken;
+        }
+        return (results, nextToken);
+    }
+}
+
+public interface IMemberNoteRepository
+{
+    Task<MemberNote> CreateAsync(MemberNote note);
+    Task<MemberNote?> GetByIdAsync(string tenantId, string memberId, string noteId);
+
+    /// <summary>
+    /// Page notes for a member, newest first. <paramref name="category"/> optional;
+    /// when null, returns all categories.
+    /// </summary>
+    Task<(IReadOnlyList<MemberNote> Items, string? ContinuationToken)> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        MemberNoteCategory? category,
+        int pageSize,
+        string? continuationToken);
+}

--- a/src/services/member-service/Repositories/MemberNoteRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberNoteRepositoryMongo.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MongoDB.Driver;
+
+namespace MemberService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IMemberNoteRepository"/>.
+/// </summary>
+public class MemberNoteRepositoryMongo : IMemberNoteRepository
+{
+    private readonly IMongoCollection<MemberNote> _collection;
+
+    public MemberNoteRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<MemberNote>("MemberNotes");
+    }
+
+    public async Task<MemberNote> CreateAsync(MemberNote note)
+    {
+        if (string.IsNullOrEmpty(note.Id)) note.Id = Guid.NewGuid().ToString();
+        if (note.CreatedDate == default) note.CreatedDate = DateTime.UtcNow;
+        await _collection.InsertOneAsync(note);
+        return note;
+    }
+
+    public async Task<MemberNote?> GetByIdAsync(string tenantId, string memberId, string noteId)
+    {
+        var filter = Builders<MemberNote>.Filter.Eq(n => n.TenantId, tenantId)
+                   & Builders<MemberNote>.Filter.Eq(n => n.MemberId, memberId)
+                   & Builders<MemberNote>.Filter.Eq(n => n.Id, noteId);
+        return await _collection.Find(filter).FirstOrDefaultAsync();
+    }
+
+    public async Task<(IReadOnlyList<MemberNote> Items, string? ContinuationToken)> ListByMemberAsync(
+        string tenantId,
+        string memberId,
+        MemberNoteCategory? category,
+        int pageSize,
+        string? continuationToken)
+    {
+        var fb = Builders<MemberNote>.Filter;
+        var filter = fb.Eq(n => n.TenantId, tenantId) & fb.Eq(n => n.MemberId, memberId);
+        if (category.HasValue) filter &= fb.Eq(n => n.Category, category.Value);
+
+        int skip = 0;
+        if (!string.IsNullOrEmpty(continuationToken) && int.TryParse(continuationToken, out var parsed))
+        {
+            skip = parsed;
+        }
+
+        var results = await _collection.Find(filter)
+            .SortByDescending(n => n.CreatedDate)
+            .Skip(skip)
+            .Limit(pageSize)
+            .ToListAsync();
+
+        string? nextToken = results.Count == pageSize ? (skip + pageSize).ToString() : null;
+        return (results, nextToken);
+    }
+}

--- a/src/services/member-service/Services/FhirFlagProjector.cs
+++ b/src/services/member-service/Services/FhirFlagProjector.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using MemberService.Models;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Projects <see cref="MemberAlert"/> records into FHIR R4 Flag resources
+/// (US Core profile). Hand-built JSON to stay consistent with
+/// <see cref="FhirPatientProjector"/> — no Hl7.Fhir.R4 dependency.
+/// </summary>
+public interface IFhirFlagProjector
+{
+    /// <summary>Project a single alert to a FHIR Flag resource.</summary>
+    JsonObject Project(MemberAlert alert);
+
+    /// <summary>Wrap a set of alerts in a FHIR searchset Bundle.</summary>
+    JsonObject ProjectBundle(IEnumerable<MemberAlert> alerts);
+}
+
+public sealed class FhirFlagProjector : IFhirFlagProjector
+{
+    private const string FlagCategorySystem = "http://terminology.hl7.org/CodeSystem/flag-category";
+    private const string CodeSystem = "https://cloudhealthoffice.com/fhir/CodeSystem/member-alert-type";
+
+    public JsonObject Project(MemberAlert alert)
+    {
+        ArgumentNullException.ThrowIfNull(alert);
+
+        var flag = new JsonObject
+        {
+            ["resourceType"] = "Flag",
+            ["id"] = alert.Id,
+            // FHIR Flag.status: active | inactive | entered-in-error.
+            // Members in the past or end-dated map to "inactive"; future-dated
+            // alerts are not in scope for this projector (callers filter first).
+            ["status"] = alert.IsActive() ? "active" : "inactive"
+        };
+
+        // Severity → flag-category. FHIR Flag has no native severity slot, but
+        // category is the conventional place for prioritisation hints; portals
+        // and downstream subscribers key off the code below for the actual type.
+        flag["category"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["coding"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["system"] = FlagCategorySystem,
+                        ["code"] = MapSeverityToCategoryCode(alert.Severity),
+                        ["display"] = alert.Severity.ToString()
+                    }
+                },
+                ["text"] = $"{alert.Severity} alert"
+            }
+        };
+
+        flag["code"] = new JsonObject
+        {
+            ["coding"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["system"] = CodeSystem,
+                    ["code"] = alert.AlertType.ToString(),
+                    ["display"] = HumanizeAlertType(alert.AlertType)
+                }
+            },
+            ["text"] = alert.Reason
+        };
+
+        flag["subject"] = new JsonObject
+        {
+            ["type"] = "Patient",
+            ["identifier"] = new JsonObject
+            {
+                ["system"] = FhirIdentifierSystems.MemberId,
+                ["value"] = alert.MemberId
+            }
+        };
+
+        var period = new JsonObject { ["start"] = alert.StartDate.ToString("o") };
+        if (alert.EndDate.HasValue) period["end"] = alert.EndDate.Value.ToString("o");
+        flag["period"] = period;
+
+        if (!string.IsNullOrEmpty(alert.RequiredAction))
+        {
+            // No standard FHIR Flag slot for "required action" — surface via
+            // an extension so downstream consumers can read it without parsing
+            // the free-text reason.
+            flag["extension"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["url"] = "https://cloudhealthoffice.com/fhir/StructureDefinition/required-action",
+                    ["valueString"] = alert.RequiredAction
+                }
+            };
+        }
+
+        flag["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = (alert.EndDate ?? alert.CreatedDate).ToString("o"),
+            ["profile"] = new JsonArray("http://hl7.org/fhir/us/core/StructureDefinition/us-core-flag")
+        };
+
+        return flag;
+    }
+
+    public JsonObject ProjectBundle(IEnumerable<MemberAlert> alerts)
+    {
+        ArgumentNullException.ThrowIfNull(alerts);
+
+        var entries = new JsonArray();
+        var count = 0;
+        foreach (var alert in alerts)
+        {
+            entries.Add(new JsonObject
+            {
+                ["fullUrl"] = $"Flag/{alert.Id}",
+                ["resource"] = Project(alert)
+            });
+            count++;
+        }
+
+        return new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "searchset",
+            ["total"] = count,
+            ["entry"] = entries
+        };
+    }
+
+    private static string MapSeverityToCategoryCode(MemberAlertSeverity severity) => severity switch
+    {
+        MemberAlertSeverity.Critical => "safety",
+        MemberAlertSeverity.Warning => "admin",
+        _ => "clinical"
+    };
+
+    private static string HumanizeAlertType(MemberAlertType type) => type switch
+    {
+        MemberAlertType.HighRisk => "High Risk",
+        MemberAlertType.LitigationHold => "Litigation Hold",
+        MemberAlertType.DoNotContact => "Do Not Contact",
+        MemberAlertType.VIP => "VIP",
+        MemberAlertType.CustodyDispute => "Custody Dispute",
+        MemberAlertType.LanguageRequirement => "Language Requirement",
+        MemberAlertType.AccessibilityNeed => "Accessibility Need",
+        MemberAlertType.SecurityFreeze => "Security Freeze",
+        MemberAlertType.KnownFraudRisk => "Known Fraud Risk",
+        MemberAlertType.EligibilityDispute => "Eligibility Dispute",
+        _ => type.ToString()
+    };
+}

--- a/src/services/member-service/Services/MemberAlertGuard.cs
+++ b/src/services/member-service/Services/MemberAlertGuard.cs
@@ -43,35 +43,44 @@ public sealed record MemberAlertBlock(
     MemberAlertAction Action,
     string Reason);
 
+/// <summary>
+/// A (type, minimum severity) pair. An alert triggers the rule when its type
+/// matches and its severity is at least the minimum — so a LitigationHold
+/// downgraded to Warning won't block terminate, and a DoNotContact raised at
+/// Info won't gate outbound comms.
+/// </summary>
+internal sealed record MemberAlertRule(MemberAlertType Type, MemberAlertSeverity MinSeverity);
+
 public sealed class MemberAlertGuard : IMemberAlertGuard
 {
     private readonly IMemberAlertRepository _alerts;
 
     // Block rules table — single source of truth.
     // Keep in sync with docs/architecture/member-alerts-notes.md#block-rules.
-    private static readonly Dictionary<MemberAlertAction, MemberAlertType[]> Rules = new()
+    // MinSeverity is inclusive: severity >= MinSeverity triggers the block.
+    private static readonly Dictionary<MemberAlertAction, MemberAlertRule[]> Rules = new()
     {
         [MemberAlertAction.Terminate] = new[]
         {
-            MemberAlertType.LitigationHold,
-            MemberAlertType.EligibilityDispute
+            new MemberAlertRule(MemberAlertType.LitigationHold, MemberAlertSeverity.Critical),
+            new MemberAlertRule(MemberAlertType.EligibilityDispute, MemberAlertSeverity.Warning)
         },
         [MemberAlertAction.HardDelete] = new[]
         {
-            MemberAlertType.LitigationHold
+            new MemberAlertRule(MemberAlertType.LitigationHold, MemberAlertSeverity.Critical)
         },
         [MemberAlertAction.UpdatePii] = new[]
         {
-            MemberAlertType.SecurityFreeze,
-            MemberAlertType.KnownFraudRisk
+            new MemberAlertRule(MemberAlertType.SecurityFreeze, MemberAlertSeverity.Critical),
+            new MemberAlertRule(MemberAlertType.KnownFraudRisk, MemberAlertSeverity.Critical)
         },
         [MemberAlertAction.NewEnrollment] = new[]
         {
-            MemberAlertType.KnownFraudRisk
+            new MemberAlertRule(MemberAlertType.KnownFraudRisk, MemberAlertSeverity.Critical)
         },
         [MemberAlertAction.OutboundCommunication] = new[]
         {
-            MemberAlertType.DoNotContact
+            new MemberAlertRule(MemberAlertType.DoNotContact, MemberAlertSeverity.Warning)
         }
     };
 
@@ -86,13 +95,19 @@ public sealed class MemberAlertGuard : IMemberAlertGuard
         MemberAlertAction action,
         CancellationToken ct = default)
     {
-        if (!Rules.TryGetValue(action, out var blockingTypes)) return null;
+        ct.ThrowIfCancellationRequested();
+
+        if (!Rules.TryGetValue(action, out var blockingRules)) return null;
 
         var active = await _alerts.ListByMemberAsync(tenantId, memberId, activeOnly: true);
-        var hit = active.FirstOrDefault(a => blockingTypes.Contains(a.AlertType));
+
+        ct.ThrowIfCancellationRequested();
+
+        var hit = active.FirstOrDefault(a =>
+            blockingRules.Any(r => r.Type == a.AlertType && a.Severity >= r.MinSeverity));
         if (hit == null) return null;
 
-        var reason = $"Action '{action}' blocked by active {hit.AlertType} alert: {hit.Reason}";
+        var reason = $"Action '{action}' blocked by active {hit.AlertType} alert ({hit.Severity}): {hit.Reason}";
         return new MemberAlertBlock(hit, action, reason);
     }
 }

--- a/src/services/member-service/Services/MemberAlertGuard.cs
+++ b/src/services/member-service/Services/MemberAlertGuard.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MemberService.Models;
+using MemberService.Repositories;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Service-layer enforcement of alert-based block rules. Centralised so the
+/// rules table lives in one place and individual controllers don't drift.
+/// See <c>docs/architecture/member-alerts-notes.md#block-rules</c>.
+/// </summary>
+public interface IMemberAlertGuard
+{
+    /// <summary>
+    /// Evaluate whether <paramref name="action"/> is permitted for the given
+    /// member. Returns the first violating active alert (if any).
+    /// </summary>
+    Task<MemberAlertBlock?> EvaluateAsync(
+        string tenantId,
+        string memberId,
+        MemberAlertAction action,
+        CancellationToken ct = default);
+}
+
+public enum MemberAlertAction
+{
+    Terminate = 1,
+    HardDelete = 2,
+    UpdatePii = 3,
+    NewEnrollment = 4,
+    OutboundCommunication = 5
+}
+
+/// <summary>
+/// A specific alert that blocks a specific action. The reason / required action
+/// come straight from the offending <see cref="MemberAlert"/>.
+/// </summary>
+public sealed record MemberAlertBlock(
+    MemberAlert Alert,
+    MemberAlertAction Action,
+    string Reason);
+
+public sealed class MemberAlertGuard : IMemberAlertGuard
+{
+    private readonly IMemberAlertRepository _alerts;
+
+    // Block rules table — single source of truth.
+    // Keep in sync with docs/architecture/member-alerts-notes.md#block-rules.
+    private static readonly Dictionary<MemberAlertAction, MemberAlertType[]> Rules = new()
+    {
+        [MemberAlertAction.Terminate] = new[]
+        {
+            MemberAlertType.LitigationHold,
+            MemberAlertType.EligibilityDispute
+        },
+        [MemberAlertAction.HardDelete] = new[]
+        {
+            MemberAlertType.LitigationHold
+        },
+        [MemberAlertAction.UpdatePii] = new[]
+        {
+            MemberAlertType.SecurityFreeze,
+            MemberAlertType.KnownFraudRisk
+        },
+        [MemberAlertAction.NewEnrollment] = new[]
+        {
+            MemberAlertType.KnownFraudRisk
+        },
+        [MemberAlertAction.OutboundCommunication] = new[]
+        {
+            MemberAlertType.DoNotContact
+        }
+    };
+
+    public MemberAlertGuard(IMemberAlertRepository alerts)
+    {
+        _alerts = alerts;
+    }
+
+    public async Task<MemberAlertBlock?> EvaluateAsync(
+        string tenantId,
+        string memberId,
+        MemberAlertAction action,
+        CancellationToken ct = default)
+    {
+        if (!Rules.TryGetValue(action, out var blockingTypes)) return null;
+
+        var active = await _alerts.ListByMemberAsync(tenantId, memberId, activeOnly: true);
+        var hit = active.FirstOrDefault(a => blockingTypes.Contains(a.AlertType));
+        if (hit == null) return null;
+
+        var reason = $"Action '{action}' blocked by active {hit.AlertType} alert: {hit.Reason}";
+        return new MemberAlertBlock(hit, action, reason);
+    }
+}


### PR DESCRIPTION
Adds two new member-bound resources to member-service:

- MemberAlert (FHIR R4 Flag): 10 alert types (HighRisk, LitigationHold,
  DoNotContact, VIP, CustodyDispute, LanguageRequirement, AccessibilityNeed,
  SecurityFreeze, KnownFraudRisk, EligibilityDispute) with three severities
  (Info/Warning/Critical). End-dated rather than deleted.
- MemberNote (FHIR R4 Communication): five categories (CustomerService,
  CareManagement, Appeals, Billing, Clinical). Append-only — corrections
  are new notes that link back to the prior note id.

Endpoints: /api/v1/members/{id}/alerts, /notes, /fhir/Flag?status=active.

Audit lives on the existing member-events stream via five new
MemberEventType values: MemberAlertCreated, MemberAlertEnded,
MemberAlertViewed, MemberNoteCreated, MemberNoteViewed.

Service-layer block rules enforced via IMemberAlertGuard:
- LitigationHold and EligibilityDispute block termination → 409
  ProblemDetails (type=member-alert-block, alertId/alertType/severity/
  action extensions). Wired into both DELETE and POST /terminate.
- Other rules (SecurityFreeze, KnownFraudRisk, DoNotContact) reserved on
  the MemberAlertAction enum for follow-up wiring.

Portal:
- MemberAlertBanner above MemberDetailsDialog tabs renders only active
  alerts color-coded by severity.
- New Notes MudTabPanel with category filter, paged log, inline entry.

Block-rules table and FHIR Flag mapping documented in
docs/architecture/member-alerts-notes.md.