### PR TITLE
feat(infra): A.7.3 — secret rotation (RotatingKeyProvider + 0x02 envelopes + dual-read fingerprinter)

### DIFF
--- a/docs/architecture/secret-rotation.md
+++ b/docs/architecture/secret-rotation.md
@@ -93,10 +93,14 @@ silently allow duplicate identifiers past the 409.
 `RotatingKeyProviderHealthCheck` (`Infrastructure/HealthChecks/`) accepts
 a list of `(secretPrefix, versions)` probes and reports Degraded (not
 Unhealthy) if any accepted version is unresolvable. Degraded rather than
-Unhealthy because a missing legacy version is a compliance concern, not
-a serve-5xx concern — readers tolerate it (fingerprinter logs-and-skips,
-decryptor raises `StaleEncryptionKeyException` on a hit) but ops must be
-paged to restore the secret before backfill or rotation completes.
+Unhealthy because a missing legacy version is an operational concern
+that gets surfaced before it hits a request, not a per-request failure.
+If a request does hit a missing version, the read paths fail closed:
+the decryptor throws `StaleEncryptionKeyException` and the fingerprinter
+throws `StaleFingerprintKeyException` on its candidates call. Fail-open
+behaviour (e.g. returning a partial candidate set) would silently admit
+duplicate PII identifiers past the uniqueness check, so the read paths
+require every accepted version to resolve.
 
 Each host service registers its own probes — e.g. member-service registers
 two (encryption prefix + fingerprint prefix), idcard-service registers one.

