### PR TITLE
A.7.4: OpenTelemetry rollout + PHI-scrubbing SpanProcessor

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -85,9 +85,19 @@ opt out.
 
 ### What's allowed
 
-- Standard OTel namespaces: `http.*`, `db.*`, `net.*`, `rpc.*`, `messaging.*`
-- The `cho.*` namespace, except where a prohibited suffix matches
-  (e.g. `cho.member_id` is stripped; `cho.member_id_hash` passes through)
+Everything that doesn't match the prohibited list — either by exact name or
+by the segment after the final `.`. Standard OTel namespaces (`http.*`,
+`db.*`, `net.*`, `rpc.*`, `messaging.*`) are NOT blanket-allowed: a prohibited
+suffix always wins. Concretely:
+
+- `http.method` / `http.status_code` / `db.statement` → pass through.
+- `http.request.header.authorization` → stripped, suffix `authorization` is prohibited.
+- `db.user.password` → stripped, suffix `password` is prohibited.
+- `cho.tenant_id` → pass through.
+- `cho.member_id` → stripped; `cho.member_id_hash` → pass through (its
+  suffix is `member_id_hash`, not in the list).
+
+Comparisons are case-insensitive.
 
 ### Hashed identifiers
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,202 @@
+# CHO Observability
+
+This doc describes the OpenTelemetry conventions every Cloud Health Office
+service shares: how tracing + metrics get wired, what PHI must never appear in
+spans, how to add new business spans, and how `/metrics` is scraped.
+
+## Wiring
+
+Every service Program.cs calls:
+
+```csharp
+using CloudHealthOffice.Infrastructure.Observability;
+
+builder.Services.AddChoObservability(builder.Configuration);
+// ...
+var app = builder.Build();
+app.UseChoObservability();
+```
+
+These come from `CloudHealthOffice.Infrastructure`. All OTel packages are
+declared there transitively; service csprojs do not PackageReference them
+directly.
+
+`AddChoObservability` wires:
+
+- Resource attributes (service.name, service.version, deployment.environment, service.namespace=CloudHealthOffice)
+- Tracing: AspNetCore, HttpClient, StackExchange.Redis, MongoDB, and the
+  CHO business-span source `ChoActivitySource`
+- Metrics: AspNetCore, HttpClient, and the CHO meter `ChoMetrics`
+- A Prometheus scraping endpoint at `/metrics`
+- An OTLP exporter pointed at `Observability:OtlpEndpoint` (when set)
+- A console exporter (when `Observability:EnableConsole` is true)
+- The mandatory `PhiScrubbingSpanProcessor` (see below)
+
+## Configuration
+
+Per-service `appsettings.json`:
+
+```json
+"Observability": {
+  "ServiceName": "<service-directory-name>",
+  "OtlpEndpoint": "http://otel-collector:4317",
+  "EnableConsole": false
+}
+```
+
+Per-service `appsettings.Development.json`:
+
+```json
+"Observability": {
+  "OtlpEndpoint": null,
+  "EnableConsole": true
+}
+```
+
+- `OtlpEndpoint: null` means "don't export OTLP". Dev reads telemetry via the
+  console exporter. Prod points at the OTLP collector.
+- Explicit `null` beats key omission for readability — a reader sees the
+  exporter is intentionally off, not forgotten.
+
+## PHI scrubbing — non-negotiable
+
+`PhiScrubbingSpanProcessor` runs on every exported Activity via `OnEnd` and
+drops any attribute whose name matches the prohibited list (SSN, MBI, DOB,
+raw member/subscriber/patient IDs, contact info, auth tokens, etc.). Drops are
+counted via `cho.telemetry.scrub.total` with `attribute_name` + `service_name`
+labels — if that counter is non-zero in production, the code writing those
+attributes has a bug.
+
+The processor is wired unconditionally. There is no config flag to disable it.
+Teams that need different scrubbing rules must fork the extension rather than
+opt out.
+
+### What's prohibited (case-insensitive, exact or suffix-after-dot match)
+
+| Category | Attribute names |
+|---|---|
+| SSN | `ssn`, `social_security_number`, `socialSecurityNumber` |
+| MBI | `mbi`, `medicareBeneficiaryIdentifier` |
+| DOB | `dob`, `dateOfBirth`, `date_of_birth`, `birthDate` |
+| Member/subscriber/patient | `member_id`, `memberId`, `subscriber_id`, `subscriberId`, `patient_id`, `patientId` |
+| Contact | `email`, `emailAddress`, `email_address`, `phone`, `phoneNumber`, `phone_number`, `address`, `streetAddress`, `street` |
+| Name | `first_name`, `firstName`, `last_name`, `lastName`, `full_name`, `fullName` |
+| Auth | `password`, `api_key`, `apiKey`, `token`, `secret`, `authorization` |
+
+### What's allowed
+
+- Standard OTel namespaces: `http.*`, `db.*`, `net.*`, `rpc.*`, `messaging.*`
+- The `cho.*` namespace, except where a prohibited suffix matches
+  (e.g. `cho.member_id` is stripped; `cho.member_id_hash` passes through)
+
+### Hashed identifiers
+
+`ChoActivitySource.StartActivity(..., memberId: "M-123", claimId: "C-456")` sets:
+
+- `cho.member_id_hash` — SHA-256(memberId), first 16 hex chars, lowercase
+- `cho.claim_id_hash` — same hashing applied to claim IDs (consistent policy)
+
+Both go through `ChoActivitySource.HashIdentifier`. Never write raw
+`cho.member_id` or `cho.claim_id` — the scrubber will strip them and increment
+`cho.telemetry.scrub.total{attribute_name="member_id"}`.
+
+## Adding a new business span
+
+```csharp
+using CloudHealthOffice.Infrastructure.Observability;
+
+using var activity = ChoActivitySource.StartActivity(
+    "adjudicate-claim",
+    ActivityKind.Internal,
+    tenantId: ctx.TenantId,
+    claimId: claim.Id,                    // hashed automatically
+    claimType: claim.Type,
+    memberId: claim.MemberId);            // hashed automatically
+
+activity?.SetTag("cho.adjudication_step", "ncci-bundling");
+// do the work
+activity?.SetTag("cho.outcome", "approved");
+```
+
+Guidelines:
+
+- Keep span names verbs — `adjudicate-claim`, not `claim-adjudication`.
+- Use `cho.*` tags for CHO-specific dimensions. Stick to snake_case after the prefix.
+- Any dimension that could identify a member goes through `HashIdentifier` or doesn't get attached.
+- Don't catch-and-re-throw just to set tags; put the tag after the operation completes normally.
+
+## Emitting metrics
+
+The shared `ChoMetrics` class exposes histograms and counters. To record from
+a service, reference the type directly:
+
+```csharp
+using CloudHealthOffice.Infrastructure.Observability;
+
+ChoMetrics.RequestDuration.Record(
+    elapsed.TotalSeconds,
+    new KeyValuePair<string, object?>("http.method", "POST"),
+    new KeyValuePair<string, object?>("http.route", "/api/v1/claims"),
+    new KeyValuePair<string, object?>("http.status_code", 200));
+```
+
+Available instruments (all under the `CloudHealthOffice` meter):
+
+| Instrument | Unit | Purpose |
+|---|---|---|
+| `cho.http.request.duration` | s (histogram) | End-to-end HTTP request latency |
+| `cho.claims.processing.duration` | s (histogram) | Claim adjudication latency |
+| `cho.edi.transactions.total` | count | EDI transactions processed (837, 835, 270, 271, …) |
+| `cho.claims.adjudication.outcome.total` | count | Adjudication outcomes (approved, denied, pended) |
+| `cho.pas.submit.duration` | s (histogram) | Da Vinci PAS $submit time (target < 15s) |
+| `cho.pas.submit.decisions.total` | count | PAS decisions by type and rule |
+| `cho.telemetry.scrub.total` | count | PHI SpanProcessor drops — should stay at 0 in prod |
+
+## Reading `/metrics`
+
+Every service exposes Prometheus-format metrics at `/metrics`. The dot-
+separated OTel names convert to underscores; a histogram ends up as three
+series (`_bucket`, `_count`, `_sum`). Example:
+
+```
+# HELP cho_http_request_duration_seconds HTTP request duration in seconds
+# TYPE cho_http_request_duration_seconds histogram
+cho_http_request_duration_seconds_bucket{http_method="GET",http_route="/health/live",http_status_code="200",le="0.005"} 12
+cho_http_request_duration_seconds_count{http_method="GET",http_route="/health/live",http_status_code="200"} 12
+cho_http_request_duration_seconds_sum{http_method="GET",http_route="/health/live",http_status_code="200"} 0.0483
+```
+
+Health endpoints (`/health`, `/health/live`, `/health/ready`, `/metrics`)
+are intentionally excluded from tracing so they don't flood spans, but
+they DO get recorded in metrics via AddAspNetCoreInstrumentation — that's
+how you spot readiness-probe regressions.
+
+## Dev vs prod exporter behavior
+
+| | Dev | Prod |
+|---|---|---|
+| OTLP exporter | disabled (`OtlpEndpoint: null`) | enabled, points at `http://otel-collector:4317` |
+| Console exporter | enabled | disabled |
+| Prometheus `/metrics` | always on | always on |
+| PHI scrubber | always on | always on |
+
+## Scraping in Kubernetes
+
+`infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml` is a scaffold
+for the future OTel collector rollout. It is NOT currently deployed; each
+service's `/metrics` is scrapable by any Prometheus running in-cluster without
+the collector in the path. The OTLP exporter is dormant until an
+`Observability:OtlpEndpoint` override is set via env var or config override.
+
+## Test contract
+
+`CloudHealthOffice.Infrastructure.Tests.ObservabilityTestHelper.AssertStandardContract`
+is the single smoke test every integration-capable service test project runs:
+
+1. `GET /metrics` → 200, body contains the CHO histogram name — proves
+   `AddChoObservability` + `UseChoObservability` are wired.
+2. A span from `ChoActivitySource.StartActivity` with a raw memberId never
+   carries the raw value — only `cho.member_id_hash`.
+
+Per-service test files are a one-line call into this helper, so the contract
+lives in exactly one place.

