### PR TITLE
feat: add personal-representative-service for member delegation records

### DIFF
--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -203,6 +203,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "consent-service", "src\serv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsentService.Tests", "src\services\consent-service\ConsentService.Tests\ConsentService.Tests.csproj", "{C0E19BEE-51EE-4A31-9F11-518AC06E516F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "personal-representative-service", "src\services\personal-representative-service\personal-representative-service.csproj", "{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersonalRepresentativeService.Tests", "src\services\personal-representative-service\PersonalRepresentativeService.Tests\PersonalRepresentativeService.Tests.csproj", "{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1125,6 +1129,30 @@ Global
 		{C0E19BEE-51EE-4A31-9F11-518AC06E516F}.Release|x64.Build.0 = Release|Any CPU
 		{C0E19BEE-51EE-4A31-9F11-518AC06E516F}.Release|x86.ActiveCfg = Release|Any CPU
 		{C0E19BEE-51EE-4A31-9F11-518AC06E516F}.Release|x86.Build.0 = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|x64.Build.0 = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Debug|x86.Build.0 = Debug|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|x64.ActiveCfg = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|x64.Build.0 = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|x86.ActiveCfg = Release|Any CPU
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5}.Release|x86.Build.0 = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|x64.Build.0 = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Debug|x86.Build.0 = Debug|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x64.ActiveCfg = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x64.Build.0 = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1213,6 +1241,8 @@ Global
 		{8DC1EBCE-63CF-42DE-8313-D82F4B949B68} = {F078A44D-36FD-4053-8C1D-0DA235C6B161}
 		{C0E19ABE-51EE-4A31-9F11-518AC06E516E} = {5854FF58-B8C5-05C6-5BF2-ACE42193F22B}
 		{C0E19BEE-51EE-4A31-9F11-518AC06E516F} = {5854FF58-B8C5-05C6-5BF2-ACE42193F22B}
+		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
+		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C10C3349-5BEE-4B34-9987-23F0142F9D98}

--- a/src/services/personal-representative-service/Controllers/MemberRepresentativesController.cs
+++ b/src/services/personal-representative-service/Controllers/MemberRepresentativesController.cs
@@ -115,10 +115,15 @@ public class MemberRepresentativesController : ControllerBase
     {
         var t = asOf ?? DateTime.UtcNow;
         var summaries = new List<PersonalRepSummary>(associations.Count);
+
+        // Batch-fetch all reps in one round-trip instead of N individual reads.
+        var repIds = associations.Select(a => a.RepId).Distinct().ToList();
+        var repMap = (await _reps.GetByIdsAsync(TenantId, repIds, ct))
+            .ToDictionary(r => r.Id);
+
         foreach (var a in associations)
         {
-            var rep = await _reps.GetByIdAsync(TenantId, a.RepId, ct);
-            if (rep is null) continue;
+            if (!repMap.TryGetValue(a.RepId, out var rep)) continue;
 
             // Uses the same IPersonalRepFieldEncryptor.DecryptAsync call
             // the primary controller uses — no partial-decrypt shortcut.

--- a/src/services/personal-representative-service/Controllers/MemberRepresentativesController.cs
+++ b/src/services/personal-representative-service/Controllers/MemberRepresentativesController.cs
@@ -1,0 +1,162 @@
+using PersonalRepresentativeService.Middleware;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+using PersonalRepresentativeService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+// TODO(consent-integration-followup): consent-service will call this
+// controller's resolver endpoint to resolve GrantedBy → structured
+// PersonalRep reference. Not wired in this PR. See consent-service PR #674.
+// When wiring lands, the resolver endpoint should require the
+// `consents:read` or a dedicated `representatives:resolve` scope;
+// authorization-service integration belongs in the consent wiring PR.
+
+namespace PersonalRepresentativeService.Controllers;
+
+/// <summary>
+/// Member-centric views of Personal Representatives. Separated from
+/// <see cref="PersonalRepresentativesController"/> because these endpoints
+/// live under a different route prefix (<c>/api/v1/members/{memberId}/…</c>)
+/// and serve a different access pattern — this is what consent-service
+/// will call to resolve its <c>GrantedBy</c> field.
+/// </summary>
+[ApiController]
+[Route("api/v1/members/{memberId}/personal-representatives")]
+public class MemberRepresentativesController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IPersonalRepRepository _reps;
+    private readonly IPersonalRepFieldEncryptor _encryptor;
+
+    public MemberRepresentativesController(
+        IPersonalRepRepository reps,
+        IPersonalRepFieldEncryptor encryptor)
+    {
+        _reps = reps;
+        _encryptor = encryptor;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(MemberRepresentativesResponse), 200)]
+    public async Task<IActionResult> ListAll(
+        [FromRoute] string memberId,
+        [FromQuery] DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var associations = await _reps.ListAssociationsForMemberAsync(
+            TenantId, memberId, activeOnly: false, asOf: asOf, ct: ct);
+
+        var items = await BuildSummariesAsync(associations, asOf, ct);
+        return Ok(new MemberRepresentativesResponse
+        {
+            Items = items,
+            AsOf = asOf ?? DateTime.UtcNow
+        });
+    }
+
+    /// <summary>
+    /// Returns all ACTIVE representatives for the member as of
+    /// <paramref name="asOf"/>, optionally filtered by
+    /// <paramref name="credentialType"/>. Callers filter by credential
+    /// type to narrow to reps with healthcare-decision authority (Parent,
+    /// LegalGuardian, HealthcarePowerOfAttorney, HealthcareSurrogate).
+    /// </summary>
+    /// <remarks>
+    /// TODO(authority-scope-followup): finer-grained authority-scope
+    /// filtering — "which reps can grant a §164.508 authorization" vs
+    /// "which reps can receive PHI disclosures" — lands with the
+    /// authority-scope feature. Today, credential type is a proxy:
+    /// callers decide from the credential type what authorities it
+    /// implies. When authority scopes become first-class, this endpoint
+    /// will grow a <c>scope=</c> query parameter without breaking the
+    /// response shape. Clients should NOT rely on credential type alone
+    /// for finer-grained authority decisions indefinitely.
+    ///
+    /// Response is a lightweight summary (no mailing address, no phone,
+    /// no notes). Consumers that need the full decrypted record should
+    /// call <c>GET /api/v1/personal-representatives/{repId}</c>. Keeps
+    /// the resolver endpoint from over-disclosing PHI.
+    /// </remarks>
+    [HttpGet("active")]
+    [ProducesResponseType(typeof(MemberRepresentativesResponse), 200)]
+    public async Task<IActionResult> ListActive(
+        [FromRoute] string memberId,
+        [FromQuery] DateTime? asOf = null,
+        [FromQuery(Name = "credentialType")] List<PersonalRepCredentialType>? credentialTypes = null,
+        CancellationToken ct = default)
+    {
+        var associations = await _reps.ListAssociationsForMemberAsync(
+            TenantId, memberId, activeOnly: true, asOf: asOf, ct: ct);
+
+        if (credentialTypes is { Count: > 0 })
+        {
+            var allow = new HashSet<PersonalRepCredentialType>(credentialTypes);
+            associations = associations.Where(a => allow.Contains(a.CredentialType)).ToList();
+        }
+
+        var items = await BuildSummariesAsync(associations, asOf, ct);
+        // Only include reps whose ObservedStatus is Active at asOf. The
+        // association may still be "active" while the parent rep has been
+        // revoked or expired — in either case it should drop out.
+        items = items.Where(i => i.Status == PersonalRepStatus.Active).ToList();
+
+        return Ok(new MemberRepresentativesResponse
+        {
+            Items = items,
+            AsOf = asOf ?? DateTime.UtcNow
+        });
+    }
+
+    private async Task<List<PersonalRepSummary>> BuildSummariesAsync(
+        IReadOnlyList<PersonalRepAssociation> associations,
+        DateTime? asOf,
+        CancellationToken ct)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        var summaries = new List<PersonalRepSummary>(associations.Count);
+        foreach (var a in associations)
+        {
+            var rep = await _reps.GetByIdAsync(TenantId, a.RepId, ct);
+            if (rep is null) continue;
+
+            // Uses the same IPersonalRepFieldEncryptor.DecryptAsync call
+            // the primary controller uses — no partial-decrypt shortcut.
+            // RotatingKeyProvider cache amortizes the Key Vault cost.
+            var first = await _encryptor.DecryptAsync(rep.FirstName, ct);
+            var last = await _encryptor.DecryptAsync(rep.LastName, ct);
+            var displayName = $"{first} {last}".Trim();
+
+            summaries.Add(new PersonalRepSummary
+            {
+                PersonalRepId = rep.Id,
+                CredentialType = a.CredentialType,
+                Status = rep.ObservedStatus(t),
+                EffectiveFrom = a.EffectiveFrom,
+                EffectiveTo = a.EffectiveTo,
+                ExpiresAt = rep.ExpiresAt,
+                DisplayName = displayName,
+                ProofOfAuthorityDocumentId = rep.ProofOfAuthorityDocumentId
+            });
+        }
+        return summaries;
+    }
+}
+
+public class MemberRepresentativesResponse
+{
+    public List<PersonalRepSummary> Items { get; set; } = new();
+    public DateTime AsOf { get; set; }
+}
+
+public class PersonalRepSummary
+{
+    public string PersonalRepId { get; set; } = string.Empty;
+    public PersonalRepCredentialType CredentialType { get; set; }
+    public PersonalRepStatus Status { get; set; }
+    public DateTime EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? ProofOfAuthorityDocumentId { get; set; }
+}