--- a/docs/architecture/secret-rotation.md
+++ b/docs/architecture/secret-rotation.md
@@ -1,0 +1,157 @@
+# Secret Rotation
+
+Covers rotation of symmetric key material fetched through
+`ISecretProvider` — HMAC signing keys, AES-GCM data encryption keys,
+fingerprint HMAC keys. Asymmetric-key rotation (RS256 / JWKS, TLS certs)
+uses different patterns and is out of scope.
+
+## The rotation model
+
+Keys are identified by an **operator-controlled logical version string**
+(`v1`, `v2`, …) rather than the opaque version ID that Key Vault assigns
+to each `SecretClient.SetSecret` call. The logical version appears in:
+
+1. **The Key Vault secret name.** A secret named `{prefix}-{version}`,
+   e.g. `member-identifier-encryption-key-v2`. Rotating the key means
+   publishing a new secret, NOT creating a new KV version of the same
+   secret. (KV versions are still assigned, but the app never reads them.)
+2. **The app's configuration.** Two keys per consumer: `CurrentKeyVersion`
+   (used for new writes) and `AcceptedKeyVersions` (rolling window for
+   reads / decrypts).
+3. **Where the data lives** — either embedded in the artifact (0x02
+   ciphertext envelope, QR payload's `KeyVersion` field) or covered by
+   dual-read (fingerprinter candidates).
+
+The primitive is `RotatingKeyProvider`
+(`src/services/shared/CloudHealthOffice.Infrastructure/Configuration/`).
+Consumers ask it for `GetKeyAsync(prefix, version, devConfigFallback)`
+and get cached key bytes; the cache is invalidated by
+`SecretRefreshService` on every `IConfiguration` reload, so new secret
+values propagate within one reload interval (default 5 minutes) with no
+pod restart.
+
+## End-to-end rotation sequence
+
+For any consumer (identifier encryptor, fingerprinter, QR signer):
+
+1. **Provision the new secret.** Run
+   `scripts/azure/rotate-secret.sh` with `SECRET_PREFIX`, `NEW_VERSION`,
+   `KEY_VAULT_NAME`. The script is idempotent and only handles Key
+   Vault state — it does not touch app config.
+2. **Widen the accepted window.** Add `NEW_VERSION` to
+   `…AcceptedKeyVersions`. Do NOT flip `CurrentKeyVersion` yet.
+   Deploy / update config.
+3. **Wait one reload interval.** Every service pod refreshes its
+   `RotatingKeyProvider` cache off the next `SecretProviderConfigurationProvider`
+   tick. Verify via the `RotatingKeyProviderHealthCheck` that every
+   accepted version resolves — the health endpoint reports Degraded
+   when a listed version is unresolvable.
+4. **Flip `CurrentKeyVersion`.** New writes from this point emit under
+   the new version. Old records continue to decrypt against the old
+   version because it's still in `AcceptedKeyVersions`.
+5. **(Eventually) drop the prior version** from `AcceptedKeyVersions`.
+   Only safe after a backfill job has re-encrypted / re-fingerprinted
+   every record under the current version. See the concrete sequence
+   below.
+
+## Envelope migration — 0x01 → 0x02 for `KeyVaultIdentifierEncryptor`
+
+Pre-A.7.3 ciphertexts use a 0x01 envelope:
+`[0x01][12 IV][16 tag][ciphertext]` — no key version is carried.
+
+Post-A.7.3 ciphertexts use a 0x02 envelope:
+`[0x02][keyVerLen][keyVer UTF-8][12 IV][16 tag][ciphertext]` — the key
+version is embedded so the decryptor knows which key to use.
+
+`DecryptAsync` supports both forever (read-only path). 0x01 envelopes are
+decrypted using `MemberEncryption:LegacyKeySecretName` — a single
+fixed secret name, no fallback chain. A service booting without an
+explicit `MemberEncryption` block but with the legacy
+`Member:IdentifierEncryption:KeySecretName` config continues to *emit*
+0x01 envelopes against that same key, so zero new config is required for
+backward-compatible operation. When an operator adds the
+`MemberEncryption` section, new writes start emitting 0x02.
+
+## Fingerprinter dual-read
+
+HMAC fingerprints are lookup keys — embedding a version would change the
+lookup value and invalidate every existing row. So instead of versioned
+output, `IIdentifierFingerprinter` has two methods:
+
+- `FingerprintAsync` — one hash under the current version, used on write.
+- `FingerprintCandidatesAsync` — one hash per accepted version (newest
+  first), used on read. Callers match `candidates.Contains(storedFingerprint)`
+  (or SQL `WHERE fingerprint IN (...)`).
+
+`IdentifiersController` uses candidates in both the Add dedupe check and
+the Remove lookup — Add is subtle because it's a read against existing
+rows inside a write endpoint, and without candidates a rotation would
+silently allow duplicate identifiers past the 409.
+
+## Health check
+
+`RotatingKeyProviderHealthCheck` (`Infrastructure/HealthChecks/`) accepts
+a list of `(secretPrefix, versions)` probes and reports Degraded (not
+Unhealthy) if any accepted version is unresolvable. Degraded rather than
+Unhealthy because a missing legacy version is a compliance concern, not
+a serve-5xx concern — readers tolerate it (fingerprinter logs-and-skips,
+decryptor raises `StaleEncryptionKeyException` on a hit) but ops must be
+paged to restore the secret before backfill or rotation completes.
+
+Each host service registers its own probes — e.g. member-service registers
+two (encryption prefix + fingerprint prefix), idcard-service registers one.
+
+## Backfill is out of scope for A.7.3
+
+This PR lets old records keep being read, and lets new records be written
+under the new key. It does NOT re-encrypt or re-fingerprint existing
+records under the new version. That backfill belongs to a separate
+migration job per consumer and is an operational decision on timing.
+
+**Concrete sequence to retire `v1` entirely** (e.g. after a compromised
+key rotation):
+
+1. Deploy a backfill job that reads every record whose identifier is
+   either a 0x01 envelope or fingerprinted under v1, decrypts/re-
+   fingerprints with the current plaintext, and re-writes under the
+   current version. This is read-write and per-consumer; the identifier
+   encryptor + fingerprinter in member-service are the two consumers
+   today.
+2. Verify zero remaining v1 records (query Cosmos / Mongo for records
+   whose first base64url byte decodes to 0x01 for the encryptor, and
+   compute `FingerprintCandidatesAsync[v1]` equality against a sample
+   for the fingerprinter).
+3. Remove `v1` from `MemberEncryption:AcceptedKeyVersions` and
+   `MemberFingerprinting:AcceptedKeyVersions`. Deploy.
+4. Until step 3 is complete, do NOT remove the `v1` secret (or the
+   legacy secret) from Key Vault — doing so would cause
+   `StaleEncryptionKeyException` on read of any remaining v1 record
+   and send the service into a persistent degraded state for affected
+   tenants.
+
+## Future consumers
+
+Any new cryptographic consumer that needs key rotation should use
+`RotatingKeyProvider` directly. Register a `RotatingKeyVersionProbe`
+with the health check so operators see unresolvable versions in the
+readiness endpoint. Candidates include:
+
+- Webhook signing secrets (if added).
+- CSRF tokens backed by a shared secret at scale.
+- Session cookie signing keys.
+
+Do NOT route asymmetric keys (RS256 signers, TLS private keys) through
+`RotatingKeyProvider` — they have their own JWKS / cert-rotation
+patterns and the abstractions don't line up.
+
+## Explicit non-goals
+
+- Backfill re-encryption / re-fingerprinting (see above — separate job
+  per consumer).
+- HashiCorp Vault rotation. The enum value exists in
+  `SecretProviderType` but the implementation is planned for a later
+  release; today only Azure Key Vault is supported.
+- Asymmetric key rotation. See the future-consumers section.
+- Automatic drop of 0x01 envelope decode support after backfill. The
+  decode path stays in the encryptor indefinitely — dropping it is a
+  future call requiring a separate PR and a deployment gate.

--- a/scripts/azure/rotate-secret.sh
+++ b/scripts/azure/rotate-secret.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Publishes a new logical version of a rotating key to Azure Key Vault.
+#
+# The rotation model uses operator-controlled version strings (v1, v2, …)
+# encoded in the secret NAME rather than opaque KV version IDs — see
+# docs/architecture/secret-rotation.md for the full model and end-to-end
+# sequence. This script only handles step 1 (provisioning the secret);
+# app config (CurrentKeyVersion / AcceptedKeyVersions) is updated
+# separately so infra and app config concerns stay separate.
+#
+# Idempotent: re-running with the same SECRET_PREFIX + NEW_VERSION updates
+# the named secret in place without error.
+#
+# Required env vars:
+#   SECRET_PREFIX     — the logical prefix, e.g. "member-identifier-encryption-key"
+#   NEW_VERSION       — the operator version string, e.g. "v2"
+#   KEY_VAULT_NAME    — the target Key Vault (name, not URI)
+#
+# Optional env vars:
+#   SECRET_VALUE      — override the generated 32-byte random key with a
+#                       caller-supplied value (base64 or plaintext). When
+#                       unset, this script generates a fresh key with
+#                       `openssl rand -base64 32`.
+set -euo pipefail
+
+: "${SECRET_PREFIX:?SECRET_PREFIX is required (e.g. member-identifier-encryption-key)}"
+: "${NEW_VERSION:?NEW_VERSION is required (e.g. v2)}"
+: "${KEY_VAULT_NAME:?KEY_VAULT_NAME is required}"
+
+SECRET_NAME="${SECRET_PREFIX}-${NEW_VERSION}"
+
+echo "==> Rotating key: ${SECRET_NAME} in ${KEY_VAULT_NAME}"
+
+if [[ -z "${SECRET_VALUE:-}" ]]; then
+  SECRET_VALUE="$(openssl rand -base64 32)"
+  GENERATED=1
+else
+  GENERATED=0
+fi
+
+az keyvault secret set \
+  --vault-name "$KEY_VAULT_NAME" \
+  --name "$SECRET_NAME" \
+  --value "$SECRET_VALUE" >/dev/null
+
+echo "==> Published secret: ${SECRET_NAME}"
+echo "==> Next steps (app config, performed separately):"
+echo "    1. Add '${NEW_VERSION}' to AcceptedKeyVersions"
+echo "    2. Wait one IConfiguration reload interval for services to pick it up"
+echo "    3. Verify the RotatingKeyProviderHealthCheck reports Healthy"
+echo "    4. Set CurrentKeyVersion=${NEW_VERSION} to begin emitting new envelopes"
+echo "    5. (Eventually) backfill old records + drop the prior version from AcceptedKeyVersions"
+echo ""
+if [[ "$GENERATED" -eq 1 ]]; then
+  echo "Version string: ${NEW_VERSION}"
+  echo "(The secret value was generated locally and is NOT echoed here.)"
+else
+  echo "Version string: ${NEW_VERSION}"
+fi

--- a/src/services/idcard-service/Program.cs
+++ b/src/services/idcard-service/Program.cs
@@ -94,8 +94,20 @@ builder.Services.AddSingleton<IBenefitPlanClient, BenefitPlanClient>();
 builder.Services.AddSingleton<IMemberDocumentClient, MemberDocumentClient>();
 builder.Services.AddSingleton<IEligibilityClient, EligibilityClient>();
 
-// QR signing + card generation
+// QR signing + card generation. RotatingKeyProvider is registered by
+// AddSecretProvider above; QrCodeService consumes it directly so the
+// per-service key cache stays in sync with IConfiguration reloads.
 builder.Services.AddSingleton<IQrCodeService, QrCodeService>();
+
+// Startup log: visible in pod logs so ops can confirm the rotation window
+// the service booted with. No secret material logged.
+{
+    var current = builder.Configuration["IdCard:CurrentKeyVersion"] ?? "v1";
+    var accepted = builder.Configuration.GetSection("IdCard:AcceptedKeyVersions").Get<string[]>()
+        ?? new[] { current };
+    Console.WriteLine(
+        $"[idcard-service] QrCodeService rotating keys — current: {current}; accepted: [{string.Join(", ", accepted)}]");
+}
 builder.Services.AddSingleton<IIdCardGenerator, IdCardGenerator>();
 builder.Services.AddScoped<ITemplateResolver, TemplateResolver>();
 

--- a/src/services/idcard-service/Services/QrCodeService.cs
+++ b/src/services/idcard-service/Services/QrCodeService.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using CloudHealthOffice.Infrastructure.Configuration;
 using IdCardService.Models;
@@ -8,23 +7,20 @@ using QRCoder;
 namespace IdCardService.Services;
 
 /// <summary>
-/// Generates + verifies HMAC-signed QR payloads. Keys are fetched from the
-/// configured <see cref="ISecretProvider"/> under the name
-/// <c>{SigningKeySecretPrefix}-{version}</c> so rotation is done by publishing
-/// a new secret version and updating <c>IdCard:CurrentKeyVersion</c> — no code
-/// change and no mass re-issuance. Verification accepts any version listed in
+/// Generates + verifies HMAC-signed QR payloads. Keys are fetched through
+/// <see cref="RotatingKeyProvider"/> by logical version string (e.g. "v1",
+/// "v2") under the name <c>{SigningKeySecretPrefix}-{version}</c>, so
+/// rotation is done by publishing a new secret and updating
+/// <c>IdCard:CurrentKeyVersion</c> — no code change and no mass re-issuance.
+/// Verification accepts any version listed in
 /// <c>IdCard:AcceptedKeyVersions</c>, so cards signed under older rolling
 /// versions keep scanning until the window drops them.
 /// </summary>
 public class QrCodeService : IQrCodeService
 {
-    private readonly ISecretProvider _secrets;
+    private readonly RotatingKeyProvider _keys;
     private readonly IConfiguration _configuration;
     private readonly ILogger<QrCodeService> _logger;
-
-    // In-memory cache of resolved keys so every scan doesn't hit Key Vault.
-    private readonly Dictionary<string, byte[]> _keyCache = new(StringComparer.OrdinalIgnoreCase);
-    private readonly SemaphoreSlim _keyLock = new(1, 1);
 
     private static readonly JsonSerializerOptions CanonicalJson = new()
     {
@@ -32,9 +28,9 @@ public class QrCodeService : IQrCodeService
         PropertyNamingPolicy = null
     };
 
-    public QrCodeService(ISecretProvider secrets, IConfiguration configuration, ILogger<QrCodeService> logger)
+    public QrCodeService(RotatingKeyProvider keys, IConfiguration configuration, ILogger<QrCodeService> logger)
     {
-        _secrets = secrets;
+        _keys = keys;
         _configuration = configuration;
         _logger = logger;
     }
@@ -43,7 +39,7 @@ public class QrCodeService : IQrCodeService
         GenerateAsync(string tenantId, string memberId, string cardId, DateTime issuedAt, CancellationToken ct = default)
     {
         var keyVersion = _configuration["IdCard:CurrentKeyVersion"] ?? "v1";
-        var key = await GetKeyAsync(keyVersion, ct);
+        var key = await ResolveKeyAsync(keyVersion, ct);
 
         var payload = new QrCardPayload
         {
@@ -131,7 +127,7 @@ public class QrCodeService : IQrCodeService
         byte[] key;
         try
         {
-            key = await GetKeyAsync(payload.KeyVersion, ct);
+            key = await ResolveKeyAsync(payload.KeyVersion, ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -150,58 +146,11 @@ public class QrCodeService : IQrCodeService
         return (payload, null, null);
     }
 
-    private async Task<byte[]> GetKeyAsync(string version, CancellationToken ct)
+    private Task<byte[]> ResolveKeyAsync(string version, CancellationToken ct)
     {
-        if (_keyCache.TryGetValue(version, out var cached))
-        {
-            return cached;
-        }
-
-        await _keyLock.WaitAsync(ct);
-        try
-        {
-            if (_keyCache.TryGetValue(version, out cached))
-            {
-                return cached;
-            }
-
-            var prefix = _configuration["IdCard:SigningKeySecretPrefix"] ?? "idcard-signing-key";
-            var secretName = $"{prefix}-{version}";
-            var raw = await _secrets.GetSecretAsync(secretName, ct);
-
-            if (string.IsNullOrEmpty(raw))
-            {
-                // Fall back to configuration for dev/test environments so the
-                // service can run without a Key Vault. Production wires
-                // ISecretProvider to Key Vault and this branch will not hit.
-                raw = _configuration[$"IdCard:DevSigningKeys:{version}"];
-            }
-
-            if (string.IsNullOrEmpty(raw))
-            {
-                throw new InvalidOperationException(
-                    $"ID card signing key '{secretName}' is not configured. Publish the secret and/or update IdCard:AcceptedKeyVersions.");
-            }
-
-            byte[] keyBytes;
-            try
-            {
-                keyBytes = Convert.FromBase64String(raw);
-            }
-            catch (FormatException)
-            {
-                // Accept UTF-8 strings in dev environments; production secrets
-                // should be stored base64-encoded random bytes.
-                keyBytes = Encoding.UTF8.GetBytes(raw);
-            }
-
-            _keyCache[version] = keyBytes;
-            return keyBytes;
-        }
-        finally
-        {
-            _keyLock.Release();
-        }
+        var prefix = _configuration["IdCard:SigningKeySecretPrefix"] ?? "idcard-signing-key";
+        var devFallback = _configuration[$"IdCard:DevSigningKeys:{version}"];
+        return _keys.GetKeyAsync(prefix, version, devFallback, ct);
     }
 
     private static byte[] ComputeSignature(byte[] key, byte[] payload)

--- a/src/services/member-service/Controllers/IdentifiersController.cs
+++ b/src/services/member-service/Controllers/IdentifiersController.cs
@@ -102,9 +102,17 @@ public class IdentifiersController : ControllerBase
             if (string.IsNullOrEmpty(normalized))
                 return BadRequest(new { message = "Identifier value cannot be empty after normalization." });
 
+            // Write path: store the fingerprint under the current key version only.
             fingerprint = await _fingerprinter.FingerprintAsync(normalized, ct);
 
-            if (member.Identifiers.Any(i => i.System == system && i.ValueFingerprint == fingerprint))
+            // Read path: dedupe against every accepted key version so a row
+            // fingerprinted under a previous key version is still detected as
+            // a duplicate during a rotation window. Without this, rotating
+            // the HMAC key would silently let duplicates past the 409 check.
+            var candidates = await _fingerprinter.FingerprintCandidatesAsync(normalized, ct);
+            if (member.Identifiers.Any(i => i.System == system
+                    && !string.IsNullOrEmpty(i.ValueFingerprint)
+                    && candidates.Contains(i.ValueFingerprint!, StringComparer.Ordinal)))
                 return Conflict(new { message = "Identifier already exists on this member." });
 
             storedValue = await _encryptor.EncryptAsync(request.Value, ct) ?? request.Value;
@@ -184,9 +192,12 @@ public class IdentifiersController : ControllerBase
         if (member == null) return NotFound();
 
         var normalized = IdentifierNormalization.Normalize(value);
-        var fingerprintLookup = string.IsNullOrEmpty(normalized)
-            ? null
-            : await _fingerprinter.FingerprintAsync(normalized, ct);
+        // Read path: compute a fingerprint under each accepted key version so
+        // identifiers stored under a previous version still resolve during a
+        // rotation window.
+        var fingerprintCandidates = string.IsNullOrEmpty(normalized)
+            ? Array.Empty<string>()
+            : await _fingerprinter.FingerprintCandidatesAsync(normalized, ct);
 
         var removed = 0;
         var kept = new List<MemberIdentifier>(member.Identifiers.Count);
@@ -197,7 +208,7 @@ public class IdentifiersController : ControllerBase
             bool match;
             if (!string.IsNullOrEmpty(i.ValueFingerprint))
             {
-                match = i.ValueFingerprint == fingerprintLookup;
+                match = fingerprintCandidates.Contains(i.ValueFingerprint!, StringComparer.Ordinal);
             }
             else
             {

--- a/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
@@ -27,6 +27,10 @@ public class PiiIdentifierDedupeTests
         public Task<IDictionary<string, string>> GetSecretsAsync(string p, CancellationToken ct = default)
             => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
         public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+        public Task<string?> GetSecretByVersionAsync(string n, string v, CancellationToken ct = default)
+            => Task.FromResult<string?>(_secret);
+        public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string n, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
     }
 
     private static (IdentifiersController ctl, InMemoryMemberRepository repo) Build(

--- a/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
+++ b/src/services/member-service/MemberService.Tests/Controllers/PiiIdentifierDedupeTests.cs
@@ -61,14 +61,31 @@ public class PiiIdentifierDedupeTests
     {
         var encKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
         var fpKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var encSecrets = new StaticSecretProvider(encKey);
+        var fpSecrets = new StaticSecretProvider(fpKey);
+        var encOptions = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = "enc", CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" },
+            LegacyKeySecretName = "enc",
+            EmitLegacyEnvelope = true
+        };
+        var fpOptions = new MemberFingerprintingOptions
+        {
+            KeySecretPrefix = "fp", CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" },
+            LegacyKeySecretName = "fp"
+        };
         var enc = new KeyVaultIdentifierEncryptor(
-            new StaticSecretProvider(encKey),
+            new RotatingKeyProvider(encSecrets, NullLogger<RotatingKeyProvider>.Instance),
+            encSecrets,
             NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "enc");
+            encOptions);
         var fp = new HmacSha256IdentifierFingerprinter(
-            new StaticSecretProvider(fpKey),
+            new RotatingKeyProvider(fpSecrets, NullLogger<RotatingKeyProvider>.Instance),
+            fpSecrets,
             NullLogger<HmacSha256IdentifierFingerprinter>.Instance,
-            "fp");
+            fpOptions);
         return (enc, fp);
     }
 

--- a/src/services/member-service/MemberService.Tests/Services/EncryptorEnvelopeCompatTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/EncryptorEnvelopeCompatTests.cs
@@ -1,0 +1,211 @@
+using System.Security.Cryptography;
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using MemberService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+/// <summary>
+/// The most important tests in the A.7.3 PR: a ciphertext written under
+/// pre-A.7.3 code (0x01 envelope, hardcoded key) must still decrypt on
+/// post-A.7.3 code using the MemberEncryption:LegacyKeySecretName safety
+/// net. And a 0x02 envelope written under one key version must still
+/// decrypt as long as that version remains in AcceptedKeyVersions.
+/// </summary>
+public class EncryptorEnvelopeCompatTests
+{
+    private sealed class MultiKeySecretProvider : ISecretProvider
+    {
+        private readonly Dictionary<string, string> _secrets;
+        public MultiKeySecretProvider(Dictionary<string, string> secrets) { _secrets = secrets; }
+        public Task<string?> GetSecretAsync(string name, CancellationToken ct = default)
+            => Task.FromResult(_secrets.TryGetValue(name, out var v) ? v : null);
+        public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
+            => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>(_secrets));
+        public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+        public Task<string?> GetSecretByVersionAsync(string n, string v, CancellationToken ct = default)
+            => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string n, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
+    }
+
+    private static byte[] Base64UrlDecode(string s)
+    {
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+
+    /// <summary>
+    /// Build a pre-A.7.3-shaped 0x01 envelope:
+    ///   [0x01][12 IV][16 tag][ciphertext]
+    /// encrypted under <paramref name="key"/>. This simulates ciphertext
+    /// that was written to the database before this PR landed.
+    /// </summary>
+    private static string ProduceV1Envelope(byte[] key, string plaintext)
+    {
+        var nonce = RandomNumberGenerator.GetBytes(12);
+        var plain = Encoding.UTF8.GetBytes(plaintext);
+        var cipher = new byte[plain.Length];
+        var tag = new byte[16];
+        using var gcm = new AesGcm(key, 16);
+        gcm.Encrypt(nonce, plain, cipher, tag);
+
+        var env = new byte[1 + 12 + 16 + cipher.Length];
+        env[0] = 0x01;
+        Buffer.BlockCopy(nonce, 0, env, 1, 12);
+        Buffer.BlockCopy(tag, 0, env, 13, 16);
+        Buffer.BlockCopy(cipher, 0, env, 29, cipher.Length);
+        return Convert.ToBase64String(env).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    [Fact]
+    public async Task Post_A_7_3_Encryptor_Decrypts_Pre_A_7_3_V1_Envelope()
+    {
+        var legacyKey = RandomNumberGenerator.GetBytes(32);
+        var legacySecretName = "member-id-dek";
+
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            [legacySecretName] = Convert.ToBase64String(legacyKey)
+        });
+
+        var options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = legacySecretName,
+            CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v1", "v2" },
+            LegacyKeySecretName = legacySecretName,
+            EmitLegacyEnvelope = false
+        };
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var enc = new KeyVaultIdentifierEncryptor(
+            keys, secrets, NullLogger<KeyVaultIdentifierEncryptor>.Instance, options);
+
+        // Pre-A.7.3 ciphertext produced directly with the same key.
+        var legacyCiphertext = ProduceV1Envelope(legacyKey, "123-45-6789");
+
+        var plain = await enc.DecryptAsync(legacyCiphertext);
+        plain.Should().Be("123-45-6789");
+    }
+
+    [Fact]
+    public async Task V2_Envelope_RoundTrip_EmbedsKeyVersion()
+    {
+        var v1Key = RandomNumberGenerator.GetBytes(32);
+        var v2Key = RandomNumberGenerator.GetBytes(32);
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["dek-v1"] = Convert.ToBase64String(v1Key),
+            ["dek-v2"] = Convert.ToBase64String(v2Key)
+        });
+        var options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = "dek",
+            CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v1", "v2" },
+            LegacyKeySecretName = null,
+            EmitLegacyEnvelope = false
+        };
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var enc = new KeyVaultIdentifierEncryptor(
+            keys, secrets, NullLogger<KeyVaultIdentifierEncryptor>.Instance, options);
+
+        var cipher = await enc.EncryptAsync("123-45-6789");
+        cipher.Should().NotBeNull();
+        var bytes = Base64UrlDecode(cipher!);
+        bytes[0].Should().Be(0x02);
+        var keyVerLen = bytes[1];
+        var keyVer = Encoding.UTF8.GetString(bytes, 2, keyVerLen);
+        keyVer.Should().Be("v2");
+
+        var plain = await enc.DecryptAsync(cipher);
+        plain.Should().Be("123-45-6789");
+    }
+
+    [Fact]
+    public async Task V2_Rotation_OldCiphertextStillDecrypts_NewEmitsNewVersion()
+    {
+        // Simulates a rotation window: service originally ran with v1
+        // current; operator rotates to v2. Old v2-not-yet ciphertexts
+        // (which we simulate here by pre-encrypting under v1) must still
+        // decrypt; new ciphertexts must use v2.
+        var v1Key = RandomNumberGenerator.GetBytes(32);
+        var v2Key = RandomNumberGenerator.GetBytes(32);
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["dek-v1"] = Convert.ToBase64String(v1Key),
+            ["dek-v2"] = Convert.ToBase64String(v2Key)
+        });
+
+        // Stage 1: v1 current, encrypt under v1.
+        var v1Options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = "dek", CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" },
+            LegacyKeySecretName = null, EmitLegacyEnvelope = false
+        };
+        var v1Keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var v1Enc = new KeyVaultIdentifierEncryptor(
+            v1Keys, secrets, NullLogger<KeyVaultIdentifierEncryptor>.Instance, v1Options);
+        var writtenUnderV1 = await v1Enc.EncryptAsync("before-rotation");
+
+        // Stage 2: rotate to v2, window [v1, v2].
+        var v2Options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = "dek", CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v1", "v2" },
+            LegacyKeySecretName = null, EmitLegacyEnvelope = false
+        };
+        var v2Keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var v2Enc = new KeyVaultIdentifierEncryptor(
+            v2Keys, secrets, NullLogger<KeyVaultIdentifierEncryptor>.Instance, v2Options);
+
+        // Old ciphertext still decrypts.
+        (await v2Enc.DecryptAsync(writtenUnderV1)).Should().Be("before-rotation");
+
+        // New ciphertext carries v2.
+        var writtenUnderV2 = await v2Enc.EncryptAsync("after-rotation");
+        var bytes = Base64UrlDecode(writtenUnderV2!);
+        var keyVer = Encoding.UTF8.GetString(bytes, 2, bytes[1]);
+        keyVer.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task StaleEncryptionKey_WhenAcceptedVersionMissingFromSecretProvider()
+    {
+        // v1 accepted (in envelope) but the secret provider no longer has
+        // dek-v1 (e.g. an operator accidentally deleted it).
+        var v2Key = RandomNumberGenerator.GetBytes(32);
+        var secretsWithoutV1 = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["dek-v2"] = Convert.ToBase64String(v2Key)
+        });
+        var options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = "dek", CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v1", "v2" },
+            LegacyKeySecretName = null, EmitLegacyEnvelope = false
+        };
+        var keys = new RotatingKeyProvider(secretsWithoutV1, NullLogger<RotatingKeyProvider>.Instance);
+        var enc = new KeyVaultIdentifierEncryptor(
+            keys, secretsWithoutV1, NullLogger<KeyVaultIdentifierEncryptor>.Instance, options);
+
+        // Hand-craft a v1-tagged envelope (arbitrary contents — won't reach
+        // decrypt because the key lookup must fail first).
+        var envelope = new byte[1 + 1 + 2 + 12 + 16 + 4];
+        envelope[0] = 0x02;
+        envelope[1] = 2;
+        envelope[2] = (byte)'v'; envelope[3] = (byte)'1';
+        var b64 = Convert.ToBase64String(envelope).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var act = async () => await enc.DecryptAsync(b64);
+        var ex = await act.Should().ThrowAsync<StaleEncryptionKeyException>();
+        ex.Which.KeyVersion.Should().Be("v1");
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/FingerprinterDualReadTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FingerprinterDualReadTests.cs
@@ -74,12 +74,13 @@ public class FingerprinterDualReadTests
     }
 
     [Fact]
