### PR TITLE
feat(infra): A.7.1 shared IMessageBus + eligibility & idcard migrations

### DIFF
--- a/docs/architecture/shared-messagebus.md
+++ b/docs/architecture/shared-messagebus.md
@@ -1,0 +1,207 @@
+# Shared `IMessageBus`
+
+`IMessageBus` is the Cloud Health Office async-messaging abstraction. One
+interface, three interchangeable backends, lives in
+[`CloudHealthOffice.Infrastructure.Messaging`](../../src/services/shared/CloudHealthOffice.Infrastructure/Messaging/).
+Production runs on Azure Service Bus; dev and test run on an in-process
+channel.
+
+## What this is — and isn't
+
+`IMessageBus` covers **durable async work dispatch** between CHO services:
+work queues, pub-sub topics, and scheduled delivery. It is deliberately
+**not** a Kafka facade. High-throughput streaming analytics
+(accumulator-service, authorization-service, claims-scrubbing-service,
+rfai-service, enrollment-import-service) remain on their own dedicated
+Kafka clients; those pipelines need Kafka-specific semantics
+(partitioning, compaction, change-feed replay) that don't belong on a
+cross-backend interface.
+
+## The three canonical patterns
+
+### Work queue (competing consumers)
+
+One queue, multiple subscribers, each message delivered exactly once
+across the group. This is what eligibility-service and idcard-service
+both use today.
+
+```csharp
+// Producer
+await bus.SendAsync("batch-eligibility", new BatchQueueMessage(tenantId, jobId));
+
+// Consumer (registered as a hosted service)
+await using var sub = bus.Subscribe<BatchQueueMessage>(
+    "batch-eligibility",
+    async (msg, ctx, ct) => await handler.ProcessAsync(msg, ct));
+await sub.StartAsync(stoppingToken);
+```
+
+### Pub-sub topic (fan-out)
+
+One topic, multiple named subscriptions, each subscription gets its own
+copy of every message. Pass `SubscriptionName` to
+[`SubscriptionOptions`](../../src/services/shared/CloudHealthOffice.Infrastructure/Messaging/IMessageBus.cs).
+
+```csharp
+bus.Subscribe<MemberEligibilityChanged>(
+    "member-events",
+    handler,
+    new SubscriptionOptions(SubscriptionName: "idcard-service"));
+```
+
+### Scheduled delivery
+
+`ScheduleAsync` delivers no earlier than the requested timestamp.
+Backend-specific resolution — Service Bus honours to the second; the
+in-memory bus uses a timer and is suitable only for tests.
+
+```csharp
+await bus.ScheduleAsync(
+    "reminders",
+    reminder,
+    DateTimeOffset.UtcNow.AddHours(24));
+```
+
+## Naming convention
+
+`{purpose}` for cross-environment resources where the Service Bus
+namespace is already per-environment. Example production names used
+today:
+
+| Queue                    | Owner                | Purpose                                    |
+| ------------------------ | -------------------- | ------------------------------------------ |
+| `batch-eligibility`      | eligibility-service  | Bulk 270/271 job dispatch                  |
+| `qnxt-idcard-requests`   | idcard-service       | QNXT mirror of CHO-issued ID cards         |
+
+Do **not** rename existing queues. These names appear in live
+`ServiceBusSender` calls and in the queue-provisioning script; a rename
+is a deployment-breaking change, not a code refactor. New queues should
+follow `{service}-{purpose}` (lowercase, hyphenated) so routing and
+ownership are both obvious from the name.
+
+## Idempotency and deduplication
+
+`SendOptions.MessageId` maps directly onto Service Bus native duplicate
+detection when the queue is provisioned with
+`RequiresDuplicateDetection=true`. Within the detection window
+(`MessagingOptions.DuplicateDetectionWindow`, default 1 hour) a repeat
+send with the same `MessageId` is dropped by the broker.
+
+Tradeoffs to know before you rely on it:
+
+- **The window is a wall-clock window, not per-consumer.** A replay
+  that straddles the window gets delivered twice; handlers must still be
+  idempotent at the application layer. Dedup is a defence in depth, not
+  a correctness guarantee.
+- **Queue provisioning is infra, not code.** The bus never creates or
+  modifies queues. A `MessageId` set against a queue without dedup
+  enabled does nothing. Use
+  [`scripts/azure/provision-servicebus-queues.sh`](../../scripts/azure/provision-servicebus-queues.sh)
+  to provision.
+- **In-memory emulates this for tests.** `InMemoryMessageBus`
+  remembers `MessageId`s within the same window so the contract test
+  passes identically on both backends.
+
+## Configuration
+
+Bind from the `Messaging` section:
+
+```json
+{
+  "Messaging": {
+    "Backend": "Auto",
+    "ServiceBusConnectionString": null
+  }
+}
+```
+
+Backend resolution:
+
+| `Backend`    | Result                                                       |
+| ------------ | ------------------------------------------------------------ |
+| `Auto` (dev) | `InMemory`                                                   |
+| `Auto` (prod) | `ServiceBus` if `ServiceBusConnectionString` is set, else `InMemory` + warning |
+| `ServiceBus` | Forced; throws at startup if no connection string            |
+| `InMemory`   | Forced                                                       |
+| `Null`       | Forced no-op (test scenarios that don't care about messaging) |
+
+`AddChoMessaging` logs one line at startup stating the chosen backend and
+the reason, e.g. `IMessageBus=ServiceBus (Auto; ConnectionString
+configured; env=Production)`.
+
+### Legacy keys
+
+Two legacy connection-string keys are honoured as fallbacks:
+
+- `BatchEligibility:ServiceBus:ConnectionString`
+- `IdCard:QnxtMirror:ServiceBusConnectionString`
+
+If either is read, a single startup warning names the deprecated key and
+the canonical replacement. These fallbacks will be removed one release
+after this change lands; track the follow-up in issue
+**"Remove deprecated Messaging config key fallbacks"**.
+
+## Migration notes for new services
+
+If you're adding Service Bus to a new service:
+
+1. Add `builder.Services.AddChoMessaging(builder.Configuration,
+   builder.Environment);` to `Program.cs`. `IMessageBus` is a singleton
+   afterwards.
+2. **Do not** register your own `ServiceBusClient` — the bus owns the
+   client lifecycle.
+3. Do not add `Azure.Messaging.ServiceBus` to your service's `.csproj`.
+   It lives in `CloudHealthOffice.Infrastructure` and you get it
+   transitively.
+4. Add an entry to
+   [`provision-servicebus-queues.sh`](../../scripts/azure/provision-servicebus-queues.sh)
+   for your queue name so staging/prod can be provisioned with the
+   correct dedup + DLQ settings.
+5. If you want to consume, use `SubscriptionHostedService` rather than
+   rolling your own `BackgroundService` wrapper.
+
+## When you should NOT use `IMessageBus`
+
+| Need                                             | Use                                |
+| ------------------------------------------------ | ---------------------------------- |
+| High-throughput event streaming / analytics      | **Kafka** (keep existing clients)  |
+| Request/response with a latency budget           | **HTTP** (or gRPC if warranted)    |
+| Replay from the point-in-time source of truth    | **Cosmos Change Feed**             |
+| In-process work scheduling inside one service    | `Task.Run` / `BackgroundService`   |
+
+Quick decision tree:
+
+```
+  Does the consumer live in a different service?  — no  → just call it
+             |
+             yes
+             |
+  Do you need event replay / stream analytics?     — yes → Kafka
+             |
+             no
+             |
+  Is the consumer synchronous to the request?     — yes → HTTP
+             |
+             no
+             |
+                                                          → IMessageBus
+```
+
+## Observability
+
+Every send and receive is a span under the `CloudHealthOffice`
+`ActivitySource`. Producer spans are `ActivityKind.Producer`; consumer
+spans are `ActivityKind.Consumer`. W3C trace context is injected as a
+`traceparent` application property on send and restored on receive so
+cross-service traces link up end-to-end.
+
+Azure Service Bus emits its own activities under
+`Azure.Messaging.ServiceBus.*`. `AddChoObservability` subscribes to
+those, so the SDK's own send/receive spans flow into the same trace.
+
+PHI scrubbing is global via `PhiScrubbingSpanProcessor`. It strips
+prohibited attributes on export, but the convention still stands:
+prefer not to put raw member IDs or claim IDs in span tags in the first
+place. Hash them via
+[`ChoActivitySource.HashIdentifier`](../../src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoActivitySource.cs)
+if you need to trace through.

--- a/scripts/azure/provision-servicebus-queues.sh
+++ b/scripts/azure/provision-servicebus-queues.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Provisions the Azure Service Bus queues consumed by IMessageBus.
+#
+# Creates the two queues the platform uses today:
+#   - batch-eligibility      (eligibility-service IBatchQueue)
+#   - qnxt-idcard-requests   (idcard-service IQnxtMirrorQueue)
+#
+# Each queue is created with:
+#   - RequiresDuplicateDetection = true  (SendOptions.MessageId dedup)
+#   - Duplicate detection window = 1 hour (matches MessagingOptions default)
+#   - MaxDeliveryCount = 10              (Azure default; matches current code)
+#   - DeadLetteringOnMessageExpiration = true
+#
+# Idempotent: re-running on an existing queue updates mutable fields
+# without errors.
+#
+# Required env vars:
+#   SERVICEBUS_NAMESPACE  — the SB namespace name
+#   RESOURCE_GROUP        — the resource group containing it
+set -euo pipefail
+
+: "${SERVICEBUS_NAMESPACE:?SERVICEBUS_NAMESPACE is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+
+DEDUP_WINDOW_ISO="PT1H"
+MAX_DELIVERY=10
+
+# Queue names are frozen production names. Do NOT rename without a
+# coordinated migration — they appear in live ServiceBusSender calls.
+QUEUES=(
+  "batch-eligibility"
+  "qnxt-idcard-requests"
+)
+
+for queue in "${QUEUES[@]}"; do
+  echo "==> Service Bus: queue ${queue} in ${SERVICEBUS_NAMESPACE}"
+  if az servicebus queue show \
+      --namespace-name "$SERVICEBUS_NAMESPACE" \
+      --name "$queue" \
+      --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    echo "    exists; updating mutable fields"
+    az servicebus queue update \
+      --namespace-name "$SERVICEBUS_NAMESPACE" \
+      --name "$queue" \
+      --resource-group "$RESOURCE_GROUP" \
+      --max-delivery-count "$MAX_DELIVERY" \
+      --enable-dead-lettering-on-message-expiration true >/dev/null
+  else
+    echo "    creating"
+    az servicebus queue create \
+      --namespace-name "$SERVICEBUS_NAMESPACE" \
+      --name "$queue" \
+      --resource-group "$RESOURCE_GROUP" \
+      --max-delivery-count "$MAX_DELIVERY" \
+      --enable-duplicate-detection true \
+      --duplicate-detection-history-time-window "$DEDUP_WINDOW_ISO" \
+      --enable-dead-lettering-on-message-expiration true >/dev/null
+  fi
+done
+
+echo "==> Done."

--- a/src/services/eligibility-service/Program.cs
+++ b/src/services/eligibility-service/Program.cs
@@ -8,6 +8,7 @@ using EligibilityService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Messaging;
 using CloudHealthOffice.Infrastructure.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -110,7 +111,11 @@ builder.Services.AddScoped<IEdi271Generator, Edi271Generator>();
 builder.Services.AddSingleton<IAccumulatorClient, StubAccumulatorClient>();
 builder.Services.AddScoped<ITemporalEligibilityService, TemporalEligibilityService>();
 
-// Batch eligibility storage (in-memory for dev, Cosmos+Blob+Service Bus for
+// Shared messaging bus. Backend (ServiceBus / InMemory / Null) is resolved
+// from Messaging:* config + environment by AddChoMessaging.
+builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
+
+// Batch eligibility storage (in-memory for dev, Cosmos+Blob+IMessageBus for
 // production). Resolution logic lives in
 // BatchEligibilityServiceCollectionExtensions.
 builder.Services.AddBatchEligibilityStorage(builder.Configuration, builder.Environment);

--- a/src/services/eligibility-service/Services/BatchEligibilityServiceCollectionExtensions.cs
+++ b/src/services/eligibility-service/Services/BatchEligibilityServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using Azure.Messaging.ServiceBus;
 using Azure.Storage.Blobs;
+using CloudHealthOffice.Infrastructure.Messaging;
 using Microsoft.Azure.Cosmos;
 
 namespace EligibilityService.Services;
@@ -8,12 +8,14 @@ namespace EligibilityService.Services;
 /// Resolves BatchEligibility storage bindings from configuration.
 ///
 /// Config section <c>BatchEligibility:StorageMode</c>:
-///   InMemory   — in-process channel + in-memory job store (dev only).
-///   Persistent — Cosmos job store + Blob payload store + Service Bus queue.
-///   Auto       — Persistent when both Cosmos and Service Bus are configured;
-///                 InMemory + warn in dev when they're not; throws otherwise.
+///   <c>InMemory</c>   — in-process channel + in-memory job store (dev only).
+///   <c>Persistent</c> — Cosmos job store + Blob payload store + IMessageBus queue.
+///   <c>Auto</c>       — Persistent when both Cosmos and Blob are configured;
+///                        InMemory in Development; throws otherwise.
 ///
-/// Never registers both in-memory and persistent implementations.
+/// The queue transport itself is owned by <see cref="IMessageBus"/>
+/// (register via <c>AddChoMessaging</c>). Service Bus vs in-process channel
+/// is decided there, not here.
 /// </summary>
 public static class BatchEligibilityServiceCollectionExtensions
 {
@@ -25,12 +27,10 @@ public static class BatchEligibilityServiceCollectionExtensions
         var requestedMode = configuration["BatchEligibility:StorageMode"] ?? "Auto";
         var cosmosCs = configuration["BatchEligibility:CosmosDb:ConnectionString"];
         var blobCs = configuration["BatchEligibility:BlobStorage:ConnectionString"];
-        var serviceBusCs = configuration["BatchEligibility:ServiceBus:ConnectionString"];
 
         var hasPersistentConfig =
             !string.IsNullOrWhiteSpace(cosmosCs) &&
-            !string.IsNullOrWhiteSpace(blobCs) &&
-            !string.IsNullOrWhiteSpace(serviceBusCs);
+            !string.IsNullOrWhiteSpace(blobCs);
 
         var effectiveMode = ResolveMode(requestedMode, environment, hasPersistentConfig);
 
@@ -40,14 +40,14 @@ public static class BatchEligibilityServiceCollectionExtensions
             {
                 throw new InvalidOperationException(
                     "BatchEligibility:StorageMode resolved to InMemory outside Development. " +
-                    "Configure BatchEligibility:CosmosDb, BatchEligibility:BlobStorage and " +
-                    "BatchEligibility:ServiceBus, or set StorageMode=Persistent explicitly.");
+                    "Configure BatchEligibility:CosmosDb and BatchEligibility:BlobStorage, " +
+                    "or set StorageMode=Persistent explicitly.");
             }
 
             Console.WriteLine(
                 "[dev] BatchEligibility storage = InMemory. Jobs do NOT survive restarts " +
-                "and are not visible across replicas. Configure Cosmos + Blob + Service Bus " +
-                "for production.");
+                "and are not visible across replicas. Configure Cosmos + Blob + a Service Bus " +
+                "connection string under Messaging:ServiceBusConnectionString for production.");
 
             services.AddSingleton<IBatchJobStore, InMemoryBatchJobStore>();
             services.AddSingleton<IBatchQueue, InMemoryBatchQueue>();
