### PR TITLE
fix(ci): unblock test-dotnet + deploy-azure-aks on main

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -68,7 +68,13 @@ jobs:
             echo "::error::vars.ACR_NAME is not set; cannot import base images"
             exit 1
           fi
-          for img in dotnet/sdk:8.0 dotnet/aspnet:8.0; do
+          # sdk:8.0 / aspnet:8.0 back the Debian-based services (the majority).
+          # sdk:8.0-alpine / aspnet:8.0-alpine back CHO.TerminologyService,
+          # whose Dockerfile pins the alpine variant for the smaller runtime
+          # footprint. Importing both pairs unconditionally keeps the
+          # preflight idempotent and covers every service Dockerfile currently
+          # in the matrix without each one needing its own import step.
+          for img in dotnet/sdk:8.0 dotnet/aspnet:8.0 dotnet/sdk:8.0-alpine dotnet/aspnet:8.0-alpine; do
             echo "::group::Importing mcr.microsoft.com/${img} → ${ACR_NAME}.azurecr.io/${img}"
             az acr import \
               --name "$ACR_NAME" \

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
@@ -17,6 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Surface the internal CachedRuleSet serialization wrapper to the
+         tests project so NSubstitute can set up returns on the exact
+         ICacheProvider.GetOrSetAsync<T> instantiation used by
+         RedisPaRuleRepository — generic method match is per-T. -->
+    <InternalsVisibleTo Include="CloudHealthOffice.PriorAuthRuleEngine.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- StackExchange.Redis arrives transitively from CloudHealthOffice.Infrastructure.
          RedisPaRuleRepository still touches IConnectionMultiplexer/IServer directly
          for the state-level SCAN invalidation path — a deliberate exception documented

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
@@ -498,10 +498,16 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
         }
     }
 
-    /// <summary>
-    /// Serialization wrapper — <see cref="ICacheProvider.GetOrSetAsync{T}"/>
-    /// requires T : class, and <see cref="IReadOnlyList{T}"/> is not a
-    /// reference type the JSON serializer can round-trip without help.
-    /// </summary>
-    private sealed record CachedRuleSet(List<PaRuleDocument> Rules);
 }
+
+/// <summary>
+/// Serialization wrapper — <see cref="ICacheProvider.GetOrSetAsync{T}"/>
+/// requires T : class, and <see cref="IReadOnlyList{T}"/> is not a
+/// reference type the JSON serializer can round-trip without help.
+/// Internal so the tests-assembly can reference the exact generic type
+/// instantiation of <see cref="ICacheProvider.GetOrSetAsync{T}"/> when
+/// setting up NSubstitute expectations — generic method match is
+/// per-T, so a mock set up for <c>GetOrSetAsync&lt;object&gt;</c> does
+/// NOT intercept <c>GetOrSetAsync&lt;CachedRuleSet&gt;</c>.
+/// </summary>
+internal sealed record CachedRuleSet(List<PaRuleDocument> Rules);

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Persistence/PaRuleRepository.cs
@@ -502,8 +502,10 @@ public sealed class RedisPaRuleRepository : IPaRuleRepository
 
 /// <summary>
 /// Serialization wrapper — <see cref="ICacheProvider.GetOrSetAsync{T}"/>
-/// requires T : class, and <see cref="IReadOnlyList{T}"/> is not a
-/// reference type the JSON serializer can round-trip without help.
+/// requires T : class, and <see cref="IReadOnlyList{T}"/> is an interface
+/// type that the JSON serializer can't reliably materialize on the read
+/// path without an explicit concrete type to bind to. Wrapping the list in
+/// a concrete record gives the serializer a fixed shape to round-trip.
 /// Internal so the tests-assembly can reference the exact generic type
 /// instantiation of <see cref="ICacheProvider.GetOrSetAsync{T}"/> when
 /// setting up NSubstitute expectations — generic method match is

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Caching/CachingServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,7 +56,11 @@ public static class CachingServiceCollectionExtensions
 
         services.AddHttpContextAccessor();
         services.AddMemoryCache();