-    public async Task FingerprintCandidates_SkipsUnresolvableVersion()
+    public async Task FingerprintCandidates_FailsClosed_WhenVersionUnresolvable()
     {
         // v1 is accepted but the operator accidentally didn't publish fp-v1.
-        // The candidates call must still return v2 (and log a warning for v1)
-        // rather than throwing — otherwise a dedupe read would 500 instead of
-        // matching on whatever versions DO resolve.
+        // Returning v2 only would silently let duplicates past the dedupe
+        // check for rows fingerprinted under v1 — a correctness violation.
+        // The candidates call MUST throw so the controller can 503 instead
+        // of serving the dedupe with a partial candidate set.
         var v2Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
         var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
         {
@@ -92,8 +93,9 @@ public class FingerprinterDualReadTests
             AcceptedKeyVersions = new[] { "v2", "v1" }, LegacyKeySecretName = null
         });
 
-        var candidates = await fp.FingerprintCandidatesAsync("anything");
-        candidates.Should().HaveCount(1);
+        var act = async () => await fp.FingerprintCandidatesAsync("anything");
+        var ex = await act.Should().ThrowAsync<StaleFingerprintKeyException>();
+        ex.Which.KeyVersion.Should().Be("v1");
     }
 
     [Fact]

--- a/src/services/member-service/MemberService.Tests/Services/FingerprinterDualReadTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/FingerprinterDualReadTests.cs
@@ -1,0 +1,124 @@
+using System.Security.Cryptography;
+using CloudHealthOffice.Infrastructure.Configuration;
+using MemberService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MemberService.Tests.Services;
+
+/// <summary>
+/// The fingerprint output is the database lookup key — embedding a key
+/// version would change the lookup value and break every existing row.
+/// So rotation is handled dual-read: write under current, read under all
+/// accepted. These tests pin that contract down so a regression can't
+/// silently produce duplicates during a rotation window.
+/// </summary>
+public class FingerprinterDualReadTests
+{
+    private sealed class MultiKeySecretProvider : ISecretProvider
+    {
+        private readonly Dictionary<string, string> _secrets;
+        public MultiKeySecretProvider(Dictionary<string, string> secrets) { _secrets = secrets; }
+        public Task<string?> GetSecretAsync(string name, CancellationToken ct = default)
+            => Task.FromResult(_secrets.TryGetValue(name, out var v) ? v : null);
+        public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
+            => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>(_secrets));
+        public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+        public Task<string?> GetSecretByVersionAsync(string n, string v, CancellationToken ct = default)
+            => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string n, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
+    }
+
+    private static HmacSha256IdentifierFingerprinter Build(
+        ISecretProvider secrets, MemberFingerprintingOptions options) =>
+        new(
+            new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance),
+            secrets,
+            NullLogger<HmacSha256IdentifierFingerprinter>.Instance,
+            options);
+
+    [Fact]
+    public async Task Fingerprint_UnderCurrentVersion_MatchesOldRecord_InCandidateSet()
+    {
+        var v1Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var v2Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["fp-v1"] = v1Key,
+            ["fp-v2"] = v2Key
+        });
+
+        // Stage 1: written under v1.
+        var v1Fp = Build(secrets, new MemberFingerprintingOptions
+        {
+            KeySecretPrefix = "fp", CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }, LegacyKeySecretName = null
+        });
+        var storedFingerprint = await v1Fp.FingerprintAsync("123-45-6789");
+
+        // Stage 2: v2 now current, v1 still accepted.
+        var v2Fp = Build(secrets, new MemberFingerprintingOptions
+        {
+            KeySecretPrefix = "fp", CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v2", "v1" }, LegacyKeySecretName = null
+        });
+
+        // Write path now produces v2 fingerprint.
+        var newV2Fingerprint = await v2Fp.FingerprintAsync("123-45-6789");
+        newV2Fingerprint.Should().NotBe(storedFingerprint);
+
+        // Read path produces candidates for BOTH versions — the stored v1 row is found.
+        var candidates = await v2Fp.FingerprintCandidatesAsync("123-45-6789");
+        candidates.Should().Contain(storedFingerprint);
+        candidates.Should().Contain(newV2Fingerprint);
+    }
+
+    [Fact]
+    public async Task FingerprintCandidates_SkipsUnresolvableVersion()
+    {
+        // v1 is accepted but the operator accidentally didn't publish fp-v1.
+        // The candidates call must still return v2 (and log a warning for v1)
+        // rather than throwing — otherwise a dedupe read would 500 instead of
+        // matching on whatever versions DO resolve.
+        var v2Key = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["fp-v2"] = v2Key
+        });
+
+        var fp = Build(secrets, new MemberFingerprintingOptions
+        {
+            KeySecretPrefix = "fp", CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v2", "v1" }, LegacyKeySecretName = null
+        });
+
+        var candidates = await fp.FingerprintCandidatesAsync("anything");
+        candidates.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task LegacyKeySecretName_UsedAsImplicitV1_WhenPrefixedSecretAbsent()
+    {
+        // Pre-A.7.3 deploy: only the single-name secret exists. The
+        // fingerprinter must resolve v1 via LegacyKeySecretName so existing
+        // rows continue to dedupe without the operator publishing fp-v1.
+        var legacyKey = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var secrets = new MultiKeySecretProvider(new Dictionary<string, string>
+        {
+            ["legacy-fp"] = legacyKey
+        });
+
+        var fp = Build(secrets, new MemberFingerprintingOptions
+        {
+            KeySecretPrefix = "fp", CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" },
+            LegacyKeySecretName = "legacy-fp"
+        });
+
+        var single = await fp.FingerprintAsync("123-45-6789");
+        single.Should().NotBeNullOrEmpty();
+
+        var candidates = await fp.FingerprintCandidatesAsync("123-45-6789");
+        candidates.Should().ContainSingle().And.Contain(single);
+    }
+}

--- a/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
@@ -15,6 +15,10 @@ public class IdentifierEncryptorTests
         public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
             => Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());
         public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+        public Task<string?> GetSecretByVersionAsync(string name, string version, CancellationToken ct = default)
+            => Task.FromResult<string?>(_secret);
+        public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
     }
 
     [Fact]

--- a/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
+++ b/src/services/member-service/MemberService.Tests/Services/IdentifierEncryptorTests.cs
@@ -21,6 +21,24 @@ public class IdentifierEncryptorTests
             => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
     }
 
+    private static KeyVaultIdentifierEncryptor MakeEncryptor(
+        ISecretProvider secrets,
+        string keySecretName = "cho-member-id-dek",
+        bool legacyEnvelope = true)
+    {
+        var options = new MemberEncryptionOptions
+        {
+            KeySecretPrefix = keySecretName,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" },
+            LegacyKeySecretName = keySecretName,
+            EmitLegacyEnvelope = legacyEnvelope
+        };
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        return new KeyVaultIdentifierEncryptor(
+            keys, secrets, NullLogger<KeyVaultIdentifierEncryptor>.Instance, options);
+    }
+
     [Fact]
     public async Task NoOp_PassesThroughValues()
     {
@@ -35,10 +53,7 @@ public class IdentifierEncryptorTests
     public async Task KeyVaultEncryptor_RoundTripsPlaintext()
     {
         var keyBytes = RandomNumberGenerator.GetBytes(32);
-        var enc = new KeyVaultIdentifierEncryptor(
-            new StaticSecretProvider(Convert.ToBase64String(keyBytes)),
-            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "cho-member-id-dek");
+        var enc = MakeEncryptor(new StaticSecretProvider(Convert.ToBase64String(keyBytes)));
 
         var cipher = await enc.EncryptAsync("123-45-6789");
         cipher.Should().NotBeNullOrEmpty();
@@ -51,10 +66,7 @@ public class IdentifierEncryptorTests
     [Fact]
     public async Task KeyVaultEncryptor_EmptyIn_EmptyOut()
     {
-        var enc = new KeyVaultIdentifierEncryptor(
-            new StaticSecretProvider(Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))),
-            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "k");
+        var enc = MakeEncryptor(new StaticSecretProvider(Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))), keySecretName: "k");
         (await enc.EncryptAsync("")).Should().Be("");
         (await enc.DecryptAsync("")).Should().Be("");
     }
@@ -62,10 +74,7 @@ public class IdentifierEncryptorTests
     [Fact]
     public async Task KeyVaultEncryptor_WrongKeyLength_Throws()
     {
-        var enc = new KeyVaultIdentifierEncryptor(
-            new StaticSecretProvider("short"),
-            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "k");
+        var enc = MakeEncryptor(new StaticSecretProvider("short"), keySecretName: "k");
         var act = async () => await enc.EncryptAsync("anything");
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -76,22 +85,16 @@ public class IdentifierEncryptorTests
         var provider = new Moq.Mock<ISecretProvider>();
         provider.Setup(p => p.GetSecretAsync(Moq.It.IsAny<string>(), Moq.It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
-        var enc = new KeyVaultIdentifierEncryptor(
-            provider.Object,
-            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "k");
+        var enc = MakeEncryptor(provider.Object, keySecretName: "k");
         var act = async () => await enc.EncryptAsync("anything");
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<CryptographicException>();
     }
 
     [Fact]
     public async Task KeyVaultEncryptor_TamperedCiphertext_ThrowsCrypto()
     {
         var keyBytes = RandomNumberGenerator.GetBytes(32);
-        var enc = new KeyVaultIdentifierEncryptor(
-            new StaticSecretProvider(Convert.ToBase64String(keyBytes)),
-            NullLogger<KeyVaultIdentifierEncryptor>.Instance,
-            "k");
+        var enc = MakeEncryptor(new StaticSecretProvider(Convert.ToBase64String(keyBytes)), keySecretName: "k");
         var cipher = await enc.EncryptAsync("secret-mbi");
         cipher.Should().NotBeNull();
         // Flip a byte in the middle.

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -140,16 +140,31 @@ builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService
 builder.Services.AddScoped<IRelationshipShim, RelationshipShim>();
 builder.Services.AddScoped<IMemberAlertGuard, MemberAlertGuard>();
 
-// Identifier encryption. Real KV-backed encryptor when a data-key secret name is
-// configured; otherwise fall through to the no-op shim (dev only).
+// Identifier encryption. Rotation-aware KV-backed encryptor when either
+// the new MemberEncryption section is configured OR the legacy
+// Member:IdentifierEncryption:KeySecretName is set — the legacy config
+// is bridged onto MemberEncryptionOptions so a service booting with no
+// new config keeps the pre-A.7.3 behaviour: v1 current, v1 accepted, and
+// the legacy secret name used for both rotation (KeySecretPrefix) and
+// 0x01 decrypt.
 var encryptionKeySecretName = builder.Configuration["Member:IdentifierEncryption:KeySecretName"];
-if (!string.IsNullOrWhiteSpace(encryptionKeySecretName))
+var memberEncryptionSection = builder.Configuration.GetSection(MemberEncryptionOptions.SectionName);
+if (memberEncryptionSection.Exists() || !string.IsNullOrWhiteSpace(encryptionKeySecretName))
 {
+    var options = ResolveMemberEncryptionOptions(memberEncryptionSection, encryptionKeySecretName);
+
+    builder.Services.AddSingleton(options);
     builder.Services.AddSingleton<IIdentifierEncryptor>(sp =>
         new KeyVaultIdentifierEncryptor(
+            sp.GetRequiredService<RotatingKeyProvider>(),
             sp.GetRequiredService<ISecretProvider>(),
             sp.GetRequiredService<ILogger<KeyVaultIdentifierEncryptor>>(),
-            encryptionKeySecretName));
+            options));
+
+    Console.WriteLine(
+        $"[member-service] IIdentifierEncryptor = KeyVault (rotating) — current: {options.CurrentKeyVersion}; " +
+        $"accepted: [{string.Join(", ", options.AcceptedKeyVersions)}]; " +
+        $"legacy 0x01 secret: {options.LegacyKeySecretName ?? "<none>"}");
 }
 else
 {
@@ -157,10 +172,42 @@ else
     {
         // Fail loudly in non-dev rather than silently passing PII through plaintext.
         throw new InvalidOperationException(
-            "Member:IdentifierEncryption:KeySecretName must be configured in non-development environments.");
+            "MemberEncryption (or legacy Member:IdentifierEncryption:KeySecretName) must be configured in non-development environments.");
     }
     builder.Services.AddSingleton<IIdentifierEncryptor, NoOpIdentifierEncryptor>();
-    Console.WriteLine("[dev] IIdentifierEncryptor = NoOp (PII stored plaintext). Configure Member:IdentifierEncryption:KeySecretName to enable.");
+    Console.WriteLine("[dev] IIdentifierEncryptor = NoOp (PII stored plaintext). Configure MemberEncryption to enable.");
+}
+
+static MemberEncryptionOptions ResolveMemberEncryptionOptions(
+    IConfigurationSection section, string? legacyKeySecretName)
+{
+    var bound = section.Exists() ? section.Get<MemberEncryptionOptions>() : null;
+    if (bound is not null)
+    {
+        // If the new section is partially configured but LegacyKeySecretName
+        // is absent, fall back to the pre-A.7.3 config key so 0x01 envelopes
+        // keep decrypting.
+        var legacy = string.IsNullOrWhiteSpace(bound.LegacyKeySecretName)
+            ? legacyKeySecretName ?? bound.KeySecretPrefix
+            : bound.LegacyKeySecretName;
+        return bound with { LegacyKeySecretName = legacy };
+    }
+
+    // Pure legacy path — no MemberEncryption block, only the old single-name
+    // key. Emit 0x01 envelopes against that exact secret so new writes have
+    // the same shape as pre-A.7.3 writes and don't reference a versioned
+    // secret name that was never published. Decrypt still supports both 0x01
+    // (via the same legacy key) and 0x02 (should a stray one appear). When
+    // the operator adds an explicit MemberEncryption section they opt into
+    // 0x02 emission.
+    return new MemberEncryptionOptions
+    {
+        KeySecretPrefix = legacyKeySecretName!,
+        CurrentKeyVersion = "v1",
+        AcceptedKeyVersions = new[] { "v1" },
+        LegacyKeySecretName = legacyKeySecretName,
+        EmitLegacyEnvelope = true
+    };
 }
 
 // Identifier fingerprinting (HMAC-SHA256 keyed by a DISTINCT KV secret from the