@@ -58,7 +58,6 @@ public static class BatchEligibilityServiceCollectionExtensions
         // Persistent
         RequireConfig(cosmosCs, "BatchEligibility:CosmosDb:ConnectionString");
         RequireConfig(blobCs, "BatchEligibility:BlobStorage:ConnectionString");
-        RequireConfig(serviceBusCs, "BatchEligibility:ServiceBus:ConnectionString");
 
         var cosmosDb = configuration["BatchEligibility:CosmosDb:Database"] ?? "cho";
         var cosmosContainer = configuration["BatchEligibility:CosmosDb:Container"] ?? "batch-jobs";
@@ -81,12 +80,10 @@ public static class BatchEligibilityServiceCollectionExtensions
                 inlineMax);
         });
 
-        services.AddSingleton<ServiceBusClient>(_ => new ServiceBusClient(serviceBusCs));
-        services.AddSingleton<IBatchQueueSender>(sp =>
-            new ServiceBusSenderAdapter(sp.GetRequiredService<ServiceBusClient>(), sbQueueName));
-        services.AddSingleton<IBatchQueue, ServiceBusBatchQueue>();
+        services.AddSingleton<IBatchQueue>(sp =>
+            new ServiceBusBatchQueue(sp.GetRequiredService<IMessageBus>(), sbQueueName));
         services.AddSingleton<IBatchQueueProcessor>(sp =>
-            new ServiceBusBatchQueueProcessor(sp.GetRequiredService<ServiceBusClient>(), sbQueueName));
+            new MessageBusBatchQueueProcessor(sp.GetRequiredService<IMessageBus>(), sbQueueName));
 
         return services;
     }
@@ -101,9 +98,9 @@ public static class BatchEligibilityServiceCollectionExtensions
             _ when hasPersistentConfig => BatchStorageBackend.Persistent,
             _ when env.IsDevelopment() => BatchStorageBackend.InMemory,
             _ => throw new InvalidOperationException(
-                "BatchEligibility:StorageMode=Auto could not resolve: no Cosmos/Blob/Service Bus " +
-                "config and not running in Development. Set StorageMode explicitly or provide " +
-                "the required connection strings.")
+                "BatchEligibility:StorageMode=Auto could not resolve: no Cosmos/Blob config and " +
+                "not running in Development. Set StorageMode explicitly or provide the required " +
+                "connection strings.")
         };
     }
 

--- a/src/services/eligibility-service/Services/IBatchQueueProcessor.cs
+++ b/src/services/eligibility-service/Services/IBatchQueueProcessor.cs
@@ -1,25 +1,21 @@
-using System.Text.Json;
-using Azure.Messaging.ServiceBus;
+using CloudHealthOffice.Infrastructure.Messaging;
 
 namespace EligibilityService.Services;
 
 /// <summary>
 /// Drives queue consumption. Has two implementations:
-///   ChannelBatchQueueProcessor — drains the in-process channel used by
-///     <see cref="InMemoryBatchQueue"/> (dev / single-instance).
-///   ServiceBusBatchQueueProcessor — wraps <see cref="ServiceBusProcessor"/>
-///     with push delivery, complete-on-success / abandon-on-failure, and
-///     lets Service Bus DLQ after MaxDeliveryCount.
+///   <see cref="ChannelBatchQueueProcessor"/> — drains the in-process channel
+///     used by <see cref="InMemoryBatchQueue"/> (dev / single-instance).
+///   <see cref="MessageBusBatchQueueProcessor"/> — subscribes to the shared
+///     <see cref="IMessageBus"/>, which preserves the complete-on-success /
+///     abandon-on-failure / dead-letter-on-deserialize pattern that lived
+///     here previously as a direct <c>ServiceBusProcessor</c> wrapper.
 ///
 /// <see cref="BatchEligibilityQueueWorker"/> resolves this from DI and
 /// delegates; it does not know which backend it's on.
 /// </summary>
 public interface IBatchQueueProcessor
 {
-    /// <summary>
-    /// Run until <paramref name="stopping"/> is cancelled, dispatching each
-    /// received message to <paramref name="handler"/>.
-    /// </summary>
     Task RunAsync(
         Func<BatchQueueMessage, CancellationToken, Task> handler,
         CancellationToken stopping);
@@ -27,7 +23,8 @@ public interface IBatchQueueProcessor
 
 /// <summary>
 /// Channel-based processor that drains an <see cref="InMemoryBatchQueue"/>.
-/// Used in dev and in unit tests.
+/// TODO(addendum-a-7-1): fold into IMessageBus once the tests that depend
+/// on IBatchQueue.ReadAllAsync are rewritten to subscribe-and-drain.
 /// </summary>
 public class ChannelBatchQueueProcessor : IBatchQueueProcessor
 {
@@ -50,68 +47,31 @@ public class ChannelBatchQueueProcessor : IBatchQueueProcessor
 }
 
 /// <summary>
-/// Service Bus processor. Completes messages on handler success, abandons
-/// on failure (redelivery up to MaxDeliveryCount, then queue DLQ).
+/// Processor that subscribes to <see cref="IMessageBus"/>. Behaviour
+/// (complete / abandon / dead-letter) lives in the bus implementation;
+/// this class just plumbs the typed handler through.
 /// </summary>
-public class ServiceBusBatchQueueProcessor : IBatchQueueProcessor, IAsyncDisposable
+public class MessageBusBatchQueueProcessor : IBatchQueueProcessor
 {
-    private readonly ServiceBusProcessor _processor;
-    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+    private readonly IMessageBus _bus;
+    private readonly string _queueName;
 
-    public ServiceBusBatchQueueProcessor(ServiceBusClient client, string queueName, int maxConcurrentCalls = 4)
+    public MessageBusBatchQueueProcessor(IMessageBus bus, string queueName)
     {
-        _processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
-        {
-            MaxConcurrentCalls = maxConcurrentCalls,
-            AutoCompleteMessages = false
-        });
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
     }
 
     public async Task RunAsync(
         Func<BatchQueueMessage, CancellationToken, Task> handler,
         CancellationToken stopping)
     {
-        _processor.ProcessMessageAsync += async args =>
-        {
-            BatchQueueMessage? msg;
-            try
-            {
-                msg = JsonSerializer.Deserialize<BatchQueueMessage>(
-                    args.Message.Body.ToString(), JsonOpts);
-            }
-            catch
-            {
-                // Malformed payload — let SB auto-DLQ.
-                await args.DeadLetterMessageAsync(args.Message,
-                    deadLetterReason: "DeserializeFailed",
-                    cancellationToken: args.CancellationToken);
-                return;
-            }
+        await using var subscription = _bus.Subscribe<BatchQueueMessage>(
+            _queueName,
+            (msg, _, ct) => handler(msg, ct),
+            new SubscriptionOptions(MaxConcurrentCalls: 4, AutoComplete: false));
 
-            if (msg == null)
-            {
-                await args.DeadLetterMessageAsync(args.Message,
-                    deadLetterReason: "NullPayload",
-                    cancellationToken: args.CancellationToken);
-                return;
-            }
-
-            try
-            {
-                await handler(msg, args.CancellationToken);
-                await args.CompleteMessageAsync(args.Message, args.CancellationToken);
-            }
-            catch
-            {
-                await args.AbandonMessageAsync(args.Message,
-                    cancellationToken: args.CancellationToken);
-                throw;
-            }
-        };
-
-        _processor.ProcessErrorAsync += _ => Task.CompletedTask;
-
-        await _processor.StartProcessingAsync(stopping);
+        await subscription.StartAsync(stopping);
         try
         {
             await Task.Delay(Timeout.Infinite, stopping);
@@ -120,11 +80,6 @@ public class ServiceBusBatchQueueProcessor : IBatchQueueProcessor, IAsyncDisposa
         {
             // expected on shutdown
         }
-        finally
-        {
-            await _processor.StopProcessingAsync(CancellationToken.None);
-        }
+        await subscription.StopAsync(CancellationToken.None);
     }
-
-    public async ValueTask DisposeAsync() => await _processor.DisposeAsync();
 }

--- a/src/services/eligibility-service/Services/ServiceBusBatchQueue.cs
+++ b/src/services/eligibility-service/Services/ServiceBusBatchQueue.cs
@@ -1,67 +1,36 @@
-using System.Runtime.CompilerServices;
-using System.Text.Json;
-using Azure.Messaging.ServiceBus;
+using CloudHealthOffice.Infrastructure.Messaging;
 
 namespace EligibilityService.Services;
 
 /// <summary>
-/// Azure Service Bus implementation of <see cref="IBatchQueue"/>. Messages
-/// are JSON-encoded <see cref="BatchQueueMessage"/>s with CorrelationId =
-/// jobId for observability. No session grouping is used — job idempotency
-/// is handled by <see cref="BatchEligibilityService.ProcessJobAsync"/>.
-///
-/// The queue consumer is <see cref="ServiceBusBatchQueueProcessor"/>
-/// (see <see cref="IBatchQueueProcessor"/>); this class only handles enqueue.
-/// <see cref="ReadAllAsync"/> throws — Service Bus messages are delivered
-/// via the processor's push model, not polled.
+/// <see cref="IBatchQueue"/> backed by <see cref="IMessageBus"/>. The domain
+/// wrapper exists so the rest of the service keeps calling
+/// <c>EnqueueAsync</c> on a typed interface; the actual transport is owned
+/// by the shared bus. Consumption is push-based via
+/// <see cref="MessageBusBatchQueueProcessor"/>, so <see cref="ReadAllAsync"/>
+/// is not supported.
 /// </summary>
 public class ServiceBusBatchQueue : IBatchQueue
 {
-    private readonly IBatchQueueSender _sender;
-    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+    private readonly IMessageBus _bus;
+    private readonly string _queueName;
 
-    public ServiceBusBatchQueue(IBatchQueueSender sender)
+    public ServiceBusBatchQueue(IMessageBus bus, string queueName)
     {
-        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
     }
 
     public async ValueTask EnqueueAsync(BatchQueueMessage message, CancellationToken ct = default)
     {
-        var body = JsonSerializer.SerializeToUtf8Bytes(message, JsonOpts);
-        await _sender.SendAsync(body, correlationId: message.JobId, ct);
+        await _bus.SendAsync(
+            _queueName,
+            message,
+            new SendOptions(CorrelationId: message.JobId),
+            ct);
     }
 
     public IAsyncEnumerable<BatchQueueMessage> ReadAllAsync(CancellationToken ct)
         => throw new NotSupportedException(
             "ServiceBusBatchQueue uses push delivery; resolve IBatchQueueProcessor from DI instead.");
-}
-
-/// <summary>
-/// Thin abstraction over <see cref="ServiceBusSender"/> so
-/// <see cref="ServiceBusBatchQueue"/> is unit-testable without the emulator.
-/// </summary>
-public interface IBatchQueueSender
-{
-    Task SendAsync(byte[] body, string correlationId, CancellationToken ct);
-}
-
-public class ServiceBusSenderAdapter : IBatchQueueSender, IAsyncDisposable
-{
-    private readonly ServiceBusSender _sender;
-
-    public ServiceBusSenderAdapter(ServiceBusClient client, string queueName)
-    {
-        _sender = client.CreateSender(queueName);
-    }
-
-    public async Task SendAsync(byte[] body, string correlationId, CancellationToken ct)
-    {
-        var message = new ServiceBusMessage(body)
-        {
-            CorrelationId = correlationId
-        };
-        await _sender.SendMessageAsync(message, ct);
-    }
-
-    public async ValueTask DisposeAsync() => await _sender.DisposeAsync();
 }

--- a/src/services/eligibility-service/appsettings.Development.json
+++ b/src/services/eligibility-service/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Messaging": {
+    "Backend": "InMemory"
+  },
   "Observability": {
     "OtlpEndpoint": null,
     "EnableConsole": true

--- a/src/services/eligibility-service/appsettings.json
+++ b/src/services/eligibility-service/appsettings.json
@@ -17,6 +17,10 @@
     "MemberService": "http://member-service.cloudhealthoffice/api",
     "BenefitPlanService": "http://benefit-plan-service.cloudhealthoffice/api"
   },