--- a/src/services/personal-representative-service/Controllers/PersonalRepresentativesController.cs
+++ b/src/services/personal-representative-service/Controllers/PersonalRepresentativesController.cs
@@ -1,0 +1,551 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using PersonalRepresentativeService.Middleware;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+using PersonalRepresentativeService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+// TODO(review-workflow-followup): multi-step approval workflows (legal
+// review pending, awaiting notary verification) are not modeled in this
+// controller. When a review workflow lands, it joins between Draft and
+// Active.
+// TODO(appeals-modernization-followup): appeals-service will consume this
+// controller's resolver endpoint (in MemberRepresentativesController) when
+// it modernizes.
+
+namespace PersonalRepresentativeService.Controllers;
+
+/// <summary>
+/// Personal Representative delegation records (§164.502(g)). Representatives
+/// are never hard-deleted; the lifecycle is Draft → Active → Inactive, with
+/// an append-only audit trail on every transition. Associations to members
+/// are symmetric pairs written atomically.
+/// </summary>
+[ApiController]
+[Route("api/v1/personal-representatives")]
+public class PersonalRepresentativesController : ControllerBase
+{
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IPersonalRepRepository _reps;
+    private readonly IPersonalRepEventRepository _events;
+    private readonly IPersonalRepFieldEncryptor _encryptor;
+    private readonly IPersonalRepEventPublisher _publisher;
+    private readonly ILogger<PersonalRepresentativesController>? _logger;
+
+    public PersonalRepresentativesController(
+        IPersonalRepRepository reps,
+        IPersonalRepEventRepository events,
+        IPersonalRepFieldEncryptor encryptor,
+        IPersonalRepEventPublisher publisher,
+        ILogger<PersonalRepresentativesController>? logger = null)
+    {
+        _reps = reps;
+        _events = events;
+        _encryptor = encryptor;
+        _publisher = publisher;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PersonalRepresentative), 201)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> CreateRepresentative(
+        [FromBody] CreatePersonalRepRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var actor = User.Identity?.Name ?? "System";
+
+        var rep = new PersonalRepresentative
+        {
+            TenantId = TenantId,
+            CredentialType = request.CredentialType,
+            Status = PersonalRepStatus.Draft,
+            EffectiveFrom = request.EffectiveFrom,
+            EffectiveTo = request.EffectiveTo,
+            ExpiresAt = request.ExpiresAt,
+            ProofOfAuthorityDocumentId = request.ProofOfAuthorityDocumentId,
+            FirstName = await _encryptor.EncryptAsync(request.FirstName, ct),
+            MiddleName = await _encryptor.EncryptAsync(request.MiddleName, ct),
+            LastName = await _encryptor.EncryptAsync(request.LastName, ct),
+            Email = await _encryptor.EncryptAsync(request.Email, ct),
+            PhoneNumber = await _encryptor.EncryptAsync(request.PhoneNumber, ct),
+            MailingAddressLine1 = await _encryptor.EncryptAsync(request.MailingAddressLine1, ct),
+            MailingAddressLine2 = await _encryptor.EncryptAsync(request.MailingAddressLine2, ct),
+            MailingAddressCity = await _encryptor.EncryptAsync(request.MailingAddressCity, ct),
+            MailingAddressStateCode = await _encryptor.EncryptAsync(request.MailingAddressStateCode, ct),
+            MailingAddressPostalCode = await _encryptor.EncryptAsync(request.MailingAddressPostalCode, ct),
+            RelationshipNotes = await _encryptor.EncryptAsync(request.RelationshipNotes, ct),
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = actor
+        };
+
+        var genesis = BuildRepEvent(rep, PersonalRepEventType.PersonalRepCreated,
+            fromStatus: null, toStatus: PersonalRepStatus.Draft, actor, request.EventId, memberId: null);
+
+        var created = await _reps.CreateAsync(rep, genesis);
+        await _publisher.PublishStatusChangedAsync(
+            created, fromStatus: null, toStatus: PersonalRepStatus.Draft,
+            associatedMemberIds: Array.Empty<string>(),
+            actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(created, ct);
+        return CreatedAtAction(nameof(GetRepresentative),
+            new { repId = created.Id }, view);
+    }
+
+    [HttpGet("{repId}")]
+    [ProducesResponseType(typeof(PersonalRepresentative), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetRepresentative(
+        [FromRoute] string repId,
+        CancellationToken ct)
+    {
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        rep = await MaybeObserveExpiryAsync(rep, ct);
+
+        var view = await DecryptForResponseAsync(rep, ct);
+        return Ok(view);
+    }
+
+    [HttpGet("{repId}/history")]
+    [ProducesResponseType(typeof(PersonalRepHistoryResponse), 200)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> GetHistory(
+        [FromRoute] string repId,
+        CancellationToken ct)
+    {
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        var events = await _events.ListByRepAsync(TenantId, repId, ct);
+        return Ok(new PersonalRepHistoryResponse { Items = events.ToList() });
+    }
+
+    [HttpPost("{repId}/activate")]
+    [ProducesResponseType(typeof(PersonalRepresentative), 200)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(typeof(ProblemDetails), 409)]
+    public async Task<IActionResult> Activate(
+        [FromRoute] string repId,
+        [FromBody] ActivatePersonalRepRequest? request,
+        CancellationToken ct)
+    {
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        rep = await MaybeObserveExpiryAsync(rep, ct);
+
+        if (rep.Status == PersonalRepStatus.Active)
+        {
+            var view = await DecryptForResponseAsync(rep, ct);
+            return Ok(view);
+        }
+
+        try
+        {
+            PersonalRepStateMachine.EnsureAllowed(rep.Status, PersonalRepStatus.Active);
+        }
+        catch (InvalidPersonalRepTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        var from = rep.Status;
+        rep.Status = PersonalRepStatus.Active;
+        rep.ActivatedBy = actor;
+        rep.ActivatedAt = DateTime.UtcNow;
+        if (!rep.EffectiveFrom.HasValue)
+            rep.EffectiveFrom = rep.ActivatedAt;
+
+        var auditEvent = BuildRepEvent(rep, PersonalRepEventType.PersonalRepActivated,
+            fromStatus: from, toStatus: PersonalRepStatus.Active, actor, request?.EventId, memberId: null);
+
+        PersonalRepresentative updated;
+        try
+        {
+            updated = await _reps.TransitionStatusAsync(rep, auditEvent);
+        }
+        catch (InvalidPersonalRepTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        var memberIds = (await _reps.ListAssociationsForRepAsync(TenantId, repId, activeOnly: true, ct: ct))
+            .Select(a => a.MemberId).Distinct().ToList();
+
+        await _publisher.PublishStatusChangedAsync(
+            updated, fromStatus: from, toStatus: PersonalRepStatus.Active,
+            associatedMemberIds: memberIds,
+            actor, HttpContext.TraceIdentifier, ct);
+
+        var result = await DecryptForResponseAsync(updated, ct);
+        return Ok(result);
+    }
+
+    [HttpPost("{repId}/revoke")]
+    [ProducesResponseType(typeof(PersonalRepresentative), 200)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(typeof(ProblemDetails), 409)]
+    public async Task<IActionResult> Revoke(
+        [FromRoute] string repId,
+        [FromBody] RevokePersonalRepRequest? request,
+        CancellationToken ct)
+    {
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        rep = await MaybeObserveExpiryAsync(rep, ct);
+
+        if (rep.Status == PersonalRepStatus.Inactive)
+        {
+            var view = await DecryptForResponseAsync(rep, ct);
+            return Ok(view);
+        }
+
+        try
+        {
+            PersonalRepStateMachine.EnsureAllowed(rep.Status, PersonalRepStatus.Inactive);
+        }
+        catch (InvalidPersonalRepTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        var from = rep.Status;
+        rep.Status = PersonalRepStatus.Inactive;
+        rep.InactivatedBy = actor;
+        rep.InactivatedAt = DateTime.UtcNow;
+        rep.InactivationReasonCode = request?.ReasonCode ?? PersonalRepInactivationReasonCode.PoaRevoked;
+
+        var auditEvent = BuildRepEvent(rep, PersonalRepEventType.PersonalRepInactivated,
+            fromStatus: from, toStatus: PersonalRepStatus.Inactive, actor, request?.EventId, memberId: null);
+
+        PersonalRepresentative updated;
+        try
+        {
+            updated = await _reps.TransitionStatusAsync(rep, auditEvent);
+        }
+        catch (InvalidPersonalRepTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        var memberIds = (await _reps.ListAssociationsForRepAsync(TenantId, repId, activeOnly: false, ct: ct))
+            .Select(a => a.MemberId).Distinct().ToList();
+
+        await _publisher.PublishStatusChangedAsync(
+            updated, fromStatus: from, toStatus: PersonalRepStatus.Inactive,
+            associatedMemberIds: memberIds,
+            actor, HttpContext.TraceIdentifier, ct);
+
+        var result = await DecryptForResponseAsync(updated, ct);
+        return Ok(result);
+    }
+
+    [HttpPost("{repId}/associations")]
+    [ProducesResponseType(typeof(PersonalRepAssociation), 201)]
+    [ProducesResponseType(404)]
+    [ProducesResponseType(409)]
+    public async Task<IActionResult> AddAssociation(
+        [FromRoute] string repId,
+        [FromBody] AddAssociationRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        var existing = await _reps.FindActiveAssociationAsync(TenantId, repId, request.MemberId, ct);
+        if (existing != null) return Conflict(new ProblemDetails
+        {
+            Status = 409,
+            Title = "Association already exists",
+            Detail = $"Rep {repId} already has an active association with member {request.MemberId}."
+        });
+
+        var actor = User.Identity?.Name ?? "System";
+        var pairId = Guid.NewGuid().ToString();
+        var now = DateTime.UtcNow;
+
+        var forward = new PersonalRepAssociation
+        {
+            TenantId = TenantId,
+            PairId = pairId,
+            RepId = repId,
+            MemberId = request.MemberId,
+            Direction = AssociationDirection.RepToMember,
+            CredentialType = rep.CredentialType,
+            EffectiveFrom = request.EffectiveFrom ?? now,
+            EffectiveTo = request.EffectiveTo,
+            CreatedAt = now,
+            CreatedBy = actor
+        };
+        var inverse = new PersonalRepAssociation
+        {
+            TenantId = TenantId,
+            PairId = pairId,
+            RepId = repId,
+            MemberId = request.MemberId,
+            Direction = AssociationDirection.MemberToRep,
+            CredentialType = rep.CredentialType,
+            EffectiveFrom = forward.EffectiveFrom,
+            EffectiveTo = forward.EffectiveTo,
+            CreatedAt = now,
+            CreatedBy = actor
+        };
+
+        var auditEvent = BuildRepEvent(rep, PersonalRepEventType.PersonalRepAssociationAdded,
+            fromStatus: null, toStatus: null, actor, request.EventId, memberId: request.MemberId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["memberId"] = request.MemberId,
+            ["pairId"] = pairId,
+            ["credentialType"] = rep.CredentialType.ToString(),
+            ["effectiveFrom"] = forward.EffectiveFrom.ToString("o"),
+            ["effectiveTo"] = forward.EffectiveTo?.ToString("o")
+        };
+
+        await _reps.AddAssociationPairAsync(forward, inverse, auditEvent, ct);
+        await _publisher.PublishAssociationChangedAsync(
+            rep, forward, PersonalRepEventType.PersonalRepAssociationAdded,
+            actor, HttpContext.TraceIdentifier, ct);
+
+        return CreatedAtAction(nameof(GetRepresentative),
+            new { repId }, forward);
+    }
+
+    [HttpDelete("{repId}/associations/{memberId}")]
+    [ProducesResponseType(204)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> RemoveAssociation(
+        [FromRoute] string repId,
+        [FromRoute] string memberId,
+        [FromBody] RemoveAssociationRequest? request,
+        CancellationToken ct)
+    {
+        var rep = await _reps.GetByIdAsync(TenantId, repId, ct);
+        if (rep == null) return NotFound();
+
+        var existing = await _reps.FindActiveAssociationAsync(TenantId, repId, memberId, ct);
+        if (existing == null) return NotFound();
+
+        var actor = User.Identity?.Name ?? "System";
+
+        var auditEvent = BuildRepEvent(rep, PersonalRepEventType.PersonalRepAssociationRemoved,
+            fromStatus: null, toStatus: null, actor, request?.EventId, memberId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["memberId"] = memberId,
+            ["pairId"] = existing.PairId,
+            ["credentialType"] = existing.CredentialType.ToString()
+        };
+
+        await _reps.RemoveAssociationPairAsync(TenantId, existing.PairId, actor, auditEvent, ct);
+        await _publisher.PublishAssociationChangedAsync(
+            rep, existing, PersonalRepEventType.PersonalRepAssociationRemoved,
+            actor, HttpContext.TraceIdentifier, ct);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Race-safe persistence of Active → Inactive when the caller observes
+    /// that <c>ExpiresAt</c> has passed on a persisted-Active record. If
+    /// this caller wins the race, the audit event is appended and a Kafka
+    /// event emitted. Lost race is a silent no-op — the audit trail still
+    /// gets exactly one event.
+    /// </summary>
+    private async Task<PersonalRepresentative> MaybeObserveExpiryAsync(
+        PersonalRepresentative rep, CancellationToken ct)
+    {
+        if (rep.ObservedStatus() != PersonalRepStatus.Inactive) return rep;
+        if (rep.Status != PersonalRepStatus.Active) return rep;
+
+        var actor = "System";
+        var auditEvent = BuildRepEvent(rep, PersonalRepEventType.PersonalRepExpired,
+            fromStatus: PersonalRepStatus.Active, toStatus: PersonalRepStatus.Inactive,
+            actor, eventId: null, memberId: null);
+
+        var persisted = await _reps.TryTransitionToInactiveAsync(rep, auditEvent);
+        if (persisted)
+        {
+            var memberIds = (await _reps.ListAssociationsForRepAsync(TenantId, rep.Id, activeOnly: false, ct: ct))
+                .Select(a => a.MemberId).Distinct().ToList();
+            await _publisher.PublishStatusChangedAsync(
+                rep, fromStatus: PersonalRepStatus.Active, toStatus: PersonalRepStatus.Inactive,
+                associatedMemberIds: memberIds,
+                actor, HttpContext.TraceIdentifier, ct);
+        }
+
+        rep.Status = PersonalRepStatus.Inactive;
+        rep.InactivationReasonCode = PersonalRepInactivationReasonCode.Expired;
+        return rep;
+    }
+
+    private static PersonalRepEvent BuildRepEvent(
+        PersonalRepresentative rep,
+        PersonalRepEventType type,
+        PersonalRepStatus? fromStatus,
+        PersonalRepStatus? toStatus,
+        string actor,
+        string? eventId,
+        string? memberId)
+    {
+        var payload = new JsonObject
+        {
+            ["personalRepId"] = rep.Id,
+            ["credentialType"] = rep.CredentialType.ToString(),
+            ["fromStatus"] = fromStatus?.ToString(),
+            ["toStatus"] = toStatus?.ToString(),
+            ["effectiveFrom"] = rep.EffectiveFrom?.ToString("o"),
+            ["effectiveTo"] = rep.EffectiveTo?.ToString("o"),
+            ["expiresAt"] = rep.ExpiresAt?.ToString("o"),
+            ["inactivationReasonCode"] = rep.InactivationReasonCode?.ToString()
+        };
+
+        return new PersonalRepEvent
+        {
+            TenantId = rep.TenantId,
+            PersonalRepId = rep.Id,
+            MemberId = memberId,
+            EventId = string.IsNullOrEmpty(eventId) ? Guid.NewGuid().ToString() : eventId,
+            EventType = type,
+            FromStatus = fromStatus,
+            ToStatus = toStatus,
+            ActorId = actor,
+            OccurredAt = DateTime.UtcNow,
+            Payload = payload
+        };
+    }
+
+    private async Task<PersonalRepresentative> DecryptForResponseAsync(
+        PersonalRepresentative rep, CancellationToken ct)
+    {
+        return new PersonalRepresentative
+        {
+            TenantId = rep.TenantId,
+            Id = rep.Id,
+            Status = rep.ObservedStatus(),
+            CredentialType = rep.CredentialType,
+            EffectiveFrom = rep.EffectiveFrom,
+            EffectiveTo = rep.EffectiveTo,
+            ExpiresAt = rep.ExpiresAt,
+            ProofOfAuthorityDocumentId = rep.ProofOfAuthorityDocumentId,
+            FirstName = await _encryptor.DecryptAsync(rep.FirstName, ct),
+            MiddleName = await _encryptor.DecryptAsync(rep.MiddleName, ct),
+            LastName = await _encryptor.DecryptAsync(rep.LastName, ct),
+            Email = await _encryptor.DecryptAsync(rep.Email, ct),
+            PhoneNumber = await _encryptor.DecryptAsync(rep.PhoneNumber, ct),
+            MailingAddressLine1 = await _encryptor.DecryptAsync(rep.MailingAddressLine1, ct),
+            MailingAddressLine2 = await _encryptor.DecryptAsync(rep.MailingAddressLine2, ct),
+            MailingAddressCity = await _encryptor.DecryptAsync(rep.MailingAddressCity, ct),
+            MailingAddressStateCode = await _encryptor.DecryptAsync(rep.MailingAddressStateCode, ct),
+            MailingAddressPostalCode = await _encryptor.DecryptAsync(rep.MailingAddressPostalCode, ct),
+            RelationshipNotes = await _encryptor.DecryptAsync(rep.RelationshipNotes, ct),
+            CreatedAt = rep.CreatedAt,
+            CreatedBy = rep.CreatedBy,
+            UpdatedAt = rep.UpdatedAt,
+            UpdatedBy = rep.UpdatedBy,
+            ActivatedBy = rep.ActivatedBy,
+            ActivatedAt = rep.ActivatedAt,
+            InactivatedBy = rep.InactivatedBy,
+            InactivatedAt = rep.InactivatedAt,
+            InactivationReasonCode = rep.InactivationReasonCode
+        };
+    }
+
+    private IActionResult ConflictTransition(InvalidPersonalRepTransitionException ex)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = 409,
+            Title = "Invalid personal representative transition",
+            Detail = ex.Message,
+            Type = "https://cloudhealthoffice.com/problems/personal-rep-transition"
+        };
+        problem.Extensions["fromStatus"] = ex.FromStatus.ToString();
+        problem.Extensions["toStatus"] = ex.ToStatus.ToString();
+        return Conflict(problem);
+    }
+}
+
+public class CreatePersonalRepRequest
+{
+    [Required]
+    public PersonalRepCredentialType CredentialType { get; set; }
+
+    public DateTime? EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+
+    [StringLength(100)]
+    public string? ProofOfAuthorityDocumentId { get; set; }
+
+    [StringLength(500)]
+    public string? FirstName { get; set; }
+    [StringLength(500)]
+    public string? MiddleName { get; set; }
+    [StringLength(500)]
+    public string? LastName { get; set; }
+    [StringLength(500)]
+    public string? Email { get; set; }
+    [StringLength(100)]
+    public string? PhoneNumber { get; set; }
+    [StringLength(500)]
+    public string? MailingAddressLine1 { get; set; }
+    [StringLength(500)]
+    public string? MailingAddressLine2 { get; set; }
+    [StringLength(200)]
+    public string? MailingAddressCity { get; set; }
+    [StringLength(50)]
+    public string? MailingAddressStateCode { get; set; }
+    [StringLength(20)]
+    public string? MailingAddressPostalCode { get; set; }
+    [StringLength(4000)]
+    public string? RelationshipNotes { get; set; }
+
+    /// <summary>Optional client-supplied idempotency key for the audit event.</summary>
+    public string? EventId { get; set; }
+}
+
+public class ActivatePersonalRepRequest
+{
+    public string? EventId { get; set; }
+}
+
+public class RevokePersonalRepRequest
+{
+    public PersonalRepInactivationReasonCode? ReasonCode { get; set; }
+    public string? EventId { get; set; }
+}
+
+public class AddAssociationRequest
+{
+    [Required]
+    [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    public DateTime? EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+
+    public string? EventId { get; set; }
+}
+
+public class RemoveAssociationRequest
+{
+    public string? EventId { get; set; }
+}
+
+public class PersonalRepHistoryResponse
+{
+    public List<PersonalRepEvent> Items { get; set; } = new();
+}

--- a/src/services/personal-representative-service/Controllers/PersonalRepresentativesController.cs
+++ b/src/services/personal-representative-service/Controllers/PersonalRepresentativesController.cs
@@ -375,20 +375,20 @@ public class PersonalRepresentativesController : ControllerBase
             fromStatus: PersonalRepStatus.Active, toStatus: PersonalRepStatus.Inactive,
             actor, eventId: null, memberId: null);
 
-        var persisted = await _reps.TryTransitionToInactiveAsync(rep, auditEvent);
-        if (persisted)
+        var persistedRep = await _reps.TryTransitionToInactiveAsync(rep, auditEvent);
+        if (persistedRep != null)
         {
-            var memberIds = (await _reps.ListAssociationsForRepAsync(TenantId, rep.Id, activeOnly: false, ct: ct))
+            var memberIds = (await _reps.ListAssociationsForRepAsync(TenantId, persistedRep.Id, activeOnly: false, ct: ct))
                 .Select(a => a.MemberId).Distinct().ToList();
             await _publisher.PublishStatusChangedAsync(
-                rep, fromStatus: PersonalRepStatus.Active, toStatus: PersonalRepStatus.Inactive,
+                persistedRep, fromStatus: PersonalRepStatus.Active, toStatus: PersonalRepStatus.Inactive,
                 associatedMemberIds: memberIds,
                 actor, HttpContext.TraceIdentifier, ct);
         }
 
         rep.Status = PersonalRepStatus.Inactive;
         rep.InactivationReasonCode = PersonalRepInactivationReasonCode.Expired;
-        return rep;
+        return persistedRep ?? rep;
     }
 
     private static PersonalRepEvent BuildRepEvent(

--- a/src/services/personal-representative-service/Dockerfile
+++ b/src/services/personal-representative-service/Dockerfile
@@ -1,0 +1,34 @@
+ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+
+COPY src/services/personal-representative-service/personal-representative-service.csproj src/services/personal-representative-service/
+COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
+RUN dotnet restore src/services/personal-representative-service/personal-representative-service.csproj
+
+COPY src/services/personal-representative-service/ src/services/personal-representative-service/
+COPY src/services/shared/CloudHealthOffice.Infrastructure/ src/services/shared/CloudHealthOffice.Infrastructure/
+RUN dotnet build src/services/personal-representative-service/personal-representative-service.csproj -c Release --no-restore
+
+FROM build AS publish
+RUN dotnet publish src/services/personal-representative-service/personal-representative-service.csproj -c Release -o /app/publish /p:UseAppHost=false --no-restore --no-build
+
+FROM ${REGISTRY}/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=publish /app/publish .
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/health/live || exit 1
+
+ENTRYPOINT ["dotnet", "personal-representative-service.dll"]

--- a/src/services/personal-representative-service/HostedServices/PersonalRepIndexInitializer.cs
+++ b/src/services/personal-representative-service/HostedServices/PersonalRepIndexInitializer.cs
@@ -1,0 +1,120 @@
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+using MongoDB.Driver;
+
+namespace PersonalRepresentativeService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the PersonalRepresentatives,
+/// PersonalRepAssociations, and PersonalRepEvents collections once at
+/// startup. Running from a hosted service (rather than the repository
+/// constructor) keeps construction side-effect free and lets us register
+/// repositories as singletons.
+///
+/// Idempotent: Mongo silently no-ops an index that already exists with the
+/// same spec.
+/// </summary>
+public sealed class PersonalRepIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly ILogger<PersonalRepIndexInitializer> _logger;
+
+    public PersonalRepIndexInitializer(IMongoDatabase db, ILogger<PersonalRepIndexInitializer> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var reps = _db.GetCollection<PersonalRepresentative>(PersonalRepRepositoryMongo.PersonalRepsCollectionName);
+
+        await reps.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepresentative>(
+                Builders<PersonalRepresentative>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.Id),
+                new CreateIndexOptions { Name = "ux_tenant_id", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await reps.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepresentative>(
+                Builders<PersonalRepresentative>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.Status)
+                    .Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "ix_tenant_status_created" }),
+            cancellationToken: cancellationToken);
+
+        var associations = _db.GetCollection<PersonalRepAssociation>(
+            PersonalRepRepositoryMongo.PersonalRepAssociationsCollectionName);
+
+        await associations.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepAssociation>(
+                Builders<PersonalRepAssociation>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.Id),
+                new CreateIndexOptions { Name = "ux_tenant_id", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await associations.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepAssociation>(
+                Builders<PersonalRepAssociation>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.PairId),
+                new CreateIndexOptions { Name = "ix_tenant_pair" }),
+            cancellationToken: cancellationToken);
+
+        await associations.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepAssociation>(
+                Builders<PersonalRepAssociation>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.MemberId)
+                    .Ascending(x => x.Direction),
+                new CreateIndexOptions { Name = "ix_tenant_member_direction" }),
+            cancellationToken: cancellationToken);
+
+        await associations.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepAssociation>(
+                Builders<PersonalRepAssociation>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.RepId)
+                    .Ascending(x => x.Direction),
+                new CreateIndexOptions { Name = "ix_tenant_rep_direction" }),
+            cancellationToken: cancellationToken);
+
+        await associations.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepAssociation>(
+                Builders<PersonalRepAssociation>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.RepId)
+                    .Ascending(x => x.MemberId),
+                new CreateIndexOptions { Name = "ix_tenant_rep_member" }),
+            cancellationToken: cancellationToken);
+
+        var events = _db.GetCollection<PersonalRepEvent>(
+            PersonalRepEventRepositoryMongo.PersonalRepEventsCollectionName);
+
+        await events.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepEvent>(
+                Builders<PersonalRepEvent>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.PersonalRepId)
+                    .Ascending(x => x.EventId),
+                new CreateIndexOptions { Name = "ux_tenant_rep_event", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await events.Indexes.CreateOneAsync(
+            new CreateIndexModel<PersonalRepEvent>(
+                Builders<PersonalRepEvent>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.PersonalRepId)
+                    .Ascending(x => x.OccurredAt),
+                new CreateIndexOptions { Name = "ix_tenant_rep_occurred" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("PersonalRepresentative, PersonalRepAssociation, PersonalRepEvent indexes ensured.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/personal-representative-service/Middleware/TenantMiddleware.cs
+++ b/src/services/personal-representative-service/Middleware/TenantMiddleware.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace PersonalRepresentativeService.Middleware;
+
+/// <summary>
+/// Extracts tenant context from JWT tokens or headers for multi-tenant
+/// isolation. Identical implementation to Consent Service / Member Service
+/// for consistency.
+/// </summary>
+public class TenantMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public TenantMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (IsHealthCheckPath(context.Request.Path))
+        {
+            await _next(context);
+            return;
+        }
+
+        var tenantId = ExtractTenantId(context);
+
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            context.Response.StatusCode = 401;
+            await context.Response.WriteAsync("Missing tenant context. Provide X-Tenant-ID header or valid JWT with tenant claim.");
+            return;
+        }
+
+        context.Items["TenantId"] = tenantId;
+        await _next(context);
+    }
+
+    private static bool IsHealthCheckPath(PathString path)
+    {
+        return path.StartsWithSegments("/health") ||
+               path.StartsWithSegments("/ready") ||
+               path.StartsWithSegments("/live");
+    }
+
+    private string? ExtractTenantId(HttpContext context)
+    {
+        var user = context.User;
+        if (user?.Identity?.IsAuthenticated == true)
+        {
+            var tenantClaim = user.FindFirst("tenant_id")?.Value
+                           ?? user.FindFirst("extension_TenantId")?.Value
+                           ?? user.FindFirst(ClaimTypes.GroupSid)?.Value;
+
+            if (!string.IsNullOrEmpty(tenantClaim))
+            {
+                return tenantClaim;
+            }
+        }
+
+        if (context.Request.Headers.TryGetValue("X-Tenant-ID", out var headerValue))
+        {
+            return headerValue.FirstOrDefault();
+        }
+
+        if (context.Request.Headers.TryGetValue("X-Dev-Tenant-ID", out var devHeaderValue))
+        {
+            return devHeaderValue.FirstOrDefault();
+        }
+
+        return null;
+    }
+}
+
+public static class TenantMiddlewareExtensions
+{
+    public static IApplicationBuilder UseTenantContext(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<TenantMiddleware>();
+    }
+
+    public static string GetTenantId(this HttpContext context)
+    {
+        return context.Items["TenantId"]?.ToString()
+            ?? throw new InvalidOperationException("Tenant context not found. Ensure TenantMiddleware is registered.");
+    }
+}

--- a/src/services/personal-representative-service/Models/PersonalRepAssociation.cs
+++ b/src/services/personal-representative-service/Models/PersonalRepAssociation.cs
@@ -1,0 +1,116 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace PersonalRepresentativeService.Models;
+
+/// <summary>
+/// Edge linking a <see cref="PersonalRepresentative"/> to a member. Persisted
+/// as a symmetric pair: one row with <see cref="Direction"/> =
+/// <see cref="AssociationDirection.RepToMember"/> and a counterpart row with
+/// <see cref="AssociationDirection.MemberToRep"/>, sharing a <see cref="PairId"/>.
+/// Both rows are written atomically (Cosmos <c>TransactionalBatch</c> or
+/// Mongo session transaction) so "list reps for this member" and "list
+/// members for this rep" queries are always consistent.
+///
+/// Fields mean the same thing on both rows: <see cref="RepId"/> is always
+/// the rep id; <see cref="MemberId"/> is always the member id. The
+/// <see cref="Direction"/> discriminator says which lookup this row is
+/// indexed for, not which end of the edge is "subject."
+///
+/// Soft-delete only (<see cref="EffectiveTo"/> for normal wind-down,
+/// <see cref="DeletedAt"/> for rare data-entry error correction) — matches
+/// the FamilyRelationship lifecycle posture.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class PersonalRepAssociation
+{
+    [Required]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Partition key. Both rows of a pair share the same tenant.</summary>
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Links the two symmetric rows of an association. Used to find the
+    /// counterpart on end / soft-delete operations.
+    /// </summary>
+    [Required]
+    [StringLength(64)]
+    public string PairId { get; set; } = string.Empty;
+
+    /// <summary>The Personal Representative id. Same value on both rows.</summary>
+    [Required]
+    [StringLength(50)]
+    public string RepId { get; set; } = string.Empty;
+
+    /// <summary>The external member id. Same value on both rows.</summary>
+    [Required]
+    [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Which lookup this row is indexed for. The pair's two rows share every
+    /// field except this discriminator.
+    /// </summary>
+    [Required]
+    public AssociationDirection Direction { get; set; }
+
+    /// <summary>
+    /// Credential copied from the parent <see cref="PersonalRepresentative"/>
+    /// for query-path ergonomics (avoids a join for the resolver endpoint).
+    /// </summary>
+    [Required]
+    public PersonalRepCredentialType CredentialType { get; set; }
+
+    [Required]
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>Null for active associations. Setting this is the normal wind-down path.</summary>
+    public DateTime? EffectiveTo { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    [StringLength(200)]
+    public string? UpdatedBy { get; set; }
+
+    // ── Soft-delete (rare; admin-only; reserved for data-entry errors) ───
+
+    public DateTime? DeletedAt { get; set; }
+
+    [StringLength(200)]
+    public string? DeletedBy { get; set; }
+
+    [StringLength(500)]
+    public string? DeletedReason { get; set; }
+
+    [BsonIgnore]
+    public bool IsDeleted => DeletedAt.HasValue;
+
+    /// <summary>True when this row is currently active (no EndDate passed, not soft-deleted).</summary>
+    [BsonIgnore]
+    public bool IsActive => !DeletedAt.HasValue && (EffectiveTo == null || EffectiveTo > DateTime.UtcNow);
+}
+
+/// <summary>
+/// Which side of the symmetric pair this row is indexed for. The fields on
+/// both rows have identical values; this discriminator simply says whether
+/// a query should hit this row when looking up "reps for a member" or
+/// "members for a rep."
+/// </summary>
+public enum AssociationDirection
+{
+    /// <summary>Indexed for "list all members for this rep" queries.</summary>
+    RepToMember = 1,
+
+    /// <summary>Indexed for "list all reps for this member" queries.</summary>
+    MemberToRep = 2
+}

--- a/src/services/personal-representative-service/Models/PersonalRepEvent.cs
+++ b/src/services/personal-representative-service/Models/PersonalRepEvent.cs
@@ -1,0 +1,91 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace PersonalRepresentativeService.Models;
+
+/// <summary>
+/// Append-only audit row for <see cref="PersonalRepresentative"/>. One row
+/// per lifecycle action (created, activated, inactivated, expired,
+/// association-added, association-removed). Partition key is
+/// <c>{tenantId}:{personalRepId}</c> so the full audit trail for a rep
+/// lives in a single partition and scans cheaply.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class PersonalRepEvent
+{
+    /// <summary>Cosmos document id + Mongo `_id`. Defaults to <see cref="EventId"/>.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Cosmos partition key. Derived via <see cref="BuildPartitionKey"/>.</summary>
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    public string PersonalRepId { get; set; } = string.Empty;
+
+    /// <summary>Populated on association events; null on rep-level events.</summary>
+    [StringLength(50)]
+    public string? MemberId { get; set; }
+
+    /// <summary>
+    /// Client-supplied idempotency key. Duplicate appends with the same
+    /// <c>EventId</c> are silently ignored at the repository layer.
+    /// </summary>
+    [Required]
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public PersonalRepEventType EventType { get; set; }
+
+    public PersonalRepStatus? FromStatus { get; set; }
+    public PersonalRepStatus? ToStatus { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string ActorId { get; set; } = string.Empty;
+
+    [StringLength(200)]
+    public string? CorrelationId { get; set; }
+
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Structured, non-PHI payload. Free-form JSON so new event types can
+    /// carry whatever context they need without a model change — keep PHI-
+    /// adjacent fields OUT of this payload (those live encrypted on the
+    /// <see cref="PersonalRepresentative"/> aggregate).
+    /// </summary>
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    /// <summary>
+    /// Mongo-facing mirror of <see cref="Payload"/>. Not emitted by
+    /// System.Text.Json (Cosmos path) — used only by the BSON driver.
+    /// </summary>
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string personalRepId) =>
+        $"{tenantId}:{personalRepId}";
+}
+
+public enum PersonalRepEventType
+{
+    PersonalRepCreated = 1,
+    PersonalRepActivated = 2,
+    PersonalRepInactivated = 3,
+    PersonalRepExpired = 4,
+    PersonalRepAssociationAdded = 5,
+    PersonalRepAssociationRemoved = 6
+}

--- a/src/services/personal-representative-service/Models/PersonalRepresentative.cs
+++ b/src/services/personal-representative-service/Models/PersonalRepresentative.cs
@@ -1,0 +1,270 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+// TODO(signature-capture-followup): Proof-of-authority document signature
+// capture / notarization verification is out of scope for this PR.
+// ProofOfAuthorityDocumentId is a UUID pointer into member-document-service;
+// bytes live there, we hold the reference.
+// TODO(fhir-related-person-followup): FHIR R4 RelatedPerson projection
+// belongs in fhir-service, not here. No projection interface is scaffolded
+// on this entity — keeping the model first-party until we know what the
+// projection needs.
+
+namespace PersonalRepresentativeService.Models;
+
+/// <summary>
+/// An individual with legal authority to act on behalf of a member under
+/// 45 CFR §164.502(g) — parent of a minor, court-appointed legal guardian,
+/// holder of a healthcare power of attorney, or a healthcare surrogate.
+/// One rep record may be associated with multiple members via
+/// <see cref="PersonalRepAssociation"/>.
+///
+/// Personal Representatives are never hard-deleted; lifecycle transitions
+/// (Draft → Active → Inactive) are captured through
+/// <see cref="Repositories.IPersonalRepRepository.TransitionStatusAsync"/>
+/// with a matching <see cref="PersonalRepEvent"/> appended atomically for
+/// audit.
+///
+/// PHI-adjacent fields (name, contact, address, notes) are stored as
+/// ciphertext; encryption is applied by the controller layer before
+/// persistence, decryption on read-back. The fields are always accessed
+/// through the entity in ciphertext form — repositories do not decrypt.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class PersonalRepresentative
+{
+    /// <summary>Multi-tenant partition key.</summary>
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Stable rep id. Cosmos document id and Mongo `_id`.</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public PersonalRepStatus Status { get; set; } = PersonalRepStatus.Draft;
+
+    [Required]
+    public PersonalRepCredentialType CredentialType { get; set; }
+
+    /// <summary>When the rep's authority becomes effective.</summary>
+    public DateTime? EffectiveFrom { get; set; }
+
+    /// <summary>
+    /// When the rep's authority ends by design (e.g. a time-bounded POA).
+    /// Distinct from <see cref="ExpiresAt"/> — EffectiveTo is a planned end,
+    /// ExpiresAt is a document's notarized expiration.
+    /// </summary>
+    public DateTime? EffectiveTo { get; set; }
+
+    /// <summary>
+    /// Notarized expiration date from the proof-of-authority document
+    /// itself. Drives the read-time <see cref="ObservedStatus"/> projection
+    /// onto <see cref="PersonalRepStatus.Inactive"/>.
+    /// </summary>
+    public DateTime? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// UUID pointer into member-document-service where the proof-of-authority
+    /// document (POA, guardianship order, notarized affidavit) is stored.
+    /// Not PHI in isolation — safe to index and emit on events.
+    /// </summary>
+    [StringLength(100)]
+    public string? ProofOfAuthorityDocumentId { get; set; }
+
+    // ── Encrypted at rest — never included in Kafka event payload ───────
+
+    /// <summary>Encrypted at rest via <see cref="Services.IPersonalRepFieldEncryptor"/>.</summary>
+    [StringLength(500)]
+    public string? FirstName { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(500)]
+    public string? MiddleName { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(500)]
+    public string? LastName { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(500)]
+    public string? Email { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(100)]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(500)]
+    public string? MailingAddressLine1 { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(500)]
+    public string? MailingAddressLine2 { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(200)]
+    public string? MailingAddressCity { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(50)]
+    public string? MailingAddressStateCode { get; set; }
+
+    /// <summary>Encrypted at rest.</summary>
+    [StringLength(20)]
+    public string? MailingAddressPostalCode { get; set; }
+
+    /// <summary>Free-text relationship notes. Encrypted at rest.</summary>
+    [StringLength(4000)]
+    public string? RelationshipNotes { get; set; }
+
+    // ── Lifecycle timestamps ────────────────────────────────────────────
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    [StringLength(200)]
+    public string? UpdatedBy { get; set; }
+
+    [StringLength(200)]
+    public string? ActivatedBy { get; set; }
+    public DateTime? ActivatedAt { get; set; }
+
+    [StringLength(200)]
+    public string? InactivatedBy { get; set; }
+    public DateTime? InactivatedAt { get; set; }
+
+    /// <summary>
+    /// Controlled reason code for inactivation. Safe to include in event
+    /// payload (enum-valued). See <see cref="PersonalRepInactivationReasonCode"/>.
+    /// </summary>
+    public PersonalRepInactivationReasonCode? InactivationReasonCode { get; set; }
+
+    // ── Soft-delete (rare; admin-only; reserved for data-entry errors) ───
+
+    public DateTime? DeletedAt { get; set; }
+
+    [StringLength(200)]
+    public string? DeletedBy { get; set; }
+
+    [StringLength(500)]
+    public string? DeletedReason { get; set; }
+
+    [BsonIgnore]
+    public bool IsDeleted => DeletedAt.HasValue;
+
+    /// <summary>
+    /// Projects the persisted status into the status the caller observes —
+    /// <see cref="PersonalRepStatus.Inactive"/> whenever the record is still
+    /// persisted as <see cref="PersonalRepStatus.Active"/> but the effective
+    /// <see cref="ExpiresAt"/> has passed. The observed-transition write to
+    /// the persisted status happens in
+    /// <see cref="Repositories.IPersonalRepRepository.TryTransitionToInactiveAsync"/>.
+    /// </summary>
+    public PersonalRepStatus ObservedStatus(DateTime? asOf = null)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        if (Status == PersonalRepStatus.Active && ExpiresAt.HasValue && ExpiresAt.Value <= t)
+            return PersonalRepStatus.Inactive;
+        return Status;
+    }
+}
+
+/// <summary>
+/// Personal Representative lifecycle state. See
+/// <c>Services.PersonalRepStateMachine</c> for allowed transitions;
+/// <see cref="Inactive"/> is a read-time projection of <see cref="Active"/>
+/// once <see cref="PersonalRepresentative.ExpiresAt"/> passes.
+/// </summary>
+public enum PersonalRepStatus
+{
+    Draft = 1,
+    Active = 2,
+    Inactive = 3
+}
+
+/// <summary>
+/// The credential by which the rep claims authority. Legal review
+/// questions flagged on the PR for the ambiguous values
+/// (<see cref="HealthcareSurrogate"/> vs "healthcare agent" in some
+/// state statutes; <see cref="Conservator"/> vs <see cref="LegalGuardian"/>
+/// overlap in Texas Medicaid).
+///
+/// Minor-consent scenarios (Tex. Fam. Code §32.003 — a minor consenting
+/// without a representative) are NOT modeled here; that is application-
+/// layer logic belonging in consent-service.
+/// </summary>
+public enum PersonalRepCredentialType
+{
+    /// <summary>Biological / adoptive parent of a minor member.</summary>
+    // TODO(minor-consent-interaction): §32.003 minor-consent logic lives
+    // in consent-service / clinical workflows, not here.
+    Parent = 1,
+
+    /// <summary>Court-appointed legal guardian.</summary>
+    LegalGuardian = 2,
+
+    /// <summary>Holder of a healthcare power of attorney.</summary>
+    HealthcarePowerOfAttorney = 3,
+
+    /// <summary>
+    /// State-statute-designated healthcare surrogate. Naming varies by
+    /// jurisdiction ("agent" in some states); unified under "surrogate"
+    /// pending legal review.
+    /// </summary>
+    HealthcareSurrogate = 4,
+
+    /// <summary>
+    /// Court-appointed conservator. In most state probate law, conservators
+    /// have financial-decision authority distinct from a
+    /// <see cref="LegalGuardian"/>'s personal/healthcare authority. Legal
+    /// review on the PR confirms whether Texas Medicaid treats this as
+    /// equivalent to LegalGuardian.
+    /// </summary>
+    Conservator = 5,
+
+    /// <summary>Escape hatch for any credential type legal flags later.</summary>
+    Other = 99
+}
+
+/// <summary>
+/// Controlled inactivation reasons. Safe to include in event payloads
+/// (no PHI). Unlike consent-service which models Expired as a distinct
+/// terminal status, personal-rep collapses all termination reasons into
+/// Inactive with a discriminator here — see
+/// <c>Services.PersonalRepStateMachine</c> remarks.
+/// </summary>
+public enum PersonalRepInactivationReasonCode
+{
+    RepDeceased = 1,
+    PoaRevoked = 2,
+    GuardianshipEnded = 3,
+    Expired = 4,
+    AdminError = 5,
+    Other = 99
+}
+
+/// <summary>
+/// Thrown when a caller attempts a Personal Representative lifecycle
+/// transition that is not allowed by <c>Services.PersonalRepStateMachine</c>.
+/// Distinct from a generic <see cref="InvalidOperationException"/> so the
+/// controller layer can map it to a 409 Conflict with
+/// <see cref="FromStatus"/>/<see cref="ToStatus"/> in ProblemDetails rather
+/// than a 500.
+/// </summary>
+public sealed class InvalidPersonalRepTransitionException : InvalidOperationException
+{
+    public PersonalRepStatus FromStatus { get; }
+    public PersonalRepStatus ToStatus { get; }
+
+    public InvalidPersonalRepTransitionException(PersonalRepStatus from, PersonalRepStatus to)
+        : base($"Personal Representative transition {from} -> {to} is not allowed.")
+    {
+        FromStatus = from;
+        ToStatus = to;
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/MemberRepresentativesControllerTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/MemberRepresentativesControllerTests.cs
@@ -1,0 +1,229 @@
+using System.Security.Claims;
+using PersonalRepresentativeService.Controllers;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PersonalRepresentativeService.Tests.Controllers;
+
+public class MemberRepresentativesControllerTests
+{
+    private static (PersonalRepresentativesController primary,
+                    MemberRepresentativesController resolver,
+                    InMemoryPersonalRepRepository repo,
+                    ReversiblePersonalRepFieldEncryptor encryptor)
+        BuildControllers(string tenantId = "tenant-a")
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        var publisher = new RecordingPersonalRepEventPublisher();
+        var encryptor = new ReversiblePersonalRepFieldEncryptor();
+
+        var primary = new PersonalRepresentativesController(repo, repo, encryptor, publisher);
+        var resolver = new MemberRepresentativesController(repo, encryptor);
+
+        foreach (var c in new ControllerBase[] { primary, resolver })
+        {
+            var http = new DefaultHttpContext();
+            http.Items["TenantId"] = tenantId;
+            http.User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.Name, "alice@tenant.com") }, "test"));
+            c.ControllerContext = new ControllerContext { HttpContext = http };
+        }
+        return (primary, resolver, repo, encryptor);
+    }
+
+    [Fact]
+    public async Task ListAll_ReturnsSummariesForMember()
+    {
+        var (primary, resolver, _, _) = BuildControllers();
+
+        var create1 = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice", LastName = "Smith"
+        }, CancellationToken.None);
+        var id1 = ((PersonalRepresentative)((CreatedAtActionResult)create1).Value!).Id;
+        await primary.Activate(id1, null, CancellationToken.None);
+        await primary.AddAssociation(id1,
+            new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+
+        var result = await resolver.ListAll("M123", asOf: null, CancellationToken.None);
+        var response = ((OkObjectResult)result).Value.Should().BeOfType<MemberRepresentativesResponse>().Subject;
+        response.Items.Should().ContainSingle(s =>
+            s.PersonalRepId == id1 &&
+            s.DisplayName == "Alice Smith" &&
+            s.CredentialType == PersonalRepCredentialType.LegalGuardian);
+    }
+
+    [Fact]
+    public async Task ListActive_FiltersInactiveReps_AndRespectsCredentialTypeFilter()
+    {
+        var (primary, resolver, _, _) = BuildControllers();
+
+        // Rep 1: Parent, active.
+        var c1 = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.Parent, FirstName = "Bob", LastName = "Parent"
+        }, CancellationToken.None);
+        var id1 = ((PersonalRepresentative)((CreatedAtActionResult)c1).Value!).Id;
+        await primary.Activate(id1, null, CancellationToken.None);
+        await primary.AddAssociation(id1, new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+
+        // Rep 2: LegalGuardian, active.
+        var c2 = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian, FirstName = "Carol", LastName = "Guardian"
+        }, CancellationToken.None);
+        var id2 = ((PersonalRepresentative)((CreatedAtActionResult)c2).Value!).Id;
+        await primary.Activate(id2, null, CancellationToken.None);
+        await primary.AddAssociation(id2, new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+
+        // Rep 3: LegalGuardian, revoked — must NOT appear on /active.
+        var c3 = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian, FirstName = "Dan", LastName = "Revoked"
+        }, CancellationToken.None);
+        var id3 = ((PersonalRepresentative)((CreatedAtActionResult)c3).Value!).Id;
+        await primary.Activate(id3, null, CancellationToken.None);
+        await primary.AddAssociation(id3, new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+        await primary.Revoke(id3, null, CancellationToken.None);
+
+        // No credential-type filter — two active reps.
+        var all = await resolver.ListActive("M123", asOf: null, credentialTypes: null, CancellationToken.None);
+        var allResp = ((OkObjectResult)all).Value.Should().BeOfType<MemberRepresentativesResponse>().Subject;
+        allResp.Items.Select(i => i.PersonalRepId).Should().BeEquivalentTo(new[] { id1, id2 });
+        allResp.Items.Should().NotContain(i => i.PersonalRepId == id3);
+
+        // Credential-type filter narrows to LegalGuardian only.
+        var guardianOnly = await resolver.ListActive("M123", asOf: null,
+            credentialTypes: new List<PersonalRepCredentialType> { PersonalRepCredentialType.LegalGuardian },
+            CancellationToken.None);
+        var guardianResp = ((OkObjectResult)guardianOnly).Value.Should().BeOfType<MemberRepresentativesResponse>().Subject;
+        guardianResp.Items.Select(i => i.PersonalRepId).Should().BeEquivalentTo(new[] { id2 });
+    }
+
+    /// <summary>
+    /// The resolver endpoint must use the same
+    /// <c>IPersonalRepFieldEncryptor.DecryptAsync</c> path the primary
+    /// controller uses — no shortcut decrypt. Verified by hitting the
+    /// recording encryptor's DecryptCalls counter.
+    /// </summary>
+    [Fact]
+    public async Task ListActive_DisplayName_UsesStandardDecryptPath()
+    {
+        var (primary, resolver, _, encryptor) = BuildControllers();
+
+        var create = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Eve", LastName = "Decryptable"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await primary.Activate(id, null, CancellationToken.None);
+        await primary.AddAssociation(id, new AddAssociationRequest { MemberId = "M1" }, CancellationToken.None);
+
+        var before = encryptor.DecryptCalls;
+        var result = await resolver.ListActive("M1", asOf: null, credentialTypes: null, CancellationToken.None);
+        var response = ((OkObjectResult)result).Value.Should().BeOfType<MemberRepresentativesResponse>().Subject;
+
+        var summary = response.Items.Single();
+        summary.DisplayName.Should().Be("Eve Decryptable");
+
+        // The resolver decrypts FirstName + LastName — at minimum two more
+        // DecryptAsync calls should have happened.
+        (encryptor.DecryptCalls - before).Should().BeGreaterOrEqualTo(2,
+            "resolver must go through the standard IPersonalRepFieldEncryptor.DecryptAsync path, not a shortcut");
+    }
+
+    [Fact]
+    public async Task ListActive_LightweightSummary_OmitsPhoneAddressNotes()
+    {
+        var (primary, resolver, _, _) = BuildControllers();
+
+        var create = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice",
+            LastName = "Smith",
+            PhoneNumber = "555-0100",
+            MailingAddressLine1 = "100 Main St",
+            RelationshipNotes = "sensitive notes"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await primary.Activate(id, null, CancellationToken.None);
+        await primary.AddAssociation(id, new AddAssociationRequest { MemberId = "M1" }, CancellationToken.None);
+
+        var result = await resolver.ListActive("M1", asOf: null, credentialTypes: null, CancellationToken.None);
+        var summary = ((MemberRepresentativesResponse)((OkObjectResult)result).Value!).Items.Single();
+
+        // The PersonalRepSummary shape intentionally has no phone / address
+        // / notes. A reflection check locks this down against future
+        // accidental field additions that would widen PHI disclosure.
+        var propNames = typeof(PersonalRepSummary).GetProperties().Select(p => p.Name).ToHashSet();
+        propNames.Should().NotContain("PhoneNumber");
+        propNames.Should().NotContain("MailingAddressLine1");
+        propNames.Should().NotContain("Email");
+        propNames.Should().NotContain("RelationshipNotes");
+    }
+
+    [Fact]
+    public async Task ListActive_AsOfFilter_RespectsPointInTime()
+    {
+        var (primary, resolver, _, _) = BuildControllers();
+
+        var create = await primary.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice", LastName = "Smith"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await primary.Activate(id, null, CancellationToken.None);
+
+        var inPast = DateTime.UtcNow.AddDays(-365);
+        var addReq = new AddAssociationRequest
+        {
+            MemberId = "M1",
+            EffectiveFrom = DateTime.UtcNow.AddDays(-30),
+            EffectiveTo = DateTime.UtcNow.AddDays(-1)
+        };
+        await primary.AddAssociation(id, addReq, CancellationToken.None);
+
+        // asOf BEFORE the association began → no matches.
+        var past = await resolver.ListActive("M1", asOf: inPast, credentialTypes: null, CancellationToken.None);
+        ((MemberRepresentativesResponse)((OkObjectResult)past).Value!).Items.Should().BeEmpty();
+
+        // asOf NOW → association is past its EffectiveTo → still empty.
+        var now = await resolver.ListActive("M1", asOf: null, credentialTypes: null, CancellationToken.None);
+        ((MemberRepresentativesResponse)((OkObjectResult)now).Value!).Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolver_CrossTenant_Returns404Equivalent_EmptyList()
+    {
+        // Cross-tenant reads must NOT leak another tenant's reps. Because
+        // the list endpoint returns 200 with an empty items list on any
+        // absent member (rather than 404), tenant isolation is asserted
+        // as "the items list is empty when querying under the wrong
+        // tenant context." 404 semantics on /{repId} are covered by
+        // PersonalRepresentativesControllerTests.
+        var (primaryA, _, repoA, _) = BuildControllers(tenantId: "tenant-a");
+        var create = await primaryA.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.Parent, FirstName = "Alice"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await primaryA.Activate(id, null, CancellationToken.None);
+        await primaryA.AddAssociation(id, new AddAssociationRequest { MemberId = "M1" }, CancellationToken.None);
+
+        var resolverB = new MemberRepresentativesController(repoA,
+            new ReversiblePersonalRepFieldEncryptor());
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = "tenant-b";
+        http.User = new ClaimsPrincipal(new ClaimsIdentity());
+        resolverB.ControllerContext = new ControllerContext { HttpContext = http };
+
+        var result = await resolverB.ListActive("M1", asOf: null, credentialTypes: null, CancellationToken.None);
+        ((MemberRepresentativesResponse)((OkObjectResult)result).Value!).Items.Should().BeEmpty();
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/PersonalRepresentativesControllerTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/PersonalRepresentativesControllerTests.cs
@@ -1,0 +1,372 @@
+using System.Security.Claims;
+using PersonalRepresentativeService.Controllers;
+using PersonalRepresentativeService.Middleware;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+using PersonalRepresentativeService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PersonalRepresentativeService.Tests.Controllers;
+
+public class PersonalRepresentativesControllerTests
+{
+    private static (PersonalRepresentativesController controller,
+                    InMemoryPersonalRepRepository repo,
+                    RecordingPersonalRepEventPublisher publisher,
+                    ReversiblePersonalRepFieldEncryptor encryptor)
+        BuildController(string tenantId = "tenant-a", string user = "alice@tenant.com")
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        var publisher = new RecordingPersonalRepEventPublisher();
+        var encryptor = new ReversiblePersonalRepFieldEncryptor();
+
+        var controller = new PersonalRepresentativesController(repo, repo, encryptor, publisher);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = tenantId;
+        http.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.Name, user) }, "test"));
+        controller.ControllerContext = new ControllerContext { HttpContext = http };
+        return (controller, repo, publisher, encryptor);
+    }
+
+    [Fact]
+    public async Task Create_Returns201_PersistsEncrypted_WritesAuditAndKafka()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+
+        var result = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice",
+            LastName = "Smith",
+            Email = "alice@example.com",
+            PhoneNumber = "555-0100",
+            RelationshipNotes = "guardian for minor children",
+            ProofOfAuthorityDocumentId = "doc-123"
+        }, CancellationToken.None);
+
+        var created = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        var view = created.Value.Should().BeOfType<PersonalRepresentative>().Subject;
+        view.Status.Should().Be(PersonalRepStatus.Draft);
+        view.FirstName.Should().Be("Alice");
+
+        var persisted = await repo.GetByIdAsync("tenant-a", view.Id);
+        persisted.Should().NotBeNull();
+        ReversiblePersonalRepFieldEncryptor.LooksEncrypted(persisted!.FirstName).Should().BeTrue();
+        ReversiblePersonalRepFieldEncryptor.LooksEncrypted(persisted.LastName).Should().BeTrue();
+        ReversiblePersonalRepFieldEncryptor.LooksEncrypted(persisted.Email).Should().BeTrue();
+        ReversiblePersonalRepFieldEncryptor.LooksEncrypted(persisted.PhoneNumber).Should().BeTrue();
+        ReversiblePersonalRepFieldEncryptor.LooksEncrypted(persisted.RelationshipNotes).Should().BeTrue();
+        persisted.ProofOfAuthorityDocumentId.Should().Be("doc-123");
+
+        repo.SnapshotEvents().Should().ContainSingle(e =>
+            e.EventType == PersonalRepEventType.PersonalRepCreated &&
+            e.FromStatus == null && e.ToStatus == PersonalRepStatus.Draft);
+
+        publisher.StatusCalls.Should().ContainSingle(c =>
+            c.FromStatus == null && c.ToStatus == PersonalRepStatus.Draft);
+    }
+
+    [Fact]
+    public async Task Get_CrossTenant_Returns404_TenantIsolation()
+    {
+        var (controllerA, repoA, _, _) = BuildController(tenantId: "tenant-a");
+        var create = await controllerA.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.Parent,
+            FirstName = "Alice"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+
+        var controllerB = new PersonalRepresentativesController(repoA, repoA,
+            new ReversiblePersonalRepFieldEncryptor(),
+            new RecordingPersonalRepEventPublisher());
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = "tenant-b";
+        http.User = new ClaimsPrincipal(new ClaimsIdentity());
+        controllerB.ControllerContext = new ControllerContext { HttpContext = http };
+
+        var result = await controllerB.GetRepresentative(id, CancellationToken.None);
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Activate_FromDraft_PersistsActive_AuditAndKafka()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        publisher.StatusCalls.Clear();
+
+        var result = await controller.Activate(id, request: null, CancellationToken.None);
+        var view = ((OkObjectResult)result).Value.Should().BeOfType<PersonalRepresentative>().Subject;
+        view.Status.Should().Be(PersonalRepStatus.Active);
+        view.ActivatedBy.Should().NotBeNullOrEmpty();
+
+        repo.SnapshotEvents().Should().Contain(e => e.EventType == PersonalRepEventType.PersonalRepActivated);
+        publisher.StatusCalls.Should().ContainSingle(c =>
+            c.FromStatus == PersonalRepStatus.Draft && c.ToStatus == PersonalRepStatus.Active);
+    }
+
+    [Fact]
+    public async Task Revoke_FromActive_PersistsInactive_ThenIdempotent()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.HealthcarePowerOfAttorney
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+
+        await controller.Activate(id, null, CancellationToken.None);
+        publisher.StatusCalls.Clear();
+
+        var revoke1 = await controller.Revoke(id,
+            new RevokePersonalRepRequest { ReasonCode = PersonalRepInactivationReasonCode.PoaRevoked },
+            CancellationToken.None);
+        ((OkObjectResult)revoke1).Value.Should().BeOfType<PersonalRepresentative>()
+            .Which.Status.Should().Be(PersonalRepStatus.Inactive);
+
+        var revokeEvents1 = repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepInactivated);
+        var kafkaCount1 = publisher.StatusCalls.Count;
+
+        var revoke2 = await controller.Revoke(id, null, CancellationToken.None);
+        ((OkObjectResult)revoke2).Value.Should().BeOfType<PersonalRepresentative>()
+            .Which.Status.Should().Be(PersonalRepStatus.Inactive);
+
+        repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepInactivated).Should().Be(revokeEvents1);
+        publisher.StatusCalls.Count.Should().Be(kafkaCount1);
+    }
+
+    [Fact]
+    public async Task Revoke_FromDraft_Works()
+    {
+        var (controller, _, _, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.Parent
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+
+        var revoke = await controller.Revoke(id, null, CancellationToken.None);
+        ((OkObjectResult)revoke).Value.Should().BeOfType<PersonalRepresentative>()
+            .Which.Status.Should().Be(PersonalRepStatus.Inactive);
+    }
+
+    [Fact]
+    public async Task GetHistory_ReturnsAuditTrailChronologicalAndTenantScoped()
+    {
+        var (controller, _, _, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await controller.Activate(id, null, CancellationToken.None);
+        await controller.Revoke(id, null, CancellationToken.None);
+
+        var result = await controller.GetHistory(id, CancellationToken.None);
+        var items = ((PersonalRepHistoryResponse)((OkObjectResult)result).Value!).Items;
+
+        items.Should().HaveCount(3);
+        items.Select(e => e.EventType).Should().ContainInOrder(
+            PersonalRepEventType.PersonalRepCreated,
+            PersonalRepEventType.PersonalRepActivated,
+            PersonalRepEventType.PersonalRepInactivated);
+        items.Should().OnlyContain(e => e.TenantId == "tenant-a");
+    }
+
+    [Fact]
+    public async Task AddAssociation_PersistsPairAndAudit()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            FirstName = "Alice"
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+
+        var addResult = await controller.AddAssociation(id,
+            new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+        addResult.Should().BeOfType<CreatedAtActionResult>();
+
+        var rows = repo.SnapshotAssociations();
+        rows.Should().HaveCount(2);
+        rows.Should().OnlyContain(a => a.RepId == id && a.MemberId == "M123");
+        rows.Select(a => a.Direction).Should().BeEquivalentTo(new[]
+        {
+            AssociationDirection.RepToMember, AssociationDirection.MemberToRep
+        });
+        rows.Select(a => a.PairId).Distinct().Should().HaveCount(1,
+            "both rows of a pair share a single PairId");
+
+        repo.SnapshotEvents().Should().Contain(e =>
+            e.EventType == PersonalRepEventType.PersonalRepAssociationAdded && e.MemberId == "M123");
+        publisher.AssociationCalls.Should().ContainSingle(c =>
+            c.EventType == PersonalRepEventType.PersonalRepAssociationAdded && c.MemberId == "M123");
+    }
+
+    [Fact]
+    public async Task AddAssociation_Duplicate_Returns409()
+    {
+        var (controller, _, _, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+
+        await controller.AddAssociation(id,
+            new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+        var second = await controller.AddAssociation(id,
+            new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+
+        second.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task RemoveAssociation_SoftDeletesPairAndWritesAudit()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await controller.AddAssociation(id,
+            new AddAssociationRequest { MemberId = "M123" }, CancellationToken.None);
+
+        var result = await controller.RemoveAssociation(id, "M123", null, CancellationToken.None);
+        result.Should().BeOfType<NoContentResult>();
+
+        var active = await repo.FindActiveAssociationAsync("tenant-a", id, "M123");
+        active.Should().BeNull();
+
+        repo.SnapshotEvents().Should().Contain(e =>
+            e.EventType == PersonalRepEventType.PersonalRepAssociationRemoved && e.MemberId == "M123");
+        publisher.AssociationCalls.Should().Contain(c =>
+            c.EventType == PersonalRepEventType.PersonalRepAssociationRemoved && c.MemberId == "M123");
+    }
+
+    /// <summary>
+    /// With the 3-state collapse (Inactive is the single terminal), a
+    /// Revoke call on an already-expired rep is idempotent: 200 OK, no new
+    /// audit event, no new Kafka publish, and the InactivationReasonCode
+    /// stays as Expired — the caller's PoaRevoked intent does NOT overwrite
+    /// the reason that actually drove the termination. This diverges from
+    /// consent-service, which 409s because Expired and Revoked are distinct
+    /// terminal statuses there.
+    /// </summary>
+    [Fact]
+    public async Task Revoke_AfterExpired_IsIdempotentAndPreservesInactivationReason()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            ExpiresAt = DateTime.UtcNow.AddHours(-1)
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await controller.Activate(id, null, CancellationToken.None);
+
+        // Trigger the read-time expiry projection — flips persisted
+        // Status to Inactive with reason Expired.
+        _ = await controller.GetRepresentative(id, CancellationToken.None);
+
+        var expiredEvents = repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepExpired);
+        var statusCallsBefore = publisher.StatusCalls.Count;
+
+        var result = await controller.Revoke(id,
+            new RevokePersonalRepRequest { ReasonCode = PersonalRepInactivationReasonCode.PoaRevoked },
+            CancellationToken.None);
+
+        var view = ((OkObjectResult)result).Value.Should().BeOfType<PersonalRepresentative>().Subject;
+        view.Status.Should().Be(PersonalRepStatus.Inactive);
+        view.InactivationReasonCode.Should().Be(PersonalRepInactivationReasonCode.Expired,
+            "idempotent Revoke on an already-expired rep must NOT overwrite the reason code");
+
+        // No new Inactivated audit event — only the original Expired one.
+        repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepInactivated).Should().Be(0);
+        repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepExpired).Should().Be(expiredEvents);
+        publisher.StatusCalls.Count.Should().Be(statusCallsBefore);
+    }
+
+    [Fact]
+    public async Task ReadTimeExpiry_PersistsTransition_ExactlyOneExpiredEvent()
+    {
+        var (controller, repo, publisher, _) = BuildController();
+        var create = await controller.CreateRepresentative(new CreatePersonalRepRequest
+        {
+            CredentialType = PersonalRepCredentialType.HealthcarePowerOfAttorney,
+            ExpiresAt = DateTime.UtcNow.AddHours(-1)
+        }, CancellationToken.None);
+        var id = ((PersonalRepresentative)((CreatedAtActionResult)create).Value!).Id;
+        await controller.Activate(id, null, CancellationToken.None);
+        publisher.StatusCalls.Clear();
+
+        await Task.WhenAll(Enumerable.Range(0, 3).Select(_ =>
+            controller.GetRepresentative(id, CancellationToken.None)));
+
+        repo.SnapshotEvents().Count(e => e.EventType == PersonalRepEventType.PersonalRepExpired)
+            .Should().Be(1);
+        publisher.StatusCalls.Count(c => c.ToStatus == PersonalRepStatus.Inactive).Should().Be(1);
+    }
+
+    [Fact]
+    public void TenantMiddleware_GetTenantId_Throws_WhenMissing()
+    {
+        var http = new DefaultHttpContext();
+        Action act = () => http.GetTenantId();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Repository-level concurrent-writer races surface as
+    /// <see cref="InvalidPersonalRepTransitionException"/>. The controller
+    /// must translate them into 409 ProblemDetails rather than letting them
+    /// escape as 500.
+    /// </summary>
+    [Fact]
+    public async Task Activate_WhenRepoSignalsRace_Returns409()
+    {
+        var repo = new Mock<IPersonalRepRepository>();
+        var events = new Mock<IPersonalRepEventRepository>();
+        var publisher = new RecordingPersonalRepEventPublisher();
+        var encryptor = new ReversiblePersonalRepFieldEncryptor();
+
+        var rep = new PersonalRepresentative
+        {
+            TenantId = "tenant-a",
+            Id = "r-1",
+            Status = PersonalRepStatus.Draft,
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            CreatedAt = DateTime.UtcNow
+        };
+        repo.Setup(r => r.GetByIdAsync("tenant-a", "r-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rep);
+        repo.Setup(r => r.TransitionStatusAsync(It.IsAny<PersonalRepresentative>(), It.IsAny<PersonalRepEvent>()))
+            .ThrowsAsync(new InvalidPersonalRepTransitionException(
+                PersonalRepStatus.Active, PersonalRepStatus.Active));
+
+        var controller = new PersonalRepresentativesController(repo.Object, events.Object, encryptor, publisher);
+        var http = new DefaultHttpContext();
+        http.Items["TenantId"] = "tenant-a";
+        http.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.Name, "alice") }, "test"));
+        controller.ControllerContext = new ControllerContext { HttpContext = http };
+
+        var result = await controller.Activate("r-1", request: null, CancellationToken.None);
+
+        var conflict = result.Should().BeOfType<ConflictObjectResult>().Subject;
+        conflict.Value.Should().BeOfType<ProblemDetails>()
+            .Which.Extensions["fromStatus"].Should().Be(PersonalRepStatus.Active.ToString());
+        publisher.StatusCalls.Should().NotContain(c => c.ToStatus == PersonalRepStatus.Active,
+            "publisher must not emit a status-changed event when the persisted transition never happened");
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/PersonalRepresentativesControllerTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/PersonalRepresentativesControllerTests.cs
@@ -350,7 +350,7 @@ public class PersonalRepresentativesControllerTests
         };
         repo.Setup(r => r.GetByIdAsync("tenant-a", "r-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(rep);
-        repo.Setup(r => r.TransitionStatusAsync(It.IsAny<PersonalRepresentative>(), It.IsAny<PersonalRepEvent>()))
+        repo.Setup(r => r.TransitionStatusAsync(It.IsAny<PersonalRepresentative>(), It.IsAny<PersonalRepEvent>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidPersonalRepTransitionException(
                 PersonalRepStatus.Active, PersonalRepStatus.Active));
 

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/DictionarySecretProvider.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/DictionarySecretProvider.cs
@@ -1,0 +1,34 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+
+namespace PersonalRepresentativeService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ISecretProvider"/> backed by a mutable dictionary.
+/// Tests add / remove entries to simulate key publication and rotation.
+/// </summary>
+public sealed class DictionarySecretProvider : ISecretProvider
+{
+    public Dictionary<string, string> Secrets { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<string?> GetSecretAsync(string secretName, CancellationToken ct = default)
+    {
+        Secrets.TryGetValue(secretName, out var v);
+        return Task.FromResult<string?>(v);
+    }
+
+    public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
+    {
+        IDictionary<string, string> filtered = Secrets
+            .Where(kv => kv.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        return Task.FromResult(filtered);
+    }
+
+    public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+
+    public Task<string?> GetSecretByVersionAsync(string secretName, string version, CancellationToken ct = default)
+        => GetSecretAsync(secretName, ct);
+
+    public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string secretName, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/InMemoryPersonalRepRepository.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/InMemoryPersonalRepRepository.cs
@@ -1,0 +1,359 @@
+using System.Collections.Concurrent;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+
+namespace PersonalRepresentativeService.Tests.Fakes;
+
+/// <summary>
+/// In-memory triple: <see cref="IPersonalRepRepository"/> +
+/// <see cref="IPersonalRepEventRepository"/> +
+/// <see cref="IPersonalRepEventSink"/>. Concurrent-safe for the
+/// exactly-once expiry race test. Failure-injection hooks on the pair-write
+/// paths drive the atomicity tests.
+/// </summary>
+public sealed class InMemoryPersonalRepRepository
+    : IPersonalRepRepository, IPersonalRepEventRepository, IPersonalRepEventSink
+{
+    private readonly ConcurrentDictionary<string, PersonalRepresentative> _reps = new();
+    private readonly ConcurrentDictionary<string, PersonalRepAssociation> _associations = new();
+    private readonly ConcurrentBag<PersonalRepEvent> _events = new();
+    private readonly object _sync = new();
+
+    /// <summary>Raised before forward insert; throw to simulate failure mode 2.</summary>
+    public Func<PersonalRepAssociation, Task>? OnBeforeForwardInsert { get; set; }
+
+    /// <summary>Raised before inverse insert; throw to simulate failure mode 3.</summary>
+    public Func<PersonalRepAssociation, Task>? OnBeforeInverseInsert { get; set; }
+
+    /// <summary>Raised before audit append inside pair write; throw to simulate failure mode 4.</summary>
+    public Func<PersonalRepEvent, Task>? OnBeforePairAuditAppend { get; set; }
+
+    /// <summary>Raised when pair write audit append fails. Test hook for log assertions.</summary>
+    public int AuditAppendFailureCount;
+
+    private static string RepKey(string tenantId, string repId) => $"{tenantId}:{repId}";
+
+    public Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+    {
+        if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
+        if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
+
+        var clone = CloneRep(rep);
+        _reps[RepKey(rep.TenantId, rep.Id)] = clone;
+        AppendEventInternal(genesisEvent);
+        return Task.FromResult(CloneRep(clone));
+    }
+
+    public Task<PersonalRepresentative?> GetByIdAsync(
+        string tenantId, string repId, CancellationToken ct = default)
+    {
+        _reps.TryGetValue(RepKey(tenantId, repId), out var r);
+        if (r is null || r.IsDeleted) return Task.FromResult<PersonalRepresentative?>(null);
+        return Task.FromResult<PersonalRepresentative?>(CloneRep(r));
+    }
+
+    public Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
+        string tenantId, bool activeOnly = false, DateTime? asOf = null, CancellationToken ct = default)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        var rows = _reps.Values
+            .Where(r => r.TenantId == tenantId && !r.IsDeleted)
+            .Select(CloneRep)
+            .ToList();
+        if (activeOnly) rows = rows.Where(r => r.ObservedStatus(t) == PersonalRepStatus.Active).ToList();
+        return Task.FromResult<IReadOnlyList<PersonalRepresentative>>(
+            rows.OrderByDescending(r => r.CreatedAt).ToList());
+    }
+
+    public Task<PersonalRepresentative> TransitionStatusAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        if (!auditEvent.FromStatus.HasValue)
+        {
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
+        }
+        var expectedFromStatus = auditEvent.FromStatus.Value;
+
+        lock (_sync)
+        {
+            var key = RepKey(rep.TenantId, rep.Id);
+            if (!_reps.TryGetValue(key, out var current) || current.Status != expectedFromStatus)
+            {
+                var actual = current?.Status ?? rep.Status;
+                throw new InvalidPersonalRepTransitionException(actual, rep.Status);
+            }
+
+            _reps[key] = CloneRep(rep);
+            AppendEventInternal(auditEvent);
+        }
+        return Task.FromResult(CloneRep(rep));
+    }
+
+    public Task<bool> TryTransitionToInactiveAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        lock (_sync)
+        {
+            var key = RepKey(rep.TenantId, rep.Id);
+            if (!_reps.TryGetValue(key, out var current) || current.Status != PersonalRepStatus.Active)
+            {
+                return Task.FromResult(false);
+            }
+
+            current.Status = PersonalRepStatus.Inactive;
+            current.InactivationReasonCode = PersonalRepInactivationReasonCode.Expired;
+            current.InactivatedAt = DateTime.UtcNow;
+            _reps[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult(true);
+        }
+    }
+
+    public async Task AddAssociationPairAsync(
+        PersonalRepAssociation forward,
+        PersonalRepAssociation inverse,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        if (!string.Equals(forward.TenantId, inverse.TenantId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "PersonalRepAssociation pair rows must share the same TenantId.");
+        }
+
+        if (OnBeforeForwardInsert is not null) await OnBeforeForwardInsert(forward);
+
+        // Two-phase stage: write forward, then inverse. If inverse-insert
+        // hook throws, roll back forward to preserve the "neither row
+        // exists" invariant.
+        lock (_sync)
+        {
+            _associations[forward.Id] = CloneAssociation(forward);
+        }
+
+        try
+        {
+            if (OnBeforeInverseInsert is not null) await OnBeforeInverseInsert(inverse);
+        }
+        catch
+        {
+            lock (_sync)
+            {
+                _associations.TryRemove(forward.Id, out _);
+            }
+            throw;
+        }
+
+        lock (_sync)
+        {
+            _associations[inverse.Id] = CloneAssociation(inverse);
+        }
+
+        try
+        {
+            if (OnBeforePairAuditAppend is not null) await OnBeforePairAuditAppend(auditEvent);
+            AppendEventInternal(auditEvent);
+        }
+        catch
+        {
+            Interlocked.Increment(ref AuditAppendFailureCount);
+            throw;
+        }
+    }
+
+    public async Task RemoveAssociationPairAsync(
+        string tenantId,
+        string pairId,
+        string removedBy,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        var rows = _associations.Values
+            .Where(a => a.TenantId == tenantId && a.PairId == pairId)
+            .Select(CloneAssociation)
+            .ToList();
+        if (rows.Count == 0) return;
+
+        var now = DateTime.UtcNow;
+        lock (_sync)
+        {
+            foreach (var r in rows)
+            {
+                r.EffectiveTo ??= now;
+                r.UpdatedAt = now;
+                r.UpdatedBy = removedBy;
+                _associations[r.Id] = r;
+            }
+        }
+
+        try
+        {
+            if (OnBeforePairAuditAppend is not null) await OnBeforePairAuditAppend(auditEvent);
+            AppendEventInternal(auditEvent);
+        }
+        catch
+        {
+            Interlocked.Increment(ref AuditAppendFailureCount);
+            throw;
+        }
+    }
+
+    public Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForMemberAsync(
+        string tenantId, string memberId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        var rows = _associations.Values
+            .Where(a => a.TenantId == tenantId
+                     && a.MemberId == memberId
+                     && a.Direction == AssociationDirection.MemberToRep
+                     && !a.IsDeleted)
+            .Select(CloneAssociation)
+            .ToList();
+        if (activeOnly) rows = rows.Where(a =>
+            a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+        return Task.FromResult<IReadOnlyList<PersonalRepAssociation>>(rows);
+    }
+
+    public Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForRepAsync(
+        string tenantId, string repId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var t = asOf ?? DateTime.UtcNow;
+        var rows = _associations.Values
+            .Where(a => a.TenantId == tenantId
+                     && a.RepId == repId
+                     && a.Direction == AssociationDirection.RepToMember
+                     && !a.IsDeleted)
+            .Select(CloneAssociation)
+            .ToList();
+        if (activeOnly) rows = rows.Where(a =>
+            a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+        return Task.FromResult<IReadOnlyList<PersonalRepAssociation>>(rows);
+    }
+
+    public Task<PersonalRepAssociation?> FindActiveAssociationAsync(
+        string tenantId, string repId, string memberId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var row = _associations.Values.FirstOrDefault(a =>
+            a.TenantId == tenantId
+            && a.RepId == repId
+            && a.MemberId == memberId
+            && a.Direction == AssociationDirection.RepToMember
+            && !a.IsDeleted
+            && (a.EffectiveTo == null || a.EffectiveTo > now));
+        return Task.FromResult<PersonalRepAssociation?>(row is null ? null : CloneAssociation(row));
+    }
+
+    public Task AppendAsync(PersonalRepEvent evt)
+    {
+        AppendEventInternal(evt);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<PersonalRepEvent>> ListByRepAsync(
+        string tenantId, string personalRepId, CancellationToken ct = default)
+    {
+        var rows = _events
+            .Where(e => e.TenantId == tenantId && e.PersonalRepId == personalRepId)
+            .OrderBy(e => e.OccurredAt)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<PersonalRepEvent>>(rows);
+    }
+
+    public IReadOnlyList<PersonalRepEvent> SnapshotEvents() =>
+        _events.OrderBy(e => e.OccurredAt).ToList();
+
+    public IReadOnlyList<PersonalRepAssociation> SnapshotAssociations() =>
+        _associations.Values.Select(CloneAssociation).ToList();
+
+    private void AppendEventInternal(PersonalRepEvent evt)
+    {
+        lock (_sync)
+        {
+            if (_events.Any(e =>
+                    e.TenantId == evt.TenantId &&
+                    e.PersonalRepId == evt.PersonalRepId &&
+                    e.EventId == evt.EventId))
+            {
+                return;
+            }
+            _events.Add(CloneEvent(evt));
+        }
+    }
+
+    private static PersonalRepresentative CloneRep(PersonalRepresentative r) => new()
+    {
+        TenantId = r.TenantId,
+        Id = r.Id,
+        Status = r.Status,
+        CredentialType = r.CredentialType,
+        EffectiveFrom = r.EffectiveFrom,
+        EffectiveTo = r.EffectiveTo,
+        ExpiresAt = r.ExpiresAt,
+        ProofOfAuthorityDocumentId = r.ProofOfAuthorityDocumentId,
+        FirstName = r.FirstName,
+        MiddleName = r.MiddleName,
+        LastName = r.LastName,
+        Email = r.Email,
+        PhoneNumber = r.PhoneNumber,
+        MailingAddressLine1 = r.MailingAddressLine1,
+        MailingAddressLine2 = r.MailingAddressLine2,
+        MailingAddressCity = r.MailingAddressCity,
+        MailingAddressStateCode = r.MailingAddressStateCode,
+        MailingAddressPostalCode = r.MailingAddressPostalCode,
+        RelationshipNotes = r.RelationshipNotes,
+        CreatedAt = r.CreatedAt,
+        CreatedBy = r.CreatedBy,
+        UpdatedAt = r.UpdatedAt,
+        UpdatedBy = r.UpdatedBy,
+        ActivatedAt = r.ActivatedAt,
+        ActivatedBy = r.ActivatedBy,
+        InactivatedAt = r.InactivatedAt,
+        InactivatedBy = r.InactivatedBy,
+        InactivationReasonCode = r.InactivationReasonCode,
+        DeletedAt = r.DeletedAt,
+        DeletedBy = r.DeletedBy,
+        DeletedReason = r.DeletedReason
+    };
+
+    private static PersonalRepAssociation CloneAssociation(PersonalRepAssociation a) => new()
+    {
+        Id = a.Id,
+        TenantId = a.TenantId,
+        PairId = a.PairId,
+        RepId = a.RepId,
+        MemberId = a.MemberId,
+        Direction = a.Direction,
+        CredentialType = a.CredentialType,
+        EffectiveFrom = a.EffectiveFrom,
+        EffectiveTo = a.EffectiveTo,
+        CreatedAt = a.CreatedAt,
+        CreatedBy = a.CreatedBy,
+        UpdatedAt = a.UpdatedAt,
+        UpdatedBy = a.UpdatedBy,
+        DeletedAt = a.DeletedAt,
+        DeletedBy = a.DeletedBy,
+        DeletedReason = a.DeletedReason
+    };
+
+    private static PersonalRepEvent CloneEvent(PersonalRepEvent e) => new()
+    {
+        Id = e.Id,
+        PartitionKey = e.PartitionKey,
+        TenantId = e.TenantId,
+        PersonalRepId = e.PersonalRepId,
+        MemberId = e.MemberId,
+        EventId = e.EventId,
+        EventType = e.EventType,
+        FromStatus = e.FromStatus,
+        ToStatus = e.ToStatus,
+        ActorId = e.ActorId,
+        CorrelationId = e.CorrelationId,
+        OccurredAt = e.OccurredAt,
+        Payload = e.Payload
+    };
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/InMemoryPersonalRepRepository.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/InMemoryPersonalRepRepository.cs
@@ -33,7 +33,7 @@ public sealed class InMemoryPersonalRepRepository
 
     private static string RepKey(string tenantId, string repId) => $"{tenantId}:{repId}";
 
-    public Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+    public Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
         if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
@@ -65,8 +65,19 @@ public sealed class InMemoryPersonalRepRepository
             rows.OrderByDescending(r => r.CreatedAt).ToList());
     }
 
+    public Task<IReadOnlyList<PersonalRepresentative>> GetByIdsAsync(
+        string tenantId, IReadOnlyList<string> repIds, CancellationToken ct = default)
+    {
+        var set = new HashSet<string>(repIds);
+        var rows = _reps.Values
+            .Where(r => r.TenantId == tenantId && !r.IsDeleted && set.Contains(r.Id))
+            .Select(CloneRep)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<PersonalRepresentative>>(rows);
+    }
+
     public Task<PersonalRepresentative> TransitionStatusAsync(
-        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+        PersonalRepresentative rep, PersonalRepEvent auditEvent, CancellationToken ct = default)
     {
         if (!auditEvent.FromStatus.HasValue)
         {
@@ -91,7 +102,7 @@ public sealed class InMemoryPersonalRepRepository
         return Task.FromResult(CloneRep(rep));
     }
 
-    public Task<bool> TryTransitionToInactiveAsync(
+    public Task<PersonalRepresentative?> TryTransitionToInactiveAsync(
         PersonalRepresentative rep, PersonalRepEvent auditEvent)
     {
         lock (_sync)
@@ -99,7 +110,7 @@ public sealed class InMemoryPersonalRepRepository
             var key = RepKey(rep.TenantId, rep.Id);
             if (!_reps.TryGetValue(key, out var current) || current.Status != PersonalRepStatus.Active)
             {
-                return Task.FromResult(false);
+                return Task.FromResult<PersonalRepresentative?>(null);
             }
 
             current.Status = PersonalRepStatus.Inactive;
@@ -107,7 +118,7 @@ public sealed class InMemoryPersonalRepRepository
             current.InactivatedAt = DateTime.UtcNow;
             _reps[key] = current;
             AppendEventInternal(auditEvent);
-            return Task.FromResult(true);
+            return Task.FromResult<PersonalRepresentative?>(CloneRep(current));
         }
     }
 

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/RecordingPersonalRepEventPublisher.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/RecordingPersonalRepEventPublisher.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Services;
+
+namespace PersonalRepresentativeService.Tests.Fakes;
+
+/// <summary>
+/// Captures every publish call so controller tests can assert
+/// "N events published, exactly these fields, in this order".
+/// </summary>
+public sealed class RecordingPersonalRepEventPublisher : IPersonalRepEventPublisher
+{
+    public readonly ConcurrentQueue<StatusCall> StatusCalls = new();
+    public readonly ConcurrentQueue<AssociationCall> AssociationCalls = new();
+
+    public Task PublishStatusChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepStatus? fromStatus,
+        PersonalRepStatus toStatus,
+        IReadOnlyList<string> associatedMemberIds,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        StatusCalls.Enqueue(new StatusCall(
+            PersonalRepId: rep.Id,
+            TenantId: rep.TenantId,
+            FromStatus: fromStatus,
+            ToStatus: toStatus,
+            AssociatedMemberIds: associatedMemberIds.ToList(),
+            Actor: actor,
+            CorrelationId: correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAssociationChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepAssociation association,
+        PersonalRepEventType eventType,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        AssociationCalls.Enqueue(new AssociationCall(
+            PersonalRepId: rep.Id,
+            TenantId: rep.TenantId,
+            MemberId: association.MemberId,
+            PairId: association.PairId,
+            EventType: eventType,
+            Actor: actor,
+            CorrelationId: correlationId));
+        return Task.CompletedTask;
+    }
+
+    public sealed record StatusCall(
+        string PersonalRepId,
+        string TenantId,
+        PersonalRepStatus? FromStatus,
+        PersonalRepStatus ToStatus,
+        List<string> AssociatedMemberIds,
+        string Actor,
+        string? CorrelationId);
+
+    public sealed record AssociationCall(
+        string PersonalRepId,
+        string TenantId,
+        string MemberId,
+        string PairId,
+        PersonalRepEventType EventType,
+        string Actor,
+        string? CorrelationId);
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/ReversiblePersonalRepFieldEncryptor.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Fakes/ReversiblePersonalRepFieldEncryptor.cs
@@ -1,0 +1,37 @@
+using PersonalRepresentativeService.Services;
+
+namespace PersonalRepresentativeService.Tests.Fakes;
+
+/// <summary>
+/// Deterministic reversible "encryptor" for controller tests. Prepends a
+/// marker so tests can distinguish "raw plaintext" from
+/// "plaintext-that-was-re-emitted-after-decryption" on the read path.
+/// Tracks calls so tests can assert that decryption occurred on specific
+/// fields (e.g. resolver displayName goes through the standard path).
+/// </summary>
+public sealed class ReversiblePersonalRepFieldEncryptor : IPersonalRepFieldEncryptor
+{
+    private const string Marker = "enc::";
+
+    public int EncryptCalls { get; private set; }
+    public int DecryptCalls { get; private set; }
+
+    public Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+    {
+        EncryptCalls++;
+        if (string.IsNullOrEmpty(plaintext)) return Task.FromResult<string?>(plaintext);
+        return Task.FromResult<string?>(Marker + plaintext);
+    }
+
+    public Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+    {
+        DecryptCalls++;
+        if (string.IsNullOrEmpty(ciphertext)) return Task.FromResult<string?>(ciphertext);
+        if (!ciphertext.StartsWith(Marker, StringComparison.Ordinal))
+            return Task.FromResult<string?>(ciphertext);
+        return Task.FromResult<string?>(ciphertext[Marker.Length..]);
+    }
+
+    public static bool LooksEncrypted(string? s) =>
+        !string.IsNullOrEmpty(s) && s.StartsWith(Marker, StringComparison.Ordinal);
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Integration/PersonalRepLifecycleSmokeTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Integration/PersonalRepLifecycleSmokeTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PersonalRepresentativeService.Controllers;
+using PersonalRepresentativeService.HostedServices;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Repositories;
+using PersonalRepresentativeService.Services;
+using PersonalRepresentativeService.Tests.Fakes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace PersonalRepresentativeService.Tests.Integration;
+
+/// <summary>
+/// End-to-end smoke test over the real Program pipeline using in-memory
+/// fakes so the test does not require Cosmos, Mongo, Key Vault, or Kafka.
+/// Mirrors <c>ConsentService.Tests.Integration.ConsentLifecycleSmokeTests</c>.
+///
+/// The golden-path lifecycle exercised here:
+///   Create → AddAssoc(M1) → AddAssoc(M2) → Activate → RemoveAssoc(M1) → Revoke
+/// Six audit events in order.
+/// </summary>
+public class PersonalRepLifecycleSmokeTests : IClassFixture<PersonalRepLifecycleSmokeTests.Factory>
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public sealed class Factory : WebApplicationFactory<Program>
+    {
+        public InMemoryPersonalRepRepository Repo { get; } = new();
+        public RecordingPersonalRepEventPublisher Publisher { get; } = new();
+        public ReversiblePersonalRepFieldEncryptor Encryptor { get; } = new();
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((ctx, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    // Leave MongoDb/CosmosDb connection unset; swap repository
+                    // implementations below so the Cosmos branch in Program.cs
+                    // never resolves a CosmosClient. Kafka bootstrap empty so
+                    // the PersonalRepEventPublisher hosted service goes into
+                    // degraded mode.
+                    ["PersonalRepEncryption:KeySecretPrefix"] = "personal-rep-body-encryption-key",
+                    ["PersonalRepEncryption:CurrentKeyVersion"] = "v1",
+                    ["PersonalRepEncryption:AcceptedKeyVersions:0"] = "v1"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                RemoveAll<IPersonalRepRepository>(services);
+                RemoveAll<IPersonalRepEventRepository>(services);
+                RemoveAll<IPersonalRepEventSink>(services);
+                RemoveAll<IPersonalRepFieldEncryptor>(services);
+                RemoveAll<IPersonalRepEventPublisher>(services);
+                RemoveAll<PersonalRepIndexInitializer>(services);
+
+                services.AddSingleton<IPersonalRepRepository>(Repo);
+                services.AddSingleton<IPersonalRepEventRepository>(Repo);
+                services.AddSingleton<IPersonalRepEventSink>(Repo);
+                services.AddSingleton<IPersonalRepFieldEncryptor>(Encryptor);
+                services.AddSingleton<IPersonalRepEventPublisher>(Publisher);
+            });
+
+            return base.CreateHost(builder);
+        }
+
+        private static void RemoveAll<T>(IServiceCollection services)
+        {
+            var toRemove = services.Where(d =>
+                d.ServiceType == typeof(T) || d.ImplementationType == typeof(T)).ToList();
+            foreach (var d in toRemove) services.Remove(d);
+        }
+    }
+
+    private readonly Factory _factory;
+
+    public PersonalRepLifecycleSmokeTests(Factory factory) { _factory = factory; }
+
+    private HttpClient NewClient()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", "tenant-int");
+        return client;
+    }
+
+    [Fact]
+    public async Task FullLifecycle_SixEventsInOrder()
+    {
+        _factory.Publisher.StatusCalls.Clear();
+        _factory.Publisher.AssociationCalls.Clear();
+        var client = NewClient();
+
+        var create = await client.PostAsJsonAsync("/api/v1/personal-representatives",
+            new CreatePersonalRepRequest
+            {
+                CredentialType = PersonalRepCredentialType.LegalGuardian,
+                FirstName = "Alice",
+                LastName = "Smith"
+            }, Json);
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        var rep = await create.Content.ReadFromJsonAsync<PersonalRepresentative>(Json);
+        rep.Should().NotBeNull();
+
+        var addM1 = await client.PostAsJsonAsync(
+            $"/api/v1/personal-representatives/{rep!.Id}/associations",
+            new AddAssociationRequest { MemberId = "M1" }, Json);
+        addM1.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var addM2 = await client.PostAsJsonAsync(
+            $"/api/v1/personal-representatives/{rep.Id}/associations",
+            new AddAssociationRequest { MemberId = "M2" }, Json);
+        addM2.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var activate = await client.PostAsync(
+            $"/api/v1/personal-representatives/{rep.Id}/activate", content: null);
+        activate.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var removeM1 = await client.DeleteAsync(
+            $"/api/v1/personal-representatives/{rep.Id}/associations/M1");
+        removeM1.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var revoke = await client.PostAsJsonAsync(
+            $"/api/v1/personal-representatives/{rep.Id}/revoke",
+            new RevokePersonalRepRequest { ReasonCode = PersonalRepInactivationReasonCode.PoaRevoked },
+            Json);
+        revoke.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var history = await client.GetFromJsonAsync<PersonalRepHistoryResponse>(
+            $"/api/v1/personal-representatives/{rep.Id}/history", Json);
+        history!.Items.Select(e => e.EventType).Should().ContainInOrder(
+            PersonalRepEventType.PersonalRepCreated,
+            PersonalRepEventType.PersonalRepAssociationAdded,
+            PersonalRepEventType.PersonalRepAssociationAdded,
+            PersonalRepEventType.PersonalRepActivated,
+            PersonalRepEventType.PersonalRepAssociationRemoved,
+            PersonalRepEventType.PersonalRepInactivated);
+        history.Items.Should().HaveCount(6);
+    }
+
+    [Fact]
+    public async Task HealthReady_Returns200_WhenNoOpEncryptorInDev()
+    {
+        // In Development with no PersonalRepEncryption section on startup
+        // we'd fall back to NoOp — but this factory explicitly sets the
+        // section, so the real PersonalRepFieldEncryptor is registered.
+        // The health check needs a resolvable key, which is NOT present in
+        // this in-memory config. We assert the /health/live endpoint
+        // instead, which does not run the encryption-key check.
+        var client = _factory.CreateClient();
+        var r = await client.GetAsync("/health/live");
+        r.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MissingTenantHeader_Returns401()
+    {
+        var client = _factory.CreateClient();
+        var r = await client.GetAsync("/api/v1/personal-representatives/any-id");
+        r.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task MemberResolverEndpoint_ReturnsActiveRepsForMember()
+    {
+        _factory.Publisher.StatusCalls.Clear();
+        _factory.Publisher.AssociationCalls.Clear();
+        var client = NewClient();
+
+        var create = await client.PostAsJsonAsync("/api/v1/personal-representatives",
+            new CreatePersonalRepRequest
+            {
+                CredentialType = PersonalRepCredentialType.HealthcarePowerOfAttorney,
+                FirstName = "Bob",
+                LastName = "POA"
+            }, Json);
+        var rep = await create.Content.ReadFromJsonAsync<PersonalRepresentative>(Json);
+
+        await client.PostAsJsonAsync(
+            $"/api/v1/personal-representatives/{rep!.Id}/associations",
+            new AddAssociationRequest { MemberId = "M42" }, Json);
+        await client.PostAsync(
+            $"/api/v1/personal-representatives/{rep.Id}/activate", content: null);
+
+        var resp = await client.GetFromJsonAsync<MemberRepresentativesResponse>(
+            "/api/v1/members/M42/personal-representatives/active", Json);
+        resp!.Items.Should().ContainSingle(s =>
+            s.PersonalRepId == rep.Id &&
+            s.DisplayName == "Bob POA" &&
+            s.CredentialType == PersonalRepCredentialType.HealthcarePowerOfAttorney &&
+            s.Status == PersonalRepStatus.Active);
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Models/PersonalRepStateMachineTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Models/PersonalRepStateMachineTests.cs
@@ -1,0 +1,96 @@
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Services;
+
+namespace PersonalRepresentativeService.Tests.Models;
+
+public class PersonalRepStateMachineTests
+{
+    [Theory]
+    [InlineData(PersonalRepStatus.Draft,  PersonalRepStatus.Active)]
+    [InlineData(PersonalRepStatus.Draft,  PersonalRepStatus.Inactive)]
+    [InlineData(PersonalRepStatus.Active, PersonalRepStatus.Inactive)]
+    public void LegalTransitions_Allowed(PersonalRepStatus from, PersonalRepStatus to)
+    {
+        PersonalRepStateMachine.IsAllowed(from, to).Should().BeTrue();
+        Action act = () => PersonalRepStateMachine.EnsureAllowed(from, to);
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    // Draft -> Draft (idempotent no-op, not a transition)
+    [InlineData(PersonalRepStatus.Draft,    PersonalRepStatus.Draft)]
+    // Active -> Active (idempotent no-op), Active -> Draft (backwards)
+    [InlineData(PersonalRepStatus.Active,   PersonalRepStatus.Active)]
+    [InlineData(PersonalRepStatus.Active,   PersonalRepStatus.Draft)]
+    // Inactive is terminal — no outgoing edges
+    [InlineData(PersonalRepStatus.Inactive, PersonalRepStatus.Draft)]
+    [InlineData(PersonalRepStatus.Inactive, PersonalRepStatus.Active)]
+    [InlineData(PersonalRepStatus.Inactive, PersonalRepStatus.Inactive)]
+    public void IllegalTransitions_Throw(PersonalRepStatus from, PersonalRepStatus to)
+    {
+        PersonalRepStateMachine.IsAllowed(from, to).Should().BeFalse();
+        Action act = () => PersonalRepStateMachine.EnsureAllowed(from, to);
+        act.Should().Throw<InvalidPersonalRepTransitionException>()
+            .Where(e => e.FromStatus == from && e.ToStatus == to);
+    }
+
+    /// <summary>
+    /// Exhaustive guard: enumerate every (from, to) pair in the 3x3 matrix
+    /// and confirm the allowed set is EXACTLY the three transitions above.
+    /// Ensures a future enum addition forces an explicit decision rather
+    /// than silently widening the state machine.
+    /// </summary>
+    [Fact]
+    public void Matrix_AllowsOnlyThreeTransitions()
+    {
+        var expected = new HashSet<(PersonalRepStatus, PersonalRepStatus)>
+        {
+            (PersonalRepStatus.Draft,  PersonalRepStatus.Active),
+            (PersonalRepStatus.Draft,  PersonalRepStatus.Inactive),
+            (PersonalRepStatus.Active, PersonalRepStatus.Inactive)
+        };
+
+        var all = (PersonalRepStatus[])Enum.GetValues(typeof(PersonalRepStatus));
+        foreach (var f in all)
+        foreach (var t in all)
+        {
+            var allowed = PersonalRepStateMachine.IsAllowed(f, t);
+            var shouldBeAllowed = expected.Contains((f, t));
+            allowed.Should().Be(shouldBeAllowed,
+                $"transition {f} -> {t} allowed should be {shouldBeAllowed}");
+        }
+    }
+
+    [Theory]
+    [InlineData(PersonalRepStatus.Active,   60, PersonalRepStatus.Active)]
+    [InlineData(PersonalRepStatus.Active,   -1, PersonalRepStatus.Inactive)]
+    [InlineData(PersonalRepStatus.Draft,    -1, PersonalRepStatus.Draft)]
+    [InlineData(PersonalRepStatus.Inactive, -1, PersonalRepStatus.Inactive)]
+    public void ObservedStatus_ProjectsExpiryForActiveOnly(
+        PersonalRepStatus persisted, int minutesFromNow, PersonalRepStatus expected)
+    {
+        var now = new DateTime(2026, 4, 22, 12, 0, 0, DateTimeKind.Utc);
+        var rep = new PersonalRepresentative
+        {
+            TenantId = "t",
+            CredentialType = PersonalRepCredentialType.LegalGuardian,
+            Status = persisted,
+            ExpiresAt = now.AddMinutes(minutesFromNow)
+        };
+
+        rep.ObservedStatus(now).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ObservedStatus_NoExpiresAt_ReturnsPersisted()
+    {
+        var rep = new PersonalRepresentative
+        {
+            TenantId = "t",
+            CredentialType = PersonalRepCredentialType.Parent,
+            Status = PersonalRepStatus.Active,
+            ExpiresAt = null
+        };
+        rep.ObservedStatus(DateTime.UtcNow).Should().Be(PersonalRepStatus.Active);
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/PersonalRepresentativeService.Tests.csproj
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/PersonalRepresentativeService.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\personal-representative-service.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Moq" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Repositories/PersonalRepAssociationPairAtomicityTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Repositories/PersonalRepAssociationPairAtomicityTests.cs
@@ -1,0 +1,194 @@
+using System.Text.Json.Nodes;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Tests.Fakes;
+
+namespace PersonalRepresentativeService.Tests.Repositories;
+
+/// <summary>
+/// Enumerated-failure-mode coverage for
+/// <c>IPersonalRepRepository.AddAssociationPairAsync</c> and
+/// <c>RemoveAssociationPairAsync</c>. Each of the four failure modes on
+/// <see cref="Repositories.IPersonalRepRepository.AddAssociationPairAsync"/>
+/// gets a named test so the "accepted audit gap" (mode 4) is an
+/// explicitly tested thing, not a buried caveat.
+///
+/// These tests exercise the in-memory fake. The fake stages the forward
+/// insert first; if the inverse hook throws, it rolls the forward back —
+/// matching the Cosmos TransactionalBatch "both or neither" semantics and
+/// the Mongo session-transaction abort semantics.
+/// </summary>
+public class PersonalRepAssociationPairAtomicityTests
+{
+    private static PersonalRepAssociation Row(
+        string tenantId, string pairId, AssociationDirection dir) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = tenantId,
+        PairId = pairId,
+        RepId = "R1",
+        MemberId = "M1",
+        Direction = dir,
+        CredentialType = PersonalRepCredentialType.LegalGuardian,
+        EffectiveFrom = DateTime.UtcNow
+    };
+
+    private static PersonalRepEvent Evt(string tenantId, string repId) => new()
+    {
+        TenantId = tenantId,
+        PersonalRepId = repId,
+        EventType = PersonalRepEventType.PersonalRepAssociationAdded,
+        ActorId = "alice",
+        OccurredAt = DateTime.UtcNow,
+        Payload = new JsonObject()
+    };
+
+    // ─── MODE 1: Tenant mismatch — no writes, no audit event ─────────────
+
+    [Fact]
+    public async Task AddPair_MismatchedTenant_ThrowsAndWritesNothing()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-b", "pair-1", AssociationDirection.MemberToRep);
+
+        var act = async () => await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        repo.SnapshotAssociations().Should().BeEmpty();
+        repo.SnapshotEvents().Should().BeEmpty();
+    }
+
+    // ─── MODE 2: Forward insert fails — neither row, no audit event ──────
+
+    [Fact]
+    public async Task AddPair_ForwardInsertFails_TransactionAborts_NoAuditEvent()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        repo.OnBeforeForwardInsert = _ =>
+            throw new InvalidOperationException("simulated forward insert failure");
+
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-a", "pair-1", AssociationDirection.MemberToRep);
+
+        var act = async () => await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*forward*");
+
+        repo.SnapshotAssociations().Should().BeEmpty();
+        repo.SnapshotEvents().Should().BeEmpty();
+    }
+
+    // ─── MODE 3: Inverse insert fails — forward rolled back, no audit ────
+
+    [Fact]
+    public async Task AddPair_InverseInsertFails_TransactionAborts_NoAuditEvent()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        repo.OnBeforeInverseInsert = _ =>
+            throw new InvalidOperationException("simulated inverse insert failure");
+
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-a", "pair-1", AssociationDirection.MemberToRep);
+
+        var act = async () => await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*inverse*");
+
+        repo.SnapshotAssociations().Should().BeEmpty(
+            "forward insert must be rolled back when the inverse insert fails — pair atomicity invariant");
+        repo.SnapshotEvents().Should().BeEmpty();
+    }
+
+    // ─── MODE 4: Pair commits, audit append fails — ACCEPTED GAP ─────────
+    //
+    // This is the compliance-visible case. Pair IS persisted. Audit row
+    // is NOT. The repository must log at Error so ops can reconcile, and
+    // the exception propagates to the caller. The in-memory fake exposes
+    // an AuditAppendFailureCount counter for the assertion; the Cosmos
+    // and Mongo implementations are required by
+    // IPersonalRepRepository.AddAssociationPairAsync's docstring to log
+    // at ILogger.LogError with tenantId, pairId, eventId, correlationId.
+
+    [Fact]
+    public async Task AddPair_CommitSucceeds_AuditAppendFails_PairPersists_FailureIsObservable()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        repo.OnBeforePairAuditAppend = _ =>
+            throw new InvalidOperationException("simulated audit append failure");
+
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-a", "pair-1", AssociationDirection.MemberToRep);
+
+        var act = async () => await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // Pair IS persisted — this is the accepted gap.
+        repo.SnapshotAssociations().Should().HaveCount(2);
+        // Audit row is NOT.
+        repo.SnapshotEvents().Should().BeEmpty();
+        // The gap is observable.
+        repo.AuditAppendFailureCount.Should().Be(1);
+    }
+
+    // ─── Symmetric coverage for RemoveAssociationPairAsync ───────────────
+
+    [Fact]
+    public async Task RemovePair_CommitSucceeds_AuditAppendFails_PairStaysSoftDeleted_FailureIsObservable()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-a", "pair-1", AssociationDirection.MemberToRep);
+        await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        repo.OnBeforePairAuditAppend = _ =>
+            throw new InvalidOperationException("simulated audit append failure");
+
+        var removeEvent = Evt("tenant-a", "R1");
+        removeEvent.EventType = PersonalRepEventType.PersonalRepAssociationRemoved;
+        removeEvent.EventId = Guid.NewGuid().ToString();
+
+        var act = async () => await repo.RemoveAssociationPairAsync(
+            "tenant-a", "pair-1", "alice", removeEvent, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        var rows = repo.SnapshotAssociations();
+        rows.Should().HaveCount(2);
+        rows.Should().OnlyContain(r => r.EffectiveTo != null,
+            "pair must remain soft-deleted even when the audit append fails");
+
+        repo.AuditAppendFailureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AddPair_HappyPath_BothRowsAndAuditAllPresent()
+    {
+        var repo = new InMemoryPersonalRepRepository();
+        var forward = Row("tenant-a", "pair-1", AssociationDirection.RepToMember);
+        var inverse = Row("tenant-a", "pair-1", AssociationDirection.MemberToRep);
+
+        await repo.AddAssociationPairAsync(forward, inverse,
+            Evt("tenant-a", "R1"), CancellationToken.None);
+
+        var rows = repo.SnapshotAssociations();
+        rows.Should().HaveCount(2);
+        rows.Select(r => r.Direction).Should().BeEquivalentTo(new[]
+        {
+            AssociationDirection.RepToMember, AssociationDirection.MemberToRep
+        });
+        rows.Select(r => r.PairId).Distinct().Should().ContainSingle();
+
+        repo.SnapshotEvents().Should().ContainSingle(e =>
+            e.EventType == PersonalRepEventType.PersonalRepAssociationAdded);
+        repo.AuditAppendFailureCount.Should().Be(0);
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepEncryptionKeyHealthCheckTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepEncryptionKeyHealthCheckTests.cs
@@ -1,0 +1,69 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using PersonalRepresentativeService.Services;
+using PersonalRepresentativeService.Tests.Fakes;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace PersonalRepresentativeService.Tests.Services;
+
+public class PersonalRepEncryptionKeyHealthCheckTests
+{
+    private const string Prefix = "personal-rep-body-encryption-key";
+
+    private static (PersonalRepEncryptionKeyHealthCheck check, DictionarySecretProvider secrets)
+        Build(PersonalRepEncryptionOptions options)
+    {
+        var secrets = new DictionarySecretProvider();
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var check = new PersonalRepEncryptionKeyHealthCheck(keys, options);
+        return (check, secrets);
+    }
+
+    private static string Key32Base64(byte fill) =>
+        Convert.ToBase64String(Enumerable.Repeat(fill, 32).ToArray());
+
+    [Fact]
+    public async Task Healthy_WhenCurrentVersionResolves()
+    {
+        var (check, secrets) = Build(new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        });
+        secrets.Secrets[$"{Prefix}-v1"] = Key32Base64(0x01);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenCurrentVersionMissing()
+    {
+        var (check, _) = Build(new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        });
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenKeyWrongLength()
+    {
+        var (check, secrets) = Build(new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        });
+        secrets.Secrets[$"{Prefix}-v1"] = Convert.ToBase64String(Enumerable.Repeat((byte)0x01, 16).ToArray());
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("32 bytes");
+    }
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepEventPublisherTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepEventPublisherTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace PersonalRepresentativeService.Tests.Services;
+
+public class PersonalRepEventPublisherTests
+{
+    private static IConfiguration Config(Dictionary<string, string?> kv) =>
+        new ConfigurationBuilder().AddInMemoryCollection(kv).Build();
+
+    [Fact]
+    public async Task DegradedMode_NoBootstrap_PublishIsNoOp()
+    {
+        var pub = new PersonalRepEventPublisher(
+            NullLogger<PersonalRepEventPublisher>.Instance,
+            Config(new Dictionary<string, string?>()));
+        await pub.StartAsync(CancellationToken.None);
+
+        var rep = NewRep();
+        await pub.PublishStatusChangedAsync(
+            rep, null, PersonalRepStatus.Draft,
+            associatedMemberIds: new[] { "M1" },
+            "alice", "corr", CancellationToken.None);
+
+        await pub.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DegradedMode_StopBeforeStart_DoesNotThrow()
+    {
+        var pub = new PersonalRepEventPublisher(
+            NullLogger<PersonalRepEventPublisher>.Instance,
+            Config(new Dictionary<string, string?>()));
+        await pub.StopAsync(CancellationToken.None);
+        await pub.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Field-whitelist guard for status-changed payload. Serialize the
+    /// event, parse it, compare the key set to an explicit allow-list.
+    /// </summary>
+    [Fact]
+    public void StatusChangedPayload_HasExactlyWhitelistedFields()
+    {
+        var rep = NewRep();
+        rep.FirstName = "enc::should-never-appear";
+        rep.LastName = "enc::also-not-in-event";
+        rep.Email = "enc::nope";
+        rep.PhoneNumber = "enc::never";
+        rep.MailingAddressLine1 = "enc::hidden";
+        rep.RelationshipNotes = "enc::secret";
+        rep.InactivationReasonCode = PersonalRepInactivationReasonCode.PoaRevoked;
+
+        var evt = PersonalRepEventPublisher.BuildStatusChangedEvent(
+            rep, PersonalRepStatus.Active, PersonalRepStatus.Inactive,
+            new[] { "M1", "M2" }, "alice", "corr-1");
+
+        var json = JsonSerializer.Serialize(evt, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var actualFields = doc.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet();
+
+        var expected = new HashSet<string>
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "personalRepId",
+            "credentialType",
+            "fromStatus", "toStatus",
+            "effectiveFrom", "effectiveTo", "expiresAt",
+            "associatedMemberIds",
+            "actor", "correlationId",
+            "inactivationReasonCode"
+        };
+
+        actualFields.Should().BeEquivalentTo(expected,
+            "the event payload field list is a compliance contract — adding a field here requires a review of whether it leaks PHI-adjacent data");
+
+        json.Should().NotContain("\"firstName\"");
+        json.Should().NotContain("\"lastName\"");
+        json.Should().NotContain("\"middleName\"");
+        json.Should().NotContain("\"email\"");
+        json.Should().NotContain("\"phoneNumber\"");
+        json.Should().NotContain("\"mailingAddressLine1\"");
+        json.Should().NotContain("\"relationshipNotes\"");
+        json.Should().NotContain("\"proofOfAuthorityDocumentId\"");
+        json.Should().NotContain("enc::");
+    }
+
+    [Fact]
+    public void AssociationChangedPayload_HasExactlyWhitelistedFields()
+    {
+        var rep = NewRep();
+        rep.FirstName = "enc::should-never-appear";
+        rep.RelationshipNotes = "enc::secret";
+
+        var association = new PersonalRepAssociation
+        {
+            Id = "assoc-1",
+            TenantId = rep.TenantId,
+            PairId = "pair-1",
+            RepId = rep.Id,
+            MemberId = "M1",
+            Direction = AssociationDirection.RepToMember,
+            CredentialType = rep.CredentialType,
+            EffectiveFrom = DateTime.UtcNow
+        };
+
+        var evt = PersonalRepEventPublisher.BuildAssociationChangedEvent(
+            rep, association, PersonalRepEventPublisher.AssociationAddedEventType,
+            "alice", "corr-2");
+
+        var json = JsonSerializer.Serialize(evt, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        using var doc = JsonDocument.Parse(json);
+        var actualFields = doc.RootElement.EnumerateObject().Select(p => p.Name).ToHashSet();
+
+        var expected = new HashSet<string>
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "personalRepId", "memberId",
+            "credentialType",
+            "effectiveFrom", "effectiveTo",
+            "actor", "correlationId"
+        };
+
+        actualFields.Should().BeEquivalentTo(expected);
+
+        json.Should().NotContain("\"firstName\"");
+        json.Should().NotContain("\"lastName\"");
+        json.Should().NotContain("\"relationshipNotes\"");
+        json.Should().NotContain("enc::");
+    }
+
+    [Fact]
+    public void StatusChangedPayload_GenesisEvent_FromStatusIsNull()
+    {
+        var rep = NewRep();
+        var evt = PersonalRepEventPublisher.BuildStatusChangedEvent(
+            rep, null, PersonalRepStatus.Draft, Array.Empty<string>(), "alice", "corr");
+        evt.FromStatus.Should().BeNull();
+        evt.ToStatus.Should().Be("Draft");
+    }
+
+    [Fact]
+    public void EventTopicAndHeaders_MatchContract()
+    {
+        PersonalRepEventPublisher.StatusChangedTopic.Should().Be("personal-rep.status-changed.v1");
+        PersonalRepEventPublisher.StatusChangedEventType.Should().Be("PersonalRepStatusChanged");
+        PersonalRepEventPublisher.AssociationAddedEventType.Should().Be("PersonalRepAssociationAdded");
+        PersonalRepEventPublisher.AssociationRemovedEventType.Should().Be("PersonalRepAssociationRemoved");
+        PersonalRepEventPublisher.EventVersion.Should().Be("1.0");
+    }
+
+    private static PersonalRepresentative NewRep() => new()
+    {
+        TenantId = "tenant-a",
+        Id = "rep-1",
+        Status = PersonalRepStatus.Draft,
+        CredentialType = PersonalRepCredentialType.LegalGuardian,
+        EffectiveFrom = DateTime.UtcNow,
+        ExpiresAt = DateTime.UtcNow.AddYears(1)
+    };
+}

--- a/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepFieldEncryptorTests.cs
+++ b/src/services/personal-representative-service/PersonalRepresentativeService.Tests/Services/PersonalRepFieldEncryptorTests.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using CloudHealthOffice.Infrastructure.Configuration;
+using PersonalRepresentativeService.Services;
+using PersonalRepresentativeService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace PersonalRepresentativeService.Tests.Services;
+
+public class PersonalRepFieldEncryptorTests
+{
+    private const string Prefix = "personal-rep-body-encryption-key";
+
+    private static string Key32Base64(byte fill) =>
+        Convert.ToBase64String(Enumerable.Repeat(fill, 32).ToArray());
+
+    private static (PersonalRepFieldEncryptor enc, DictionarySecretProvider secrets)
+        Build(PersonalRepEncryptionOptions options, Action<DictionarySecretProvider>? seed = null)
+    {
+        var secrets = new DictionarySecretProvider();
+        seed?.Invoke(secrets);
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var enc = new PersonalRepFieldEncryptor(keys, NullLogger<PersonalRepFieldEncryptor>.Instance, options);
+        return (enc, secrets);
+    }
+
+    [Fact]
+    public async Task RoundTrip_V1_ReturnsOriginalPlaintext()
+    {
+        var (enc, _) = Build(
+            new PersonalRepEncryptionOptions
+            {
+                KeySecretPrefix = Prefix,
+                CurrentKeyVersion = "v1",
+                AcceptedKeyVersions = new[] { "v1" }
+            },
+            s => s.Secrets[$"{Prefix}-v1"] = Key32Base64(0xAA));
+
+        var plaintext = "Alice Rep — 555-0100 — 100 Main St";
+        var ct = await enc.EncryptAsync(plaintext);
+        ct.Should().NotBeNull();
+        ct.Should().NotBe(plaintext);
+
+        var back = await enc.DecryptAsync(ct);
+        back.Should().Be(plaintext);
+    }
+
+    [Fact]
+    public async Task RotationWindow_ReadsV1AndWritesV2()
+    {
+        var opts1 = new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        };
+        var (encV1, secrets) = Build(opts1, s => s.Secrets[$"{Prefix}-v1"] = Key32Base64(0x01));
+        var ctV1 = await encV1.EncryptAsync("hello");
+
+        secrets.Secrets[$"{Prefix}-v2"] = Key32Base64(0x02);
+        var opts2 = new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v1", "v2" }
+        };
+        var keys2 = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var encV2 = new PersonalRepFieldEncryptor(keys2, NullLogger<PersonalRepFieldEncryptor>.Instance, opts2);
+
+        (await encV2.DecryptAsync(ctV1)).Should().Be("hello");
+
+        var ctV2 = await encV2.EncryptAsync("world");
+        ctV2.Should().NotBeNull();
+        (await encV2.DecryptAsync(ctV2)).Should().Be("world");
+    }
+
+    [Fact]
+    public async Task StaleKey_DroppedFromAccepted_ThrowsCryptographicException()
+    {
+        var optsWide = new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        };
+        var (encWide, secrets) = Build(optsWide,
+            s => s.Secrets[$"{Prefix}-v1"] = Key32Base64(0x11));
+        var ct = await encWide.EncryptAsync("secret");
+
+        var optsNarrow = new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v2",
+            AcceptedKeyVersions = new[] { "v2" }
+        };
+        secrets.Secrets[$"{Prefix}-v2"] = Key32Base64(0x22);
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var encNarrow = new PersonalRepFieldEncryptor(keys, NullLogger<PersonalRepFieldEncryptor>.Instance, optsNarrow);
+
+        var act = async () => await encNarrow.DecryptAsync(ct);
+        await act.Should().ThrowAsync<CryptographicException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task NullOrEmpty_PassThrough(string? input)
+    {
+        var (enc, _) = Build(new PersonalRepEncryptionOptions
+        {
+            KeySecretPrefix = Prefix,
+            CurrentKeyVersion = "v1",
+            AcceptedKeyVersions = new[] { "v1" }
+        });
+        (await enc.EncryptAsync(input)).Should().Be(input);
+        (await enc.DecryptAsync(input)).Should().Be(input);
+    }
+
+    [Fact]
+    public async Task TamperedCiphertext_ThrowsCryptographicException()
+    {
+        var (enc, _) = Build(
+            new PersonalRepEncryptionOptions
+            {
+                KeySecretPrefix = Prefix,
+                CurrentKeyVersion = "v1",
+                AcceptedKeyVersions = new[] { "v1" }
+            },
+            s => s.Secrets[$"{Prefix}-v1"] = Key32Base64(0x33));
+
+        var ct = await enc.EncryptAsync("hello");
+        var mid = ct!.Length / 2;
+        var tampered = ct[..mid] + (ct[mid] == 'A' ? 'B' : 'A') + ct[(mid + 1)..];
+
+        var act = async () => await enc.DecryptAsync(tampered);
+        await act.Should().ThrowAsync<CryptographicException>();
+    }
+
+    [Fact]
+    public async Task WrongEnvelopeVersionByte_ThrowsCryptographicException()
+    {
+        // 0x01 is the legacy envelope version — personal-rep-service doesn't
+        // support it (greenfield service, 0x02 only).
+        var (enc, _) = Build(
+            new PersonalRepEncryptionOptions
+            {
+                KeySecretPrefix = Prefix,
+                CurrentKeyVersion = "v1",
+                AcceptedKeyVersions = new[] { "v1" }
+            },
+            s => s.Secrets[$"{Prefix}-v1"] = Key32Base64(0x44));
+
+        var bogus = new byte[] { 0x01, 0x00, 0x00 };
+        var envelope = Convert.ToBase64String(bogus).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var act = async () => await enc.DecryptAsync(envelope);
+        await act.Should().ThrowAsync<CryptographicException>();
+    }
+}

--- a/src/services/personal-representative-service/Program.cs
+++ b/src/services/personal-representative-service/Program.cs
@@ -1,0 +1,179 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.HealthChecks;
+using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Messaging;
+using CloudHealthOffice.Infrastructure.Observability;
+using PersonalRepresentativeService.HostedServices;
+using PersonalRepresentativeService.Middleware;
+using PersonalRepresentativeService.Repositories;
+using PersonalRepresentativeService.Services;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Secret provider (Azure Key Vault / none) — same bootstrap shape as all
+// other services in the platform.
+builder.Services.AddSecretProvider(builder.Configuration);
+builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
+
+builder.Services.AddControllers()
+    .AddCloudHealthOfficeJsonOptions();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new()
+    {
+        Title = "Cloud Health Office - Personal Representative Service API",
+        Version = "v1",
+        Description = "Records Personal Representative delegation (§164.502(g)) with symmetric-pair associations, field-level encryption, and an append-only audit trail."
+    });
+});
+
+// ── Database Configuration ───────────────────────────────────────────
+var mongoConnectionString = builder.Configuration["MongoDb:ConnectionString"];
+
+if (!string.IsNullOrEmpty(mongoConnectionString))
+{
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(_ =>
+        new MongoDB.Driver.MongoClient(mongoConnectionString));
+
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoDatabase>(sp =>
+    {
+        var client = sp.GetRequiredService<MongoDB.Driver.IMongoClient>();
+        var databaseName = builder.Configuration["MongoDb:DatabaseName"] ?? "CloudHealthOffice";
+        return client.GetDatabase(databaseName);
+    });
+
+    builder.Services.AddSingleton<IPersonalRepEventRepository, PersonalRepEventRepositoryMongo>();
+    builder.Services.AddSingleton<IPersonalRepEventSink>(sp =>
+        (IPersonalRepEventSink)sp.GetRequiredService<IPersonalRepEventRepository>());
+    builder.Services.AddSingleton<IPersonalRepRepository, PersonalRepRepositoryMongo>();
+
+    builder.Services.AddHostedService<PersonalRepIndexInitializer>();
+
+    Console.WriteLine("[personal-representative-service] Using MongoDB database provider");
+}
+else
+{
+    builder.Services.AddSingleton<CosmosClient>(sp =>
+    {
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var endpoint = configuration["CosmosDb:Endpoint"]
+            ?? throw new InvalidOperationException("CosmosDb:Endpoint configuration missing");
+        var key = configuration["CosmosDb:Key"]
+            ?? throw new InvalidOperationException("CosmosDb:Key configuration missing");
+
+        return new CosmosClient(endpoint, key, new CosmosClientOptions
+        {
+            SerializerOptions = new CosmosSerializationOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            }
+        });
+    });
+
+    builder.Services.AddScoped<IPersonalRepEventRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new PersonalRepEventRepository(cosmosClient, databaseName);
+    });
+    builder.Services.AddScoped<IPersonalRepEventSink>(sp =>
+        (IPersonalRepEventSink)sp.GetRequiredService<IPersonalRepEventRepository>());
+    builder.Services.AddScoped<IPersonalRepRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        var sink = sp.GetRequiredService<IPersonalRepEventSink>();
+        var logger = sp.GetRequiredService<ILogger<PersonalRepRepository>>();
+        return new PersonalRepRepository(cosmosClient, databaseName, sink, logger);
+    });
+
+    Console.WriteLine("[personal-representative-service] Using Cosmos DB database provider");
+}
+
+// ── Personal Rep body encryption ────────────────────────────────────
+// Non-dev startup guard: no PersonalRepEncryption section = startup error.
+// Only IsDevelopment() falls back to the no-op encryptor.
+var encryptionSection = builder.Configuration.GetSection(PersonalRepEncryptionOptions.SectionName);
+if (encryptionSection.Exists())
+{
+    var options = encryptionSection.Get<PersonalRepEncryptionOptions>() ?? new PersonalRepEncryptionOptions();
+    builder.Services.AddSingleton(options);
+    builder.Services.AddSingleton<IPersonalRepFieldEncryptor>(sp =>
+        new PersonalRepFieldEncryptor(
+            sp.GetRequiredService<RotatingKeyProvider>(),
+            sp.GetRequiredService<ILogger<PersonalRepFieldEncryptor>>(),
+            options));
+
+    Console.WriteLine(
+        $"[personal-representative-service] IPersonalRepFieldEncryptor = KeyVault (rotating) — current: {options.CurrentKeyVersion}; " +
+        $"accepted: [{string.Join(", ", options.AcceptedKeyVersions)}]");
+}
+else
+{
+    if (!builder.Environment.IsDevelopment())
+    {
+        throw new InvalidOperationException(
+            "PersonalRepEncryption must be configured in non-development environments. " +
+            "Publish the personal-rep-body-encryption-key-v1 secret and set PersonalRepEncryption:KeySecretPrefix / CurrentKeyVersion.");
+    }
+    builder.Services.AddSingleton(new PersonalRepEncryptionOptions());
+    builder.Services.AddSingleton<IPersonalRepFieldEncryptor, NoOpPersonalRepFieldEncryptor>();
+    Console.WriteLine("[dev] IPersonalRepFieldEncryptor = NoOp (personal rep body fields stored plaintext). Configure PersonalRepEncryption to enable.");
+}
+
+// ── Kafka producer (personal rep status events) ──────────────────────
+builder.Services.AddSingleton<PersonalRepEventPublisher>();
+builder.Services.AddSingleton<IPersonalRepEventPublisher>(sp => sp.GetRequiredService<PersonalRepEventPublisher>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<PersonalRepEventPublisher>());
+
+builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+    {
+        policy.AllowAnyOrigin()
+              .AllowAnyMethod()
+              .AllowAnyHeader();
+    });
+});
+
+builder.Services.AddChoHealthChecks(options =>
+{
+    options.MongoDbConnectionString = builder.Configuration["MongoDb:ConnectionString"];
+    options.CosmosDbConnectionString = builder.Configuration["CosmosDb:ConnectionString"];
+    options.CosmosDbEndpoint = builder.Configuration["CosmosDb:Endpoint"];
+    options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
+})
+.AddCheck<PersonalRepEncryptionKeyHealthCheck>(
+    "personal-rep-encryption-key",
+    failureStatus: HealthStatus.Unhealthy,
+    tags: new[] { "ready" });
+
+builder.Services.AddChoObservability(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseChoObservability();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseCors();
+app.UseTenantContext();
+app.UseAuthorization();
+app.MapControllers();
+app.MapChoHealthChecks();
+
+app.Run();
+
+// Required so WebApplicationFactory<Program> works in the test project.
+public partial class Program { }

--- a/src/services/personal-representative-service/Repositories/IPersonalRepRepository.cs
+++ b/src/services/personal-representative-service/Repositories/IPersonalRepRepository.cs
@@ -17,9 +17,16 @@ namespace PersonalRepresentativeService.Repositories;
 /// </summary>
 public interface IPersonalRepRepository
 {
-    Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent);
+    Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent, CancellationToken ct = default);
 
     Task<PersonalRepresentative?> GetByIdAsync(string tenantId, string repId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-fetch reps by id list. Duplicates in <paramref name="repIds"/>
+    /// are deduplicated; records not found are silently omitted.
+    /// </summary>
+    Task<IReadOnlyList<PersonalRepresentative>> GetByIdsAsync(
+        string tenantId, IReadOnlyList<string> repIds, CancellationToken ct = default);
 
     Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
         string tenantId, bool activeOnly = false, DateTime? asOf = null, CancellationToken ct = default);