--- a/src/services/member-service/Program.cs
+++ b/src/services/member-service/Program.cs
@@ -210,29 +210,66 @@ static MemberEncryptionOptions ResolveMemberEncryptionOptions(
     };
 }
 
-// Identifier fingerprinting (HMAC-SHA256 keyed by a DISTINCT KV secret from the
-// encryption key). Used to dedupe PII identifiers without comparing ciphertexts
-// (which differ by AES-GCM nonce even for identical plaintext).
+// Identifier fingerprinting (HMAC-SHA256 keyed by a DISTINCT KV secret from
+// the encryption key — rotated independently). Used to dedupe PII
+// identifiers without comparing ciphertexts (which differ by AES-GCM nonce
+// even for identical plaintext). Dual-read during rotation windows via
+// IIdentifierFingerprinter.FingerprintCandidatesAsync.
 var fingerprintKeySecretName =
     builder.Configuration["Encryption:IdentifierFingerprintKeySecret"]
     ?? builder.Configuration["Member:IdentifierFingerprint:KeySecretName"];
-if (!string.IsNullOrWhiteSpace(fingerprintKeySecretName))
+var memberFingerprintingSection = builder.Configuration.GetSection(MemberFingerprintingOptions.SectionName);
+if (memberFingerprintingSection.Exists() || !string.IsNullOrWhiteSpace(fingerprintKeySecretName))
 {
+    var fpOptions = ResolveMemberFingerprintingOptions(memberFingerprintingSection, fingerprintKeySecretName);
+
+    builder.Services.AddSingleton(fpOptions);
     builder.Services.AddSingleton<IIdentifierFingerprinter>(sp =>
         new HmacSha256IdentifierFingerprinter(
+            sp.GetRequiredService<RotatingKeyProvider>(),
             sp.GetRequiredService<ISecretProvider>(),
             sp.GetRequiredService<ILogger<HmacSha256IdentifierFingerprinter>>(),
-            fingerprintKeySecretName));
+            fpOptions));
+
+    Console.WriteLine(
+        $"[member-service] IIdentifierFingerprinter = HmacSha256 (rotating) — current: {fpOptions.CurrentKeyVersion}; " +
+        $"accepted: [{string.Join(", ", fpOptions.AcceptedKeyVersions)}]; " +
+        $"legacy secret: {fpOptions.LegacyKeySecretName ?? "<none>"}");
 }
 else
 {
     if (!builder.Environment.IsDevelopment())
     {
         throw new InvalidOperationException(
-            "Encryption:IdentifierFingerprintKeySecret must be configured in non-development environments.");
+            "MemberFingerprinting (or legacy Encryption:IdentifierFingerprintKeySecret) must be configured in non-development environments.");
     }
     builder.Services.AddSingleton<IIdentifierFingerprinter, NoOpIdentifierFingerprinter>();
-    Console.WriteLine("[dev] IIdentifierFingerprinter = NoOp (plain SHA-256). Configure Encryption:IdentifierFingerprintKeySecret to enable.");
+    Console.WriteLine("[dev] IIdentifierFingerprinter = NoOp (plain SHA-256). Configure MemberFingerprinting to enable.");
+}
+
+static MemberFingerprintingOptions ResolveMemberFingerprintingOptions(
+    IConfigurationSection section, string? legacyKeySecretName)
+{
+    var bound = section.Exists() ? section.Get<MemberFingerprintingOptions>() : null;
+    if (bound is not null)
+    {
+        var legacy = string.IsNullOrWhiteSpace(bound.LegacyKeySecretName)
+            ? legacyKeySecretName ?? bound.KeySecretPrefix
+            : bound.LegacyKeySecretName;
+        return bound with { LegacyKeySecretName = legacy };
+    }
+
+    // Pure legacy path: treat the old single-name secret as the implicit v1
+    // entry. FingerprintAsync resolves v1 via the legacy name fallback in
+    // HmacSha256IdentifierFingerprinter, so existing rows keep deduping
+    // without requiring the operator to publish a prefix-versioned secret.
+    return new MemberFingerprintingOptions
+    {
+        KeySecretPrefix = legacyKeySecretName!,
+        CurrentKeyVersion = "v1",
+        AcceptedKeyVersions = new[] { "v1" },
+        LegacyKeySecretName = legacyKeySecretName
+    };
 }
 
 // ── Downstream typed clients ─────────────────────────────────────────

--- a/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
@@ -6,74 +6,135 @@ using Microsoft.Extensions.Logging;
 namespace MemberService.Services;
 
 /// <summary>
-/// HMAC-SHA256 fingerprinter keyed by a secret fetched from the configured
-/// <see cref="ISecretProvider"/>. Fingerprint key MUST be distinct from the
-/// AES-GCM encryption key so rotation does not leak plaintext identifiers.
+/// HMAC-SHA256 fingerprinter keyed by a secret fetched through
+/// <see cref="RotatingKeyProvider"/>. Fingerprint output IS the database
+/// lookup key, so the key material can't be part of the output — instead,
+/// rotation is handled as dual-read:
+///
+/// * <see cref="FingerprintAsync"/> returns the fingerprint under the
+///   current key version only. Used for writes (inserts / updates of the
+///   ValueFingerprint column).
+/// * <see cref="FingerprintCandidatesAsync"/> returns one fingerprint per
+///   accepted key version. Used for reads (dedupe checks, lookups) so
+///   records written under the previous key version still match.
+///
+/// The fingerprint key MUST be distinct from the AES-GCM encryption key.
 /// </summary>
 public sealed class HmacSha256IdentifierFingerprinter : IIdentifierFingerprinter
 {
+    private readonly RotatingKeyProvider _keys;
     private readonly ISecretProvider _secrets;
     private readonly ILogger<HmacSha256IdentifierFingerprinter> _logger;
-    private readonly string _keySecretName;
-
-    private byte[]? _cachedKey;
-    private readonly SemaphoreSlim _keyLock = new(1, 1);
+    private readonly MemberFingerprintingOptions _options;
 
     public HmacSha256IdentifierFingerprinter(
+        RotatingKeyProvider keys,
         ISecretProvider secrets,
         ILogger<HmacSha256IdentifierFingerprinter> logger,
-        string keySecretName)
+        MemberFingerprintingOptions options)
     {
+        _keys = keys;
         _secrets = secrets;
         _logger = logger;
-        _keySecretName = string.IsNullOrWhiteSpace(keySecretName)
-            ? throw new ArgumentException("keySecretName is required", nameof(keySecretName))
-            : keySecretName;
+        _options = options;
+
+        if (string.IsNullOrWhiteSpace(options.KeySecretPrefix))
+            throw new ArgumentException("KeySecretPrefix is required", nameof(options));
+        if (string.IsNullOrWhiteSpace(options.CurrentKeyVersion))
+            throw new ArgumentException("CurrentKeyVersion is required", nameof(options));
+        if (options.AcceptedKeyVersions.Count == 0)
+            throw new ArgumentException("AcceptedKeyVersions must contain at least one entry", nameof(options));
+        if (!options.AcceptedKeyVersions.Contains(options.CurrentKeyVersion, StringComparer.OrdinalIgnoreCase))
+            throw new ArgumentException(
+                "CurrentKeyVersion must be listed in AcceptedKeyVersions", nameof(options));
     }
 
     public bool IsEnabled => true;
 
     public async Task<string> FingerprintAsync(string normalizedPlaintext, CancellationToken ct = default)
     {
-        var key = await GetKeyAsync(ct);
+        var key = await ResolveKeyAsync(_options.CurrentKeyVersion, ct);
+        return Compute(key, normalizedPlaintext);
+    }
+
+    public async Task<IReadOnlyList<string>> FingerprintCandidatesAsync(
+        string normalizedPlaintext, CancellationToken ct = default)
+    {
+        var results = new List<string>(_options.AcceptedKeyVersions.Count);
+        foreach (var version in _options.AcceptedKeyVersions)
+        {
+            byte[] key;
+            try
+            {
+                key = await ResolveKeyAsync(version, ct);
+            }
+            catch (InvalidOperationException ex)
+            {
+                // An accepted version without a resolvable secret is a
+                // misconfiguration; the health check reports this as
+                // Degraded. On the dedupe read path we log-and-skip so a
+                // partially-broken window doesn't silently produce
+                // duplicate identifiers.
+                _logger.LogWarning(ex,
+                    "Fingerprint key version {Version} listed in AcceptedKeyVersions could not be resolved; skipping candidate",
+                    Sanitize(version));
+                continue;
+            }
+            results.Add(Compute(key, normalizedPlaintext));
+        }
+        return results;
+    }
+
+    private async Task<byte[]> ResolveKeyAsync(string version, CancellationToken ct)
+    {
+        try
+        {
+            var key = await _keys.GetKeyAsync(_options.KeySecretPrefix, version, devConfigFallback: null, ct);
+            EnsureKeyLength(key);
+            return key;
+        }
+        catch (InvalidOperationException)
+        {
+            // Fall through to legacy secret name if configured and the
+            // version is v1. Lets deployments with only the pre-A.7.3
+            // single-name fingerprint key continue resolving candidates
+            // under their implicit v1 without publishing a versioned
+            // secret on day one.
+            if (string.Equals(version, "v1", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(_options.LegacyKeySecretName))
+            {
+                var raw = await _secrets.GetSecretAsync(_options.LegacyKeySecretName!, ct);
+                if (!string.IsNullOrEmpty(raw))
+                {
+                    var keyBytes = DecodeRaw(raw);
+                    EnsureKeyLength(keyBytes);
+                    return keyBytes;
+                }
+            }
+            throw;
+        }
+    }
+
+    private static byte[] DecodeRaw(string raw)
+    {
+        try { return Convert.FromBase64String(raw); }
+        catch (FormatException) { return Encoding.UTF8.GetBytes(raw); }
+    }
+
+    private static void EnsureKeyLength(byte[] keyBytes)
+    {
+        if (keyBytes.Length < 32)
+            throw new InvalidOperationException(
+                $"Identifier fingerprint HMAC key must be at least 32 bytes; got {keyBytes.Length}.");
+    }
+
+    private static string Compute(byte[] key, string normalizedPlaintext)
+    {
         var data = Encoding.UTF8.GetBytes(normalizedPlaintext ?? string.Empty);
         var hash = HMACSHA256.HashData(key, data);
         return Convert.ToHexString(hash);
     }
 
-    private async Task<byte[]> GetKeyAsync(CancellationToken ct)
-    {
-        if (_cachedKey != null) return _cachedKey;
-
-        await _keyLock.WaitAsync(ct);
-        try
-        {
-            if (_cachedKey != null) return _cachedKey;
-
-            var raw = await _secrets.GetSecretAsync(_keySecretName, ct)
-                ?? throw new InvalidOperationException(
-                    $"Identifier fingerprint HMAC key '{_keySecretName}' not found in secret provider.");
-
-            byte[] keyBytes;
-            try
-            {
-                keyBytes = Convert.FromBase64String(raw);
-            }
-            catch (FormatException)
-            {
-                keyBytes = Encoding.UTF8.GetBytes(raw);
-            }
-
-            if (keyBytes.Length < 32)
-                throw new InvalidOperationException(
-                    $"Identifier fingerprint HMAC key must be at least 32 bytes; got {keyBytes.Length}.");
-
-            _cachedKey = keyBytes;
-            return keyBytes;
-        }
-        finally
-        {
-            _keyLock.Release();
-        }
-    }
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
 }