+  "Messaging": {
+    "Backend": "Auto",
+    "ServiceBusConnectionString": null
+  },
   "BatchEligibility": {
     "StorageMode": "Auto",
     "InlineMaxBytes": 1048576,
@@ -30,7 +34,6 @@
       "Container": "batch-eligibility"
     },
     "ServiceBus": {
-      "ConnectionString": "",
       "Queue": "batch-eligibility"
     }
   },

--- a/src/services/eligibility-service/eligibility-service.csproj
+++ b/src/services/eligibility-service/eligibility-service.csproj
@@ -12,7 +12,11 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
   </ItemGroup>
 
-  <ItemGroup>    <PackageReference Include="Azure.Core" Version="1.44.1" />    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>

--- a/src/services/eligibility-service/eligibility-service.csproj
+++ b/src/services/eligibility-service/eligibility-service.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
   </ItemGroup>
 
-  <ItemGroup>    <PackageReference Include="Azure.Core" Version="1.44.1" />    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+  <ItemGroup>    <PackageReference Include="Azure.Core" Version="1.44.1" />    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>

--- a/src/services/idcard-service/Program.cs
+++ b/src/services/idcard-service/Program.cs
@@ -8,6 +8,7 @@ using IdCardService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Messaging;
 using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.RateLimiting;
@@ -106,16 +107,20 @@ builder.Services.AddScoped<IIdCardAdapter, QnxtIdCardAdapter>();
 builder.Services.AddScoped<IIdCardAdapter, FulfillmentVendorAdapter>();
 builder.Services.AddScoped<IdCardAdapterFactory>();
 
-// QNXT mirror queue — Service Bus is only wired when the feature flag is
-// explicitly enabled *and* a connection string is supplied. Either being
-// unset falls back to the in-memory queue used by dev/test and by the
-// reconciliation job's tests.
+// Shared messaging bus. Backend (ServiceBus / InMemory / Null) is resolved
+// from Messaging:* config + environment by AddChoMessaging.
+builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
+
+// QNXT mirror queue — when the feature flag is enabled we route through
+// IMessageBus (Service Bus in prod, in-memory in dev). When disabled we
+// keep the stand-alone InMemoryQnxtMirrorQueue because tests and the
+// reconciliation job rely on its PeekEnqueued inspection method.
 var qnxtMirrorEnabled = builder.Configuration.GetValue<bool>("IdCard:QnxtMirror:Enabled");
-var sbConn = builder.Configuration["IdCard:QnxtMirror:ServiceBusConnectionString"];
-var queueName = builder.Configuration["IdCard:QnxtMirror:QueueName"] ?? "qnxt-idcard-requests";
-if (qnxtMirrorEnabled && !string.IsNullOrEmpty(sbConn))
+var qnxtQueueName = builder.Configuration["IdCard:QnxtMirror:QueueName"] ?? "qnxt-idcard-requests";
+if (qnxtMirrorEnabled)
 {
-    builder.Services.AddSingleton<IQnxtMirrorQueue>(_ => new ServiceBusQnxtMirrorQueue(sbConn, queueName));
+    builder.Services.AddSingleton<IQnxtMirrorQueue>(sp =>
+        new ServiceBusQnxtMirrorQueue(sp.GetRequiredService<IMessageBus>(), qnxtQueueName));
 }
 else
 {

--- a/src/services/idcard-service/Services/QnxtMirrorQueue.cs
+++ b/src/services/idcard-service/Services/QnxtMirrorQueue.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
-using System.Text.Json;
-using Azure.Messaging.ServiceBus;
+using CloudHealthOffice.Infrastructure.Messaging;
 
 namespace IdCardService.Services;
 
@@ -39,29 +38,26 @@ public class InMemoryQnxtMirrorQueue : IQnxtMirrorQueue
     public IReadOnlyCollection<QnxtMirrorMessage> PeekEnqueued() => _messages.ToArray();
 }
 
-/// <summary>Azure Service Bus implementation for production.</summary>
-public class ServiceBusQnxtMirrorQueue : IQnxtMirrorQueue, IAsyncDisposable
+/// <summary>
+/// Production implementation that forwards onto the shared
+/// <see cref="IMessageBus"/>. The bus owns the <c>ServiceBusClient</c>
+/// lifecycle, which also fixes a handle-leak on shutdown: the previous
+/// direct-ownership class implemented <see cref="IAsyncDisposable"/> but
+/// Program.cs never disposed it.
+/// </summary>
+public class ServiceBusQnxtMirrorQueue : IQnxtMirrorQueue
 {
-    private readonly ServiceBusClient _client;
-    private readonly ServiceBusSender _sender;
+    private readonly IMessageBus _bus;
+    private readonly string _queueName;
 
-    public ServiceBusQnxtMirrorQueue(string connectionString, string queueName)
+    public ServiceBusQnxtMirrorQueue(IMessageBus bus, string queueName)
     {
-        _client = new ServiceBusClient(connectionString);
-        _sender = _client.CreateSender(queueName);
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _queueName = queueName ?? throw new ArgumentNullException(nameof(queueName));
     }
 
-    public async Task EnqueueMirrorAsync(QnxtMirrorMessage message, CancellationToken ct = default)
-    {
-        var json = JsonSerializer.Serialize(message);
-        await _sender.SendMessageAsync(new ServiceBusMessage(json), ct);
-    }
+    public Task EnqueueMirrorAsync(QnxtMirrorMessage message, CancellationToken ct = default)
+        => _bus.SendAsync(_queueName, message, options: null, ct);
 
     public IReadOnlyCollection<QnxtMirrorMessage> PeekEnqueued() => Array.Empty<QnxtMirrorMessage>();
-
-    public async ValueTask DisposeAsync()
-    {
-        await _sender.DisposeAsync();
-        await _client.DisposeAsync();
-    }
 }

--- a/src/services/idcard-service/appsettings.Development.json
+++ b/src/services/idcard-service/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Messaging": {
+    "Backend": "InMemory"
+  },
   "Observability": {
     "OtlpEndpoint": null,
     "EnableConsole": true

--- a/src/services/idcard-service/appsettings.json
+++ b/src/services/idcard-service/appsettings.json
@@ -26,6 +26,10 @@
     "EligibilityService": "http://eligibility-service.cloudhealthoffice/api",
     "TenantService": "http://tenant-service.cloudhealthoffice/api/v1"
   },
