### PR TITLE
docs: add member-eligibility phase 1 SVG asset

### DIFF
--- a/docs/images/member-eligibility-phase1.svg
+++ b/docs/images/member-eligibility-phase1.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="cyanGrad3" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#00ffff"/>
+      <stop offset="100%" stop-color="#00ff88"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1400" height="900" fill="#000000"/>
+
+  <text x="700" y="38" font-size="22" font-weight="700" fill="#ffffff" text-anchor="middle" filter="url(#glow)">MEMBER + ELIGIBILITY</text>
+  <text x="700" y="60" font-size="12" fill="#00ffff" text-anchor="middle" letter-spacing="3">PHASE 1 SHIPPED · PHASE 2 ROADMAP</text>
+  <line x1="530" y1="72" x2="870" y2="72" stroke="#00ffff" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- CENTER HUB -->
+  <g transform="translate(700,460)">
+    <circle cx="0" cy="0" r="118" fill="rgba(8,8,8,0.9)" stroke="#00ffff" stroke-width="2"/>
+    <circle cx="0" cy="0" r="108" fill="none" stroke="rgba(0,255,255,0.2)" stroke-width="0.5"/>
+    <text x="0" y="-22" text-anchor="middle" font-size="18" font-weight="700" fill="#00ffff">member-service</text>
+    <text x="0" y="0" text-anchor="middle" font-size="11" fill="#b0b0b0">Identifiers · Demographics</text>
+    <text x="0" y="15" text-anchor="middle" font-size="11" fill="#b0b0b0">Temporal coverage</text>
+    <text x="0" y="38" text-anchor="middle" font-size="10" font-style="italic" fill="#ffaa00">MBI · SSN · ext-ids encrypted</text>
+    <text x="0" y="52" text-anchor="middle" font-size="10" font-style="italic" fill="#ffaa00">0x02 envelope · v1+v2 accepted</text>
+  </g>
+
+  <!-- ============ CAPABILITY BOXES ============ -->
+  <!-- 5.1 Member Foundation -->
+  <g>
+    <rect x="280" y="160" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="300" cy="180" r="11" fill="#00ff88"/>
+    <text x="300" y="184" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.1</text>
+    <text x="320" y="184" font-size="13" font-weight="700" fill="#00ff88">Member Foundation</text>
+    <text x="295" y="208" font-size="10" fill="#b0b0b0">• Cosmos + Mongo dual-persist</text>
+    <text x="295" y="222" font-size="10" fill="#b0b0b0">• PII-encrypted identifier lookup</text>
+    <text x="295" y="236" font-size="10" fill="#b0b0b0">• Fingerprint-based dedup</text>
+    <text x="485" y="245" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #650</text>
+  </g>
+
+  <!-- 5.2 Temporal -->
+  <g>
+    <rect x="520" y="130" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="540" cy="150" r="11" fill="#00ff88"/>
+    <text x="540" y="154" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.2</text>
+    <text x="560" y="154" font-size="13" font-weight="700" fill="#00ff88">Temporal Eligibility</text>
+    <text x="535" y="178" font-size="10" fill="#b0b0b0">• As-of date slices</text>
+    <text x="535" y="192" font-size="10" fill="#b0b0b0">• Batch via IMessageBus</text>
+    <text x="535" y="206" font-size="10" fill="#b0b0b0">• 271 response feed</text>
+    <text x="725" y="215" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #651</text>
+  </g>
+
+  <!-- 5.3 Benefits -->
+  <g>
+    <rect x="760" y="130" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="780" cy="150" r="11" fill="#00ff88"/>
+    <text x="780" y="154" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.3</text>
+    <text x="800" y="154" font-size="13" font-weight="700" fill="#00ff88">Benefits Viewer</text>
+    <text x="775" y="178" font-size="10" fill="#b0b0b0">• Plan + network + accum</text>
+    <text x="775" y="192" font-size="10" fill="#b0b0b0">• As-of service-date resolution</text>
+    <text x="775" y="206" font-size="10" fill="#b0b0b0">• Blazor portal integration</text>
+    <text x="965" y="215" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #652</text>
+  </g>
+
+  <!-- 5.4 Accumulators -->
+  <g>
+    <rect x="1000" y="160" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="1020" cy="180" r="11" fill="#00ff88"/>
+    <text x="1020" y="184" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.4</text>
+    <text x="1040" y="184" font-size="13" font-weight="700" fill="#00ff88">Accumulators</text>
+    <text x="1015" y="208" font-size="10" fill="#b0b0b0">• RedisAccum (HINCRBYFLOAT)</text>
+    <text x="1015" y="222" font-size="10" fill="#b0b0b0">• Runtime calc from claims</text>
+    <text x="1015" y="236" font-size="10" fill="#b0b0b0">• Family + individual rollups</text>
+    <text x="1205" y="245" text-anchor="end" font-size="9" fill="#ffaa00" font-style="italic">A.7.2 exception</text>
+  </g>
+
+  <!-- 5.5 Family -->
+  <g>
+    <rect x="120" y="280" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="140" cy="300" r="11" fill="#00ff88"/>
+    <text x="140" y="304" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.5</text>
+    <text x="160" y="304" font-size="13" font-weight="700" fill="#00ff88">Family Relationships</text>
+    <text x="135" y="328" font-size="10" fill="#b0b0b0">• Subscriber + dependent graph</text>
+    <text x="135" y="342" font-size="10" fill="#b0b0b0">• Cross-member operations</text>
+    <text x="135" y="356" font-size="10" fill="#b0b0b0">• Family accum targeting</text>
+  </g>
+
+  <!-- 5.6 Enrollment events -->
+  <g>
+    <rect x="1060" y="280" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="1080" cy="300" r="11" fill="#00ff88"/>
+    <text x="1080" y="304" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.6</text>
+    <text x="1100" y="304" font-size="13" font-weight="700" fill="#00ff88">Enrollment Events</text>
+    <text x="1075" y="328" font-size="10" fill="#b0b0b0">• Append-only event stream</text>
+    <text x="1075" y="342" font-size="10" fill="#b0b0b0">• 834 + portal + admin</text>
+    <text x="1075" y="356" font-size="10" fill="#b0b0b0">• Audit source of truth</text>
+  </g>
+
+  <!-- 5.7 PCP -->
+  <g>
+    <rect x="120" y="420" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="140" cy="440" r="11" fill="#00ff88"/>
+    <text x="140" y="444" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.7</text>
+    <text x="160" y="444" font-size="13" font-weight="700" fill="#00ff88">PCP Assignment</text>
+    <text x="135" y="468" font-size="10" fill="#b0b0b0">• Auto-assign rules per LOB</text>
+    <text x="135" y="482" font-size="10" fill="#b0b0b0">• Provider network validation</text>
+    <text x="135" y="496" font-size="10" fill="#b0b0b0">• Member change request flow</text>
+    <text x="325" y="505" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #656</text>
+  </g>
+
+  <!-- 5.9 Alerts -->
+  <g>
+    <rect x="1060" y="420" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="1080" cy="440" r="11" fill="#00ff88"/>
+    <text x="1080" y="444" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.9</text>
+    <text x="1100" y="444" font-size="13" font-weight="700" fill="#00ff88">Alerts · Notes</text>
+    <text x="1075" y="468" font-size="10" fill="#b0b0b0">• Severity-ranked alerts</text>
+    <text x="1075" y="482" font-size="10" fill="#b0b0b0">• Threaded CSR notes</text>
+    <text x="1075" y="496" font-size="10" fill="#b0b0b0">• Dismissal + escalation audit</text>
+    <text x="1265" y="505" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #657</text>
+  </g>
+
+  <!-- 5.10 Documents -->
+  <g>
+    <rect x="120" y="560" width="220" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="140" cy="580" r="11" fill="#00ff88"/>
+    <text x="140" y="584" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.10</text>
+    <text x="160" y="584" font-size="13" font-weight="700" fill="#00ff88">Member Documents</text>
+    <text x="135" y="608" font-size="10" fill="#b0b0b0">• Blob + presigned URLs</text>
+    <text x="135" y="622" font-size="10" fill="#b0b0b0">• Two-step upload + confirm</text>
+    <text x="135" y="636" font-size="10" fill="#b0b0b0">• Tag + category classification</text>
+    <text x="325" y="645" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #662</text>
+  </g>
+
+  <!-- 5.11 ID Cards -->
+  <g>
+    <rect x="1060" y="560" width="220" height="92" rx="8" fill="rgba(255,170,0,0.06)" stroke="rgba(255,170,0,0.6)" stroke-width="1.5"/>
+    <circle cx="1080" cy="580" r="11" fill="#ffaa00"/>
+    <text x="1080" y="584" text-anchor="middle" font-size="10" font-weight="700" fill="#000000">5.11</text>
+    <text x="1100" y="584" font-size="13" font-weight="700" fill="#ffaa00">ID Cards + QR</text>
+    <text x="1075" y="608" font-size="10" fill="#b0b0b0">• PNG + PDF generation</text>
+    <text x="1075" y="622" font-size="10" fill="#b0b0b0">• QR · RotatingKeyProvider</text>
+    <text x="1075" y="636" font-size="10" fill="#b0b0b0">• Reprint · QNXT mirror</text>
+    <text x="1265" y="645" text-anchor="end" font-size="9" fill="#808080" font-style="italic">PR #663</text>
+  </g>
+
+  <!-- 5.12-5.16 Linkage tabs (bottom center) -->
+  <g>
+    <rect x="540" y="720" width="320" height="92" rx="8" fill="rgba(0,255,136,0.06)" stroke="rgba(0,255,136,0.5)" stroke-width="1.5"/>
+    <circle cx="560" cy="740" r="11" fill="#00ff88"/>
+    <text x="560" y="744" text-anchor="middle" font-size="9" font-weight="700" fill="#000000">5.12–.16</text>
+    <text x="592" y="744" font-size="13" font-weight="700" fill="#00ff88">Member Linkage Tabs</text>
+    <text x="555" y="768" font-size="10" fill="#b0b0b0">• Authorization · Claim · Coverage · COB · Encounter history</text>
+    <text x="555" y="782" font-size="10" fill="#b0b0b0">• Cross-service reads, Blazor-native</text>
+    <text x="555" y="796" font-size="10" fill="#b0b0b0">• CSR 360° member view</text>
+  </g>
+
+  <!-- Connector lines from hub to capabilities (subtle) -->
+  <g stroke="rgba(0,255,255,0.2)" stroke-width="1" fill="none">
+    <path d="M 610 390 L 500 220"/>
+    <path d="M 650 350 L 650 222"/>
+    <path d="M 750 350 L 750 222"/>
+    <path d="M 790 390 L 1000 220"/>
+    <path d="M 590 430 L 340 325"/>
+    <path d="M 810 430 L 1060 325"/>
+    <path d="M 580 470 L 340 465"/>
+    <path d="M 820 470 L 1060 465"/>
+    <path d="M 590 530 L 340 605"/>
+    <path d="M 810 530 L 1060 605"/>
+    <path d="M 700 578 L 700 720"/>
+  </g>
+
+  <!-- PHASE 2 ROADMAP -->
+  <rect x="50" y="830" width="1300" height="58" rx="8" fill="rgba(255,170,0,0.04)" stroke="rgba(255,170,0,0.3)" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="68" y="853" font-size="10" font-weight="700" fill="#ffaa00" letter-spacing="2">PHASE 2 ROADMAP · UNBLOCKED BY SHARED INFRASTRUCTURE</text>
+
+  <g transform="translate(150,873)">
+    <rect x="-65" y="-11" width="130" height="22" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-dasharray="3,2"/>
+    <text x="0" y="3" text-anchor="middle" font-size="10" fill="#00ffff">5.8 · Personal Rep</text>
+  </g>
+  <g transform="translate(325,873)">
+    <rect x="-85" y="-11" width="170" height="22" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-dasharray="3,2"/>
+    <text x="0" y="3" text-anchor="middle" font-size="10" fill="#00ffff">5.17 · Value-Based Benefits</text>
+  </g>
+  <g transform="translate(510,873)">
+    <rect x="-80" y="-11" width="160" height="22" rx="4" fill="rgba(255,170,0,0.1)" stroke="rgba(255,170,0,0.6)"/>
+    <text x="0" y="3" text-anchor="middle" font-size="10" font-weight="700" fill="#ffaa00">5.18 · HIPAA Consent ★ next</text>
+  </g>
+  <g transform="translate(680,873)">
+    <rect x="-75" y="-11" width="150" height="22" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-dasharray="3,2"/>
+    <text x="0" y="3" text-anchor="middle" font-size="10" fill="#00ffff">5.22 · Call Tracking</text>
+  </g>
+  <g transform="translate(835,873)">
+    <rect x="-65" y="-11" width="130" height="22" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-dasharray="3,2"/>
+    <text x="0" y="3" text-anchor="middle" font-size="10" fill="#00ffff">5.23 · Appeals</text>
+  </g>
+  <text x="1336" y="877" text-anchor="end" font-size="9" fill="#808080" font-style="italic">all consume IMessageBus · ICacheProvider · RotatingKeyProvider · OTel</text>
+</svg>