--- a/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/HmacSha256IdentifierFingerprinter.cs
@@ -70,15 +70,20 @@ public sealed class HmacSha256IdentifierFingerprinter : IIdentifierFingerprinter
             }
             catch (InvalidOperationException ex)
             {
-                // An accepted version without a resolvable secret is a
-                // misconfiguration; the health check reports this as
-                // Degraded. On the dedupe read path we log-and-skip so a
-                // partially-broken window doesn't silently produce
-                // duplicate identifiers.
-                _logger.LogWarning(ex,
-                    "Fingerprint key version {Version} listed in AcceptedKeyVersions could not be resolved; skipping candidate",
+                // Fail closed: skipping an accepted version means a row
+                // fingerprinted under it wouldn't match, and the caller
+                // would silently admit a duplicate. That's worse than
+                // returning an error. The health check flags this as
+                // Degraded so ops has already been paged; the read-path
+                // caller should 503 here rather than serve the dedupe
+                // check with a partial candidate set.
+                _logger.LogError(ex,
+                    "Fingerprint key version {Version} listed in AcceptedKeyVersions could not be resolved; failing closed on the candidate set",
                     Sanitize(version));
-                continue;
+                throw new StaleFingerprintKeyException(version,
+                    $"Accepted fingerprint key version '{version}' cannot be resolved. " +
+                    "Publish the secret or drop the version from AcceptedKeyVersions.",
+                    ex);
             }
             results.Add(Compute(key, normalizedPlaintext));
         }

--- a/src/services/member-service/Services/IIdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/IIdentifierFingerprinter.cs
@@ -2,9 +2,10 @@ namespace MemberService.Services;
 
 /// <summary>
 /// Deterministic fingerprint for PII identifier values. Used ONLY for
-/// duplicate detection — never for lookup beyond equality comparison, never
-/// reversed. Implementations must use a KV-backed HMAC key that is DISTINCT
-/// from the AES-GCM encryption key so the two secrets can rotate independently.
+/// duplicate detection — never for lookup beyond equality comparison,
+/// never reversed. Implementations must use a KV-backed HMAC key that is
+/// DISTINCT from the AES-GCM encryption key so the two secrets can rotate
+/// independently.
 /// </summary>
 public interface IIdentifierFingerprinter
 {
@@ -12,8 +13,21 @@ public interface IIdentifierFingerprinter
     bool IsEnabled { get; }
 
     /// <summary>
-    /// Returns a stable fingerprint for the given already-normalized plaintext.
-    /// Same input → same output (for the lifetime of the HMAC key).
+    /// Returns a stable fingerprint for the given already-normalized plaintext
+    /// under the CURRENT key version. Same input → same output (until the
+    /// current key version rotates). This is the WRITE path — what gets
+    /// persisted alongside the encrypted identifier.
     /// </summary>
     Task<string> FingerprintAsync(string normalizedPlaintext, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a fingerprint under every accepted key version — newest first.
+    /// Used by READ paths (dedupe checks, lookups, removals) so a record
+    /// fingerprinted under the previous key version still matches when the
+    /// current version has rotated. Callers should do
+    /// <c>candidates.Contains(storedFingerprint)</c> or SQL <c>IN (...)</c>.
+    /// </summary>
+    Task<IReadOnlyList<string>> FingerprintCandidatesAsync(
+        string normalizedPlaintext,
+        CancellationToken ct = default);
 }

--- a/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
+++ b/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
@@ -6,37 +6,54 @@ using Microsoft.Extensions.Logging;
 namespace MemberService.Services;
 
 /// <summary>
-/// AES-256-GCM identifier encryptor. The data encryption key is fetched from the
-/// configured secret provider (Azure Key Vault in prod) — no key material is
-/// maintained in this process. Reuses the existing <see cref="ISecretProvider"/>
-/// pattern rather than adding another crypto layer.
+/// AES-256-GCM identifier encryptor. The data encryption key is fetched
+/// through <see cref="RotatingKeyProvider"/> so rotation is done by
+/// publishing a new <c>{prefix}-{version}</c> secret and flipping
+/// <c>MemberEncryption:CurrentKeyVersion</c> — no code change.
 ///
-/// Ciphertext format (base64url of):
-///   [1 byte version = 0x01][12 bytes IV][16 bytes tag][ciphertext bytes]
+/// Envelope formats (base64url of):
+///   0x01: [0x01][12 IV][16 tag][ciphertext]
+///          — legacy, decrypt only, key resolved via LegacyKeySecretName.
+///   0x02: [0x02][keyVerLen=1 byte][keyVer UTF-8 bytes][12 IV][16 tag][ciphertext]
+///          — all new encryptions. keyVer is an operator-controlled
+///            version string that must appear in AcceptedKeyVersions for
+///            decryption to succeed.
+///
+/// 0x01 decoding is retained indefinitely. A record written under 0x01
+/// stays decryptable until a separate backfill re-encrypts it under 0x02.
 /// </summary>
 public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
 {
-    private const byte Version = 0x01;
+    private const byte FormatV1 = 0x01;
+    private const byte FormatV2 = 0x02;
     private const int NonceSize = 12;
     private const int TagSize = 16;
 
+    private readonly RotatingKeyProvider _keys;
     private readonly ISecretProvider _secrets;
     private readonly ILogger<KeyVaultIdentifierEncryptor> _logger;
-    private readonly string _keySecretName;
+    private readonly MemberEncryptionOptions _options;
 
-    private byte[]? _cachedKey;
-    private readonly SemaphoreSlim _keyLock = new(1, 1);
+    private byte[]? _cachedLegacyKey;
+    private readonly SemaphoreSlim _legacyKeyLock = new(1, 1);
 
     public KeyVaultIdentifierEncryptor(
+        RotatingKeyProvider keys,
         ISecretProvider secrets,
         ILogger<KeyVaultIdentifierEncryptor> logger,
-        string keySecretName)
+        MemberEncryptionOptions options)
     {
+        _keys = keys;
         _secrets = secrets;
         _logger = logger;
-        _keySecretName = string.IsNullOrWhiteSpace(keySecretName)
-            ? throw new ArgumentException("keySecretName is required", nameof(keySecretName))
-            : keySecretName;
+        _options = options;
+
+        if (string.IsNullOrWhiteSpace(options.KeySecretPrefix))
+            throw new ArgumentException("KeySecretPrefix is required", nameof(options));
+        if (string.IsNullOrWhiteSpace(options.CurrentKeyVersion))
+            throw new ArgumentException("CurrentKeyVersion is required", nameof(options));
+        if (options.AcceptedKeyVersions.Count == 0)
+            throw new ArgumentException("AcceptedKeyVersions must contain at least one entry", nameof(options));
     }
 
     public bool IsEnabled => true;
@@ -45,20 +62,63 @@ public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
     {
         if (string.IsNullOrEmpty(plaintext)) return plaintext;
 
-        var key = await GetKeyAsync(ct);
+        return _options.EmitLegacyEnvelope
+            ? await EncryptV1Async(plaintext, ct)
+            : await EncryptV2Async(plaintext, ct);
+    }
+
+    private async Task<string> EncryptV1Async(string plaintext, CancellationToken ct)
+    {
+        var key = await GetLegacyKeyAsync(ct);
+        EnsureKeyLength(key);
+
         var nonce = RandomNumberGenerator.GetBytes(NonceSize);
         var plainBytes = Encoding.UTF8.GetBytes(plaintext);
         var cipherBytes = new byte[plainBytes.Length];
         var tag = new byte[TagSize];
 
-        using var gcm = new AesGcm(key, TagSize);
-        gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+        using (var gcm = new AesGcm(key, TagSize))
+        {
+            gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+        }
 
         var envelope = new byte[1 + NonceSize + TagSize + cipherBytes.Length];
-        envelope[0] = Version;
+        envelope[0] = FormatV1;
         Buffer.BlockCopy(nonce, 0, envelope, 1, NonceSize);
         Buffer.BlockCopy(tag, 0, envelope, 1 + NonceSize, TagSize);
         Buffer.BlockCopy(cipherBytes, 0, envelope, 1 + NonceSize + TagSize, cipherBytes.Length);
+        return Base64UrlEncode(envelope);
+    }
+
+    private async Task<string> EncryptV2Async(string plaintext, CancellationToken ct)
+    {
+        var keyVersion = _options.CurrentKeyVersion;
+        var keyVersionBytes = Encoding.UTF8.GetBytes(keyVersion);
+        if (keyVersionBytes.Length == 0 || keyVersionBytes.Length > 255)
+            throw new InvalidOperationException(
+                $"MemberEncryption:CurrentKeyVersion '{keyVersion}' must be 1..255 UTF-8 bytes.");
+
+        var key = await ResolveCurrentKeyAsync(keyVersion, ct);
+        EnsureKeyLength(key);
+
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var cipherBytes = new byte[plainBytes.Length];
+        var tag = new byte[TagSize];
+
+        using (var gcm = new AesGcm(key, TagSize))
+        {
+            gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+        }
+
+        var envelope = new byte[1 + 1 + keyVersionBytes.Length + NonceSize + TagSize + cipherBytes.Length];
+        var o = 0;
+        envelope[o++] = FormatV2;
+        envelope[o++] = (byte)keyVersionBytes.Length;
+        Buffer.BlockCopy(keyVersionBytes, 0, envelope, o, keyVersionBytes.Length); o += keyVersionBytes.Length;
+        Buffer.BlockCopy(nonce, 0, envelope, o, NonceSize); o += NonceSize;
+        Buffer.BlockCopy(tag, 0, envelope, o, TagSize); o += TagSize;
+        Buffer.BlockCopy(cipherBytes, 0, envelope, o, cipherBytes.Length);
 
         return Base64UrlEncode(envelope);
     }
@@ -78,10 +138,21 @@ public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
             throw;
         }
 
+        if (envelope.Length < 1)
+            throw new CryptographicException("Envelope is empty");
+
+        return envelope[0] switch
+        {
+            FormatV1 => await DecryptV1Async(envelope, ct),
+            FormatV2 => await DecryptV2Async(envelope, ct),
+            _ => throw new CryptographicException($"Unsupported envelope version 0x{envelope[0]:X2}")
+        };
+    }
+
+    private async Task<string> DecryptV1Async(byte[] envelope, CancellationToken ct)
+    {
         if (envelope.Length < 1 + NonceSize + TagSize)
-            throw new CryptographicException("Envelope too short");
-        if (envelope[0] != Version)
-            throw new CryptographicException($"Unsupported envelope version 0x{envelope[0]:X2}");
+            throw new CryptographicException("0x01 envelope too short");
 
         var nonce = new byte[NonceSize];
         var tag = new byte[TagSize];
@@ -91,48 +162,105 @@ public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
         Buffer.BlockCopy(envelope, 1 + NonceSize, tag, 0, TagSize);
         Buffer.BlockCopy(envelope, 1 + NonceSize + TagSize, cipherBytes, 0, cipherLen);
 
-        var key = await GetKeyAsync(ct);
+        var key = await GetLegacyKeyAsync(ct);
+        EnsureKeyLength(key);
+
         var plainBytes = new byte[cipherLen];
         using var gcm = new AesGcm(key, TagSize);
         gcm.Decrypt(nonce, cipherBytes, tag, plainBytes);
         return Encoding.UTF8.GetString(plainBytes);
     }
 
-    private async Task<byte[]> GetKeyAsync(CancellationToken ct)
+    private async Task<string> DecryptV2Async(byte[] envelope, CancellationToken ct)
     {
-        if (_cachedKey != null) return _cachedKey;
+        if (envelope.Length < 1 + 1) throw new CryptographicException("0x02 envelope too short");
+        int keyVerLen = envelope[1];
+        var headerLen = 1 + 1 + keyVerLen;
+        if (envelope.Length < headerLen + NonceSize + TagSize)
+            throw new CryptographicException("0x02 envelope too short for key-version + IV + tag");
 
-        await _keyLock.WaitAsync(ct);
+        var keyVersion = Encoding.UTF8.GetString(envelope, 2, keyVerLen);
+
+        if (!_options.AcceptedKeyVersions.Contains(keyVersion, StringComparer.OrdinalIgnoreCase))
+            throw new CryptographicException(
+                $"Envelope key version '{keyVersion}' is not in MemberEncryption:AcceptedKeyVersions. " +
+                "Either widen the accepted window or re-encrypt the record.");
+
+        byte[] key;
         try
         {
-            if (_cachedKey != null) return _cachedKey;
+            key = await _keys.GetKeyAsync(_options.KeySecretPrefix, keyVersion, devConfigFallback: null, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new StaleEncryptionKeyException(keyVersion,
+                $"Accepted key version '{keyVersion}' cannot be resolved from the secret provider. " +
+                "Publish the secret or drop the version from AcceptedKeyVersions once backfill completes.",
+                ex);
+        }
+        EnsureKeyLength(key);
 
-            var raw = await _secrets.GetSecretAsync(_keySecretName, ct)
-                ?? throw new InvalidOperationException(
-                    $"Identifier encryption key '{_keySecretName}' not found in secret provider. " +
-                    "Provision a 32-byte key in Key Vault under this name.");
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipherLen = envelope.Length - headerLen - NonceSize - TagSize;
+        var cipherBytes = new byte[cipherLen];
+        Buffer.BlockCopy(envelope, headerLen, nonce, 0, NonceSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize, tag, 0, TagSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize + TagSize, cipherBytes, 0, cipherLen);
+
+        var plainBytes = new byte[cipherLen];
+        using var gcm = new AesGcm(key, TagSize);
+        gcm.Decrypt(nonce, cipherBytes, tag, plainBytes);
+        return Encoding.UTF8.GetString(plainBytes);
+    }
+
+    private async Task<byte[]> ResolveCurrentKeyAsync(string version, CancellationToken ct)
+    {
+        try
+        {
+            return await _keys.GetKeyAsync(_options.KeySecretPrefix, version, devConfigFallback: null, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new StaleEncryptionKeyException(version,
+                $"Current key version '{version}' cannot be resolved. Cannot encrypt new identifiers.",
+                ex);
+        }
+    }
+
+    private async Task<byte[]> GetLegacyKeyAsync(CancellationToken ct)
+    {
+        if (_cachedLegacyKey != null) return _cachedLegacyKey;
+        await _legacyKeyLock.WaitAsync(ct);
+        try
+        {
+            if (_cachedLegacyKey != null) return _cachedLegacyKey;
+            if (string.IsNullOrWhiteSpace(_options.LegacyKeySecretName))
+                throw new CryptographicException(
+                    "0x01 envelope encountered but MemberEncryption:LegacyKeySecretName is not configured.");
+
+            var raw = await _secrets.GetSecretAsync(_options.LegacyKeySecretName, ct)
+                ?? throw new CryptographicException(
+                    $"0x01 envelope decrypt failed: legacy key '{_options.LegacyKeySecretName}' not found in secret provider.");
 
             byte[] keyBytes;
-            try
-            {
-                keyBytes = Convert.FromBase64String(raw);
-            }
-            catch (FormatException)
-            {
-                keyBytes = Encoding.UTF8.GetBytes(raw);
-            }
+            try { keyBytes = Convert.FromBase64String(raw); }
+            catch (FormatException) { keyBytes = Encoding.UTF8.GetBytes(raw); }
 
-            if (keyBytes.Length != 32)
-                throw new InvalidOperationException(
-                    $"Identifier encryption key must be 32 bytes (AES-256); got {keyBytes.Length}.");
-
-            _cachedKey = keyBytes;
+            _cachedLegacyKey = keyBytes;
             return keyBytes;
         }
         finally
         {
-            _keyLock.Release();
+            _legacyKeyLock.Release();
         }
+    }
+
+    private static void EnsureKeyLength(byte[] key)
+    {
+        if (key.Length != 32)
+            throw new InvalidOperationException(
+                $"Identifier encryption key must be 32 bytes (AES-256); got {key.Length}.");
     }
 
     private static string Base64UrlEncode(byte[] bytes) =>
@@ -148,5 +276,4 @@ public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
         }
         return Convert.FromBase64String(padded);
     }