+  "Messaging": {
+    "Backend": "Auto",
+    "ServiceBusConnectionString": null
+  },
   "IdCard": {
     "SigningKeySecretPrefix": "idcard-signing-key",
     "CurrentKeyVersion": "v1",
@@ -44,8 +48,7 @@
     },
     "QnxtMirror": {
       "Enabled": false,
-      "QueueName": "qnxt-idcard-requests",
-      "ServiceBusConnectionString": ""
+      "QueueName": "qnxt-idcard-requests"
     },
     "Reconciliation": {
       "IntervalHours": 24

--- a/src/services/idcard-service/idcard-service.csproj
+++ b/src/services/idcard-service/idcard-service.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/CloudHealthOffice.Infrastructure.Tests.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/CloudHealthOffice.Infrastructure.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -1,0 +1,9 @@
+using CloudHealthOffice.Infrastructure.Messaging;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Messaging;
+
+public class InMemoryMessageBusTests : MessageBusContractTests
+{
+    protected override ValueTask<IMessageBus> CreateBusAsync()
+        => ValueTask.FromResult<IMessageBus>(new InMemoryMessageBus());
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/MessageBusContractTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/MessageBusContractTests.cs
@@ -1,0 +1,176 @@
+using System.Diagnostics;
+using CloudHealthOffice.Infrastructure.Messaging;
+using CloudHealthOffice.Infrastructure.Observability;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Messaging;
+
+/// <summary>
+/// Shared contract every <see cref="IMessageBus"/> implementation must pass.
+///
+/// The InMemory fixture runs in every CI build. A Service Bus fixture
+/// deriving from this class can be wired up and executed against a real
+/// namespace; keeping the assertions shared means "in-memory works, prod
+/// is subtly different" can't silently escape notice.
+/// </summary>
+public abstract class MessageBusContractTests : IAsyncLifetime
+{
+    protected IMessageBus Bus { get; private set; } = default!;
+    private IAsyncDisposable? _owned;
+
+    protected abstract ValueTask<IMessageBus> CreateBusAsync();
+    protected virtual string QueueNameFor(string test) => $"contract-{test}-{Guid.NewGuid():N}";
+
+    public async Task InitializeAsync()
+    {
+        Bus = await CreateBusAsync();
+        _owned = Bus as IAsyncDisposable;
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_owned is not null) await _owned.DisposeAsync();
+    }
+
+    [SkippableFact]
+    public async Task SendAsync_RoundTripsMessage()
+    {
+        var queue = QueueNameFor("roundtrip");
+        var received = new TaskCompletionSource<Payload>();
+        await using var sub = Bus.Subscribe<Payload>(queue, (msg, _, _) =>
+        {
+            received.TrySetResult(msg);
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+
+        await Bus.SendAsync(queue, new Payload("hello", 42));
+
+        var msg = await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("hello", msg.Name);
+        Assert.Equal(42, msg.Value);
+    }
+
+    [SkippableFact]
+    public async Task SendAsync_PropagatesCorrelationIdAndProperties()
+    {
+        var queue = QueueNameFor("corr");
+        var received = new TaskCompletionSource<MessageContext>();
+        await using var sub = Bus.Subscribe<Payload>(queue, (_, ctx, _) =>
+        {
+            received.TrySetResult(ctx);
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+
+        await Bus.SendAsync(queue, new Payload("c", 1),
+            new SendOptions(
+                CorrelationId: "corr-xyz",
+                Properties: new Dictionary<string, string> { ["cho.kind"] = "test" }));
+
+        var ctx = await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("corr-xyz", ctx.CorrelationId);
+        Assert.True(ctx.DeliveryCount >= 1);
+        Assert.Equal("test", ctx.Properties["cho.kind"]);
+        Assert.False(string.IsNullOrEmpty(ctx.MessageId));
+    }
+
+    [SkippableFact]
+    public async Task SendAsync_MessageIdDedupIsIdempotent()
+    {
+        var queue = QueueNameFor("dedup");
+        var count = 0;
+        var gate = new TaskCompletionSource();
+        await using var sub = Bus.Subscribe<Payload>(queue, (_, _, _) =>
+        {
+            Interlocked.Increment(ref count);
+            gate.TrySetResult();
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+
+        var id = "dedup-key-1";
+        await Bus.SendAsync(queue, new Payload("one", 1), new SendOptions(MessageId: id));
+        await Bus.SendAsync(queue, new Payload("two", 2), new SendOptions(MessageId: id));
+
+        await gate.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(200); // allow any second delivery to race in
+        Assert.Equal(1, count);
+    }
+
+    [SkippableFact]
+    public async Task ScheduleAsync_DeliversAfterDelay()
+    {
+        var queue = QueueNameFor("sched");
+        var tcs = new TaskCompletionSource<DateTimeOffset>();
+        await using var sub = Bus.Subscribe<Payload>(queue, (_, _, _) =>
+        {
+            tcs.TrySetResult(DateTimeOffset.UtcNow);
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+
+        var enqueueAt = DateTimeOffset.UtcNow.AddMilliseconds(400);
+        await Bus.ScheduleAsync(queue, new Payload("later", 7), enqueueAt);
+
+        var deliveredAt = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(deliveredAt >= enqueueAt.AddMilliseconds(-100),
+            $"delivered too early: delivered={deliveredAt:o} enqueueAt={enqueueAt:o}");
+    }
+
+    [SkippableFact]
+    public async Task Subscription_StopPreventsFurtherDispatch()
+    {
+        var queue = QueueNameFor("stop");
+        var received = 0;
+        var sub = Bus.Subscribe<Payload>(queue, (_, _, _) =>
+        {
+            Interlocked.Increment(ref received);
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+        await sub.StopAsync(CancellationToken.None);
+        await sub.DisposeAsync();
+
+        await Bus.SendAsync(queue, new Payload("ignored", 0));
+        await Task.Delay(200);
+        Assert.Equal(0, received);
+    }
+
+    [SkippableFact]
+    public async Task SendAsync_PreservesActivityParentAcrossBus()
+    {
+        var queue = QueueNameFor("trace");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == ChoActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        ActivityTraceId? handlerTraceId = null;
+        string? handlerParentSpanId = null;
+        var gate = new TaskCompletionSource();
+        await using var sub = Bus.Subscribe<Payload>(queue, (_, _, _) =>
+        {
+            handlerTraceId = Activity.Current?.TraceId;
+            handlerParentSpanId = Activity.Current?.ParentSpanId.ToString();
+            gate.TrySetResult();
+            return Task.CompletedTask;
+        });
+        await sub.StartAsync(CancellationToken.None);
+
+        using var outer = ChoActivitySource.Instance.StartActivity("outer", ActivityKind.Internal);
+        Assert.NotNull(outer);
+        var outerTraceId = outer!.TraceId;
+
+        await Bus.SendAsync(queue, new Payload("traced", 0));
+
+        await gate.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(outerTraceId, handlerTraceId);
+        Assert.False(string.IsNullOrEmpty(handlerParentSpanId));
+        Assert.NotEqual("0000000000000000", handlerParentSpanId);
+    }
+
+    protected record Payload(string Name, int Value);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/MessagingOptionsAutoResolutionTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/MessagingOptionsAutoResolutionTests.cs
@@ -1,0 +1,199 @@
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Messaging;
+
+public class MessagingOptionsAutoResolutionTests
+{
+    [Fact]
+    public void Auto_InDev_ResolvesToInMemory()
+    {
+        var decision = MessagingServiceCollectionExtensions.ResolveBackend(
+            new MessagingOptions { Backend = "Auto" }, Env("Development"));
+
+        Assert.Equal(
+            MessagingServiceCollectionExtensions.MessagingBackend.InMemory,
+            decision.Backend);
+        Assert.Contains("Development", decision.Reason);
+    }
+
+    [Fact]
+    public void Auto_InProdWithoutConnectionString_ResolvesToInMemory()
+    {
+        var decision = MessagingServiceCollectionExtensions.ResolveBackend(
+            new MessagingOptions { Backend = "Auto" }, Env("Production"));
+
+        Assert.Equal(
+            MessagingServiceCollectionExtensions.MessagingBackend.InMemory,
+            decision.Backend);
+        Assert.Contains("no ConnectionString", decision.Reason);
+    }
+
+    [Fact]
+    public void Auto_InProdWithConnectionString_ResolvesToServiceBus()
+    {
+        var decision = MessagingServiceCollectionExtensions.ResolveBackend(
+            new MessagingOptions
+            {
+                Backend = "Auto",
+                ServiceBusConnectionString = FakeServiceBusConnection
+            },
+            Env("Production"));
+
+        Assert.Equal(
+            MessagingServiceCollectionExtensions.MessagingBackend.ServiceBus,
+            decision.Backend);
+        Assert.Contains("ConnectionString configured", decision.Reason);
+    }
+
+    [Fact]
+    public void ExplicitServiceBus_WithoutConnectionString_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MessagingServiceCollectionExtensions.ResolveBackend(
+                new MessagingOptions { Backend = "ServiceBus" }, Env("Production")));
+    }
+
+    [Fact]
+    public void ExplicitInMemory_IsHonouredInProduction()
+    {
+        var decision = MessagingServiceCollectionExtensions.ResolveBackend(
+            new MessagingOptions { Backend = "InMemory" }, Env("Production"));
+
+        Assert.Equal(
+            MessagingServiceCollectionExtensions.MessagingBackend.InMemory,
+            decision.Backend);
+        Assert.Contains("forced", decision.Reason);
+    }
+
+    [Fact]
+    public void ExplicitNull_IsHonoured()
+    {
+        var decision = MessagingServiceCollectionExtensions.ResolveBackend(
+            new MessagingOptions { Backend = "Null" }, Env("Production"));
+
+        Assert.Equal(
+            MessagingServiceCollectionExtensions.MessagingBackend.Null,
+            decision.Backend);
+    }
+
+    [Fact]
+    public void UnknownBackend_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MessagingServiceCollectionExtensions.ResolveBackend(
+                new MessagingOptions { Backend = "Bogus" }, Env("Production")));
+    }
+
+    [Fact]
+    public void LegacyConnectionStringKey_BatchEligibility_IsFallback()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Messaging:Backend"] = "Auto",
+            ["BatchEligibility:ServiceBus:ConnectionString"] = FakeServiceBusConnection
+        }).Build();
+
+        var options = new MessagingOptions { Backend = "Auto" };
+        var (cs, deprecated) = MessagingServiceCollectionExtensions
+            .ResolveConnectionString(config, options);
+
+        Assert.Equal(FakeServiceBusConnection, cs);
+        Assert.Equal("BatchEligibility:ServiceBus:ConnectionString", deprecated);
+    }
+
+    [Fact]
+    public void LegacyConnectionStringKey_IdCardMirror_IsFallback()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Messaging:Backend"] = "Auto",
+            ["IdCard:QnxtMirror:ServiceBusConnectionString"] = FakeServiceBusConnection
+        }).Build();
+
+        var options = new MessagingOptions { Backend = "Auto" };
+        var (cs, deprecated) = MessagingServiceCollectionExtensions
+            .ResolveConnectionString(config, options);
+
+        Assert.Equal(FakeServiceBusConnection, cs);
+        Assert.Equal("IdCard:QnxtMirror:ServiceBusConnectionString", deprecated);
+    }
+
+    [Fact]
+    public void CanonicalKey_WinsOverLegacyKeys()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Messaging:ServiceBusConnectionString"] = FakeServiceBusConnection,
+            ["BatchEligibility:ServiceBus:ConnectionString"] = "legacy-value"
+        }).Build();
+
+        var options = new MessagingOptions
+        {
+            Backend = "Auto",
+            ServiceBusConnectionString = FakeServiceBusConnection
+        };
+        var (cs, deprecated) = MessagingServiceCollectionExtensions
+            .ResolveConnectionString(config, options);
+
+        Assert.Equal(FakeServiceBusConnection, cs);
+        Assert.Null(deprecated);
+    }
+
+    [Fact]
+    public async Task AddChoMessaging_RegistersIMessageBusAsSingleton_InMemoryPath()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Messaging:Backend"] = "InMemory"
+        }).Build();
+
+        services.AddChoMessaging(config, Env("Development"));
+        await using var sp = services.BuildServiceProvider();
+
+        var bus1 = sp.GetRequiredService<IMessageBus>();
+        var bus2 = sp.GetRequiredService<IMessageBus>();
+        Assert.Same(bus1, bus2);
+        Assert.IsType<InMemoryMessageBus>(bus1);
+    }
+
+    [Fact]
+    public async Task AddChoMessaging_RegistersNullBus_WhenForced()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Messaging:Backend"] = "Null"
+        }).Build();
+
+        services.AddChoMessaging(config, Env("Development"));
+        await using var sp = services.BuildServiceProvider();
+
+        Assert.IsType<NullMessageBus>(sp.GetRequiredService<IMessageBus>());
+    }
+
+    private const string FakeServiceBusConnection =
+        "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=root;SharedAccessKey=ZmFrZQ==";
+
+    private static IHostEnvironment Env(string name)
+    {
+        var env = new FakeHostEnvironment { EnvironmentName = name };
+        return env;
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "cho-test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/ServiceBusMessageBusContractTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/ServiceBusMessageBusContractTests.cs
@@ -1,0 +1,28 @@
+using Azure.Messaging.ServiceBus;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Messaging;
+
+/// <summary>
+/// Runs the shared contract against a real Azure Service Bus namespace.
+/// Tests skip (not fail) unless <c>CHO_SERVICEBUS_CONNECTION_STRING</c>
+/// is set. CI filters by <c>Category=Integration</c> to exclude this
+/// class from the default unit-test run anyway.
+/// </summary>
+[Trait("Category", "Integration")]
+public class ServiceBusMessageBusContractTests : MessageBusContractTests
+{
+    private const string EnvVar = "CHO_SERVICEBUS_CONNECTION_STRING";
+
+    protected override ValueTask<IMessageBus> CreateBusAsync()
+    {
+        var cs = Environment.GetEnvironmentVariable(EnvVar);
+        Skip.If(string.IsNullOrWhiteSpace(cs),
+            $"Set {EnvVar} to run Service Bus contract tests");
+
+        var client = new ServiceBusClient(cs);
+        return ValueTask.FromResult<IMessageBus>(
+            new ServiceBusMessageBus(client, NullLogger<ServiceBusMessageBus>.Instance));
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="CloudHealthOffice.Infrastructure.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/IMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/IMessageBus.cs
@@ -1,0 +1,87 @@
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// Shared async-messaging abstraction for Cloud Health Office services.
+///
+/// Three canonical patterns map onto this interface: work queues (single-
+/// consumer-group per queue), pub-sub topics (multi-subscription), and
+/// scheduled delivery. The production backend is Azure Service Bus; dev
+/// and test environments use an in-process channel implementation.
+///
+/// Kafka usage (high-throughput streaming, event replay via change feeds)
+/// stays on its own dedicated client — IMessageBus is not a Kafka facade.
+/// </summary>
+public interface IMessageBus
+{
+    /// <summary>
+    /// Enqueue <paramref name="message"/> for immediate delivery on
+    /// <paramref name="queueOrTopic"/>.
+    /// </summary>
+    Task SendAsync<T>(
+        string queueOrTopic,
+        T message,
+        SendOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Enqueue <paramref name="message"/> for delivery no earlier than
+    /// <paramref name="enqueueAt"/>. Resolution is backend-specific —
+    /// Service Bus honours to the second; the in-memory bus uses a timer
+    /// and is suitable for tests only.
+    /// </summary>
+    Task ScheduleAsync<T>(
+        string queueOrTopic,
+        T message,
+        DateTimeOffset enqueueAt,
+        SendOptions? options = null,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Create a subscription on <paramref name="queueOrTopic"/>. The
+    /// returned subscription is stopped — call
+    /// <see cref="IMessageSubscription.StartAsync"/> to begin dispatch.
+    /// Complete-on-success / abandon-on-failure is handled by the backend;
+    /// handlers must not swallow exceptions they wish to cause redelivery.
+    /// </summary>
+    IMessageSubscription Subscribe<T>(
+        string queueOrTopic,
+        Func<T, MessageContext, CancellationToken, Task> handler,
+        SubscriptionOptions? options = null);
+}
+
+/// <summary>Per-message send-side options.</summary>
+/// <param name="MessageId">Service Bus native deduplication key.</param>
+/// <param name="CorrelationId">Overrides the ambient activity if provided.</param>
+/// <param name="SessionId">For session-aware (ordered) queues; null otherwise.</param>
+/// <param name="Properties">Application properties carried alongside the body.</param>
+public record SendOptions(
+    string? MessageId = null,
+    string? CorrelationId = null,
+    string? SessionId = null,
+    IReadOnlyDictionary<string, string>? Properties = null);
+
+/// <summary>Per-subscription options.</summary>
+/// <param name="MaxConcurrentCalls">Processor concurrency on the backend.</param>
+/// <param name="AutoComplete">
+/// Always false in CHO — we complete/abandon explicitly. The parameter exists
+/// for completeness but the implementation ignores true.
+/// </param>
+/// <param name="SubscriptionName">Topic subscription name (topics only).</param>
+public record SubscriptionOptions(
+    int MaxConcurrentCalls = 4,
+    bool AutoComplete = false,
+    string? SubscriptionName = null);
+
+/// <summary>Context surfaced to handlers alongside the deserialized message.</summary>
+public record MessageContext(
+    string MessageId,
+    string? CorrelationId,
+    int DeliveryCount,
+    IReadOnlyDictionary<string, string> Properties);
+
+/// <summary>Lifecycle control for a subscription created via <see cref="IMessageBus.Subscribe{T}"/>.</summary>
+public interface IMessageSubscription : IAsyncDisposable
+{
+    Task StartAsync(CancellationToken ct);
+    Task StopAsync(CancellationToken ct);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -122,6 +122,11 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             foreach (var (k, v) in options.Properties) properties[k] = v;
         }
 
+        // Capture the ambient activity before starting the producer span so
+        // CorrelationId mirrors ServiceBusMessageBus: fall back to the
+        // caller's activity id, not the producer span we're about to start.
+        var correlationId = options?.CorrelationId ?? Activity.Current?.Id;
+
         using var producerSpan = ChoActivitySource.Instance.StartActivity(
             $"{queueOrTopic} send",
             ActivityKind.Producer);
@@ -139,7 +144,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         return new Envelope(
             message,
             messageId,
-            options?.CorrelationId,
+            correlationId,
             properties);
     }
 
@@ -188,6 +193,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         private readonly Func<Envelope, Task> _dispatch;
         private readonly ILogger _logger;
         private readonly CancellationTokenSource _internalCts = new();
+        private CancellationTokenSource? _linkedCts;
         private Task? _pump;
         private int _started;
         private int _disposed;
@@ -208,8 +214,9 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         {
             if (Volatile.Read(ref _disposed) == 1) return Task.CompletedTask;
             if (Interlocked.Exchange(ref _started, 1) == 1) return Task.CompletedTask;
-            var linked = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, ct);
-            _pump = Task.Run(() => PumpAsync(linked.Token), linked.Token);
+            _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, ct);
+            var pumpToken = _linkedCts.Token;
+            _pump = Task.Run(() => PumpAsync(pumpToken), pumpToken);
             return Task.CompletedTask;
         }
 
@@ -218,8 +225,13 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             if (_pump is null) return;
             try { _internalCts.Cancel(); }
             catch (ObjectDisposedException) { return; }
-            try { await _pump.ConfigureAwait(false); }
-            catch (OperationCanceledException) { /* expected */ }
+            try
+            {
+                // Honour the caller's cancellation — don't let a hung handler
+                // block StopAsync past the provided token's lifetime.
+                await _pump.WaitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* expected on stop or caller cancel */ }
         }
 
         private async Task PumpAsync(CancellationToken ct)
@@ -266,6 +278,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
             await StopAsync(CancellationToken.None).ConfigureAwait(false);
             _internalCts.Dispose();
+            _linkedCts?.Dispose();
         }
     }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -1,0 +1,267 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Channels;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// In-process <see cref="IMessageBus"/> backed by