--- a/infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml
+++ b/infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml
@@ -26,6 +26,12 @@ metadata:
   namespace: observability
 data:
   config.yaml: |
+    extensions:
+      # Exposes /health (200 when the collector pipelines are running) on 13133.
+      # Wired below in service.extensions and targeted by the container probes.
+      health_check:
+        endpoint: 0.0.0.0:13133
+
     receivers:
       otlp:
         protocols:
@@ -51,6 +57,7 @@ data:
         verbosity: normal
 
     service:
+      extensions: [health_check]
       pipelines:
         traces:
           receivers: [otlp]
@@ -82,7 +89,9 @@ spec:
       serviceAccountName: otel-collector
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:latest
+          # Pinned for reproducibility. Bump to a current stable tag at deploy time
+          # and keep it pinned — never float on :latest in production.
+          image: otel/opentelemetry-collector-contrib:0.102.1
           args:
             - --config=/etc/otel/config.yaml
           ports:
@@ -91,6 +100,9 @@ spec:
               protocol: TCP
             - name: otlp-http
               containerPort: 4318
+              protocol: TCP
+            - name: health
+              containerPort: 13133
               protocol: TCP
           volumeMounts:
             - name: config
@@ -106,12 +118,12 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: health
             initialDelaySeconds: 5
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: health
             initialDelaySeconds: 10
       volumes:
         - name: config

--- a/infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml
+++ b/infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml
@@ -1,0 +1,145 @@
+# OpenTelemetry Collector DaemonSet — SCAFFOLD, NOT DEPLOYED
+#
+# This manifest is a starting point for CHO's OTel collector rollout. It is
+# intentionally NOT referenced by any existing service Deployment — services
+# run fine without it because AddChoObservability only wires the OTLP exporter
+# when Observability:OtlpEndpoint is configured.
+#
+# Next steps (follow-up work, out of scope for A.7.4):
+#   - Replace the `debug` exporter with Azure Monitor / Tempo / your backend
+#   - Tighten resource requests/limits based on observed volume
+#   - Add a ServiceMonitor (if using Prometheus Operator) so /metrics is scraped
+#   - Add RBAC for k8sattributes processor (node/pod/service discovery)
+#
+# To deploy later:
+#   kubectl apply -f infrastructure/k8s/otel-collector/otel-collector-daemonset.yaml
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: observability
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 1024
+
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+
+    exporters:
+      # Placeholder. Replace with azuremonitor / otlp / prometheusremotewrite
+      # / tempo as appropriate once a production backend is selected.
+      debug:
+        verbosity: normal
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-collector
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/component: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/component: observability
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:latest
+          args:
+            - --config=/etc/otel/config.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: observability
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: otel-collector
+spec:
+  selector:
+    app.kubernetes.io/name: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP

--- a/src/services/CHO.TerminologyService/Program.cs
+++ b/src/services/CHO.TerminologyService/Program.cs
@@ -6,6 +6,7 @@ using CHO.TerminologyService.Services.Rules;
 using MongoDB.Driver;
 using Serilog;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -103,7 +104,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // ──────────────────────────────────────────────────────
 // Pipeline

--- a/src/services/CHO.TerminologyService/appsettings.Development.json
+++ b/src/services/CHO.TerminologyService/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/CHO.TerminologyService/appsettings.json
+++ b/src/services/CHO.TerminologyService/appsettings.json
@@ -31,5 +31,10 @@
     ]
   },
   "AllowedHosts": "*",
-  "Urls": "http://+:5080"
+  "Urls": "http://+:5080",
+  "Observability": {
+    "ServiceName": "CHO.TerminologyService",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/CloudHealthOffice.PricingApi/Program.cs
+++ b/src/services/CloudHealthOffice.PricingApi/Program.cs
@@ -6,6 +6,7 @@ using CloudHealthOffice.PricingApi.Data;
 using CloudHealthOffice.PricingApi.Middleware;
 using CloudHealthOffice.PricingApi.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Observability;
 using MongoDB.Driver;
 using Serilog;
 
@@ -154,7 +155,11 @@ try
     // ── Health Checks ──
     builder.Services.AddHealthChecks();
 
+    builder.Services.AddChoObservability(builder.Configuration);
+
     var app = builder.Build();
+
+    app.UseChoObservability();
 
     // ── Middleware Pipeline ──
     app.UseSerilogRequestLogging();

--- a/src/services/CloudHealthOffice.PricingApi/appsettings.Development.json
+++ b/src/services/CloudHealthOffice.PricingApi/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/CloudHealthOffice.PricingApi/appsettings.json
+++ b/src/services/CloudHealthOffice.PricingApi/appsettings.json
@@ -28,5 +28,10 @@
     "WindowSeconds": 60,
     "QueueLimit": 10
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "CloudHealthOffice.PricingApi",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/accumulator-service/Program.cs
+++ b/src/services/accumulator-service/Program.cs
@@ -4,6 +4,7 @@ using AccumulatorService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.Azure.Cosmos;
 using MongoDB.Driver;
 
@@ -81,7 +82,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/accumulator-service/appsettings.Development.json
+++ b/src/services/accumulator-service/appsettings.Development.json
@@ -11,5 +11,9 @@
   },
   "Kafka": {
     "BootstrapServers": "localhost:9092"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/accumulator-service/appsettings.json
+++ b/src/services/accumulator-service/appsettings.json
@@ -21,5 +21,10 @@
     "ClaimFinalized": {
       "GroupId": "accumulator-service.claims-finalized"
     }
+  },
+  "Observability": {
+    "ServiceName": "accumulator-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/appeals-service/Program.cs
+++ b/src/services/appeals-service/Program.cs
@@ -5,6 +5,7 @@ using AppealsService.Repositories;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -90,7 +91,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/appeals-service/appsettings.Development.json
+++ b/src/services/appeals-service/appsettings.Development.json
@@ -14,5 +14,9 @@
   },
   "ClaimsService": {
     "BaseUrl": "http://localhost:5003"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/appeals-service/appsettings.json
+++ b/src/services/appeals-service/appsettings.json
@@ -20,7 +20,20 @@
   },
   "Appeal": {
     "MaxAttachmentSizeMB": 50,
-    "AllowedFileTypes": [".pdf", ".jpg", ".jpeg", ".png", ".tiff", ".dcm", ".xml"],
+    "AllowedFileTypes": [
+      ".pdf",
+      ".jpg",
+      ".jpeg",
+      ".png",
+      ".tiff",
+      ".dcm",
+      ".xml"
+    ],
     "DefaultAppealLevelTimeLimitDays": 60
+  },
+  "Observability": {
+    "ServiceName": "appeals-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/ar-service/Program.cs
+++ b/src/services/ar-service/Program.cs
@@ -5,6 +5,7 @@ using ArService.Repositories;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -68,7 +69,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/ar-service/appsettings.Development.json
+++ b/src/services/ar-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/ar-service/appsettings.json
+++ b/src/services/ar-service/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Observability": {
+    "ServiceName": "ar-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
+}

--- a/src/services/attachment-service/Program.cs
+++ b/src/services/attachment-service/Program.cs
@@ -10,6 +10,7 @@ using CloudHealthOffice.DocumentStore;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -121,7 +122,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/services/attachment-service/appsettings.Development.json
+++ b/src/services/attachment-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/attachment-service/appsettings.json
+++ b/src/services/attachment-service/appsettings.json
@@ -30,5 +30,10 @@
   },
   "BlobStorage": {
     "ConnectionString": ""
+  },
+  "Observability": {
+    "ServiceName": "attachment-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/authorization-service/Program.cs
+++ b/src/services/authorization-service/Program.cs
@@ -12,6 +12,7 @@ using MongoDB.Driver;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -169,7 +170,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/authorization-service/appsettings.Development.json
+++ b/src/services/authorization-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/authorization-service/appsettings.json
+++ b/src/services/authorization-service/appsettings.json
@@ -21,5 +21,10 @@
       "ValidateLifetime": true,
       "ClockSkew": "00:05:00"
     }