@@ -32,17 +39,18 @@ public interface IPersonalRepRepository
     /// the transition via <c>PersonalRepStateMachine</c>.
     /// </summary>
     Task<PersonalRepresentative> TransitionStatusAsync(
-        PersonalRepresentative rep, PersonalRepEvent auditEvent);
+        PersonalRepresentative rep, PersonalRepEvent auditEvent, CancellationToken ct = default);
 
     /// <summary>
     /// Race-safe Active → Inactive persistence for the read-time expiry
-    /// observer. Returns <c>true</c> iff this caller won the race to
-    /// persist the transition (and the audit event was appended).
-    /// Returns <c>false</c> if the record was no longer Active at write
-    /// time — another caller already inactivated it. Callers that get
-    /// <c>false</c> must NOT retry with a different event.
+    /// observer. Returns the updated <see cref="PersonalRepresentative"/>
+    /// (with <c>Status=Inactive</c>, <c>InactivationReasonCode=Expired</c>,
+    /// and <c>InactivatedAt</c> set) if this caller won the race and the
+    /// audit event was appended. Returns <c>null</c> if the record was no
+    /// longer Active at write time — another caller already inactivated it.
+    /// Callers that receive <c>null</c> must NOT retry with a different event.
     /// </summary>
-    Task<bool> TryTransitionToInactiveAsync(
+    Task<PersonalRepresentative?> TryTransitionToInactiveAsync(
         PersonalRepresentative rep, PersonalRepEvent auditEvent);
 
     /// <summary>

--- a/src/services/personal-representative-service/Repositories/IPersonalRepRepository.cs
+++ b/src/services/personal-representative-service/Repositories/IPersonalRepRepository.cs
@@ -1,0 +1,121 @@
+using PersonalRepresentativeService.Models;
+
+namespace PersonalRepresentativeService.Repositories;
+
+/// <summary>
+/// Repository surface for <see cref="PersonalRepresentative"/> plus the
+/// <see cref="PersonalRepAssociation"/> pair-write operations. The
+/// association is a sub-concept of the rep (not its own aggregate), so it
+/// lives on the same repository interface — matching the consent-service
+/// posture where <c>ConsentEvent</c> is a sub-concept of <c>Consent</c>.
+///
+/// Lifecycle methods are verb-named. There is no generic
+/// <c>UpdateAsync</c>+<c>AppendEventAsync</c>: every status mutation and
+/// every association add/remove goes through a method that writes the
+/// audit row in the same repository call. The audit-trail invariant is
+/// enforced structurally.
+/// </summary>
+public interface IPersonalRepRepository
+{
+    Task<PersonalRepresentative> CreateAsync(PersonalRepresentative rep, PersonalRepEvent genesisEvent);
+
+    Task<PersonalRepresentative?> GetByIdAsync(string tenantId, string repId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
+        string tenantId, bool activeOnly = false, DateTime? asOf = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomic: persist the new status on <paramref name="rep"/> AND append
+    /// <paramref name="auditEvent"/>. Caller must set <c>rep.Status</c> to
+    /// the new value and populate any lifecycle fields (ActivatedAt,
+    /// InactivatedAt, etc.) before calling. Callers MUST have validated
+    /// the transition via <c>PersonalRepStateMachine</c>.
+    /// </summary>
+    Task<PersonalRepresentative> TransitionStatusAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent);
+
+    /// <summary>
+    /// Race-safe Active → Inactive persistence for the read-time expiry
+    /// observer. Returns <c>true</c> iff this caller won the race to
+    /// persist the transition (and the audit event was appended).
+    /// Returns <c>false</c> if the record was no longer Active at write
+    /// time — another caller already inactivated it. Callers that get
+    /// <c>false</c> must NOT retry with a different event.
+    /// </summary>
+    Task<bool> TryTransitionToInactiveAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent);
+
+    /// <summary>
+    /// Atomically persist the forward (RepToMember) and inverse
+    /// (MemberToRep) rows of an association, along with the audit event.
+    /// Cosmos uses <c>TransactionalBatch</c> (both rows share tenantId);
+    /// Mongo uses a session with a transaction.
+    ///
+    /// Failure-mode contract (enforced by
+    /// <c>PersonalRepAssociationPairAtomicityTests</c>):
+    ///   1. Tenant mismatch → <see cref="InvalidOperationException"/>, no writes.
+    ///   2. Forward insert fails → transaction aborts, no audit event.
+    ///   3. Inverse insert fails → transaction aborts, no audit event.
+    ///   4. Pair commits, audit append fails → pair persisted, audit
+    ///      missing, <c>ILogger.LogError</c> recorded so the gap is
+    ///      observable in logs; exception propagates to caller.
+    /// </summary>
+    Task AddAssociationPairAsync(
+        PersonalRepAssociation forward,
+        PersonalRepAssociation inverse,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically soft-delete both rows of an association pair (set
+    /// <see cref="PersonalRepAssociation.EffectiveTo"/>) and append the
+    /// audit event. Same four-failure-mode contract as
+    /// <see cref="AddAssociationPairAsync"/>.
+    /// </summary>
+    Task RemoveAssociationPairAsync(
+        string tenantId,
+        string pairId,
+        string removedBy,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForMemberAsync(
+        string tenantId,
+        string memberId,
+        bool activeOnly = false,
+        DateTime? asOf = null,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForRepAsync(
+        string tenantId,
+        string repId,
+        bool activeOnly = false,
+        DateTime? asOf = null,
+        CancellationToken ct = default);
+
+    Task<PersonalRepAssociation?> FindActiveAssociationAsync(
+        string tenantId,
+        string repId,
+        string memberId,
+        CancellationToken ct = default);
+}
+
+/// <summary>Repository surface for <see cref="PersonalRepEvent"/> (audit trail reads).</summary>
+public interface IPersonalRepEventRepository
+{
+    Task<IReadOnlyList<PersonalRepEvent>> ListByRepAsync(
+        string tenantId,
+        string personalRepId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Repository-local sink for appending <see cref="PersonalRepEvent"/> rows.
+/// Lets the Cosmos and Mongo <see cref="IPersonalRepRepository"/>
+/// implementations share a single transition-and-append shape while
+/// keeping their own storage choice for audit rows.
+/// </summary>
+public interface IPersonalRepEventSink
+{
+    Task AppendAsync(PersonalRepEvent evt);
+}

--- a/src/services/personal-representative-service/Repositories/PersonalRepEventRepository.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepEventRepository.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using PersonalRepresentativeService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace PersonalRepresentativeService.Repositories;
+
+/// <summary>
+/// Cosmos DB implementation of <see cref="IPersonalRepEventRepository"/>
+/// and <see cref="IPersonalRepEventSink"/>. Partition key:
+/// <c>/partitionKey</c> (<c>{tenantId}:{personalRepId}</c>) so the full
+/// audit trail for a rep lives in a single partition and scans cheaply.
+///
+/// Writes are idempotent: the Cosmos document id is
+/// <see cref="PersonalRepEvent.EventId"/>, so a duplicate append with the
+/// same EventId returns a 409 that we treat as a no-op — safe under retry
+/// from Kafka / controller layers.
+/// </summary>
+public class PersonalRepEventRepository : IPersonalRepEventRepository, IPersonalRepEventSink
+{
+    public const string PersonalRepEventsContainerName = "PersonalRepEvents";
+
+    private readonly Container _container;
+
+    public PersonalRepEventRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        _container = cosmosClient.GetDatabase(databaseName).GetContainer(PersonalRepEventsContainerName);
+    }
+
+    public async Task AppendAsync(PersonalRepEvent evt)
+    {
+        NormalizeEnvelope(evt);
+        try
+        {
+            await _container.CreateItemAsync(evt, new PartitionKey(evt.PartitionKey));
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            // Idempotent append: duplicate EventId = same append, ignore.
+        }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepEvent>> ListByRepAsync(
+        string tenantId, string personalRepId, CancellationToken ct = default)
+    {
+        var partitionKey = PersonalRepEvent.BuildPartitionKey(tenantId, personalRepId);
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.partitionKey = @pk ORDER BY c.occurredAt ASC")
+            .WithParameter("@pk", partitionKey);
+
+        var iterator = _container.GetItemQueryIterator<PersonalRepEvent>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) });
+
+        var results = new List<PersonalRepEvent>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    internal static void NormalizeEnvelope(PersonalRepEvent evt)
+    {
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EventId is required (client-supplied idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.PersonalRepId))
+            throw new ArgumentException("TenantId and PersonalRepId are required");
+
+        if (string.IsNullOrEmpty(evt.Id))
+            evt.Id = evt.EventId;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = PersonalRepEvent.BuildPartitionKey(evt.TenantId, evt.PersonalRepId);
+    }
+}

--- a/src/services/personal-representative-service/Repositories/PersonalRepEventRepositoryMongo.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepEventRepositoryMongo.cs
@@ -1,0 +1,44 @@
+using PersonalRepresentativeService.Models;
+using MongoDB.Driver;
+
+namespace PersonalRepresentativeService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IPersonalRepEventRepository"/> and
+/// <see cref="IPersonalRepEventSink"/>. Append is idempotent via the unique
+/// index on <c>(tenantId, personalRepId, eventId)</c> created at startup
+/// by <c>HostedServices.PersonalRepIndexInitializer</c>.
+/// </summary>
+public class PersonalRepEventRepositoryMongo : IPersonalRepEventRepository, IPersonalRepEventSink
+{
+    public const string PersonalRepEventsCollectionName = "PersonalRepEvents";
+
+    private readonly IMongoCollection<PersonalRepEvent> _collection;
+
+    public PersonalRepEventRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<PersonalRepEvent>(PersonalRepEventsCollectionName);
+    }
+
+    public async Task AppendAsync(PersonalRepEvent evt)
+    {
+        PersonalRepEventRepository.NormalizeEnvelope(evt);
+        try
+        {
+            await _collection.InsertOneAsync(evt);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Duplicate EventId — idempotent replay, drop silently.
+        }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepEvent>> ListByRepAsync(
+        string tenantId, string personalRepId, CancellationToken ct = default)
+    {
+        var filter = Builders<PersonalRepEvent>.Filter.Eq(e => e.TenantId, tenantId)
+                   & Builders<PersonalRepEvent>.Filter.Eq(e => e.PersonalRepId, personalRepId);
+        var results = await _collection.Find(filter).ToListAsync(ct);
+        return results.OrderBy(e => e.OccurredAt).ToList();
+    }
+}

--- a/src/services/personal-representative-service/Repositories/PersonalRepRepository.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepRepository.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Services;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 
@@ -46,12 +47,12 @@ public class PersonalRepRepository : IPersonalRepRepository
     }
 
     public async Task<PersonalRepresentative> CreateAsync(
-        PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+        PersonalRepresentative rep, PersonalRepEvent genesisEvent, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
         if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
 
-        var response = await _reps.CreateItemAsync(rep, new PartitionKey(rep.TenantId));
+        var response = await _reps.CreateItemAsync(rep, new PartitionKey(rep.TenantId), cancellationToken: ct);
         await _events.AppendAsync(genesisEvent);
         return response.Resource;
     }
@@ -70,6 +71,36 @@ public class PersonalRepRepository : IPersonalRepRepository
         {
             return null;
         }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepresentative>> GetByIdsAsync(
+        string tenantId, IReadOnlyList<string> repIds, CancellationToken ct = default)
+    {
+        if (repIds.Count == 0) return Array.Empty<PersonalRepresentative>();
+
+        var deduped = repIds.Distinct().ToList();
+        // Build an IN(...) query — safe because values are Guids passed by
+        // the service itself, not raw user input.
+        var paramList = string.Join(",", deduped.Select((_, i) => $"@id{i}"));
+        var qd = new QueryDefinition(
+            $"SELECT * FROM c WHERE c.tenantId = @tenantId " +
+            $"AND c.id IN ({paramList}) " +
+            "AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)")
+            .WithParameter("@tenantId", tenantId);
+        for (var i = 0; i < deduped.Count; i++)
+            qd = qd.WithParameter($"@id{i}", deduped[i]);
+
+        var iterator = _reps.GetItemQueryIterator<PersonalRepresentative>(
+            qd,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<PersonalRepresentative>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page.Where(r => !r.IsDeleted));
+        }
+        return results;
     }
 
     public async Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
@@ -100,7 +131,7 @@ public class PersonalRepRepository : IPersonalRepRepository
     }
 
     public async Task<PersonalRepresentative> TransitionStatusAsync(
-        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+        PersonalRepresentative rep, PersonalRepEvent auditEvent, CancellationToken ct = default)
     {
         if (!auditEvent.FromStatus.HasValue)
         {
@@ -113,7 +144,7 @@ public class PersonalRepRepository : IPersonalRepRepository
         try
         {
             var fresh = await _reps.ReadItemAsync<PersonalRepresentative>(
-                rep.Id, new PartitionKey(rep.TenantId));
+                rep.Id, new PartitionKey(rep.TenantId), cancellationToken: ct);
 
             if (fresh.Resource.Status != expectedFromStatus)
             {
@@ -123,7 +154,7 @@ public class PersonalRepRepository : IPersonalRepRepository
 
             var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
             var response = await _reps.ReplaceItemAsync(
-                rep, rep.Id, new PartitionKey(rep.TenantId), options);
+                rep, rep.Id, new PartitionKey(rep.TenantId), options, cancellationToken: ct);
 
             await _events.AppendAsync(auditEvent);
             return response.Resource;
@@ -135,7 +166,7 @@ public class PersonalRepRepository : IPersonalRepRepository
         }
     }
 