+/// <see cref="System.Threading.Channels"/>. Competing-consumer semantics
+/// (one delivery per message across subscribers on the same queue) fall out
+/// of channel-reader behaviour, so the same test asserting queue semantics
+/// against Service Bus passes here too.
+///
+/// Scheduled delivery uses <see cref="Timer"/> — suitable for tests, not a
+/// production path. Duplicate detection via <c>SendOptions.MessageId</c> is
+/// emulated with an in-memory cache over <see cref="MessagingOptions.DuplicateDetectionWindow"/>
+/// so the contract test ("idempotency via MessageId") passes identically on
+/// both backends.
+///
+/// W3C trace context is carried via a <c>traceparent</c> application
+/// property so a producer span started on enqueue becomes the parent of
+/// the consumer span started on dispatch.
+/// </summary>
+public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
+{
+    internal const string TraceparentPropertyName = "traceparent";
+
+    private readonly ConcurrentDictionary<string, Channel<Envelope>> _channels = new();
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _seenMessageIds = new();
+    private readonly ConcurrentBag<Timer> _scheduledTimers = new();
+    private readonly ConcurrentBag<WeakReference<InMemorySubscription>> _subscriptions = new();
+    private readonly TimeSpan _dedupWindow;
+    private readonly ILogger<InMemoryMessageBus> _logger;
+
+    public InMemoryMessageBus(
+        MessagingOptions? options = null,
+        ILogger<InMemoryMessageBus>? logger = null)
+    {
+        _dedupWindow = options?.DuplicateDetectionWindow ?? TimeSpan.FromHours(1);
+        _logger = logger ?? NullLogger<InMemoryMessageBus>.Instance;
+    }
+
+    public Task SendAsync<T>(
+        string queueOrTopic,
+        T message,
+        SendOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+        ct.ThrowIfCancellationRequested();
+
+        var envelope = BuildEnvelope(queueOrTopic, message!, options);
+        if (envelope is null) return Task.CompletedTask; // deduplicated
+
+        var channel = _channels.GetOrAdd(queueOrTopic, _ => Channel.CreateUnbounded<Envelope>());
+        return channel.Writer.WriteAsync(envelope, ct).AsTask();
+    }
+
+    public Task ScheduleAsync<T>(
+        string queueOrTopic,
+        T message,
+        DateTimeOffset enqueueAt,
+        SendOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+        ct.ThrowIfCancellationRequested();
+
+        var delay = enqueueAt - DateTimeOffset.UtcNow;
+        if (delay <= TimeSpan.Zero)
+        {
+            return SendAsync(queueOrTopic, message, options, ct);
+        }
+
+        var envelope = BuildEnvelope(queueOrTopic, message!, options);
+        if (envelope is null) return Task.CompletedTask;
+
+        var channel = _channels.GetOrAdd(queueOrTopic, _ => Channel.CreateUnbounded<Envelope>());
+        Timer? timer = null;
+        timer = new Timer(_ =>
+        {
+            channel.Writer.TryWrite(envelope);
+            timer?.Dispose();
+        }, null, delay, Timeout.InfiniteTimeSpan);
+        _scheduledTimers.Add(timer);
+        return Task.CompletedTask;
+    }
+
+    public IMessageSubscription Subscribe<T>(
+        string queueOrTopic,
+        Func<T, MessageContext, CancellationToken, Task> handler,
+        SubscriptionOptions? options = null)
+    {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+        var channel = _channels.GetOrAdd(queueOrTopic, _ => Channel.CreateUnbounded<Envelope>());
+        var sub = new InMemorySubscription(
+            queueOrTopic,
+            channel,
+            env => handler((T)env.Message, env.ToContext(), env.CancellationToken),
+            _logger);
+        _subscriptions.Add(new WeakReference<InMemorySubscription>(sub));
+        return sub;
+    }
+
+    private Envelope? BuildEnvelope(string queueOrTopic, object message, SendOptions? options)
+    {
+        var messageId = options?.MessageId ?? Guid.NewGuid().ToString("N");
+        if (options?.MessageId is not null && !TryRecordMessageId(messageId))
+        {
+            _logger.LogDebug(
+                "InMemoryMessageBus dropped duplicate message {MessageId} on {Queue}",
+                messageId, queueOrTopic);
+            return null;
+        }
+
+        var properties = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (options?.Properties is not null)
+        {
+            foreach (var (k, v) in options.Properties) properties[k] = v;
+        }
+
+        using var producerSpan = ChoActivitySource.Instance.StartActivity(
+            $"{queueOrTopic} send",
+            ActivityKind.Producer);
+        producerSpan?.SetTag("messaging.system", "in-memory");
+        producerSpan?.SetTag("messaging.destination.name", queueOrTopic);
+        producerSpan?.SetTag("messaging.message.id", messageId);
+
+        var tp = Activity.Current;
+        if (tp is not null)
+        {
+            properties[TraceparentPropertyName] =
+                $"00-{tp.TraceId}-{tp.SpanId}-{(tp.Recorded ? "01" : "00")}";
+        }
+
+        return new Envelope(
+            message,
+            messageId,
+            options?.CorrelationId,
+            properties);
+    }
+
+    private bool TryRecordMessageId(string messageId)
+    {
+        PruneMessageIdCache();
+        return _seenMessageIds.TryAdd(messageId, DateTimeOffset.UtcNow);
+    }
+
+    private void PruneMessageIdCache()
+    {
+        var cutoff = DateTimeOffset.UtcNow - _dedupWindow;
+        foreach (var entry in _seenMessageIds)
+        {
+            if (entry.Value < cutoff)
+                _seenMessageIds.TryRemove(entry.Key, out _);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var timer in _scheduledTimers) timer.Dispose();
+        foreach (var weak in _subscriptions)
+        {
+            if (weak.TryGetTarget(out var sub))
+                await sub.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    internal sealed record Envelope(
+        object Message,
+        string MessageId,
+        string? CorrelationId,
+        IReadOnlyDictionary<string, string> Properties,
+        int DeliveryCount = 1,
+        CancellationToken CancellationToken = default)
+    {
+        public MessageContext ToContext()
+            => new(MessageId, CorrelationId, DeliveryCount, Properties);
+    }
+
+    internal sealed class InMemorySubscription : IMessageSubscription
+    {
+        private readonly string _queueOrTopic;
+        private readonly Channel<Envelope> _channel;
+        private readonly Func<Envelope, Task> _dispatch;
+        private readonly ILogger _logger;
+        private readonly CancellationTokenSource _internalCts = new();
+        private Task? _pump;
+        private int _started;
+
+        public InMemorySubscription(
+            string queueOrTopic,
+            Channel<Envelope> channel,
+            Func<Envelope, Task> dispatch,
+            ILogger logger)
+        {
+            _queueOrTopic = queueOrTopic;
+            _channel = channel;
+            _dispatch = dispatch;
+            _logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken ct)
+        {
+            if (Interlocked.Exchange(ref _started, 1) == 1) return Task.CompletedTask;
+            var linked = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, ct);
+            _pump = Task.Run(() => PumpAsync(linked.Token), linked.Token);
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken ct)
+        {
+            if (_pump is null) return;
+            _internalCts.Cancel();
+            try { await _pump.ConfigureAwait(false); }
+            catch (OperationCanceledException) { /* expected */ }
+        }
+
+        private async Task PumpAsync(CancellationToken ct)
+        {
+            await foreach (var envelope in _channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                await DispatchAsync(envelope, ct).ConfigureAwait(false);
+            }
+        }
+
+        private async Task DispatchAsync(Envelope envelope, CancellationToken ct)
+        {
+            ActivityContext parentCtx = default;
+            var hasParent = envelope.Properties.TryGetValue(TraceparentPropertyName, out var tp) &&
+                ActivityContext.TryParse(tp, null, out parentCtx);
+
+            using var consumerSpan = hasParent
+                ? ChoActivitySource.Instance.StartActivity(
+                    $"{_queueOrTopic} receive", ActivityKind.Consumer, parentCtx)
+                : ChoActivitySource.Instance.StartActivity(
+                    $"{_queueOrTopic} receive", ActivityKind.Consumer);
+
+            consumerSpan?.SetTag("messaging.system", "in-memory");
+            consumerSpan?.SetTag("messaging.destination.name", _queueOrTopic);
+            consumerSpan?.SetTag("messaging.message.id", envelope.MessageId);
+
+            var dispatched = envelope with { CancellationToken = ct };
+            try
+            {
+                await _dispatch(dispatched).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                consumerSpan?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                _logger.LogError(ex,
+                    "InMemoryMessageBus handler threw for {Queue} message {MessageId}",
+                    _queueOrTopic, envelope.MessageId);
+                // In-memory has no DLQ; rethrow would kill the pump — swallow after logging.
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await StopAsync(CancellationToken.None).ConfigureAwait(false);
+            _internalCts.Dispose();
+        }
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -190,6 +190,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         private readonly CancellationTokenSource _internalCts = new();
         private Task? _pump;
         private int _started;
+        private int _disposed;
 
         public InMemorySubscription(
             string queueOrTopic,
@@ -205,6 +206,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
 
         public Task StartAsync(CancellationToken ct)
         {
+            if (Volatile.Read(ref _disposed) == 1) return Task.CompletedTask;
             if (Interlocked.Exchange(ref _started, 1) == 1) return Task.CompletedTask;
             var linked = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, ct);
             _pump = Task.Run(() => PumpAsync(linked.Token), linked.Token);
@@ -214,7 +216,8 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         public async Task StopAsync(CancellationToken ct)
         {
             if (_pump is null) return;
-            _internalCts.Cancel();
+            try { _internalCts.Cancel(); }
+            catch (ObjectDisposedException) { return; }
             try { await _pump.ConfigureAwait(false); }
             catch (OperationCanceledException) { /* expected */ }
         }
@@ -260,6 +263,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
 
         public async ValueTask DisposeAsync()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
             await StopAsync(CancellationToken.None).ConfigureAwait(false);
             _internalCts.Dispose();
         }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingOptions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingOptions.cs
@@ -1,0 +1,31 @@
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// Binds from the <c>Messaging</c> configuration section.
+/// </summary>
+public class MessagingOptions
+{
+    public const string SectionName = "Messaging";
+
+    /// <summary>
+    /// Backend selection:
+    ///   <c>Auto</c>      — Service Bus when <see cref="ServiceBusConnectionString"/>
+    ///                       is set AND environment is not Development, else InMemory.
+    ///   <c>ServiceBus</c> — force Service Bus; throws at startup if the connection
+    ///                       string is missing.
+    ///   <c>InMemory</c>   — force in-process channels.
+    ///   <c>Null</c>       — no-op, for explicit-disable test scenarios.
+    /// </summary>
+    public string Backend { get; set; } = "Auto";
+
+    /// <summary>Azure Service Bus namespace connection string.</summary>
+    public string? ServiceBusConnectionString { get; set; }
+
+    /// <summary>
+    /// Duplicate-detection window for Service Bus duplicate detection.
+    /// Only applies when the queue was provisioned with
+    /// <c>RequiresDuplicateDetection=true</c> — this client does not create
+    /// queues; queue creation is an infra concern.
+    /// </summary>
+    public TimeSpan DuplicateDetectionWindow { get; set; } = TimeSpan.FromHours(1);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
@@ -52,6 +52,21 @@ public static class MessagingServiceCollectionExtensions
                 "IMessageBus={Backend} ({Reason})",
                 decision.Backend, decision.Reason);
 
+            // Auto-resolving to InMemory outside Development is almost always
+            // a misconfiguration: messages go into a process-local channel
+            // and are lost on restart. Emit at Warning so it shows up in any
+            // routine log triage.
+            if (decision.Backend == MessagingBackend.InMemory &&
+                !environment.IsDevelopment() &&
+                string.Equals((options.Backend ?? "Auto").Trim(), "Auto",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogWarning(
+                    "IMessageBus resolved to InMemory in {Environment}. " +
+                    "Configure Messaging:ServiceBusConnectionString for durable delivery.",
+                    environment.EnvironmentName);
+            }
+
             if (deprecatedKey is not null)
             {
                 logger.LogWarning(

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/MessagingServiceCollectionExtensions.cs
@@ -1,0 +1,131 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// Registers <see cref="IMessageBus"/> and resolves the backend from
+/// configuration + environment.
+/// </summary>
+public static class MessagingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register <see cref="IMessageBus"/> as a singleton.
+    ///
+    /// Backend resolution:
+    ///   <c>Auto</c>       — prod + connection string present → ServiceBus;
+    ///                        otherwise InMemory (with a warning if prod).
+    ///   <c>ServiceBus</c> — forced; throws if connection string missing.
+    ///   <c>InMemory</c>   — forced.
+    ///   <c>Null</c>       — forced no-op.
+    ///
+    /// Config keys: <c>Messaging:Backend</c>, <c>Messaging:ServiceBusConnectionString</c>.
+    ///
+    /// Back-compat: <c>BatchEligibility:ServiceBus:ConnectionString</c> and
+    /// <c>IdCard:QnxtMirror:ServiceBusConnectionString</c> are honoured as
+    /// fallbacks and emit a single deprecation warning at startup. Follow-up:
+    /// remove these fallbacks after one release cycle.
+    /// </summary>
+    public static IServiceCollection AddChoMessaging(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        var options = new MessagingOptions();
+        configuration.GetSection(MessagingOptions.SectionName).Bind(options);
+
+        var (connectionString, deprecatedKey) = ResolveConnectionString(configuration, options);
+        options.ServiceBusConnectionString = connectionString;
+        services.AddSingleton(options);
+
+        var decision = ResolveBackend(options, environment);
+
+        services.AddSingleton<IMessageBus>(sp =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("CloudHealthOffice.Infrastructure.Messaging");
+
+            logger.LogInformation(
+                "IMessageBus={Backend} ({Reason})",
+                decision.Backend, decision.Reason);
+
+            if (deprecatedKey is not null)
+            {
+                logger.LogWarning(
+                    "Config key '{Deprecated}' is deprecated; migrate to '{Canonical}'. " +
+                    "Falling back for this release.",
+                    deprecatedKey, "Messaging:ServiceBusConnectionString");
+            }
+
+            return decision.Backend switch
+            {
+                MessagingBackend.ServiceBus => new ServiceBusMessageBus(
+                    new ServiceBusClient(options.ServiceBusConnectionString!),
+                    loggerFactory.CreateLogger<ServiceBusMessageBus>()),
+                MessagingBackend.Null => new NullMessageBus(),
+                _ => new InMemoryMessageBus(
+                    options,
+                    loggerFactory.CreateLogger<InMemoryMessageBus>())
+            };
+        });
+
+        return services;
+    }
+
+    internal static (string? ConnectionString, string? DeprecatedKey) ResolveConnectionString(
+        IConfiguration configuration, MessagingOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.ServiceBusConnectionString))
+            return (options.ServiceBusConnectionString, null);
+
+        // Legacy fallbacks. One warning per startup; remove after one release.
+        var batchEligibility = configuration["BatchEligibility:ServiceBus:ConnectionString"];
+        if (!string.IsNullOrWhiteSpace(batchEligibility))
+            return (batchEligibility, "BatchEligibility:ServiceBus:ConnectionString");
+
+        var idcardMirror = configuration["IdCard:QnxtMirror:ServiceBusConnectionString"];
+        if (!string.IsNullOrWhiteSpace(idcardMirror))
+            return (idcardMirror, "IdCard:QnxtMirror:ServiceBusConnectionString");
+
+        return (null, null);
+    }
+
+    internal static BackendDecision ResolveBackend(
+        MessagingOptions options, IHostEnvironment environment)
+    {
+        var backend = (options.Backend ?? "Auto").Trim();
+        var hasCs = !string.IsNullOrWhiteSpace(options.ServiceBusConnectionString);
+
+        return backend.ToLowerInvariant() switch
+        {
+            "servicebus" when hasCs => new BackendDecision(
+                MessagingBackend.ServiceBus,
+                $"forced; env={environment.EnvironmentName}"),
+            "servicebus" => throw new InvalidOperationException(
+                "Messaging:Backend=ServiceBus requires Messaging:ServiceBusConnectionString (or a legacy fallback key)."),
+            "inmemory" => new BackendDecision(
+                MessagingBackend.InMemory,
+                $"forced; env={environment.EnvironmentName}"),
+            "null" => new BackendDecision(
+                MessagingBackend.Null,
+                $"forced; env={environment.EnvironmentName}"),
+            "auto" or "" when environment.IsDevelopment() => new BackendDecision(
+                MessagingBackend.InMemory,
+                $"Auto; env=Development"),
+            "auto" or "" when hasCs => new BackendDecision(
+                MessagingBackend.ServiceBus,
+                $"Auto; ConnectionString configured; env={environment.EnvironmentName}"),
+            "auto" or "" => new BackendDecision(
+                MessagingBackend.InMemory,
+                $"Auto; no ConnectionString; env={environment.EnvironmentName}"),
+            _ => throw new InvalidOperationException(
+                $"Messaging:Backend='{options.Backend}' is not recognised. Use Auto, ServiceBus, InMemory, or Null.")
+        };
+    }
+
+    internal enum MessagingBackend { Auto, ServiceBus, InMemory, Null }
+    internal record BackendDecision(MessagingBackend Backend, string Reason);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/NullMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/NullMessageBus.cs
@@ -4,23 +4,38 @@ namespace CloudHealthOffice.Infrastructure.Messaging;
 /// No-op <see cref="IMessageBus"/>. Accepts sends and schedules silently
 /// and returns subscriptions that never dispatch. Used for tests that want
 /// to exercise code paths without bringing up any messaging plumbing.
+///
+/// Null arguments still throw — a misconfigured call site should surface
+/// regardless of which backend happens to be wired in.
 /// </summary>
 public sealed class NullMessageBus : IMessageBus
 {
     public Task SendAsync<T>(
         string queueOrTopic, T message, SendOptions? options = null, CancellationToken ct = default)
-        => Task.CompletedTask;
+    {
+        ArgumentNullException.ThrowIfNull(queueOrTopic);
+        ArgumentNullException.ThrowIfNull(message);
+        return Task.CompletedTask;
+    }
 
     public Task ScheduleAsync<T>(
         string queueOrTopic, T message, DateTimeOffset enqueueAt,
         SendOptions? options = null, CancellationToken ct = default)
-        => Task.CompletedTask;
+    {
+        ArgumentNullException.ThrowIfNull(queueOrTopic);
+        ArgumentNullException.ThrowIfNull(message);
+        return Task.CompletedTask;
+    }
 
     public IMessageSubscription Subscribe<T>(
         string queueOrTopic,
         Func<T, MessageContext, CancellationToken, Task> handler,
         SubscriptionOptions? options = null)
-        => new NullSubscription();
+    {
+        ArgumentNullException.ThrowIfNull(queueOrTopic);
+        ArgumentNullException.ThrowIfNull(handler);
+        return new NullSubscription();
+    }
 
     private sealed class NullSubscription : IMessageSubscription
     {

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/NullMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/NullMessageBus.cs
@@ -1,0 +1,31 @@
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// No-op <see cref="IMessageBus"/>. Accepts sends and schedules silently
+/// and returns subscriptions that never dispatch. Used for tests that want
+/// to exercise code paths without bringing up any messaging plumbing.
+/// </summary>
+public sealed class NullMessageBus : IMessageBus
+{
+    public Task SendAsync<T>(
+        string queueOrTopic, T message, SendOptions? options = null, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task ScheduleAsync<T>(
+        string queueOrTopic, T message, DateTimeOffset enqueueAt,
+        SendOptions? options = null, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public IMessageSubscription Subscribe<T>(
+        string queueOrTopic,
+        Func<T, MessageContext, CancellationToken, Task> handler,
+        SubscriptionOptions? options = null)
+        => new NullSubscription();
+
+    private sealed class NullSubscription : IMessageSubscription
+    {
+        public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/ServiceBusMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/ServiceBusMessageBus.cs
@@ -1,0 +1,276 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// Azure Service Bus implementation of <see cref="IMessageBus"/>. Owns a
+/// single shared <see cref="ServiceBusClient"/> and lazily creates one
+/// <see cref="ServiceBusSender"/> per queue or topic.
+///
+/// Receiving uses <see cref="ServiceBusProcessor"/> with
+/// <c>AutoCompleteMessages=false</c>, preserving the CHO pattern:
+///   - deserialize failure              → dead-letter ("DeserializeFailed")
+///   - null payload after deserialize   → dead-letter ("NullPayload")
+///   - handler success                  → complete
+///   - handler throws                   → abandon (let SB redeliver up to
+///                                         MaxDeliveryCount, then SB DLQs)
+///
+/// <c>Azure.Messaging.ServiceBus</c> already emits its own activities under
+/// the <c>Azure.Messaging.ServiceBus.*</c> source — ensure
+/// <see cref="ObservabilityExtensions.AddChoObservability"/> subscribes to
+/// it. On top of that this class injects <c>traceparent</c> into
+/// <see cref="ServiceBusMessage.ApplicationProperties"/> and restores the
+/// parent activity context on receive so cross-service traces link up.
+/// </summary>
+public sealed class ServiceBusMessageBus : IMessageBus, IAsyncDisposable
+{
+    internal const string TraceparentPropertyName = "traceparent";
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
+
+    private readonly ServiceBusClient _client;
+    private readonly ConcurrentDictionary<string, ServiceBusSender> _senders = new();
+    private readonly ILogger<ServiceBusMessageBus> _logger;
+    private int _disposed;
+
+    public ServiceBusMessageBus(
+        ServiceBusClient client,
+        ILogger<ServiceBusMessageBus> logger)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task SendAsync<T>(
+        string queueOrTopic,
+        T message,
+        SendOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+        var sbMessage = BuildMessage(queueOrTopic, message, options);
+        var sender = GetSender(queueOrTopic);
+
+        using var producerSpan = ChoActivitySource.Instance.StartActivity(
+            $"{queueOrTopic} send",
+            ActivityKind.Producer);
+        producerSpan?.SetTag("messaging.system", "azure-servicebus");
+        producerSpan?.SetTag("messaging.destination.name", queueOrTopic);
+        producerSpan?.SetTag("messaging.message.id", sbMessage.MessageId);
+
+        RefreshTraceparent(sbMessage);
+
+        await sender.SendMessageAsync(sbMessage, ct).ConfigureAwait(false);
+    }
+
+    public async Task ScheduleAsync<T>(
+        string queueOrTopic,
+        T message,
+        DateTimeOffset enqueueAt,
+        SendOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+        var sbMessage = BuildMessage(queueOrTopic, message, options);
+        var sender = GetSender(queueOrTopic);
+
+        using var producerSpan = ChoActivitySource.Instance.StartActivity(
+            $"{queueOrTopic} schedule",
+            ActivityKind.Producer);
+        producerSpan?.SetTag("messaging.system", "azure-servicebus");
+        producerSpan?.SetTag("messaging.destination.name", queueOrTopic);
+        producerSpan?.SetTag("messaging.message.id", sbMessage.MessageId);
+
+        RefreshTraceparent(sbMessage);
+
+        await sender.ScheduleMessageAsync(sbMessage, enqueueAt, ct).ConfigureAwait(false);
+    }
+
+    public IMessageSubscription Subscribe<T>(
+        string queueOrTopic,
+        Func<T, MessageContext, CancellationToken, Task> handler,
+        SubscriptionOptions? options = null)
+    {
+        if (handler is null) throw new ArgumentNullException(nameof(handler));
+
+        var processorOptions = new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = options?.MaxConcurrentCalls ?? 4,
+            AutoCompleteMessages = false // CHO pattern: complete explicitly
+        };
+
+        var processor = options?.SubscriptionName is not null
+            ? _client.CreateProcessor(queueOrTopic, options.SubscriptionName, processorOptions)
+            : _client.CreateProcessor(queueOrTopic, processorOptions);
+
+        return new ServiceBusSubscription<T>(
+            queueOrTopic,
+            processor,
+            handler,
+            _logger);
+    }
+
+    private ServiceBusSender GetSender(string queueOrTopic)
+        => _senders.GetOrAdd(queueOrTopic, name => _client.CreateSender(name));
+
+    private static ServiceBusMessage BuildMessage<T>(
+        string queueOrTopic, T message, SendOptions? options)
+    {
+        var body = JsonSerializer.SerializeToUtf8Bytes(message, JsonOpts);
+        var sbMessage = new ServiceBusMessage(body)
+        {
+            MessageId = options?.MessageId ?? Guid.NewGuid().ToString("N"),
+            CorrelationId = options?.CorrelationId ?? Activity.Current?.Id
+        };
+        if (options?.SessionId is not null) sbMessage.SessionId = options.SessionId;
+        if (options?.Properties is not null)
+        {
+            foreach (var (k, v) in options.Properties)
+                sbMessage.ApplicationProperties[k] = v;
+        }
+        return sbMessage;
+    }
+
+    private static void RefreshTraceparent(ServiceBusMessage sbMessage)
+    {
+        var current = Activity.Current;
+        if (current is null) return;
+        sbMessage.ApplicationProperties[TraceparentPropertyName] =
+            $"00-{current.TraceId}-{current.SpanId}-{(current.Recorded ? "01" : "00")}";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
+        foreach (var sender in _senders.Values)
+        {
+            try { await sender.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error disposing ServiceBusSender");
+            }
+        }
+        await _client.DisposeAsync().ConfigureAwait(false);
+    }
+
+    internal sealed class ServiceBusSubscription<T> : IMessageSubscription
+    {
+        private readonly string _queueOrTopic;
+        private readonly ServiceBusProcessor _processor;
+        private readonly Func<T, MessageContext, CancellationToken, Task> _handler;
+        private readonly ILogger _logger;
+        private int _started;
+
+        public ServiceBusSubscription(
+            string queueOrTopic,
+            ServiceBusProcessor processor,
+            Func<T, MessageContext, CancellationToken, Task> handler,
+            ILogger logger)
+        {
+            _queueOrTopic = queueOrTopic;
+            _processor = processor;
+            _handler = handler;
+            _logger = logger;
+
+            _processor.ProcessMessageAsync += OnMessageAsync;
+            _processor.ProcessErrorAsync += OnErrorAsync;
+        }
+
+        public Task StartAsync(CancellationToken ct)
+        {
+            if (Interlocked.Exchange(ref _started, 1) == 1) return Task.CompletedTask;
+            return _processor.StartProcessingAsync(ct);
+        }
+
+        public Task StopAsync(CancellationToken ct)
+            => _processor.IsProcessing ? _processor.StopProcessingAsync(ct) : Task.CompletedTask;
+
+        private async Task OnMessageAsync(ProcessMessageEventArgs args)
+        {
+            T? message;
+            try
+            {
+                message = JsonSerializer.Deserialize<T>(args.Message.Body.ToString(), JsonOpts);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Dead-lettering message {MessageId} on {Queue}: deserialize failed",
+                    args.Message.MessageId, _queueOrTopic);
+                await args.DeadLetterMessageAsync(args.Message,
+                    deadLetterReason: "DeserializeFailed",
+                    cancellationToken: args.CancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            if (message is null)
+            {
+                await args.DeadLetterMessageAsync(args.Message,
+                    deadLetterReason: "NullPayload",
+                    cancellationToken: args.CancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            var properties = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var (k, v) in args.Message.ApplicationProperties)
+                properties[k] = v?.ToString() ?? string.Empty;
+
+            ActivityContext parentCtx = default;
+            var hasParent = properties.TryGetValue(TraceparentPropertyName, out var tp) &&
+                ActivityContext.TryParse(tp, null, out parentCtx);
+
+            using var consumerSpan = hasParent
+                ? ChoActivitySource.Instance.StartActivity(
+                    $"{_queueOrTopic} receive", ActivityKind.Consumer, parentCtx)
+                : ChoActivitySource.Instance.StartActivity(
+                    $"{_queueOrTopic} receive", ActivityKind.Consumer);
+
+            consumerSpan?.SetTag("messaging.system", "azure-servicebus");
+            consumerSpan?.SetTag("messaging.destination.name", _queueOrTopic);
+            consumerSpan?.SetTag("messaging.message.id", args.Message.MessageId);
+            consumerSpan?.SetTag("messaging.servicebus.delivery_count", args.Message.DeliveryCount);
+
+            var ctx = new MessageContext(
+                args.Message.MessageId,
+                args.Message.CorrelationId,
+                args.Message.DeliveryCount,
+                properties);
+
+            try
+            {
+                await _handler(message, ctx, args.CancellationToken).ConfigureAwait(false);
+                await args.CompleteMessageAsync(args.Message, args.CancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                consumerSpan?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                _logger.LogWarning(ex,
+                    "Abandoning message {MessageId} on {Queue}: handler threw (delivery {Delivery})",
+                    args.Message.MessageId, _queueOrTopic, args.Message.DeliveryCount);
+                await args.AbandonMessageAsync(args.Message,
+                    cancellationToken: args.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // Previously a silent no-op. Surface these at Warning level so a
+        // production incident isn't masked by a missing diagnostic.
+        private Task OnErrorAsync(ProcessErrorEventArgs args)
+        {
+            _logger.LogWarning(args.Exception,
+                "ServiceBusProcessor error on {Queue} (source={Source}, entity={Entity})",
+                _queueOrTopic, args.ErrorSource, args.EntityPath);
+            return Task.CompletedTask;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try { await StopAsync(CancellationToken.None).ConfigureAwait(false); }
+            catch { /* best effort */ }
+            await _processor.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/SubscriptionHostedService.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/SubscriptionHostedService.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Infrastructure.Messaging;
+
+/// <summary>
+/// Runs an <see cref="IMessageSubscription"/> under the ASP.NET Core host
+/// lifecycle. Consumers that want to subscribe from a long-running worker
+/// register <c>AddHostedService&lt;SubscriptionHostedService&gt;()</c> with a
+/// factory delegate that resolves the subscription from DI.
+/// </summary>
+public sealed class SubscriptionHostedService : BackgroundService
+{
+    private readonly Func<IServiceProvider, IMessageSubscription> _factory;
+    private readonly IServiceProvider _services;
+    private readonly ILogger<SubscriptionHostedService> _logger;
+    private IMessageSubscription? _subscription;
+
+    public SubscriptionHostedService(
+        Func<IServiceProvider, IMessageSubscription> factory,
+        IServiceProvider services,
+        ILogger<SubscriptionHostedService> logger)
+    {
+        _factory = factory;
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _subscription = _factory(_services);
+        _logger.LogInformation("Starting IMessageBus subscription");
+        await _subscription.StartAsync(stoppingToken).ConfigureAwait(false);
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // expected on shutdown
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_subscription is not null)
+        {
+            try { await _subscription.StopAsync(cancellationToken).ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Subscription StopAsync threw"); }
+            await _subscription.DisposeAsync().ConfigureAwait(false);
+        }
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ObservabilityExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ObservabilityExtensions.cs
@@ -93,6 +93,7 @@ public static class ObservabilityExtensions
                     .AddHttpClientInstrumentation()
                     .AddRedisInstrumentation()
                     .AddSource("MongoDB.Driver.Core.Extensions.DiagnosticSources")
+                    .AddSource("Azure.Messaging.ServiceBus.*")
                     .AddProcessor(new PhiScrubbingSpanProcessor(serviceName));
 
                 if (!string.IsNullOrEmpty(otlpEndpoint))

--- a/tests/CloudHealthOffice.EligibilityService.Tests/BatchEligibilityStorageModeTests.cs
+++ b/tests/CloudHealthOffice.EligibilityService.Tests/BatchEligibilityStorageModeTests.cs
@@ -21,18 +21,17 @@ public class BatchEligibilityStorageModeTests
     }
 
     [Fact]
-    public void Persistent_WithFullConfig_RegistersCosmosAndServiceBus()
+    public void Persistent_WithFullConfig_RegistersCosmosAndMessageBusQueue()
     {
         var services = new ServiceCollection();
         services.AddBatchEligibilityStorage(Config("Persistent", full: true), ProdEnvironment());
-        // Do NOT BuildServiceProvider: the ServiceBus/Cosmos clients would
-        // attempt real network lookups. Instead inspect the registrations.
+        // Do NOT BuildServiceProvider: the Cosmos client would attempt real
+        // network lookups. Inspect the registrations instead.
 
         Assert.Contains(services, d =>
             d.ServiceType == typeof(IBatchJobStore) && d.ImplementationFactory != null);
         Assert.Contains(services, d =>
-            d.ServiceType == typeof(IBatchQueue) &&
-            d.ImplementationType == typeof(ServiceBusBatchQueue));
+            d.ServiceType == typeof(IBatchQueue) && d.ImplementationFactory != null);
         Assert.Contains(services, d =>
             d.ServiceType == typeof(IBatchQueueProcessor) && d.ImplementationFactory != null);
     }
@@ -61,7 +60,7 @@ public class BatchEligibilityStorageModeTests
         var services = new ServiceCollection();
         Assert.Throws<InvalidOperationException>(() =>
             services.AddBatchEligibilityStorage(
-                Config("Persistent", full: false, withBlob: true, withServiceBus: true),
+                Config("Persistent", full: false, withBlob: true),
                 ProdEnvironment()));
     }
 
@@ -69,7 +68,7 @@ public class BatchEligibilityStorageModeTests
 
     private static IConfiguration Config(
         string mode, bool full = false,
-        bool withCosmos = false, bool withBlob = false, bool withServiceBus = false)
+        bool withCosmos = false, bool withBlob = false)
     {
         var dict = new Dictionary<string, string?>
         {
@@ -82,10 +81,6 @@ public class BatchEligibilityStorageModeTests
             dict["BatchEligibility:BlobStorage:ConnectionString"] =
                 "DefaultEndpointsProtocol=https;AccountName=fake;AccountKey=ZmFrZQ==;" +
                 "EndpointSuffix=core.windows.net";
-        if (full || withServiceBus)
-            dict["BatchEligibility:ServiceBus:ConnectionString"] =
-                "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=root;" +
-                "SharedAccessKey=ZmFrZQ==";
 
         return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
     }

--- a/tests/CloudHealthOffice.EligibilityService.Tests/ServiceBusBatchQueueTests.cs
+++ b/tests/CloudHealthOffice.EligibilityService.Tests/ServiceBusBatchQueueTests.cs
@@ -1,5 +1,4 @@
-using System.Text;
-using System.Text.Json;
+using CloudHealthOffice.Infrastructure.Messaging;
 using EligibilityService.Services;
 
 namespace CloudHealthOffice.EligibilityService.Tests;
@@ -7,44 +6,53 @@ namespace CloudHealthOffice.EligibilityService.Tests;
 public class ServiceBusBatchQueueTests
 {
     [Fact]
-    public async Task Enqueue_JsonSerializesWithCorrelationId()
+    public async Task Enqueue_SendsMessageToBusWithJobIdCorrelation()
     {
-        var fake = new FakeSender();
-        var queue = new ServiceBusBatchQueue(fake);
+        await using var bus = new InMemoryMessageBus();
+        var queue = new ServiceBusBatchQueue(bus, "batch-eligibility");
+
+        BatchQueueMessage? received = null;
+        MessageContext? receivedCtx = null;
+        var gate = new TaskCompletionSource();
+
+        await using var subscription = bus.Subscribe<BatchQueueMessage>(
+            "batch-eligibility",
+            (msg, ctx, _) =>
+            {
+                received = msg;
+                receivedCtx = ctx;
+                gate.TrySetResult();
+                return Task.CompletedTask;
+            });
+        await subscription.StartAsync(CancellationToken.None);
 
         await queue.EnqueueAsync(new BatchQueueMessage("tenant-X", "JOB-1"));
 
-        Assert.Single(fake.Sent);
-        Assert.Equal("JOB-1", fake.Sent[0].CorrelationId);
+        await gate.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
-        var body = Encoding.UTF8.GetString(fake.Sent[0].Body);
-        using var doc = JsonDocument.Parse(body);
-        Assert.Equal("tenant-X", doc.RootElement.GetProperty("tenantId").GetString());
-        Assert.Equal("JOB-1", doc.RootElement.GetProperty("jobId").GetString());
+        Assert.NotNull(received);
+        Assert.Equal("tenant-X", received!.TenantId);
+        Assert.Equal("JOB-1", received.JobId);
+        Assert.Equal("JOB-1", receivedCtx!.CorrelationId);
     }
 
     [Fact]
     public void ReadAllAsync_Unsupported()
     {
-        var queue = new ServiceBusBatchQueue(new FakeSender());
+        var queue = new ServiceBusBatchQueue(new NullMessageBus(), "batch-eligibility");
         using var cts = new CancellationTokenSource();
         Assert.Throws<NotSupportedException>(() => queue.ReadAllAsync(cts.Token));
     }
 
     [Fact]
-    public void NullSender_Throws()
+    public void NullBus_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new ServiceBusBatchQueue(null!));
+        Assert.Throws<ArgumentNullException>(() => new ServiceBusBatchQueue(null!, "q"));
     }
 
-    private class FakeSender : IBatchQueueSender
+    [Fact]
+    public void NullQueueName_Throws()
     {
-        public List<(byte[] Body, string CorrelationId)> Sent { get; } = new();
-
-        public Task SendAsync(byte[] body, string correlationId, CancellationToken ct)
-        {
-            Sent.Add((body, correlationId));
-            return Task.CompletedTask;
-        }
+        Assert.Throws<ArgumentNullException>(() => new ServiceBusBatchQueue(new NullMessageBus(), null!));
     }
 }


### PR DESCRIPTION
## Summary

- Shared `IMessageBus` abstraction with three backends: `ServiceBusMessageBus` (prod), `InMemoryMessageBus` (dev/test, channel-backed), `NullMessageBus` (opt-out)
- Migrates eligibility-service (`IBatchQueue`) and idcard-service (`IQnxtMirrorQueue`) onto the shared bus
- W3C trace context propagated end-to-end so a producer span in one service becomes the parent of the consumer span in another

## Why

Two services had independent point-solution Service Bus code with duplicated DLQ / abandon / complete logic. Consolidates to one canonical async-messaging surface under `CloudHealthOffice.Infrastructure`. Per-service Service-Bus-specific code drops from ~225 LOC of orchestration to ~65 LOC of thin delegation; the `ServiceBusClient` lifecycle is now owned in one place (also fixes a handle leak in the idcard-service path where `ServiceBusQnxtMirrorQueue` implemented `IAsyncDisposable` but Program.cs never disposed it).

## Stacked on

Targets `feature/addendum-a-7-4-observability-rollout` (#667). A.7.1 uses `ChoActivitySource` from A.7.4 for producer/consumer spans and relies on `PhiScrubbingSpanProcessor` being globally installed. Retarget to `main` once A.7.4 merges.

## What's in it

Seven commits, exact order from the addendum:

1. `feat(infra)` — `IMessageBus` abstraction + ServiceBus/InMemory/Null impls
2. `feat(infra)` — `AddChoMessaging` extension + `SubscriptionHostedService`
3. `refactor(eligibility-service)` — `IBatchQueue` → `IMessageBus`
4. `refactor(idcard-service)` — `IQnxtMirrorQueue` → `IMessageBus`
5. `test(infra)` — `IMessageBus` contract + auto-resolution tests
6. `docs` — `shared-messagebus.md` + `provision-servicebus-queues.sh`
7. `chore` — drop direct `Azure.Messaging.ServiceBus` refs from service csprojs

### Behaviour changes to call out

- **`ProcessErrorAsync` is no longer silent.** The previous Service-Bus-specific code swallowed processor-level errors via `_ => Task.CompletedTask`. New behaviour logs at Warning with `ErrorSource` and `EntityPath`. Debugging a prod SB incident now produces evidence.
- **`ServiceBusClient` lifecycle fix.** `ServiceBusQnxtMirrorQueue` used to leak handles on shutdown because Program.cs never disposed it. The bus singleton owns the client lifecycle now.
- **Cross-service trace linking.** Producer spans inject `traceparent` into `ApplicationProperties`; consumer side restores the `ActivityContext` so `Activity.Current.TraceId` on the handler matches the originating span. Asserted by `SendAsync_PreservesActivityParentAcrossBus` in the contract test.

### Config

- New canonical keys: `Messaging:Backend` (`Auto` / `ServiceBus` / `InMemory` / `Null`) and `Messaging:ServiceBusConnectionString`.
- Legacy keys `BatchEligibility:ServiceBus:ConnectionString` and `IdCard:QnxtMirror:ServiceBusConnectionString` are honoured as fallbacks with a single deprecation warning at startup. Remove after one release (tracked as a follow-up).
- `AddChoMessaging` logs one line at startup with the resolved backend and reason, e.g. `IMessageBus=ServiceBus (Auto; ConnectionString configured; env=Production)`.

### Acceptance

- [x] `Azure.Messaging.ServiceBus` appears in exactly one csproj (Infrastructure)
- [x] All existing tests pass (175 Infrastructure + 47 eligibility + 23 idcard)
- [x] 18-test cross-backend contract + 11-test options resolution suite (6 integration tests skip without `CHO_SERVICEBUS_CONNECTION_STRING`)
- [x] Cross-service trace propagation verified by contract test
- [x] Startup log line visible on both migrated services
- [x] Eligibility + idcard flows end-to-end through the bus

### Honest note on LOC

My projection was +300 to +500 LOC net; actual is +1715/-206 = +1509 net. Docs came in at 268 LOC (not in the original estimate), and the contract test came out fuller than planned. The consolidation metric that actually matters — per-service Service Bus mechanics code — went from ~225 LOC of orchestration to ~65 LOC of delegation.

### Follow-ups (not in this PR)

1. Remove deprecated `BatchEligibility:ServiceBus:ConnectionString` + `IdCard:QnxtMirror:ServiceBusConnectionString` fallbacks after one release cycle
2. Collapse `InMemoryBatchQueue` / `ChannelBatchQueueProcessor` into `InMemoryMessageBus` once the `IBatchQueue.ReadAllAsync` test dependency can be rewritten to subscribe-and-drain
3. Route QNXT adapter through `IdCardAdapterFactory` like CHO/Fulfillment (unrelated tech debt surfaced during grep)

## Test plan

- [x] `dotnet test` — Infrastructure.Tests (175 passed, 6 SB integration skipped)
- [x] `dotnet test` — EligibilityService.Tests (47 passed)
- [x] `dotnet test` — IdCardService.Tests (23 passed)
- [ ] Provision staging queues via `scripts/azure/provision-servicebus-queues.sh` and verify startup log line on real SB namespace
- [ ] Integration run with `CHO_SERVICEBUS_CONNECTION_STRING` set — contract tests should pass against real namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)