+  },
+  "Observability": {
+    "ServiceName": "authorization-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -13,6 +13,7 @@ using CloudHealthOffice.NcciEngine.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using CloudHealthOffice.OperatingMode;
 using CloudHealthOffice.ProviderEnrollmentService.Configuration;
 using CloudHealthOffice.ProviderEnrollmentService.Gates;
@@ -186,7 +187,11 @@ builder.Services.AddChoHealthChecks(options =>
 builder.Services.AddCors(options => options.AddPolicy("AllowAll",
     policy => policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment()) { app.UseSwagger(); app.UseSwaggerUI(); }
 app.UseMiddleware<CloudHealthOffice.Infrastructure.Middleware.ExceptionHandlingMiddleware>();

--- a/src/services/benefit-plan-service/appsettings.Development.json
+++ b/src/services/benefit-plan-service/appsettings.Development.json
@@ -14,5 +14,9 @@
   },
   "Services": {
     "ClaimsServiceUrl": "http://localhost:5001"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/benefit-plan-service/appsettings.json
+++ b/src/services/benefit-plan-service/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "benefit-plan-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/capitation-service/Program.cs
+++ b/src/services/capitation-service/Program.cs
@@ -7,6 +7,7 @@ using CapitationService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -124,7 +125,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/capitation-service/appsettings.Development.json
+++ b/src/services/capitation-service/appsettings.Development.json
@@ -17,5 +17,9 @@
   },
   "RiskAdjustmentService": {
     "BaseUrl": "http://localhost:5003"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/capitation-service/appsettings.json
+++ b/src/services/capitation-service/appsettings.json
@@ -38,5 +38,10 @@
     "CompanyId": "",
     "OriginatingDfi": "",
     "CompanyEntryDescription": "CAPITATION"
+  },
+  "Observability": {
+    "ServiceName": "capitation-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/claims-examiner-service/Program.cs
+++ b/src/services/claims-examiner-service/Program.cs
@@ -4,6 +4,7 @@ using ClaimsExaminerService.Services.Examiner;
 using ClaimsExaminerService.Services.Kafka;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Extensions;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -57,7 +58,11 @@ builder.Services.AddSingleton<IProviderRfaiHistoryClient, NoOpProviderRfaiHistor
 // without Kafka still come up.
 builder.Services.AddHostedService<ClaimPendedConsumer>();
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Shared middleware pipeline
 app.UseChoInfrastructure(builder.Configuration);

--- a/src/services/claims-examiner-service/appsettings.Development.json
+++ b/src/services/claims-examiner-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/claims-examiner-service/appsettings.json
+++ b/src/services/claims-examiner-service/appsettings.json
@@ -26,5 +26,10 @@
   "Examiner": {
     "PromptVersion": "ncci-pend-v1",
     "MinConfidenceForRecommendation": 0.0
+  },
+  "Observability": {
+    "ServiceName": "claims-examiner-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/claims-scrubbing-service/Program.cs
+++ b/src/services/claims-scrubbing-service/Program.cs
@@ -1,5 +1,6 @@
 using CloudHealthOffice.Infrastructure.Extensions;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Observability;
 using ClaimsScrubbingService.Repositories;
 using ClaimsScrubbingService.Services;
 
@@ -50,8 +51,11 @@ if (!string.IsNullOrEmpty(storageConnection) || !string.IsNullOrEmpty(storageAcc
 
 // ── Pipeline ──────────────────────────────────────────────────────────────────
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
 
+app.UseChoObservability();
 app.UseChoInfrastructure(builder.Configuration);
 app.UseMiddleware<CloudHealthOffice.Infrastructure.Middleware.ExceptionHandlingMiddleware>();
 app.MapControllers();

--- a/src/services/claims-scrubbing-service/appsettings.Development.json
+++ b/src/services/claims-scrubbing-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/claims-scrubbing-service/appsettings.json
+++ b/src/services/claims-scrubbing-service/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Observability": {
+    "ServiceName": "claims-scrubbing-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -1,5 +1,6 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Extensions;
+using CloudHealthOffice.Infrastructure.Observability;
 using ClaimsService.EDI.Florida;
 using ClaimsService.Fhir;
 using ClaimsService.Repositories;
@@ -89,7 +90,11 @@ builder.Services.AddSingleton<ClaimEventPublisher>();
 builder.Services.AddSingleton<IClaimEventPublisher>(sp => sp.GetRequiredService<ClaimEventPublisher>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ClaimEventPublisher>());
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Shared middleware pipeline: exception handling, Swagger (dev), tenant middleware, CORS, health checks
 app.UseChoInfrastructure(builder.Configuration);

--- a/src/services/claims-service/appsettings.Development.json
+++ b/src/services/claims-service/appsettings.Development.json
@@ -8,5 +8,9 @@
   "MongoDb": {
     "ConnectionString": "mongodb://localhost:27017",
     "DatabaseName": "ClaimsDB"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/claims-service/appsettings.json
+++ b/src/services/claims-service/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "claims-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/coverage-service/Program.cs
+++ b/src/services/coverage-service/Program.cs
@@ -5,6 +5,7 @@ using CoverageService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -128,7 +129,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/coverage-service/appsettings.Development.json
+++ b/src/services/coverage-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/coverage-service/appsettings.json
+++ b/src/services/coverage-service/appsettings.json
@@ -9,5 +9,10 @@
   "Authentication": {
     "Authority": "https://yourtenant.b2clogin.com/yourtenant.onmicrosoft.com/v2.0/",
     "Audience": "api://coverage-service"
+  },
+  "Observability": {
+    "ServiceName": "coverage-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/eligibility-service/Program.cs
+++ b/src/services/eligibility-service/Program.cs
@@ -8,6 +8,7 @@ using EligibilityService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -136,7 +137,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure middleware pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/eligibility-service/appsettings.Development.json
+++ b/src/services/eligibility-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/eligibility-service/appsettings.json
+++ b/src/services/eligibility-service/appsettings.json
@@ -33,5 +33,10 @@
       "ConnectionString": "",
       "Queue": "batch-eligibility"
     }
+  },
+  "Observability": {
+    "ServiceName": "eligibility-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/encounter-service/Program.cs
+++ b/src/services/encounter-service/Program.cs
@@ -8,6 +8,7 @@ using EncounterService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -105,7 +106,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/encounter-service/appsettings.Development.json
+++ b/src/services/encounter-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/encounter-service/appsettings.json
+++ b/src/services/encounter-service/appsettings.json
@@ -20,5 +20,10 @@
     "SubmitterName": "Cloud Health Office",
     "SubmitterContactName": "EDI Department",
     "SubmitterContactPhone": "5555555555"
+  },
+  "Observability": {
+    "ServiceName": "encounter-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/encounter-submission-service/Program.cs
+++ b/src/services/encounter-submission-service/Program.cs
@@ -5,6 +5,7 @@ using EncounterSubmissionService.Workers;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -93,7 +94,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/encounter-submission-service/appsettings.Development.json
+++ b/src/services/encounter-submission-service/appsettings.Development.json
@@ -16,5 +16,9 @@
   "Services": {
     "ClaimsService": "http://localhost:5001",
     "ReferenceDataService": "http://localhost:5011"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/encounter-submission-service/appsettings.json
+++ b/src/services/encounter-submission-service/appsettings.json
@@ -36,5 +36,10 @@
   "Services": {
     "ClaimsService": "http://claims-service:8080",
     "ReferenceDataService": "http://reference-data-service:8080"
+  },
+  "Observability": {
+    "ServiceName": "encounter-submission-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -4,6 +4,7 @@ using EnrollmentImportService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.Azure.Cosmos;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -60,7 +61,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/enrollment-import-service/appsettings.Development.json
+++ b/src/services/enrollment-import-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/enrollment-import-service/appsettings.json
+++ b/src/services/enrollment-import-service/appsettings.json
@@ -15,5 +15,10 @@
     "TransactionsContainerName": "enrollment-transactions",
     "EnrollmentEventsContainerName": "enrollment-events"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "enrollment-import-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/ffs-service/Program.cs
+++ b/src/services/ffs-service/Program.cs
@@ -1,5 +1,6 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -7,7 +8,9 @@ builder.Services.AddSecretProvider(builder.Configuration);
 builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
 builder.Services.AddControllers()
     .AddCloudHealthOfficeJsonOptions();
+builder.Services.AddChoObservability(builder.Configuration);
 var app = builder.Build();
+app.UseChoObservability();
 app.MapControllers();
 app.Run();
 

--- a/src/services/ffs-service/appsettings.Development.json
+++ b/src/services/ffs-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/ffs-service/appsettings.json
+++ b/src/services/ffs-service/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Observability": {
+    "ServiceName": "ffs-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
+}

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Observability;
 using CloudHealthOffice.ProviderEnrollmentService.Configuration;
 using CloudHealthOffice.PriorAuthRuleEngine.Configuration;
 using Microsoft.Azure.Cosmos;
@@ -193,7 +194,11 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddCors(options => options.AddPolicy("AllowAll",
     p => p.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment()) { app.UseSwagger(); app.UseSwaggerUI(); }
 app.UseMiddleware<CloudHealthOffice.Infrastructure.Middleware.ExceptionHandlingMiddleware>();

--- a/src/services/fhir-service/appsettings.Development.json
+++ b/src/services/fhir-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/fhir-service/appsettings.json
+++ b/src/services/fhir-service/appsettings.json
@@ -47,5 +47,10 @@
   "MongoDb": {
     "ConnectionString": "",
     "DatabaseName": "cloudhealthoffice"
+  },
+  "Observability": {
+    "ServiceName": "fhir-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/idcard-service/Program.cs
+++ b/src/services/idcard-service/Program.cs
@@ -8,6 +8,7 @@ using IdCardService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Azure.Cosmos;
@@ -229,7 +230,11 @@ builder.Services.AddChoHealthChecks(options =>
 builder.Services.AddHealthChecks()
     .AddCheck<GlobalTemplateHealthCheck>("idcard-global-template", tags: new[] { "ready" });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/idcard-service/appsettings.Development.json
+++ b/src/services/idcard-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/idcard-service/appsettings.json
+++ b/src/services/idcard-service/appsettings.json
@@ -29,7 +29,9 @@
   "IdCard": {
     "SigningKeySecretPrefix": "idcard-signing-key",
     "CurrentKeyVersion": "v1",
-    "AcceptedKeyVersions": [ "v1" ],
+    "AcceptedKeyVersions": [
+      "v1"
+    ],
     "DefaultTemplateId": "global-default",
     "Qr": {
       "PixelsPerModule": 6,
@@ -53,5 +55,10 @@
     "Authority": "",
     "Audience": "",
     "RequireHttpsMetadata": true
+  },
+  "Observability": {
+    "ServiceName": "idcard-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/member-document-service/Program.cs
+++ b/src/services/member-document-service/Program.cs
@@ -2,6 +2,7 @@ using Azure.Storage.Blobs;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using MemberDocumentService.Middleware;
 using MemberDocumentService.Repositories;
 using MemberDocumentService.Services;
@@ -98,7 +99,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/member-document-service/appsettings.Development.json
+++ b/src/services/member-document-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/member-document-service/appsettings.json
+++ b/src/services/member-document-service/appsettings.json
@@ -19,5 +19,10 @@
   "BlobStorage": {
     "ConnectionString": "",
     "ContainerName": "member-documents"
+  },
+  "Observability": {
+    "ServiceName": "member-document-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -1,6 +1,7 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 using MemberService.HostedServices;
 using MemberService.Middleware;
 using MemberService.Repositories;
@@ -227,7 +228,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/member-service/appsettings.Development.json
+++ b/src/services/member-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/member-service/appsettings.json
+++ b/src/services/member-service/appsettings.json
@@ -27,8 +27,19 @@
     "IdentifierFingerprintKeySecret": ""
   },
   "Downstream": {
-    "CoverageService": { "BaseUrl": "" },
-    "EnrollmentImportService": { "BaseUrl": "" },
-    "AccumulatorService": { "BaseUrl": "" }
+    "CoverageService": {
+      "BaseUrl": ""
+    },
+    "EnrollmentImportService": {
+      "BaseUrl": ""
+    },
+    "AccumulatorService": {
+      "BaseUrl": ""
+    }
+  },
+  "Observability": {
+    "ServiceName": "member-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/payment-service/Program.cs
+++ b/src/services/payment-service/Program.cs
@@ -7,6 +7,7 @@ using PaymentService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -103,7 +104,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/payment-service/appsettings.Development.json
+++ b/src/services/payment-service/appsettings.Development.json
@@ -11,5 +11,9 @@
   },
   "ClaimsService": {
     "BaseUrl": "http://localhost:5001"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/payment-service/appsettings.json
+++ b/src/services/payment-service/appsettings.json
@@ -18,5 +18,10 @@
     "Name": "",
     "Id": "",
     "TaxId": ""
+  },
+  "Observability": {
+    "ServiceName": "payment-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/premium-billing-service/Program.cs
+++ b/src/services/premium-billing-service/Program.cs
@@ -7,6 +7,7 @@ using PremiumBillingService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -113,7 +114,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/premium-billing-service/appsettings.Development.json
+++ b/src/services/premium-billing-service/appsettings.Development.json
@@ -14,5 +14,9 @@
   },
   "SponsorService": {
     "BaseUrl": "http://localhost:5002"
+  },
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
   }
 }

--- a/src/services/premium-billing-service/appsettings.json
+++ b/src/services/premium-billing-service/appsettings.json
@@ -30,5 +30,10 @@
     "CompanyId": "",
     "OriginatingDfi": "",
     "CompanyEntryDescription": "PREMIUM"
+  },
+  "Observability": {
+    "ServiceName": "premium-billing-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/provider-contracts-service/Program.cs
+++ b/src/services/provider-contracts-service/Program.cs
@@ -5,6 +5,7 @@ using ProviderContractsService.Repositories;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -67,7 +68,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/provider-contracts-service/appsettings.Development.json
+++ b/src/services/provider-contracts-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/provider-contracts-service/appsettings.json
+++ b/src/services/provider-contracts-service/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Observability": {
+    "ServiceName": "provider-contracts-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -6,6 +6,7 @@ using ProviderService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -94,7 +95,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/provider-service/appsettings.Development.json
+++ b/src/services/provider-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/provider-service/appsettings.json
+++ b/src/services/provider-service/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "provider-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/provider-verification-service/Program.cs
+++ b/src/services/provider-verification-service/Program.cs
@@ -9,7 +9,10 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Observability;
 
+// TODO(refactor): consider converting this Program to top-level statements for
+// consistency with the rest of the service fleet (out of scope for A.7.4).
 public class Program
 {
     public static void Main(string[] args)
@@ -98,7 +101,11 @@ public class Program
             });
         });
 
+        builder.Services.AddChoObservability(builder.Configuration);
+
         var app = builder.Build();
+
+        app.UseChoObservability();
 
         if (app.Environment.IsDevelopment())
         {

--- a/src/services/provider-verification-service/appsettings.Development.json
+++ b/src/services/provider-verification-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/provider-verification-service/appsettings.json
+++ b/src/services/provider-verification-service/appsettings.json
@@ -22,7 +22,6 @@
     "ReverificationInterval": "30.00:00:00",
     "MaxConcurrentVerifications": 10,
     "OpenPaymentsConflictThreshold": 25000,
-
     "ScoringWeights": {
       "NpiValidation": 30,
       "ExclusionScreening": 30,
@@ -34,5 +33,10 @@
   "HealthChecks": {
     "EnableExternalNppesCheck": true
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Observability": {
+    "ServiceName": "provider-verification-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
 }

--- a/src/services/reference-data-service/Program.cs
+++ b/src/services/reference-data-service/Program.cs
@@ -6,6 +6,7 @@ using ReferenceDataService.Repositories;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -102,7 +103,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/reference-data-service/appsettings.Development.json
+++ b/src/services/reference-data-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/reference-data-service/appsettings.json
+++ b/src/services/reference-data-service/appsettings.json
@@ -9,5 +9,10 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "PostgreSQL": "Server=postgres-0.postgres-service;Port=5432;Database=referencedata;User Id=postgres;Password=${POSTGRES_PASSWORD}"
+  },
+  "Observability": {
+    "ServiceName": "reference-data-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/rfai-service/Program.cs
+++ b/src/services/rfai-service/Program.cs
@@ -6,6 +6,7 @@ using RfaiService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -87,9 +88,13 @@ builder.Services.AddCors(options =>
         policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 // ── Pipeline ──────────────────────────────────────────────────────────────────
 
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/rfai-service/appsettings.Development.json
+++ b/src/services/rfai-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/rfai-service/appsettings.json
+++ b/src/services/rfai-service/appsettings.json
@@ -15,5 +15,10 @@
     "Key": "",
     "DatabaseName": "CloudHealthOffice",
     "RfaiContainer": "RfaiCases"
+  },
+  "Observability": {
+    "ServiceName": "rfai-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/risk-adjustment-service/Program.cs
+++ b/src/services/risk-adjustment-service/Program.cs
@@ -8,6 +8,7 @@ using CloudHealthOffice.RiskAdjustmentEngine.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -108,7 +109,11 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/risk-adjustment-service/appsettings.Development.json
+++ b/src/services/risk-adjustment-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/risk-adjustment-service/appsettings.json
+++ b/src/services/risk-adjustment-service/appsettings.json
@@ -11,5 +11,10 @@
     "Key": "your-cosmos-key-here",
     "DatabaseName": "RiskAdjustmentDB",
     "ContainerName": "RiskScores"
+  },
+  "Observability": {
+    "ServiceName": "risk-adjustment-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ChoActivitySourceTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ChoActivitySourceTests.cs
@@ -24,36 +24,36 @@ public class ChoActivitySourceTests
     }
 
     [Fact]
-    public void HashMemberId_ReturnsConsistentHash()
+    public void HashIdentifier_ReturnsConsistentHash()
     {
-        var hash1 = ChoActivitySource.HashMemberId("member-123");
-        var hash2 = ChoActivitySource.HashMemberId("member-123");
+        var hash1 = ChoActivitySource.HashIdentifier("member-123");
+        var hash2 = ChoActivitySource.HashIdentifier("member-123");
 
         hash1.Should().Be(hash2);
     }
 
     [Fact]
-    public void HashMemberId_ReturnsDifferentHashForDifferentIds()
+    public void HashIdentifier_ReturnsDifferentHashForDifferentIds()
     {
-        var hash1 = ChoActivitySource.HashMemberId("member-123");
-        var hash2 = ChoActivitySource.HashMemberId("member-456");
+        var hash1 = ChoActivitySource.HashIdentifier("member-123");
+        var hash2 = ChoActivitySource.HashIdentifier("member-456");
 
         hash1.Should().NotBe(hash2);
     }
 
     [Fact]
-    public void HashMemberId_Returns16CharacterHex()
+    public void HashIdentifier_Returns16CharacterHex()
     {
-        var hash = ChoActivitySource.HashMemberId("any-member-id");
+        var hash = ChoActivitySource.HashIdentifier("any-member-id");
 
         hash.Should().HaveLength(16);
         hash.Should().MatchRegex("^[0-9a-f]{16}$");
     }
 
     [Fact]
-    public void HashMemberId_ReturnsLowercase()
+    public void HashIdentifier_ReturnsLowercase()
     {
-        var hash = ChoActivitySource.HashMemberId("TEST-MEMBER");
+        var hash = ChoActivitySource.HashIdentifier("TEST-MEMBER");
 
         hash.Should().Be(hash.ToLowerInvariant());
     }
@@ -75,7 +75,7 @@ public class ChoActivitySourceTests
     }
 
     [Fact]
-    public void StartActivity_WithListener_SetsClaimTags()
+    public void StartActivity_WithListener_HashesClaimIdAndSetsClaimType()
     {
         using var listener = new ActivityListener
         {
@@ -90,7 +90,8 @@ public class ChoActivitySourceTests
             claimType: "professional");
 
         activity.Should().NotBeNull();
-        activity!.GetTagItem("cho.claim_id").Should().Be("CLM-001");
+        activity!.GetTagItem("cho.claim_id").Should().BeNull("raw claim IDs must not be exported");
+        activity.GetTagItem("cho.claim_id_hash").Should().Be(ChoActivitySource.HashIdentifier("CLM-001"));
         activity.GetTagItem("cho.claim_type").Should().Be("professional");
     }
 
@@ -110,7 +111,7 @@ public class ChoActivitySourceTests
         var tagValue = activity!.GetTagItem("cho.member_id_hash")?.ToString();
         tagValue.Should().NotBeNull();
         tagValue.Should().NotBe("MBR-12345", "member ID should be hashed, not stored as plaintext");
-        tagValue.Should().Be(ChoActivitySource.HashMemberId("MBR-12345"));
+        tagValue.Should().Be(ChoActivitySource.HashIdentifier("MBR-12345"));
     }
 
     [Fact]
@@ -128,6 +129,7 @@ public class ChoActivitySourceTests
         activity.Should().NotBeNull();
         activity!.GetTagItem("cho.tenant_id").Should().BeNull();
         activity.GetTagItem("cho.claim_id").Should().BeNull();
+        activity.GetTagItem("cho.claim_id_hash").Should().BeNull();
         activity.GetTagItem("cho.claim_type").Should().BeNull();
         activity.GetTagItem("cho.member_id_hash").Should().BeNull();
     }

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/CloudHealthOffice.Infrastructure.Tests.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/CloudHealthOffice.Infrastructure.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestFactory.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestFactory.cs
@@ -2,21 +2,32 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using StackExchange.Redis;
 
 namespace CloudHealthOffice.Infrastructure.Tests;
 
 /// <summary>
 /// WebApplicationFactory variant used by <see cref="ObservabilityTestHelper"/>.
-/// Strips every app-defined <see cref="IHostedService"/> before the test host
-/// starts so smoke tests don't get bogged down in production workers —
-/// OpenIddict seed loaders, Kafka consumers, SLA watchdogs, Mongo index
-/// initializers, Service Bus mirror reconcilers, etc. — many of which throw
-/// during <c>StartAsync</c> when the external dependency they need isn't
-/// reachable from the CI runner.
 ///
-/// OpenTelemetry's own hosted service is preserved so the MeterProvider boots
-/// and <c>/metrics</c> stays scrapable — that is exactly what these smoke
-/// tests assert on.
+/// Two test-host modifications:
+///
+/// 1. Strips every app-defined <see cref="IHostedService"/> so smoke tests
+///    don't wake up production workers — OpenIddict seed loaders, Kafka
+///    consumers, SLA watchdogs, Mongo index initializers, Service Bus mirror
+///    reconcilers — many of which throw during <c>StartAsync</c> when the
+///    external dependency they need isn't reachable from a CI runner.
+///    OpenTelemetry's own hosted service (namespace-based filter) is kept so
+///    the MeterProvider boots and <c>/metrics</c> stays scrapable.
+///
+/// 2. If the app registers an <see cref="IConnectionMultiplexer"/>, replaces
+///    its factory with a non-connecting Moq stub. Background: AddChoObservability
+///    wires OpenTelemetry's Redis instrumentation, and OTel eagerly resolves
+///    IConnectionMultiplexer from DI when the TracerProvider is built during
+///    the OTel hosted service StartAsync. In production that resolution hits
+///    a real multiplexer; in tests it triggers StackExchange.Redis.Connect,
+///    which throws when no Redis is reachable. The stub satisfies the DI
+///    resolution — OTel only needs a non-null reference at build time, it
+///    doesn't exercise the multiplexer during the smoke test.
 /// </summary>
 public class ObservabilityTestFactory<TProgram> : WebApplicationFactory<TProgram>
     where TProgram : class
@@ -25,7 +36,7 @@ public class ObservabilityTestFactory<TProgram> : WebApplicationFactory<TProgram
     {
         builder.ConfigureServices(services =>
         {
-            var toRemove = services
+            var hostedToRemove = services
                 .Where(d => d.ServiceType == typeof(IHostedService))
                 .Where(d =>
                 {
@@ -41,9 +52,18 @@ public class ObservabilityTestFactory<TProgram> : WebApplicationFactory<TProgram
                 })
                 .ToList();
 
-            foreach (var descriptor in toRemove)
+            foreach (var descriptor in hostedToRemove)
             {
                 services.Remove(descriptor);
+            }
+
+            var multiplexer = services.FirstOrDefault(
+                d => d.ServiceType == typeof(IConnectionMultiplexer));
+            if (multiplexer is not null)
+            {
+                services.Remove(multiplexer);
+                services.AddSingleton<IConnectionMultiplexer>(_ =>
+                    new Mock<IConnectionMultiplexer>().Object);
             }
         });
     }

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestFactory.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestFactory.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CloudHealthOffice.Infrastructure.Tests;
+
+/// <summary>
+/// WebApplicationFactory variant used by <see cref="ObservabilityTestHelper"/>.
+/// Strips every app-defined <see cref="IHostedService"/> before the test host
+/// starts so smoke tests don't get bogged down in production workers —
+/// OpenIddict seed loaders, Kafka consumers, SLA watchdogs, Mongo index
+/// initializers, Service Bus mirror reconcilers, etc. — many of which throw
+/// during <c>StartAsync</c> when the external dependency they need isn't
+/// reachable from the CI runner.
+///
+/// OpenTelemetry's own hosted service is preserved so the MeterProvider boots
+/// and <c>/metrics</c> stays scrapable — that is exactly what these smoke
+/// tests assert on.
+/// </summary>
+public class ObservabilityTestFactory<TProgram> : WebApplicationFactory<TProgram>
+    where TProgram : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var toRemove = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .Where(d =>
+                {
+                    var implType = d.ImplementationType
+                        ?? d.ImplementationInstance?.GetType();
+                    // Factory-based registrations (ImplementationFactory only)
+                    // have no statically knowable type — treat those as
+                    // app-defined and strip them. OpenTelemetry registers its
+                    // TelemetryHostedService via AddHostedService<T>, so its
+                    // ImplementationType resolves and this check preserves it.
+                    var ns = implType?.Namespace ?? string.Empty;
+                    return !ns.StartsWith("OpenTelemetry", StringComparison.Ordinal);
+                })
+                .ToList();
+
+            foreach (var descriptor in toRemove)
+            {
+                services.Remove(descriptor);
+            }
+        });
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestHelper.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestHelper.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics;
+using System.Net;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace CloudHealthOffice.Infrastructure.Tests;
+
+/// <summary>
+/// Shared smoke-test helpers for the CHO observability contract. Per-service
+/// test projects call <see cref="AssertStandardContract"/> instead of
+/// duplicating the assertion logic.
+///
+/// Assertions:
+/// 1. <c>GET /metrics</c> returns 200 and the Prometheus body contains the
+///    expected CHO histogram name (proves AddChoObservability + Prometheus
+///    exporter are wired end-to-end in the service pipeline).
+/// 2. A span started via <see cref="ChoActivitySource.StartActivity"/> with a
+///    raw memberId never carries the raw value — only the hashed form.
+/// </summary>
+public static class ObservabilityTestHelper
+{
+    /// <summary>
+    /// Runs both smoke assertions against a service's test host.
+    /// Records a single sample on <see cref="ChoMetrics.RequestDuration"/> so
+    /// the Prometheus exporter has something to emit under the CHO histogram
+    /// name (the /metrics endpoint itself is filtered out of AspNetCore
+    /// instrumentation and can't self-populate the counter).
+    /// </summary>
+    public static async Task AssertStandardContract<TProgram>(
+        WebApplicationFactory<TProgram> factory)
+        where TProgram : class
+    {
+        ChoMetrics.RequestDuration.Record(
+            0.001,
+            new KeyValuePair<string, object?>("http.method", "GET"),
+            new KeyValuePair<string, object?>("http.route", "/__smoke-test"),
+            new KeyValuePair<string, object?>("http.status_code", 200));
+
+        using var client = factory.CreateClient();
+        var response = await client.GetAsync("/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "AddChoObservability + UseChoObservability must expose the Prometheus /metrics endpoint");
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("cho_http_request_duration",
+            "the CHO meter must be registered and rendered by the Prometheus exporter");
+
+        AssertMemberIdIsHashed();
+    }
+
+    /// <summary>
+    /// Asserts that ChoActivitySource hashes memberId rather than exporting it raw.
+    /// Exposed separately for test projects without a WebApplicationFactory.
+    /// </summary>
+    public static void AssertMemberIdIsHashed()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ChoActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        const string rawMemberId = "raw-member-id";
+        using var activity = ChoActivitySource.StartActivity(
+            "test-span",
+            memberId: rawMemberId);
+
+        activity.Should().NotBeNull();
+        activity!.TagObjects
+            .Any(t => t.Value is string s && s.Contains(rawMemberId))
+            .Should().BeFalse("raw member IDs must never appear on exported spans");
+        activity.GetTagItem("cho.member_id_hash")
+            .Should().Be(ChoActivitySource.HashIdentifier(rawMemberId));
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestHelper.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ObservabilityTestHelper.cs
@@ -21,22 +21,31 @@ public static class ObservabilityTestHelper
 {
     /// <summary>
     /// Runs both smoke assertions against a service's test host.
-    /// Records a single sample on <see cref="ChoMetrics.RequestDuration"/> so
-    /// the Prometheus exporter has something to emit under the CHO histogram
-    /// name (the /metrics endpoint itself is filtered out of AspNetCore
-    /// instrumentation and can't self-populate the counter).
+    ///
+    /// Ordering matters here: <c>CreateClient</c> is called first because that
+    /// is what forces WebApplicationFactory to build the app, which in turn
+    /// subscribes the OTel MeterProvider to the <c>CloudHealthOffice</c> meter.
+    /// Any <c>ChoMetrics.RequestDuration.Record</c> call made *before* the
+    /// subscription is dropped (no listener yet) and the sample never reaches
+    /// the Prometheus exporter — a latent failure that only shows up under
+    /// certain xUnit test-class orderings. The single sample we record after
+    /// build ensures <c>/metrics</c> always has a cho_http_request_duration
+    /// series to assert on, regardless of which tests ran before this one.
+    /// The /metrics endpoint itself is filtered out of AspNetCore
+    /// instrumentation, so it can't self-populate the counter.
     /// </summary>
     public static async Task AssertStandardContract<TProgram>(
         WebApplicationFactory<TProgram> factory)
         where TProgram : class
     {
+        using var client = factory.CreateClient();
+
         ChoMetrics.RequestDuration.Record(
             0.001,
             new KeyValuePair<string, object?>("http.method", "GET"),
             new KeyValuePair<string, object?>("http.route", "/__smoke-test"),
             new KeyValuePair<string, object?>("http.status_code", 200));
 
-        using var client = factory.CreateClient();
         var response = await client.GetAsync("/metrics");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK,

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/PhiScrubbingSpanProcessorTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/PhiScrubbingSpanProcessorTests.cs
@@ -1,0 +1,158 @@
+using System.Diagnostics;
+using CloudHealthOffice.Infrastructure.Observability;
+
+namespace CloudHealthOffice.Infrastructure.Tests;
+
+public sealed class PhiScrubbingSpanProcessorTests : IDisposable
+{
+    private readonly ActivitySource _source = new("cho-scrub-tests");
+    private readonly ActivityListener _listener;
+    private readonly PhiScrubbingSpanProcessor _processor = new("test-service");
+
+    public PhiScrubbingSpanProcessorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == _source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        _source.Dispose();
+    }
+
+    private Activity StartActivity() => _source.StartActivity("op")!;
+
+    [Theory]
+    [InlineData("ssn")]
+    [InlineData("social_security_number")]
+    [InlineData("mbi")]
+    [InlineData("dob")]
+    [InlineData("member_id")]
+    [InlineData("email")]
+    [InlineData("password")]
+    [InlineData("authorization")]
+    public void OnEnd_DropsExactProhibitedAttribute(string key)
+    {
+        using var activity = StartActivity();
+        activity.SetTag(key, "sensitive-value");
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem(key).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("http.request.header.authorization")]
+    [InlineData("db.user.password")]
+    [InlineData("net.peer.ssn")]
+    [InlineData("rpc.request.token")]
+    [InlineData("messaging.headers.api_key")]
+    [InlineData("custom.namespace.member_id")]
+    public void OnEnd_DropsDotSuffixProhibitedAttribute_EvenUnderStandardOTelPrefix(string key)
+    {
+        // A prohibited suffix always wins — standard OTel namespaces like http.*
+        // / db.* / net.* do NOT buy a blanket pass. This is the semantics the
+        // Copilot review flagged: if we allowed http.* wholesale we'd leak
+        // Authorization headers.
+        using var activity = StartActivity();
+        activity.SetTag(key, "sensitive-value");
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem(key).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("SSN")]
+    [InlineData("Authorization")]
+    [InlineData("Http.Request.Header.AUTHORIZATION")]
+    [InlineData("cho.Member_Id")]
+    public void OnEnd_IsCaseInsensitive(string key)
+    {
+        using var activity = StartActivity();
+        activity.SetTag(key, "sensitive-value");
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem(key).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("cho.tenant_id", "t-1")]
+    [InlineData("cho.claim_type", "professional")]
+    [InlineData("cho.adjudication_step", "ncci-bundling")]
+    [InlineData("http.method", "GET")]
+    [InlineData("http.status_code", "200")]
+    [InlineData("db.statement", "select 1")]
+    [InlineData("net.peer.name", "claims-service")]
+    [InlineData("custom.benign_attribute", "value")]
+    public void OnEnd_PreservesNonProhibitedAttributes(string key, string value)
+    {
+        using var activity = StartActivity();
+        activity.SetTag(key, value);
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem(key).Should().Be(value);
+    }
+
+    [Fact]
+    public void OnEnd_PreservesHashedMemberId_ButScrubsRaw()
+    {
+        // cho.member_id_hash must not collide with the member_id denylist entry —
+        // its suffix after the final '.' is "member_id_hash", not "member_id".
+        using var activity = StartActivity();
+        activity.SetTag("cho.member_id_hash", "abc123def4567890");
+        activity.SetTag("cho.member_id", "M-999");
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem("cho.member_id_hash").Should().Be("abc123def4567890");
+        activity.GetTagItem("cho.member_id").Should().BeNull();
+    }
+
+    [Fact]
+    public void OnEnd_DropsMultipleProhibitedAttributesInOneSpan()
+    {
+        using var activity = StartActivity();
+        activity.SetTag("ssn", "123-45-6789");
+        activity.SetTag("cho.member_id", "M-1");
+        activity.SetTag("http.request.header.authorization", "Bearer x");
+        activity.SetTag("cho.tenant_id", "t-1"); // should survive
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem("ssn").Should().BeNull();
+        activity.GetTagItem("cho.member_id").Should().BeNull();
+        activity.GetTagItem("http.request.header.authorization").Should().BeNull();
+        activity.GetTagItem("cho.tenant_id").Should().Be("t-1");
+    }
+
+    [Fact]
+    public void OnEnd_NoOp_WhenNoProhibitedTags()
+    {
+        using var activity = StartActivity();
+        activity.SetTag("cho.tenant_id", "t-1");
+        activity.SetTag("http.method", "GET");
+
+        _processor.OnEnd(activity);
+
+        activity.GetTagItem("cho.tenant_id").Should().Be("t-1");
+        activity.GetTagItem("http.method").Should().Be("GET");
+    }
+
+    [Fact]
+    public void OnEnd_HandlesActivityWithNoTags()
+    {
+        using var activity = StartActivity();
+
+        var act = () => _processor.OnEnd(activity);
+
+        act.Should().NotThrow();
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoActivitySource.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoActivitySource.cs
@@ -33,21 +33,23 @@ public static class ChoActivitySource
         if (tenantId is not null)
             activity.SetTag("cho.tenant_id", tenantId);
         if (claimId is not null)
-            activity.SetTag("cho.claim_id", claimId);
+            activity.SetTag("cho.claim_id_hash", HashIdentifier(claimId));
         if (claimType is not null)
             activity.SetTag("cho.claim_type", claimType);
         if (memberId is not null)
-            activity.SetTag("cho.member_id_hash", HashMemberId(memberId));
+            activity.SetTag("cho.member_id_hash", HashIdentifier(memberId));
 
         return activity;
     }
 
     /// <summary>
-    /// One-way SHA-256 hash of member ID to avoid leaking PHI into traces.
+    /// One-way SHA-256 hash of an identifier to avoid leaking PHI into traces.
+    /// Used for member IDs, claim IDs, and any other identifier that could
+    /// be joined back to a member.
     /// </summary>
-    public static string HashMemberId(string memberId)
+    public static string HashIdentifier(string identifier)
     {
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(memberId));
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(identifier));
         return Convert.ToHexString(hash)[..16].ToLowerInvariant();
     }
 

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -74,6 +74,16 @@ public static class ChoMetrics
             unit: "{decision}",
             description: "PAS $submit decisions by type");
 
+    /// <summary>
+    /// Counter tracking span attributes dropped by the PHI-scrubbing SpanProcessor.
+    /// Dimensions: attribute_name, service_name.
+    /// </summary>
+    public static readonly Counter<long> TelemetryScrubCount =
+        Meter.CreateCounter<long>(
+            "cho.telemetry.scrub.total",
+            unit: "{attribute}",
+            description: "Span attributes scrubbed by the PHI SpanProcessor");
+
     private static string GetAssemblyVersion()
     {
         return typeof(ChoMetrics).Assembly

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ObservabilityExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ObservabilityExtensions.cs
@@ -92,7 +92,8 @@ public static class ObservabilityExtensions
                     })
                     .AddHttpClientInstrumentation()
                     .AddRedisInstrumentation()
-                    .AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources");
+                    .AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
+                    .AddProcessor(new PhiScrubbingSpanProcessor(serviceName));
 
                 if (!string.IsNullOrEmpty(otlpEndpoint))
                 {

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/PhiScrubbingSpanProcessor.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/PhiScrubbingSpanProcessor.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace CloudHealthOffice.Infrastructure.Observability;
+
+/// <summary>
+/// Mandatory PHI-scrubbing SpanProcessor. Runs on <see cref="OnEnd"/> and
+/// removes prohibited attributes from every exported Activity before it
+/// reaches any exporter. Enforced as a positive list: any attribute whose
+/// name matches a prohibited pattern is dropped and counted via
+/// <c>cho.telemetry.scrub.total</c>.
+///
+/// This processor cannot be disabled by configuration — it is a compliance
+/// control. Callers wanting different scrubbing rules must fork the shared
+/// extension, not opt out.
+/// </summary>
+public sealed class PhiScrubbingSpanProcessor : BaseProcessor<Activity>
+{
+    private static readonly HashSet<string> ProhibitedAttributes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ssn", "social_security_number", "socialSecurityNumber",
+        "mbi", "medicareBeneficiaryIdentifier",
+        "dob", "dateOfBirth", "date_of_birth", "birthDate",
+        "member_id", "memberId",
+        "subscriber_id", "subscriberId",
+        "patient_id", "patientId",
+        "email", "emailAddress", "email_address",
+        "phone", "phoneNumber", "phone_number",
+        "address", "streetAddress", "street",
+        "first_name", "firstName", "last_name", "lastName", "full_name", "fullName",
+        "password", "api_key", "apiKey", "token", "secret", "authorization",
+    };
+
+    private static readonly string[] AlwaysAllowedPrefixes =
+    {
+        "http.", "db.", "net.", "rpc.", "messaging.",
+    };
+
+    private readonly string _serviceName;
+
+    public PhiScrubbingSpanProcessor(string? serviceName = null)
+    {
+        _serviceName = serviceName ?? "cho-unknown-service";
+    }
+
+    public override void OnEnd(Activity activity)
+    {
+        List<string>? toRemove = null;
+
+        foreach (var tag in activity.TagObjects)
+        {
+            if (IsProhibited(tag.Key))
+            {
+                toRemove ??= new List<string>();
+                toRemove.Add(tag.Key);
+            }
+        }
+
+        if (toRemove is null) return;
+
+        foreach (var key in toRemove)
+        {
+            activity.SetTag(key, null);
+            ChoMetrics.TelemetryScrubCount.Add(
+                1,
+                new KeyValuePair<string, object?>("attribute_name", key),
+                new KeyValuePair<string, object?>("service_name", _serviceName));
+        }
+    }
+
+    private static bool IsProhibited(string attributeName)
+    {
+        foreach (var prefix in AlwaysAllowedPrefixes)
+        {
+            if (attributeName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return false;
+        }
+
+        if (ProhibitedAttributes.Contains(attributeName))
+            return true;
+
+        var lastDot = attributeName.LastIndexOf('.');
+        if (lastDot >= 0 && lastDot < attributeName.Length - 1)
+        {
+            var suffix = attributeName[(lastDot + 1)..];
+            if (ProhibitedAttributes.Contains(suffix))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/PhiScrubbingSpanProcessor.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/PhiScrubbingSpanProcessor.cs
@@ -6,9 +6,19 @@ namespace CloudHealthOffice.Infrastructure.Observability;
 /// <summary>
 /// Mandatory PHI-scrubbing SpanProcessor. Runs on <see cref="OnEnd"/> and
 /// removes prohibited attributes from every exported Activity before it
-/// reaches any exporter. Enforced as a positive list: any attribute whose
-/// name matches a prohibited pattern is dropped and counted via
-/// <c>cho.telemetry.scrub.total</c>.
+/// reaches any exporter.
+///
+/// Enforced as a denylist: an attribute is dropped if its name exactly
+/// matches one on the prohibited list, OR if the segment after the final
+/// '.' matches one on the list (so <c>http.request.header.authorization</c>
+/// is scrubbed because the suffix <c>authorization</c> is prohibited, even
+/// though <c>http.*</c> is otherwise a standard OTel namespace). Everything
+/// not matching is allowed through. Comparisons are case-insensitive.
+///
+/// Drops are counted via <c>cho.telemetry.scrub.total</c> with
+/// <c>attribute_name</c> and <c>service_name</c> labels so the rate can be
+/// alerted on — a non-zero rate in production means a raw PHI attribute is
+/// being written somewhere.
 ///
 /// This processor cannot be disabled by configuration — it is a compliance
 /// control. Callers wanting different scrubbing rules must fork the shared
@@ -29,11 +39,6 @@ public sealed class PhiScrubbingSpanProcessor : BaseProcessor<Activity>
         "address", "streetAddress", "street",
         "first_name", "firstName", "last_name", "lastName", "full_name", "fullName",
         "password", "api_key", "apiKey", "token", "secret", "authorization",
-    };
-
-    private static readonly string[] AlwaysAllowedPrefixes =
-    {
-        "http.", "db.", "net.", "rpc.", "messaging.",
     };
 
     private readonly string _serviceName;
@@ -70,12 +75,6 @@ public sealed class PhiScrubbingSpanProcessor : BaseProcessor<Activity>
 
     private static bool IsProhibited(string attributeName)
     {
-        foreach (var prefix in AlwaysAllowedPrefixes)
-        {
-            if (attributeName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                return false;
-        }
-
         if (ProhibitedAttributes.Contains(attributeName))
             return true;
 

--- a/src/services/smart-auth-service/Program.cs
+++ b/src/services/smart-auth-service/Program.cs
@@ -8,6 +8,7 @@ using static OpenIddict.Abstractions.OpenIddictConstants;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -159,7 +160,11 @@ builder.Services.AddChoHealthChecks(options =>
 builder.Services.AddCors(options =>
     options.AddPolicy("AllowAll", p => p.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()));
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/services/smart-auth-service/appsettings.Development.json
+++ b/src/services/smart-auth-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/smart-auth-service/appsettings.json
+++ b/src/services/smart-auth-service/appsettings.json
@@ -18,5 +18,10 @@
     "RefreshTokenLifetimeDays": 7,
     "LaunchContextTtlMinutes": 5,
     "DevMode": true
+  },
+  "Observability": {
+    "ServiceName": "smart-auth-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/sponsor-service/Program.cs
+++ b/src/services/sponsor-service/Program.cs
@@ -5,6 +5,7 @@ using MongoDB.Driver;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -94,7 +95,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/sponsor-service/appsettings.Development.json
+++ b/src/services/sponsor-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/sponsor-service/appsettings.json
+++ b/src/services/sponsor-service/appsettings.json
@@ -15,5 +15,10 @@
   "Authentication": {
     "Authority": "https://yourtenant.b2clogin.com/yourtenant.onmicrosoft.com/v2.0/",
     "Audience": "api://sponsor-service"
+  },
+  "Observability": {
+    "ServiceName": "sponsor-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/tenant-service/Program.cs
+++ b/src/services/tenant-service/Program.cs
@@ -5,6 +5,7 @@ using TenantService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -72,6 +73,8 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
 
 // Seed admin TenantUser and standard roles on startup.
@@ -126,6 +129,8 @@ using (var scope = app.Services.CreateScope())
         logger.LogWarning(ex, "Failed to seed standard roles on startup.");
     }
 }
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/tenant-service/appsettings.Development.json
+++ b/src/services/tenant-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/tenant-service/appsettings.json
+++ b/src/services/tenant-service/appsettings.json
@@ -6,7 +6,6 @@
     }
   },
   "AllowedHosts": "*",
-
   "_comment_seedadmin": "Bootstrap-only: seeds the first TenantAdmin so you can log in. Override via GitHub secret / env vars: SeedAdmin__Email, SeedAdmin__DisplayName. All other tenants self-serve via /signup and /settings/users.",
   "SeedAdmin": {
     "TenantId": "aurelianware",
@@ -23,5 +22,10 @@
       "professional_monthly": "price_...",
       "enterprise_monthly": "price_..."
     }
+  },
+  "Observability": {
+    "ServiceName": "tenant-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/src/services/trading-partner-service/Program.cs
+++ b/src/services/trading-partner-service/Program.cs
@@ -5,6 +5,7 @@ using CloudHealthOffice.TradingPartnerService.Services;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -76,7 +77,11 @@ builder.Services.AddChoHealthChecks(options =>
     options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
 });
 
+builder.Services.AddChoObservability(builder.Configuration);
+
 var app = builder.Build();
+
+app.UseChoObservability();
 
 // Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())

--- a/src/services/trading-partner-service/appsettings.Development.json
+++ b/src/services/trading-partner-service/appsettings.Development.json
@@ -1,0 +1,6 @@
+{
+  "Observability": {
+    "OtlpEndpoint": null,
+    "EnableConsole": true
+  }
+}

--- a/src/services/trading-partner-service/appsettings.json
+++ b/src/services/trading-partner-service/appsettings.json
@@ -17,5 +17,10 @@
     "Key": "",
     "DatabaseName": "CloudHealthOffice",
     "ContainerName": "TradingPartners"
+  },
+  "Observability": {
+    "ServiceName": "trading-partner-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
   }
 }

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/CloudHealthOffice.AccumulatorService.Tests.csproj
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/CloudHealthOffice.AccumulatorService.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\accumulator-service\accumulator-service.csproj" />
     <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Events\CloudHealthOffice.Events.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.AccumulatorService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.AccumulatorService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.AccumulatorService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.AccumulatorService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.AuthorizationService.Tests/CloudHealthOffice.AuthorizationService.Tests.csproj
+++ b/tests/CloudHealthOffice.AuthorizationService.Tests/CloudHealthOffice.AuthorizationService.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\authorization-service\authorization-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/CloudHealthOffice.AuthorizationService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.AuthorizationService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.AuthorizationService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.AuthorizationService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.AuthorizationService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.AuthorizationService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.BenefitPlanService.Tests/CloudHealthOffice.BenefitPlanService.Tests.csproj
+++ b/tests/CloudHealthOffice.BenefitPlanService.Tests/CloudHealthOffice.BenefitPlanService.Tests.csproj
@@ -7,6 +7,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <!--
       Microsoft.Extensions.Logging.Abstractions is intentionally NOT declared here.
@@ -23,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\benefit-plan-service\benefit-plan-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/CloudHealthOffice.BenefitPlanService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.BenefitPlanService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.BenefitPlanService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.BenefitPlanService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.BenefitPlanService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.BenefitPlanService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.CapitationService.Tests/CloudHealthOffice.CapitationService.Tests.csproj
+++ b/tests/CloudHealthOffice.CapitationService.Tests/CloudHealthOffice.CapitationService.Tests.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\capitation-service\capitation-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CloudHealthOffice.CapitationService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.CapitationService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.CapitationService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.CapitationService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.CapitationService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.CapitationService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.ClaimsExaminerService.Tests/CloudHealthOffice.ClaimsExaminerService.Tests.csproj
+++ b/tests/CloudHealthOffice.ClaimsExaminerService.Tests/CloudHealthOffice.ClaimsExaminerService.Tests.csproj
@@ -18,5 +18,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\claims-examiner-service\claims-examiner-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CloudHealthOffice.ClaimsExaminerService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsExaminerService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.ClaimsExaminerService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.ClaimsExaminerService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsExaminerService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsExaminerService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\claims-service\claims-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.ClaimsService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.EligibilityService.Tests/CloudHealthOffice.EligibilityService.Tests.csproj
+++ b/tests/CloudHealthOffice.EligibilityService.Tests/CloudHealthOffice.EligibilityService.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\eligibility-service\eligibility-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/CloudHealthOffice.EligibilityService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.EligibilityService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.EligibilityService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.EligibilityService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.EligibilityService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.EligibilityService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/CloudHealthOffice.FhirService.Tests.csproj
+++ b/tests/CloudHealthOffice.FhirService.Tests/CloudHealthOffice.FhirService.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <ProjectReference Include="..\..\src\services\fhir-service\fhir-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/CloudHealthOffice.FhirService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.FhirService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.FhirService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.IdCardService.Tests/CloudHealthOffice.IdCardService.Tests.csproj
+++ b/tests/CloudHealthOffice.IdCardService.Tests/CloudHealthOffice.IdCardService.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\idcard-service\idcard-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/tests/CloudHealthOffice.IdCardService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.IdCardService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.IdCardService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.IdCardService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.IdCardService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.IdCardService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.PaymentService.Tests/CloudHealthOffice.PaymentService.Tests.csproj
+++ b/tests/CloudHealthOffice.PaymentService.Tests/CloudHealthOffice.PaymentService.Tests.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\payment-service\payment-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/CloudHealthOffice.PaymentService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.PaymentService.Tests/ObservabilityTests.cs
@@ -1,0 +1,16 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.PaymentService.Tests;
+
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}

--- a/tests/CloudHealthOffice.PaymentService.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.PaymentService.Tests/ObservabilityTests.cs
@@ -4,11 +4,11 @@ using Xunit;
 
 namespace CloudHealthOffice.PaymentService.Tests;
 
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<Program>>
 {
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ObservabilityTestFactory<Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<Program> factory) => _factory = factory;
+    public ObservabilityTests(ObservabilityTestFactory<Program> factory) => _factory = factory;
 
     [Fact]
     public Task ObservabilityWiring_SatisfiesStandardContract() =>

--- a/tests/CloudHealthOffice.SmartAuth.Tests/CloudHealthOffice.SmartAuth.Tests.csproj
+++ b/tests/CloudHealthOffice.SmartAuth.Tests/CloudHealthOffice.SmartAuth.Tests.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\services\fhir-service\fhir-service.csproj" />
     <ProjectReference Include="..\..\src\services\smart-auth-service\smart-auth-service.csproj" />
+    <ProjectReference Include="..\..\src\services\shared\CloudHealthOffice.Infrastructure.Tests\CloudHealthOffice.Infrastructure.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/CloudHealthOffice.SmartAuth.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.SmartAuth.Tests/ObservabilityTests.cs
@@ -7,11 +7,11 @@ namespace CloudHealthOffice.SmartAuth.Tests;
 // smart-auth-service exposes its Program under the SmartAuthService namespace
 // (SmartAuthProgram.cs) to disambiguate from the fhir-service Program in the
 // global namespace — this test project references both services.
-public class ObservabilityTests : IClassFixture<WebApplicationFactory<SmartAuthService.Program>>
+public class ObservabilityTests : IClassFixture<ObservabilityTestFactory<SmartAuthService.Program>>
 {
-    private readonly WebApplicationFactory<SmartAuthService.Program> _factory;
+    private readonly ObservabilityTestFactory<SmartAuthService.Program> _factory;
 
-    public ObservabilityTests(WebApplicationFactory<SmartAuthService.Program> factory) =>
+    public ObservabilityTests(ObservabilityTestFactory<SmartAuthService.Program> factory) =>
         _factory = factory;
 
     [Fact]

--- a/tests/CloudHealthOffice.SmartAuth.Tests/ObservabilityTests.cs
+++ b/tests/CloudHealthOffice.SmartAuth.Tests/ObservabilityTests.cs
@@ -1,0 +1,20 @@
+using CloudHealthOffice.Infrastructure.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace CloudHealthOffice.SmartAuth.Tests;
+
+// smart-auth-service exposes its Program under the SmartAuthService namespace
+// (SmartAuthProgram.cs) to disambiguate from the fhir-service Program in the
+// global namespace — this test project references both services.
+public class ObservabilityTests : IClassFixture<WebApplicationFactory<SmartAuthService.Program>>
+{
+    private readonly WebApplicationFactory<SmartAuthService.Program> _factory;
+
+    public ObservabilityTests(WebApplicationFactory<SmartAuthService.Program> factory) =>
+        _factory = factory;
+
+    [Fact]
+    public Task ObservabilityWiring_SatisfiesStandardContract() =>
+        ObservabilityTestHelper.AssertStandardContract(_factory);
+}


### PR DESCRIPTION
## Summary

Wires OpenTelemetry tracing + metrics into every CHO service, adds a mandatory PHI-scrubbing SpanProcessor, and proves coverage with one smoke test per integration-ready service test project.

- **Every Program.cs touched** (34 services): `builder.Services.AddChoObservability(builder.Configuration)` + `app.UseChoObservability()`. Consistency check — `grep -c "AddChoObservability\|UseChoObservability" src/services/*/Program.cs` returns exactly 2 for all 34.
- **PhiScrubbingSpanProcessor** runs on every exported Activity. Drops SSN/MBI/DOB, raw member/subscriber/patient IDs, contact info, auth tokens. Non-disableable. Drops counted via `cho.telemetry.scrub.total{attribute_name,service_name}`.
- **Claim IDs now hashed**: `cho.claim_id` → `cho.claim_id_hash`. `HashMemberId` renamed to `HashIdentifier` since the same policy now applies to claim IDs. 3 call sites (1 source, 2 test assertions) updated inline — no follow-up issue needed.
- **Config defaults** added to every `appsettings.json` (prod exports to `http://otel-collector:4317`) and `appsettings.Development.json` (literal `null` OtlpEndpoint + console exporter on).
- **Shared test helper** in `CloudHealthOffice.Infrastructure.Tests.ObservabilityTestHelper` — one-line invocation from each of 11 service test projects. 3 remaining test projects (PricingApi, ProviderService, ClaimsScrubbingService) are pure unit-test; adding `WebApplicationFactory` infrastructure to them is out of scope.
- **OTel Collector DaemonSet** scaffolded at `infrastructure/k8s/otel-collector/` — NOT deployed, NOT referenced by any existing Deployment. Services run fine without it; `/metrics` is scrapable directly off each pod.
- **Docs** at `docs/architecture/observability.md` capture conventions, PHI policy, span/metric recipes, and dev-vs-prod exporter behavior.

Commits are split logically for readable review:
1. `feat(infra): PHI-scrubbing SpanProcessor + claim-id hashing`
2. `feat(infra): wire AddChoObservability across 34 services`
3. `feat(infra): Observability config defaults in appsettings`
4. `test(infra): /metrics + scrubbing smoke tests (11 services)`
5. `chore(infra): OTel Collector DaemonSet scaffold (not deployed)`
6. `docs(architecture): observability conventions, PHI policy, /metrics guide`

## Special cases

- **provider-verification-service** — mechanical insertion inside `Main()` (class-based Program, unchanged). `TODO(refactor)` comment tracks top-level-statements follow-up.
- **tenant-service** — `UseChoObservability()` placed AFTER the startup seed block so `/metrics` only comes online once the service is ready to accept traffic.
- **fhir-service** — intentionally unchanged FHIR-specific middleware; observability added alongside.
- **CHO.TerminologyService / CloudHealthOffice.PricingApi** — JSON serialization config untouched per constraint.
- **4 services without existing `appsettings.json`** (ar-service, claims-scrubbing-service, ffs-service, provider-contracts-service) get minimal files containing only the Observability section — no existing behavior changed.

## Test plan

- [ ] `dotnet build` succeeds across the solution (infrastructure packages resolve transitively; no new service csproj PackageReferences added)
- [ ] `dotnet test` passes `CloudHealthOffice.Infrastructure.Tests` (renamed HashIdentifier tests + updated claim_id assertions)
- [ ] `dotnet test` passes all 11 service test projects with the new ObservabilityTests suite
- [ ] Manually curl `/metrics` on any running service; confirm it returns 200 and contains `cho_http_request_duration`
- [ ] Verify `cho.telemetry.scrub.total` stays at 0 across staging traffic — any non-zero value indicates a raw PHI attribute being written somewhere
- [ ] Confirm `cho.claim_id` no longer appears in exported traces; `cho.claim_id_hash` does

🤖 Generated with [Claude Code](https://claude.com/claude-code)