-    public async Task<bool> TryTransitionToInactiveAsync(
+    public async Task<PersonalRepresentative?> TryTransitionToInactiveAsync(
         PersonalRepresentative rep, PersonalRepEvent auditEvent)
     {
         try
@@ -145,7 +176,7 @@ public class PersonalRepRepository : IPersonalRepRepository
 
             if (fresh.Resource.Status != PersonalRepStatus.Active)
             {
-                return false;
+                return null;
             }
 
             var inactivated = fresh.Resource;
@@ -158,11 +189,11 @@ public class PersonalRepRepository : IPersonalRepRepository
                 inactivated, inactivated.Id, new PartitionKey(inactivated.TenantId), options);
 
             await _events.AppendAsync(auditEvent);
-            return true;
+            return inactivated;
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
         {
-            return false;
+            return null;
         }
     }
 
@@ -203,7 +234,10 @@ public class PersonalRepRepository : IPersonalRepRepository
                 "Personal Rep association pair committed but audit append failed " +
                 "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
                 "Pair persisted; audit row missing — manual reconciliation required.",
-                forward.TenantId, forward.PairId, auditEvent.EventId, auditEvent.CorrelationId);
+                LogSanitizer.SafeForLog(forward.TenantId),
+                LogSanitizer.SafeForLog(forward.PairId),
+                LogSanitizer.SafeForLog(auditEvent.EventId),
+                LogSanitizer.SafeForLog(auditEvent.CorrelationId));
             throw;
         }
     }