-        services.AddSingleton<CacheKeyGuard>();
+        // Capture the passed-in IHostEnvironment so callers (tests, or hosts
+        // that build a ServiceCollection without a HostBuilder) don't have
+        // to separately register IHostEnvironment in DI for CacheKeyGuard.
+        services.AddSingleton<CacheKeyGuard>(sp =>
+            new CacheKeyGuard(sp.GetRequiredService<IHttpContextAccessor>(), environment));
         services.AddSingleton<SingleFlightRunner>(_ =>
             new SingleFlightRunner(options.SingleFlightMaxInFlight));
 

--- a/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
+++ b/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
@@ -69,13 +69,16 @@ public class RedisPaRuleRepositoryTests
     [Fact]
     public async Task GetRulesAsync_DelegatesToCacheProvider_WithGlobalScope()
     {
-        _cache.GetOrSetAsync<object>(
+        // Match on the exact generic instantiation the SUT invokes —
+        // NSubstitute matches generic methods per-T, so a setup for
+        // GetOrSetAsync<object> does NOT intercept GetOrSetAsync<CachedRuleSet>.
+        _cache.GetOrSetAsync<CachedRuleSet>(
             Arg.Any<string>(),
-            Arg.Any<Func<CancellationToken, Task<object?>>>(),
+            Arg.Any<Func<CancellationToken, Task<CachedRuleSet?>>>(),
             Arg.Any<TimeSpan>(),
             Arg.Any<CacheScope>(),
             Arg.Any<CancellationToken>())
-            .ReturnsForAnyArgs(Task.FromResult<object?>(null));
+            .ReturnsForAnyArgs(Task.FromResult<CachedRuleSet?>(null));
 
         await _sut.GetRulesAsync(TxStarKey);
 
@@ -99,17 +102,16 @@ public class RedisPaRuleRepositoryTests
 
         // Invoke the factory the SUT passes in — verify it hits the inner
         // repo and that the SUT unwraps the CachedRuleSet shape correctly.
-        _cache.GetOrSetAsync(
+        _cache.GetOrSetAsync<CachedRuleSet>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, Task<object?>>>(),
+                Arg.Any<Func<CancellationToken, Task<CachedRuleSet?>>>(),
                 Arg.Any<TimeSpan>(),
                 Arg.Any<CacheScope>(),
                 Arg.Any<CancellationToken>())
             .ReturnsForAnyArgs(async ci =>
             {
-                var factory = (Delegate)ci.ArgAt<object>(1);
-                var result = await (Task<object?>)factory.DynamicInvoke(CancellationToken.None)!;
-                return result;
+                var factory = ci.ArgAt<Func<CancellationToken, Task<CachedRuleSet?>>>(1);
+                return await factory(CancellationToken.None);
             });
 
         var result = await _sut.GetRulesAsync(TxStarKey);


### PR DESCRIPTION
Two independent post-merge failures on commit 7190e61:

1. test-dotnet.yml — Infrastructure.Tests and PriorAuthRuleEngine.Tests both
   failed. Root causes:
   - CachingServiceCollectionExtensions.AddChoCaching took IHostEnvironment
     as a parameter but registered CacheKeyGuard with plain AddSingleton<T>,
     requiring the container to also hold IHostEnvironment. Tests that build
     a raw ServiceCollection (no HostBuilder) don't have it registered, so
     GetRequiredService<ICacheProvider> threw at resolve time. Switch to a
     factory that captures the passed-in environment.
   - RedisPaRuleRepositoryTests mocked ICacheProvider.GetOrSetAsync<object>
     but the SUT calls GetOrSetAsync<CachedRuleSet>. NSubstitute matches
     generic methods per-T so the mock returned default (null), collapsing
     the result to an empty list. Promote CachedRuleSet from private nested
     record to an internal top-level type, InternalsVisibleTo the tests
     project, and set up the mock on the exact generic instantiation.

2. deploy-azure-aks.yml — build-push-services (CHO.TerminologyService)
   failed with "dotnet/aspnet:8.0-alpine not found" in ACR. The
   ensure-base-images preflight imported only dotnet/sdk:8.0 and
   dotnet/aspnet:8.0, but CHO.TerminologyService's Dockerfile pins the
   alpine variants. Extend the import loop to cover both pairs.