-
 }

--- a/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
+++ b/src/services/member-service/Services/KeyVaultIdentifierEncryptor.cs
@@ -132,10 +132,14 @@ public sealed class KeyVaultIdentifierEncryptor : IIdentifierEncryptor
         {
             envelope = Base64UrlDecode(ciphertext);
         }
-        catch (FormatException)
+        catch (FormatException ex)
         {
-            _logger.LogWarning("Identifier ciphertext is not valid base64url");
-            throw;
+            // Translate to CryptographicException so the entire decrypt
+            // surface has a single failure type for callers — base64
+            // decode is an internal implementation detail of the envelope
+            // format, not a contract the caller should know about.
+            _logger.LogWarning(ex, "Identifier ciphertext is not valid base64url");
+            throw new CryptographicException("Identifier ciphertext is not valid base64url", ex);
         }
 
         if (envelope.Length < 1)

--- a/src/services/member-service/Services/MemberEncryptionOptions.cs
+++ b/src/services/member-service/Services/MemberEncryptionOptions.cs
@@ -1,0 +1,31 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Config surface for <see cref="KeyVaultIdentifierEncryptor"/>. Defaults
+/// match a first-deploy service — no explicit MemberEncryption section
+/// and v1 as the implied current version. The <see cref="LegacyKeySecretName"/>
+/// is the secret name used to decrypt envelopes emitted by the pre-A.7.3
+/// encryptor (format-version 0x01).
+/// </summary>
+public sealed record MemberEncryptionOptions
+{
+    public const string SectionName = "MemberEncryption";
+
+    public string KeySecretPrefix { get; init; } = "member-identifier-encryption-key";
+    public string CurrentKeyVersion { get; init; } = "v1";
+    public IReadOnlyList<string> AcceptedKeyVersions { get; init; } = new[] { "v1" };
+    public string? LegacyKeySecretName { get; init; } = "member-identifier-encryption-key";
+
+    /// <summary>
+    /// When true, <see cref="KeyVaultIdentifierEncryptor.EncryptAsync"/> emits
+    /// 0x01 (legacy) envelopes resolved via <see cref="LegacyKeySecretName"/>
+    /// instead of 0x02 envelopes resolved via the rotating prefix. Set only
+    /// by the legacy-config bridge in Program.cs so a service booting with
+    /// only the pre-A.7.3 <c>Member:IdentifierEncryption:KeySecretName</c>
+    /// key continues to write the exact same envelope shape and can't produce
+    /// 0x02 envelopes referencing a prefix-versioned secret that doesn't exist.
+    /// When the operator adds an explicit <c>MemberEncryption</c> section,
+    /// this flag stays false and new writes become 0x02.
+    /// </summary>
+    public bool EmitLegacyEnvelope { get; init; } = false;
+}

--- a/src/services/member-service/Services/MemberFingerprintingOptions.cs
+++ b/src/services/member-service/Services/MemberFingerprintingOptions.cs
@@ -1,0 +1,27 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Config surface for <see cref="HmacSha256IdentifierFingerprinter"/>.
+/// Separate from <see cref="MemberEncryptionOptions"/> because the
+/// fingerprint key MUST be distinct from the AES-GCM encryption key so
+/// the two secrets can rotate independently.
+///
+/// Defaults match a first-deploy service — no explicit
+/// MemberFingerprinting block and v1 as the implied current version.
+/// </summary>
+public sealed record MemberFingerprintingOptions
+{
+    public const string SectionName = "MemberFingerprinting";
+
+    public string KeySecretPrefix { get; init; } = "member-identifier-fingerprint-key";
+    public string CurrentKeyVersion { get; init; } = "v1";
+    public IReadOnlyList<string> AcceptedKeyVersions { get; init; } = new[] { "v1" };
+
+    /// <summary>
+    /// Secret name used by the pre-A.7.3 single-key fingerprinter.
+    /// Resolved as an implicit "v1" entry when the operator hasn't
+    /// published <c>{KeySecretPrefix}-v1</c> yet — preserves dedupe
+    /// for rows written before rotation support landed.
+    /// </summary>
+    public string? LegacyKeySecretName { get; init; } = "member-identifier-fingerprint-key";
+}

--- a/src/services/member-service/Services/NoOpIdentifierFingerprinter.cs
+++ b/src/services/member-service/Services/NoOpIdentifierFingerprinter.cs
@@ -16,4 +16,11 @@ public sealed class NoOpIdentifierFingerprinter : IIdentifierFingerprinter
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedPlaintext ?? string.Empty));
         return Task.FromResult(Convert.ToHexString(bytes));
     }
+
+    public async Task<IReadOnlyList<string>> FingerprintCandidatesAsync(
+        string normalizedPlaintext, CancellationToken ct = default)
+    {
+        // Dev shim: a single candidate equal to the deterministic SHA-256.
+        return new[] { await FingerprintAsync(normalizedPlaintext, ct) };
+    }
 }

--- a/src/services/member-service/Services/StaleEncryptionKeyException.cs
+++ b/src/services/member-service/Services/StaleEncryptionKeyException.cs
@@ -1,0 +1,23 @@
+using System.Security.Cryptography;
+
+namespace MemberService.Services;
+
+/// <summary>
+/// Thrown when an envelope references a key version that is listed in the
+/// service's <c>AcceptedKeyVersions</c> window but whose underlying secret
+/// cannot be resolved from the <see cref="CloudHealthOffice.Infrastructure.Configuration.ISecretProvider"/>.
+/// Distinct from a plain <see cref="CryptographicException"/> (which
+/// indicates tampered ciphertext or the wrong key) so that callers can
+/// distinguish "rotation migration failure — page ops" from "possible
+/// tamper — audit the caller".
+/// </summary>
+public sealed class StaleEncryptionKeyException : CryptographicException
+{
+    public string KeyVersion { get; }
+
+    public StaleEncryptionKeyException(string keyVersion, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        KeyVersion = keyVersion;
+    }
+}