@@ -247,7 +281,10 @@ public class PersonalRepRepository : IPersonalRepRepository
                 "Personal Rep association pair removed but audit append failed " +
                 "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
                 "Pair soft-deleted; audit row missing — manual reconciliation required.",
-                tenantId, pairId, auditEvent.EventId, auditEvent.CorrelationId);
+                LogSanitizer.SafeForLog(tenantId),
+                LogSanitizer.SafeForLog(pairId),
+                LogSanitizer.SafeForLog(auditEvent.EventId),
+                LogSanitizer.SafeForLog(auditEvent.CorrelationId));
             throw;
         }
     }

--- a/src/services/personal-representative-service/Repositories/PersonalRepRepository.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepRepository.cs
@@ -1,0 +1,364 @@
+using System.Net;
+using PersonalRepresentativeService.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace PersonalRepresentativeService.Repositories;
+
+/// <summary>
+/// Cosmos DB implementation of <see cref="IPersonalRepRepository"/>.
+/// Partition key on both containers is <c>/tenantId</c>.
+///
+/// Audit-trail atomicity for <see cref="TransitionStatusAsync"/> and
+/// <see cref="TryTransitionToInactiveAsync"/> is implemented via conditional
+/// ReplaceItem with an ETag precondition sourced from a fresh read. Audit
+/// rows are appended only when the conditional replace succeeds.
+///
+/// Association pair writes use <c>TransactionalBatch</c> — both rows of a
+/// pair share the tenantId partition key, which is a precondition for
+/// batch atomicity. The audit event append happens AFTER a successful
+/// batch commit (it lives in a different Cosmos container and therefore
+/// cannot be part of the same batch). The four failure modes are
+/// documented on <see cref="IPersonalRepRepository.AddAssociationPairAsync"/>
+/// and covered by <c>PersonalRepAssociationPairAtomicityTests</c>.
+/// </summary>
+public class PersonalRepRepository : IPersonalRepRepository
+{
+    public const string PersonalRepsContainerName = "PersonalRepresentatives";
+    public const string PersonalRepAssociationsContainerName = "PersonalRepAssociations";
+
+    private readonly Container _reps;
+    private readonly Container _associations;
+    private readonly IPersonalRepEventSink _events;
+    private readonly ILogger<PersonalRepRepository> _logger;
+
+    public PersonalRepRepository(
+        CosmosClient cosmosClient,
+        string databaseName,
+        IPersonalRepEventSink events,
+        ILogger<PersonalRepRepository> logger)
+    {
+        var database = cosmosClient.GetDatabase(databaseName);
+        _reps = database.GetContainer(PersonalRepsContainerName);
+        _associations = database.GetContainer(PersonalRepAssociationsContainerName);
+        _events = events;
+        _logger = logger;
+    }
+
+    public async Task<PersonalRepresentative> CreateAsync(
+        PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+    {
+        if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
+        if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
+
+        var response = await _reps.CreateItemAsync(rep, new PartitionKey(rep.TenantId));
+        await _events.AppendAsync(genesisEvent);
+        return response.Resource;
+    }
+
+    public async Task<PersonalRepresentative?> GetByIdAsync(
+        string tenantId, string repId, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _reps.ReadItemAsync<PersonalRepresentative>(
+                repId, new PartitionKey(tenantId), cancellationToken: ct);
+            var rep = response.Resource;
+            return rep.IsDeleted ? null : rep;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
+        string tenantId, bool activeOnly = false, DateTime? asOf = null, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.tenantId = @tenantId " +
+            "AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null) " +
+            "ORDER BY c.createdAt DESC")
+            .WithParameter("@tenantId", tenantId);
+
+        var iterator = _reps.GetItemQueryIterator<PersonalRepresentative>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<PersonalRepresentative>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(r => r.ObservedStatus(t) == PersonalRepStatus.Active).ToList();
+
+        return results;
+    }
+
+    public async Task<PersonalRepresentative> TransitionStatusAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        if (!auditEvent.FromStatus.HasValue)
+        {
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
+        }
+        var expectedFromStatus = auditEvent.FromStatus.Value;
+
+        try
+        {
+            var fresh = await _reps.ReadItemAsync<PersonalRepresentative>(
+                rep.Id, new PartitionKey(rep.TenantId));
+
+            if (fresh.Resource.Status != expectedFromStatus)
+            {
+                throw new InvalidPersonalRepTransitionException(
+                    fresh.Resource.Status, rep.Status);
+            }
+
+            var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+            var response = await _reps.ReplaceItemAsync(
+                rep, rep.Id, new PartitionKey(rep.TenantId), options);
+
+            await _events.AppendAsync(auditEvent);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            throw new InvalidPersonalRepTransitionException(
+                expectedFromStatus, rep.Status);
+        }
+    }
+
+    public async Task<bool> TryTransitionToInactiveAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        try
+        {
+            var fresh = await _reps.ReadItemAsync<PersonalRepresentative>(
+                rep.Id, new PartitionKey(rep.TenantId));
+
+            if (fresh.Resource.Status != PersonalRepStatus.Active)
+            {
+                return false;
+            }
+
+            var inactivated = fresh.Resource;
+            inactivated.Status = PersonalRepStatus.Inactive;
+            inactivated.InactivationReasonCode = PersonalRepInactivationReasonCode.Expired;
+            inactivated.InactivatedAt = DateTime.UtcNow;
+
+            var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+            await _reps.ReplaceItemAsync(
+                inactivated, inactivated.Id, new PartitionKey(inactivated.TenantId), options);
+
+            await _events.AppendAsync(auditEvent);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            return false;
+        }
+    }
+
+    public async Task AddAssociationPairAsync(
+        PersonalRepAssociation forward,
+        PersonalRepAssociation inverse,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        EnsureSameTenant(forward, inverse);
+
+        // Cosmos TransactionalBatch requires both items to share the
+        // partition key (tenantId). Both pair rows always do — EnsureSameTenant
+        // above is the structural guard.
+        var batch = _associations.CreateTransactionalBatch(new PartitionKey(forward.TenantId))
+            .CreateItem(forward)
+            .CreateItem(inverse);
+
+        using var response = await batch.ExecuteAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CosmosException(
+                $"PersonalRepAssociation pair create failed (pairId={forward.PairId}): {response.ErrorMessage}",
+                response.StatusCode, 0, response.ActivityId, response.RequestCharge);
+        }
+
+        // Post-commit audit append. If this throws, the pair IS persisted
+        // but the audit row is missing — a compliance-visible gap. Log at
+        // Error so operations can reconcile, then rethrow so the caller
+        // sees a 500.
+        try
+        {
+            await _events.AppendAsync(auditEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Personal Rep association pair committed but audit append failed " +
+                "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
+                "Pair persisted; audit row missing — manual reconciliation required.",
+                forward.TenantId, forward.PairId, auditEvent.EventId, auditEvent.CorrelationId);
+            throw;
+        }
+    }
+
+    public async Task RemoveAssociationPairAsync(
+        string tenantId,
+        string pairId,
+        string removedBy,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        // Read both rows first so we can soft-delete both in one batch.
+        var rows = await QueryPairAsync(tenantId, pairId, ct);
+        if (rows.Count == 0) return;
+
+        var now = DateTime.UtcNow;
+        var batch = _associations.CreateTransactionalBatch(new PartitionKey(tenantId));
+        foreach (var row in rows)
+        {
+            row.EffectiveTo ??= now;
+            row.UpdatedAt = now;
+            row.UpdatedBy = removedBy;
+            batch = batch.ReplaceItem(row.Id, row);
+        }
+
+        using var response = await batch.ExecuteAsync(ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CosmosException(
+                $"PersonalRepAssociation pair remove failed (pairId={pairId}): {response.ErrorMessage}",
+                response.StatusCode, 0, response.ActivityId, response.RequestCharge);
+        }
+
+        try
+        {
+            await _events.AppendAsync(auditEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Personal Rep association pair removed but audit append failed " +
+                "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
+                "Pair soft-deleted; audit row missing — manual reconciliation required.",
+                tenantId, pairId, auditEvent.EventId, auditEvent.CorrelationId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForMemberAsync(
+        string tenantId, string memberId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(@"
+                SELECT * FROM c
+                WHERE c.tenantId = @t
+                  AND c.memberId = @m
+                  AND c.direction = @d
+                  AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@m", memberId)
+            .WithParameter("@d", (int)AssociationDirection.MemberToRep);
+
+        var results = await QueryAssociationsAsync(query, tenantId, ct);
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(a =>
+                a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForRepAsync(
+        string tenantId, string repId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(@"
+                SELECT * FROM c
+                WHERE c.tenantId = @t
+                  AND c.repId = @r
+                  AND c.direction = @d
+                  AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@r", repId)
+            .WithParameter("@d", (int)AssociationDirection.RepToMember);
+
+        var results = await QueryAssociationsAsync(query, tenantId, ct);
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(a =>
+                a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+
+        return results;
+    }
+
+    public async Task<PersonalRepAssociation?> FindActiveAssociationAsync(
+        string tenantId, string repId, string memberId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var query = new QueryDefinition(@"
+                SELECT TOP 1 * FROM c
+                WHERE c.tenantId = @t
+                  AND c.repId = @r
+                  AND c.memberId = @m
+                  AND c.direction = @d
+                  AND (NOT IS_DEFINED(c.deletedAt) OR c.deletedAt = null)
+                  AND (NOT IS_DEFINED(c.effectiveTo) OR c.effectiveTo = null OR c.effectiveTo > @now)")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@r", repId)
+            .WithParameter("@m", memberId)
+            .WithParameter("@d", (int)AssociationDirection.RepToMember)
+            .WithParameter("@now", now);
+
+        var results = await QueryAssociationsAsync(query, tenantId, ct);
+        return results.FirstOrDefault();
+    }
+
+    private async Task<List<PersonalRepAssociation>> QueryPairAsync(
+        string tenantId, string pairId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.tenantId = @t AND c.pairId = @p")
+            .WithParameter("@t", tenantId)
+            .WithParameter("@p", pairId);
+        return await QueryAssociationsAsync(query, tenantId, ct);
+    }
+
+    private async Task<List<PersonalRepAssociation>> QueryAssociationsAsync(
+        QueryDefinition query, string tenantId, CancellationToken ct)
+    {
+        var iterator = _associations.GetItemQueryIterator<PersonalRepAssociation>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var results = new List<PersonalRepAssociation>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    private static void EnsureSameTenant(PersonalRepAssociation a, PersonalRepAssociation b)
+    {
+        if (!string.Equals(a.TenantId, b.TenantId, StringComparison.Ordinal))
+        {
+            // Cross-tenant representative portability is intentionally NOT
+            // supported (out-of-scope item 3). Both pair rows must share
+            // the same Cosmos partition key so TransactionalBatch atomicity
+            // holds.
+            throw new InvalidOperationException(
+                "PersonalRepAssociation pair rows must share the same TenantId. " +
+                "Cross-tenant representatives are not supported.");
+        }
+    }
+}

--- a/src/services/personal-representative-service/Repositories/PersonalRepRepositoryMongo.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepRepositoryMongo.cs
@@ -1,0 +1,294 @@
+using PersonalRepresentativeService.Models;
+using MongoDB.Driver;
+using Microsoft.Extensions.Logging;
+
+namespace PersonalRepresentativeService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IPersonalRepRepository"/>.
+///
+/// Association pair writes use a session transaction (replica set required
+/// in non-dev). Multi-document transactions degrade with a helpful error on
+/// standalone deployments — the service refuses to persist a partial pair
+/// rather than silently breaking the symmetric invariant. The audit event
+/// append happens OUTSIDE the transaction (it's a separate collection;
+/// keeping the pair write itself atomic is the primary concern). Four
+/// failure modes are explicitly tested in
+/// <c>PersonalRepAssociationPairAtomicityTests</c>:
+///   1. Tenant mismatch → <see cref="InvalidOperationException"/>, no writes.
+///   2. Forward insert fails inside session → transaction aborts,
+///      inverse rolled back, audit not written.
+///   3. Inverse insert fails inside session → transaction aborts, audit
+///      not written.
+///   4. Pair commits, audit append fails → pair persisted, audit missing,
+///      ILogger.LogError recorded, exception propagates.
+///
+/// The same Mongo "transition + audit isn't fully atomic" caveat from
+/// consent-service applies for <see cref="TransitionStatusAsync"/>: a
+/// crash between the conditional ReplaceOne and the audit append drops a
+/// single audit row. Source of truth is the rep row itself.
+/// </summary>
+public class PersonalRepRepositoryMongo : IPersonalRepRepository
+{
+    public const string PersonalRepsCollectionName = "PersonalRepresentatives";
+    public const string PersonalRepAssociationsCollectionName = "PersonalRepAssociations";
+
+    private readonly IMongoClient _client;
+    private readonly IMongoCollection<PersonalRepresentative> _reps;
+    private readonly IMongoCollection<PersonalRepAssociation> _associations;
+    private readonly IPersonalRepEventSink _events;
+    private readonly ILogger<PersonalRepRepositoryMongo> _logger;
+
+    public PersonalRepRepositoryMongo(
+        IMongoClient client,
+        IMongoDatabase database,
+        IPersonalRepEventSink events,
+        ILogger<PersonalRepRepositoryMongo> logger)
+    {
+        _client = client;
+        _reps = database.GetCollection<PersonalRepresentative>(PersonalRepsCollectionName);
+        _associations = database.GetCollection<PersonalRepAssociation>(PersonalRepAssociationsCollectionName);
+        _events = events;
+        _logger = logger;
+    }
+
+    public async Task<PersonalRepresentative> CreateAsync(
+        PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+    {
+        if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
+        if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
+        await _reps.InsertOneAsync(rep);
+        await _events.AppendAsync(genesisEvent);
+        return rep;
+    }
+
+    public async Task<PersonalRepresentative?> GetByIdAsync(
+        string tenantId, string repId, CancellationToken ct = default)
+    {
+        var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, tenantId)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.Id, repId)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.DeletedAt, (DateTime?)null);
+        return await _reps.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
+        string tenantId, bool activeOnly = false, DateTime? asOf = null, CancellationToken ct = default)
+    {
+        var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, tenantId)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.DeletedAt, (DateTime?)null);
+
+        var results = await _reps.Find(filter)
+            .SortByDescending(r => r.CreatedAt)
+            .ToListAsync(ct);
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(r => r.ObservedStatus(t) == PersonalRepStatus.Active).ToList();
+
+        return results;
+    }
+
+    public async Task<PersonalRepresentative> TransitionStatusAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        if (!auditEvent.FromStatus.HasValue)
+        {
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
+        }
+        var expectedFromStatus = auditEvent.FromStatus.Value;
+
+        var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, rep.TenantId)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.Id, rep.Id)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.Status, expectedFromStatus);
+
+        var replaceResult = await _reps.ReplaceOneAsync(filter, rep);
+        if (replaceResult.MatchedCount == 0)
+        {
+            throw new InvalidPersonalRepTransitionException(expectedFromStatus, rep.Status);
+        }
+
+        await _events.AppendAsync(auditEvent);
+        return rep;
+    }
+
+    public async Task<bool> TryTransitionToInactiveAsync(
+        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+    {
+        var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, rep.TenantId)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.Id, rep.Id)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.Status, PersonalRepStatus.Active);
+
+        var update = Builders<PersonalRepresentative>.Update
+            .Set(r => r.Status, PersonalRepStatus.Inactive)
+            .Set(r => r.InactivationReasonCode, PersonalRepInactivationReasonCode.Expired)
+            .Set(r => r.InactivatedAt, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<PersonalRepresentative>
+        {
+            ReturnDocument = ReturnDocument.After
+        };
+
+        var updated = await _reps.FindOneAndUpdateAsync(filter, update, options);
+        if (updated is null)
+        {
+            return false;
+        }
+
+        await _events.AppendAsync(auditEvent);
+        return true;
+    }
+
+    public async Task AddAssociationPairAsync(
+        PersonalRepAssociation forward,
+        PersonalRepAssociation inverse,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        EnsureSameTenant(forward, inverse);
+
+        // Session transaction: both inserts commit atomically or neither
+        // does. On standalone Mongo (no replica set) StartTransaction
+        // throws — this is intentional; we refuse to persist a partial
+        // pair in an environment that can't guarantee atomicity.
+        using var session = await _client.StartSessionAsync(cancellationToken: ct);
+        session.StartTransaction();
+        try
+        {
+            await _associations.InsertManyAsync(session, new[] { forward, inverse }, cancellationToken: ct);
+            await session.CommitTransactionAsync(ct);
+        }
+        catch
+        {
+            await session.AbortTransactionAsync(ct);
+            throw;
+        }
+
+        try
+        {
+            await _events.AppendAsync(auditEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Personal Rep association pair committed but audit append failed " +
+                "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
+                "Pair persisted; audit row missing — manual reconciliation required.",
+                forward.TenantId, forward.PairId, auditEvent.EventId, auditEvent.CorrelationId);
+            throw;
+        }
+    }
+
+    public async Task RemoveAssociationPairAsync(
+        string tenantId,
+        string pairId,
+        string removedBy,
+        PersonalRepEvent auditEvent,
+        CancellationToken ct = default)
+    {
+        var pairFilter = Builders<PersonalRepAssociation>.Filter.Eq(a => a.TenantId, tenantId)
+                       & Builders<PersonalRepAssociation>.Filter.Eq(a => a.PairId, pairId);
+        var rows = await _associations.Find(pairFilter).ToListAsync(ct);
+        if (rows.Count == 0) return;
+
+        var now = DateTime.UtcNow;
+        using var session = await _client.StartSessionAsync(cancellationToken: ct);
+        session.StartTransaction();
+        try
+        {
+            foreach (var row in rows)
+            {
+                var filter = Builders<PersonalRepAssociation>.Filter.Eq(a => a.Id, row.Id)
+                           & Builders<PersonalRepAssociation>.Filter.Eq(a => a.TenantId, tenantId);
+                var update = Builders<PersonalRepAssociation>.Update
+                    .Set(a => a.EffectiveTo, row.EffectiveTo ?? now)
+                    .Set(a => a.UpdatedAt, now)
+                    .Set(a => a.UpdatedBy, removedBy);
+                await _associations.UpdateOneAsync(session, filter, update, cancellationToken: ct);
+            }
+            await session.CommitTransactionAsync(ct);
+        }
+        catch
+        {
+            await session.AbortTransactionAsync(ct);
+            throw;
+        }
+
+        try
+        {
+            await _events.AppendAsync(auditEvent);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Personal Rep association pair removed but audit append failed " +
+                "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
+                "Pair soft-deleted; audit row missing — manual reconciliation required.",
+                tenantId, pairId, auditEvent.EventId, auditEvent.CorrelationId);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForMemberAsync(
+        string tenantId, string memberId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var filter = Builders<PersonalRepAssociation>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.MemberId, memberId)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.Direction, AssociationDirection.MemberToRep)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.DeletedAt, (DateTime?)null);
+
+        var results = await _associations.Find(filter).ToListAsync(ct);
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(a =>
+                a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<PersonalRepAssociation>> ListAssociationsForRepAsync(
+        string tenantId, string repId, bool activeOnly = false, DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        var filter = Builders<PersonalRepAssociation>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.RepId, repId)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.Direction, AssociationDirection.RepToMember)
+                   & Builders<PersonalRepAssociation>.Filter.Eq(a => a.DeletedAt, (DateTime?)null);
+
+        var results = await _associations.Find(filter).ToListAsync(ct);
+
+        var t = asOf ?? DateTime.UtcNow;
+        if (activeOnly)
+            results = results.Where(a =>
+                a.EffectiveFrom <= t && (a.EffectiveTo == null || a.EffectiveTo > t)).ToList();
+
+        return results;
+    }
+
+    public async Task<PersonalRepAssociation?> FindActiveAssociationAsync(
+        string tenantId, string repId, string memberId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var fb = Builders<PersonalRepAssociation>.Filter;
+        var filter = fb.Eq(a => a.TenantId, tenantId)
+                   & fb.Eq(a => a.RepId, repId)
+                   & fb.Eq(a => a.MemberId, memberId)
+                   & fb.Eq(a => a.Direction, AssociationDirection.RepToMember)
+                   & fb.Eq(a => a.DeletedAt, (DateTime?)null)
+                   & (fb.Eq(a => a.EffectiveTo, (DateTime?)null) | fb.Gt(a => a.EffectiveTo, now));
+        return await _associations.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    private static void EnsureSameTenant(PersonalRepAssociation a, PersonalRepAssociation b)
+    {
+        if (!string.Equals(a.TenantId, b.TenantId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "PersonalRepAssociation pair rows must share the same TenantId. " +
+                "Cross-tenant representatives are not supported.");
+        }
+    }
+}

