### PR TITLE
feat(infra): A.7.2 — shared ICacheProvider + Redis/InMemory/Null backends

### DIFF
--- a/docs/architecture/shared-cache.md
+++ b/docs/architecture/shared-cache.md
@@ -1,0 +1,192 @@
+# Shared `ICacheProvider`
+
+`ICacheProvider` is the Cloud Health Office cache abstraction. One
+interface, three interchangeable backends, lives in
+[`CloudHealthOffice.Infrastructure.Caching`](../../src/services/shared/CloudHealthOffice.Infrastructure/Caching/).
+Production runs on Redis; dev and test run on `IMemoryCache`.
+
+## What this is — and isn't
+
+`ICacheProvider` covers the **90% of Redis usage that is string key /
+object value with TTL**: the read-through decorator pattern most of our
+engines already implement, where a Cosmos or Mongo hit is expensive and
+can be amortized behind a short-TTL cache. It is deliberately **not** a
+general-purpose Redis facade.
+
+**In the interface:** `GetAsync`, `SetAsync`, `RemoveAsync` (single + bulk),
+`GetOrSetAsync` (read-through with per-key single-flight coalescing).
+
+**Deliberately NOT in the interface:**
+
+- Hash operations (`HashGet`, `HashSet`, `HashIncrement`) — the atomic
+  increment on a hash field is the whole reason `RedisAccumulatorService`
+  was designed around Redis; exposing those operations on a neutral cache
+  interface would leak Redis semantics into every consumer.
+- Pub/sub. That is messaging, not caching — `IMessageBus` is the right
+  surface (and for streaming pipelines, Kafka).
+- Distributed locks. A legitimate use case, but one that deserves its
+  own `IDistributedLock` abstraction when we need it.
+- Atomic counters / `Increment`. Same reasoning as hashes — the whole
+  point is atomicity, and hiding it behind `ICacheProvider` would imply
+  guarantees the abstraction can't make.
+- Pattern-based deletion (`KEYS pattern*` / `SCAN`). Expensive on large
+  key spaces in production; exposing it invites accidental N-second
+  blocking calls. When a legitimate use case arises, callers take a
+  bounded dependency on `IConnectionMultiplexer` directly (see the PA
+  rule repository below) rather than push that shape into the shared
+  interface.
+
+## Decision tree — when to use what
+
+```
+Reads dominate, data is regeneratable, loss is recoverable?
+  └─ Yes → ICacheProvider
+       └─ Key is pure string, value is JSON-round-trippable, TTL fits?
+            └─ Yes → ICacheProvider (via AddChoCaching)
+            └─ No  → stop, rethink the design
+
+Atomic ops on structured state (hashes, counters, sets)?
+  └─ Yes → IConnectionMultiplexer directly, with a class-level
+            <remarks> block explaining the specific Redis-native
+            capability you need and why ICacheProvider cannot express
+            it. Current examples: RedisAccumulatorService, the
+            SCAN-based flush path inside RedisPaRuleRepository.
+
+Durable business state the system cannot reconstruct?
+  └─ Cosmos / Mongo, never Redis. Don't treat cache as storage.
+```
+
+## The two deliberate exceptions
+
+`ICacheProvider` deliberately covers the 90% of Redis usage that is
+K/V-with-TTL. Two consumers are called out as deliberate exceptions —
+`RedisAccumulatorService` (atomic hash increments) and `PaRuleRepository`
+(pattern-based SCAN invalidation) — each keeps direct
+`IConnectionMultiplexer` access with a class-level XML comment explaining
+the specific Redis-native capability that would be lost by going through
+the abstraction.
+
+### 1. `RedisAccumulatorService` (BenefitEngine)
+
+[`Redisaccumulatorservice.cs`](../../src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs)
+uses Redis hashes with `HINCRBYFLOAT` to accumulate member deductible /
+out-of-pocket-max totals as claims finalize. The operation MUST be
+server-side atomic: two concurrent claim adjudications for the same
+member hit the same hash field simultaneously, and a read-modify-write
+cycle on the application side would race and lose increments.
+
+Routing that through `ICacheProvider.SetAsync` would JSON-serialize the
+entire hash on every update — reintroducing the race the current design
+avoids. Routing through a hypothetical `IncrementAsync` on
+`ICacheProvider` would bake Redis-specific atomicity guarantees into a
+neutral interface that `InMemoryCacheProvider` could not honestly
+implement.
+
+### 2. `RedisPaRuleRepository.DeleteAsync` (PriorAuthRuleEngine)
+
+[`PaRuleRepository.cs`](../../src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs)
+moves K/V operations (read, set, exact-key invalidate on upsert /
+bulk-upsert) onto `ICacheProvider`. The `DeleteAsync(ruleId, stateCode)`
+path is the exception: the cache is keyed on
+`(stateCode, lob, program, tenantId)`, and `(ruleId, stateCode)` alone
+cannot reconstruct the cache key set. The only safe option is a
+`SCAN` over `pa-rules:{stateCode}:*` and a `DEL` of every match.
+
+Pattern deletion is exactly what `ICacheProvider` does not expose.
+Rather than bend the interface, `RedisPaRuleRepository` takes a bounded
+second dependency on `IConnectionMultiplexer` and uses it only inside
+the flush path. A `TODO(scale)` comment at the SCAN call site documents
+the sidecar-index follow-up if rule cardinality grows past a few
+thousand keys per state.
+
+## Configuration
+
+```jsonc
+"Caching": {
+  // Auto | Redis | InMemory | Null — mirrors MessagingOptions.Backend.
+  // Auto resolves to Redis when RedisConnectionString is set AND env is
+  // not Development; otherwise InMemory. Auto → InMemory outside
+  // Development emits a startup warning because a process-local cache
+  // doesn't share state across replicas.
+  "Backend": "Auto",
+
+  // Canonical location for the Redis connection string. The legacy
+  // top-level "Redis:ConnectionString" key is honoured for one release
+  // with a deprecation warning.
+  "RedisConnectionString": "redis-prod.redis.cache.windows.net:6380,password=...,ssl=true",
+
+  // Safety cap for the single-flight coalescer. Under pathological load
+  // (key space expanding faster than factories complete) the coalescer
+  // prunes released entries opportunistically and emits
+  // cho_cache_singleflight_evictions. Default 10000.
+  "SingleFlightMaxInFlight": 10000
+}
+```
+
+## Tenant prefixing and PHI rejection
+
+Every cache key is mandatorily transformed by `CacheKeyGuard` before
+hitting the backend. Two compliance controls:
+
+1. **Tenant prefixing.** The logical key `enrollment:config:pchp`
+   becomes `{env}:{tenantId}:enrollment:config:pchp`. `tenantId` is
+   resolved from `HttpContext.Items["TenantId"]` (set by
+   `TenantMiddleware`). Cross-tenant cache pollution is unreachable by
+   construction. The sole escape hatch is `CacheScope.Global`, which
+   must be passed deliberately at the call site — the guard will not
+   infer it from a missing tenant context.
+
+2. **PHI-token rejection.** Cache keys surface in Redis SLOWLOG, ops
+   dashboards, and distributed traces. The guard rejects keys whose
+   separator-bounded tokens contain any of `ssn`, `mbi`, `dob`,
+   `memberId`, `patientId`, `ssnHash` (case-insensitive). The
+   pseudonymized form `memberIdHash` is explicitly permitted because
+   it is already safe to surface in logs. Violations throw
+   `ArgumentException` at runtime — fail fast, not silent.
+
+### Examples
+
+| Logical key                                | Scope  | Result |
+|--------------------------------------------|--------|--------|
+| `enrollment:config:pchp`                   | Tenant | ✅ `production:pchp:enrollment:config:pchp` |
+| `member:memberIdHash:deadbeef`             | Tenant | ✅ allowed — hashed form |
+| `feature-flags:pas-auto`                   | Global | ✅ `production:_global:feature-flags:pas-auto` |
+| `enrollment:memberId:M12345`               | Tenant | ❌ `ArgumentException` — PHI token `memberId` |
+| `enrollment ssn 123`                       | Tenant | ❌ `ArgumentException` — whitespace + PHI token |
+| `enrollment:config`                        | Tenant | ❌ `InvalidOperationException` — no tenant on HttpContext |
+
+## Observability
+
+Redis tracing from A.7.4 (`AddRedisInstrumentation` in
+`ObservabilityExtensions`) attaches at the `IConnectionMultiplexer`
+level, so every `ICacheProvider` operation that lands on
+`RedisCacheProvider` produces a `db.system=redis` span without any
+additional wiring. When the same physical multiplexer is shared with
+the accumulator / PA-rule SCAN path, all three surfaces flow through
+the same instrumented client.
+
+Single-flight coalescer evictions emit a counter named
+`cho_cache_singleflight_evictions`; sustained non-zero readings indicate
+either a pathological key-space growth or a `SingleFlightMaxInFlight`
+that needs tuning.
+
+## Migration guidance
+
+- **New consumer is pure K/V + TTL?** Inject `ICacheProvider`. Rename
+  the decorator registration to `WithTenantConfigCache()` /
+  `WithRuleCache()` — no "Redis" in the name, because backend is an
+  `AddChoCaching` concern.
+- **New consumer needs atomic hash / counter / SCAN?** Inject
+  `IConnectionMultiplexer` directly and add a class-level XML
+  `<remarks>` block pointing back to this decision tree. Update this
+  document's "Two deliberate exceptions" section so the next person
+  knows the rule isn't being bent without a reason.
+- **New consumer needs distributed locking?** Come talk to the platform
+  team — that deserves its own abstraction (`IDistributedLock`) rather
+  than a fourth informal exception.
+
+## Provisioning
+
+[`scripts/azure/provision-redis.sh`](../../scripts/azure/provision-redis.sh)
+creates or updates the Azure Cache for Redis instance at Standard SKU,
+idempotently. Pattern mirrors `provision-servicebus-queues.sh`.

--- a/scripts/azure/provision-redis.sh
+++ b/scripts/azure/provision-redis.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Provisions the Azure Cache for Redis instance consumed by ICacheProvider
+# and by the two direct IConnectionMultiplexer callers (RedisAccumulatorService
+# for atomic HINCRBYFLOAT, RedisPaRuleRepository for SCAN-based state flush).
+#
+# Single Standard-tier instance serves all three workloads; see
+# docs/architecture/shared-cache.md for the decision tree that keeps the
+# two exceptions off the ICacheProvider abstraction but on the same
+# physical Redis.
+#
+# Idempotent: re-running on an existing instance updates mutable fields
+# without errors.
+#
+# Required env vars:
+#   REDIS_NAME            — the Azure Redis resource name (DNS-safe, globally unique)
+#   RESOURCE_GROUP        — the resource group containing it
+#   LOCATION              — Azure region (e.g. "eastus2") — only used on create
+#
+# Optional env vars:
+#   REDIS_SKU             — Basic | Standard | Premium (default Standard;
+#                            Standard gives us replica + SLA, Premium adds
+#                            clustering/geo-replication which we don't need yet)
+#   REDIS_VM_SIZE         — C0..C6 / P1..P5 (default C1 — 1 GiB, ~250 ops/s headroom)
+set -euo pipefail
+
+: "${REDIS_NAME:?REDIS_NAME is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+
+REDIS_SKU="${REDIS_SKU:-Standard}"
+REDIS_VM_SIZE="${REDIS_VM_SIZE:-C1}"
+
+echo "==> Azure Cache for Redis: ${REDIS_NAME} in ${RESOURCE_GROUP} (${REDIS_SKU} ${REDIS_VM_SIZE})"
+
+if az redis show \
+    --name "$REDIS_NAME" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "    exists; updating mutable fields"
+  az redis update \
+    --name "$REDIS_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --set enableNonSslPort=false minimumTlsVersion=1.2 >/dev/null
+else
+  : "${LOCATION:?LOCATION is required on first create}"
+  echo "    creating in ${LOCATION}"
+  az redis create \
+    --name "$REDIS_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --location "$LOCATION" \
+    --sku "$REDIS_SKU" \
+    --vm-size "$REDIS_VM_SIZE" \
+    --enable-non-ssl-port false \
+    --minimum-tls-version 1.2 >/dev/null
+fi
+
+echo "==> Done."

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
@@ -60,6 +60,25 @@ namespace CloudHealthOffice.BenefitEngine.Services;
 /// from claim history (which no longer includes the voided claim).
 /// Either way, the result is correct.
 /// </summary>
+/// <remarks>
+/// This service intentionally does NOT use the shared
+/// <see cref="CloudHealthOffice.Infrastructure.Caching.ICacheProvider"/>
+/// abstraction introduced in Addendum A.7.2. Accumulators use Redis hashes
+/// with server-side atomic <c>HINCRBYFLOAT</c> to avoid read-modify-write
+/// races between concurrent claim adjudications — behaviour that a
+/// string-K/V cache abstraction cannot express. Moving this class onto
+/// <c>ICacheProvider</c> would either require expanding the interface with
+/// hash operations (leaking Redis semantics into a neutral abstraction) or
+/// JSON-serializing the full hash on every update (reintroducing the race
+/// we designed around). Neither is acceptable.
+///
+/// The pattern: <c>ICacheProvider</c> is for caches — reads dominated, data
+/// is regeneratable, loss is recoverable. This service uses Redis as
+/// structured hot storage with domain-specific atomic semantics, which is
+/// a different job. See <c>docs/architecture/shared-cache.md</c> for the
+/// decision tree and the second deliberate exception
+/// (<c>RedisPaRuleRepository</c> for SCAN-based invalidation).
+/// </remarks>
 public class RedisAccumulatorService : IAccumulatorService
 {
     private readonly IConnectionMultiplexer _redis;

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
@@ -17,9 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- StackExchange.Redis arrives transitively from CloudHealthOffice.Infrastructure.
+         RedisPaRuleRepository still touches IConnectionMultiplexer/IServer directly
+         for the state-level SCAN invalidation path — a deliberate exception documented
+         on the class. See docs/architecture/shared-cache.md and Addendum A.7.2. -->
+    <ProjectReference Include="..\..\services\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
+
     <PackageReference Include="Microsoft.Azure.Cosmos"              Version="3.58.0" />
     <PackageReference Include="MongoDB.Driver"                      Version="3.7.1" />
-    <PackageReference Include="StackExchange.Redis"                 Version="2.8.16" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Configuration/PriorAuthRuleEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Configuration/PriorAuthRuleEngineRegistration.cs
@@ -1,3 +1,4 @@
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.PriorAuthRuleEngine.Abstractions;
 using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using CloudHealthOffice.PriorAuthRuleEngine.Persistence;
@@ -105,15 +106,24 @@ public sealed class PriorAuthRuleEngineBuilder
     }
 
     /// <summary>
-    /// Add a Redis read-through cache in front of the rule repository.
+    /// Add a read-through cache in front of the rule repository.
     /// Call AFTER UseCosmosRepository() or UseMongoRepository().
-    /// Requires IConnectionMultiplexer registered by the host.
+    ///
+    /// Requires:
+    ///   • <see cref="ICacheProvider"/>       — for K/V reads, writes,
+    ///     and exact-key invalidation. Registered by the host via
+    ///     <c>AddChoCaching(IConfiguration, IHostEnvironment)</c>.
+    ///   • <see cref="IConnectionMultiplexer"/> — for the state-level
+    ///     <c>SCAN</c> invalidation path on <see cref="RedisPaRuleRepository.DeleteAsync"/>.
+    ///     This is a deliberate exception to the shared abstraction,
+    ///     documented on the class and in
+    ///     <c>docs/architecture/shared-cache.md</c>.
     ///
     /// Cache key: pa-rules:{stateCode}:{lob}:{program}:{tenantId}
     /// Default TTL: 15 minutes (PriorAuthRuleEngineOptions.RuleSetCacheTtl)
-    /// Invalidated on every UpsertAsync and DeleteAsync.
+    /// Invalidated on every UpsertAsync, BulkUpsertAsync, and DeleteAsync.
     /// </summary>