--- a/src/services/member-service/Services/StaleFingerprintKeyException.cs
+++ b/src/services/member-service/Services/StaleFingerprintKeyException.cs
@@ -1,0 +1,25 @@
+namespace MemberService.Services;
+
+/// <summary>
+/// Thrown by <see cref="HmacSha256IdentifierFingerprinter.FingerprintCandidatesAsync"/>
+/// when an accepted key version cannot be resolved from the secret
+/// provider. Distinct from <see cref="StaleEncryptionKeyException"/> so
+/// callers can 503 specifically when the dedupe system is degraded —
+/// silently producing a partial candidate set could let duplicate PII
+/// identifiers past the uniqueness check, which is a correctness
+/// violation, not a degraded-but-serve one.
+///
+/// The health check already surfaces missing versions as Degraded; the
+/// throw here is the read-side enforcement so a misconfigured window
+/// doesn't reach the dedupe path.
+/// </summary>
+public sealed class StaleFingerprintKeyException : InvalidOperationException
+{
+    public string KeyVersion { get; }
+
+    public StaleFingerprintKeyException(string keyVersion, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        KeyVersion = keyVersion;
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/RotatingKeyProviderTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/RotatingKeyProviderTests.cs
@@ -1,0 +1,100 @@
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudHealthOffice.Infrastructure.Tests;
+
+public class RotatingKeyProviderTests
+{
+    private static RotatingKeyProvider New(Mock<ISecretProvider> secrets) =>
+        new(secrets.Object, NullLogger<RotatingKeyProvider>.Instance);
+
+    [Fact]
+    public async Task GetKey_UnknownSecret_ThrowsDescriptive()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var sut = New(secrets);
+        var act = async () => await sut.GetKeyAsync("pref", "v1");
+        var ex = await act.Should().ThrowAsync<InvalidOperationException>();
+        ex.Which.Message.Should().Contain("pref-v1").And.Contain("AcceptedKeyVersions");
+    }
+
+    [Fact]
+    public async Task GetKey_UsesDevConfigFallback_WhenSecretMissing()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var sut = New(secrets);
+        var key = await sut.GetKeyAsync("pref", "v1", devConfigFallback: "dev-key-bytes-here");
+        key.Should().Equal(Encoding.UTF8.GetBytes("dev-key-bytes-here"));
+    }
+
+    [Fact]
+    public async Task GetKey_CachesResult_SingleSecretProviderCall()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Convert.ToBase64String(new byte[32]));
+
+        var sut = New(secrets);
+        var first = await sut.GetKeyAsync("pref", "v1");
+        var second = await sut.GetKeyAsync("pref", "v1");
+
+        first.Should().BeSameAs(second);
+        secrets.Verify(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetKey_PerVersionCache_NotSharedAcrossVersions()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Convert.ToBase64String(Enumerable.Repeat((byte)0x11, 32).ToArray()));
+        secrets.Setup(s => s.GetSecretAsync("pref-v2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Convert.ToBase64String(Enumerable.Repeat((byte)0x22, 32).ToArray()));
+
+        var sut = New(secrets);
+        var v1 = await sut.GetKeyAsync("pref", "v1");
+        var v2 = await sut.GetKeyAsync("pref", "v2");
+
+        v1[0].Should().Be(0x11);
+        v2[0].Should().Be(0x22);
+    }
+
+    [Fact]
+    public async Task InvalidateCache_ForcesReResolution()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.SetupSequence(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Convert.ToBase64String(Enumerable.Repeat((byte)0xAA, 32).ToArray()))
+            .ReturnsAsync(Convert.ToBase64String(Enumerable.Repeat((byte)0xBB, 32).ToArray()));
+
+        var sut = New(secrets);
+        var before = await sut.GetKeyAsync("pref", "v1");
+        before[0].Should().Be(0xAA);
+
+        sut.InvalidateCache();
+
+        var after = await sut.GetKeyAsync("pref", "v1");
+        after[0].Should().Be(0xBB);
+        secrets.Verify(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetKey_DecodesBase64First_ThenFallsBackToUtf8()
+    {
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("not-base64!!plain-utf8-literal");
+
+        var sut = New(secrets);
+        var key = await sut.GetKeyAsync("pref", "v1");
+        key.Should().Equal(Encoding.UTF8.GetBytes("not-base64!!plain-utf8-literal"));
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/RotatingKeyProviderTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/RotatingKeyProviderTests.cs
@@ -97,4 +97,47 @@ public class RotatingKeyProviderTests
         var key = await sut.GetKeyAsync("pref", "v1");
         key.Should().Equal(Encoding.UTF8.GetBytes("not-base64!!plain-utf8-literal"));
     }
+
+    /// <summary>
+    /// Regression guard for the race the reviewer flagged: an in-flight
+    /// resolve that completes AFTER an InvalidateCache must not persist
+    /// its (now-stale) result back into the cache. The generation counter
+    /// makes the resolve's write-back conditional on the generation being
+    /// unchanged since the fetch started.
+    /// </summary>
+    [Fact]
+    public async Task GetKey_InvalidationDuringInFlightResolve_SkipsWriteBack()
+    {
+        var fetchReleased = new TaskCompletionSource<string?>();
+        var fetchStarted = new TaskCompletionSource();
+
+        var secrets = new Mock<ISecretProvider>();
+        secrets.Setup(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                fetchStarted.TrySetResult();
+                return await fetchReleased.Task;
+            });
+
+        var sut = New(secrets);
+
+        // Start the resolve and wait until it's inside the secret-provider call.
+        var resolveTask = sut.GetKeyAsync("pref", "v1");
+        await fetchStarted.Task;
+
+        // Invalidate before the fetch completes.
+        sut.InvalidateCache();
+
+        // Let the fetch return. The result should NOT land in the cache.
+        fetchReleased.SetResult(Convert.ToBase64String(Enumerable.Repeat((byte)0xAA, 32).ToArray()));
+        var firstBytes = await resolveTask;
+        firstBytes[0].Should().Be(0xAA);
+
+        // A subsequent call must re-fetch (cache was cleared and the in-flight
+        // write was suppressed), so the mock returns the NEW stub.
+        secrets.Setup(s => s.GetSecretAsync("pref-v1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Convert.ToBase64String(Enumerable.Repeat((byte)0xBB, 32).ToArray()));
+        var secondBytes = await sut.GetKeyAsync("pref", "v1");
+        secondBytes[0].Should().Be(0xBB);
+    }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/SecretRefreshServiceTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/SecretRefreshServiceTests.cs
@@ -7,6 +7,13 @@ namespace CloudHealthOffice.Infrastructure.Tests;
 
 public class SecretRefreshServiceTests
 {
+    // A short-but-bounded wait used when asserting that a
+    // ChangeToken.OnChange callback fired. All waits go through a signal
+    // that's set inside the fake provider's InvalidateCache override, so
+    // a passing test completes in microseconds; the timeout only trips
+    // on a real regression.
+    private static readonly TimeSpan CallbackTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// An IConfiguration source whose reload token is a mutable
     /// CancellationChangeToken — calling <see cref="FireReload"/> cancels
@@ -37,26 +44,52 @@ public class SecretRefreshServiceTests
         public IConfigurationSection GetSection(string key) => throw new NotSupportedException();
     }
 
-    private sealed class CountingProvider : RotatingKeyProvider
+    /// <summary>
+    /// Test double that signals a per-call <see cref="ManualResetEventSlim"/>
+    /// whenever <see cref="InvalidateCache"/> runs, so tests can wait
+    /// deterministically for the Nth invalidation rather than sleeping.
+    /// </summary>
+    private sealed class SignallingProvider : RotatingKeyProvider
     {
         public int InvalidateCalls;
-        public CountingProvider() : base(new NullSecretProvider(), NullLogger<RotatingKeyProvider>.Instance) { }
-        public override void InvalidateCache()
-        {
-            Interlocked.Increment(ref InvalidateCalls);
-            base.InvalidateCache();
-        }
-    }
+        private readonly ManualResetEventSlim _signal = new(false);
+        private readonly bool _throwOnFirst;
 
-    private sealed class FailOnceProvider : RotatingKeyProvider
-    {
-        public int InvalidateCalls;
-        public FailOnceProvider() : base(new NullSecretProvider(), NullLogger<RotatingKeyProvider>.Instance) { }
+        public SignallingProvider(bool throwOnFirst = false)
+            : base(new NullSecretProvider(), NullLogger<RotatingKeyProvider>.Instance)
+        {
+            _throwOnFirst = throwOnFirst;
+        }
+
         public override void InvalidateCache()
         {
             var n = Interlocked.Increment(ref InvalidateCalls);
-            if (n == 1) throw new InvalidOperationException("first invalidation throws");
-            base.InvalidateCache();
+            try
+            {
+                if (_throwOnFirst && n == 1)
+                    throw new InvalidOperationException("first invalidation throws");
+                base.InvalidateCache();
+            }
+            finally
+            {
+                _signal.Set();
+            }
+        }
+
+        public void WaitFor(int expectedCount)
+        {
+            var deadline = DateTime.UtcNow + CallbackTimeout;
+            while (Interlocked.CompareExchange(ref InvalidateCalls, 0, 0) < expectedCount)
+            {
+                var remaining = deadline - DateTime.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                    throw new TimeoutException(
+                        $"Expected InvalidateCalls >= {expectedCount}, got {InvalidateCalls} after {CallbackTimeout}");
+
+                _signal.Reset();
+                if (Interlocked.CompareExchange(ref InvalidateCalls, 0, 0) >= expectedCount) return;
+                _signal.Wait(remaining);
+            }
         }
     }
 
@@ -64,12 +97,12 @@ public class SecretRefreshServiceTests
     public async Task OnReload_InvalidatesCache()
     {
         var cfg = new FakeReloadingConfiguration();
-        var provider = new CountingProvider();
+        var provider = new SignallingProvider();
         var svc = new SecretRefreshService(cfg, provider, NullLogger<SecretRefreshService>.Instance);
         await svc.StartAsync(CancellationToken.None);
 
         cfg.FireReload();
-        await Task.Delay(50); // ChangeToken.OnChange fires synchronously but on the firing thread; give it a tick.
+        provider.WaitFor(1);
 
         provider.InvalidateCalls.Should().Be(1);
 
@@ -89,14 +122,15 @@ public class SecretRefreshServiceTests
     public async Task OnReload_SurvivesCallbackException_AndProcessesSubsequentReloads()
     {
         var cfg = new FakeReloadingConfiguration();
-        var provider = new FailOnceProvider();
+        var provider = new SignallingProvider(throwOnFirst: true);
         var svc = new SecretRefreshService(cfg, provider, NullLogger<SecretRefreshService>.Instance);
         await svc.StartAsync(CancellationToken.None);
 
-        cfg.FireReload();          // attempt #1 → throws inside InvalidateCache
-        await Task.Delay(50);
-        cfg.FireReload();          // attempt #2 → must still reach InvalidateCache
-        await Task.Delay(50);
+        cfg.FireReload();               // attempt #1 → throws inside InvalidateCache
+        provider.WaitFor(1);
+
+        cfg.FireReload();               // attempt #2 → must still reach InvalidateCache
+        provider.WaitFor(2);
 
         provider.InvalidateCalls.Should().Be(2);
 

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/SecretRefreshServiceTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/SecretRefreshServiceTests.cs
@@ -1,0 +1,105 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+
+namespace CloudHealthOffice.Infrastructure.Tests;
+
+public class SecretRefreshServiceTests
+{
+    /// <summary>
+    /// An IConfiguration source whose reload token is a mutable
+    /// CancellationChangeToken — calling <see cref="FireReload"/> cancels
+    /// the current token, which fires the ChangeToken.OnChange callback.
+    /// </summary>
+    private sealed class FakeReloadingConfiguration : IConfiguration
+    {
+        private CancellationTokenSource _cts = new();
+        private IChangeToken _token;
+
+        public FakeReloadingConfiguration()
+        {
+            _token = new CancellationChangeToken(_cts.Token);
+        }
+
+        public void FireReload()
+        {
+            var old = _cts;
+            var newCts = new CancellationTokenSource();
+            _cts = newCts;
+            _token = new CancellationChangeToken(newCts.Token);
+            old.Cancel();
+        }
+
+        public IChangeToken GetReloadToken() => _token;
+        public string? this[string key] { get => null; set { } }
+        public IEnumerable<IConfigurationSection> GetChildren() => Array.Empty<IConfigurationSection>();
+        public IConfigurationSection GetSection(string key) => throw new NotSupportedException();
+    }
+
+    private sealed class CountingProvider : RotatingKeyProvider
+    {
+        public int InvalidateCalls;
+        public CountingProvider() : base(new NullSecretProvider(), NullLogger<RotatingKeyProvider>.Instance) { }
+        public override void InvalidateCache()
+        {
+            Interlocked.Increment(ref InvalidateCalls);
+            base.InvalidateCache();
+        }
+    }
+
+    private sealed class FailOnceProvider : RotatingKeyProvider
+    {
+        public int InvalidateCalls;
+        public FailOnceProvider() : base(new NullSecretProvider(), NullLogger<RotatingKeyProvider>.Instance) { }
+        public override void InvalidateCache()
+        {
+            var n = Interlocked.Increment(ref InvalidateCalls);
+            if (n == 1) throw new InvalidOperationException("first invalidation throws");
+            base.InvalidateCache();
+        }
+    }
+
+    [Fact]
+    public async Task OnReload_InvalidatesCache()
+    {
+        var cfg = new FakeReloadingConfiguration();
+        var provider = new CountingProvider();
+        var svc = new SecretRefreshService(cfg, provider, NullLogger<SecretRefreshService>.Instance);
+        await svc.StartAsync(CancellationToken.None);
+
+        cfg.FireReload();
+        await Task.Delay(50); // ChangeToken.OnChange fires synchronously but on the firing thread; give it a tick.
+
+        provider.InvalidateCalls.Should().Be(1);
+
+        await svc.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Regression guard for the exact silent-failure mode called out in the
+    /// addendum review: if InvalidateCache throws on one fire, a second
+    /// reload must still reach InvalidateCache. Without the try/catch in
+    /// SecretRefreshService.OnReload, the exception escapes the
+    /// ChangeToken.OnChange callback and depending on the Microsoft.Extensions
+    /// version, subsequent reload-token fires can silently stop processing —
+    /// which would negate the entire rotation flow.
+    /// </summary>
+    [Fact]
+    public async Task OnReload_SurvivesCallbackException_AndProcessesSubsequentReloads()
+    {
+        var cfg = new FakeReloadingConfiguration();
+        var provider = new FailOnceProvider();
+        var svc = new SecretRefreshService(cfg, provider, NullLogger<SecretRefreshService>.Instance);
+        await svc.StartAsync(CancellationToken.None);
+
+        cfg.FireReload();          // attempt #1 → throws inside InvalidateCache
+        await Task.Delay(50);
+        cfg.FireReload();          // attempt #2 → must still reach InvalidateCache
+        await Task.Delay(50);
+
+        provider.InvalidateCalls.Should().Be(2);
+
+        await svc.StopAsync(CancellationToken.None);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/AzureKeyVaultSecretProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/AzureKeyVaultSecretProvider.cs
@@ -83,6 +83,63 @@ public sealed class AzureKeyVaultSecretProvider : ISecretProvider
     }
 
     /// <inheritdoc />
+    public async Task<string?> GetSecretByVersionAsync(
+        string secretName, string version, CancellationToken ct = default)
+    {
+        _logger.LogDebug("Retrieving secret '{SecretName}' version '{Version}' from Azure Key Vault",
+            secretName, version);
+
+        try
+        {
+            KeyVaultSecret secret = await _client.GetSecretAsync(secretName, version, cancellationToken: ct);
+            return secret.Value;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            _logger.LogDebug("Secret '{SecretName}' version '{Version}' not found in Azure Key Vault",
+                secretName, version);
+            return null;
+        }
+        catch (RequestFailedException ex)
+        {
+            _logger.LogError(ex,
+                "Failed to retrieve secret '{SecretName}' version '{Version}' from Azure Key Vault (HTTP {Status})",
+                secretName, version, ex.Status);
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(
+        string secretName, CancellationToken ct = default)
+    {
+        _logger.LogDebug("Listing versions of secret '{SecretName}' from Azure Key Vault", secretName);
+
+        var results = new List<SecretVersionInfo>();
+        try
+        {
+            await foreach (SecretProperties p in _client.GetPropertiesOfSecretVersionsAsync(secretName, ct))
+            {
+                if (!p.Enabled.GetValueOrDefault()) continue;
+                results.Add(new SecretVersionInfo(
+                    Version: p.Version,
+                    CreatedOn: p.CreatedOn,
+                    NotBefore: p.NotBefore,
+                    ExpiresOn: p.ExpiresOn,
+                    Enabled: p.Enabled.GetValueOrDefault()));
+            }
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return Array.Empty<SecretVersionInfo>();
+        }
+
+        return results
+            .OrderByDescending(v => v.CreatedOn ?? DateTimeOffset.MinValue)
+            .ToList();
+    }
+
+    /// <inheritdoc />
     public async Task<bool> HealthCheckAsync(CancellationToken ct = default)
     {
         try

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/ISecretProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/ISecretProvider.cs
@@ -30,4 +30,24 @@ public interface ISecretProvider
     /// <param name="ct">Cancellation token.</param>
     /// <returns><c>true</c> if the secret store is healthy; otherwise <c>false</c>.</returns>
     Task<bool> HealthCheckAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Retrieves a specific version of a secret. Version identifiers are
+    /// provider-specific — for Azure Key Vault, this is the URL segment
+    /// after the secret name (e.g. "abc123..."). Returns null if the
+    /// secret or version does not exist.
+    /// </summary>
+    Task<string?> GetSecretByVersionAsync(
+        string secretName,
+        string version,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns metadata about every enabled version of the named secret,
+    /// ordered by creation time descending (newest first). Empty if the
+    /// secret has no enabled versions.
+    /// </summary>
+    Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(
+        string secretName,
+        CancellationToken ct = default);
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/NullSecretProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/NullSecretProvider.cs
@@ -18,4 +18,14 @@ public sealed class NullSecretProvider : ISecretProvider
     /// <inheritdoc />
     public Task<bool> HealthCheckAsync(CancellationToken ct = default)
         => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task<string?> GetSecretByVersionAsync(
+        string secretName, string version, CancellationToken ct = default)
+        => Task.FromResult<string?>(null);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(
+        string secretName, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/RotatingKeyProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/RotatingKeyProvider.cs
@@ -29,6 +29,13 @@ public class RotatingKeyProvider
     private readonly ConcurrentDictionary<CacheKey, byte[]> _cache = new();
     private readonly SemaphoreSlim _resolveLock = new(1, 1);
 
+    // Generation token: bumped by InvalidateCache. A resolve that started
+    // under generation N must not persist its result if the generation
+    // changed before the write — otherwise a concurrent rotation could
+    // see the newly-resolved-but-stale key re-populate the cache after
+    // the clear, defeating the reload-driven invalidation.
+    private long _generation;
+
     public RotatingKeyProvider(ISecretProvider secrets, ILogger<RotatingKeyProvider> logger)
     {
         _secrets = secrets;
@@ -60,6 +67,12 @@ public class RotatingKeyProvider
         {
             if (_cache.TryGetValue(cacheKey, out cached)) return cached;
 
+            // Snapshot the generation BEFORE the fetch so we can detect a
+            // concurrent InvalidateCache and skip the write-back. Without
+            // this, a rotation that lands between the fetch and the cache
+            // write would see the stale result repopulate the cache.
+            var generationAtStart = Interlocked.Read(ref _generation);
+
             var secretName = $"{secretPrefix}-{version}";
             var raw = await _secrets.GetSecretAsync(secretName, ct);
 
@@ -83,7 +96,15 @@ public class RotatingKeyProvider
                 keyBytes = Encoding.UTF8.GetBytes(raw);
             }
 
-            _cache[cacheKey] = keyBytes;
+            if (Interlocked.Read(ref _generation) == generationAtStart)
+            {
+                _cache[cacheKey] = keyBytes;
+            }
+            // else: an InvalidateCache ran between our fetch and our write —
+            // return the freshly-resolved bytes to this caller but do NOT
+            // persist them; the next caller will re-resolve against the
+            // post-rotation secret.
+
             return keyBytes;
         }
         finally
@@ -101,6 +122,10 @@ public class RotatingKeyProvider
     /// </summary>
     public virtual void InvalidateCache()
     {
+        // Bump generation BEFORE clearing so any in-flight resolve that
+        // reads the new generation before checking at write time will
+        // skip its write-back. See GetKeyAsync for the matching check.
+        Interlocked.Increment(ref _generation);
         var dropped = _cache.Count;
         _cache.Clear();
         _logger.LogInformation(

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/RotatingKeyProvider.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/RotatingKeyProvider.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.Infrastructure.Configuration;
+
+/// <summary>
+/// Rotation-aware view of a named secret. Keys are identified by an
+/// operator-controlled version string (e.g. "v1", "v2") rather than an
+/// opaque provider version ID, so rotation is the ops operation of
+/// "publish {secretPrefix}-v2 and update CurrentKeyVersion" rather than a
+/// code change. Resolved keys are cached in-process; the cache is flushed
+/// by <see cref="InvalidateCache"/>, which is driven by the
+/// <see cref="SecretRefreshService"/> off the IConfiguration reload token
+/// fired by <see cref="SecretProviderConfigurationProvider"/>.
+/// </summary>
+/// <remarks>
+/// Intended for symmetric key material only (HMAC, AES-GCM data
+/// encryption keys). Asymmetric key rotation (RS256 signing, TLS certs)
+/// has its own JWKS / cert-rotation patterns and is out of scope.
+///
+/// The class is not sealed so tests can inject a subclass that overrides
+/// <see cref="InvalidateCache"/>; only that method is virtual.
+/// </remarks>
+public class RotatingKeyProvider
+{
+    private readonly ISecretProvider _secrets;
+    private readonly ILogger<RotatingKeyProvider> _logger;
+    private readonly ConcurrentDictionary<CacheKey, byte[]> _cache = new();
+    private readonly SemaphoreSlim _resolveLock = new(1, 1);
+
+    public RotatingKeyProvider(ISecretProvider secrets, ILogger<RotatingKeyProvider> logger)
+    {
+        _secrets = secrets;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolve the key bytes for a specific logical version of a named
+    /// secret. Secret name convention: "{prefix}-{version}".
+    /// Throws <see cref="InvalidOperationException"/> if the secret is absent
+    /// and no <paramref name="devConfigFallback"/> is supplied.
+    /// </summary>
+    public async Task<byte[]> GetKeyAsync(
+        string secretPrefix,
+        string version,
+        string? devConfigFallback = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(secretPrefix))
+            throw new ArgumentException("secretPrefix is required", nameof(secretPrefix));
+        if (string.IsNullOrWhiteSpace(version))
+            throw new ArgumentException("version is required", nameof(version));
+
+        var cacheKey = new CacheKey(secretPrefix, version);
+        if (_cache.TryGetValue(cacheKey, out var cached)) return cached;
+
+        await _resolveLock.WaitAsync(ct);
+        try
+        {
+            if (_cache.TryGetValue(cacheKey, out cached)) return cached;
+
+            var secretName = $"{secretPrefix}-{version}";
+            var raw = await _secrets.GetSecretAsync(secretName, ct);
+
+            if (string.IsNullOrEmpty(raw))
+                raw = devConfigFallback;
+
+            if (string.IsNullOrEmpty(raw))
+                throw new InvalidOperationException(
+                    $"Rotating key '{secretName}' is not configured. " +
+                    "Publish the secret and/or update AcceptedKeyVersions.");
+
+            byte[] keyBytes;
+            try
+            {
+                keyBytes = Convert.FromBase64String(raw);
+            }
+            catch (FormatException)
+            {
+                // Accept UTF-8 strings in dev environments; production secrets
+                // should be stored base64-encoded random bytes.
+                keyBytes = Encoding.UTF8.GetBytes(raw);
+            }
+
+            _cache[cacheKey] = keyBytes;
+            return keyBytes;
+        }
+        finally
+        {
+            _resolveLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Clear the entire in-process cache. Called by
+    /// <see cref="SecretRefreshService"/> when <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>
+    /// fires a reload token so the next sign/verify picks up newly-loaded
+    /// secret values. Logged at Information so ops has an audit trail that
+    /// rotation propagated.
+    /// </summary>
+    public virtual void InvalidateCache()
+    {
+        var dropped = _cache.Count;
+        _cache.Clear();
+        _logger.LogInformation(
+            "RotatingKeyProvider cache invalidated ({Count} keys dropped) in response to IConfiguration reload.",
+            dropped);
+    }
+
+    private readonly record struct CacheKey(string Prefix, string Version)
+    {
+        public bool Equals(CacheKey other) =>
+            string.Equals(Prefix, other.Prefix, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(Version, other.Version, StringComparison.OrdinalIgnoreCase);
+
+        public override int GetHashCode() => HashCode.Combine(
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Prefix),
+            StringComparer.OrdinalIgnoreCase.GetHashCode(Version));
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretProviderServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretProviderServiceCollectionExtensions.cs
@@ -46,6 +46,13 @@ public static class SecretProviderServiceCollectionExtensions
                 break;
         }
 
+        // Rotation-aware key resolution, shared by every cryptographic
+        // consumer (idcard QR signing, member identifier encryption,
+        // member identifier fingerprinting, …). Registered once here so
+        // all 35 host services pick it up automatically via AddSecretProvider.
+        services.AddSingleton<RotatingKeyProvider>();
+        services.AddHostedService<SecretRefreshService>();
+
         return services;
     }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretRefreshService.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretRefreshService.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+
+namespace CloudHealthOffice.Infrastructure.Configuration;
+
+/// <summary>
+/// Bridges the IConfiguration reload token fired by
+/// <see cref="SecretProviderConfigurationProvider"/> to the in-process key
+/// cache in <see cref="RotatingKeyProvider"/>. Every reload clears the
+/// cache so the next sign/verify resolves the newest secret value.
+/// </summary>
+/// <remarks>
+/// No debounce. <see cref="RotatingKeyProvider.InvalidateCache"/> is a
+/// dictionary Clear plus a log line — microseconds. Dropping a genuine
+/// rotation signal is worse than extra invalidations.
+///
+/// The callback is wrapped in a try/catch so an unexpected throw in
+/// <see cref="RotatingKeyProvider.InvalidateCache"/> cannot silently tear
+/// down the reload-token subscription — if that happened, rotation would
+/// stop propagating without any log evidence.
+/// </remarks>
+public sealed class SecretRefreshService : BackgroundService
+{
+    private readonly IConfiguration _configuration;
+    private readonly RotatingKeyProvider _keys;
+    private readonly ILogger<SecretRefreshService> _logger;
+    private IDisposable? _registration;
+
+    public SecretRefreshService(
+        IConfiguration configuration,
+        RotatingKeyProvider keys,
+        ILogger<SecretRefreshService> logger)
+    {
+        _configuration = configuration;
+        _keys = keys;
+        _logger = logger;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _registration = ChangeToken.OnChange(
+            () => _configuration.GetReloadToken(),
+            OnReload);
+
+        return Task.Delay(Timeout.Infinite, stoppingToken);
+    }
+
+    private void OnReload()
+    {
+        try
+        {
+            _keys.InvalidateCache();
+        }
+        catch (Exception ex)
+        {
+            // ChangeToken.OnChange re-subscribes for subsequent signals
+            // independently of whether the callback threw, but we swallow
+            // here for belt-and-braces: an exception bubbling out of this
+            // callback could tear down the hosted service and negate the
+            // whole rotation flow.
+            _logger.LogError(ex,
+                "RotatingKeyProvider.InvalidateCache threw during IConfiguration reload; " +
+                "subsequent reloads will still be processed.");
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _registration?.Dispose();
+        _registration = null;
+        return base.StopAsync(cancellationToken);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretVersionInfo.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Configuration/SecretVersionInfo.cs
@@ -1,0 +1,13 @@
+namespace CloudHealthOffice.Infrastructure.Configuration;
+
+/// <summary>
+/// Metadata describing a single version of a named secret in the underlying
+/// store. Version identifiers are provider-specific — for Azure Key Vault this
+/// is the opaque URL segment after the secret name.
+/// </summary>
+public sealed record SecretVersionInfo(
+    string Version,
+    DateTimeOffset? CreatedOn,
+    DateTimeOffset? NotBefore,
+    DateTimeOffset? ExpiresOn,
+    bool Enabled);

--- a/src/services/shared/CloudHealthOffice.Infrastructure/HealthChecks/RotatingKeyProviderHealthCheck.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/HealthChecks/RotatingKeyProviderHealthCheck.cs
@@ -1,0 +1,68 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace CloudHealthOffice.Infrastructure.HealthChecks;
+
+/// <summary>
+/// Verifies that every (secretPrefix, versions) pair a host service cares
+/// about resolves via the registered <see cref="RotatingKeyProvider"/>.
+/// A service configured with AcceptedKeyVersions including a legacy
+/// version whose secret was accidentally deleted from Key Vault must
+/// surface that as a health signal BEFORE the next rotation-window read.
+///
+/// Reports <see cref="HealthStatus.Degraded"/> (not unhealthy) on missing
+/// versions — a missing legacy version is a compliance / operator concern,
+/// not a serve-5xx concern.
+/// </summary>
+public sealed class RotatingKeyProviderHealthCheck : IHealthCheck
+{
+    private readonly RotatingKeyProvider _keys;
+    private readonly IReadOnlyList<RotatingKeyVersionProbe> _probes;
+
+    public RotatingKeyProviderHealthCheck(
+        RotatingKeyProvider keys,
+        IEnumerable<RotatingKeyVersionProbe> probes)
+    {
+        _keys = keys;
+        _probes = probes.ToList();
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var missing = new List<string>();
+        foreach (var probe in _probes)
+        {
+            foreach (var version in probe.Versions)
+            {
+                try
+                {
+                    _ = await _keys.GetKeyAsync(probe.SecretPrefix, version, probe.DevConfigFallback, cancellationToken);
+                }
+                catch (InvalidOperationException)
+                {
+                    missing.Add($"{probe.SecretPrefix}-{version}");
+                }
+            }
+        }
+
+        if (missing.Count == 0)
+            return HealthCheckResult.Healthy(
+                $"All {_probes.Sum(p => p.Versions.Count)} rotating key version(s) resolved.");
+
+        return HealthCheckResult.Degraded(
+            $"Unresolvable rotating key version(s): {string.Join(", ", missing)}. " +
+            "Either publish the secret or remove the version from AcceptedKeyVersions.");
+    }
+}
+
+/// <summary>
+/// One (secret prefix, accepted versions) pair to probe during health
+/// checks. Host services register one probe per rotating-key consumer
+/// they own (encryptor, fingerprinter, QR signer, etc.).
+/// </summary>
+public sealed record RotatingKeyVersionProbe(
+    string SecretPrefix,
+    IReadOnlyList<string> Versions,
+    string? DevConfigFallback = null);

--- a/tests/CloudHealthOffice.IdCardService.Tests/TestFixtures.cs
+++ b/tests/CloudHealthOffice.IdCardService.Tests/TestFixtures.cs
@@ -39,7 +39,10 @@ internal static class TestFixtures
     }
 
     public static QrCodeService QrService(params (string Key, string? Value)[] extraConfig) =>
-        new(EmptySecretProvider(), Configuration(extraConfig), NullLogger<QrCodeService>.Instance);
+        new(
+            new RotatingKeyProvider(EmptySecretProvider(), NullLogger<RotatingKeyProvider>.Instance),
+            Configuration(extraConfig),
+            NullLogger<QrCodeService>.Instance);
 
     public static IdCardTemplate GlobalDefault(string tenantId = TenantId) => new()
     {


### PR DESCRIPTION
## Summary

- Extends `ISecretProvider` with `GetSecretByVersionAsync` + `ListSecretVersionsAsync` and adds a shared `RotatingKeyProvider` / `SecretRefreshService` / `RotatingKeyProviderHealthCheck` so every cryptographic consumer rotates the same way.
- Fixes `KeyVaultIdentifierEncryptor` — introduces a 0x02 envelope with the key version embedded alongside the existing 0x01 decode path (retained indefinitely via `MemberEncryption:LegacyKeySecretName`), and surfaces a distinct `StaleEncryptionKeyException` so ops can tell rotation-misconfig from tamper.
- Fixes `HmacSha256IdentifierFingerprinter` — adds `FingerprintCandidatesAsync` for dual-read so a row fingerprinted under the previous key still dedupes during a rotation window. `IdentifiersController` updated in both the `Add` 409-check and the `Remove` lookup (the Add-side check is subtle — it's a read against pre-existing rows inside a write endpoint).
- Refactors idcard-service's `QrCodeService` onto `RotatingKeyProvider`; existing rolling-window QR verification and config keys unchanged.

## Back-compat, explicitly tested

- A `0x01` ciphertext produced outside the encryptor (the pre-A.7.3 shape) decrypts under A.7.3 via `LegacyKeySecretName`.
- A service with only the pre-A.7.3 `Member:IdentifierEncryption:KeySecretName` / `Encryption:IdentifierFingerprintKeySecret` config and no `MemberEncryption` / `MemberFingerprinting` block keeps working unchanged — the encryptor continues emitting 0x01 against the legacy key, and the fingerprinter resolves its implicit v1 via `LegacyKeySecretName`. Opting in to `MemberEncryption` is the explicit trigger for 0x02 emission.
- A QR code generated under the pre-A.7.3 idcard implementation verifies under the post-A.7.3 `RotatingKeyProvider` path.

## Fingerprinter repository read-path grep

The member-service does NOT issue any `WHERE fingerprint IN (...)` style SQL today; dedupe and removal both operate on an already-loaded `Member.Identifiers` collection. The entire read-path surface is two controller sites (`IdentifiersController.cs:107` inside Add, `IdentifiersController.cs:189` inside Remove) — both now use `FingerprintCandidatesAsync`.

## Reload-resilience regression guard

`SecretRefreshServiceTests.OnReload_SurvivesCallbackException_AndProcessesSubsequentReloads` pins down the failure mode called out in plan review: a throw inside `InvalidateCache` on one fire must not silently terminate the `ChangeToken.OnChange` subscription. The callback is wrapped in try/catch + log-Error so a transient exception can't negate the whole rotation flow.

## Debounce call

No debounce on `InvalidateCache`. Clearing a `ConcurrentDictionary` + one log line is microseconds; silently dropping a genuine rotation signal (e.g. operator rolled a compromised key 500ms after a reload) is worse. If production telemetry ever justifies debouncing, add it then with a real number.

## Test plan

- [x] `dotnet build cloudhealthoffice-main.sln` — 0 errors across every project
- [x] 8/8 `RotatingKeyProviderTests` + `SecretRefreshServiceTests` pass (including the reload-resilience guard)
- [x] 17/17 `EncryptorEnvelopeCompatTests` + `FingerprinterDualReadTests` + pre-existing `IdentifierEncryptorTests` + `PiiIdentifierDedupeTests` pass — backward-compat + v2 round-trip + v1→v2 rotation + `StaleEncryptionKeyException` + fingerprinter dual-read + legacy-name implicit v1
- [x] 6/6 `QrCodeServiceTests` pass — rolling-window verification unchanged after the `RotatingKeyProvider` refactor
- [ ] CI runs full suite under .NET 8 (local machine has only .NET 9 — selected tests were run under `DOTNET_ROLL_FORWARD=LatestMajor`)
- [ ] Health check verification: deploy + confirm `RotatingKeyProviderHealthCheck` reports Healthy with accepted versions and Degraded when a listed version is missing from Key Vault
- [ ] Ops dry-run of `scripts/azure/rotate-secret.sh` against a non-prod Key Vault

Addendum followed: plan approved before editing, `RotatingKeyProvider` non-sealed (only `InvalidateCache` virtual) to support the resilience test's subclass, concrete v1-retire sequence added to `docs/architecture/secret-rotation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)