--- a/docs/images/rotation-flow.svg
+++ b/docs/images/rotation-flow.svg
@@ -1,0 +1,248 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" font-family="Segoe UI, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="cyanGrad2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#00ffff"/>
+      <stop offset="100%" stop-color="#00ff88"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowAmber" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#ffaa00" opacity="0.7"/>
+    </marker>
+  </defs>
+
+  <rect width="1400" height="900" fill="#000000"/>
+
+  <!-- Title -->
+
+<text x="700" y="38" font-size="22" font-weight="700" fill="#ffffff" text-anchor="middle" filter="url(#glow)">KEY ROTATION FLOW</text>
+<text x="700" y="60" font-size="12" fill="#00ffff" text-anchor="middle" letter-spacing="3">ADDENDUM A.7.3 · HOW ROTATION WORKS AT RUNTIME</text>
+<line x1="530" y1="72" x2="870" y2="72" stroke="url(#cyanGrad2)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- TIMELINE -->
+
+  <rect x="50" y="95" width="1300" height="48" rx="8" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-width="1"/>
+  <text x="122" y="124" font-size="10" font-weight="700" fill="#00ffff" letter-spacing="1.5">TIMELINE</text>
+  <line x1="220" y1="119" x2="1320" y2="119" stroke="rgba(0,255,255,0.3)" stroke-width="1"/>
+
+  <circle cx="320" cy="119" r="6" fill="#00ffff" stroke="#ffffff" stroke-width="1.5" filter="url(#glow)"/>
+  <text x="320" y="137" text-anchor="middle" font-size="10" font-weight="600" fill="#00ffff">T0 · v1 only</text>
+
+  <circle cx="625" cy="119" r="6" fill="#ffaa00" stroke="#ffffff" stroke-width="1.5" filter="url(#glow)"/>
+  <text x="625" y="137" text-anchor="middle" font-size="10" font-weight="600" fill="#ffaa00">T1 · rotation window</text>
+
+  <circle cx="930" cy="119" r="6" fill="#00ff88" stroke="#ffffff" stroke-width="1.5" filter="url(#glow)"/>
+  <text x="930" y="137" text-anchor="middle" font-size="10" font-weight="600" fill="#00ff88">T2 · v1+v2 accepted</text>
+
+  <circle cx="1235" cy="119" r="6" fill="#00ff88" stroke="#ffffff" stroke-width="1.5" filter="url(#glow)"/>
+  <text x="1235" y="137" text-anchor="middle" font-size="10" font-weight="600" fill="#00ff88">T3 · v2 only · post-backfill</text>
+
+  <!-- LEFT: OPS ACTIONS -->
+
+  <rect x="50" y="170" width="290" height="660" rx="10" fill="rgba(8,8,8,0.5)" stroke="rgba(255,170,0,0.3)" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="68" y="195" font-size="10" font-weight="700" fill="#ffaa00" letter-spacing="2">OPS ACTIONS</text>
+
+  <g>
+    <circle cx="80" cy="228" r="12" fill="#ffaa00"/>
+    <text x="80" y="232" text-anchor="middle" font-size="11" font-weight="700" fill="#000000">1</text>
+    <text x="105" y="226" font-size="12" font-weight="700" fill="#ffffff">Publish new secret</text>
+    <text x="105" y="244" font-size="10" fill="#b0b0b0">$ ./rotate-secret.sh \</text>
+    <text x="105" y="257" font-size="10" fill="#b0b0b0">&#160;&#160;--prefix member-identifier-key \</text>
+    <text x="105" y="270" font-size="10" fill="#b0b0b0">&#160;&#160;--version v2</text>
+    <text x="105" y="287" font-size="9" fill="#808080" font-style="italic">idempotent · generates 32 bytes</text>
+  </g>
+
+  <g>
+    <circle cx="80" cy="328" r="12" fill="#ffaa00"/>
+    <text x="80" y="332" text-anchor="middle" font-size="11" font-weight="700" fill="#000000">2</text>
+    <text x="105" y="326" font-size="12" font-weight="700" fill="#ffffff">Expand accepted window</text>
+    <text x="105" y="344" font-size="10" fill="#b0b0b0">MemberEncryption:</text>
+    <text x="105" y="357" font-size="10" fill="#b0b0b0">&#160;&#160;AcceptedKeyVersions:</text>
+    <text x="105" y="370" font-size="10" fill="#b0b0b0">&#160;&#160;&#160;&#160;- v1</text>
+    <text x="105" y="383" font-size="10" fill="#00ff88">&#160;&#160;&#160;&#160;- v2  # ← ADD</text>
+    <text x="105" y="400" font-size="9" fill="#808080" font-style="italic">deploy · SecretRefresh invalidates cache</text>
+  </g>
+
+  <g>
+    <circle cx="80" cy="448" r="12" fill="#ffaa00"/>
+    <text x="80" y="452" text-anchor="middle" font-size="11" font-weight="700" fill="#000000">3</text>
+    <text x="105" y="446" font-size="12" font-weight="700" fill="#ffffff">Flip current version</text>
+    <text x="105" y="464" font-size="10" fill="#b0b0b0">MemberEncryption:</text>
+    <text x="105" y="477" font-size="10" fill="#00ff88">&#160;&#160;CurrentKeyVersion: v2  # ← FLIP</text>
+    <text x="105" y="494" font-size="9" fill="#808080" font-style="italic">new writes emit 0x02 v2</text>
+    <text x="105" y="506" font-size="9" fill="#808080" font-style="italic">old 0x02 v1 records still decrypt</text>
+    <text x="105" y="518" font-size="9" fill="#808080" font-style="italic">old 0x01 records still decrypt (legacy)</text>
+  </g>
+
+  <g>
+    <circle cx="80" cy="568" r="12" fill="#ffaa00"/>
+    <text x="80" y="572" text-anchor="middle" font-size="11" font-weight="700" fill="#000000">4</text>
+    <text x="105" y="566" font-size="12" font-weight="700" fill="#ffffff">Backfill re-encrypt</text>
+    <text x="105" y="584" font-size="10" fill="#b0b0b0">per-consumer async job:</text>
+    <text x="105" y="597" font-size="10" fill="#b0b0b0">• read rows · decrypt via accepted</text>
+    <text x="105" y="610" font-size="10" fill="#b0b0b0">• re-encrypt under v2 · write back</text>
+    <text x="105" y="623" font-size="10" fill="#b0b0b0">• verify zero 0x01 or v1 records</text>
+    <text x="105" y="640" font-size="9" fill="#808080" font-style="italic">ops decides when · not bundled in A.7.3</text>
+  </g>
+
+  <g>
+    <circle cx="80" cy="690" r="12" fill="#ffaa00"/>
+    <text x="80" y="694" text-anchor="middle" font-size="11" font-weight="700" fill="#000000">5</text>
+    <text x="105" y="688" font-size="12" font-weight="700" fill="#ffffff">Retire v1 from window</text>
+    <text x="105" y="706" font-size="10" fill="#b0b0b0">MemberEncryption:</text>
+    <text x="105" y="719" font-size="10" fill="#b0b0b0">&#160;&#160;AcceptedKeyVersions:</text>
+    <text x="105" y="732" font-size="10" fill="#ff6080">&#160;&#160;&#160;&#160;- v1  # ← REMOVE</text>
+    <text x="105" y="745" font-size="10" fill="#b0b0b0">&#160;&#160;&#160;&#160;- v2</text>
+    <text x="105" y="762" font-size="9" fill="#808080" font-style="italic">health check: all accepted resolve</text>
+    <text x="105" y="774" font-size="9" fill="#808080" font-style="italic">eventually: disable secret in Key Vault</text>
+  </g>
+
+  <!-- MIDDLE: RUNTIME -->
+
+  <rect x="360" y="170" width="660" height="660" rx="10" fill="rgba(255,170,0,0.04)" stroke="rgba(255,170,0,0.4)" stroke-width="1.5"/>
+  <text x="378" y="195" font-size="10" font-weight="700" fill="#ffaa00" letter-spacing="2" filter="url(#glow)">RUNTIME DURING ROTATION WINDOW</text>
+
+  <!-- service box -->
+
+  <g transform="translate(513,242)">
+    <rect x="-125" y="-30" width="250" height="60" rx="6" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)" stroke-width="1.5"/>
+    <text x="0" y="-10" text-anchor="middle" font-size="13" font-weight="700" fill="#00ffff">member-service</text>
+    <text x="0" y="8" text-anchor="middle" font-size="10" fill="#b0b0b0">KeyVaultIdentifierEncryptor</text>
+    <text x="0" y="22" text-anchor="middle" font-size="10" fill="#b0b0b0">HmacSha256IdentifierFingerprinter</text>
+  </g>
+
+  <g transform="translate(865,242)">
+    <rect x="-125" y="-30" width="250" height="60" rx="6" fill="rgba(255,170,0,0.1)" stroke="rgba(255,170,0,0.5)" stroke-width="1.5"/>
+    <text x="0" y="-10" text-anchor="middle" font-size="13" font-weight="700" fill="#ffaa00">RotatingKeyProvider</text>
+    <text x="0" y="8" text-anchor="middle" font-size="10" fill="#b0b0b0">Cache [(prefix, version) → bytes]</text>
+    <text x="0" y="22" text-anchor="middle" font-size="10" fill="#b0b0b0">InvalidateCache on reload token</text>
+  </g>
+
+  <line x1="640" y1="242" x2="738" y2="242" stroke="#ffaa00" stroke-width="2" marker-end="url(#arrowAmber)" opacity="0.7"/>
+  <text x="689" y="234" text-anchor="middle" font-size="10" font-weight="600" fill="#ffaa00">GetKeyAsync</text>
+  <text x="689" y="258" text-anchor="middle" font-size="9" fill="#808080" font-style="italic">(prefix, version)</text>
+
+  <!-- WRITE PATH -->
+
+  <rect x="380" y="298" width="620" height="170" rx="7" fill="rgba(0,255,136,0.04)" stroke="rgba(0,255,136,0.3)" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="395" y="320" font-size="11" font-weight="700" fill="#00ff88" letter-spacing="1.5">WRITE PATH · EncryptAsync("123-45-6789")</text>
+
+  <rect x="395" y="332" width="590" height="24" rx="3" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)"/>
+  <text x="408" y="349" font-size="11" fill="#ffffff">1. Read config: CurrentKeyVersion → "v2"</text>
+  <text x="972" y="349" text-anchor="end" font-size="10" font-weight="600" fill="#00ff88">→ hot cache hit</text>
+
+  <rect x="395" y="360" width="590" height="24" rx="3" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)"/>
+  <text x="408" y="377" font-size="11" fill="#ffffff">2. RotatingKeyProvider.GetKeyAsync("member-enc-key", "v2")</text>
+  <text x="972" y="377" text-anchor="end" font-size="10" font-weight="600" fill="#00ff88">→ 32 bytes</text>
+
+  <rect x="395" y="388" width="590" height="24" rx="3" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)"/>
+  <text x="408" y="405" font-size="11" fill="#ffffff">3. AES-GCM(key, plaintext) · build 0x02 envelope:</text>
+
+  <!-- envelope byte strip -->
+
+  <g>
+    <rect x="395" y="420" width="42" height="26" rx="2" fill="rgba(0,255,136,0.25)" stroke="#00ff88"/>
+    <text x="416" y="437" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">0x02</text>
+    <rect x="440" y="420" width="28" height="26" rx="2" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)"/>
+    <text x="454" y="437" text-anchor="middle" font-size="10" fill="#b0b0b0">len</text>
+    <rect x="471" y="420" width="50" height="26" rx="2" fill="rgba(0,255,136,0.25)" stroke="#00ff88"/>
+    <text x="496" y="437" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">"v2"</text>
+    <rect x="524" y="420" width="108" height="26" rx="2" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)"/>
+    <text x="578" y="437" text-anchor="middle" font-size="10" fill="#b0b0b0">IV (12 bytes)</text>
+    <rect x="635" y="420" width="108" height="26" rx="2" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)"/>
+    <text x="689" y="437" text-anchor="middle" font-size="10" fill="#b0b0b0">tag (16 bytes)</text>
+    <rect x="746" y="420" width="239" height="26" rx="2" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)"/>
+    <text x="865" y="437" text-anchor="middle" font-size="10" fill="#b0b0b0">ciphertext bytes</text>
+  </g>
+
+  <!-- READ PATH -->
+
+  <rect x="380" y="488" width="620" height="320" rx="7" fill="rgba(0,255,255,0.04)" stroke="rgba(0,255,255,0.3)" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="395" y="510" font-size="11" font-weight="700" fill="#00ffff" letter-spacing="1.5">READ PATH · DecryptAsync(ciphertext)</text>
+
+  <g>
+    <rect x="395" y="524" width="590" height="60" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,136,0.5)"/>
+    <text x="408" y="543" font-size="11" font-weight="600" fill="#00ff88">A · New record (written T2, tag = 0x02 v2)</text>
+    <text x="408" y="561" font-size="10" fill="#b0b0b0">Read envelope · format=0x02 · version="v2"</text>
+    <text x="408" y="575" font-size="10" fill="#b0b0b0">"v2" ∈ AcceptedKeyVersions ✓ · GetKeyAsync → decrypt · return plaintext</text>
+  </g>
+
+  <g>
+    <rect x="395" y="592" width="590" height="60" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.5)"/>
+    <text x="408" y="611" font-size="11" font-weight="600" fill="#00ffff">B · Older record (written T1, tag = 0x02 v1)</text>
+    <text x="408" y="629" font-size="10" fill="#b0b0b0">Read envelope · format=0x02 · version="v1"</text>
+    <text x="408" y="643" font-size="10" fill="#b0b0b0">"v1" ∈ AcceptedKeyVersions ✓ · GetKeyAsync → decrypt · return plaintext</text>
+  </g>
+
+  <g>
+    <rect x="395" y="660" width="590" height="60" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(128,128,200,0.5)"/>
+    <text x="408" y="679" font-size="11" font-weight="600" fill="#a0a0ff">C · Pre-A.7.3 record (tag = 0x01, no version in envelope)</text>
+    <text x="408" y="697" font-size="10" fill="#b0b0b0">Read envelope · format=0x01 · fall back to MemberEncryption:LegacyKeySecretName</text>
+    <text x="408" y="711" font-size="10" fill="#b0b0b0">GetSecretAsync(legacyName) → decrypt · return plaintext · retained forever</text>
+  </g>
+
+  <g>
+    <rect x="395" y="728" width="590" height="52" rx="4" fill="rgba(8,8,8,0.9)" stroke="rgba(255,170,0,0.6)"/>
+    <text x="408" y="747" font-size="11" font-weight="600" fill="#ffaa00">D · Accepted version missing from Key Vault</text>
+    <text x="408" y="764" font-size="10" fill="#b0b0b0">StaleEncryptionKeyException · distinct from tamper failures</text>
+    <text x="408" y="776" font-size="10" fill="#b0b0b0">HealthCheck reports Degraded · ops alerted before clients see 500s</text>
+  </g>
+
+  <!-- RIGHT: KEY VAULT STATE -->
+
+  <rect x="1040" y="170" width="310" height="660" rx="10" fill="rgba(8,8,8,0.5)" stroke="rgba(255,170,0,0.3)" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="1058" y="195" font-size="10" font-weight="700" fill="#ffaa00" letter-spacing="2">AZURE KEY VAULT STATE</text>
+
+  <g>
+    <rect x="1058" y="215" width="274" height="112" rx="7" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.4)" stroke-width="1"/>
+    <text x="1073" y="238" font-size="11" font-weight="700" fill="#00ffff">member-identifier-encryption-key-v1</text>
+    <text x="1073" y="258" font-size="10" fill="#b0b0b0">Created: 2026-03-14</text>
+    <text x="1073" y="273" font-size="10" fill="#b0b0b0">Enabled · 32-byte AES-256 key</text>
+    <text x="1073" y="291" font-size="10" fill="#b0b0b0">Used by:</text>
+    <text x="1073" y="305" font-size="10" fill="#ffffff">&#160;• 0x02 envelopes tagged "v1"</text>
+    <text x="1073" y="317" font-size="10" fill="#ffffff">&#160;• LegacyKeySecretName (0x01 path)</text>
+  </g>
+
+  <g>
+    <rect x="1058" y="340" width="274" height="112" rx="7" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,136,0.6)" stroke-width="1.5"/>
+    <text x="1073" y="363" font-size="11" font-weight="700" fill="#00ff88">member-identifier-encryption-key-v2</text>
+    <text x="1073" y="383" font-size="10" fill="#b0b0b0">Created: 2026-04-22 (today)</text>
+    <text x="1073" y="398" font-size="10" fill="#b0b0b0">Enabled · 32-byte AES-256 key</text>
+    <text x="1073" y="416" font-size="10" fill="#b0b0b0">Used by:</text>
+    <text x="1073" y="430" font-size="10" fill="#ffffff">&#160;• New 0x02 writes (after step 3)</text>
+    <text x="1073" y="442" font-size="10" fill="#ffffff">&#160;• Re-encrypted rows (after step 4)</text>
+  </g>
+
+  <!-- config -->
+
+  <g>
+    <rect x="1058" y="465" width="274" height="220" rx="7" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-width="1"/>
+    <text x="1073" y="486" font-size="11" font-weight="700" fill="#ffaa00">appsettings.json (at T2)</text>
+    <text x="1073" y="509" font-size="10" fill="#00ffff">"MemberEncryption": {</text>
+    <text x="1073" y="525" font-size="10" fill="#b0b0b0">&#160;&#160;"KeySecretPrefix":</text>
+    <text x="1083" y="539" font-size="10" fill="#ffffff">&#160;&#160;&#160;&#160;"member-identifier-encryption-key",</text>
+    <text x="1073" y="559" font-size="10" fill="#b0b0b0">&#160;&#160;"CurrentKeyVersion":</text>
+    <text x="1083" y="573" font-size="10" fill="#00ff88">&#160;&#160;&#160;&#160;"v2",</text>
+    <text x="1073" y="593" font-size="10" fill="#b0b0b0">&#160;&#160;"AcceptedKeyVersions":</text>
+    <text x="1083" y="607" font-size="10" fill="#ffffff">&#160;&#160;&#160;&#160;["v1", "v2"],</text>
+    <text x="1073" y="627" font-size="10" fill="#b0b0b0">&#160;&#160;"LegacyKeySecretName":</text>
+    <text x="1083" y="641" font-size="10" fill="#ffffff">&#160;&#160;&#160;&#160;"member-identifier-</text>
+    <text x="1083" y="653" font-size="10" fill="#ffffff">&#160;&#160;&#160;&#160;&#160;encryption-key"</text>
+    <text x="1073" y="673" font-size="10" fill="#00ffff">}</text>
+  </g>
+
+  <!-- health -->
+
+  <g>
+    <rect x="1058" y="698" width="274" height="118" rx="7" fill="rgba(8,8,8,0.9)" stroke="rgba(0,255,255,0.3)" stroke-width="1"/>
+    <text x="1073" y="719" font-size="11" font-weight="700" fill="#ffaa00">Health · /health/ready</text>
+    <circle cx="1078" cy="743" r="5" fill="#00ff88"/>
+    <text x="1094" y="747" font-size="10" font-weight="600" fill="#00ff88">RotatingKeyProvider: Healthy</text>
+    <text x="1094" y="761" font-size="9" fill="#b0b0b0">All 2 accepted versions resolve</text>
+    <circle cx="1078" cy="783" r="5" fill="#00ff88"/>
+    <text x="1094" y="787" font-size="10" font-weight="600" fill="#00ff88">SecretRefreshService: Running</text>
+    <text x="1094" y="801" font-size="9" fill="#b0b0b0">Last reload 287s ago · 5min cycle</text>
+  </g>
+</svg>


### PR DESCRIPTION
First of three Sentinel-branded SVGs landing as part of the
post-addendum-A docs revamp. Platform architecture and rotation
flow SVGs to follow in subsequent commits. Referenced by
docs/architecture/PLATFORM-OVERVIEW.md (not yet added).

https://claude.ai/code/session_014icvJtgm7g4Gz766kpvQFe