-    public PriorAuthRuleEngineBuilder WithRedisRuleCache()
+    public PriorAuthRuleEngineBuilder WithRuleCache()
     {
         _services.AddScoped<IPaRuleRepository>(sp =>
         {
@@ -121,11 +131,12 @@ public sealed class PriorAuthRuleEngineBuilder
                 (IPaRuleRepository?)sp.GetService<PaRuleRepositoryCosmos>()
              ?? sp.GetService<PaRuleRepositoryMongo>()
              ?? throw new InvalidOperationException(
-                    "WithRedisRuleCache() must be called after UseCosmosRepository() " +
+                    "WithRuleCache() must be called after UseCosmosRepository() " +
                     "or UseMongoRepository().");
 
             return new RedisPaRuleRepository(
                 inner,
+                sp.GetRequiredService<ICacheProvider>(),
                 sp.GetRequiredService<IConnectionMultiplexer>(),
                 sp.GetRequiredService<IOptions<PriorAuthRuleEngineOptions>>(),
                 sp.GetRequiredService<ILogger<RedisPaRuleRepository>>());
@@ -133,6 +144,15 @@ public sealed class PriorAuthRuleEngineBuilder
 
         return this;
     }
+
+    /// <summary>
+    /// Deprecated alias for <see cref="WithRuleCache"/>. The backend is
+    /// now selected by <c>AddChoCaching</c>, not by this method name.
+    /// Kept for one release so host services can migrate the rename
+    /// separately from the ICacheProvider cutover.
+    /// </summary>
+    [Obsolete("Renamed to WithRuleCache — the backend (Redis / InMemory / Null) is selected by AddChoCaching.")]
+    public PriorAuthRuleEngineBuilder WithRedisRuleCache() => WithRuleCache();
 
     // ── Rule implementations ──────────────────────────────────────
 

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Configuration/PriorAuthRuleEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Configuration/PriorAuthRuleEngineRegistration.cs
@@ -110,14 +110,18 @@ public sealed class PriorAuthRuleEngineBuilder
     /// Call AFTER UseCosmosRepository() or UseMongoRepository().
     ///
     /// Requires:
-    ///   • <see cref="ICacheProvider"/>       — for K/V reads, writes,
-    ///     and exact-key invalidation. Registered by the host via
-    ///     <c>AddChoCaching(IConfiguration, IHostEnvironment)</c>.
-    ///   • <see cref="IConnectionMultiplexer"/> — for the state-level
-    ///     <c>SCAN</c> invalidation path on <see cref="RedisPaRuleRepository.DeleteAsync"/>.
-    ///     This is a deliberate exception to the shared abstraction,
-    ///     documented on the class and in
-    ///     <c>docs/architecture/shared-cache.md</c>.
+    ///   • <see cref="ICacheProvider"/> + <see cref="CacheKeyGuard"/> —
+    ///     for K/V reads, writes, and exact-key invalidation. Registered
+    ///     by the host via <c>AddChoCaching(IConfiguration, IHostEnvironment)</c>.
+    ///   • <see cref="IConnectionMultiplexer"/> — OPTIONAL. Used by the
+    ///     state-level <c>SCAN</c> path on
+    ///     <see cref="RedisPaRuleRepository.DeleteAsync"/>. Registered
+    ///     automatically by <c>AddChoCaching</c> when the cache backend
+    ///     resolves to Redis; absent when it resolves to InMemory / Null.
+    ///     When absent, the state-flush degrades to a debug log and
+    ///     InMemory entries rely on TTL. Exact-key invalidation on
+    ///     Upsert / BulkUpsert continues to work via
+    ///     <see cref="ICacheProvider"/>.
     ///
     /// Cache key: pa-rules:{stateCode}:{lob}:{program}:{tenantId}
     /// Default TTL: 15 minutes (PriorAuthRuleEngineOptions.RuleSetCacheTtl)
@@ -137,7 +141,8 @@ public sealed class PriorAuthRuleEngineBuilder
             return new RedisPaRuleRepository(
                 inner,
                 sp.GetRequiredService<ICacheProvider>(),
-                sp.GetRequiredService<IConnectionMultiplexer>(),
+                sp.GetService<IConnectionMultiplexer>(),
+                sp.GetRequiredService<CacheKeyGuard>(),
                 sp.GetRequiredService<IOptions<PriorAuthRuleEngineOptions>>(),
                 sp.GetRequiredService<ILogger<RedisPaRuleRepository>>());
         });

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
@@ -350,20 +350,32 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
 {
     private readonly IPaRuleRepository _inner;
     private readonly ICacheProvider _cache;
-    private readonly IConnectionMultiplexer _multiplexer;
+    private readonly IConnectionMultiplexer? _multiplexer;
+    private readonly CacheKeyGuard _keyGuard;
     private readonly TimeSpan _ttl;
     private readonly ILogger<RedisPaRuleRepository> _logger;
 
+    /// <summary>
+    /// <paramref name="multiplexer"/> is optional: it is null when the
+    /// cache backend resolves to InMemory or Null, in which case the
+    /// SCAN-based state flush degrades to a debug log + no-op. Exact-key
+    /// invalidation on Upsert/BulkUpsert continues to work via
+    /// <see cref="ICacheProvider"/>. This lets fhir-service and any other
+    /// host wire <c>WithRuleCache()</c> unconditionally without the
+    /// previous "Redis must be present" gate.
+    /// </summary>
     public RedisPaRuleRepository(
         IPaRuleRepository inner,
         ICacheProvider cache,
-        IConnectionMultiplexer multiplexer,
+        IConnectionMultiplexer? multiplexer,
+        CacheKeyGuard keyGuard,
         IOptions<PriorAuthRuleEngineOptions> options,
         ILogger<RedisPaRuleRepository> logger)
     {
         _inner       = inner;
         _cache       = cache;
         _multiplexer = multiplexer;
+        _keyGuard    = keyGuard;
         _ttl         = options.Value.RuleSetCacheTtl;
         _logger      = logger;
     }
@@ -446,6 +458,19 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
 
     private async Task FlushStateViaScanAsync(string stateCode)
     {
+        if (_multiplexer is null)
+        {
+            // Cache backend is InMemory or Null; SCAN is unreachable and
+            // also unnecessary. InMemory entries are process-local — they
+            // will expire via TTL, and exact-key invalidation on Upsert /
+            // BulkUpsert already handles the common write path. Skip.
+            _logger.LogDebug(
+                "PA rule state-flush skipped for {State}: no IConnectionMultiplexer " +
+                "(cache backend is not Redis). Entries will expire via TTL.",
+                stateCode);
+            return;
+        }
+
         // TODO(scale): SCAN across every pa-rules:{state}:* key is fine at
         // today's rule cardinality (~hundreds of keys per state) but becomes
         // expensive once a state carries thousands of (lob, program, tenant)
@@ -453,18 +478,16 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
         // explicit per-state index set (SADD pa-rules:{state}:index on write;
         // SMEMBERS + DEL on flush). Tracked as a follow-up.
         //
-        // SCAN returns RAW Redis keys (already carrying CacheKeyGuard's
-        // {env}:_global: prefix from prior writes) so DEL must run against
-        // the multiplexer directly; routing back through ICacheProvider
-        // would double-prefix. The SCAN pattern matches every tenant's
-        // entry for this state because the prefix precedes the
-        // "pa-rules:{state}:" portion only on the guard's side — the
-        // wildcard "*pa-rules:{state}:*" (with leading * to skip the
-        // guard prefix) covers every env/scope combination in one sweep.
+        // The pattern is ANCHORED at CacheKeyGuard's deterministic prefix
+        // ({env}:_global:) so SCAN traverses only keys in this env + scope
+        // instead of the full keyspace. Rule-set writes go through
+        // CacheScope.Global (see GetRulesAsync / UpsertAsync), so Global is
+        // the correct scope to flush here.
         try
         {
+            var prefix  = _keyGuard.BuildPrefix(CacheScope.Global);
+            var pattern = $"{prefix}pa-rules:{stateCode}:*";
             var server  = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
-            var pattern = $"*pa-rules:{stateCode}:*";
             var keys    = server.Keys(pattern: pattern).ToArray();
             if (keys.Length > 0)
                 await _multiplexer.GetDatabase().KeyDeleteAsync(keys);

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
@@ -1,3 +1,4 @@
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.PriorAuthRuleEngine.Domain;
 using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using Microsoft.Azure.Cosmos;
@@ -7,7 +8,6 @@ using Microsoft.Extensions.Options;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Driver;
 using StackExchange.Redis;
-using System.Text.Json;
 
 namespace CloudHealthOffice.PriorAuthRuleEngine.Persistence;
 
@@ -311,85 +311,98 @@ public sealed class PaRuleRepositoryMongo : IPaRuleRepository
 }
 
 // ─────────────────────────────────────────────────────────────────
-// Redis caching decorator
+// Cache-wrapped rule repository
 // ─────────────────────────────────────────────────────────────────
 
 /// <summary>
-/// Redis read-through cache for PA rule sets.
+/// Read-through cache for PA rule sets.
 ///
-/// Cache key:  pa-rules:{stateCode}:{lob}:{program ?? "any"}:{tenantId ?? "platform"}
-/// TTL:        15 minutes (PriorAuthRuleEngineOptions.RuleSetCacheTtl)
-/// Invalidation: UpsertAsync and DeleteAsync delete affected cache keys.
+/// Cache key:   pa-rules:{stateCode}:{lob}:{program ?? "any"}:{tenantId ?? "platform"}
+/// TTL:         15 minutes (PriorAuthRuleEngineOptions.RuleSetCacheTtl)
+/// Invalidation: UpsertAsync + BulkUpsertAsync invalidate exact keys;
+///               DeleteAsync flushes every key under pa-rules:{state}:* via SCAN.
 ///
-/// Rule sets change only at onboarding or admin update — 15-minute TTL
-/// provides a good balance between freshness and Redis pressure.
+/// ── Why this class still depends on IConnectionMultiplexer ────────
+///
+/// This repository is one of two deliberate exceptions to the shared
+/// <see cref="ICacheProvider"/> abstraction (the other is
+/// <c>RedisAccumulatorService</c> in BenefitEngine). The K/V
+/// operations (read, set, single-key delete, bulk delete) flow through
+/// <see cref="ICacheProvider"/> and benefit from its guard layer,
+/// serialization, and coalescing. The exception is the
+/// <see cref="DeleteAsync"/> invalidation path: a single rule delete
+/// cannot reconstruct the cache key set because the cache is keyed on
+/// <c>(stateCode, lob, program, tenantId)</c> and the caller only
+/// supplies <c>(ruleId, stateCode)</c>. The conservative-but-correct
+/// fix is a Redis <c>SCAN</c> for <c>pa-rules:{state}:*</c> — an
+/// operation that <see cref="ICacheProvider"/> deliberately does NOT
+/// expose (pattern deletion is expensive on large key spaces and
+/// leaks Redis semantics into a neutral abstraction).
+///
+/// We therefore accept a second, bounded dependency on
+/// <see cref="IConnectionMultiplexer"/> rather than either (a) bending
+/// the shared interface to accommodate a pattern-delete that nobody
+/// else needs, or (b) changing the rule-delete semantics to force
+/// callers into state-level invalidation. See
+/// <c>docs/architecture/shared-cache.md</c> and Addendum A.7.2.
 /// </summary>
 public sealed class RedisPaRuleRepository : IPaRuleRepository
 {
     private readonly IPaRuleRepository _inner;
-    private readonly IDatabase _db;
+    private readonly ICacheProvider _cache;
+    private readonly IConnectionMultiplexer _multiplexer;
     private readonly TimeSpan _ttl;
     private readonly ILogger<RedisPaRuleRepository> _logger;
 
-    private static readonly JsonSerializerOptions _json = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     public RedisPaRuleRepository(
         IPaRuleRepository inner,
-        IConnectionMultiplexer redis,
+        ICacheProvider cache,
+        IConnectionMultiplexer multiplexer,
         IOptions<PriorAuthRuleEngineOptions> options,
         ILogger<RedisPaRuleRepository> logger)
     {
-        _inner  = inner;
-        _db     = redis.GetDatabase();
-        _ttl    = options.Value.RuleSetCacheTtl;
-        _logger = logger;
+        _inner       = inner;
+        _cache       = cache;
+        _multiplexer = multiplexer;
+        _ttl         = options.Value.RuleSetCacheTtl;
+        _logger      = logger;
     }
 
     public async Task<IReadOnlyList<PaRuleDocument>> GetRulesAsync(
         RuleSetKey key, CancellationToken ct = default)
     {
-        var cacheKey = MakeCacheKey(key);
-
-        try
-        {
-            var cached = await _db.StringGetAsync(cacheKey);
-            if (cached.HasValue)
+        // Rule sets are serialized as CachedRuleSet (a list wrapper) because
+        // ICacheProvider.GetOrSetAsync<T> requires T : class. The wrapper is
+        // stable over time and adds a trivial allocation per read.
+        var result = await _cache.GetOrSetAsync<CachedRuleSet>(
+            MakeCacheKey(key),
+            async token =>
             {
-                var rules = JsonSerializer.Deserialize<List<PaRuleDocument>>(cached!, _json);
-                if (rules is not null)
-                {
-                    _logger.LogDebug("PA rule cache hit: {Key}", cacheKey);
-                    return rules;
-                }
-            }
-        }
-        catch (RedisException ex)
-        {
-            _logger.LogWarning(ex, "Redis unavailable for PA rule read — falling through");
-        }
+                var rules = await _inner.GetRulesAsync(key, token);
+                return new CachedRuleSet(rules.ToList());
+            },
+            _ttl,
+            // Rule sets straddle tenant/platform data. Keying includes the
+            // tenant (or "platform" sentinel), but the tenant scope on the
+            // guard requires an HttpContext. Platform rules are legitimately
+            // global — so we use Global here and rely on the embedded
+            // tenantId in the logical key for multi-tenant uniqueness.
+            CacheScope.Global,
+            ct);
 
-        var fresh = await _inner.GetRulesAsync(key, ct);
-
-        try
-        {
-            var payload = JsonSerializer.Serialize(fresh, _json);
-            await _db.StringSetAsync(cacheKey, payload, _ttl);
-        }
-        catch (RedisException ex)
-        {
-            _logger.LogWarning(ex, "Failed to cache PA rules for key {Key}", cacheKey);
-        }
-
-        return fresh;
+        return (IReadOnlyList<PaRuleDocument>?)result?.Rules ?? Array.Empty<PaRuleDocument>();
     }
 
     public async Task UpsertAsync(PaRuleDocument rule, CancellationToken ct = default)
     {
         await _inner.UpsertAsync(rule, ct);
-        await TryInvalidateAsync(rule);
+        await _cache.RemoveAsync(MakeCacheKey(new RuleSetKey
+        {
+            StateCode = rule.StateCode,
+            Lob       = rule.Lob,
+            Program   = rule.Program,
+            TenantId  = rule.TenantId
+        }), CacheScope.Global, ct);
     }
 
     public async Task BulkUpsertAsync(
@@ -398,7 +411,6 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
         var list = rules.ToList();
         await _inner.BulkUpsertAsync(list, ct);
 
-        // Invalidate all unique cache keys touched by the bulk write
         var keys = list
             .Select(r => MakeCacheKey(new RuleSetKey
             {
@@ -408,18 +420,21 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
                 TenantId  = r.TenantId
             }))
             .Distinct()
-            .ToArray();
+            .ToList();
 
-        try { await _db.KeyDeleteAsync(keys.Select(k => (RedisKey)k).ToArray()); }
-        catch (RedisException ex) { _logger.LogWarning(ex, "Failed to invalidate PA rule cache"); }
+        if (keys.Count > 0)
+            await _cache.RemoveAsync(keys, CacheScope.Global, ct);
     }
 
     public async Task DeleteAsync(string ruleId, string stateCode, CancellationToken ct = default)
     {
         await _inner.DeleteAsync(ruleId, stateCode, ct);
-        // Cannot derive a precise cache key without knowing lob/program/tenantId,
-        // so flush all keys for this state — conservative but safe.
-        await TryFlushStateAsync(stateCode);
+        // The cache key cannot be reconstructed from (ruleId, stateCode) alone,
+        // so flush every pa-rules:{state}:* key via SCAN. Uses the direct
+        // multiplexer because pattern deletion is not exposed on
+        // ICacheProvider by design — see class remarks above and
+        // docs/architecture/shared-cache.md.
+        await FlushStateViaScanAsync(stateCode);
     }
 
     public Task<IReadOnlyList<PaRuleDocument>> ListAsync(
@@ -429,30 +444,41 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
     private static string MakeCacheKey(RuleSetKey key) =>
         $"pa-rules:{key.StateCode}:{(int)key.Lob}:{key.Program ?? "any"}:{key.TenantId ?? "platform"}";
 
-    private async Task TryInvalidateAsync(PaRuleDocument rule)
+    private async Task FlushStateViaScanAsync(string stateCode)
     {
-        var key = MakeCacheKey(new RuleSetKey
-        {
-            StateCode = rule.StateCode,
-            Lob       = rule.Lob,
-            Program   = rule.Program,
-            TenantId  = rule.TenantId
-        });
-        try { await _db.KeyDeleteAsync(key); }
-        catch (RedisException ex) { _logger.LogWarning(ex, "Failed to invalidate {Key}", key); }
-    }
-
-    private async Task TryFlushStateAsync(string stateCode)
-    {
-        // Scan for all pa-rules:{stateCode}:* keys and delete them
-        // Use SCAN — never KEYS in production
-        var server  = _db.Multiplexer.GetServer(_db.Multiplexer.GetEndPoints().First());
-        var pattern = $"pa-rules:{stateCode}:*";
+        // TODO(scale): SCAN across every pa-rules:{state}:* key is fine at
+        // today's rule cardinality (~hundreds of keys per state) but becomes
+        // expensive once a state carries thousands of (lob, program, tenant)
+        // combinations. If this shows up in Redis SLOWLOG, switch to an
+        // explicit per-state index set (SADD pa-rules:{state}:index on write;
+        // SMEMBERS + DEL on flush). Tracked as a follow-up.
+        //
+        // SCAN returns RAW Redis keys (already carrying CacheKeyGuard's
+        // {env}:_global: prefix from prior writes) so DEL must run against
+        // the multiplexer directly; routing back through ICacheProvider
+        // would double-prefix. The SCAN pattern matches every tenant's
+        // entry for this state because the prefix precedes the
+        // "pa-rules:{state}:" portion only on the guard's side — the
+        // wildcard "*pa-rules:{state}:*" (with leading * to skip the
+        // guard prefix) covers every env/scope combination in one sweep.
         try
         {
-            var keys = server.Keys(pattern: pattern).Select(k => (RedisKey)k.ToString()).ToArray();
-            if (keys.Length > 0) await _db.KeyDeleteAsync(keys);
+            var server  = _multiplexer.GetServer(_multiplexer.GetEndPoints().First());
+            var pattern = $"*pa-rules:{stateCode}:*";
+            var keys    = server.Keys(pattern: pattern).ToArray();
+            if (keys.Length > 0)
+                await _multiplexer.GetDatabase().KeyDeleteAsync(keys);
         }
-        catch (RedisException ex) { _logger.LogWarning(ex, "Failed to flush state {State} from cache", stateCode); }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Failed to flush state {State} from PA rule cache", stateCode);
+        }
     }
+
+    /// <summary>
+    /// Serialization wrapper — <see cref="ICacheProvider.GetOrSetAsync{T}"/>
+    /// requires T : class, and <see cref="IReadOnlyList{T}"/> is not a
+    /// reference type the JSON serializer can round-trip without help.
+    /// </summary>
+    private sealed record CachedRuleSet(List<PaRuleDocument> Rules);
 }

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/Cache/RedisTenantEnrollmentConfigRepository.cs
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/Cache/RedisTenantEnrollmentConfigRepository.cs
@@ -1,201 +1,81 @@
-using System.Text.Json;
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.ProviderEnrollmentService.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using StackExchange.Redis;
 
 namespace CloudHealthOffice.ProviderEnrollmentService.Cache;
 
 /// <summary>
-/// Redis caching decorator for ITenantEnrollmentConfigRepository.
-///
-/// Wraps either TenantEnrollmentConfigRepositoryCosmos or
-/// TenantEnrollmentConfigRepositoryMongo and adds a Redis read-through
-/// cache in front of every GetAsync call.
-///
-/// Follows the exact CHO Redis pattern from RedisAccumulatorService:
-///   IConnectionMultiplexer → IDatabase → StringGetAsync / StringSetAsync
-///
-/// ── Key layout ────────────────────────────────────────────────────
-///
-///   enrollment:config:{tenantId}
-///
-///   Example: enrollment:config:pchp
+/// Read-through cache decorator for <see cref="ITenantEnrollmentConfigRepository"/>
+/// built on the shared <see cref="ICacheProvider"/>.
 ///
 /// ── Cache behaviour ───────────────────────────────────────────────
 ///
-///   GetAsync:    Redis hit  → deserialize and return
-///                Redis miss → call inner repo → cache result → return
-///   UpsertAsync: write to inner repo → delete Redis key (invalidate)
-///   DeleteAsync: delete from inner repo → delete Redis key
-///   ListAsync:   always hits inner repo (admin path — not cached)
+///   GetAsync:    ICacheProvider.GetOrSetAsync — hit returns cached
+///                value, miss invokes inner repo and caches the result.
+///                A null result from inner (tenant not configured) is
+///                NOT cached so a newly seeded tenant document becomes
+///                visible immediately.
+///   UpsertAsync: inner write → RemoveAsync (invalidate).
+///   DeleteAsync: inner delete → RemoveAsync (invalidate).
+///   ListAsync:   always hits the inner repo (admin path — not cached).
 ///
-/// ── TTL ───────────────────────────────────────────────────────────
+/// ── Key layout ────────────────────────────────────────────────────
 ///
-///   Default 5 minutes (ProviderEnrollmentOptions.TenantConfigCacheTtl).
-///   Short because config changes (gate mode flip from Warn → Enforce)
-///   must propagate to all pods within one cache window.
-///   Operators can lower this to 1 minute during rollout.
+///   Logical key: <c>enrollment:config:{tenantId}</c>
+///   CacheKeyGuard rewrites to <c>{env}:{tenantId}:enrollment:config:{tenantId}</c>
+///   so cross-tenant collisions are structurally impossible.
 ///
-/// ── Null tenants ──────────────────────────────────────────────────
+/// ── Backend resilience ────────────────────────────────────────────
 ///
-///   A null result from the inner repo (tenant not configured) is NOT
-///   cached. This lets a new tenant config document become visible
-///   immediately after seeding without a forced cache flush.
-///
-/// ── Redis unavailability ──────────────────────────────────────────
-///
-///   Any Redis exception is caught and logged as a warning; the call
-///   falls through to the inner repository. The gate continues to
-///   function — just with database latency on every call rather than
-///   sub-millisecond Redis reads.
+///   ICacheProvider swallows RedisException internally and degrades
+///   to a miss / no-op. The gate continues to function — just with
+///   database latency on every call rather than sub-millisecond
+///   Redis reads.
 /// </summary>
 public sealed class RedisTenantEnrollmentConfigRepository : ITenantEnrollmentConfigRepository
 {
     private readonly ITenantEnrollmentConfigRepository _inner;
-    private readonly IConnectionMultiplexer _redis;
+    private readonly ICacheProvider _cache;
     private readonly TimeSpan _ttl;
     private readonly ILogger<RedisTenantEnrollmentConfigRepository> _logger;
 
-    private static readonly JsonSerializerOptions _json = new()
-    {
-        PropertyNamingPolicy        = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition      = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
-
     public RedisTenantEnrollmentConfigRepository(
         ITenantEnrollmentConfigRepository inner,
-        IConnectionMultiplexer redis,
+        ICacheProvider cache,
         IOptions<ProviderEnrollmentOptions> options,
         ILogger<RedisTenantEnrollmentConfigRepository> logger)
     {
         _inner  = inner;
-        _redis  = redis;
+        _cache  = cache;
         _ttl    = options.Value.TenantConfigCacheTtl;
         _logger = logger;
     }
 
-    // ── Read-through ──────────────────────────────────────────────
-
-    public async Task<TenantEnrollmentConfig?> GetAsync(
-        string tenantId, CancellationToken ct = default)
+    public Task<TenantEnrollmentConfig?> GetAsync(string tenantId, CancellationToken ct = default)
     {
-        var key = MakeKey(tenantId);
-
-        // 1. Try Redis
-        try
-        {
-            var db    = _redis.GetDatabase();
-            var value = await db.StringGetAsync(key);
-
-            if (value.HasValue)
-            {
-                _logger.LogDebug("TenantEnrollmentConfig Redis hit for tenant {TenantId}", SanitizeForLog(tenantId));
-                try
-                {
-                    var cached = JsonSerializer.Deserialize<TenantEnrollmentConfig>(value!, _json);
-                    if (cached is not null)
-                        return cached;
-
-                    // Null deserialization (corrupted entry) — treat as cache miss
-                    _logger.LogWarning(
-                        "TenantEnrollmentConfig Redis entry for tenant {TenantId} deserialized to null — deleting corrupted key",
-                        SanitizeForLog(tenantId));
-                    await db.KeyDeleteAsync(key);
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogWarning(ex,
-                        "TenantEnrollmentConfig Redis entry for tenant {TenantId} failed to deserialize — deleting corrupted key",
-                        SanitizeForLog(tenantId));
-                    await db.KeyDeleteAsync(key);
-                }
-            }
-        }
-        catch (RedisException ex)
-        {
-            _logger.LogWarning(ex,
-                "Redis unavailable for TenantEnrollmentConfig read — falling through to store");
-        }
-
-        // 2. Miss — hit the backing store
-        var config = await _inner.GetAsync(tenantId, ct);
-
-        // 3. Cache non-null results only (null = tenant not configured — don't cache)
-        if (config is not null)
-        {
-            await TryCacheAsync(key, config);
-        }
-
-        return config;
+        return _cache.GetOrSetAsync<TenantEnrollmentConfig>(
+            MakeKey(tenantId),
+            token => _inner.GetAsync(tenantId, token),
+            _ttl,
+            CacheScope.Tenant,
+            ct);
     }
 
-    // ── Write-through invalidation ────────────────────────────────
-
-    public async Task UpsertAsync(
-        TenantEnrollmentConfig config, CancellationToken ct = default)
+    public async Task UpsertAsync(TenantEnrollmentConfig config, CancellationToken ct = default)
     {
-        // Write to backing store first — Redis is a cache, not the source of truth
         await _inner.UpsertAsync(config, ct);
-        await TryInvalidateAsync(MakeKey(config.TenantId));
+        await _cache.RemoveAsync(MakeKey(config.TenantId), CacheScope.Tenant, ct);
     }
 
     public async Task DeleteAsync(string tenantId, CancellationToken ct = default)
     {
         await _inner.DeleteAsync(tenantId, ct);
-        await TryInvalidateAsync(MakeKey(tenantId));
+        await _cache.RemoveAsync(MakeKey(tenantId), CacheScope.Tenant, ct);
     }
 
-    // ── Admin list — always hits store ───────────────────────────
+    public Task<IReadOnlyList<TenantEnrollmentConfig>> ListAsync(CancellationToken ct = default)
+        => _inner.ListAsync(ct);
 
-    public Task<IReadOnlyList<TenantEnrollmentConfig>> ListAsync(
-        CancellationToken ct = default) => _inner.ListAsync(ct);
-
-    // ── Helpers ───────────────────────────────────────────────────
-
-    private static RedisKey MakeKey(string tenantId) =>
-        $"enrollment:config:{tenantId}";
-
-    private async Task TryCacheAsync(RedisKey key, TenantEnrollmentConfig config)
-    {
-        try
-        {
-            var db      = _redis.GetDatabase();
-            var payload = JsonSerializer.Serialize(config, _json);
-            await db.StringSetAsync(key, payload, _ttl);
-
-            _logger.LogDebug(
-                "TenantEnrollmentConfig cached for tenant {TenantId} with TTL {Ttl}",
-                config.TenantId, _ttl);
-        }
-        catch (RedisException ex)
-        {
-            // Non-fatal — next request will hit the backing store again
-            _logger.LogWarning(ex,
-                "Failed to cache TenantEnrollmentConfig for tenant {TenantId}",
-                config.TenantId);
-        }
-    }
-
-    private async Task TryInvalidateAsync(RedisKey key)
-    {
-        try
-        {
-            var db = _redis.GetDatabase();
-            await db.KeyDeleteAsync(key);
-            _logger.LogDebug("TenantEnrollmentConfig cache invalidated for key {Key}", (string)key);
-        }
-        catch (RedisException ex)
-        {
-            // Non-fatal — stale entry will expire within TTL window
-            _logger.LogWarning(ex,
-                "Failed to invalidate TenantEnrollmentConfig cache for key {Key}", (string)key);
-        }
-    }
-
-    private static string SanitizeForLog(string? value)
-    {
-        if (string.IsNullOrEmpty(value)) return string.Empty;
-        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
-    }
+    private static string MakeKey(string tenantId) => $"enrollment:config:{tenantId}";
 }

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
@@ -16,6 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\services\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Azure -->
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <!-- MongoDB -->
@@ -27,8 +31,9 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <!-- Redis -->
-    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
+    <!-- Cache is consumed through ICacheProvider from CloudHealthOffice.Infrastructure.
+         StackExchange.Redis lives there and arrives transitively. See Addendum A.7.2
+         and docs/architecture/shared-cache.md. -->
     <!-- Polly (resilience) -->
     <PackageReference Include="Polly.Extensions" Version="8.5.0" />
     <!-- SFTP for batch file pulls -->

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/Configuration/ProviderEnrollmentServiceRegistration.cs
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/Configuration/ProviderEnrollmentServiceRegistration.cs
@@ -1,3 +1,4 @@
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.ProviderEnrollmentService.Abstractions;
 using CloudHealthOffice.ProviderEnrollmentService.Aggregator;
 using CloudHealthOffice.ProviderEnrollmentService.Cache;
@@ -14,7 +15,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using StackExchange.Redis;
 
 namespace CloudHealthOffice.ProviderEnrollmentService.Configuration;
 
@@ -150,21 +150,21 @@ public sealed class ProviderEnrollmentServiceBuilder
     }
 
     /// <summary>
-    /// Wrap ITenantEnrollmentConfigRepository with a Redis read-through cache.
+    /// Wrap ITenantEnrollmentConfigRepository with a read-through cache
+    /// backed by the shared <see cref="ICacheProvider"/>.
     ///
-    /// Call AFTER UseCosmosRepositories() or UseMongoRepositories().
-    /// Requires IConnectionMultiplexer to already be registered by the host
-    /// (benefit-plan-service and fhir-service both do this).
+    /// Call AFTER UseCosmosRepositories() or UseMongoRepositories(). The
+    /// host service must register <see cref="ICacheProvider"/> via
+    /// <c>AddChoCaching(IConfiguration, IHostEnvironment)</c> before this
+    /// method resolves — benefit-plan-service and fhir-service both do.
     ///
-    /// The decorator re-registers ITenantEnrollmentConfigRepository, replacing
-    /// the raw Cosmos/Mongo binding with the Redis-wrapped version.
-    /// The concrete Cosmos/Mongo type remains registered for the decorator
-    /// to resolve as its inner dependency.
+    /// The decorator re-registers ITenantEnrollmentConfigRepository,
+    /// replacing the raw Cosmos/Mongo binding with the cache-wrapped
+    /// version. The concrete Cosmos/Mongo type remains registered for the
+    /// decorator to resolve as its inner dependency.
     /// </summary>
-    public ProviderEnrollmentServiceBuilder WithRedisTenantConfigCache()
+    public ProviderEnrollmentServiceBuilder WithTenantConfigCache()
     {
-        // Re-register ITenantEnrollmentConfigRepository as the Redis decorator.
-        // The concrete Cosmos/Mongo types registered above are used as the inner.
         _services.AddScoped<ITenantEnrollmentConfigRepository>(sp =>
         {
             ITenantEnrollmentConfigRepository inner =
@@ -172,18 +172,28 @@ public sealed class ProviderEnrollmentServiceBuilder
                     sp.GetService<TenantEnrollmentConfigRepositoryCosmos>()
              ?? sp.GetService<TenantEnrollmentConfigRepositoryMongo>()
              ?? throw new InvalidOperationException(
-                    "WithRedisTenantConfigCache() must be called after " +
+                    "WithTenantConfigCache() must be called after " +
                     "UseCosmosRepositories() or UseMongoRepositories().");
 
             return new RedisTenantEnrollmentConfigRepository(
                 inner,
-                sp.GetRequiredService<IConnectionMultiplexer>(),
+                sp.GetRequiredService<ICacheProvider>(),
                 sp.GetRequiredService<IOptions<ProviderEnrollmentOptions>>(),
                 sp.GetRequiredService<ILogger<RedisTenantEnrollmentConfigRepository>>());
         });
 
         return this;
     }
+
+    /// <summary>
+    /// Deprecated alias for <see cref="WithTenantConfigCache"/>. Backend is
+    /// now selected by <c>AddChoCaching</c>, not by this extension method.
+    /// Kept for one release so host services can migrate without coupling
+    /// the rename to the ICacheProvider cutover.
+    /// </summary>
+    [Obsolete("Renamed to WithTenantConfigCache — the backend (Redis / InMemory / Null) is selected by AddChoCaching.")]
+    public ProviderEnrollmentServiceBuilder WithRedisTenantConfigCache() =>
+        WithTenantConfigCache();
 
     // ── State source registration ─────────────────────────────────
 

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -12,6 +12,7 @@ using CloudHealthOffice.ClaimsScrubEngine.Configuration;
 using CloudHealthOffice.NcciEngine.Configuration;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.Infrastructure.Json;
 using CloudHealthOffice.Infrastructure.Observability;
 using CloudHealthOffice.OperatingMode;
@@ -52,10 +53,20 @@ else
 }
 
 // ── Redis — shared across all engines ────────────────────────────────────────