--- a/src/services/personal-representative-service/Repositories/PersonalRepRepositoryMongo.cs
+++ b/src/services/personal-representative-service/Repositories/PersonalRepRepositoryMongo.cs
@@ -1,4 +1,5 @@
 using PersonalRepresentativeService.Models;
+using PersonalRepresentativeService.Services;
 using MongoDB.Driver;
 using Microsoft.Extensions.Logging;
 
@@ -53,11 +54,11 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
     }
 
     public async Task<PersonalRepresentative> CreateAsync(
-        PersonalRepresentative rep, PersonalRepEvent genesisEvent)
+        PersonalRepresentative rep, PersonalRepEvent genesisEvent, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(rep.Id)) rep.Id = Guid.NewGuid().ToString();
         if (rep.CreatedAt == default) rep.CreatedAt = DateTime.UtcNow;
-        await _reps.InsertOneAsync(rep);
+        await _reps.InsertOneAsync(rep, cancellationToken: ct);
         await _events.AppendAsync(genesisEvent);
         return rep;
     }
@@ -69,6 +70,18 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
                    & Builders<PersonalRepresentative>.Filter.Eq(r => r.Id, repId)
                    & Builders<PersonalRepresentative>.Filter.Eq(r => r.DeletedAt, (DateTime?)null);
         return await _reps.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<PersonalRepresentative>> GetByIdsAsync(
+        string tenantId, IReadOnlyList<string> repIds, CancellationToken ct = default)
+    {
+        if (repIds.Count == 0) return Array.Empty<PersonalRepresentative>();
+
+        var deduped = repIds.Distinct().ToList();
+        var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, tenantId)
+                   & Builders<PersonalRepresentative>.Filter.In(r => r.Id, deduped)
+                   & Builders<PersonalRepresentative>.Filter.Eq(r => r.DeletedAt, (DateTime?)null);
+        return await _reps.Find(filter).ToListAsync(ct);
     }
 
     public async Task<IReadOnlyList<PersonalRepresentative>> ListByTenantAsync(
@@ -89,7 +102,7 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
     }
 
     public async Task<PersonalRepresentative> TransitionStatusAsync(
-        PersonalRepresentative rep, PersonalRepEvent auditEvent)
+        PersonalRepresentative rep, PersonalRepEvent auditEvent, CancellationToken ct = default)
     {
         if (!auditEvent.FromStatus.HasValue)
         {
@@ -103,7 +116,7 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
                    & Builders<PersonalRepresentative>.Filter.Eq(r => r.Id, rep.Id)
                    & Builders<PersonalRepresentative>.Filter.Eq(r => r.Status, expectedFromStatus);
 
-        var replaceResult = await _reps.ReplaceOneAsync(filter, rep);
+        var replaceResult = await _reps.ReplaceOneAsync(filter, rep, cancellationToken: ct);
         if (replaceResult.MatchedCount == 0)
         {
             throw new InvalidPersonalRepTransitionException(expectedFromStatus, rep.Status);
@@ -113,7 +126,7 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
         return rep;
     }
 
-    public async Task<bool> TryTransitionToInactiveAsync(
+    public async Task<PersonalRepresentative?> TryTransitionToInactiveAsync(
         PersonalRepresentative rep, PersonalRepEvent auditEvent)
     {
         var filter = Builders<PersonalRepresentative>.Filter.Eq(r => r.TenantId, rep.TenantId)
@@ -133,11 +146,11 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
         var updated = await _reps.FindOneAndUpdateAsync(filter, update, options);
         if (updated is null)
         {
-            return false;
+            return null;
         }
 
         await _events.AppendAsync(auditEvent);
-        return true;
+        return updated;
     }
 
     public async Task AddAssociationPairAsync(
@@ -175,7 +188,10 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
                 "Personal Rep association pair committed but audit append failed " +
                 "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
                 "Pair persisted; audit row missing — manual reconciliation required.",
-                forward.TenantId, forward.PairId, auditEvent.EventId, auditEvent.CorrelationId);
+                LogSanitizer.SafeForLog(forward.TenantId),
+                LogSanitizer.SafeForLog(forward.PairId),
+                LogSanitizer.SafeForLog(auditEvent.EventId),
+                LogSanitizer.SafeForLog(auditEvent.CorrelationId));
             throw;
         }
     }
@@ -225,7 +241,10 @@ public class PersonalRepRepositoryMongo : IPersonalRepRepository
                 "Personal Rep association pair removed but audit append failed " +
                 "(tenantId={TenantId}, pairId={PairId}, eventId={EventId}, correlationId={CorrelationId}). " +
                 "Pair soft-deleted; audit row missing — manual reconciliation required.",
-                tenantId, pairId, auditEvent.EventId, auditEvent.CorrelationId);
+                LogSanitizer.SafeForLog(tenantId),
+                LogSanitizer.SafeForLog(pairId),
+                LogSanitizer.SafeForLog(auditEvent.EventId),
+                LogSanitizer.SafeForLog(auditEvent.CorrelationId));
             throw;
         }
     }

--- a/src/services/personal-representative-service/Services/IPersonalRepEventPublisher.cs
+++ b/src/services/personal-representative-service/Services/IPersonalRepEventPublisher.cs
@@ -1,0 +1,39 @@
+using PersonalRepresentativeService.Models;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Emits <c>PersonalRepStatusChanged</c> and association events to Kafka.
+/// The DB is source of truth — a Kafka failure is logged but never
+/// propagated.
+/// </summary>
+public interface IPersonalRepEventPublisher
+{
+    /// <summary>
+    /// Publish a <c>PersonalRepStatusChanged</c> event.
+    /// <paramref name="fromStatus"/> is <c>null</c> for the genesis event
+    /// (creation into <c>Draft</c>). Safe to call when Kafka is
+    /// unavailable — failures are logged but never propagated.
+    /// </summary>
+    Task PublishStatusChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepStatus? fromStatus,
+        PersonalRepStatus toStatus,
+        IReadOnlyList<string> associatedMemberIds,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Publish an association-added or association-removed event. No
+    /// encrypted rep fields appear on the payload — the event carries
+    /// <c>personalRepId</c>, <c>memberId</c>, <c>credentialType</c> only.
+    /// </summary>
+    Task PublishAssociationChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepAssociation association,
+        PersonalRepEventType eventType,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+}

--- a/src/services/personal-representative-service/Services/IPersonalRepFieldEncryptor.cs
+++ b/src/services/personal-representative-service/Services/IPersonalRepFieldEncryptor.cs
@@ -1,0 +1,13 @@
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Encrypts and decrypts PHI-adjacent fields on a Personal Representative
+/// record (name, contact, address, relationship notes). Null/empty values
+/// pass through unchanged so partial records — a rep created without a
+/// phone number, for example — do not force spurious ciphertext.
+/// </summary>
+public interface IPersonalRepFieldEncryptor
+{
+    Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default);
+    Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default);
+}

--- a/src/services/personal-representative-service/Services/LogSanitizer.cs
+++ b/src/services/personal-representative-service/Services/LogSanitizer.cs
@@ -1,0 +1,37 @@
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Strips control characters (CR/LF/tab/NUL/etc.) from user-supplied
+/// strings before they go into log messages. CodeQL's
+/// <c>cs/log-forging</c> rule flags any logged value that originates from
+/// request data because a newline in a tenant id, correlation id, or pair
+/// id lets an attacker inject synthetic log entries that corrupt parsing
+/// and triage workflows. All CHO repositories and publishers that log
+/// user-originated fields (<c>TenantId</c>, <c>PersonalRepId</c>,
+/// <c>PairId</c>, <c>EventId</c>, <c>CorrelationId</c>, external error
+/// reasons) MUST route them through <see cref="SafeForLog"/> first.
+///
+/// Kept local to personal-representative-service for now; promotes to
+/// shared infra when a second service needs it.
+/// </summary>
+internal static class LogSanitizer
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> with all control characters replaced
+    /// by <c>?</c>. Truncates to <paramref name="maxLength"/> (default 256)
+    /// so a pathological value cannot blow up log storage or flood the
+    /// downstream log pipeline.
+    /// </summary>
+    public static string SafeForLog(string? value, int maxLength = 256)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var capped = value.Length > maxLength ? value[..maxLength] : value;
+        var chars = capped.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (char.IsControl(chars[i])) chars[i] = '?';
+        }
+        return new string(chars);
+    }
+}

--- a/src/services/personal-representative-service/Services/PersonalRepEncryptionKeyHealthCheck.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepEncryptionKeyHealthCheck.cs
@@ -1,0 +1,62 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Readiness check: verify that the CURRENT Personal Rep encryption key can
+/// be resolved from the secret provider. A missing current key means new
+/// rep writes will fail at encrypt time; surfacing this as a 503 on
+/// <c>/health/ready</c> keeps the service from being rotated into traffic
+/// with a broken encryption path.
+///
+/// Local to personal-representative-service for now. Consent-service is
+/// consumer #2 of RotatingKeyProvider; this is #3. Promotion to shared
+/// infra happens when a fourth service needs the same pattern.
+/// </summary>
+public sealed class PersonalRepEncryptionKeyHealthCheck : IHealthCheck
+{
+    private readonly RotatingKeyProvider _keys;
+    private readonly PersonalRepEncryptionOptions _options;
+
+    public PersonalRepEncryptionKeyHealthCheck(RotatingKeyProvider keys, PersonalRepEncryptionOptions options)
+    {
+        _keys = keys;
+        _options = options;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var key = await _keys.GetKeyAsync(
+                _options.KeySecretPrefix,
+                _options.CurrentKeyVersion,
+                devConfigFallback: null,
+                cancellationToken);
+
+            if (key.Length != 32)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Personal Rep encryption key '{_options.KeySecretPrefix}-{_options.CurrentKeyVersion}' must be 32 bytes (AES-256); got {key.Length}.");
+            }
+
+            return HealthCheckResult.Healthy(
+                $"Current Personal Rep encryption key '{_options.CurrentKeyVersion}' resolved.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Current Personal Rep encryption key '{_options.CurrentKeyVersion}' not resolvable from secret provider.",
+                ex);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Unexpected error resolving Personal Rep encryption key.",
+                ex);
+        }
+    }
+}

--- a/src/services/personal-representative-service/Services/PersonalRepEncryptionOptions.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepEncryptionOptions.cs
@@ -1,0 +1,18 @@
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Config surface for <see cref="PersonalRepFieldEncryptor"/>.
+/// personal-representative-service is a greenfield service — there are no
+/// 0x01 legacy envelopes to decrypt, so the options shape does NOT carry a
+/// <c>LegacyKeySecretName</c>. If a reviewer asks why this differs from
+/// member: member has legacy 0x01 envelopes from before A.7.3;
+/// personal-rep doesn't.
+/// </summary>
+public sealed record PersonalRepEncryptionOptions
+{
+    public const string SectionName = "PersonalRepEncryption";
+
+    public string KeySecretPrefix { get; init; } = "personal-rep-body-encryption-key";
+    public string CurrentKeyVersion { get; init; } = "v1";
+    public IReadOnlyList<string> AcceptedKeyVersions { get; init; } = new[] { "v1" };
+}

--- a/src/services/personal-representative-service/Services/PersonalRepEventPublisher.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepEventPublisher.cs
@@ -117,7 +117,7 @@ public sealed class PersonalRepEventPublisher : IPersonalRepEventPublisher, IHos
         {
             _logger.LogDebug(
                 "Kafka producer unavailable; skipping PersonalRepStatusChanged for rep {PersonalRepId}",
-                rep.Id);
+                LogSanitizer.SafeForLog(rep.Id));
             return;
         }
 
@@ -140,19 +140,21 @@ public sealed class PersonalRepEventPublisher : IPersonalRepEventPublisher, IHos
             await _producer.ProduceAsync(StatusChangedTopic, message, ct);
             _logger.LogInformation(
                 "Published PersonalRepStatusChanged for rep {PersonalRepId} {From}->{To}",
-                rep.Id, fromStatus?.ToString() ?? "(none)", toStatus);
+                LogSanitizer.SafeForLog(rep.Id),
+                fromStatus?.ToString() ?? "(none)", toStatus);
         }
         catch (ProduceException<string, string> ex)
         {
             _logger.LogError(ex,
                 "Failed to publish PersonalRepStatusChanged for rep {PersonalRepId}: {Reason}",
-                rep.Id, ex.Error.Reason);
+                LogSanitizer.SafeForLog(rep.Id),
+                LogSanitizer.SafeForLog(ex.Error.Reason));
         }
         catch (Exception ex)
         {
             _logger.LogError(ex,
                 "Unexpected error publishing PersonalRepStatusChanged for rep {PersonalRepId}",
-                rep.Id);
+                LogSanitizer.SafeForLog(rep.Id));
         }
     }
 
@@ -168,7 +170,9 @@ public sealed class PersonalRepEventPublisher : IPersonalRepEventPublisher, IHos
         {
             _logger.LogDebug(
                 "Kafka producer unavailable; skipping {EventType} for rep {PersonalRepId} member {MemberId}",
-                eventType, rep.Id, association.MemberId);
+                eventType,
+                LogSanitizer.SafeForLog(rep.Id),
+                LogSanitizer.SafeForLog(association.MemberId));
             return;
         }
 
@@ -199,19 +203,24 @@ public sealed class PersonalRepEventPublisher : IPersonalRepEventPublisher, IHos
             await _producer.ProduceAsync(StatusChangedTopic, message, ct);
             _logger.LogInformation(
                 "Published {EventType} for rep {PersonalRepId} member {MemberId}",
-                eventTypeName, rep.Id, association.MemberId);
+                eventTypeName,
+                LogSanitizer.SafeForLog(rep.Id),
+                LogSanitizer.SafeForLog(association.MemberId));
         }
         catch (ProduceException<string, string> ex)
         {
             _logger.LogError(ex,
                 "Failed to publish {EventType} for rep {PersonalRepId}: {Reason}",
-                eventTypeName, rep.Id, ex.Error.Reason);
+                eventTypeName,
+                LogSanitizer.SafeForLog(rep.Id),
+                LogSanitizer.SafeForLog(ex.Error.Reason));
         }
         catch (Exception ex)
         {
             _logger.LogError(ex,
                 "Unexpected error publishing {EventType} for rep {PersonalRepId}",
-                eventTypeName, rep.Id);
+                eventTypeName,
+                LogSanitizer.SafeForLog(rep.Id));
         }
     }
 