+// Two registrations coexist on the same physical Redis instance:
+//   1. IConnectionMultiplexer — required by RedisAccumulatorService
+//      (atomic HINCRBYFLOAT on hashes) and by the SCAN-based state flush
+//      inside RedisPaRuleRepository. Both are deliberate exceptions to
+//      ICacheProvider — see docs/architecture/shared-cache.md.
+//   2. ICacheProvider (via AddChoCaching) — tenant-config + rule-set K/V
+//      consumers. AddChoCaching reuses the multiplexer above rather than
+//      opening a second connection.
 builder.Services.AddSingleton<IConnectionMultiplexer>(_ =>
     ConnectionMultiplexer.Connect(
         builder.Configuration["Redis:ConnectionString"]
         ?? throw new InvalidOperationException("Redis:ConnectionString is required.")));
+
+builder.Services.AddChoCaching(builder.Configuration, builder.Environment);
 
 // ── Benefit Engine ────────────────────────────────────────────────────────────
 builder.Services.AddScoped<IBenefitPlanService, BenefitPlanServiceImpl>();
@@ -101,11 +112,11 @@ builder.Services.AddScoped<IEnrollmentDecisionGate, PassthroughEnrollmentGate>()
 
 if (useMongo)
     builder.Services.AddProviderEnrollmentService(builder.Configuration)
-        .UseMongoRepositories().WithRedisTenantConfigCache()
+        .UseMongoRepositories().WithTenantConfigCache()
         .WithTexasSource().WithCaqhSource();
 else
     builder.Services.AddProviderEnrollmentService(builder.Configuration)
-        .UseCosmosRepositories().WithRedisTenantConfigCache()
+        .UseCosmosRepositories().WithTenantConfigCache()
         .WithTexasSource().WithCaqhSource();
 
 // ── Prior Auth Rule Engine ────────────────────────────────────────────────────
@@ -121,11 +132,11 @@ else
 //   }
 if (useMongo)
     builder.Services.AddPriorAuthRuleEngine(builder.Configuration)
-        .UseMongoRepository().WithRedisRuleCache()
+        .UseMongoRepository().WithRuleCache()
         .WithPlatformRules().SeedOnStartup();
 else
     builder.Services.AddPriorAuthRuleEngine(builder.Configuration)
-        .UseCosmosRepository().WithRedisRuleCache()
+        .UseCosmosRepository().WithRuleCache()
         .WithPlatformRules().SeedOnStartup();
 
 // ── Operating Mode Provider ───────────────────────────────────────────────────

--- a/src/services/benefit-plan-service/appsettings.json
+++ b/src/services/benefit-plan-service/appsettings.json
@@ -10,5 +10,8 @@
     "ServiceName": "benefit-plan-service",
     "OtlpEndpoint": "http://otel-collector:4317",
     "EnableConsole": false
+  },
+  "Caching": {
+    "Backend": "Auto"
   }
 }

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -6,12 +6,12 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.Infrastructure.Observability;
 using CloudHealthOffice.ProviderEnrollmentService.Configuration;
 using CloudHealthOffice.PriorAuthRuleEngine.Configuration;
 using Microsoft.Azure.Cosmos;
 using MongoDB.Driver;
-using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,12 +40,12 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 // ── Shared infrastructure ─────────────────────────────────────────────────────
-// Redis — shared by ProviderEnrollmentService and PriorAuthRuleEngine caches
-if (!string.IsNullOrEmpty(builder.Configuration["Redis:ConnectionString"]))
-{
-    builder.Services.AddSingleton<IConnectionMultiplexer>(_ =>
-        ConnectionMultiplexer.Connect(builder.Configuration["Redis:ConnectionString"]!));
-}
+// ICacheProvider (via AddChoCaching) backs the tenant-config and rule-set
+// K/V caches. On the Redis backend path it also registers a shared
+// IConnectionMultiplexer in DI so RedisPaRuleRepository's SCAN-based
+// state-flush — a deliberate exception to ICacheProvider — can inject
+// it. See docs/architecture/shared-cache.md.
+builder.Services.AddChoCaching(builder.Configuration, builder.Environment);
 
 var useMongo = !string.IsNullOrEmpty(builder.Configuration["MongoDb:ConnectionString"]);
 
@@ -76,22 +76,24 @@ else if (!string.IsNullOrEmpty(builder.Configuration["CosmosDb:Endpoint"]))
 //     "Caqh": { "Username": "...", "Password": "...(from AKV)" }
 //   }
 var hasDb = useMongo || !string.IsNullOrEmpty(builder.Configuration["CosmosDb:Endpoint"]);
-var hasRedis = !string.IsNullOrEmpty(builder.Configuration["Redis:ConnectionString"]);
-
-if (hasDb && hasRedis)
+// Cache backend presence is decided by AddChoCaching (Redis when a
+// connection string is configured AND env is Production; InMemory
+// otherwise). Either resolves to a working ICacheProvider, so the
+// engine wiring no longer hinges on "hasRedis" — only on "hasDb".
+if (hasDb)
 {
     if (useMongo)
         builder.Services.AddProviderEnrollmentService(builder.Configuration)
-            .UseMongoRepositories().WithRedisTenantConfigCache()
+            .UseMongoRepositories().WithTenantConfigCache()
             .WithTexasSource().WithCaqhSource();
     else
         builder.Services.AddProviderEnrollmentService(builder.Configuration)
-            .UseCosmosRepositories().WithRedisTenantConfigCache()
+            .UseCosmosRepositories().WithTenantConfigCache()
             .WithTexasSource().WithCaqhSource();
 
     // ── Prior Auth Rule Engine ────────────────────────────────────────────────────
     // Supplies IPriorAuthRuleEngine → PasAutoAdjudicator Rule 5.
-    // Rule sets cached in Redis (15 min TTL, invalidated on admin write).
+    // Rule sets cached via ICacheProvider (15 min TTL, invalidated on admin write).
     // Seeds TX platform rules (STAR / STARPlus / STARKids) on first deployment.
     //
     // Required appsettings.json:
@@ -102,11 +104,11 @@ if (hasDb && hasRedis)
     //   }
     if (useMongo)
         builder.Services.AddPriorAuthRuleEngine(builder.Configuration)
-            .UseMongoRepository().WithRedisRuleCache()
+            .UseMongoRepository().WithRuleCache()
             .WithPlatformRules().SeedOnStartup();
     else
         builder.Services.AddPriorAuthRuleEngine(builder.Configuration)
-            .UseCosmosRepository().WithRedisRuleCache()
+            .UseCosmosRepository().WithRuleCache()
             .WithPlatformRules().SeedOnStartup();
 }
 else

--- a/src/services/fhir-service/appsettings.json
+++ b/src/services/fhir-service/appsettings.json
@@ -52,5 +52,8 @@
     "ServiceName": "fhir-service",
     "OtlpEndpoint": "http://otel-collector:4317",
     "EnableConsole": false
+  },
+  "Caching": {
+    "Backend": "Auto"
   }
 }

--- a/src/services/fhir-service/fhir-service.csproj
+++ b/src/services/fhir-service/fhir-service.csproj
@@ -14,7 +14,10 @@
     <ProjectReference Include="..\..\engines\CloudHealthOffice.ProviderEnrollmentService\CloudHealthOffice.ProviderEnrollmentService.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.PriorAuthRuleEngine\CloudHealthOffice.PriorAuthRuleEngine.csproj" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
+    <!-- StackExchange.Redis is pulled in transitively via
+         CloudHealthOffice.Infrastructure. fhir-service has no direct
+         IConnectionMultiplexer consumer after A.7.2 — the Redis client is
+         opened and owned by AddChoCaching. -->
     <PackageReference Include="Hl7.Fhir.R4" Version="5.10.2" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
     <!-- Standard JWT Bearer validation — tokens issued by smart-auth-service with

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
@@ -81,6 +81,45 @@ public class CacheKeyGuardTests
     }
 
     [Fact]
+    public void Build_RejectionMessage_DoesNotEchoRawKey()
+    {
+        // The exception message flows through ExceptionHandlingMiddleware
+        // and into production logs; if it echoed the PHI-containing key,
+        // the guard would leak the exact value it was designed to reject.
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        var sensitive = "member:ssn:123-45-6789";
+        var ex = Assert.Throws<ArgumentException>(() => guard.Build(sensitive));
+        Assert.DoesNotContain("123-45-6789", ex.Message);
+        Assert.DoesNotContain(sensitive, ex.Message);
+        Assert.Contains("ssn", ex.Message); // token name is OK — not the value
+    }
+
+    [Fact]
+    public void Build_WhitespaceRejectionMessage_DoesNotEchoRawKey()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+        var sensitive = "something member-ssn-123-45-6789";
+        var ex = Assert.Throws<ArgumentException>(() => guard.Build(sensitive));
+        Assert.DoesNotContain(sensitive, ex.Message);
+        Assert.DoesNotContain("123-45-6789", ex.Message);
+    }
+
+    [Fact]
+    public void BuildPrefix_TenantScope_UsesAmbientTenant()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+        Assert.Equal("production:pchp:", guard.BuildPrefix());
+    }
+
+    [Fact]
+    public void BuildPrefix_GlobalScope_UsesGlobalSentinel()
+    {
+        var guard = MakeGuard("Development", tenantId: null);
+        Assert.Equal("development:_global:", guard.BuildPrefix(CacheScope.Global));
+    }
+
+    [Fact]
     public void BuildMany_AppliesGuardToEach()
     {
         var guard = MakeGuard("Production", tenantId: "pchp");

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
@@ -1,0 +1,124 @@
+using CloudHealthOffice.Infrastructure.Caching;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Caching;
+
+public class CacheKeyGuardTests
+{
+    [Fact]
+    public void Build_WithTenantContext_PrependsEnvAndTenant()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        var key = guard.Build("enrollment:config:pchp");
+
+        Assert.Equal("production:pchp:enrollment:config:pchp", key);
+    }
+
+    [Fact]
+    public void Build_GlobalScope_UsesGlobalSentinel_NoTenantRequired()
+    {
+        var guard = MakeGuard("Development", tenantId: null);
+
+        var key = guard.Build("feature-flags:pas-auto", CacheScope.Global);
+
+        Assert.Equal("development:_global:feature-flags:pas-auto", key);
+    }
+
+    [Fact]
+    public void Build_TenantScopeWithoutContext_Throws()
+    {
+        var guard = MakeGuard("Production", tenantId: null);
+
+        Assert.Throws<InvalidOperationException>(() => guard.Build("enrollment:config"));
+    }
+
+    [Theory]
+    [InlineData("enrollment:ssn:123")]          // ssn
+    [InlineData("users:ssnHash:abc")]           // ssnHash (hashes of SSN still rejected)
+    [InlineData("members:MBI:something")]       // mbi, case-insensitive
+    [InlineData("mbr:DOB:1970-01-01")]           // dob
+    [InlineData("config:memberId:M12345")]       // memberId raw
+    [InlineData("patient:patientId:P99")]        // patientId
+    public void Build_RejectsPhiTokens(string badKey)
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+        Assert.Throws<ArgumentException>(() => guard.Build(badKey));
+    }
+
+    [Fact]
+    public void Build_AllowsMemberIdHash_NotPhi()
+    {
+        // The hashed form of a member ID is explicitly permitted. Rejecting
+        // it would block a large class of legitimate per-member cache keys
+        // that have already been pseudonymized.
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        var key = guard.Build("member:memberIdHash:deadbeef");
+
+        Assert.Equal("production:pchp:member:memberIdHash:deadbeef", key);
+    }
+
+    [Theory]
+    [InlineData("enrollment config pchp")]      // spaces
+    [InlineData("enrollment\tconfig")]            // tab
+    [InlineData("enrollment\nconfig")]            // newline
+    [InlineData("enrollment\0config")]            // null byte
+    public void Build_RejectsControlAndWhitespaceChars(string badKey)
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+        Assert.Throws<ArgumentException>(() => guard.Build(badKey));
+    }
+
+    [Fact]
+    public void Build_NullOrEmptyKey_Throws()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        Assert.Throws<ArgumentException>(() => guard.Build(""));
+        Assert.Throws<ArgumentException>(() => guard.Build(null!));
+    }
+
+    [Fact]
+    public void BuildMany_AppliesGuardToEach()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        var keys = guard.BuildMany(new[] { "a:b", "c:d" });
+
+        Assert.Equal(new[] { "production:pchp:a:b", "production:pchp:c:d" }, keys);
+    }
+
+    [Fact]
+    public void BuildMany_OneBadKey_ThrowsAndDoesNotReturnPartial()
+    {
+        var guard = MakeGuard("Production", tenantId: "pchp");
+
+        Assert.Throws<ArgumentException>(() =>
+            guard.BuildMany(new[] { "ok:one", "bad:ssn:2", "ok:three" }));
+    }
+
+    private static CacheKeyGuard MakeGuard(string envName, string? tenantId)
+    {
+        var accessor = new HttpContextAccessor();
+        if (tenantId is not null)
+        {
+            var ctx = new DefaultHttpContext();
+            ctx.Items["TenantId"] = tenantId;
+            accessor.HttpContext = ctx;
+        }
+
+        var env = new FakeEnv { EnvironmentName = envName };
+        return new CacheKeyGuard(accessor, env);
+    }
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "cho-test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheProviderContractTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheProviderContractTests.cs
@@ -1,0 +1,180 @@
+using CloudHealthOffice.Infrastructure.Caching;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Caching;
+
+/// <summary>
+/// Shared contract every <see cref="ICacheProvider"/> implementation must pass.
+/// Mirrors the <c>MessageBusContractTests</c> pattern: the InMemory fixture
+/// runs in every CI build and the real-Redis fixture
+/// (<see cref="RedisCacheProviderContractTests"/>) runs only when an env
+/// var is set, so "in-memory works, Redis is subtly different" cannot
+/// silently escape notice.
+///
+/// These tests operate BELOW the guard — the SUT is the raw implementation,
+/// not <c>GuardedCacheProvider</c>, so keys are opaque strings without
+/// tenant prefix.
+/// </summary>
+public abstract class CacheProviderContractTests : IAsyncLifetime
+{
+    protected ICacheProvider Cache { get; private set; } = default!;
+    private IDisposable? _owned;
+
+    protected abstract ValueTask<(ICacheProvider, IDisposable?)> CreateCacheAsync();
+
+    protected virtual string KeyFor(string test) => $"contract-{test}-{Guid.NewGuid():N}";
+
+    public async Task InitializeAsync()
+    {
+        (Cache, _owned) = await CreateCacheAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _owned?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [SkippableFact]
+    public async Task GetAsync_Missing_ReturnsNull()
+    {
+        var result = await Cache.GetAsync<Payload>(KeyFor("miss"));
+        Assert.Null(result);
+    }
+
+    [SkippableFact]
+    public async Task SetThenGet_RoundTripsValue()
+    {
+        var key = KeyFor("roundtrip");
+        await Cache.SetAsync(key, new Payload("hello", 42), TimeSpan.FromMinutes(1));
+
+        var result = await Cache.GetAsync<Payload>(key);
+        Assert.NotNull(result);
+        Assert.Equal("hello", result!.Name);
+        Assert.Equal(42, result.Value);
+    }
+
+    [SkippableFact]
+    public async Task SetWithTtl_ExpiresAfterTtl()
+    {
+        var key = KeyFor("ttl");
+        await Cache.SetAsync(key, new Payload("expires", 1), TimeSpan.FromMilliseconds(150));
+
+        // Immediately: hit
+        Assert.NotNull(await Cache.GetAsync<Payload>(key));
+
+        await Task.Delay(300);
+        // After TTL: miss
+        Assert.Null(await Cache.GetAsync<Payload>(key));
+    }
+
+    [SkippableFact]
+    public async Task RemoveAsync_DeletesKey()
+    {
+        var key = KeyFor("remove");
+        await Cache.SetAsync(key, new Payload("rm", 1), TimeSpan.FromMinutes(1));
+        Assert.NotNull(await Cache.GetAsync<Payload>(key));
+
+        await Cache.RemoveAsync(key);
+        Assert.Null(await Cache.GetAsync<Payload>(key));
+    }
+
+    [SkippableFact]
+    public async Task RemoveAsync_Bulk_DeletesAllKeys()
+    {
+        var keys = Enumerable.Range(0, 5).Select(i => KeyFor($"bulk-{i}")).ToArray();
+        foreach (var k in keys)
+            await Cache.SetAsync(k, new Payload(k, 1), TimeSpan.FromMinutes(1));
+
+        await Cache.RemoveAsync(keys);
+
+        foreach (var k in keys)
+            Assert.Null(await Cache.GetAsync<Payload>(k));
+    }
+
+    [SkippableFact]
+    public async Task RemoveAsync_Bulk_EmptyCollection_IsNoOp()
+    {
+        await Cache.RemoveAsync(Array.Empty<string>()); // must not throw
+    }
+
+    [SkippableFact]
+    public async Task GetOrSetAsync_Miss_InvokesFactory_CachesResult()
+    {
+        var key = KeyFor("gos-miss");
+        var invocations = 0;
+
+        var first = await Cache.GetOrSetAsync<Payload>(
+            key,
+            _ => { Interlocked.Increment(ref invocations); return Task.FromResult<Payload?>(new Payload("fresh", 1)); },
+            TimeSpan.FromMinutes(1));
+
+        Assert.NotNull(first);
+        Assert.Equal(1, invocations);
+
+        // Second call: hit (factory not invoked)
+        var second = await Cache.GetOrSetAsync<Payload>(
+            key,
+            _ => { Interlocked.Increment(ref invocations); return Task.FromResult<Payload?>(new Payload("stale", 2)); },
+            TimeSpan.FromMinutes(1));
+
+        Assert.Equal("fresh", second!.Name);
+        Assert.Equal(1, invocations);
+    }
+
+    [SkippableFact]
+    public async Task GetOrSetAsync_NullResult_IsNotCached()
+    {
+        var key = KeyFor("gos-null");
+        var invocations = 0;
+
+        var first = await Cache.GetOrSetAsync<Payload>(
+            key,
+            _ => { Interlocked.Increment(ref invocations); return Task.FromResult<Payload?>(null); },
+            TimeSpan.FromMinutes(1));
+
+        Assert.Null(first);
+        Assert.Equal(1, invocations);
+
+        // Next call: factory invoked again (null not cached)
+        var second = await Cache.GetOrSetAsync<Payload>(
+            key,
+            _ => { Interlocked.Increment(ref invocations); return Task.FromResult<Payload?>(new Payload("now", 1)); },
+            TimeSpan.FromMinutes(1));
+
+        Assert.Equal("now", second!.Name);
+        Assert.Equal(2, invocations);
+    }
+
+    [SkippableFact]
+    public async Task GetOrSetAsync_ConcurrentMisses_FactoryInvokedOnce()
+    {
+        var key = KeyFor("gos-coalesce");
+        var invocations = 0;
+        var gate = new TaskCompletionSource();
+
+        // 20 concurrent cold-start callers race against the same key.
+        var tasks = Enumerable.Range(0, 20).Select(_ => Task.Run(async () =>
+        {
+            return await Cache.GetOrSetAsync<Payload>(
+                key,
+                async _ =>
+                {
+                    Interlocked.Increment(ref invocations);
+                    // Hold inside the factory long enough that every other
+                    // task has queued on the semaphore before we release.
+                    await gate.Task;
+                    return new Payload("single-flight", 1);
+                },
+                TimeSpan.FromMinutes(1));
+        })).ToArray();
+
+        await Task.Delay(100); // let every task reach the coalescer
+        gate.SetResult();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, invocations);
+        Assert.All(results, r => Assert.Equal("single-flight", r!.Name));
+    }
+
+    public record Payload(string Name, int Value);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CachingOptionsAutoResolutionTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CachingOptionsAutoResolutionTests.cs
@@ -1,0 +1,164 @@
+using CloudHealthOffice.Infrastructure.Caching;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Caching;
+
+public class CachingOptionsAutoResolutionTests
+{
+    private const string FakeRedisConnection = "fake.redis:6379,abortConnect=false";
+
+    [Fact]
+    public void Auto_InDev_ResolvesToInMemory()
+    {
+        var decision = CachingServiceCollectionExtensions.ResolveBackend(
+            new CachingOptions { Backend = "Auto" }, Env("Development"));
+
+        Assert.Equal(CachingServiceCollectionExtensions.CachingBackend.InMemory, decision.Backend);
+        Assert.Contains("Development", decision.Reason);
+    }
+
+    [Fact]
+    public void Auto_InProdWithoutConnectionString_ResolvesToInMemory()
+    {
+        var decision = CachingServiceCollectionExtensions.ResolveBackend(
+            new CachingOptions { Backend = "Auto" }, Env("Production"));
+
+        Assert.Equal(CachingServiceCollectionExtensions.CachingBackend.InMemory, decision.Backend);
+        Assert.Contains("no ConnectionString", decision.Reason);
+    }
+
+    [Fact]
+    public void Auto_InProdWithConnectionString_ResolvesToRedis()
+    {
+        var decision = CachingServiceCollectionExtensions.ResolveBackend(
+            new CachingOptions { Backend = "Auto", RedisConnectionString = FakeRedisConnection },
+            Env("Production"));
+
+        Assert.Equal(CachingServiceCollectionExtensions.CachingBackend.Redis, decision.Backend);
+        Assert.Contains("ConnectionString configured", decision.Reason);
+    }
+
+    [Fact]
+    public void ExplicitRedis_WithoutConnectionString_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            CachingServiceCollectionExtensions.ResolveBackend(
+                new CachingOptions { Backend = "Redis" }, Env("Production")));
+    }
+
+    [Fact]
+    public void ExplicitInMemory_IsHonouredInProduction()
+    {
+        var decision = CachingServiceCollectionExtensions.ResolveBackend(
+            new CachingOptions { Backend = "InMemory" }, Env("Production"));
+
+        Assert.Equal(CachingServiceCollectionExtensions.CachingBackend.InMemory, decision.Backend);
+        Assert.Contains("forced", decision.Reason);
+    }
+
+    [Fact]
+    public void ExplicitNull_IsHonoured()
+    {
+        var decision = CachingServiceCollectionExtensions.ResolveBackend(
+            new CachingOptions { Backend = "Null" }, Env("Production"));
+
+        Assert.Equal(CachingServiceCollectionExtensions.CachingBackend.Null, decision.Backend);
+    }
+
+    [Fact]
+    public void UnknownBackend_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            CachingServiceCollectionExtensions.ResolveBackend(
+                new CachingOptions { Backend = "Bogus" }, Env("Production")));
+    }
+
+    [Fact]
+    public void LegacyRedisConnectionString_IsFallback()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Caching:Backend"]        = "Auto",
+            ["Redis:ConnectionString"] = FakeRedisConnection
+        }).Build();
+
+        var (cs, deprecated) = CachingServiceCollectionExtensions
+            .ResolveConnectionString(config, new CachingOptions { Backend = "Auto" });
+
+        Assert.Equal(FakeRedisConnection, cs);
+        Assert.Equal("Redis:ConnectionString", deprecated);
+    }
+
+    [Fact]
+    public void CanonicalKey_WinsOverLegacyFallback()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Caching:RedisConnectionString"] = FakeRedisConnection,
+            ["Redis:ConnectionString"]        = "legacy-value"
+        }).Build();
+
+        var (cs, deprecated) = CachingServiceCollectionExtensions
+            .ResolveConnectionString(config, new CachingOptions
+            {
+                Backend               = "Auto",
+                RedisConnectionString = FakeRedisConnection
+            });
+
+        Assert.Equal(FakeRedisConnection, cs);
+        Assert.Null(deprecated);
+    }
+
+    [Fact]
+    public async Task AddChoCaching_RegistersSingleton_InMemoryPath()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Caching:Backend"] = "InMemory"
+        }).Build();
+
+        services.AddChoCaching(config, Env("Development"));
+        await using var sp = services.BuildServiceProvider();
+
+        var c1 = sp.GetRequiredService<ICacheProvider>();
+        var c2 = sp.GetRequiredService<ICacheProvider>();
+        Assert.Same(c1, c2);
+        Assert.IsType<GuardedCacheProvider>(c1);
+    }
+
+    [Fact]
+    public async Task AddChoCaching_RegistersNullProvider_WhenForced()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Caching:Backend"] = "Null"
+        }).Build();
+
+        services.AddChoCaching(config, Env("Development"));
+        await using var sp = services.BuildServiceProvider();
+
+        var cache = sp.GetRequiredService<ICacheProvider>();
+        Assert.IsType<GuardedCacheProvider>(cache);
+        // Round-trip a set-then-get: null backend means the get always
+        // misses even right after a set.
+        await cache.SetAsync("k", "v", TimeSpan.FromMinutes(1), CacheScope.Global);
+        Assert.Null(await cache.GetAsync<string>("k", CacheScope.Global));
+    }
+
+    private static IHostEnvironment Env(string name) => new FakeEnv { EnvironmentName = name };
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Production";
+        public string ApplicationName { get; set; } = "cho-test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/InMemoryCacheProviderTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/InMemoryCacheProviderTests.cs
@@ -1,0 +1,25 @@
+using CloudHealthOffice.Infrastructure.Caching;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Caching;
+
+public class InMemoryCacheProviderTests : CacheProviderContractTests
+{
+    protected override ValueTask<(ICacheProvider, IDisposable?)> CreateCacheAsync()
+    {
+        var cache       = new MemoryCache(new MemoryCacheOptions());
+        var singleFlight = new SingleFlightRunner(maxInFlight: 1024);
+        var provider     = new InMemoryCacheProvider(cache, singleFlight);
+
+        return ValueTask.FromResult<(ICacheProvider, IDisposable?)>(
+            (provider, new Disposables(cache, singleFlight)));
+    }
+
+    private sealed class Disposables : IDisposable
+    {
+        private readonly MemoryCache _cache;
+        private readonly SingleFlightRunner _sf;
+        public Disposables(MemoryCache cache, SingleFlightRunner sf) { _cache = cache; _sf = sf; }
+        public void Dispose() { _sf.Dispose(); _cache.Dispose(); }
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/RedisCacheProviderContractTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/RedisCacheProviderContractTests.cs
@@ -1,0 +1,41 @@
+using CloudHealthOffice.Infrastructure.Caching;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace CloudHealthOffice.Infrastructure.Tests.Caching;
+
+/// <summary>
+/// Real-Redis contract fixture. Skipped unless
+/// <c>CHO_REDIS_CONNECTION_STRING</c> is set in the environment, mirroring
+/// the Service Bus pattern (<c>CHO_SERVICEBUS_CONNECTION_STRING</c>) and
+/// keeping CI green on workers that have no Redis available.
+/// </summary>
+[Trait("Category", "Integration")]
+public class RedisCacheProviderContractTests : CacheProviderContractTests
+{
+    private const string EnvVar = "CHO_REDIS_CONNECTION_STRING";
+
+    protected override async ValueTask<(ICacheProvider, IDisposable?)> CreateCacheAsync()
+    {
+        var cs = Environment.GetEnvironmentVariable(EnvVar);
+        Skip.If(string.IsNullOrWhiteSpace(cs), $"{EnvVar} not set; skipping real-Redis contract tests.");
+
+        var multiplexer = await ConnectionMultiplexer.ConnectAsync(cs!);
+        var singleFlight = new SingleFlightRunner(maxInFlight: 1024);
+        var provider = new RedisCacheProvider(
+            multiplexer,
+            singleFlight,
+            NullLogger<RedisCacheProvider>.Instance);
+
+        return (provider, new Disposables(multiplexer, singleFlight));
+    }
+
+    private sealed class Disposables : IDisposable
+    {
+        private readonly ConnectionMultiplexer _mx;
+        private readonly SingleFlightRunner _sf;
+        public Disposables(ConnectionMultiplexer mx, SingleFlightRunner sf) { _mx = mx; _sf = sf; }
+        public void Dispose() { _sf.Dispose(); _mx.Dispose(); }
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheKeyGuard.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheKeyGuard.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Validates and rewrites cache keys before they hit the backend.
+///
+/// Two compliance controls:
+///   1. <b>Tenant prefixing</b> — every key becomes
+///      <c>{env}:{tenantId}:{logicalKey}</c>. Cross-tenant cache pollution
+///      has been a real incident class in multi-tenant platforms; this
+///      guard makes it unreachable by construction. Global scope
+///      (<see cref="CacheScope.Global"/>) is the explicit opt-out.
+///   2. <b>PHI rejection</b> — cache keys surface in Redis SLOWLOG, ops
+///      dashboards, traces, and monitoring. Raw PHI in a key is a
+///      compliance issue even if the value is hashed. Tokens like
+///      <c>ssn</c>, <c>mbi</c>, <c>dob</c>, <c>memberId</c>, <c>patientId</c>,
+///      <c>ssnHash</c> trigger an <see cref="ArgumentException"/> at
+///      runtime — fail fast, not silently. The hashed form
+///      <c>memberIdHash</c> is permitted (hashes of member IDs are not
+///      PHI under CHO's current risk model); <c>ssnHash</c> is not.
+/// </summary>
+public sealed class CacheKeyGuard
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly string _envPrefix;
+
+    // Token blocklist — matched case-insensitively against each token in
+    // the logical key (tokens are bounded by colons, hyphens, underscores,
+    // dots, or slashes). `memberId` rejects both raw and colon-qualified
+    // uses without also rejecting the permitted `memberIdHash`.
+    private static readonly HashSet<string> PhiTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ssn", "mbi", "dob", "memberid", "patientid", "ssnhash"
+    };
+
+    private static readonly char[] Separators = { ':', '-', '_', '.', '/' };
+
+    public CacheKeyGuard(IHttpContextAccessor httpContextAccessor, IHostEnvironment env)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _envPrefix           = env.EnvironmentName.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Validate <paramref name="logicalKey"/> and return the final Redis
+    /// key. Throws <see cref="ArgumentException"/> if the key contains
+    /// a PHI token, whitespace, a newline, or a null character — or if
+    /// <paramref name="scope"/> is <see cref="CacheScope.Tenant"/> and no
+    /// tenant is resolvable from the ambient HttpContext.
+    /// </summary>
+    public string Build(string logicalKey, CacheScope scope = CacheScope.Tenant)
+    {
+        if (string.IsNullOrEmpty(logicalKey))
+            throw new ArgumentException("Cache key cannot be null or empty.", nameof(logicalKey));
+
+        ValidateShape(logicalKey);
+        ValidateNoPhi(logicalKey);
+
+        var tenant = scope == CacheScope.Global
+            ? "_global"
+            : ResolveTenantOrThrow();
+
+        return $"{_envPrefix}:{tenant}:{logicalKey}";
+    }
+
+    /// <summary>Bulk-apply <see cref="Build"/> to a collection of keys.</summary>
+    public IReadOnlyCollection<string> BuildMany(
+        IReadOnlyCollection<string> logicalKeys, CacheScope scope = CacheScope.Tenant)
+    {
+        var output = new List<string>(logicalKeys.Count);
+        foreach (var k in logicalKeys) output.Add(Build(k, scope));
+        return output;
+    }
+
+    private static void ValidateShape(string key)
+    {
+        foreach (var c in key)
+        {
+            if (c == '\0' || c == '\r' || c == '\n' || char.IsWhiteSpace(c))
+                throw new ArgumentException(
+                    $"Cache key '{key}' contains whitespace or control characters.",
+                    nameof(key));
+        }
+    }
+
+    private static void ValidateNoPhi(string key)
+    {
+        var tokens = key.Split(Separators, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            if (PhiTokens.Contains(token))
+                throw new ArgumentException(
+                    $"Cache key '{key}' contains PHI token '{token}'. " +
+                    "Hash, pseudonymize, or redesign the key. See docs/architecture/shared-cache.md.",
+                    nameof(key));
+        }
+    }
+
+    private string ResolveTenantOrThrow()
+    {
+        var ctx = _httpContextAccessor.HttpContext;
+        if (ctx is not null && ctx.Items.TryGetValue("TenantId", out var raw) && raw is string s && !string.IsNullOrWhiteSpace(s))
+            return s;
+
+        throw new InvalidOperationException(
+            "CacheKeyGuard: tenant-scoped cache operation requested but no " +
+            "TenantId is present on HttpContext.Items. " +
+            "Either run inside a request that went through TenantMiddleware, " +
+            "or pass CacheScope.Global at the call site.");
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheKeyGuard.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheKeyGuard.cs
@@ -74,13 +74,34 @@ public sealed class CacheKeyGuard
         return output;
     }
 
+    /// <summary>
+    /// Return just the prefix the guard would prepend for a given scope —
+    /// <c>{env}:{tenantId}:</c> or <c>{env}:_global:</c>. Consumers that
+    /// need to construct a Redis SCAN pattern against already-stored
+    /// (prefixed) keys use this to anchor the pattern on the correct
+    /// environment + scope, instead of a leading-wildcard <c>"*..."</c>
+    /// pattern that would force a full-keyspace SCAN.
+    /// </summary>
+    public string BuildPrefix(CacheScope scope = CacheScope.Tenant)
+    {
+        var tenant = scope == CacheScope.Global ? "_global" : ResolveTenantOrThrow();
+        return $"{_envPrefix}:{tenant}:";
+    }
+
     private static void ValidateShape(string key)
     {
         foreach (var c in key)
         {
             if (c == '\0' || c == '\r' || c == '\n' || char.IsWhiteSpace(c))
+                // Do NOT echo the raw key. ExceptionHandlingMiddleware logs
+                // exception.Message in production and may surface it to
+                // clients in Development; a rejected key can contain PHI
+                // (that's why we're rejecting it). Describe the problem
+                // without quoting the input.
                 throw new ArgumentException(
-                    $"Cache key '{key}' contains whitespace or control characters.",
+                    "Cache key contains whitespace, newline, or null characters. " +
+                    "Keys must be printable ASCII; whitespace is disallowed to prevent " +
+                    "log-forging via user-controlled cache keys.",
                     nameof(key));
         }
     }
@@ -91,8 +112,11 @@ public sealed class CacheKeyGuard
         foreach (var token in tokens)
         {
             if (PhiTokens.Contains(token))
+                // Token name is not PHI (it's the identifier class, not a
+                // value); safe to include. The surrounding key value is
+                // NOT included — see docs/architecture/shared-cache.md.
                 throw new ArgumentException(
-                    $"Cache key '{key}' contains PHI token '{token}'. " +
+                    $"Cache key contains PHI token '{token.ToLowerInvariant()}'. " +
                     "Hash, pseudonymize, or redesign the key. See docs/architecture/shared-cache.md.",
                     nameof(key));
         }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheScope.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CacheScope.cs
@@ -1,0 +1,20 @@
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// How a cache key should be scoped by <c>CacheKeyGuard</c>.
+///
+/// Default (<see cref="Tenant"/>): the guard requires an ambient tenant on
+/// <c>IHttpContextAccessor.HttpContext.Items["TenantId"]</c> and prepends it
+/// so no two tenants collide. This is the right choice for every cache that
+/// stores tenant-scoped data.
+///
+/// <see cref="Global"/> is an explicit opt-out — rare, for platform-wide
+/// configuration with no per-tenant variance (feature flags, terminology
+/// tables). Must be passed deliberately at the call site; the guard will not
+/// infer it from a missing tenant context.
+/// </summary>
+public enum CacheScope
+{
+    Tenant = 0,
+    Global = 1
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingOptions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingOptions.cs
@@ -1,0 +1,37 @@
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Binds from the <c>Caching</c> configuration section. Shape mirrors
+/// <c>MessagingOptions</c> — Auto / Redis / InMemory / Null — so the two
+/// shared abstractions resolve identically.
+/// </summary>
+public class CachingOptions
+{
+    public const string SectionName = "Caching";
+
+    /// <summary>
+    /// Backend selection:
+    ///   <c>Auto</c>     — Redis when <see cref="RedisConnectionString"/> is set
+    ///                     AND environment is not Development, else InMemory.
+    ///   <c>Redis</c>    — force Redis; throws at startup if the connection
+    ///                     string is missing.
+    ///   <c>InMemory</c> — force in-process <see cref="Microsoft.Extensions.Caching.Memory.IMemoryCache"/>.
+    ///   <c>Null</c>     — no-op, for explicit-disable scenarios (canary
+    ///                     rollbacks, tests that want every request to hit
+    ///                     the backing store).
+    /// </summary>
+    public string Backend { get; set; } = "Auto";
+
+    /// <summary>StackExchange.Redis connection string.</summary>
+    public string? RedisConnectionString { get; set; }
+
+    /// <summary>
+    /// Upper bound on the number of in-flight cache-miss coalescer entries.
+    /// When this is exceeded the coalescer prunes released entries
+    /// opportunistically and bumps <c>cho_cache_singleflight_evictions</c>.
+    /// Default 10000 — well above expected cold-start fan-in; large enough
+    /// that legitimate load never trips it, small enough that a runaway
+    /// high-cardinality key space cannot OOM a pod.
+    /// </summary>
+    public int SingleFlightMaxInFlight { get; set; } = 10_000;
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
@@ -58,6 +59,18 @@ public static class CachingServiceCollectionExtensions
         services.AddSingleton<SingleFlightRunner>(_ =>
             new SingleFlightRunner(options.SingleFlightMaxInFlight));
 
+        // On the Redis backend path, ensure IConnectionMultiplexer is
+        // registered in DI so callers that hold a deliberate direct
+        // dependency (RedisAccumulatorService, RedisPaRuleRepository's
+        // SCAN flush) can inject it without the host having to open a
+        // second connection. TryAdd so hosts that pre-register their own
+        // multiplexer (benefit-plan-service) win.
+        if (decision.Backend == CachingBackend.Redis)
+        {
+            services.TryAddSingleton<IConnectionMultiplexer>(_ =>
+                ConnectionMultiplexer.Connect(options.RedisConnectionString!));
+        }
+
         services.AddSingleton<ICacheProvider>(sp =>
         {
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
@@ -110,15 +123,11 @@ public static class CachingServiceCollectionExtensions
         CachingOptions options,
         ILoggerFactory loggerFactory)
     {
-        // Resolve an already-registered IConnectionMultiplexer if one exists
-        // (the host service may have its own for RedisAccumulatorService /
-        // RedisPaRuleRepository). Otherwise spin up a new one against the
-        // same connection string.
-        var multiplexer = sp.GetService<IConnectionMultiplexer>()
-            ?? ConnectionMultiplexer.Connect(options.RedisConnectionString!);
-
+        // The multiplexer is already in DI (via TryAddSingleton above or a
+        // host pre-registration). Resolve it so every Redis touchpoint in
+        // the process shares one connection.
         return new RedisCacheProvider(
-            multiplexer,
+            sp.GetRequiredService<IConnectionMultiplexer>(),
             sp.GetRequiredService<SingleFlightRunner>(),
             loggerFactory.CreateLogger<RedisCacheProvider>());
     }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Registers <see cref="ICacheProvider"/> and resolves the backend from
+/// configuration + environment. Mirrors
+/// <c>AddChoMessaging</c> — same Auto/InMemory/Production resolution logic,
+/// same soft deprecation of the legacy <c>Redis:ConnectionString</c> key.
+/// </summary>
+public static class CachingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register <see cref="ICacheProvider"/> as a singleton.
+    ///
+    /// Backend resolution:
+    ///   <c>Auto</c>     — prod + connection string present → Redis;
+    ///                      otherwise InMemory (with a warning if prod).
+    ///   <c>Redis</c>    — forced; throws if connection string missing.
+    ///   <c>InMemory</c> — forced.
+    ///   <c>Null</c>     — forced no-op.
+    ///
+    /// Config keys: <c>Caching:Backend</c>, <c>Caching:RedisConnectionString</c>.
+    ///
+    /// Back-compat: <c>Redis:ConnectionString</c> is honoured as a fallback
+    /// and emits a single deprecation warning at startup. Follow-up: remove
+    /// this fallback after one release cycle.
+    ///
+    /// Safe to call after an <c>AddSingleton&lt;IConnectionMultiplexer&gt;</c>
+    /// registration — the host service (e.g. benefit-plan-service) keeps its
+    /// direct multiplexer for callers that need Redis-native semantics
+    /// (<c>RedisAccumulatorService</c>, <c>RedisPaRuleRepository</c>), and
+    /// this method layers <c>ICacheProvider</c> on top of the same physical
+    /// Redis instance.
+    /// </summary>
+    public static IServiceCollection AddChoCaching(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        var options = new CachingOptions();
+        configuration.GetSection(CachingOptions.SectionName).Bind(options);
+
+        var (connectionString, deprecatedKey) = ResolveConnectionString(configuration, options);
+        options.RedisConnectionString = connectionString;
+        services.AddSingleton(options);
+
+        var decision = ResolveBackend(options, environment);
+
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+        services.AddSingleton<CacheKeyGuard>();
+        services.AddSingleton<SingleFlightRunner>(_ =>
+            new SingleFlightRunner(options.SingleFlightMaxInFlight));
+
+        services.AddSingleton<ICacheProvider>(sp =>
+        {
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var logger        = loggerFactory.CreateLogger("CloudHealthOffice.Infrastructure.Caching");
+
+            logger.LogInformation(
+                "ICacheProvider={Backend} ({Reason})",
+                decision.Backend, decision.Reason);
+
+            if (decision.Backend == CachingBackend.InMemory &&
+                !environment.IsDevelopment() &&
+                string.Equals((options.Backend ?? "Auto").Trim(), "Auto",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                // Same reasoning as AddChoMessaging: Auto → InMemory outside
+                // Development is almost always a misconfig. A process-local
+                // cache doesn't share state across replicas, so
+                // invalidations don't propagate and TTLs are inconsistent.
+                logger.LogWarning(
+                    "ICacheProvider resolved to InMemory in {Environment}. " +
+                    "Configure Caching:RedisConnectionString for cross-replica cache coherence.",
+                    environment.EnvironmentName);
+            }
+
+            if (deprecatedKey is not null)
+            {
+                logger.LogWarning(
+                    "Config key '{Deprecated}' is deprecated; migrate to '{Canonical}'. " +
+                    "Falling back for this release.",
+                    deprecatedKey, "Caching:RedisConnectionString");
+            }
+
+            ICacheProvider inner = decision.Backend switch
+            {
+                CachingBackend.Redis => BuildRedisProvider(sp, options, loggerFactory),
+                CachingBackend.Null  => new NullCacheProvider(),
+                _                     => new InMemoryCacheProvider(
+                                             sp.GetRequiredService<IMemoryCache>(),
+                                             sp.GetRequiredService<SingleFlightRunner>())
+            };
+
+            return new GuardedCacheProvider(inner, sp.GetRequiredService<CacheKeyGuard>());
+        });
+
+        return services;
+    }
+
+    private static ICacheProvider BuildRedisProvider(
+        IServiceProvider sp,
+        CachingOptions options,
+        ILoggerFactory loggerFactory)
+    {
+        // Resolve an already-registered IConnectionMultiplexer if one exists
+        // (the host service may have its own for RedisAccumulatorService /
+        // RedisPaRuleRepository). Otherwise spin up a new one against the
+        // same connection string.
+        var multiplexer = sp.GetService<IConnectionMultiplexer>()
+            ?? ConnectionMultiplexer.Connect(options.RedisConnectionString!);
+
+        return new RedisCacheProvider(
+            multiplexer,
+            sp.GetRequiredService<SingleFlightRunner>(),
+            loggerFactory.CreateLogger<RedisCacheProvider>());
+    }
+
+    internal static (string? ConnectionString, string? DeprecatedKey) ResolveConnectionString(
+        IConfiguration configuration, CachingOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(options.RedisConnectionString))
+            return (options.RedisConnectionString, null);
+
+        // Legacy fallback: Redis:ConnectionString is where benefit-plan-service
+        // and fhir-service currently read the string from. Honour it so the
+        // refactor lands without a config migration, and flag it so the next
+        // release can drop it.
+        var legacy = configuration["Redis:ConnectionString"];
+        if (!string.IsNullOrWhiteSpace(legacy))
+            return (legacy, "Redis:ConnectionString");
+
+        return (null, null);
+    }
+
+    internal static BackendDecision ResolveBackend(
+        CachingOptions options, IHostEnvironment environment)
+    {
+        var backend = (options.Backend ?? "Auto").Trim();
+        var hasCs   = !string.IsNullOrWhiteSpace(options.RedisConnectionString);
+
+        return backend.ToLowerInvariant() switch
+        {
+            "redis" when hasCs => new BackendDecision(
+                CachingBackend.Redis,
+                $"forced; env={environment.EnvironmentName}"),
+            "redis" => throw new InvalidOperationException(
+                "Caching:Backend=Redis requires Caching:RedisConnectionString (or the legacy Redis:ConnectionString fallback)."),
+            "inmemory" => new BackendDecision(
+                CachingBackend.InMemory,
+                $"forced; env={environment.EnvironmentName}"),
+            "null" => new BackendDecision(
+                CachingBackend.Null,
+                $"forced; env={environment.EnvironmentName}"),
+            "auto" or "" when environment.IsDevelopment() => new BackendDecision(
+                CachingBackend.InMemory,
+                "Auto; env=Development"),
+            "auto" or "" when hasCs => new BackendDecision(
+                CachingBackend.Redis,
+                $"Auto; ConnectionString configured; env={environment.EnvironmentName}"),
+            "auto" or "" => new BackendDecision(
+                CachingBackend.InMemory,
+                $"Auto; no ConnectionString; env={environment.EnvironmentName}"),
+            _ => throw new InvalidOperationException(
+                $"Caching:Backend='{options.Backend}' is not recognised. Use Auto, Redis, InMemory, or Null.")
+        };
+    }
+
+    internal enum CachingBackend { Auto, Redis, InMemory, Null }
+    internal record BackendDecision(CachingBackend Backend, string Reason);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/GuardedCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/GuardedCacheProvider.cs
@@ -1,0 +1,43 @@
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Decorator that routes every <see cref="ICacheProvider"/> call through
+/// <see cref="CacheKeyGuard"/> before delegating to the inner provider.
+/// This is the type actually registered as <see cref="ICacheProvider"/>
+/// by <c>AddChoCaching</c>; consumers never see the raw Redis/InMemory/Null
+/// implementation and therefore cannot sidestep tenant prefixing or PHI
+/// rejection.
+/// </summary>
+internal sealed class GuardedCacheProvider : ICacheProvider
+{
+    private readonly ICacheProvider _inner;
+    private readonly CacheKeyGuard _guard;
+
+    public GuardedCacheProvider(ICacheProvider inner, CacheKeyGuard guard)
+    {
+        _inner = inner;
+        _guard = guard;
+    }
+
+    public Task<T?> GetAsync<T>(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
+        where T : class
+        => _inner.GetAsync<T>(_guard.Build(key, scope), scope, ct);
+
+    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
+        => _inner.SetAsync(_guard.Build(key, scope), value, ttl, scope, ct);
+
+    public Task RemoveAsync(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
+        => _inner.RemoveAsync(_guard.Build(key, scope), scope, ct);
+
+    public Task RemoveAsync(IReadOnlyCollection<string> keys, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
+        => _inner.RemoveAsync(_guard.BuildMany(keys, scope), scope, ct);
+
+    public Task<T?> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        TimeSpan ttl,
+        CacheScope scope = CacheScope.Tenant,
+        CancellationToken ct = default)
+        where T : class
+        => _inner.GetOrSetAsync(_guard.Build(key, scope), factory, ttl, scope, ct);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/ICacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/ICacheProvider.cs
@@ -1,0 +1,67 @@
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Shared cache abstraction for Cloud Health Office services.
+///
+/// Scoped deliberately to string key / object value with TTL — the 90% shape
+/// that ProviderEnrollmentService and PriorAuthRuleEngine already use against
+/// Redis. Two callers are deliberate exceptions and keep their
+/// <c>IConnectionMultiplexer</c> dependency:
+///   • <c>RedisAccumulatorService</c> — needs server-side atomic
+///     <c>HINCRBYFLOAT</c> on Redis hashes to avoid read-modify-write races
+///     between concurrent claim adjudications.
+///   • <c>RedisPaRuleRepository</c>   — needs <c>SCAN</c>-based pattern delete
+///     on state-level invalidation; the post-delete cache keys cannot be
+///     reconstructed from a <c>ruleId</c> alone.
+/// Both classes carry a <c>&lt;remarks&gt;</c> block explaining why. New
+/// consumers that look like caches should use this interface; new consumers
+/// that need Redis-native semantics (hashes, counters, pub/sub, locks,
+/// pattern deletion) own their own multiplexer and document the reason.
+///
+/// See <c>docs/architecture/shared-cache.md</c> for the decision tree.
+/// </summary>
+public interface ICacheProvider
+{
+    /// <summary>
+    /// Read a cached value. Returns <c>null</c> if the key is absent.
+    /// Deserialization failures are treated as misses — the corrupted entry
+    /// is best-effort deleted and <c>null</c> returned.
+    /// </summary>
+    Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+        where T : class;
+
+    /// <summary>
+    /// Write a value with an explicit TTL. Overwrites any existing entry at
+    /// the same key.
+    /// </summary>
+    Task SetAsync<T>(string key, T value, TimeSpan ttl,
+                     CancellationToken ct = default);
+
+    /// <summary>Delete by key. No-op if the key does not exist.</summary>
+    Task RemoveAsync(string key, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete many keys in one round trip. Used by
+    /// <c>RedisPaRuleRepository.BulkUpsertAsync</c> to invalidate every
+    /// distinct cache key touched by a bulk write.
+    /// </summary>
+    Task RemoveAsync(IReadOnlyCollection<string> keys,
+                     CancellationToken ct = default);
+
+    /// <summary>
+    /// Read-through helper. If the key is absent, invoke <paramref name="factory"/>,
+    /// cache the result with <paramref name="ttl"/>, and return it.
+    /// Concurrent misses for the same key on the same process are coalesced:
+    /// the factory is invoked at most once even under a stampede. See the
+    /// per-key <c>SingleFlightRunner</c> for the memory-bounded implementation.
+    ///
+    /// The factory MAY return <c>null</c>; a null result is NOT cached — the
+    /// next caller will re-invoke. (This matches the "tenant not configured"
+    /// semantics in <c>RedisTenantEnrollmentConfigRepository</c>.)
+    /// </summary>
+    Task<T?> GetOrSetAsync<T>(string key,
+                              Func<CancellationToken, Task<T?>> factory,
+                              TimeSpan ttl,
+                              CancellationToken ct = default)
+        where T : class;
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/ICacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/ICacheProvider.cs
@@ -18,6 +18,12 @@ namespace CloudHealthOffice.Infrastructure.Caching;
 /// that need Redis-native semantics (hashes, counters, pub/sub, locks,
 /// pattern deletion) own their own multiplexer and document the reason.
 ///
+/// All operations route through <c>CacheKeyGuard</c> in the production
+/// composition — keys are tenant-prefixed and screened for PHI tokens
+/// before they reach the backend. The <paramref name="scope"/> parameter
+/// defaults to <see cref="CacheScope.Tenant"/>; pass
+/// <see cref="CacheScope.Global"/> deliberately for platform-wide entries.
+///
 /// See <c>docs/architecture/shared-cache.md</c> for the decision tree.
 /// </summary>
 public interface ICacheProvider
@@ -27,7 +33,9 @@ public interface ICacheProvider
     /// Deserialization failures are treated as misses — the corrupted entry
     /// is best-effort deleted and <c>null</c> returned.
     /// </summary>
-    Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+    Task<T?> GetAsync<T>(string key,
+                         CacheScope scope = CacheScope.Tenant,
+                         CancellationToken ct = default)
         where T : class;
 
     /// <summary>
@@ -35,10 +43,13 @@ public interface ICacheProvider
     /// the same key.
     /// </summary>
     Task SetAsync<T>(string key, T value, TimeSpan ttl,
+                     CacheScope scope = CacheScope.Tenant,
                      CancellationToken ct = default);
 
     /// <summary>Delete by key. No-op if the key does not exist.</summary>
-    Task RemoveAsync(string key, CancellationToken ct = default);
+    Task RemoveAsync(string key,
+                     CacheScope scope = CacheScope.Tenant,
+                     CancellationToken ct = default);
 
     /// <summary>
     /// Delete many keys in one round trip. Used by
@@ -46,6 +57,7 @@ public interface ICacheProvider
     /// distinct cache key touched by a bulk write.
     /// </summary>
     Task RemoveAsync(IReadOnlyCollection<string> keys,
+                     CacheScope scope = CacheScope.Tenant,
                      CancellationToken ct = default);
 
     /// <summary>
@@ -62,6 +74,7 @@ public interface ICacheProvider
     Task<T?> GetOrSetAsync<T>(string key,
                               Func<CancellationToken, Task<T?>> factory,
                               TimeSpan ttl,
+                              CacheScope scope = CacheScope.Tenant,
                               CancellationToken ct = default)
         where T : class;
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/InMemoryCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/InMemoryCacheProvider.cs
@@ -11,6 +11,10 @@ namespace CloudHealthOffice.Infrastructure.Caching;
 /// across calls on the same key. Production code should always use a
 /// consistent type per key; the Redis implementation would raise a
 /// JsonException on the mismatch.
+///
+/// The <see cref="CacheScope"/> parameter is ignored here — scope-based
+/// prefixing happens in <see cref="GuardedCacheProvider"/>, which wraps
+/// this class in the production composition.
 /// </summary>
 internal sealed class InMemoryCacheProvider : ICacheProvider
 {
@@ -23,13 +27,13 @@ internal sealed class InMemoryCacheProvider : ICacheProvider
         _singleFlight = singleFlight;
     }
 
-    public Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+    public Task<T?> GetAsync<T>(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         where T : class
     {
         return Task.FromResult(_cache.TryGetValue<T>(key, out var value) ? value : null);
     }
 
-    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         _cache.Set(key, value, new MemoryCacheEntryOptions
         {
@@ -38,13 +42,13 @@ internal sealed class InMemoryCacheProvider : ICacheProvider
         return Task.CompletedTask;
     }
 
-    public Task RemoveAsync(string key, CancellationToken ct = default)
+    public Task RemoveAsync(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         _cache.Remove(key);
         return Task.CompletedTask;
     }
 
-    public Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+    public Task RemoveAsync(IReadOnlyCollection<string> keys, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         foreach (var k in keys) _cache.Remove(k);
         return Task.CompletedTask;
@@ -54,6 +58,7 @@ internal sealed class InMemoryCacheProvider : ICacheProvider
         string key,
         Func<CancellationToken, Task<T?>> factory,
         TimeSpan ttl,
+        CacheScope scope = CacheScope.Tenant,
         CancellationToken ct = default)
         where T : class
     {
@@ -63,7 +68,7 @@ internal sealed class InMemoryCacheProvider : ICacheProvider
                 return cached;
 
             var fresh = await factory(token).ConfigureAwait(false);
-            if (fresh is not null) await SetAsync(key, fresh, ttl, token).ConfigureAwait(false);
+            if (fresh is not null) await SetAsync(key, fresh, ttl, scope, token).ConfigureAwait(false);
             return fresh;
         }, ct);
     }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/InMemoryCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/InMemoryCacheProvider.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// <see cref="ICacheProvider"/> backed by <see cref="IMemoryCache"/> — used in
+/// Development and in unit tests. Values are stored by reference (no
+/// serialization round-trip), so this provider is noticeably faster than
+/// Redis in tight test loops but, unlike Redis, will silently tolerate type
+/// mismatches between writer and reader when <typeparamref name="T"/> differs
+/// across calls on the same key. Production code should always use a
+/// consistent type per key; the Redis implementation would raise a
+/// JsonException on the mismatch.
+/// </summary>
+internal sealed class InMemoryCacheProvider : ICacheProvider
+{
+    private readonly IMemoryCache _cache;
+    private readonly SingleFlightRunner _singleFlight;
+
+    public InMemoryCacheProvider(IMemoryCache cache, SingleFlightRunner singleFlight)
+    {
+        _cache        = cache;
+        _singleFlight = singleFlight;
+    }
+
+    public Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+        where T : class
+    {
+        return Task.FromResult(_cache.TryGetValue<T>(key, out var value) ? value : null);
+    }
+
+    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+    {
+        _cache.Set(key, value, new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = ttl
+        });
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(string key, CancellationToken ct = default)
+    {
+        _cache.Remove(key);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+    {
+        foreach (var k in keys) _cache.Remove(k);
+        return Task.CompletedTask;
+    }
+
+    public Task<T?> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        TimeSpan ttl,
+        CancellationToken ct = default)
+        where T : class
+    {
+        return _singleFlight.RunAsync<T>(key, async token =>
+        {
+            if (_cache.TryGetValue<T>(key, out var cached) && cached is not null)
+                return cached;
+
+            var fresh = await factory(token).ConfigureAwait(false);
+            if (fresh is not null) await SetAsync(key, fresh, ttl, token).ConfigureAwait(false);
+            return fresh;
+        }, ct);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/NullCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/NullCacheProvider.cs
@@ -9,23 +9,24 @@ namespace CloudHealthOffice.Infrastructure.Caching;
 /// </summary>
 internal sealed class NullCacheProvider : ICacheProvider
 {
-    public Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+    public Task<T?> GetAsync<T>(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         where T : class
         => Task.FromResult<T?>(null);
 
-    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         => Task.CompletedTask;
 
-    public Task RemoveAsync(string key, CancellationToken ct = default)
+    public Task RemoveAsync(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         => Task.CompletedTask;
 
-    public Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+    public Task RemoveAsync(IReadOnlyCollection<string> keys, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         => Task.CompletedTask;
 
     public Task<T?> GetOrSetAsync<T>(
         string key,
         Func<CancellationToken, Task<T?>> factory,
         TimeSpan ttl,
+        CacheScope scope = CacheScope.Tenant,
         CancellationToken ct = default)
         where T : class
         => factory(ct);

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/NullCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/NullCacheProvider.cs
@@ -1,0 +1,32 @@
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Explicit-disable no-op <see cref="ICacheProvider"/>. <see cref="GetAsync"/>
+/// always returns <c>null</c>; writes and invalidations are silently dropped;
+/// <see cref="GetOrSetAsync"/> invokes the factory on every call without
+/// caching. Useful for canary rollbacks (force every request to hit the
+/// backing store) and for tests that want to exercise the cold path.
+/// </summary>
+internal sealed class NullCacheProvider : ICacheProvider
+{
+    public Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+        where T : class
+        => Task.FromResult<T?>(null);
+
+    public Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task RemoveAsync(string key, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task<T?> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        TimeSpan ttl,
+        CancellationToken ct = default)
+        where T : class
+        => factory(ct);
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
@@ -15,7 +15,9 @@ namespace CloudHealthOffice.Infrastructure.Caching;
 ///
 /// This provider treats keys as opaque strings — tenant prefixing and PHI
 /// rejection are applied by <see cref="GuardedCacheProvider"/>, which wraps
-/// this type in the production composition in <c>AddChoCaching</c>.
+/// this type in the production composition in <c>AddChoCaching</c>. The
+/// <see cref="CacheScope"/> parameter is intentionally ignored here for
+/// the same reason.
 ///
 /// Redis connectivity failures degrade to cache misses (read path) or
 /// best-effort no-ops (write/invalidate path) so a Redis incident does not
@@ -37,7 +39,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         _logger       = logger;
     }
 
-    public async Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+    public async Task<T?> GetAsync<T>(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
         where T : class
     {
         try
@@ -65,7 +67,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
     }
 
-    public async Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+    public async Task SetAsync<T>(string key, T value, TimeSpan ttl, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         try
         {
@@ -79,7 +81,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
     }
 
-    public async Task RemoveAsync(string key, CancellationToken ct = default)
+    public async Task RemoveAsync(string key, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         try
         {
@@ -92,7 +94,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
     }
 
-    public async Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+    public async Task RemoveAsync(IReadOnlyCollection<string> keys, CacheScope scope = CacheScope.Tenant, CancellationToken ct = default)
     {
         if (keys.Count == 0) return;
         try
@@ -111,17 +113,18 @@ internal sealed class RedisCacheProvider : ICacheProvider
         string key,
         Func<CancellationToken, Task<T?>> factory,
         TimeSpan ttl,
+        CacheScope scope = CacheScope.Tenant,
         CancellationToken ct = default)
         where T : class
     {
         return _singleFlight.RunAsync<T>(key, async token =>
         {
-            var cached = await GetAsync<T>(key, token).ConfigureAwait(false);
+            var cached = await GetAsync<T>(key, scope, token).ConfigureAwait(false);
             if (cached is not null) return cached;
 
             var fresh = await factory(token).ConfigureAwait(false);
             if (fresh is not null)
-                await SetAsync(key, fresh, ttl, token).ConfigureAwait(false);
+                await SetAsync(key, fresh, ttl, scope, token).ConfigureAwait(false);
 
             return fresh;
         }, ct);

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using CloudHealthOffice.Infrastructure.Json;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// <see cref="ICacheProvider"/> backed by <see cref="IConnectionMultiplexer"/>.
+///
+/// Values are serialized via <see cref="CloudHealthOfficeJsonOptions.DefaultOptions"/>.
+/// Redis tracing from <c>OpenTelemetry.Instrumentation.StackExchangeRedis</c>
+/// (A.7.4) attaches at the multiplexer level, so every operation here
+/// produces a <c>db.system=redis</c> span without any additional wiring.
+///
+/// This provider treats keys as opaque strings — tenant prefixing and PHI
+/// rejection are applied by <see cref="GuardedCacheProvider"/>, which wraps
+/// this type in the production composition in <c>AddChoCaching</c>.
+///
+/// Redis connectivity failures degrade to cache misses (read path) or
+/// best-effort no-ops (write/invalidate path) so a Redis incident does not
+/// take down caller services — the backing store absorbs the load instead.
+/// </summary>
+internal sealed class RedisCacheProvider : ICacheProvider
+{
+    private readonly IConnectionMultiplexer _redis;
+    private readonly SingleFlightRunner _singleFlight;
+    private readonly ILogger<RedisCacheProvider> _logger;
+
+    public RedisCacheProvider(
+        IConnectionMultiplexer redis,
+        SingleFlightRunner singleFlight,
+        ILogger<RedisCacheProvider> logger)
+    {
+        _redis        = redis;
+        _singleFlight = singleFlight;
+        _logger       = logger;
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken ct = default)
+        where T : class
+    {
+        try
+        {
+            var db    = _redis.GetDatabase();
+            var value = await db.StringGetAsync(key).ConfigureAwait(false);
+            if (!value.HasValue) return null;
+
+            try
+            {
+                return JsonSerializer.Deserialize<T>(value!, CloudHealthOfficeJsonOptions.DefaultOptions);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Corrupted cache entry at {Key} — deleting", key);
+                try { await db.KeyDeleteAsync(key).ConfigureAwait(false); }
+                catch (RedisException) { /* best-effort */ }
+                return null;
+            }
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis unavailable on GetAsync({Key}) — treating as miss", key);
+            return null;
+        }
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken ct = default)
+    {
+        try
+        {
+            var db      = _redis.GetDatabase();
+            var payload = JsonSerializer.Serialize(value, CloudHealthOfficeJsonOptions.DefaultOptions);
+            await db.StringSetAsync(key, payload, ttl).ConfigureAwait(false);
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis unavailable on SetAsync({Key}) — entry not cached", key);
+        }
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken ct = default)
+    {
+        try
+        {
+            var db = _redis.GetDatabase();
+            await db.KeyDeleteAsync(key).ConfigureAwait(false);
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis unavailable on RemoveAsync({Key}) — stale entry will expire via TTL", key);
+        }
+    }
+
+    public async Task RemoveAsync(IReadOnlyCollection<string> keys, CancellationToken ct = default)
+    {
+        if (keys.Count == 0) return;
+        try
+        {
+            var db    = _redis.GetDatabase();
+            var array = keys.Select(k => (RedisKey)k).ToArray();
+            await db.KeyDeleteAsync(array).ConfigureAwait(false);
+        }
+        catch (RedisException ex)
+        {
+            _logger.LogWarning(ex, "Redis unavailable on bulk RemoveAsync(count={Count})", keys.Count);
+        }
+    }
+
+    public Task<T?> GetOrSetAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        TimeSpan ttl,
+        CancellationToken ct = default)
+        where T : class
+    {
+        return _singleFlight.RunAsync<T>(key, async token =>
+        {
+            var cached = await GetAsync<T>(key, token).ConfigureAwait(false);
+            if (cached is not null) return cached;
+
+            var fresh = await factory(token).ConfigureAwait(false);
+            if (fresh is not null)
+                await SetAsync(key, fresh, ttl, token).ConfigureAwait(false);
+
+            return fresh;
+        }, ct);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/RedisCacheProvider.cs
@@ -54,7 +54,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning(ex, "Corrupted cache entry at {Key} — deleting", key);
+                _logger.LogWarning(ex, "Corrupted cache entry at {Key} — deleting", LogSanitize(key));
                 try { await db.KeyDeleteAsync(key).ConfigureAwait(false); }
                 catch (RedisException) { /* best-effort */ }
                 return null;
@@ -62,7 +62,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
         catch (RedisException ex)
         {
-            _logger.LogWarning(ex, "Redis unavailable on GetAsync({Key}) — treating as miss", key);
+            _logger.LogWarning(ex, "Redis unavailable on GetAsync({Key}) — treating as miss", LogSanitize(key));
             return null;
         }
     }
@@ -77,7 +77,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
         catch (RedisException ex)
         {
-            _logger.LogWarning(ex, "Redis unavailable on SetAsync({Key}) — entry not cached", key);
+            _logger.LogWarning(ex, "Redis unavailable on SetAsync({Key}) — entry not cached", LogSanitize(key));
         }
     }
 
@@ -90,7 +90,7 @@ internal sealed class RedisCacheProvider : ICacheProvider
         }
         catch (RedisException ex)
         {
-            _logger.LogWarning(ex, "Redis unavailable on RemoveAsync({Key}) — stale entry will expire via TTL", key);
+            _logger.LogWarning(ex, "Redis unavailable on RemoveAsync({Key}) — stale entry will expire via TTL", LogSanitize(key));
         }
     }
 
@@ -128,5 +128,21 @@ internal sealed class RedisCacheProvider : ICacheProvider
 
             return fresh;
         }, ct);
+    }
+
+    /// <summary>
+    /// Strips CR/LF/NUL before a cache key enters a log entry. CacheKeyGuard
+    /// already rejects those characters at the entry boundary, but CodeQL
+    /// (and any other taint tracker) cannot see that invariant across the
+    /// Guard → Provider call boundary. Applying defense-in-depth here is
+    /// cheap and silences the cs/log-forging alerts.
+    /// </summary>
+    private static string LogSanitize(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return string.Empty;
+        return key
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\0", string.Empty);
     }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/SingleFlightRunner.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/SingleFlightRunner.cs
@@ -21,6 +21,21 @@ namespace CloudHealthOffice.Infrastructure.Caching;
 /// refcount zero and bumps <c>cho_cache_singleflight_evictions</c>. An
 /// evicted key simply loses its coalescing guarantee for that one miss
 /// window — duplicate factory invocations, not correctness loss.
+///
+/// ── Disposal ──────────────────────────────────────────────────────
+///
+/// We deliberately do NOT call <see cref="SemaphoreSlim.Dispose"/> on
+/// entries that exit via normal refcount-drain or via <see cref="TryEvict"/>.
+/// There is an inherent TOCTOU between "observe RefCount==0" /
+/// "TryRemove(key)" / "Dispose" and a concurrent <see cref="RunAsync{T}"/>
+/// caller that races through <see cref="ConcurrentDictionary{TKey, TValue}.GetOrAdd"/>
+/// + <see cref="Interlocked.Increment(ref int)"/>; closing that race by
+/// disposing would hand the late caller a disposed semaphore and raise
+/// <see cref="ObjectDisposedException"/>. <see cref="SemaphoreSlim"/>
+/// created without accessing <see cref="SemaphoreSlim.AvailableWaitHandle"/>
+/// holds no kernel resources — GC finalization is safe. The
+/// <see cref="Dispose"/> method is retained for app-shutdown paths only,
+/// where no new callers are arriving.
 /// </summary>
 internal sealed class SingleFlightRunner : IDisposable
 {
@@ -67,8 +82,11 @@ internal sealed class SingleFlightRunner : IDisposable
         {
             if (Interlocked.Decrement(ref entry.RefCount) == 0)
             {
-                if (_entries.TryRemove(new KeyValuePair<string, Entry>(key, entry)))
-                    entry.Semaphore.Dispose();
+                // TryRemove gates against a stale key/value pair — if another
+                // caller re-entered and is using the same entry, the remove
+                // fails and we leave it alone. See class remarks re: why we
+                // do not Dispose here.
+                _entries.TryRemove(new KeyValuePair<string, Entry>(key, entry));
             }
         }
     }
@@ -81,7 +99,17 @@ internal sealed class SingleFlightRunner : IDisposable
             if (Volatile.Read(ref kv.Value.RefCount) == 0 &&
                 _entries.TryRemove(kv))
             {
-                kv.Value.Semaphore.Dispose();
+                // No Dispose: a concurrent RunAsync caller may have just
+                // incremented the refcount between the Volatile.Read and
+                // TryRemove. TryRemove's value-comparison gate prevents us
+                // from removing a LIVE entry (the entry reference differs
+                // post-increment only if a new Entry was inserted, which
+                // cannot happen while we still hold the old one in the dict
+                // — so we'd never hit this branch). The surviving concern is
+                // purely the race against a caller that's *about to* call
+                // GetOrAdd with the same key and race back to this entry via
+                // the reference already obtained before TryRemove. Leaving
+                // the semaphore undisposed closes that race cleanly.
                 pruned++;
                 if (_entries.Count <= _maxInFlight) break;
             }
@@ -91,6 +119,10 @@ internal sealed class SingleFlightRunner : IDisposable
 
     public void Dispose()
     {
+        // App-shutdown path only — no live callers racing. Safe to Dispose
+        // now to return any lazily-allocated kernel handles. Entries that
+        // had their AvailableWaitHandle accessed (none in our usage) would
+        // release here.
         foreach (var kv in _entries)
         {
             if (_entries.TryRemove(kv))

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/SingleFlightRunner.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/SingleFlightRunner.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace CloudHealthOffice.Infrastructure.Caching;
+
+/// <summary>
+/// Coalesces concurrent cache-miss callers on the same key so the read-through
+/// factory is invoked at most once per miss. The alternative is a cold-start
+/// stampede where N concurrent requests each hit the backing store.
+///
+/// Implementation: a ConcurrentDictionary of refcounted entries. Each entry
+/// owns a <see cref="SemaphoreSlim"/>(1,1); the first waiter runs the factory
+/// while the rest block, then the entry is removed when its refcount returns
+/// to zero. Under normal load the dictionary oscillates around
+/// <em>concurrent outstanding misses</em>, NOT total distinct keys — no
+/// unbounded growth.
+///
+/// The <paramref name="maxInFlight"/> cap is a safety ceiling for pathological
+/// cases (a key space expanding faster than factories complete). When the cap
+/// is exceeded, an opportunistic sweep removes any entry currently at
+/// refcount zero and bumps <c>cho_cache_singleflight_evictions</c>. An
+/// evicted key simply loses its coalescing guarantee for that one miss
+/// window — duplicate factory invocations, not correctness loss.
+/// </summary>
+internal sealed class SingleFlightRunner : IDisposable
+{
+    private readonly ConcurrentDictionary<string, Entry> _entries = new();
+    private readonly int _maxInFlight;
+    private readonly Counter<long>? _evictions;
+
+    public SingleFlightRunner(int maxInFlight, Meter? meter = null)
+    {
+        _maxInFlight = maxInFlight > 0 ? maxInFlight : 10_000;
+        _evictions   = meter?.CreateCounter<long>(
+            "cho_cache_singleflight_evictions",
+            description: "Coalescer entries pruned because in-flight cap was exceeded.");
+    }
+
+    public async Task<T?> RunAsync<T>(
+        string key,
+        Func<CancellationToken, Task<T?>> factory,
+        CancellationToken ct)
+        where T : class
+    {
+        // GetOrAdd may invoke the factory redundantly under contention; the
+        // losing Entry + its semaphore are GC'd without ever entering the
+        // dict. Every caller increments the surviving entry's refcount
+        // identically — no "was I the creator?" branch needed.
+        var entry = _entries.GetOrAdd(key, _ => new Entry());
+        Interlocked.Increment(ref entry.RefCount);
+
+        if (_entries.Count > _maxInFlight) TryEvict();
+
+        try
+        {
+            await entry.Semaphore.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                return await factory(ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                entry.Semaphore.Release();
+            }
+        }
+        finally
+        {
+            if (Interlocked.Decrement(ref entry.RefCount) == 0)
+            {
+                if (_entries.TryRemove(new KeyValuePair<string, Entry>(key, entry)))
+                    entry.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private void TryEvict()
+    {
+        var pruned = 0;
+        foreach (var kv in _entries)
+        {
+            if (Volatile.Read(ref kv.Value.RefCount) == 0 &&
+                _entries.TryRemove(kv))
+            {
+                kv.Value.Semaphore.Dispose();
+                pruned++;
+                if (_entries.Count <= _maxInFlight) break;
+            }
+        }
+        if (pruned > 0) _evictions?.Add(pruned);
+    }
+
+    public void Dispose()
+    {
+        foreach (var kv in _entries)
+        {
+            if (_entries.TryRemove(kv))
+                kv.Value.Semaphore.Dispose();
+        }
+    }
+
+    private sealed class Entry
+    {
+        public readonly SemaphoreSlim Semaphore = new(1, 1);
+        public int RefCount;
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
 
     <!-- OpenTelemetry -->

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Json/CloudHealthOfficeJsonOptions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Json/CloudHealthOfficeJsonOptions.cs
@@ -61,6 +61,11 @@ public static class CloudHealthOfficeJsonOptions
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
         opts.Converters.Add(new JsonStringEnumConverter());
+        // Freeze. A mutable singleton surfaces as a subtle global: any
+        // caller adding a Converter here would reshape serialization for
+        // every sibling service that consumes this property. MakeReadOnly
+        // converts future mutation into a clear InvalidOperationException.
+        opts.MakeReadOnly();
         return opts;
     }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Json/CloudHealthOfficeJsonOptions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Json/CloudHealthOfficeJsonOptions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -38,5 +39,28 @@ public static class CloudHealthOfficeJsonOptions
         {
             o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
         });
+    }
+
+    /// <summary>
+    /// Default <see cref="JsonSerializerOptions"/> for non-MVC serialization paths —
+    /// Redis cache payloads, Service Bus envelopes, Cosmos document bodies that
+    /// round-trip through the app. camelCase on the wire, omit-null-on-write
+    /// (smaller payloads, cheaper Redis), and the same string-enum convention
+    /// the MVC pipeline uses.
+    ///
+    /// PascalCase-on-the-wire surfaces must continue to use their own local
+    /// <c>JsonSerializerOptions</c> — see docs/architecture/shared-json-options.md.
+    /// </summary>
+    public static JsonSerializerOptions DefaultOptions { get; } = CreateDefault();
+
+    private static JsonSerializerOptions CreateDefault()
+    {
+        var opts = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy   = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+        opts.Converters.Add(new JsonStringEnumConverter());
+        return opts;
     }
 }

--- a/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
+++ b/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
@@ -4,6 +4,8 @@ using CloudHealthOffice.PriorAuthRuleEngine.Domain;
 using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using CloudHealthOffice.PriorAuthRuleEngine.Persistence;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -35,14 +37,33 @@ public class RedisPaRuleRepositoryTests
     };
     private const string TxStarCacheKey = "pa-rules:TX:3:STAR:pchp";
 
+    private readonly CacheKeyGuard _keyGuard = BuildGuard();
+
     public RedisPaRuleRepositoryTests()
     {
         _sut = new RedisPaRuleRepository(
             _inner,
             _cache,
             _multiplexer,
+            _keyGuard,
             Options.Create(new PriorAuthRuleEngineOptions { RuleSetCacheTtl = Ttl }),
             Substitute.For<ILogger<RedisPaRuleRepository>>());
+    }
+
+    private static CacheKeyGuard BuildGuard()
+    {
+        var accessor = new HttpContextAccessor();
+        var env = new FakeEnv { EnvironmentName = "test" };
+        return new CacheKeyGuard(accessor, env);
+    }
+
+    private sealed class FakeEnv : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "test";
+        public string ApplicationName { get; set; } = "cho-test";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
     }
 
     [Fact]
@@ -132,7 +153,7 @@ public class RedisPaRuleRepositoryTests
     }
 
     [Fact]
-    public async Task DeleteAsync_FlushesStateKeys_ViaMultiplexerScan()
+    public async Task DeleteAsync_FlushesStateKeys_ViaAnchoredScan()
     {
         var server   = Substitute.For<IServer>();
         var database = Substitute.For<IDatabase>();
@@ -151,13 +172,26 @@ public class RedisPaRuleRepositoryTests
             Arg.Any<CommandFlags>())
             .Returns(new RedisKey[]
             {
-                "development:_global:pa-rules:TX:3:STAR:pchp",
-                "development:_global:pa-rules:TX:3:any:platform"
+                "test:_global:pa-rules:TX:3:STAR:pchp",
+                "test:_global:pa-rules:TX:3:any:platform"
             });
 
         await _sut.DeleteAsync("TX-STAR-REG-001", "TX");
 
         await _inner.Received(1).DeleteAsync("TX-STAR-REG-001", "TX", Arg.Any<CancellationToken>());
+
+        // SCAN pattern is ANCHORED at the guard prefix — no leading wildcard.
+        // Copilot flagged the previous "*pa-rules:…" pattern because it
+        // forced SCAN to traverse the entire keyspace; the anchored form
+        // keeps Redis's trie pruning intact. Keys() is synchronous on IServer.
+        server.Received(1).Keys(
+            Arg.Any<int>(),
+            Arg.Is<RedisValue>(v => v.ToString() == "test:_global:pa-rules:TX:*"),
+            Arg.Any<int>(),
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Any<CommandFlags>());
+
         // SCAN path goes direct to multiplexer — bulk RemoveAsync on
         // ICacheProvider must NOT be called (it would double-prefix).
         await database.Received(1).KeyDeleteAsync(
@@ -167,6 +201,27 @@ public class RedisPaRuleRepositoryTests
             Arg.Any<IReadOnlyCollection<string>>(),
             Arg.Any<CacheScope>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithoutMultiplexer_SkipsScanGracefully()
+    {
+        // When the cache backend is InMemory / Null, AddChoCaching does not
+        // register IConnectionMultiplexer. RedisPaRuleRepository must still
+        // construct — the SCAN path becomes a debug-logged no-op. Exact-key
+        // invalidation on Upsert/BulkUpsert covers the common write path.
+        var sutWithoutMux = new RedisPaRuleRepository(
+            _inner,
+            _cache,
+            multiplexer: null,
+            _keyGuard,
+            Options.Create(new PriorAuthRuleEngineOptions { RuleSetCacheTtl = Ttl }),
+            Substitute.For<ILogger<RedisPaRuleRepository>>());
+
+        await sutWithoutMux.DeleteAsync("TX-STAR-REG-001", "TX");
+
+        await _inner.Received(1).DeleteAsync("TX-STAR-REG-001", "TX", Arg.Any<CancellationToken>());
+        // No multiplexer → no SCAN, no KeyDelete, no throw.
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
+++ b/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.PriorAuthRuleEngine.Domain;
 using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using CloudHealthOffice.PriorAuthRuleEngine.Persistence;
@@ -8,52 +7,179 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using StackExchange.Redis;
 
 namespace CloudHealthOffice.PriorAuthRuleEngine.Tests.Persistence;
 
+/// <summary>
+/// Post-A.7.2 tests: the K/V operations go through <see cref="ICacheProvider"/>
+/// and we mock it directly. The SCAN-based state flush still uses
+/// <see cref="IConnectionMultiplexer"/> — the deliberate exception — so the
+/// delete path tests still mock <c>IServer</c> for Keys() and <c>IDatabase</c>
+/// for KeyDelete().
+/// </summary>
 public class RedisPaRuleRepositoryTests
 {
-    private readonly IPaRuleRepository _inner;
-    private readonly IDatabase _db;
-    private readonly IConnectionMultiplexer _redis;
+    private readonly IPaRuleRepository _inner = Substitute.For<IPaRuleRepository>();
+    private readonly ICacheProvider _cache = Substitute.For<ICacheProvider>();
+    private readonly IConnectionMultiplexer _multiplexer = Substitute.For<IConnectionMultiplexer>();
     private readonly RedisPaRuleRepository _sut;
 
     private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(15);
-
-    private static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     private static readonly RuleSetKey TxStarKey = new()
     {
         StateCode = "TX",
-        Lob = PaLineOfBusiness.Medicaid,
-        Program = "STAR",
-        TenantId = "pchp"
+        Lob       = PaLineOfBusiness.Medicaid,
+        Program   = "STAR",
+        TenantId  = "pchp"
     };
+    private const string TxStarCacheKey = "pa-rules:TX:3:STAR:pchp";
 
     public RedisPaRuleRepositoryTests()
     {
-        _inner = Substitute.For<IPaRuleRepository>();
-        _db = Substitute.For<IDatabase>();
-        _redis = Substitute.For<IConnectionMultiplexer>();
-
-        // GetDatabase() is called in the constructor — must return _db
-        _redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(_db);
-        // Needed by TryFlushStateAsync → _db.Multiplexer
-        _db.Multiplexer.Returns(_redis);
-
         _sut = new RedisPaRuleRepository(
             _inner,
-            _redis,
+            _cache,
+            _multiplexer,
             Options.Create(new PriorAuthRuleEngineOptions { RuleSetCacheTtl = Ttl }),
             Substitute.For<ILogger<RedisPaRuleRepository>>());
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetRulesAsync_DelegatesToCacheProvider_WithGlobalScope()
+    {
+        _cache.GetOrSetAsync<object>(
+            Arg.Any<string>(),
+            Arg.Any<Func<CancellationToken, Task<object?>>>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CacheScope>(),
+            Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(Task.FromResult<object?>(null));
+
+        await _sut.GetRulesAsync(TxStarKey);
+
+        // Verify exactly one GetOrSetAsync with the expected key + scope.
+        var calls = _cache.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(ICacheProvider.GetOrSetAsync))
+            .ToList();
+        calls.Should().HaveCount(1);
+
+        var args = calls[0].GetArguments();
+        args[0].Should().Be(TxStarCacheKey);
+        args[2].Should().Be(Ttl);
+        args[3].Should().Be(CacheScope.Global);
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_FactoryDelegatesToInner_AndReturnsWrappedRules()
+    {
+        var rules = new List<PaRuleDocument> { MakeRule() };
+        _inner.GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>()).Returns(rules);
+
+        // Invoke the factory the SUT passes in — verify it hits the inner
+        // repo and that the SUT unwraps the CachedRuleSet shape correctly.
+        _cache.GetOrSetAsync(
+                Arg.Any<string>(),
+                Arg.Any<Func<CancellationToken, Task<object?>>>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CacheScope>(),
+                Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(async ci =>
+            {
+                var factory = (Delegate)ci.ArgAt<object>(1);
+                var result = await (Task<object?>)factory.DynamicInvoke(CancellationToken.None)!;
+                return result;
+            });
+
+        var result = await _sut.GetRulesAsync(TxStarKey);
+
+        result.Should().HaveCount(1);
+        result[0].RuleId.Should().Be("TX-STAR-REG-001");
+        await _inner.Received(1).GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WritesToInner_ThenInvalidatesExactKey()
+    {
+        var rule = MakeRule();
+
+        await _sut.UpsertAsync(rule);
+
+        Received.InOrder(() =>
+        {
+            _inner.UpsertAsync(rule, Arg.Any<CancellationToken>());
+            _cache.RemoveAsync(TxStarCacheKey, CacheScope.Global, Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task BulkUpsertAsync_WritesToInner_ThenBulkInvalidatesDistinctKeys()
+    {
+        var rules = new[]
+        {
+            MakeRule(ruleId: "R1", program: "STAR"),
+            MakeRule(ruleId: "R2", program: "STAR"),       // dup key
+            MakeRule(ruleId: "R3", program: "STARPlus")    // different key
+        };
+
+        await _sut.BulkUpsertAsync(rules);
+
+        await _inner.Received(1).BulkUpsertAsync(Arg.Any<IEnumerable<PaRuleDocument>>(), Arg.Any<CancellationToken>());
+        await _cache.Received(1).RemoveAsync(
+            Arg.Is<IReadOnlyCollection<string>>(keys => keys.Count == 2),
+            CacheScope.Global,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_FlushesStateKeys_ViaMultiplexerScan()
+    {
+        var server   = Substitute.For<IServer>();
+        var database = Substitute.For<IDatabase>();
+        var endpoint = new DnsEndPoint("localhost", 6379);
+
+        _multiplexer.GetEndPoints(Arg.Any<bool>()).Returns(new EndPoint[] { endpoint });
+        _multiplexer.GetServer(endpoint, Arg.Any<object>()).Returns(server);
+        _multiplexer.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(database);
+
+        server.Keys(
+            Arg.Any<int>(),
+            Arg.Any<RedisValue>(),
+            Arg.Any<int>(),
+            Arg.Any<long>(),
+            Arg.Any<int>(),
+            Arg.Any<CommandFlags>())
+            .Returns(new RedisKey[]
+            {
+                "development:_global:pa-rules:TX:3:STAR:pchp",
+                "development:_global:pa-rules:TX:3:any:platform"
+            });
+
+        await _sut.DeleteAsync("TX-STAR-REG-001", "TX");
+
+        await _inner.Received(1).DeleteAsync("TX-STAR-REG-001", "TX", Arg.Any<CancellationToken>());
+        // SCAN path goes direct to multiplexer — bulk RemoveAsync on
+        // ICacheProvider must NOT be called (it would double-prefix).
+        await database.Received(1).KeyDeleteAsync(
+            Arg.Is<RedisKey[]>(ks => ks.Length == 2),
+            Arg.Any<CommandFlags>());
+        await _cache.DidNotReceive().RemoveAsync(
+            Arg.Any<IReadOnlyCollection<string>>(),
+            Arg.Any<CacheScope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_BypassesCache()
+    {
+        var rules = new List<PaRuleDocument> { MakeRule() };
+        _inner.ListAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(rules);
+
+        var result = await _sut.ListAsync(tenantId: "pchp", stateCode: "TX");
+
+        result.Should().HaveCount(1);
+        await _inner.Received(1).ListAsync("pchp", "TX", Arg.Any<CancellationToken>());
+    }
 
     private static PaRuleDocument MakeRule(
         string ruleId = "TX-STAR-REG-001",
@@ -62,172 +188,15 @@ public class RedisPaRuleRepositoryTests
         string? program = "STAR",
         string? tenantId = "pchp") => new()
     {
-        RuleId = ruleId,
-        RuleName = $"Rule {ruleId}",
+        RuleId    = ruleId,
+        RuleName  = $"Rule {ruleId}",
         StateCode = stateCode,
-        Lob = lob,
-        Program = program,
-        TenantId = tenantId,
-        Category = RuleCategory.RegulatoryExemption,
-        Scope = tenantId is null ? RuleScope.Platform : RuleScope.Tenant,
-        Priority = 1,
-        RuleType = "TxGoldCardExemption"
+        Lob       = lob,
+        Program   = program,
+        TenantId  = tenantId,
+        Category  = RuleCategory.RegulatoryExemption,
+        Scope     = tenantId is null ? RuleScope.Platform : RuleScope.Tenant,
+        Priority  = 1,
+        RuleType  = "TxGoldCardExemption"
     };
-
-    // ── 1. Cache hit ─────────────────────────────────────────────────
-
-    [Fact]
-    public async Task GetRulesAsync_CacheHit_ReturnsDeserializedRules_WithoutHittingInner()
-    {
-        var rules = new List<PaRuleDocument> { MakeRule() };
-        var json = JsonSerializer.Serialize(rules, JsonOpts);
-
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns((RedisValue)json);
-
-        var result = await _sut.GetRulesAsync(TxStarKey);
-
-        result.Should().HaveCount(1);
-        result[0].RuleId.Should().Be("TX-STAR-REG-001");
-
-        await _inner.DidNotReceive()
-            .GetRulesAsync(Arg.Any<RuleSetKey>(), Arg.Any<CancellationToken>());
-    }
-
-    // ── 2. Cache miss ────────────────────────────────────────────────
-
-    [Fact]
-    public async Task GetRulesAsync_CacheMiss_CallsInner_CachesResult_WithCorrectTtl()
-    {
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(RedisValue.Null);
-
-        var rules = new List<PaRuleDocument> { MakeRule() };
-        _inner.GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>())
-            .Returns(rules);
-
-        var result = await _sut.GetRulesAsync(TxStarKey);
-
-        result.Should().HaveCount(1);
-
-        await _inner.Received(1)
-            .GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>());
-
-        await _db.Received(1).StringSetAsync(
-            Arg.Any<RedisKey>(),
-            Arg.Any<RedisValue>(),
-            Ttl,
-            Arg.Any<bool>(),
-            Arg.Any<When>(),
-            Arg.Any<CommandFlags>());
-    }
-
-    // ── 3. Redis throws ──────────────────────────────────────────────
-
-    [Fact]
-    public async Task GetRulesAsync_RedisThrows_FallsThroughToInner()
-    {
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
-
-        var rules = new List<PaRuleDocument> { MakeRule() };
-        _inner.GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>())
-            .Returns(rules);
-
-        var result = await _sut.GetRulesAsync(TxStarKey);
-
-        result.Should().HaveCount(1);
-        await _inner.Received(1)
-            .GetRulesAsync(TxStarKey, Arg.Any<CancellationToken>());
-    }
-
-    // ── 4. Cache key format ──────────────────────────────────────────
-
-    [Fact]
-    public async Task GetRulesAsync_CacheKey_Format_IsCorrect()
-    {
-        // PaLineOfBusiness.Medicaid = 3
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(RedisValue.Null);
-        _inner.GetRulesAsync(Arg.Any<RuleSetKey>(), Arg.Any<CancellationToken>())
-            .Returns(Array.Empty<PaRuleDocument>());
-
-        await _sut.GetRulesAsync(TxStarKey);
-
-        await _db.Received().StringGetAsync(
-            (RedisKey)"pa-rules:TX:3:STAR:pchp",
-            Arg.Any<CommandFlags>());
-    }
-
-    // ── 5. Upsert invalidates ────────────────────────────────────────
-
-    [Fact]
-    public async Task UpsertAsync_WritesToInner_ThenInvalidatesCacheKey()
-    {
-        var rule = MakeRule();
-
-        await _sut.UpsertAsync(rule);
-
-        await _inner.Received(1).UpsertAsync(rule, Arg.Any<CancellationToken>());
-
-        await _db.Received(1).KeyDeleteAsync(
-            (RedisKey)"pa-rules:TX:3:STAR:pchp",
-            Arg.Any<CommandFlags>());
-    }
-
-    // ── 6. BulkUpsert deduplicates keys ──────────────────────────────
-
-    [Fact]
-    public async Task BulkUpsertAsync_InvalidatesAllAffectedKeys_Deduplicated()
-    {
-        // 3 rules: 2 share the same key (TX/Medicaid/STAR/pchp), 1 different (TX/Medicaid/STARPlus/pchp)
-        var rules = new[]
-        {
-            MakeRule(ruleId: "R1", program: "STAR"),
-            MakeRule(ruleId: "R2", program: "STAR"),
-            MakeRule(ruleId: "R3", program: "STARPlus")
-        };
-
-        await _sut.BulkUpsertAsync(rules);
-
-        await _inner.Received(1)
-            .BulkUpsertAsync(Arg.Any<IEnumerable<PaRuleDocument>>(), Arg.Any<CancellationToken>());
-
-        // KeyDeleteAsync(RedisKey[]) — should be called with exactly 2 distinct keys
-        await _db.Received(1).KeyDeleteAsync(
-            Arg.Is<RedisKey[]>(keys => keys.Length == 2),
-            Arg.Any<CommandFlags>());
-    }
-
-    // ── 7. Delete flushes state keys via SCAN ────────────────────────
-
-    [Fact]
-    public async Task DeleteAsync_FlushesAllKeysForState_UsingScan()
-    {
-        var server = Substitute.For<IServer>();
-        var endpoint = new DnsEndPoint("localhost", 6379);
-
-        _redis.GetEndPoints(Arg.Any<bool>()).Returns(new EndPoint[] { endpoint });
-        _redis.GetServer(endpoint, Arg.Any<object>()).Returns(server);
-
-        // Server.Keys returns matching keys
-        server.Keys(
-            Arg.Any<int>(),
-            Arg.Is<RedisValue>(v => v.ToString().Contains("pa-rules:TX:*")),
-            Arg.Any<int>(),
-            Arg.Any<long>(),
-            Arg.Any<int>(),
-            Arg.Any<CommandFlags>())
-            .Returns(new RedisKey[] { "pa-rules:TX:3:STAR:pchp", "pa-rules:TX:3:any:platform" });
-
-        await _sut.DeleteAsync("TX-STAR-REG-001", "TX");
-
-        await _inner.Received(1)
-            .DeleteAsync("TX-STAR-REG-001", "TX", Arg.Any<CancellationToken>());
-
-        // KeyDeleteAsync called with the 2 keys from SCAN
-        await _db.Received(1).KeyDeleteAsync(
-            Arg.Is<RedisKey[]>(keys => keys.Length == 2),
-            Arg.Any<CommandFlags>());
-    }
 }

--- a/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Cache/RedisTenantEnrollmentConfigRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Cache/RedisTenantEnrollmentConfigRepositoryTests.cs
@@ -1,5 +1,4 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using CloudHealthOffice.Infrastructure.Caching;
 using CloudHealthOffice.ProviderEnrollmentService.Cache;
 using CloudHealthOffice.ProviderEnrollmentService.Models;
 using FluentAssertions;
@@ -7,170 +6,144 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using StackExchange.Redis;
 
 namespace CloudHealthOffice.ProviderEnrollmentService.Tests.Cache;
 
+/// <summary>
+/// Post-A.7.2 tests: the decorator now delegates to <see cref="ICacheProvider"/>
+/// instead of reaching into <c>IConnectionMultiplexer</c>. We assert the same
+/// observable behaviour — hit-short-circuits-inner, miss-calls-inner,
+/// write-invalidates — through the abstraction.
+/// </summary>
 public class RedisTenantEnrollmentConfigRepositoryTests
 {
-    private readonly ITenantEnrollmentConfigRepository _inner;
-    private readonly IDatabase _db;
+    private readonly ITenantEnrollmentConfigRepository _inner = Substitute.For<ITenantEnrollmentConfigRepository>();
+    private readonly ICacheProvider _cache = Substitute.For<ICacheProvider>();
     private readonly RedisTenantEnrollmentConfigRepository _sut;
 
     private const string TenantId = "pchp";
     private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
-
-    // Must match the JsonSerializerOptions used inside the production code
-    private static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        PropertyNamingPolicy   = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
+    private static readonly string ExpectedKey = $"enrollment:config:{TenantId}";
 
     public RedisTenantEnrollmentConfigRepositoryTests()
     {
-        _inner = Substitute.For<ITenantEnrollmentConfigRepository>();
-        _db = Substitute.For<IDatabase>();
-
-        var redis = Substitute.For<IConnectionMultiplexer>();
-        redis.GetDatabase(Arg.Any<int>(), Arg.Any<object>()).Returns(_db);
-
-        var options = Options.Create(new ProviderEnrollmentOptions
-        {
-            TenantConfigCacheTtl = Ttl
-        });
-        var logger = Substitute.For<ILogger<RedisTenantEnrollmentConfigRepository>>();
-
-        _sut = new RedisTenantEnrollmentConfigRepository(_inner, redis, options, logger);
+        var options = Options.Create(new ProviderEnrollmentOptions { TenantConfigCacheTtl = Ttl });
+        _sut = new RedisTenantEnrollmentConfigRepository(
+            _inner, _cache, options,
+            Substitute.For<ILogger<RedisTenantEnrollmentConfigRepository>>());
     }
 
-    // ── 1. Redis hit returns cached config without touching inner repo ──
-
     [Fact]
-    public async Task GetAsync_RedisHit_ReturnsCachedConfig_WithoutHittingInnerRepository()
+    public async Task GetAsync_DelegatesToGetOrSetAsync_WithCorrectKeyAndTtl()
     {
-        // Arrange
         var config = MakeConfig();
-        var json = JsonSerializer.Serialize(config, JsonOpts);
 
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns((RedisValue)json);
-
-        // Act
-        var result = await _sut.GetAsync(TenantId);
-
-        // Assert
-        result.Should().NotBeNull();
-        result!.TenantId.Should().Be(TenantId);
-        result.DefaultGateMode.Should().Be(EnrollmentGateMode.Enforce);
-
-        await _inner.DidNotReceive()
-            .GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    // ── 2. Redis miss falls through to inner, caches the result ─────
-
-    [Fact]
-    public async Task GetAsync_RedisMiss_HitsInnerRepository_AndCachesResult()
-    {
-        // Arrange — Redis returns nothing
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(RedisValue.Null);
-
-        var config = MakeConfig();
-        _inner.GetAsync(TenantId, Arg.Any<CancellationToken>())
+        _cache.GetOrSetAsync<TenantEnrollmentConfig>(
+                Arg.Any<string>(),
+                Arg.Any<Func<CancellationToken, Task<TenantEnrollmentConfig?>>>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CacheScope>(),
+                Arg.Any<CancellationToken>())
             .Returns(config);
 
-        // Act
         var result = await _sut.GetAsync(TenantId);
 
-        // Assert — correct result
         result.Should().NotBeNull();
         result!.TenantId.Should().Be(TenantId);
 
-        // Assert — StringSetAsync called with right key and TTL
-        await _db.Received(1).StringSetAsync(
-            (RedisKey)$"enrollment:config:{TenantId}",
-            Arg.Any<RedisValue>(),
+        await _cache.Received(1).GetOrSetAsync<TenantEnrollmentConfig>(
+            ExpectedKey,
+            Arg.Any<Func<CancellationToken, Task<TenantEnrollmentConfig?>>>(),
             Ttl,
-            Arg.Any<bool>(),
-            Arg.Any<When>(),
-            Arg.Any<CommandFlags>());
+            CacheScope.Tenant,
+            Arg.Any<CancellationToken>());
     }
 
-    // ── 3. Null from inner repo does NOT get cached ─────────────────
-
     [Fact]
-    public async Task GetAsync_NullResultFromInner_DoesNotCache()
+    public async Task GetAsync_FactoryHitsInnerRepository_WhenInvoked()
     {
-        // Arrange
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .Returns(RedisValue.Null);
-
-        _inner.GetAsync(TenantId, Arg.Any<CancellationToken>())
-            .Returns((TenantEnrollmentConfig?)null);
-
-        // Act
-        var result = await _sut.GetAsync(TenantId);
-
-        // Assert
-        result.Should().BeNull();
-
-        await _db.DidNotReceive().StringSetAsync(
-            Arg.Any<RedisKey>(),
-            Arg.Any<RedisValue>(),
-            Arg.Any<TimeSpan?>(),
-            Arg.Any<bool>(),
-            Arg.Any<When>(),
-            Arg.Any<CommandFlags>());
-    }
-
-    // ── 4. Redis exception falls through to inner repo ──────────────
-
-    [Fact]
-    public async Task GetAsync_RedisThrows_FallsThroughToInnerRepository()
-    {
-        // Arrange — Redis blows up
-        _db.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
-            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
-
         var config = MakeConfig();
-        _inner.GetAsync(TenantId, Arg.Any<CancellationToken>())
-            .Returns(config);
+        _inner.GetAsync(TenantId, Arg.Any<CancellationToken>()).Returns(config);
 
-        // Act
+        // Capture and invoke the factory the SUT handed to GetOrSetAsync.
+        Func<CancellationToken, Task<TenantEnrollmentConfig?>>? factory = null;
+        _cache.GetOrSetAsync<TenantEnrollmentConfig>(
+                Arg.Any<string>(),
+                Arg.Do<Func<CancellationToken, Task<TenantEnrollmentConfig?>>>(f => factory = f),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CacheScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ci => factory!(CancellationToken.None));
+
         var result = await _sut.GetAsync(TenantId);
 
-        // Assert — inner repo result returned despite Redis failure
         result.Should().NotBeNull();
-        result!.TenantId.Should().Be(TenantId);
-
-        await _inner.Received(1)
-            .GetAsync(TenantId, Arg.Any<CancellationToken>());
+        await _inner.Received(1).GetAsync(TenantId, Arg.Any<CancellationToken>());
     }
 
-    // ── 5. Upsert writes to inner then invalidates Redis key ────────
-
     [Fact]
-    public async Task UpsertAsync_WritesToInnerRepo_ThenInvalidatesRedisKey()
+    public async Task UpsertAsync_WritesToInnerRepo_ThenInvalidatesCache()
     {
-        // Arrange
         var config = MakeConfig();
 
-        // Act
         await _sut.UpsertAsync(config);
 
-        // Assert — inner repo written
-        await _inner.Received(1)
-            .UpsertAsync(config, Arg.Any<CancellationToken>());
-
-        // Assert — Redis key invalidated
-        await _db.Received(1).KeyDeleteAsync(
-            (RedisKey)$"enrollment:config:{TenantId}",
-            Arg.Any<CommandFlags>());
+        Received.InOrder(() =>
+        {
+            _inner.UpsertAsync(config, Arg.Any<CancellationToken>());
+            _cache.RemoveAsync(ExpectedKey, CacheScope.Tenant, Arg.Any<CancellationToken>());
+        });
     }
 
-    // ── 6. ResolveFor: LOB override wins over tenant default ────────
+    [Fact]
+    public async Task DeleteAsync_RemovesFromInnerRepo_ThenInvalidatesCache()
+    {
+        await _sut.DeleteAsync(TenantId);
+
+        Received.InOrder(() =>
+        {
+            _inner.DeleteAsync(TenantId, Arg.Any<CancellationToken>());
+            _cache.RemoveAsync(ExpectedKey, CacheScope.Tenant, Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task ListAsync_BypassesCache()
+    {
+        var configs = new List<TenantEnrollmentConfig> { MakeConfig() };
+        _inner.ListAsync(Arg.Any<CancellationToken>()).Returns(configs);
+
+        var result = await _sut.ListAsync();
+
+        result.Should().HaveCount(1);
+        await _inner.Received(1).ListAsync(Arg.Any<CancellationToken>());
+
+        // No cache interactions on the admin path
+        await _cache.DidNotReceive().GetOrSetAsync<TenantEnrollmentConfig>(
+            Arg.Any<string>(),
+            Arg.Any<Func<CancellationToken, Task<TenantEnrollmentConfig?>>>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CacheScope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetAsync_CacheProviderThrows_BubblesUp()
+    {
+        // ICacheProvider is expected to absorb Redis failures internally;
+        // if it throws anyway, the decorator surfaces the exception so
+        // an infrastructure failure doesn't get silently swallowed twice.
+        _cache.GetOrSetAsync<TenantEnrollmentConfig>(
+                Arg.Any<string>(),
+                Arg.Any<Func<CancellationToken, Task<TenantEnrollmentConfig?>>>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CacheScope>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("cache layer bug"));
+
+        await FluentActions.Awaiting(() => _sut.GetAsync(TenantId))
+            .Should().ThrowAsync<InvalidOperationException>();
+    }
 
     [Theory]
     [InlineData(LineOfBusiness.Marketplace, EnrollmentGateMode.Disabled)]
@@ -179,7 +152,6 @@ public class RedisTenantEnrollmentConfigRepositoryTests
     public void ResolveFor_LobOverride_WinsOverTenantDefault(
         LineOfBusiness lob, EnrollmentGateMode expectedGateMode)
     {
-        // Arrange — Warn by default, Marketplace overridden to Disabled
         var config = new TenantEnrollmentConfig
         {
             TenantId        = TenantId,
@@ -194,16 +166,12 @@ public class RedisTenantEnrollmentConfigRepositoryTests
             ]
         };
 
-        // Act
         var resolved = config.ResolveFor(lob);
 
-        // Assert
         resolved.GateMode.Should().Be(expectedGateMode);
         resolved.TenantId.Should().Be(TenantId);
         resolved.Lob.Should().Be(lob);
     }
-
-    // ── Helpers ──────────────────────────────────────────────────────
 
     private static TenantEnrollmentConfig MakeConfig() => new()
     {


### PR DESCRIPTION
## Summary

ICacheProvider deliberately covers the 90% of Redis usage that is K/V-with-TTL. Two consumers are called out as deliberate exceptions — **RedisAccumulatorService** (atomic hash increments) and **PaRuleRepository** (pattern-based SCAN invalidation) — each keeps direct `IConnectionMultiplexer` access with a class-level XML comment explaining the specific Redis-native capability that would be lost by going through the abstraction.

- **New abstraction** in [`CloudHealthOffice.Infrastructure.Caching`](src/services/shared/CloudHealthOffice.Infrastructure/Caching/): `ICacheProvider` + `RedisCacheProvider` / `InMemoryCacheProvider` / `NullCacheProvider`, `CacheKeyGuard` (mandatory tenant prefix + PHI-token rejection), `GuardedCacheProvider` decorator, `SingleFlightRunner` (per-key semaphore coalescer with LRU-style cap + `cho_cache_singleflight_evictions` metric), `AddChoCaching(...)` mirroring `AddChoMessaging`.
- **Migrations**: `RedisTenantEnrollmentConfigRepository` and the K/V paths of `RedisPaRuleRepository` now use `ICacheProvider`. `RedisPaRuleRepository` remains dual-dependent because its `DeleteAsync` requires a SCAN across `pa-rules:{state}:*` — the cache key cannot be reconstructed from `(ruleId, stateCode)`. TODO(scale) documents the sidecar-index follow-up.
- **Hosts**: `benefit-plan-service` keeps its direct `IConnectionMultiplexer` (accumulator path) and adds `AddChoCaching`. `fhir-service` replaces its conditional multiplexer registration with `AddChoCaching` alone; the multiplexer is provisioned in DI by `AddChoCaching` on the Redis backend path (via `TryAddSingleton`).
- **Docs**: [`docs/architecture/shared-cache.md`](docs/architecture/shared-cache.md) — decision tree, the two deliberate exceptions, tenant-prefix / PHI contract with worked examples, migration guidance.
- **Ops**: [`scripts/azure/provision-redis.sh`](scripts/azure/provision-redis.sh) — idempotent `az redis` script, mirrors `provision-servicebus-queues.sh`.

Net: **+8 commits**, roughly +1800 / -300 LOC.

## Acceptance

- ✅ `ConnectionMultiplexer.Connect` zero hits in migrated engines (`ProviderEnrollmentService`, `PriorAuthRuleEngine`); remaining hits only in `benefit-plan-service/Program.cs`, `AddChoCaching` itself, and the real-Redis test fixture.
- ✅ Direct `StackExchange.Redis` dropped from `ProviderEnrollmentService`, `PriorAuthRuleEngine`, and `fhir-service` csprojs (transitive via Infrastructure).
- ✅ Retained in `BenefitEngine` + `benefit-plan-service` csprojs (accumulator path).
- ✅ OpenTelemetry Redis instrumentation preserved — `RedisCacheProvider` flows through the same `IConnectionMultiplexer` A.7.4 traces.
- ✅ Full-solution build clean (0 errors; 58 pre-existing warnings unrelated to this PR).

## Test plan

- [ ] CI green on `CloudHealthOffice.Infrastructure.Tests` (contract + key guard + auto-resolution)
- [ ] CI green on `CloudHealthOffice.ProviderEnrollmentService.Tests` (harness mocks updated to `ICacheProvider`)
- [ ] CI green on `CloudHealthOffice.PriorAuthRuleEngine.Tests` (harness mocks updated; SCAN path still asserts against `IConnectionMultiplexer`)
- [ ] Integration fixture `RedisCacheProviderContractTests` skips when `CHO_REDIS_CONNECTION_STRING` is not set
- [ ] Deploy to dev, verify startup log line `ICacheProvider=Redis (Auto; ConnectionString configured; env=Development)` (or `=InMemory (Auto; env=Development)` for local) on both `benefit-plan-service` and `fhir-service`
- [ ] Deploy to dev, confirm cache operations surface as `db.system=redis` spans in Jaeger / OTLP backend
- [ ] Deprecation warning for `Redis:ConnectionString` fires once at startup on any host that hasn't migrated to `Caching:RedisConnectionString`

🤖 Generated with [Claude Code](https://claude.com/claude-code)