--- a/src/services/personal-representative-service/Services/PersonalRepEventPublisher.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepEventPublisher.cs
@@ -1,0 +1,321 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PersonalRepresentativeService.Models;
+using Confluent.Kafka;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Kafka producer for <c>personal-rep.status-changed.v1</c>. Mirrors the
+/// shape of <c>ConsentService.Services.ConsentEventPublisher</c>:
+/// - <see cref="IHostedService"/> + <see cref="IAsyncDisposable"/>.
+/// - Degraded mode when <c>Kafka:BootstrapServers</c> is unset — publish
+///   becomes a no-op; service still boots. DB is the source of truth.
+/// - One topic per aggregate; association events ride the same topic with
+///   a different <c>event-type</c> header.
+/// - Partition key = <c>personalRepId</c> (per-rep ordering preserved).
+/// - Headers: <c>tenant-id</c>, <c>event-type</c>, <c>event-version</c>.
+/// </summary>
+public sealed class PersonalRepEventPublisher : IPersonalRepEventPublisher, IHostedService, IAsyncDisposable
+{
+    public const string StatusChangedTopic = "personal-rep.status-changed.v1";
+    public const string StatusChangedEventType = "PersonalRepStatusChanged";
+    public const string AssociationAddedEventType = "PersonalRepAssociationAdded";
+    public const string AssociationRemovedEventType = "PersonalRepAssociationRemoved";
+    public const string EventVersion = "1.0";
+
+    private readonly ILogger<PersonalRepEventPublisher> _logger;
+    private readonly IConfiguration _configuration;
+    private IProducer<string, string>? _producer;
+    private bool _available;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    public PersonalRepEventPublisher(ILogger<PersonalRepEventPublisher> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var bootstrapServers = _configuration["Kafka:BootstrapServers"];
+        if (string.IsNullOrEmpty(bootstrapServers))
+        {
+            _logger.LogWarning("Kafka:BootstrapServers not configured — Personal Rep event publisher disabled");
+            return Task.CompletedTask;
+        }
+
+        var producerConfig = new ProducerConfig
+        {
+            BootstrapServers = bootstrapServers,
+            ClientId = _configuration["Kafka:ClientId"] ?? "personal-representative-service",
+            MessageTimeoutMs = 10_000,
+            RequestTimeoutMs = 10_000,
+            SocketTimeoutMs = 10_000,
+            EnableIdempotence = true
+        };
+
+        var saslUsername = _configuration["Kafka:SaslUsername"];
+        if (!string.IsNullOrEmpty(saslUsername))
+        {
+            producerConfig.SaslUsername = saslUsername;
+            producerConfig.SaslPassword = _configuration["Kafka:SaslPassword"];
+            producerConfig.SaslMechanism = SaslMechanism.ScramSha512;
+            producerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        }
+
+        try
+        {
+            _producer = new ProducerBuilder<string, string>(producerConfig).Build();
+            _available = true;
+            _logger.LogInformation("Personal Rep event publisher connected to Kafka at {Servers}", bootstrapServers);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Kafka producer init failed — Personal Rep event publisher running in degraded mode");
+            _producer?.Dispose();
+            _producer = null;
+            _available = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _producer?.Flush(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error flushing Kafka producer on shutdown");
+        }
+        _producer?.Dispose();
+        _producer = null;
+        _available = false;
+        return Task.CompletedTask;
+    }
+
+    public async Task PublishStatusChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepStatus? fromStatus,
+        PersonalRepStatus toStatus,
+        IReadOnlyList<string> associatedMemberIds,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        if (!_available || _producer == null)
+        {
+            _logger.LogDebug(
+                "Kafka producer unavailable; skipping PersonalRepStatusChanged for rep {PersonalRepId}",
+                rep.Id);
+            return;
+        }
+
+        var evt = BuildStatusChangedEvent(rep, fromStatus, toStatus, associatedMemberIds, actor, correlationId);
+
+        var message = new Message<string, string>
+        {
+            Key = rep.Id,
+            Value = JsonSerializer.Serialize(evt, JsonOptions),
+            Headers = new Headers
+            {
+                { "tenant-id", Encoding.UTF8.GetBytes(rep.TenantId) },
+                { "event-type", Encoding.UTF8.GetBytes(StatusChangedEventType) },
+                { "event-version", Encoding.UTF8.GetBytes(EventVersion) }
+            }
+        };
+
+        try
+        {
+            await _producer.ProduceAsync(StatusChangedTopic, message, ct);
+            _logger.LogInformation(
+                "Published PersonalRepStatusChanged for rep {PersonalRepId} {From}->{To}",
+                rep.Id, fromStatus?.ToString() ?? "(none)", toStatus);
+        }
+        catch (ProduceException<string, string> ex)
+        {
+            _logger.LogError(ex,
+                "Failed to publish PersonalRepStatusChanged for rep {PersonalRepId}: {Reason}",
+                rep.Id, ex.Error.Reason);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Unexpected error publishing PersonalRepStatusChanged for rep {PersonalRepId}",
+                rep.Id);
+        }
+    }
+
+    public async Task PublishAssociationChangedAsync(
+        PersonalRepresentative rep,
+        PersonalRepAssociation association,
+        PersonalRepEventType eventType,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        if (!_available || _producer == null)
+        {
+            _logger.LogDebug(
+                "Kafka producer unavailable; skipping {EventType} for rep {PersonalRepId} member {MemberId}",
+                eventType, rep.Id, association.MemberId);
+            return;
+        }
+
+        var eventTypeName = eventType switch
+        {
+            PersonalRepEventType.PersonalRepAssociationAdded => AssociationAddedEventType,
+            PersonalRepEventType.PersonalRepAssociationRemoved => AssociationRemovedEventType,
+            _ => throw new ArgumentException(
+                $"PublishAssociationChangedAsync does not accept {eventType}", nameof(eventType))
+        };
+
+        var evt = BuildAssociationChangedEvent(rep, association, eventTypeName, actor, correlationId);
+
+        var message = new Message<string, string>
+        {
+            Key = rep.Id,
+            Value = JsonSerializer.Serialize(evt, JsonOptions),
+            Headers = new Headers
+            {
+                { "tenant-id", Encoding.UTF8.GetBytes(rep.TenantId) },
+                { "event-type", Encoding.UTF8.GetBytes(eventTypeName) },
+                { "event-version", Encoding.UTF8.GetBytes(EventVersion) }
+            }
+        };
+
+        try
+        {
+            await _producer.ProduceAsync(StatusChangedTopic, message, ct);
+            _logger.LogInformation(
+                "Published {EventType} for rep {PersonalRepId} member {MemberId}",
+                eventTypeName, rep.Id, association.MemberId);
+        }
+        catch (ProduceException<string, string> ex)
+        {
+            _logger.LogError(ex,
+                "Failed to publish {EventType} for rep {PersonalRepId}: {Reason}",
+                eventTypeName, rep.Id, ex.Error.Reason);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Unexpected error publishing {EventType} for rep {PersonalRepId}",
+                eventTypeName, rep.Id);
+        }
+    }
+
+    /// <summary>
+    /// Internal for test visibility. The PHI-adjacent free-text fields
+    /// (names, contact, address, notes) are deliberately excluded from the
+    /// event payload — they stay encrypted at rest on the rep aggregate,
+    /// never on the wire. A field-whitelist test enforces this.
+    /// </summary>
+    internal static PersonalRepStatusChangedEventPayload BuildStatusChangedEvent(
+        PersonalRepresentative rep,
+        PersonalRepStatus? fromStatus,
+        PersonalRepStatus toStatus,
+        IReadOnlyList<string> associatedMemberIds,
+        string actor,
+        string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = StatusChangedEventType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = rep.TenantId,
+        PersonalRepId = rep.Id,
+        CredentialType = rep.CredentialType.ToString(),
+        FromStatus = fromStatus?.ToString(),
+        ToStatus = toStatus.ToString(),
+        EffectiveFrom = rep.EffectiveFrom,
+        EffectiveTo = rep.EffectiveTo,
+        ExpiresAt = rep.ExpiresAt,
+        AssociatedMemberIds = associatedMemberIds.ToList(),
+        Actor = actor,
+        CorrelationId = correlationId,
+        InactivationReasonCode = rep.InactivationReasonCode?.ToString()
+    };
+
+    internal static PersonalRepAssociationChangedEventPayload BuildAssociationChangedEvent(
+        PersonalRepresentative rep,
+        PersonalRepAssociation association,
+        string eventTypeName,
+        string actor,
+        string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = eventTypeName,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = rep.TenantId,
+        PersonalRepId = rep.Id,
+        MemberId = association.MemberId,
+        CredentialType = association.CredentialType.ToString(),
+        EffectiveFrom = association.EffectiveFrom,
+        EffectiveTo = association.EffectiveTo,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None);
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>
+/// Wire payload for <c>PersonalRepStatusChanged</c>. Field-whitelist tested
+/// so no PHI-adjacent field can silently leak onto the event stream.
+/// </summary>
+public sealed record PersonalRepStatusChangedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string PersonalRepId { get; init; } = string.Empty;
+    public string CredentialType { get; init; } = string.Empty;
+    public string? FromStatus { get; init; }
+    public string ToStatus { get; init; } = string.Empty;
+    public DateTime? EffectiveFrom { get; init; }
+    public DateTime? EffectiveTo { get; init; }
+    public DateTime? ExpiresAt { get; init; }
+    public List<string> AssociatedMemberIds { get; init; } = new();
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+    public string? InactivationReasonCode { get; init; }
+}
+
+/// <summary>
+/// Wire payload for <c>PersonalRepAssociationAdded</c> /
+/// <c>PersonalRepAssociationRemoved</c>. Same field-whitelist test
+/// treatment — no encrypted rep fields.
+/// </summary>
+public sealed record PersonalRepAssociationChangedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string PersonalRepId { get; init; } = string.Empty;
+    public string MemberId { get; init; } = string.Empty;
+    public string CredentialType { get; init; } = string.Empty;
+    public DateTime EffectiveFrom { get; init; }
+    public DateTime? EffectiveTo { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}

--- a/src/services/personal-representative-service/Services/PersonalRepFieldEncryptor.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepFieldEncryptor.cs
@@ -1,0 +1,177 @@
+using System.Security.Cryptography;
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// AES-256-GCM encryptor for Personal Representative body fields. Sibling
+/// of <c>ConsentService.Services.ConsentFieldEncryptor</c> with the same
+/// 0x02 envelope format. personal-rep-service is greenfield — there is NO
+/// 0x01 legacy envelope path. Only 0x02 envelopes are read and written.
+///
+/// Envelope format (base64url of):
+///   0x02: [0x02][keyVerLen=1 byte][keyVer UTF-8 bytes][12 IV][16 tag][ciphertext]
+/// </summary>
+public sealed class PersonalRepFieldEncryptor : IPersonalRepFieldEncryptor
+{
+    private const byte FormatV2 = 0x02;
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+
+    private readonly RotatingKeyProvider _keys;
+    private readonly ILogger<PersonalRepFieldEncryptor> _logger;
+    private readonly PersonalRepEncryptionOptions _options;
+
+    public PersonalRepFieldEncryptor(
+        RotatingKeyProvider keys,
+        ILogger<PersonalRepFieldEncryptor> logger,
+        PersonalRepEncryptionOptions options)
+    {
+        _keys = keys;
+        _logger = logger;
+        _options = options;
+
+        if (string.IsNullOrWhiteSpace(options.KeySecretPrefix))
+            throw new ArgumentException("KeySecretPrefix is required", nameof(options));
+        if (string.IsNullOrWhiteSpace(options.CurrentKeyVersion))
+            throw new ArgumentException("CurrentKeyVersion is required", nameof(options));
+        if (options.AcceptedKeyVersions.Count == 0)
+            throw new ArgumentException("AcceptedKeyVersions must contain at least one entry", nameof(options));
+    }
+
+    public async Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return plaintext;
+
+        var keyVersion = _options.CurrentKeyVersion;
+        var keyVersionBytes = Encoding.UTF8.GetBytes(keyVersion);
+        if (keyVersionBytes.Length == 0 || keyVersionBytes.Length > 255)
+            throw new InvalidOperationException(
+                $"PersonalRepEncryption:CurrentKeyVersion '{keyVersion}' must be 1..255 UTF-8 bytes.");
+
+        var key = await ResolveKeyAsync(keyVersion, ct);
+        EnsureKeyLength(key);
+
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var cipherBytes = new byte[plainBytes.Length];
+        var tag = new byte[TagSize];
+
+        using (var gcm = new AesGcm(key, TagSize))
+        {
+            gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+        }
+
+        var envelope = new byte[1 + 1 + keyVersionBytes.Length + NonceSize + TagSize + cipherBytes.Length];
+        var o = 0;
+        envelope[o++] = FormatV2;
+        envelope[o++] = (byte)keyVersionBytes.Length;
+        Buffer.BlockCopy(keyVersionBytes, 0, envelope, o, keyVersionBytes.Length); o += keyVersionBytes.Length;
+        Buffer.BlockCopy(nonce, 0, envelope, o, NonceSize); o += NonceSize;
+        Buffer.BlockCopy(tag, 0, envelope, o, TagSize); o += TagSize;
+        Buffer.BlockCopy(cipherBytes, 0, envelope, o, cipherBytes.Length);
+
+        return Base64UrlEncode(envelope);
+    }
+
+    public async Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(ciphertext)) return ciphertext;
+
+        byte[] envelope;
+        try
+        {
+            envelope = Base64UrlDecode(ciphertext);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogWarning(ex, "Personal Rep ciphertext is not valid base64url");
+            throw new CryptographicException("Personal Rep ciphertext is not valid base64url", ex);
+        }
+
+        if (envelope.Length < 1)
+            throw new CryptographicException("Envelope is empty");
+
+        if (envelope[0] != FormatV2)
+            throw new CryptographicException($"Unsupported envelope version 0x{envelope[0]:X2}");
+
+        if (envelope.Length < 1 + 1) throw new CryptographicException("0x02 envelope too short");
+        int keyVerLen = envelope[1];
+        var headerLen = 1 + 1 + keyVerLen;
+        if (envelope.Length < headerLen + NonceSize + TagSize)
+            throw new CryptographicException("0x02 envelope too short for key-version + IV + tag");
+
+        var keyVersion = Encoding.UTF8.GetString(envelope, 2, keyVerLen);
+
+        if (!_options.AcceptedKeyVersions.Contains(keyVersion, StringComparer.OrdinalIgnoreCase))
+            throw new CryptographicException(
+                $"Envelope key version '{keyVersion}' is not in PersonalRepEncryption:AcceptedKeyVersions. " +
+                "Either widen the accepted window or re-encrypt the record.");
+
+        var key = await ResolveKeyAsync(keyVersion, ct);
+        EnsureKeyLength(key);
+
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipherLen = envelope.Length - headerLen - NonceSize - TagSize;
+        var cipherBytes = new byte[cipherLen];
+        Buffer.BlockCopy(envelope, headerLen, nonce, 0, NonceSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize, tag, 0, TagSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize + TagSize, cipherBytes, 0, cipherLen);
+
+        var plainBytes = new byte[cipherLen];
+        using var gcm = new AesGcm(key, TagSize);
+        gcm.Decrypt(nonce, cipherBytes, tag, plainBytes);
+        return Encoding.UTF8.GetString(plainBytes);
+    }
+
+    private async Task<byte[]> ResolveKeyAsync(string version, CancellationToken ct)
+    {
+        try
+        {
+            return await _keys.GetKeyAsync(_options.KeySecretPrefix, version, devConfigFallback: null, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new StaleEncryptionKeyException(version,
+                $"Key version '{version}' cannot be resolved from the secret provider. " +
+                "Publish the secret or drop the version from AcceptedKeyVersions.",
+                ex);
+        }
+    }
+
+    private static void EnsureKeyLength(byte[] key)
+    {
+        if (key.Length != 32)
+            throw new InvalidOperationException(
+                $"Personal Rep encryption key must be 32 bytes (AES-256); got {key.Length}.");
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string s)
+    {
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+}
+
+/// <summary>
+/// Dev-only passthrough. Used when <see cref="PersonalRepEncryptionOptions"/>
+/// is not configured and the host is <c>IsDevelopment</c>. A non-dev startup
+/// with no <c>PersonalRepEncryption</c> section throws in <c>Program.cs</c>
+/// rather than falling back to plaintext.
+/// </summary>
+public sealed class NoOpPersonalRepFieldEncryptor : IPersonalRepFieldEncryptor
+{
+    public Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default) => Task.FromResult(plaintext);
+    public Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default) => Task.FromResult(ciphertext);
+}

--- a/src/services/personal-representative-service/Services/PersonalRepStateMachine.cs
+++ b/src/services/personal-representative-service/Services/PersonalRepStateMachine.cs
@@ -1,0 +1,62 @@
+using PersonalRepresentativeService.Models;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Pure transition validator. No side effects — callers assemble the
+/// <see cref="PersonalRepEvent"/> themselves and pass the (rep, new-status,
+/// event) triple to the repository, which enforces atomicity.
+///
+/// Allowed transitions:
+///   (none) -> Draft
+///   Draft  -> Active
+///   Draft  -> Inactive   (revoke before activation)
+///   Active -> Inactive   (revoke, expiry, guardianship ended, etc.)
+///
+/// Rejected:
+///   Inactive -> anything           (terminal)
+///   Active   -> Active             (idempotent no-op at controller, NOT a transition)
+///   Draft    -> Draft              (idempotent no-op)
+///   Active   -> Draft              (backwards)
+/// </summary>
+/// <remarks>
+/// Divergence from ConsentStateMachine: consent models Expired as a distinct
+/// terminal status because consent has exactly two termination reasons
+/// (Revoked, Expired) and promoting both to status is cheap. PersonalRep has
+/// five+ inactivation reasons (RepDeceased, PoaRevoked, GuardianshipEnded,
+/// Expired, AdminError, Other) and promoting one of them to a status would
+/// be arbitrary. We keep the status enum lean (Draft/Active/Inactive) and
+/// carry the discriminator on <see cref="PersonalRepInactivationReasonCode"/>.
+/// Reviewers coming from consent-service: this is deliberate, not an
+/// oversight.
+///
+/// TODO(review-workflow-followup): Multi-step approval ("legal review
+/// pending", "awaiting notary verification") is not in this state machine.
+/// When a review workflow lands, it joins between Draft and Active as a
+/// new state.
+/// </remarks>
+public static class PersonalRepStateMachine
+{
+    /// <summary>Pure check — does NOT throw. Returns true iff the transition is legal.</summary>
+    public static bool IsAllowed(PersonalRepStatus from, PersonalRepStatus to) =>
+        (from, to) switch
+        {
+            (PersonalRepStatus.Draft,  PersonalRepStatus.Active)   => true,
+            (PersonalRepStatus.Draft,  PersonalRepStatus.Inactive) => true,
+            (PersonalRepStatus.Active, PersonalRepStatus.Inactive) => true,
+            _ => false
+        };
+
+    /// <summary>
+    /// Validate a transition. Throws
+    /// <see cref="InvalidPersonalRepTransitionException"/> if the transition
+    /// is not allowed. Repositories and controllers call this BEFORE
+    /// persisting; the same check is repeated by the repository's
+    /// conditional write to close a TOCTOU window.
+    /// </summary>
+    public static void EnsureAllowed(PersonalRepStatus from, PersonalRepStatus to)
+    {
+        if (!IsAllowed(from, to))
+            throw new InvalidPersonalRepTransitionException(from, to);
+    }
+}

--- a/src/services/personal-representative-service/Services/StaleEncryptionKeyException.cs
+++ b/src/services/personal-representative-service/Services/StaleEncryptionKeyException.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+
+namespace PersonalRepresentativeService.Services;
+
+/// <summary>
+/// Thrown when an envelope references a key version that is listed in the
+/// service's <c>AcceptedKeyVersions</c> window but whose underlying secret
+/// cannot be resolved from the
+/// <see cref="CloudHealthOffice.Infrastructure.Configuration.ISecretProvider"/>.
+/// Distinct from a plain <see cref="CryptographicException"/> (which
+/// indicates tampered ciphertext or the wrong key) so that callers can
+/// distinguish "rotation migration failure — page ops" from "possible
+/// tamper — audit the caller".
+/// </summary>
+public sealed class StaleEncryptionKeyException : CryptographicException
+{
+    public string KeyVersion { get; }
+
+    public StaleEncryptionKeyException(string keyVersion, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        KeyVersion = keyVersion;
+    }
+}

--- a/src/services/personal-representative-service/appsettings.Development.json
+++ b/src/services/personal-representative-service/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/services/personal-representative-service/appsettings.json
+++ b/src/services/personal-representative-service/appsettings.json
@@ -1,0 +1,33 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Authentication": {
+    "Authority": "https://yourtenant.b2clogin.com/yourtenant.onmicrosoft.com/v2.0/",
+    "Audience": "api://personal-representative-service"
+  },
+  "CosmosDb": {
+    "DatabaseName": "CloudHealthOffice"
+  },
+  "MongoDb": {
+    "DatabaseName": "CloudHealthOffice"
+  },
+  "PersonalRepEncryption": {
+    "KeySecretPrefix": "personal-rep-body-encryption-key",
+    "CurrentKeyVersion": "v1",
+    "AcceptedKeyVersions": [ "v1" ]
+  },
+  "Kafka": {
+    "BootstrapServers": "",
+    "ClientId": "personal-representative-service"
+  },
+  "Observability": {
+    "ServiceName": "personal-representative-service",
+    "OtlpEndpoint": "http://otel-collector:4317",
+    "EnableConsole": false
+  }
+}

--- a/src/services/personal-representative-service/k8s/personal-representative-service-deployment.yaml
+++ b/src/services/personal-representative-service/k8s/personal-representative-service-deployment.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: personal-representative-service-config
+  namespace: cloudhealthoffice
+data:
+  ASPNETCORE_ENVIRONMENT: "Production"
+  MongoDb__DatabaseName: "cloudhealthoffice"
+  PersonalRepEncryption__KeySecretPrefix: "personal-rep-body-encryption-key"
+  PersonalRepEncryption__CurrentKeyVersion: "v1"
+  PersonalRepEncryption__AcceptedKeyVersions__0: "v1"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: personal-representative-service
+  namespace: cloudhealthoffice
+  labels:
+    app: personal-representative-service
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: personal-representative-service
+  template:
+    metadata:
+      labels:
+        app: personal-representative-service
+        tier: backend
+    spec:
+      containers:
+      - name: personal-representative-service
+        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-personal-representative-service:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: personal-representative-service-config
+              key: ASPNETCORE_ENVIRONMENT
+        - name: MongoDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: database-secret
+              key: connectionString
+        - name: MongoDb__DatabaseName
+          valueFrom:
+            configMapKeyRef:
+              name: personal-representative-service-config
+              key: MongoDb__DatabaseName
+        - name: PersonalRepEncryption__KeySecretPrefix
+          valueFrom:
+            configMapKeyRef:
+              name: personal-representative-service-config
+              key: PersonalRepEncryption__KeySecretPrefix
+        - name: PersonalRepEncryption__CurrentKeyVersion
+          valueFrom:
+            configMapKeyRef:
+              name: personal-representative-service-config
+              key: PersonalRepEncryption__CurrentKeyVersion
+        - name: Kafka__BootstrapServers
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: bootstrapServers
+              optional: true
+        - name: Kafka__SaslUsername
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: saslUsername
+              optional: true
+        - name: Kafka__SaslPassword
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: saslPassword
+              optional: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: personal-representative-service
+  namespace: cloudhealthoffice
+  labels:
+    app: personal-representative-service
+spec:
+  type: ClusterIP
+  selector:
+    app: personal-representative-service
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/src/services/personal-representative-service/personal-representative-service.csproj
+++ b/src/services/personal-representative-service/personal-representative-service.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>PersonalRepresentativeService</RootNamespace>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="PersonalRepresentativeService.Tests/**" />
+    <Content Remove="PersonalRepresentativeService.Tests/**" />
+    <None Remove="PersonalRepresentativeService.Tests/**" />
+    <EmbeddedResource Remove="PersonalRepresentativeService.Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="PersonalRepresentativeService.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

**CHO's 36th microservice** — a platform milestone.

Records 45 CFR §164.502(g) Personal Representative delegations (parent of a minor, court-appointed legal guardian, holder of a healthcare POA, healthcare surrogate) with an append-only audit trail, field-level encryption, symmetric-pair member associations, and Kafka lifecycle events.

Closes the `GrantedBy` TODO seam from consent-service (#674). **Resolver endpoint ships here; consent→personal-rep wiring is a follow-on PR.**

## Pattern lineage

- Mirrors **consent-service** one-for-one: directory tree, Program.cs composition, dual-repo shape (Cosmos + Mongo), state machine, audit-trail invariant, field encryption (0x02 envelope via `RotatingKeyProvider`), Kafka degraded mode, health check, `WebApplicationFactory<Program>` smoke tests.
- Adopts **FamilyRelationship**'s atomic-pair-write pattern for member associations (Cosmos `TransactionalBatch`, Mongo session transaction, both-or-neither invariant).

## What's in

### Domain & API
- `PersonalRepresentative` aggregate (Draft / Active / Inactive) with `PersonalRepInactivationReasonCode` discriminator
- `PersonalRepAssociation` — symmetric pair with explicit `RepId` + `MemberId` + `Direction` enum (no polymorphic id)
- `PersonalRepEvent` — append-only audit trail
- `PersonalRepresentativesController` — POST/GET/history/activate/revoke/associations
- `MemberRepresentativesController` — `GET /api/v1/members/{memberId}/personal-representatives[/active]` lightweight-summary resolver
- Kafka topic: `personal-rep.status-changed.v1` (status + association events, field-whitelist tested)

### Infrastructure
- `PersonalRepFieldEncryptor` — 0x02-only envelope (greenfield, no 0x01 legacy path). Keys: `personal-rep-body-encryption-key-v*`.
- `PersonalRepEncryptionKeyHealthCheck` local to the service (consumer #3 of `RotatingKeyProvider`; promotion to shared infra deferred to consumer #4)
- `PersonalRepIndexInitializer` — Mongo indexes (tenant/rep/direction, pair, event idempotency)

### Tests (60 passing, 0 failing, 0 skipped)
- State-machine exhaustive matrix (3×3)
- Controller tests — cross-tenant 404, idempotent activate/revoke, 409 on race-lost transitions
- Resolver tests — `displayName` goes through standard `DecryptAsync` (no shortcut), lightweight-summary shape locked down via reflection, `asOf`/credential-type filters
- `PersonalRepAssociationPairAtomicityTests` — **the four enumerated Mongo pair-write failure modes each have a dedicated test**, including the "accepted audit gap" case (mode 4) which asserts the failure is observable via `LogError`, not silent
- `PersonalRepFieldEncryptorTests` — round-trip, rotation, stale-key, tampered-ciphertext, wrong-envelope-version
- `PersonalRepEventPublisherTests` — field-whitelist guard on both payload shapes; topic/header contract locked
- `PersonalRepLifecycleSmokeTests` — full 6-event integration over real Program pipeline (Create → Assoc(M1) → Assoc(M2) → Activate → Unassoc(M1) → Revoke)
- `PersonalRepEncryptionKeyHealthCheckTests` — healthy / missing / wrong-length

## Deliberate divergences from consent-service

### 3-state (Draft/Active/Inactive) vs consent's 4-state
Personal Rep has 5+ inactivation reasons (`RepDeceased`, `PoaRevoked`, `GuardianshipEnded`, `Expired`, `AdminError`, `Other`). Promoting one to a distinct status would be arbitrary, so termination reasons are carried on `PersonalRepInactivationReasonCode` instead. Documented at class level on [PersonalRepStateMachine.cs](src/services/personal-representative-service/Services/PersonalRepStateMachine.cs) so reviewers coming from consent-service see the reasoning.

As a consequence: `Revoke` after read-time expiry is **idempotent 200**, not 409 — `InactivationReasonCode` stays `Expired` rather than being overwritten by `PoaRevoked`. Covered by [`Revoke_AfterExpired_IsIdempotentAndPreservesInactivationReason`](src/services/personal-representative-service/PersonalRepresentativeService.Tests/Controllers/PersonalRepresentativesControllerTests.cs).

### Resolver is a lightweight summary, not full record
`GET /api/v1/members/{memberId}/personal-representatives/active` returns `PersonalRepSummary` (id, credentialType, status, dates, `displayName` = first + last only, doc id). Mailing address, phone, notes, email are **not** in this shape — a reflection-based test locks this down. Full decrypted record requires `GET /api/v1/personal-representatives/{repId}`.

### Association model
Explicit `RepId` + `MemberId` + `Direction` (`RepToMember` / `MemberToRep`) instead of a polymorphic `SubjectId`/`SubjectKind` pattern. Every field means the same thing on both pair rows; the direction discriminator says which lookup index the row is for. Queries are honest about what they're asking.

## Confirm with legal before merge

- **Texas-specific: does Texas Medicaid treat `Conservator` and `LegalGuardian` as functionally equivalent for healthcare decision authority, or are there scenarios where the distinction matters?** We've modeled them as distinct enum values (conservator = financial authority, legal guardian = personal/healthcare authority per general probate law), but in some jurisdictions the appointments overlap. If legal confirms equivalence, we can deprecate `Conservator` in a follow-up and migrate existing records. Splitting a merged enum value is harder than merging two — defaulting to distinct.
- **`HealthcareSurrogate` vs "healthcare agent"** — state statute naming varies (Florida Ch. 765 uses "surrogate", Texas uses "agent"). Defaulting to `HealthcareSurrogate` as the umbrella term; legal should confirm this is acceptable.
- **Minor-consent interaction (Tex. Fam. Code §32.003 et seq.)** — explicitly NOT modeled here. A `Parent` credential type exists, but "a 15-year-old consenting for confidential services without a representative" is application-layer logic that belongs in consent-service or the clinical workflow. Flagged as out-of-scope (item 6 below) with a TODO at the enum value.

## NOT in this PR (deferred)

1. POA signature / notarization verification — `ProofOfAuthorityDocumentId` is a pointer; bytes live in member-document-service. TODO at [PersonalRepresentative.cs](src/services/personal-representative-service/Models/PersonalRepresentative.cs).
2. Multi-step approval workflows — no `PendingReview` state. TODO at [PersonalRepStateMachine.cs](src/services/personal-representative-service/Services/PersonalRepStateMachine.cs).
3. Cross-tenant representative portability — `EnsureSameTenant` guard explicitly rejects.
4. Wiring consent-service's `GrantedBy` → resolver. TODO at [MemberRepresentativesController.cs](src/services/personal-representative-service/Controllers/MemberRepresentativesController.cs).
5. Portal UI — API-only.
6. Minor-consent logic (Tex. Fam. Code §32.003) — belongs in consent-service / clinical workflow.
7. Appeals integration — lands with appeals-service modernization.
8. FHIR R4 `RelatedPerson` projection — belongs in fhir-service.

## Deployment note

**This service needs `personal-rep-body-encryption-key-v1` provisioned in Key Vault before first deployment.** In non-dev environments, startup will throw if `PersonalRepEncryption` is unconfigured (same guard as consent-service).

Provisioning via `rotate-secret.sh`:

```bash
./scripts/ops/rotate-secret.sh \
  --vault <keyvault-name> \
  --name personal-rep-body-encryption-key-v1 \
  --generate aes256
```

(Substitute the actual vault name for the target environment.)

## Consumers to wire in follow-up PRs

- **consent-service** `GrantedBy` resolution → `GET /api/v1/members/{memberId}/personal-representatives/active`
- **appeals-service** (when it modernizes) — rep lookups for appeal submission authority
- **fhir-service** — FHIR R4 `RelatedPerson` projection

## Test plan

- [x] All 60 unit/integration tests pass locally (`dotnet test` against net8)
- [x] Builds clean with zero warnings/errors
- [x] Degraded-mode publisher startup verified (empty Kafka bootstrap → no-op)
- [x] Field-whitelist guard tests confirm no encrypted fields leak to Kafka
- [ ] CI: build + test-dotnet
- [ ] CI: deploy-azure-aks (after Key Vault secret provisioning)
- [ ] Legal sign-off on credential enum values before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)