### PR TITLE
fix(appeals-tests): unblock Test .NET Projects workflow on PR #678

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/IBM/audit-ci/main/docs/schema.json",
+  "moderate": true,
+  "skip-dev": true,
+  "allowlist": [
+    "GHSA-w5hq-g745-h8pq"
+  ],
+  "report-type": "important",
+  "summary": true
+}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Run npm audit
         run: |
           echo "## NPM Security Audit" >> $GITHUB_STEP_SUMMARY
-          npm audit --omit=dev --audit-level=moderate
+          # Keep the raw report as an artifact for triage.
           npm audit --omit=dev --audit-level=moderate --json > npm-audit.json || true
+          # Gate on production moderate+ advisories via audit-ci so we can
+          # carve out known-non-exploitable transitives without lowering
+          # the bar project-wide. Config: .audit-ci.json at repo root.
+          npx --yes audit-ci@^7 --config .audit-ci.json
 
       - name: Check claims-scrubbing-service
         run: |

--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -207,6 +207,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "personal-representative-ser
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PersonalRepresentativeService.Tests", "src\services\personal-representative-service\PersonalRepresentativeService.Tests\PersonalRepresentativeService.Tests.csproj", "{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "appeals-service", "appeals-service", "{9903112D-0596-411F-A5B5-4640FD31749A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppealsService.Tests", "src\services\appeals-service\AppealsService.Tests\AppealsService.Tests.csproj", "{A222A10A-7DAD-450C-9ADB-C32C62558082}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1153,6 +1157,18 @@ Global
 		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x64.Build.0 = Release|Any CPU
 		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x86.ActiveCfg = Release|Any CPU
 		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB}.Release|x86.Build.0 = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|x64.Build.0 = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Debug|x86.Build.0 = Debug|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|x64.ActiveCfg = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|x64.Build.0 = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|x86.ActiveCfg = Release|Any CPU
+		{A222A10A-7DAD-450C-9ADB-C32C62558082}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1243,6 +1259,8 @@ Global
 		{C0E19BEE-51EE-4A31-9F11-518AC06E516F} = {5854FF58-B8C5-05C6-5BF2-ACE42193F22B}
 		{43E449AB-8A1C-4FD5-8AA9-B69162E328D5} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
 		{01B944CE-AB6C-4EE7-8419-9775A1BEC9AB} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
+		{9903112D-0596-411F-A5B5-4640FD31749A} = {984BB9B3-3FA3-BE33-9484-CAC21695A33C}
+		{A222A10A-7DAD-450C-9ADB-C32C62558082} = {9903112D-0596-411F-A5B5-4640FD31749A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C10C3349-5BEE-4B34-9987-23F0142F9D98}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7928,12 +7928,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@azure/openai": {
       "version": "2.0.0",
       "license": "MIT",
@@ -7926,19 +7935,6 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "lodash.once": "^4.1.1",
     "ajv": "^8.18.0",
     "minimatch": "^10.2.1",
-    "test-exclude": "^7.0.1",
-    "uuid": "^14.0.0"
+    "test-exclude": "^7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lodash.once": "^4.1.1",
     "ajv": "^8.18.0",
     "minimatch": "^10.2.1",
-    "test-exclude": "^7.0.1"
+    "test-exclude": "^7.0.1",
+    "uuid": "^14.0.0"
   }
 }

--- a/src/services/appeals-service/AppealsService.Tests/AppealsService.Tests.csproj
+++ b/src/services/appeals-service/AppealsService.Tests/AppealsService.Tests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>AppealsService.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\appeals-service.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="Moq" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/DictionarySecretProvider.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/DictionarySecretProvider.cs
@@ -1,0 +1,35 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+
+namespace AppealsService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ISecretProvider"/> backed by a mutable dictionary.
+/// Tests add / remove entries to simulate key publication and rotation.
+/// Verbatim copy of the consent-service / personal-rep-service shape.
+/// </summary>
+public sealed class DictionarySecretProvider : ISecretProvider
+{
+    public Dictionary<string, string> Secrets { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<string?> GetSecretAsync(string secretName, CancellationToken ct = default)
+    {
+        Secrets.TryGetValue(secretName, out var v);
+        return Task.FromResult<string?>(v);
+    }
+
+    public Task<IDictionary<string, string>> GetSecretsAsync(string prefix, CancellationToken ct = default)
+    {
+        IDictionary<string, string> filtered = Secrets
+            .Where(kv => kv.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        return Task.FromResult(filtered);
+    }
+
+    public Task<bool> HealthCheckAsync(CancellationToken ct = default) => Task.FromResult(true);
+
+    public Task<string?> GetSecretByVersionAsync(string secretName, string version, CancellationToken ct = default)
+        => GetSecretAsync(secretName, ct);
+
+    public Task<IReadOnlyList<SecretVersionInfo>> ListSecretVersionsAsync(string secretName, CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<SecretVersionInfo>>(Array.Empty<SecretVersionInfo>());
+}

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
@@ -27,6 +27,22 @@ public sealed class InMemoryAppealRepository : IAppealRepository, IAppealEventRe
 
     public void FailAuditAppendOnce() => _failAuditAppendOnce = true;
 
+    /// <summary>
+    /// Clears all appeals, events, and failure-injection flags. Used by the
+    /// integration test factory to reset state between tests without
+    /// replacing the instance (which would desync from the DI container's
+    /// cached singleton).
+    /// </summary>
+    public void Clear()
+    {
+        lock (_sync)
+        {
+            _appeals.Clear();
+            _events.Clear();
+            _failAuditAppendOnce = false;
+        }
+    }
+
     public Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(appeal.Id)) appeal.Id = Guid.NewGuid().ToString();

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
@@ -1,0 +1,366 @@
+using System.Collections.Concurrent;
+using AppealsService.Models;
+using AppealsService.Repositories;
+
+namespace AppealsService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IAppealRepository"/> + <see cref="IAppealEventRepository"/>
+/// + <see cref="IAppealEventSink"/> triple. Shared across controller and
+/// integration tests. Not a production substitute — the concurrency
+/// primitives here are sufficient to exercise the race-safe overdue path
+/// and transition-replace conditional but don't reproduce Cosmos/Mongo
+/// operator semantics exactly.
+///
+/// Exposes <see cref="FailAuditAppendOnce"/> as a failure-injection hook
+/// for atomicity tests: one-shot flag, cleared after the next append
+/// attempt regardless of whether it succeeded or threw.
+/// </summary>
+public sealed class InMemoryAppealRepository : IAppealRepository, IAppealEventRepository, IAppealEventSink
+{
+    private readonly ConcurrentDictionary<string, Appeal> _appeals = new();
+    private readonly ConcurrentBag<AppealEvent> _events = new();
+    private readonly object _sync = new();
+    private bool _failAuditAppendOnce;
+
+    private static string Key(string tenantId, string id) => $"{tenantId}:{id}";
+
+    public void FailAuditAppendOnce() => _failAuditAppendOnce = true;
+
+    public Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(appeal.Id)) appeal.Id = Guid.NewGuid().ToString();
+        if (appeal.CreatedAt == default) appeal.CreatedAt = DateTime.UtcNow;
+
+        lock (_sync)
+        {
+            var clone = Clone(appeal);
+            _appeals[Key(appeal.TenantId, appeal.Id)] = clone;
+            AppendEventInternal(genesisEvent);
+        }
+        return Task.FromResult(Clone(appeal));
+    }
+
+    public Task<Appeal?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        _appeals.TryGetValue(Key(tenantId, id), out var a);
+        return Task.FromResult<Appeal?>(a is null ? null : Clone(a));
+    }
+
+    public Task<Appeal?> GetByAppealNumberAsync(string tenantId, string appealNumber, CancellationToken ct = default)
+    {
+        var match = _appeals.Values.FirstOrDefault(a => a.TenantId == tenantId && a.AppealNumber == appealNumber);
+        return Task.FromResult<Appeal?>(match is null ? null : Clone(match));
+    }
+
+    public Task<IReadOnlyList<Appeal>> GetByClaimIdAsync(string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var results = _appeals.Values
+            .Where(a => a.TenantId == tenantId && a.ClaimId == claimId)
+            .OrderByDescending(a => a.CreatedAt)
+            .Select(Clone)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Appeal>>(results);
+    }
+
+    public Task<IReadOnlyList<Appeal>> SearchAsync(string tenantId, AppealSearchParams p, CancellationToken ct = default)
+    {
+        var query = _appeals.Values.Where(a => a.TenantId == tenantId);
+        if (!string.IsNullOrEmpty(p.MemberId)) query = query.Where(a => a.MemberId == p.MemberId);
+        if (!string.IsNullOrEmpty(p.ProviderNPI)) query = query.Where(a => a.ProviderNPI == p.ProviderNPI);
+        if (p.SubmittedFrom.HasValue) query = query.Where(a => a.SubmittedDate >= p.SubmittedFrom.Value);
+        if (p.SubmittedTo.HasValue) query = query.Where(a => a.SubmittedDate <= p.SubmittedTo.Value);
+        if (p.Status.HasValue) query = query.Where(a => a.Status == p.Status.Value);
+        if (p.ClosureReasonCode.HasValue) query = query.Where(a => a.ClosureReasonCode == p.ClosureReasonCode.Value);
+        if (p.LineOfBusiness.HasValue) query = query.Where(a => a.LineOfBusiness == p.LineOfBusiness.Value);
+        if (!string.IsNullOrEmpty(p.AssignedReviewerId))
+            query = query.Where(a => a.AssignedReviewerId == p.AssignedReviewerId);
+
+        var page = Math.Max(1, p.Page);
+        var pageSize = Math.Clamp(p.PageSize, 1, 100);
+        var results = query.OrderByDescending(a => a.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(Clone)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Appeal>>(results);
+    }
+
+    public async Task<AppealsSummary> GetAppealsSummaryAsync(
+        string tenantId, DateTime from, DateTime to, CancellationToken ct = default)
+    {
+        var rows = _appeals.Values
+            .Where(a => a.TenantId == tenantId && a.SubmittedDate >= from && a.SubmittedDate <= to)
+            .Select(Clone)
+            .ToList();
+        return await Task.FromResult(SummaryBuilder.Build(rows));
+    }
+
+    public Task<Appeal> TransitionStatusAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        if (!auditEvent.FromStatus.HasValue)
+        {
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
+        }
+        var expected = auditEvent.FromStatus.Value;
+
+        lock (_sync)
+        {
+            var key = Key(appeal.TenantId, appeal.Id);
+            if (!_appeals.TryGetValue(key, out var current) || current.Status != expected)
+            {
+                var actual = current?.Status ?? appeal.Status;
+                throw new InvalidAppealTransitionException(actual, appeal.Status);
+            }
+
+            _appeals[key] = Clone(appeal);
+            AppendEventInternal(auditEvent);
+        }
+        return Task.FromResult(Clone(appeal));
+    }
+
+    public Task<Appeal?> TryTransitionToOverdueAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var key = Key(appeal.TenantId, appeal.Id);
+            if (!_appeals.TryGetValue(key, out var current)) return Task.FromResult<Appeal?>(null);
+            if (current.OverdueAuditEmitted) return Task.FromResult<Appeal?>(null);
+            if (current.Status != AppealStatus.Submitted
+                && current.Status != AppealStatus.InReview
+                && current.Status != AppealStatus.PendingInfo)
+                return Task.FromResult<Appeal?>(null);
+
+            current.OverdueAuditEmitted = true;
+            current.UpdatedAt = DateTime.UtcNow;
+            _appeals[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult<Appeal?>(Clone(current));
+        }
+    }
+
+    public Task<Appeal> AppendNoteAsync(Appeal appeal, AppealNote note, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var key = Key(appeal.TenantId, appeal.Id);
+            if (!_appeals.TryGetValue(key, out var current))
+                throw new InvalidOperationException($"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+            current.Notes.Add(note);
+            current.UpdatedAt = DateTime.UtcNow;
+            _appeals[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult(Clone(current));
+        }
+    }
+
+    public Task<Appeal> AppendAttachmentAsync(Appeal appeal, AppealAttachment attachment, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var key = Key(appeal.TenantId, appeal.Id);
+            if (!_appeals.TryGetValue(key, out var current))
+                throw new InvalidOperationException($"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+            current.Attachments.Add(attachment);
+            if (!string.IsNullOrEmpty(attachment.ControlNumber))
+                current.AttachmentControlNumbers.Add(attachment.ControlNumber);
+            current.UpdatedAt = DateTime.UtcNow;
+            _appeals[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult(Clone(current));
+        }
+    }
+
+    public Task<Appeal> AcknowledgeAttachmentAsync(
+        string tenantId, string appealId, string attachmentId, bool acknowledgmentReceived,
+        AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var key = Key(tenantId, appealId);
+            if (!_appeals.TryGetValue(key, out var current))
+                throw new InvalidOperationException($"Appeal {appealId} not found for tenant {tenantId}.");
+            var attachment = current.Attachments.FirstOrDefault(a => a.AttachmentId == attachmentId)
+                ?? throw new InvalidOperationException(
+                    $"Attachment {attachmentId} not found on appeal {appealId}.");
+            attachment.AcknowledgmentReceived = acknowledgmentReceived;
+            attachment.Status = acknowledgmentReceived ? AttachmentStatus.Acknowledged : AttachmentStatus.Sent;
+            if (acknowledgmentReceived) attachment.SentDate = DateTime.UtcNow;
+            current.UpdatedAt = DateTime.UtcNow;
+            _appeals[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult(Clone(current));
+        }
+    }
+
+    public Task<Appeal> AssignReviewerAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var key = Key(appeal.TenantId, appeal.Id);
+            if (!_appeals.TryGetValue(key, out var current))
+                throw new InvalidOperationException($"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+            current.AssignedReviewerId = appeal.AssignedReviewerId;
+            current.UpdatedAt = DateTime.UtcNow;
+            _appeals[key] = current;
+            AppendEventInternal(auditEvent);
+            return Task.FromResult(Clone(current));
+        }
+    }
+
+    public Task AppendAsync(AppealEvent evt, CancellationToken ct = default)
+    {
+        AppendEventInternal(evt);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<AppealEvent>> ListByAppealAsync(
+        string tenantId, string appealId, CancellationToken ct = default)
+    {
+        var rows = _events
+            .Where(e => e.TenantId == tenantId && e.AppealId == appealId)
+            .OrderBy(e => e.OccurredAt)
+            .ThenBy(e => e.EventId) // stable order for same-millisecond events
+            .ToList();
+        return Task.FromResult<IReadOnlyList<AppealEvent>>(rows);
+    }
+
+    /// <summary>Returns the full audit trail across all tenants / appeals for test assertions.</summary>
+    public IReadOnlyList<AppealEvent> SnapshotEvents() =>
+        _events.OrderBy(e => e.OccurredAt).ThenBy(e => e.EventId).ToList();
+
+    /// <summary>Returns the stored (pre-decrypt) appeal for test assertions.</summary>
+    public Appeal? PeekStored(string tenantId, string id) =>
+        _appeals.TryGetValue(Key(tenantId, id), out var a) ? a : null;
+
+    private void AppendEventInternal(AppealEvent evt)
+    {
+        lock (_sync)
+        {
+            if (_failAuditAppendOnce)
+            {
+                _failAuditAppendOnce = false;
+                throw new InvalidOperationException("FailAuditAppendOnce: injected failure");
+            }
+            if (_events.Any(e =>
+                    e.TenantId == evt.TenantId &&
+                    e.AppealId == evt.AppealId &&
+                    e.EventId == evt.EventId))
+            {
+                return;
+            }
+            _events.Add(CloneEvent(evt));
+        }
+    }
+
+    private static Appeal Clone(Appeal a) => new()
+    {
+        TenantId = a.TenantId,
+        Id = a.Id,
+        AppealNumber = a.AppealNumber,
+        ClaimId = a.ClaimId,
+        ClaimNumber = a.ClaimNumber,
+        MemberId = a.MemberId,
+        PatientName = a.PatientName,
+        ProviderNPI = a.ProviderNPI,
+        ProviderName = a.ProviderName,
+        DenialReasonCode = a.DenialReasonCode,
+        DenialReason = a.DenialReason,
+        DeniedAmount = a.DeniedAmount,
+        AppealedAmount = a.AppealedAmount,
+        AppealType = a.AppealType,
+        AppealLevel = a.AppealLevel,
+        LineOfBusiness = a.LineOfBusiness,
+        Status = a.Status,
+        AppealReason = a.AppealReason,
+        Source = a.Source,
+        Attachments = a.Attachments.Select(CloneAttachment).ToList(),
+        ClinicalDocuments = a.ClinicalDocuments.Select(CloneDoc).ToList(),
+        Decision = a.Decision == null ? null : CloneDecision(a.Decision),
+        SubmittedDate = a.SubmittedDate,
+        ReceivedDate = a.ReceivedDate,
+        TargetResponseDate = a.TargetResponseDate,
+        DecisionDate = a.DecisionDate,
+        SubmittedBy = a.SubmittedBy,
+        Notes = a.Notes.Select(CloneNote).ToList(),
+        AttachmentControlNumbers = new List<string>(a.AttachmentControlNumbers),
+        IsUrgent = a.IsUrgent,
+        ServiceDate = a.ServiceDate,
+        DiagnosisCodes = new List<string>(a.DiagnosisCodes),
+        ProcedureCodes = new List<string>(a.ProcedureCodes),
+        AssignedReviewerId = a.AssignedReviewerId,
+        CreatedAt = a.CreatedAt,
+        CreatedBy = a.CreatedBy,
+        UpdatedAt = a.UpdatedAt,
+        UpdatedBy = a.UpdatedBy,
+        ClosedAt = a.ClosedAt,
+        ClosedBy = a.ClosedBy,
+        ClosureReasonCode = a.ClosureReasonCode,
+        OverdueAuditEmitted = a.OverdueAuditEmitted
+    };
+
+    private static AppealAttachment CloneAttachment(AppealAttachment a) => new()
+    {
+        AttachmentId = a.AttachmentId,
+        ControlNumber = a.ControlNumber,
+        AttachmentTypeCode = a.AttachmentTypeCode,
+        AttachmentTypeDescription = a.AttachmentTypeDescription,
+        TransmissionCode = a.TransmissionCode,
+        FileName = a.FileName,
+        BlobUrl = a.BlobUrl,
+        ContentType = a.ContentType,
+        FileSizeBytes = a.FileSizeBytes,
+        UploadedAt = a.UploadedAt,
+        Description = a.Description,
+        Status = a.Status,
+        SentDate = a.SentDate,
+        AcknowledgmentReceived = a.AcknowledgmentReceived
+    };
+
+    private static ClinicalDocument CloneDoc(ClinicalDocument d) => new()
+    {
+        DocumentId = d.DocumentId,
+        DocumentType = d.DocumentType,
+        DocumentDate = d.DocumentDate,
+        Provider = d.Provider,
+        BlobUrl = d.BlobUrl,
+        Summary = d.Summary
+    };
+
+    private static AppealDecision CloneDecision(AppealDecision d) => new()
+    {
+        DecisionType = d.DecisionType,
+        ApprovedAmount = d.ApprovedAmount,
+        DecisionReason = d.DecisionReason,
+        ReviewerNotes = d.ReviewerNotes,
+        DecisionMaker = d.DecisionMaker,
+        DecisionDate = d.DecisionDate
+    };
+
+    private static AppealNote CloneNote(AppealNote n) => new()
+    {
+        NoteId = n.NoteId,
+        CreatedAt = n.CreatedAt,
+        CreatedBy = n.CreatedBy,
+        NoteText = n.NoteText,
+        IsInternal = n.IsInternal
+    };
+
+    private static AppealEvent CloneEvent(AppealEvent e) => new()
+    {
+        Id = e.Id,
+        PartitionKey = e.PartitionKey,
+        TenantId = e.TenantId,
+        AppealId = e.AppealId,
+        EventId = e.EventId,
+        EventType = e.EventType,
+        FromStatus = e.FromStatus,
+        ToStatus = e.ToStatus,
+        ActorId = e.ActorId,
+        CorrelationId = e.CorrelationId,
+        OccurredAt = e.OccurredAt,
+        Payload = e.Payload
+    };
+}

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAppealEventPublisher.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAppealEventPublisher.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using AppealsService.Models;
+using AppealsService.Services;
+
+namespace AppealsService.Tests.Fakes;
+
+/// <summary>
+/// Captures every publish call so controller + integration tests can
+/// assert "one event published, exactly these fields, in this order".
+/// One queue per event type keeps assertions simple.
+/// </summary>
+public sealed class RecordingAppealEventPublisher : IAppealEventPublisher
+{
+    public readonly ConcurrentQueue<CreatedCall> Created = new();
+    public readonly ConcurrentQueue<StatusChangedCall> StatusChanged = new();
+    public readonly ConcurrentQueue<ClosedCall> Closed = new();
+    public readonly ConcurrentQueue<NoteAddedCall> NotesAdded = new();
+    public readonly ConcurrentQueue<AttachmentAddedCall> AttachmentsAdded = new();
+    public readonly ConcurrentQueue<AttachmentAckCall> AttachmentsAcknowledged = new();
+    public readonly ConcurrentQueue<OverdueCall> OverdueObserved = new();
+    public readonly ConcurrentQueue<AssignedCall> Assigned = new();
+    public readonly ConcurrentQueue<MigratedCall> Migrated = new();
+
+    public Task PublishCreatedAsync(Appeal appeal, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        Created.Enqueue(new CreatedCall(appeal.Id, appeal.TenantId, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishStatusChangedAsync(
+        Appeal appeal, AppealStatus fromStatus, AppealStatus toStatus,
+        string actor, string? correlationId, CancellationToken ct = default)
+    {
+        StatusChanged.Enqueue(new StatusChangedCall(appeal.Id, appeal.TenantId, fromStatus, toStatus, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishClosedAsync(
+        Appeal appeal, AppealStatus fromStatus, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        Closed.Enqueue(new ClosedCall(appeal.Id, appeal.TenantId, fromStatus, appeal.ClosureReasonCode,
+            appeal.Decision?.DecisionType, appeal.Decision?.ApprovedAmount, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishNoteAddedAsync(
+        Appeal appeal, AppealNote note, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        NotesAdded.Enqueue(new NoteAddedCall(appeal.Id, appeal.TenantId, note.NoteId, note.IsInternal, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAttachmentAddedAsync(
+        Appeal appeal, AppealAttachment attachment, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        AttachmentsAdded.Enqueue(new AttachmentAddedCall(
+            appeal.Id, appeal.TenantId, attachment.AttachmentId,
+            attachment.AttachmentTypeCode, attachment.TransmissionCode,
+            attachment.ControlNumber, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAttachmentAcknowledgedAsync(
+        Appeal appeal, AppealAttachment attachment, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        AttachmentsAcknowledged.Enqueue(new AttachmentAckCall(
+            appeal.Id, appeal.TenantId, attachment.AttachmentId,
+            attachment.AcknowledgmentReceived, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishOverdueObservedAsync(Appeal appeal, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        OverdueObserved.Enqueue(new OverdueCall(appeal.Id, appeal.TenantId, appeal.Status, appeal.TargetResponseDate, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishAssignedAsync(
+        Appeal appeal, string? previousReviewerId, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        Assigned.Enqueue(new AssignedCall(appeal.Id, appeal.TenantId, appeal.AssignedReviewerId, previousReviewerId, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public Task PublishStatusMigratedAsync(
+        Appeal appeal, string legacyStatus, AppealClosureReasonCode mappedReasonCode,
+        string actor, string? correlationId, CancellationToken ct = default)
+    {
+        Migrated.Enqueue(new MigratedCall(appeal.Id, appeal.TenantId, legacyStatus, mappedReasonCode, actor, correlationId));
+        return Task.CompletedTask;
+    }
+
+    public sealed record CreatedCall(string AppealId, string TenantId, string Actor, string? CorrelationId);
+    public sealed record StatusChangedCall(string AppealId, string TenantId, AppealStatus From, AppealStatus To, string Actor, string? CorrelationId);
+    public sealed record ClosedCall(string AppealId, string TenantId, AppealStatus From, AppealClosureReasonCode? Reason, AppealDecisionType? DecisionType, decimal? ApprovedAmount, string Actor, string? CorrelationId);
+    public sealed record NoteAddedCall(string AppealId, string TenantId, string NoteId, bool IsInternal, string Actor, string? CorrelationId);
+    public sealed record AttachmentAddedCall(string AppealId, string TenantId, string AttachmentId, string AttachmentTypeCode, string TransmissionCode, string? ControlNumber, string Actor, string? CorrelationId);
+    public sealed record AttachmentAckCall(string AppealId, string TenantId, string AttachmentId, bool AcknowledgmentReceived, string Actor, string? CorrelationId);
+    public sealed record OverdueCall(string AppealId, string TenantId, AppealStatus Status, DateTime? TargetResponseDate, string Actor, string? CorrelationId);
+    public sealed record AssignedCall(string AppealId, string TenantId, string? AssignedReviewerId, string? PreviousReviewerId, string Actor, string? CorrelationId);
+    public sealed record MigratedCall(string AppealId, string TenantId, string LegacyStatus, AppealClosureReasonCode MappedReasonCode, string Actor, string? CorrelationId);
+}

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAppealEventPublisher.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAppealEventPublisher.cs
@@ -21,6 +21,24 @@ public sealed class RecordingAppealEventPublisher : IAppealEventPublisher
     public readonly ConcurrentQueue<AssignedCall> Assigned = new();
     public readonly ConcurrentQueue<MigratedCall> Migrated = new();
 
+    /// <summary>
+    /// Clears all recorded publish calls. Used by the integration test
+    /// factory to reset state between tests without replacing the instance
+    /// (which would desync from the DI container's cached singleton).
+    /// </summary>
+    public void Clear()
+    {
+        Created.Clear();
+        StatusChanged.Clear();
+        Closed.Clear();
+        NotesAdded.Clear();
+        AttachmentsAdded.Clear();
+        AttachmentsAcknowledged.Clear();
+        OverdueObserved.Clear();
+        Assigned.Clear();
+        Migrated.Clear();
+    }
+
     public Task PublishCreatedAsync(Appeal appeal, string actor, string? correlationId, CancellationToken ct = default)
     {
         Created.Enqueue(new CreatedCall(appeal.Id, appeal.TenantId, actor, correlationId));

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/ReversibleAppealFieldEncryptor.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/ReversibleAppealFieldEncryptor.cs
@@ -1,0 +1,31 @@
+using AppealsService.Services;
+
+namespace AppealsService.Tests.Fakes;
+
+/// <summary>
+/// Deterministic reversible "encryptor" for controller tests. Prepends a
+/// marker so tests can distinguish "raw plaintext" from
+/// "plaintext-that-was-re-emitted-after-decryption" on the read path, and
+/// assert that stored state looks encrypted at rest.
+/// </summary>
+public sealed class ReversibleAppealFieldEncryptor : IAppealFieldEncryptor
+{
+    private const string Marker = "enc::";
+
+    public Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return Task.FromResult<string?>(plaintext);
+        return Task.FromResult<string?>(Marker + plaintext);
+    }
+
+    public Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(ciphertext)) return Task.FromResult<string?>(ciphertext);
+        if (!ciphertext.StartsWith(Marker, StringComparison.Ordinal))
+            return Task.FromResult<string?>(ciphertext);
+        return Task.FromResult<string?>(ciphertext[Marker.Length..]);
+    }
+
+    public static bool LooksEncrypted(string? s) =>
+        !string.IsNullOrEmpty(s) && s.StartsWith(Marker, StringComparison.Ordinal);
+}

--- a/src/services/appeals-service/AppealsService.Tests/HostedServices/AppealStatusMigrationTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/HostedServices/AppealStatusMigrationTests.cs
@@ -1,0 +1,32 @@
+using AppealsService.HostedServices;
+using AppealsService.Models;
+
+namespace AppealsService.Tests.HostedServices;
+
+/// <summary>
+/// Unit tests for the legacy-status → (Closed + ClosureReasonCode)
+/// mapping. Full end-to-end migration (Mongo scan + rewrite + audit-event
+/// emission) is covered via in-memory fakes in the integration-style
+/// smoke tests — this suite pins the mapping table itself.
+/// </summary>
+public class AppealStatusMigrationTests
+{
+    [Theory]
+    [InlineData("Approved", AppealClosureReasonCode.Approved)]
+    [InlineData("Denied", AppealClosureReasonCode.Denied)]
+    [InlineData("PartialApproval", AppealClosureReasonCode.PartialApproval)]
+    [InlineData("Withdrawn", AppealClosureReasonCode.Withdrawn)]
+    public void MapLegacyStatus_ProducesExpectedReason(string legacy, AppealClosureReasonCode expected)
+    {
+        AppealStatusMigrationHostedService.MapLegacyStatus(legacy).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("UnknownStatus")]
+    [InlineData("Draft")]       // non-terminal — should not reach the migration filter
+    [InlineData("Submitted")]   // same
+    public void MapLegacyStatus_UnknownFallsBackToOther(string legacy)
+    {
+        AppealStatusMigrationHostedService.MapLegacyStatus(legacy).Should().Be(AppealClosureReasonCode.Other);
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Integration/AppealLifecycleSmokeTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Integration/AppealLifecycleSmokeTests.cs
@@ -376,13 +376,16 @@ public class AppealLifecycleSmokeTests : IClassFixture<AppealsWebApplicationFact
 /// </summary>
 public sealed class AppealsWebApplicationFactory : WebApplicationFactory<Program>
 {
-    public InMemoryAppealRepository Repo { get; private set; } = new();
-    public RecordingAppealEventPublisher Publisher { get; private set; } = new();
+    public InMemoryAppealRepository Repo { get; } = new();
+    public RecordingAppealEventPublisher Publisher { get; } = new();
 
+    // Clears state on the same instances the DI container holds. Replacing
+    // the instances here would leave the cached singletons pointing at the
+    // old Repo / Publisher and every assertion would read an empty one.
     public void Reset()
     {
-        Repo = new InMemoryAppealRepository();
-        Publisher = new RecordingAppealEventPublisher();
+        Repo.Clear();
+        Publisher.Clear();
     }
 
     protected override IHost CreateHost(IHostBuilder builder)

--- a/src/services/appeals-service/AppealsService.Tests/Integration/AppealLifecycleSmokeTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Integration/AppealLifecycleSmokeTests.cs
@@ -1,0 +1,443 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AppealsService.Controllers;
+using AppealsService.Models;
+using AppealsService.Repositories;
+using AppealsService.Services;
+using AppealsService.Tests.Fakes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace AppealsService.Tests.Integration;
+
+/// <summary>
+/// End-to-end controller + repository + encryption + publisher smoke via
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> over in-memory fakes.
+/// Exercises the full appeal lifecycle and pins three contract invariants
+/// that modernization must not regress:
+///
+/// 1. Every PHI-adjacent field is stored encrypted-at-rest. The
+///    <see cref="ReversibleAppealFieldEncryptor.LooksEncrypted"/> helper
+///    asserts the stored record's sensitive fields carry the marker
+///    prefix on both snapshots and the published-event payloads are
+///    free of decrypted values.
+/// 2. Every mutation writes an <c>AppealEvent</c> to the audit trail.
+///    The full lifecycle enumerates the expected event sequence and we
+///    assert it appears in order.
+/// 3. The portal's four <see cref="AppealsSummary"/> wire-shape buckets
+///    (<c>OpenAppeals</c>, <c>UrgentExpedited</c>, <c>DueThisWeek</c>,
+///    <c>OverturnedRate</c>) are preserved across the status-enum
+///    consolidation — including records seeded with the new
+///    <c>Closed + ClosureReasonCode</c> shape.
+/// </summary>
+public class AppealLifecycleSmokeTests : IClassFixture<AppealsWebApplicationFactory>
+{
+    private readonly AppealsWebApplicationFactory _factory;
+
+    public AppealLifecycleSmokeTests(AppealsWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private HttpClient NewClient(string tenant = "tenant-a")
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", tenant);
+        return client;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    private static async Task<Appeal> ReadAppealAsync(HttpResponseMessage response)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Request failed: {(int)response.StatusCode} {response.StatusCode}. Body: {body}");
+        }
+        return JsonSerializer.Deserialize<Appeal>(body, JsonOptions)!;
+    }
+
+    private static CreateAppealRequest BuildCreate(string claimId = "CLM-LIFE-001") => new()
+    {
+        ClaimId = claimId,
+        ClaimNumber = "CLM-0001",
+        MemberId = "M-0001",
+        PatientName = "Jane Doe",
+        ProviderNPI = "1234567890",
+        AppealReason = "Denied service was medically necessary.",
+        DenialReason = "CO-45: Charge exceeds fee schedule.",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        AppealType = AppealType.Reconsideration,
+        AppealLevel = AppealLevel.FirstLevel,
+        AppealedAmount = 2500.00m,
+        DeniedAmount = 2500.00m,
+        IsUrgent = false
+    };
+
+    [Fact]
+    public async Task FullLifecycle_Create_Submit_BeginReview_RequestInfo_ResumeReview_Close_Approved()
+    {
+        _factory.Reset();
+        var client = NewClient();
+
+        // 1. Create
+        var create = await client.PostAsJsonAsync("/api/appeals", BuildCreate(), JsonOptions);
+        var appeal = await ReadAppealAsync(create);
+        create.StatusCode.Should().Be(HttpStatusCode.Created);
+        appeal.Status.Should().Be(AppealStatus.Draft);
+
+        // 2. Add note + attachment in Draft
+        var noteBody = new AddNoteRequest { NoteText = "Initial provider notes.", CreatedBy = "prov-1", IsInternal = false };
+        (await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/notes", noteBody, JsonOptions))
+            .EnsureSuccessStatusCode();
+
+        var attachBody = new AddAttachmentRequest
+        {
+            AttachmentTypeCode = "OZ",
+            TransmissionCode = "EL",
+            FileName = "op-report.pdf",
+            BlobUrl = "mds://doc-1",
+            Description = "Operative report for denied surgery."
+        };
+        (await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/attachments", attachBody, JsonOptions))
+            .EnsureSuccessStatusCode();
+
+        // 3. Submit
+        var submit = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/submit", new IdempotencyEnvelope(), JsonOptions);
+        (await ReadAppealAsync(submit)).Status.Should().Be(AppealStatus.Submitted);
+
+        // Idempotent submit: second call returns 200 with no second event.
+        var eventCountBeforeIdempotent = _factory.Repo.SnapshotEvents().Count;
+        var submitIdempotent = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/submit", new IdempotencyEnvelope(), JsonOptions);
+        submitIdempotent.StatusCode.Should().Be(HttpStatusCode.OK);
+        _factory.Repo.SnapshotEvents().Count.Should().Be(eventCountBeforeIdempotent,
+            "idempotent same-status call must not write a second audit event");
+
+        // 4. Begin review
+        var begin = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/begin-review", new IdempotencyEnvelope(), JsonOptions);
+        (await ReadAppealAsync(begin)).Status.Should().Be(AppealStatus.InReview);
+
+        // 5. Request info (transitions to PendingInfo + appends a note)
+        var request = new RequestInfoRequest { Description = "Need op notes + pre-auth record." };
+        var req = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/request-info", request, JsonOptions);
+        var afterReq = await ReadAppealAsync(req);
+        afterReq.Status.Should().Be(AppealStatus.PendingInfo);
+        afterReq.Notes.Should().Contain(n => n.NoteText.Contains("Need op notes"), "request-info body becomes a note");
+
+        // 6. Resume review
+        var resume = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/resume-review", new IdempotencyEnvelope(), JsonOptions);
+        (await ReadAppealAsync(resume)).Status.Should().Be(AppealStatus.InReview);
+
+        // 7. Close with Approved decision
+        var close = new CloseAppealRequest
+        {
+            ClosureReasonCode = AppealClosureReasonCode.Approved,
+            Decision = new AppealDecisionInput
+            {
+                DecisionType = AppealDecisionType.Approved,
+                ApprovedAmount = 2500.00m,
+                DecisionReason = "Medical necessity confirmed by clinical review.",
+                ReviewerNotes = "Reviewer: Dr. Smith.",
+                DecisionMaker = "reviewer-99"
+            }
+        };
+        var closed = await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/close", close, JsonOptions);
+        var closedAppeal = await ReadAppealAsync(closed);
+        closedAppeal.Status.Should().Be(AppealStatus.Closed);
+        closedAppeal.ClosureReasonCode.Should().Be(AppealClosureReasonCode.Approved);
+
+        // ── Audit trail assertions ──────────────────────────────────────
+        var events = _factory.Repo.SnapshotEvents().Where(e => e.AppealId == appeal.Id).ToList();
+        events.Select(e => e.EventType).Should().ContainInOrder(
+            AppealEventType.AppealCreated,
+            AppealEventType.AppealNoteAdded,
+            AppealEventType.AppealAttachmentAdded,
+            AppealEventType.AppealStatusChanged, // Draft -> Submitted
+            AppealEventType.AppealStatusChanged, // Submitted -> InReview
+            AppealEventType.AppealStatusChanged, // InReview -> PendingInfo
+            AppealEventType.AppealNoteAdded,     // request-info description
+            AppealEventType.AppealStatusChanged, // PendingInfo -> InReview
+            AppealEventType.AppealClosed);
+
+        // ── Publisher assertions ────────────────────────────────────────
+        _factory.Publisher.Created.Should().ContainSingle(c => c.AppealId == appeal.Id);
+        _factory.Publisher.Closed.Should().ContainSingle(c =>
+            c.AppealId == appeal.Id
+            && c.Reason == AppealClosureReasonCode.Approved
+            && c.DecisionType == AppealDecisionType.Approved
+            && c.ApprovedAmount == 2500.00m);
+
+        // ── Encryption-at-rest assertions ───────────────────────────────
+        var stored = _factory.Repo.PeekStored("tenant-a", appeal.Id);
+        stored.Should().NotBeNull();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored!.PatientName).Should().BeTrue();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.AppealReason).Should().BeTrue();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.DenialReason).Should().BeTrue();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.Notes[0].NoteText).Should().BeTrue();
+        stored.Attachments.Should().ContainSingle();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.Attachments[0].Description).Should().BeTrue();
+        stored.Decision.Should().NotBeNull();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.Decision!.DecisionReason).Should().BeTrue();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(stored.Decision.ReviewerNotes).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CrossTenant_Get_Returns404_NotFound()
+    {
+        _factory.Reset();
+
+        var aliceClient = NewClient("tenant-alice");
+        var create = await aliceClient.PostAsJsonAsync("/api/appeals", BuildCreate(), JsonOptions);
+        var appeal = await ReadAppealAsync(create);
+
+        var bobClient = NewClient("tenant-bob");
+        var bobGet = await bobClient.GetAsync($"/api/appeals/{appeal.Id}");
+        bobGet.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "cross-tenant must return 404, not 403, to avoid tenant enumeration");
+
+        var aliceGet = await aliceClient.GetAsync($"/api/appeals/{appeal.Id}");
+        aliceGet.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MissingTenantHeader_Returns401()
+    {
+        _factory.Reset();
+        var client = _factory.CreateClient();
+        // No X-Tenant-ID header — TenantMiddleware must 401 rather than fall
+        // back to a default.
+        var response = await client.GetAsync("/api/appeals/some-id");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task InvalidTransition_Returns409_WithProblemDetails()
+    {
+        _factory.Reset();
+        var client = NewClient();
+
+        var create = await client.PostAsJsonAsync("/api/appeals", BuildCreate(), JsonOptions);
+        var appeal = await ReadAppealAsync(create);
+
+        // Draft -> InReview is illegal (must go through Submitted first).
+        var begin = await client.PostAsJsonAsync(
+            $"/api/appeals/{appeal.Id}/begin-review", new IdempotencyEnvelope(), JsonOptions);
+
+        begin.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        var body = await begin.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        root.GetProperty("status").GetInt32().Should().Be(409);
+        root.GetProperty("title").GetString().Should().Be("Invalid appeal transition");
+        root.GetProperty("type").GetString().Should().Be("https://cloudhealthoffice.com/problems/appeal-transition");
+        root.GetProperty("fromStatus").GetString().Should().Be("Draft");
+        root.GetProperty("toStatus").GetString().Should().Be("InReview");
+    }
+
+    [Fact]
+    public async Task Overdue_EmitsExactlyOneObservedEvent_AcrossConcurrentReads()
+    {
+        _factory.Reset();
+        var client = NewClient();
+
+        // Create + submit, then force the appeal past TargetResponseDate by
+        // rewriting the stored record. (The test seam PeekStored returns
+        // the live object; mutating it emulates time passing.)
+        var create = await client.PostAsJsonAsync("/api/appeals", BuildCreate(), JsonOptions);
+        var appeal = await ReadAppealAsync(create);
+        await client.PostAsJsonAsync($"/api/appeals/{appeal.Id}/submit", new IdempotencyEnvelope(), JsonOptions);
+
+        var stored = _factory.Repo.PeekStored("tenant-a", appeal.Id)!;
+        stored.TargetResponseDate = DateTime.UtcNow.AddMinutes(-1);
+
+        // Fan-out concurrent GETs. Each GET observes overdue; the race-safe
+        // TryTransitionToOverdueAsync must emit exactly one event.
+        var gets = Enumerable.Range(0, 8)
+            .Select(_ => client.GetAsync($"/api/appeals/{appeal.Id}"))
+            .ToArray();
+        await Task.WhenAll(gets);
+
+        var history = await _factory.Repo.ListByAppealAsync("tenant-a", appeal.Id);
+        history.Count(e => e.EventType == AppealEventType.AppealOverdueObserved).Should().Be(1);
+        _factory.Publisher.OverdueObserved.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AppealsSummary_PortalWireShape_Preserved()
+    {
+        _factory.Reset();
+        var client = NewClient("tenant-summary");
+        var now = DateTime.UtcNow;
+
+        // 5 open appeals (Submitted/InReview/PendingInfo), 2 urgent, 3 with
+        // target response in the next week. 4 closed with mix of reasons
+        // (2 Approved, 1 PartialApproval, 1 Denied) → OverturnedRate = 75%.
+        async Task<string> CreateAsync(CreateAppealRequest body)
+        {
+            var r = await client.PostAsJsonAsync("/api/appeals", body, JsonOptions);
+            return (await ReadAppealAsync(r)).Id;
+        }
+
+        async Task SubmitAsync(string id)
+            => (await client.PostAsJsonAsync($"/api/appeals/{id}/submit", new IdempotencyEnvelope(), JsonOptions))
+                .EnsureSuccessStatusCode();
+        async Task BeginReviewAsync(string id)
+            => (await client.PostAsJsonAsync($"/api/appeals/{id}/begin-review", new IdempotencyEnvelope(), JsonOptions))
+                .EnsureSuccessStatusCode();
+        async Task CloseAsync(string id, AppealClosureReasonCode reason, AppealDecisionType? dt = null)
+        {
+            var body = new CloseAppealRequest
+            {
+                ClosureReasonCode = reason,
+                Decision = dt.HasValue
+                    ? new AppealDecisionInput { DecisionType = dt.Value, ApprovedAmount = 1000m }
+                    : null
+            };
+            (await client.PostAsJsonAsync($"/api/appeals/{id}/close", body, JsonOptions))
+                .EnsureSuccessStatusCode();
+        }
+
+        // 5 open: 2 urgent, 3 due-this-week (overlap allowed).
+        var openIds = new List<string>();
+        for (var i = 0; i < 5; i++)
+        {
+            var body = BuildCreate($"CLM-OPEN-{i:000}");
+            body.IsUrgent = i < 2;
+            body.TargetResponseDate = i < 3 ? now.AddDays(3) : now.AddDays(30);
+            var id = await CreateAsync(body);
+            await SubmitAsync(id);
+            if (i % 2 == 0) await BeginReviewAsync(id);
+            openIds.Add(id);
+        }
+
+        // 4 closed.
+        for (var i = 0; i < 4; i++)
+        {
+            var id = await CreateAsync(BuildCreate($"CLM-CLOSED-{i:000}"));
+            await SubmitAsync(id);
+            await BeginReviewAsync(id);
+            AppealClosureReasonCode reason = i switch
+            {
+                0 or 1 => AppealClosureReasonCode.Approved,
+                2 => AppealClosureReasonCode.PartialApproval,
+                _ => AppealClosureReasonCode.Denied
+            };
+            AppealDecisionType dt = reason switch
+            {
+                AppealClosureReasonCode.Approved => AppealDecisionType.Approved,
+                AppealClosureReasonCode.PartialApproval => AppealDecisionType.PartialApproval,
+                _ => AppealDecisionType.Denied
+            };
+            await CloseAsync(id, reason, dt);
+        }
+
+        var summaryResponse = await client.GetAsync("/api/appeals/summary");
+        var summary = JsonSerializer.Deserialize<AppealsSummary>(
+            await summaryResponse.Content.ReadAsStringAsync(), JsonOptions)!;
+
+        // Portal-observed contract:
+        summary.OpenAppeals.Should().Be(5);
+        summary.UrgentExpedited.Should().Be(2);
+        summary.DueThisWeek.Should().Be(3);
+        summary.OverturnedRate.Should().BeApproximately(75.0, 0.01,
+            "3 of 4 closed had reason Approved or PartialApproval");
+
+        // Additional shape verifications:
+        summary.Approved.Should().Be(2);
+        summary.PartialApprovals.Should().Be(1);
+        summary.Denied.Should().Be(1);
+    }
+}
+
+/// <summary>
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> wiring that swaps in
+/// the in-memory fakes for repository, encryptor, publisher, and secret
+/// provider so the controller tests run fully in-process with no Mongo /
+/// Cosmos / Kafka / Key Vault dependencies.
+///
+/// Also sets <c>MongoDb:ConnectionString</c> to a non-empty sentinel so
+/// the Mongo branch of the Program.cs DI wiring is chosen (we override
+/// every registration after) and the Cosmos branch's CosmosDb:Endpoint
+/// validation doesn't trip.
+/// </summary>
+public sealed class AppealsWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public InMemoryAppealRepository Repo { get; private set; } = new();
+    public RecordingAppealEventPublisher Publisher { get; private set; } = new();
+
+    public void Reset()
+    {
+        Repo = new InMemoryAppealRepository();
+        Publisher = new RecordingAppealEventPublisher();
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        // Force an environment where the NoOp fallback for field encryption
+        // is allowed (dev-mode guard). We then replace it with the
+        // reversible encryptor below.
+        builder.UseEnvironment("Development");
+        builder.ConfigureHostConfiguration(c => c.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            // Force Mongo branch (we'll override all the Mongo services).
+            ["MongoDb:ConnectionString"] = "mongodb://fake/test",
+            ["MongoDb:DatabaseName"] = "test",
+            ["Kafka:BootstrapServers"] = "" // degraded mode; RecordingPublisher replaces it anyway
+        }));
+        return base.CreateHost(builder);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Strip all hosted services — we don't want the Mongo index
+            // initializer, the migration scanner, the Kafka publisher
+            // background task, or the repository's Mongo client to run
+            // during tests.
+            foreach (var hs in services.Where(d => d.ServiceType == typeof(IHostedService)).ToList())
+                services.Remove(hs);
+
+            // Strip the Mongo client / database registrations — they would
+            // try to resolve against the sentinel connection string.
+            services.RemoveAll<MongoDB.Driver.IMongoClient>();
+            services.RemoveAll<MongoDB.Driver.IMongoDatabase>();
+
+            // Swap in the in-memory fakes.
+            services.RemoveAll<IAppealRepository>();
+            services.RemoveAll<IAppealEventRepository>();
+            services.RemoveAll<IAppealEventSink>();
+            services.RemoveAll<IAppealFieldEncryptor>();
+            services.RemoveAll<IAppealEventPublisher>();
+            services.RemoveAll<AppealEventPublisher>();
+
+            services.AddSingleton(Repo);
+            services.AddSingleton<IAppealRepository>(sp => sp.GetRequiredService<InMemoryAppealRepository>());
+            services.AddSingleton<IAppealEventRepository>(sp => sp.GetRequiredService<InMemoryAppealRepository>());
+            services.AddSingleton<IAppealEventSink>(sp => sp.GetRequiredService<InMemoryAppealRepository>());
+            services.AddSingleton<IAppealFieldEncryptor, ReversibleAppealFieldEncryptor>();
+            services.AddSingleton(Publisher);
+            services.AddSingleton<IAppealEventPublisher>(sp => sp.GetRequiredService<RecordingAppealEventPublisher>());
+        });
+    }
+
+    protected override void ConfigureClient(HttpClient client)
+    {
+        base.ConfigureClient(client);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Models/AppealStateMachineTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Models/AppealStateMachineTests.cs
@@ -1,0 +1,141 @@
+using AppealsService.Models;
+using AppealsService.Services;
+
+namespace AppealsService.Tests.Models;
+
+public class AppealStateMachineTests
+{
+    [Theory]
+    [InlineData(AppealStatus.Draft,       AppealStatus.Submitted)]
+    [InlineData(AppealStatus.Draft,       AppealStatus.Closed)]
+    [InlineData(AppealStatus.Submitted,   AppealStatus.InReview)]
+    [InlineData(AppealStatus.Submitted,   AppealStatus.Closed)]
+    [InlineData(AppealStatus.InReview,    AppealStatus.PendingInfo)]
+    [InlineData(AppealStatus.InReview,    AppealStatus.Closed)]
+    [InlineData(AppealStatus.PendingInfo, AppealStatus.InReview)]
+    [InlineData(AppealStatus.PendingInfo, AppealStatus.Closed)]
+    public void LegalTransitions_Allowed(AppealStatus from, AppealStatus to)
+    {
+        AppealStateMachine.IsAllowed(from, to).Should().BeTrue();
+        Action act = () => AppealStateMachine.EnsureAllowed(from, to);
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    // Same-status → illegal at the state machine layer (idempotency is a
+    // controller-layer concern, not a legal state-machine transition).
+    [InlineData(AppealStatus.Draft,       AppealStatus.Draft)]
+    [InlineData(AppealStatus.Submitted,   AppealStatus.Submitted)]
+    [InlineData(AppealStatus.InReview,    AppealStatus.InReview)]
+    [InlineData(AppealStatus.PendingInfo, AppealStatus.PendingInfo)]
+    [InlineData(AppealStatus.Closed,      AppealStatus.Closed)]
+    // Backwards transitions
+    [InlineData(AppealStatus.Submitted,   AppealStatus.Draft)]
+    [InlineData(AppealStatus.InReview,    AppealStatus.Submitted)]
+    [InlineData(AppealStatus.PendingInfo, AppealStatus.Submitted)]
+    // Illegal forward transitions
+    [InlineData(AppealStatus.Draft,       AppealStatus.InReview)]
+    [InlineData(AppealStatus.Draft,       AppealStatus.PendingInfo)]
+    [InlineData(AppealStatus.Submitted,   AppealStatus.PendingInfo)]
+    // Closed is terminal — no outgoing edges.
+    [InlineData(AppealStatus.Closed,      AppealStatus.Draft)]
+    [InlineData(AppealStatus.Closed,      AppealStatus.Submitted)]
+    [InlineData(AppealStatus.Closed,      AppealStatus.InReview)]
+    [InlineData(AppealStatus.Closed,      AppealStatus.PendingInfo)]
+    public void IllegalTransitions_Throw(AppealStatus from, AppealStatus to)
+    {
+        AppealStateMachine.IsAllowed(from, to).Should().BeFalse();
+        Action act = () => AppealStateMachine.EnsureAllowed(from, to);
+        act.Should().Throw<InvalidAppealTransitionException>()
+            .Where(e => e.FromStatus == from && e.ToStatus == to);
+    }
+
+    /// <summary>
+    /// Exhaustive guard: enumerate every (from, to) pair in the 5x5 matrix
+    /// and confirm the allowed set is EXACTLY the eight transitions above.
+    /// Ensures a future enum addition forces an explicit decision rather
+    /// than silently widening the state machine.
+    /// </summary>
+    [Fact]
+    public void Matrix_AllowsOnlyEightTransitions()
+    {
+        var expected = new HashSet<(AppealStatus, AppealStatus)>
+        {
+            (AppealStatus.Draft,       AppealStatus.Submitted),
+            (AppealStatus.Draft,       AppealStatus.Closed),
+            (AppealStatus.Submitted,   AppealStatus.InReview),
+            (AppealStatus.Submitted,   AppealStatus.Closed),
+            (AppealStatus.InReview,    AppealStatus.PendingInfo),
+            (AppealStatus.InReview,    AppealStatus.Closed),
+            (AppealStatus.PendingInfo, AppealStatus.InReview),
+            (AppealStatus.PendingInfo, AppealStatus.Closed),
+        };
+
+        var all = (AppealStatus[])Enum.GetValues(typeof(AppealStatus));
+        foreach (var f in all)
+        foreach (var t in all)
+        {
+            var allowed = AppealStateMachine.IsAllowed(f, t);
+            var shouldBeAllowed = expected.Contains((f, t));
+            allowed.Should().Be(shouldBeAllowed,
+                $"transition {f} -> {t} allowed should be {shouldBeAllowed}");
+        }
+    }
+
+    [Fact]
+    public void Closed_IsTerminal_NeverHasLegalOutgoingEdge()
+    {
+        foreach (AppealStatus to in Enum.GetValues(typeof(AppealStatus)))
+        {
+            AppealStateMachine.IsAllowed(AppealStatus.Closed, to).Should().BeFalse(
+                $"Closed is terminal; Closed -> {to} must be illegal");
+        }
+    }
+
+    // ── Closure reason × from-status validity ───────────────────────────
+
+    [Theory]
+    // From Draft: only Withdrawn is valid (no decision yet).
+    [InlineData(AppealStatus.Draft,       AppealClosureReasonCode.Withdrawn)]
+    // From Submitted: only Withdrawn (not yet under review).
+    [InlineData(AppealStatus.Submitted,   AppealClosureReasonCode.Withdrawn)]
+    // From InReview: decision-bearing + admin + other + withdrawn.
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.Approved)]
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.Denied)]
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.PartialApproval)]
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.Withdrawn)]
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.AdminError)]
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.Other)]
+    // From PendingInfo: all of the above + Expired (no-response timeout).
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.Approved)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.Denied)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.PartialApproval)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.Withdrawn)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.Expired)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.AdminError)]
+    [InlineData(AppealStatus.PendingInfo, AppealClosureReasonCode.Other)]
+    public void ClosureReason_LegalFromStatus(AppealStatus from, AppealClosureReasonCode reason)
+    {
+        AppealStateMachine.IsClosureReasonAllowed(from, reason).Should().BeTrue();
+    }
+
+    [Theory]
+    // Expired is NOT valid from InReview (only from PendingInfo — no-response timeout requires info-pending first).
+    [InlineData(AppealStatus.InReview,    AppealClosureReasonCode.Expired)]
+    // Decision reasons NOT valid from Draft / Submitted (appeal hasn't been reviewed).
+    [InlineData(AppealStatus.Draft,       AppealClosureReasonCode.Approved)]
+    [InlineData(AppealStatus.Draft,       AppealClosureReasonCode.Denied)]
+    [InlineData(AppealStatus.Draft,       AppealClosureReasonCode.PartialApproval)]
+    [InlineData(AppealStatus.Draft,       AppealClosureReasonCode.Expired)]
+    [InlineData(AppealStatus.Submitted,   AppealClosureReasonCode.Approved)]
+    [InlineData(AppealStatus.Submitted,   AppealClosureReasonCode.Denied)]
+    [InlineData(AppealStatus.Submitted,   AppealClosureReasonCode.PartialApproval)]
+    [InlineData(AppealStatus.Submitted,   AppealClosureReasonCode.Expired)]
+    // Closed → any close reason: illegal (already closed).
+    [InlineData(AppealStatus.Closed,      AppealClosureReasonCode.Approved)]
+    [InlineData(AppealStatus.Closed,      AppealClosureReasonCode.Withdrawn)]
+    public void ClosureReason_IllegalFromStatus(AppealStatus from, AppealClosureReasonCode reason)
+    {
+        AppealStateMachine.IsClosureReasonAllowed(from, reason).Should().BeFalse();
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Repositories/AppealAtomicityTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Repositories/AppealAtomicityTests.cs
@@ -1,0 +1,236 @@
+using AppealsService.Models;
+using AppealsService.Repositories;
+using AppealsService.Tests.Fakes;
+
+namespace AppealsService.Tests.Repositories;
+
+/// <summary>
+/// Atomicity / race-safety guarantees of the InMemory repository, which
+/// mirrors the Cosmos + Mongo repositories' conditional-replace pattern.
+/// The production repositories carry the same invariants; this suite
+/// documents and guards them in a reproducible form.
+/// </summary>
+public class AppealAtomicityTests
+{
+    private static Appeal NewAppeal(AppealStatus status = AppealStatus.Draft) => new()
+    {
+        TenantId = "t1",
+        Id = Guid.NewGuid().ToString(),
+        AppealNumber = "APL-" + Guid.NewGuid().ToString("N")[..6],
+        ClaimId = "c1",
+        ClaimNumber = "CLM-001",
+        MemberId = "m1",
+        PatientName = "enc::patient",
+        ProviderNPI = "1234567890",
+        AppealReason = "enc::reason",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        AppealType = AppealType.Reconsideration,
+        AppealLevel = AppealLevel.FirstLevel,
+        Status = status,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    private static AppealEvent StatusChangeEvent(Appeal a, AppealStatus from, AppealStatus to) => new()
+    {
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealEventType.AppealStatusChanged,
+        FromStatus = from,
+        ToStatus = to,
+        ActorId = "user1"
+    };
+
+    [Fact]
+    public async Task TransitionStatusAsync_ConcurrentRace_OneWinsOneThrows()
+    {
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal();
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(), EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "user1"
+        };
+        await repo.CreateAsync(appeal, genesis);
+
+        // Two writers concurrently try to transition Draft -> Submitted.
+        // The InMemory repo simulates the Cosmos ETag / Mongo conditional-
+        // replace semantics: one wins cleanly, the other surfaces
+        // InvalidAppealTransitionException.
+        var entityA = await repo.GetByIdAsync(appeal.TenantId, appeal.Id);
+        var entityB = await repo.GetByIdAsync(appeal.TenantId, appeal.Id);
+        entityA!.Status = AppealStatus.Submitted;
+        entityB!.Status = AppealStatus.Submitted;
+
+        // Wrap calls in Task.Run so both writers genuinely race — the
+        // InMemory fake's lock serializes synchronously, and without
+        // Task.Run the second call throws on the caller thread before
+        // reaching Task.WhenAll's unwrap.
+        var results = await Task.WhenAll(
+            InvokeAsync(() => repo.TransitionStatusAsync(
+                entityA, StatusChangeEvent(entityA, AppealStatus.Draft, AppealStatus.Submitted))),
+            InvokeAsync(() => repo.TransitionStatusAsync(
+                entityB, StatusChangeEvent(entityB, AppealStatus.Draft, AppealStatus.Submitted))));
+
+        results.Count(r => r.Success).Should().Be(1);
+        results.Count(r => !r.Success).Should().Be(1);
+        results.First(r => !r.Success).Exception.Should().BeOfType<InvalidAppealTransitionException>();
+    }
+
+    [Fact]
+    public async Task TryTransitionToOverdueAsync_IsExactlyOnce_UnderConcurrentReads()
+    {
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal(AppealStatus.Submitted);
+        appeal.TargetResponseDate = DateTime.UtcNow.AddMinutes(-1); // already overdue
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(), EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Submitted, ActorId = "user1"
+        };
+        await repo.CreateAsync(appeal, genesis);
+
+        // Ten concurrent readers all observe overdue at once.
+        var events = Enumerable.Range(0, 10).Select(i => new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealOverdueObserved,
+            ActorId = "reader-" + i,
+            OccurredAt = DateTime.UtcNow
+        }).ToList();
+
+        var snapshot = await repo.GetByIdAsync(appeal.TenantId, appeal.Id);
+        var tasks = events.Select(e => repo.TryTransitionToOverdueAsync(snapshot!, e)).ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        // Exactly one caller persisted the transition (returned non-null).
+        // The other nine observed OverdueAuditEmitted=true and returned null.
+        results.Count(r => r != null).Should().Be(1);
+        results.Count(r => r == null).Should().Be(9);
+
+        // And exactly one AppealOverdueObserved event in the audit trail.
+        var history = await repo.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        history.Count(e => e.EventType == AppealEventType.AppealOverdueObserved).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AppendNoteAsync_FailureInjection_NoteAppendedEvenIfAuditFails()
+    {
+        // Documents the documented crash-window posture: the entity update
+        // is the source of truth; a crash between entity update and audit
+        // append can drop the audit row. Same inherited posture as consent
+        // and personal-rep. This test asserts the failure mode is bounded —
+        // entity mutation survives, audit is missing, caller sees the
+        // exception.
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal();
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(), EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "user1"
+        };
+        await repo.CreateAsync(appeal, genesis);
+
+        var note = new AppealNote { CreatedBy = "u", NoteText = "enc::note", IsInternal = true };
+        var auditEvent = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealNoteAdded,
+            ActorId = "u"
+        };
+
+        // The genesis event succeeded already. Fail the NEXT audit append
+        // (the note append) and assert the entity still saw the note.
+        // This reproduces the documented crash window, not the desired
+        // atomic behavior — we test that the failure mode is exactly this
+        // and not worse.
+        repo.FailAuditAppendOnce();
+
+        Func<Task> act = () => repo.AppendNoteAsync(appeal, note, auditEvent);
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .Where(ex => ex.Message.Contains("FailAuditAppendOnce"));
+
+        var stored = repo.PeekStored(appeal.TenantId, appeal.Id);
+        stored.Should().NotBeNull();
+        stored!.Notes.Should().ContainSingle(n => n.NoteId == note.NoteId,
+            "the entity mutation committed before the audit-append failure");
+
+        var history = await repo.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        history.Should().NotContain(e => e.EventId == auditEvent.EventId,
+            "the audit append failed and its event must not appear in history");
+    }
+
+    [Fact]
+    public async Task TenantScope_GetByIdCrossTenantReturnsNull()
+    {
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal();
+        appeal.TenantId = "tenant-a";
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(), EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "user1"
+        };
+        await repo.CreateAsync(appeal, genesis);
+
+        (await repo.GetByIdAsync("tenant-b", appeal.Id)).Should().BeNull();
+        (await repo.GetByIdAsync("tenant-a", appeal.Id)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task TenantScope_SearchCrossTenantReturnsEmpty()
+    {
+        var repo = new InMemoryAppealRepository();
+        var a1 = NewAppeal(); a1.TenantId = "tenant-a";
+        var genesis = new AppealEvent
+        {
+            TenantId = a1.TenantId, AppealId = a1.Id,
+            EventId = Guid.NewGuid().ToString(), EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "user1"
+        };
+        await repo.CreateAsync(a1, genesis);
+
+        var results = await repo.SearchAsync("tenant-b", new AppealSearchParams());
+        results.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task IdempotentEventAppend_DuplicateEventIdIsIgnored()
+    {
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal();
+        var eventId = Guid.NewGuid().ToString();
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = eventId,
+            EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "u"
+        };
+        await repo.CreateAsync(appeal, genesis);
+
+        // Same EventId replay → no duplicate row.
+        await repo.AppendAsync(new AppealEvent
+        {
+            TenantId = appeal.TenantId, AppealId = appeal.Id,
+            EventId = eventId,
+            EventType = AppealEventType.AppealCreated,
+            FromStatus = null, ToStatus = AppealStatus.Draft, ActorId = "u"
+        });
+
+        var history = await repo.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        history.Count(e => e.EventId == eventId).Should().Be(1);
+    }
+
+    private static async Task<(bool Success, Exception? Exception)> InvokeAsync(Func<Task> call)
+    {
+        try { await Task.Run(call); return (true, null); }
+        catch (Exception ex) { return (false, ex); }
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Services/AppealEncryptionKeyHealthCheckTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Services/AppealEncryptionKeyHealthCheckTests.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using AppealsService.Services;
+using AppealsService.Tests.Fakes;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppealsService.Tests.Services;
+
+public class AppealEncryptionKeyHealthCheckTests
+{
+    private static AppealEncryptionKeyHealthCheck Build(DictionarySecretProvider secrets, string currentVersion = "v1")
+    {
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var options = new AppealEncryptionOptions
+        {
+            KeySecretPrefix = "appeal-body-encryption-key",
+            CurrentKeyVersion = currentVersion,
+            AcceptedKeyVersions = new[] { currentVersion }
+        };
+        return new AppealEncryptionKeyHealthCheck(keys, options);
+    }
+
+    [Fact]
+    public async Task Healthy_WhenKeyPresentAnd32Bytes()
+    {
+        var secrets = new DictionarySecretProvider();
+        secrets.Secrets["appeal-body-encryption-key-v1"] = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+        var check = Build(secrets);
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenKeyMissing()
+    {
+        var check = Build(new DictionarySecretProvider());
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+    }
+
+    [Fact]
+    public async Task Unhealthy_WhenKeyWrongLength()
+    {
+        var secrets = new DictionarySecretProvider();
+        secrets.Secrets["appeal-body-encryption-key-v1"] = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+
+        var check = Build(secrets);
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("32 bytes");
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Services/AppealEventPublisherTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Services/AppealEventPublisherTests.cs
@@ -1,0 +1,268 @@
+using System.Text.Json;
+using AppealsService.Models;
+using AppealsService.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppealsService.Tests.Services;
+
+/// <summary>
+/// Field-whitelist tests for every event payload. Serializes the payload
+/// to JSON, enumerates the emitted keys, and asserts the exact set —
+/// substring scans would miss "decisionReasonText" sneaking in under an
+/// innocent-looking name. Also negative-asserts that no encrypted-at-rest
+/// field name appears anywhere in the payload.
+///
+/// These tests are the primary guard that PHI-adjacent fields
+/// (PatientName, AppealReason, DenialReason, NoteText, DecisionReason,
+/// ReviewerNotes, Summary, Description) cannot silently leak onto the
+/// event stream when the event payload builder is refactored.
+/// </summary>
+public class AppealEventPublisherTests
+{
+    private static readonly HashSet<string> EncryptedAtRestFieldNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "patientName", "appealReason", "denialReason",
+        "noteText", "decisionReason", "reviewerNotes",
+        "summary", "description"
+    };
+
+    private static Appeal NewAppeal() => new()
+    {
+        TenantId = "t1",
+        Id = "a1",
+        AppealNumber = "APL-001",
+        ClaimId = "c1",
+        ClaimNumber = "CLM-001",
+        MemberId = "m1",
+        ProviderNPI = "1234567890",
+        AppealType = AppealType.Reconsideration,
+        AppealLevel = AppealLevel.FirstLevel,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        Status = AppealStatus.Submitted,
+        Source = AppealSource.ProviderPortal,
+        IsUrgent = true,
+        TargetResponseDate = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        // Encrypted-at-rest on the entity — these must NEVER leak into a
+        // payload, so set them to distinctive strings that would be easy
+        // to spot if they did.
+        PatientName = "PATIENT::MUST::NOT::LEAK",
+        AppealReason = "APPEAL_REASON::MUST::NOT::LEAK",
+        DenialReason = "DENIAL_REASON::MUST::NOT::LEAK"
+    };
+
+    private static HashSet<string> JsonFields<T>(T payload)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var json = JsonSerializer.Serialize(payload, options);
+        using var doc = JsonDocument.Parse(json);
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var prop in doc.RootElement.EnumerateObject())
+        {
+            keys.Add(prop.Name);
+        }
+        return keys;
+    }
+
+    private static void AssertNoEncryptedFieldValues<T>(T payload)
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+        var json = JsonSerializer.Serialize(payload, options);
+        json.Should().NotContain("MUST::NOT::LEAK", "encrypted-at-rest field values must not appear in event payloads");
+    }
+
+    [Fact]
+    public void AppealCreated_FieldWhitelist()
+    {
+        var payload = AppealEventPublisher.BuildCreatedPayload(NewAppeal(), "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "appealNumber", "claimId", "claimNumber", "memberId", "providerNPI",
+            "appealType", "appealLevel", "lineOfBusiness", "source",
+            "targetResponseDate", "isUrgent",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealStatusChanged_FieldWhitelist()
+    {
+        var payload = AppealEventPublisher.BuildStatusChangedPayload(
+            NewAppeal(), AppealStatus.Submitted, AppealStatus.InReview, "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "fromStatus", "toStatus",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealClosed_FieldWhitelist()
+    {
+        var a = NewAppeal();
+        a.Status = AppealStatus.Closed;
+        a.ClosureReasonCode = AppealClosureReasonCode.PartialApproval;
+        a.Decision = new AppealDecision
+        {
+            DecisionType = AppealDecisionType.PartialApproval,
+            ApprovedAmount = 1500.00m,
+            DecisionReason = "MUST::NOT::LEAK", // encrypted on entity; must not be on payload
+            ReviewerNotes = "MUST::NOT::LEAK"
+        };
+        a.DecisionDate = new DateTime(2026, 5, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        var payload = AppealEventPublisher.BuildClosedPayload(a, AppealStatus.InReview, "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "fromStatus", "closureReasonCode",
+            "decisionType", "approvedAmount", "decisionDate",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealNoteAdded_FieldWhitelist()
+    {
+        var note = new AppealNote
+        {
+            CreatedBy = "reviewer1",
+            NoteText = "MUST::NOT::LEAK",
+            IsInternal = true
+        };
+        var payload = AppealEventPublisher.BuildNoteAddedPayload(NewAppeal(), note, "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "noteId", "author", "createdAt", "isInternal",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealAttachmentAdded_FieldWhitelist()
+    {
+        var att = new AppealAttachment
+        {
+            AttachmentTypeCode = "OZ",
+            TransmissionCode = "EL",
+            ControlNumber = "275-000001",
+            Description = "MUST::NOT::LEAK"
+        };
+        var payload = AppealEventPublisher.BuildAttachmentAddedPayload(NewAppeal(), att, "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "attachmentId", "attachmentTypeCode", "transmissionCode", "controlNumber", "uploadedAt",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealAttachmentAcknowledged_FieldWhitelist()
+    {
+        var att = new AppealAttachment
+        {
+            AttachmentTypeCode = "OZ",
+            TransmissionCode = "EL",
+            AcknowledgmentReceived = true,
+            SentDate = new DateTime(2026, 5, 3, 0, 0, 0, DateTimeKind.Utc),
+            Description = "MUST::NOT::LEAK"
+        };
+        var payload = AppealEventPublisher.BuildAttachmentAcknowledgedPayload(NewAppeal(), att, "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "attachmentId", "acknowledgmentReceived", "sentDate",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealOverdueObserved_FieldWhitelist()
+    {
+        var payload = AppealEventPublisher.BuildOverdueObservedPayload(NewAppeal(), "system", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "currentStatus", "targetResponseDate",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealAssigned_FieldWhitelist()
+    {
+        var a = NewAppeal();
+        a.AssignedReviewerId = "reviewer-99";
+        var payload = AppealEventPublisher.BuildAssignedPayload(a, "reviewer-01", "user1", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "assignedReviewerId", "previousReviewerId",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    [Fact]
+    public void AppealStatusMigrated_FieldWhitelist()
+    {
+        var payload = AppealEventPublisher.BuildStatusMigratedPayload(
+            NewAppeal(), "Approved", AppealClosureReasonCode.Approved, "system:migration", "corr1");
+        JsonFields(payload).Should().BeEquivalentTo(new[]
+        {
+            "eventId", "eventType", "eventVersion", "occurredAt",
+            "tenantId", "appealId",
+            "legacyStatus", "mappedReasonCode",
+            "actor", "correlationId"
+        });
+        AssertNoEncryptedFieldValues(payload);
+    }
+
+    // ── Degraded mode ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DegradedMode_WhenBootstrapServersEmpty_PublishIsNoOp()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Kafka:BootstrapServers"] = ""
+            })
+            .Build();
+
+        var publisher = new AppealEventPublisher(NullLogger<AppealEventPublisher>.Instance, config);
+        await publisher.StartAsync(CancellationToken.None);
+
+        // Should not throw — degraded-mode publish is a silent no-op.
+        await publisher.PublishCreatedAsync(NewAppeal(), "user1", "corr1");
+        await publisher.PublishStatusChangedAsync(
+            NewAppeal(), AppealStatus.Draft, AppealStatus.Submitted, "user1", "corr1");
+        await publisher.PublishClosedAsync(NewAppeal(), AppealStatus.InReview, "user1", "corr1");
+        await publisher.PublishStatusMigratedAsync(
+            NewAppeal(), "Approved", AppealClosureReasonCode.Approved, "system", "corr1");
+
+        await publisher.StopAsync(CancellationToken.None);
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Services/AppealFieldEncryptorTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Services/AppealFieldEncryptorTests.cs
@@ -1,0 +1,155 @@
+using System.Security.Cryptography;
+using AppealsService.Services;
+using AppealsService.Tests.Fakes;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppealsService.Tests.Services;
+
+public class AppealFieldEncryptorTests
+{
+    private static (AppealFieldEncryptor Encryptor, DictionarySecretProvider Secrets) BuildEncryptor(
+        string currentVersion = "v1",
+        IReadOnlyList<string>? acceptedVersions = null,
+        params (string Version, byte[] Key)[] seeded)
+    {
+        var secrets = new DictionarySecretProvider();
+        foreach (var s in seeded)
+        {
+            secrets.Secrets[$"appeal-body-encryption-key-{s.Version}"] = Convert.ToBase64String(s.Key);
+        }
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+        var options = new AppealEncryptionOptions
+        {
+            KeySecretPrefix = "appeal-body-encryption-key",
+            CurrentKeyVersion = currentVersion,
+            AcceptedKeyVersions = acceptedVersions ?? new[] { currentVersion }
+        };
+        return (new AppealFieldEncryptor(keys, NullLogger<AppealFieldEncryptor>.Instance, options), secrets);
+    }
+
+    [Fact]
+    public async Task RoundTrip_RestoresPlaintext()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var (enc, _) = BuildEncryptor(seeded: new[] { ("v1", key) });
+
+        var cipher = await enc.EncryptAsync("patient name");
+        cipher.Should().NotBeNullOrEmpty();
+        cipher.Should().NotBe("patient name");
+
+        var plain = await enc.DecryptAsync(cipher);
+        plain.Should().Be("patient name");
+    }
+
+    [Fact]
+    public async Task Encrypt_PassesThroughNullAndEmpty()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var (enc, _) = BuildEncryptor(seeded: new[] { ("v1", key) });
+
+        (await enc.EncryptAsync(null)).Should().BeNull();
+        (await enc.EncryptAsync("")).Should().Be("");
+    }
+
+    [Fact]
+    public async Task Rotation_OldEnvelopeDecryptsIfVersionAccepted()
+    {
+        var v1Key = RandomNumberGenerator.GetBytes(32);
+        var v2Key = RandomNumberGenerator.GetBytes(32);
+
+        var (v1Enc, _) = BuildEncryptor(
+            currentVersion: "v1", acceptedVersions: new[] { "v1" },
+            seeded: new[] { ("v1", v1Key) });
+        var oldCipher = await v1Enc.EncryptAsync("old secret");
+
+        var (v2Enc, _) = BuildEncryptor(
+            currentVersion: "v2", acceptedVersions: new[] { "v2", "v1" },
+            seeded: new[] { ("v1", v1Key), ("v2", v2Key) });
+
+        var plain = await v2Enc.DecryptAsync(oldCipher);
+        plain.Should().Be("old secret");
+
+        var newCipher = await v2Enc.EncryptAsync("new secret");
+        newCipher.Should().NotBe(oldCipher);
+        (await v2Enc.DecryptAsync(newCipher)).Should().Be("new secret");
+    }
+
+    [Fact]
+    public async Task StaleKey_ThrowsStaleEncryptionKeyException()
+    {
+        var v1Key = RandomNumberGenerator.GetBytes(32);
+        var (v1Enc, _) = BuildEncryptor(
+            currentVersion: "v1", acceptedVersions: new[] { "v1" },
+            seeded: new[] { ("v1", v1Key) });
+        var cipher = await v1Enc.EncryptAsync("will become stale");
+
+        // New deployment: v1 is still in AcceptedKeyVersions but the secret
+        // was dropped from the provider (operator mistake) — decrypt must
+        // surface StaleEncryptionKeyException, not a silent CryptographicException.
+        var (staleEnc, _) = BuildEncryptor(
+            currentVersion: "v2", acceptedVersions: new[] { "v2", "v1" },
+            seeded: new[] { ("v2", RandomNumberGenerator.GetBytes(32)) });
+
+        await FluentActions.Invoking(() => staleEnc.DecryptAsync(cipher))
+            .Should().ThrowAsync<StaleEncryptionKeyException>();
+    }
+
+    [Fact]
+    public async Task EnvelopeKeyVersion_NotInAcceptedList_Throws()
+    {
+        var v1Key = RandomNumberGenerator.GetBytes(32);
+        var (v1Enc, _) = BuildEncryptor(
+            currentVersion: "v1", acceptedVersions: new[] { "v1" },
+            seeded: new[] { ("v1", v1Key) });
+        var cipher = await v1Enc.EncryptAsync("classified");
+
+        var (v2Only, _) = BuildEncryptor(
+            currentVersion: "v2", acceptedVersions: new[] { "v2" },
+            seeded: new[] { ("v1", v1Key), ("v2", RandomNumberGenerator.GetBytes(32)) });
+
+        await FluentActions.Invoking(() => v2Only.DecryptAsync(cipher))
+            .Should().ThrowAsync<CryptographicException>()
+            .Where(ex => ex.Message.Contains("AcceptedKeyVersions"));
+    }
+
+    [Fact]
+    public async Task WrongKeyLength_Throws()
+    {
+        var badKey = RandomNumberGenerator.GetBytes(16); // AES-128, not AES-256
+        var (enc, _) = BuildEncryptor(seeded: new[] { ("v1", badKey) });
+
+        await FluentActions.Invoking(() => enc.EncryptAsync("whatever"))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .Where(ex => ex.Message.Contains("32 bytes"));
+    }
+
+    [Fact]
+    public async Task DecryptMalformedCiphertext_ThrowsCryptographicException()
+    {
+        var key = RandomNumberGenerator.GetBytes(32);
+        var (enc, _) = BuildEncryptor(seeded: new[] { ("v1", key) });
+
+        await FluentActions.Invoking(() => enc.DecryptAsync("not-base64-at-all"))
+            .Should().ThrowAsync<CryptographicException>();
+    }
+
+    [Fact]
+    public void Options_InvalidValues_ConstructorThrows()
+    {
+        var secrets = new DictionarySecretProvider();
+        var keys = new RotatingKeyProvider(secrets, NullLogger<RotatingKeyProvider>.Instance);
+
+        Action missingPrefix = () => new AppealFieldEncryptor(keys, NullLogger<AppealFieldEncryptor>.Instance,
+            new AppealEncryptionOptions { KeySecretPrefix = "", CurrentKeyVersion = "v1" });
+        missingPrefix.Should().Throw<ArgumentException>();
+
+        Action missingVersion = () => new AppealFieldEncryptor(keys, NullLogger<AppealFieldEncryptor>.Instance,
+            new AppealEncryptionOptions { CurrentKeyVersion = "" });
+        missingVersion.Should().Throw<ArgumentException>();
+
+        Action emptyAccepted = () => new AppealFieldEncryptor(keys, NullLogger<AppealFieldEncryptor>.Instance,
+            new AppealEncryptionOptions { AcceptedKeyVersions = Array.Empty<string>() });
+        emptyAccepted.Should().Throw<ArgumentException>();
+    }
+}

--- a/src/services/appeals-service/Controllers/AppealsController.cs
+++ b/src/services/appeals-service/Controllers/AppealsController.cs
@@ -1,319 +1,1025 @@
-using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using AppealsService.Middleware;
 using AppealsService.Models;
 using AppealsService.Repositories;
+using AppealsService.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AppealsService.Controllers;
 
+/// <summary>
+/// Appeal lifecycle REST surface. Appeals are never hard-deleted; the
+/// lifecycle is Draft → Submitted → InReview → PendingInfo → Closed,
+/// with an append-only audit trail on every transition and every
+/// mutation (note add, attachment add, attachment acknowledge, reviewer
+/// assignment).
+///
+/// Routes stay at <c>/api/appeals/*</c> (unversioned) to preserve the
+/// portal contract. Route-versioning across the platform is a separate
+/// decision; this modernization PR does NOT bundle it.
+///
+/// 404-on-cross-tenant: a read for an id that belongs to a different
+/// tenant returns 404 (not 403) to avoid tenant enumeration — same posture
+/// as consent-service and personal-rep-service.
+///
+/// 409-on-invalid-transition: state-machine rejections surface as
+/// <see cref="ProblemDetails"/> with <c>fromStatus</c>/<c>toStatus</c>
+/// extensions. Same shape as consent's <c>ConflictTransition</c>.
+///
+/// Idempotent same-status requests (e.g. submit when already Submitted)
+/// short-circuit at the controller layer — the state machine itself
+/// rejects X→X as illegal; the controller handles UX idempotency.
+/// </summary>
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/appeals")]
 [Produces("application/json")]
 public class AppealsController : ControllerBase
 {
-    private readonly IAppealRepository _appealRepository;
+    private string TenantId => HttpContext.GetTenantId();
+
+    private readonly IAppealRepository _appeals;
+    private readonly IAppealEventRepository _events;
+    private readonly IAppealFieldEncryptor _encryptor;
+    private readonly IAppealEventPublisher _publisher;
     private readonly ILogger<AppealsController> _logger;
 
     public AppealsController(
-        IAppealRepository appealRepository,
+        IAppealRepository appeals,
+        IAppealEventRepository events,
+        IAppealFieldEncryptor encryptor,
+        IAppealEventPublisher publisher,
         ILogger<AppealsController> logger)
     {
-        _appealRepository = appealRepository;
+        _appeals = appeals;
+        _events = events;
+        _encryptor = encryptor;
+        _publisher = publisher;
         _logger = logger;
     }
 
-    /// <summary>
-    /// Submit new appeal
-    /// </summary>
+    // ── Create / Read ───────────────────────────────────────────────────
+
     [HttpPost]
     [ProducesResponseType(typeof(Appeal), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<Appeal>> SubmitAppeal([FromBody] Appeal appeal)
+    public async Task<IActionResult> CreateAppeal([FromBody] CreateAppealRequest request, CancellationToken ct)
     {
-        _logger.LogInformation("Submitting appeal for claim {ClaimId}", SanitizeForLog(appeal.ClaimId));
+        if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        // Validation
-        if (string.IsNullOrEmpty(appeal.ClaimId))
+        var actor = User.Identity?.Name ?? "System";
+        var now = DateTime.UtcNow;
+
+        var appeal = new Appeal
         {
-            return BadRequest("Claim ID is required");
-        }
+            TenantId = TenantId,
+            AppealNumber = string.IsNullOrEmpty(request.AppealNumber)
+                ? $"APL-{now:yyyyMMdd}-{Guid.NewGuid().ToString("N")[..8].ToUpperInvariant()}"
+                : request.AppealNumber,
+            ClaimId = request.ClaimId,
+            ClaimNumber = request.ClaimNumber,
+            MemberId = request.MemberId,
+            ProviderNPI = request.ProviderNPI,
+            ProviderName = request.ProviderName,
+            DenialReasonCode = request.DenialReasonCode,
+            DeniedAmount = request.DeniedAmount,
+            AppealedAmount = request.AppealedAmount,
+            AppealType = request.AppealType,
+            AppealLevel = request.AppealLevel,
+            LineOfBusiness = request.LineOfBusiness,
+            Status = AppealStatus.Draft,
+            Source = request.Source,
+            SubmittedDate = now,
+            TargetResponseDate = request.TargetResponseDate ?? now.AddDays(request.IsUrgent ? 30 : 60),
+            SubmittedBy = request.SubmittedBy,
+            IsUrgent = request.IsUrgent,
+            ServiceDate = request.ServiceDate,
+            DiagnosisCodes = request.DiagnosisCodes ?? new(),
+            ProcedureCodes = request.ProcedureCodes ?? new(),
+            AssignedReviewerId = request.AssignedReviewerId,
+            CreatedAt = now,
+            CreatedBy = actor,
 
-        if (string.IsNullOrEmpty(appeal.AppealReason))
-        {
-            return BadRequest("Appeal reason is required");
-        }
+            PatientName = await _encryptor.EncryptAsync(request.PatientName, ct) ?? string.Empty,
+            AppealReason = await _encryptor.EncryptAsync(request.AppealReason, ct) ?? string.Empty,
+            DenialReason = await _encryptor.EncryptAsync(request.DenialReason, ct)
+        };
 
-        // Generate appeal number
-        if (string.IsNullOrEmpty(appeal.AppealNumber))
-        {
-            appeal.AppealNumber = $"APL-{DateTime.UtcNow:yyyyMMdd}-{Guid.NewGuid().ToString("N").Substring(0, 8).ToUpper()}";
-        }
+        var genesis = BuildEvent(appeal, AppealEventType.AppealCreated,
+            fromStatus: null, toStatus: AppealStatus.Draft, actor, request.EventId);
 
-        var created = await _appealRepository.CreateAsync(appeal);
+        var created = await _appeals.CreateAsync(appeal, genesis, ct);
+        await _publisher.PublishCreatedAsync(created, actor, HttpContext.TraceIdentifier, ct);
 
-        return CreatedAtAction(
-            nameof(GetAppealById),
-            new { id = created.Id },
-            created);
+        var view = await DecryptForResponseAsync(created, ct);
+        return CreatedAtAction(nameof(GetAppealById), new { id = created.Id }, view);
     }
 
-    /// <summary>
-    /// Get appeal by ID
-    /// </summary>
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> GetAppealById(string id)
+    public async Task<IActionResult> GetAppealById([FromRoute] string id, CancellationToken ct)
     {
-        var appeal = await _appealRepository.GetByIdAsync(id);
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
 
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {id} not found");
-        }
+        appeal = await MaybeObserveOverdueAsync(appeal, ct);
 
-        return Ok(appeal);
+        var view = await DecryptForResponseAsync(appeal, ct);
+        return Ok(view);
     }
 
-    /// <summary>
-    /// Get appeal by appeal number
-    /// </summary>
     [HttpGet("number/{appealNumber}")]
     [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> GetAppealByNumber(string appealNumber)
+    public async Task<IActionResult> GetAppealByNumber([FromRoute] string appealNumber, CancellationToken ct)
     {
-        var appeal = await _appealRepository.GetByAppealNumberAsync(appealNumber);
+        var appeal = await _appeals.GetByAppealNumberAsync(TenantId, appealNumber, ct);
+        if (appeal == null) return NotFound();
 
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {appealNumber} not found");
-        }
+        appeal = await MaybeObserveOverdueAsync(appeal, ct);
 
-        return Ok(appeal);
+        var view = await DecryptForResponseAsync(appeal, ct);
+        return Ok(view);
     }
 
-    /// <summary>
-    /// Get appeals for a specific claim
-    /// </summary>
     [HttpGet("claim/{claimId}")]
-    [ProducesResponseType(typeof(IEnumerable<Appeal>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<Appeal>>> GetAppealsByClaimId(string claimId)
+    [ProducesResponseType(typeof(AppealListResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAppealsByClaimId([FromRoute] string claimId, CancellationToken ct)
     {
-        var appeals = await _appealRepository.GetByClaimIdAsync(claimId);
-        return Ok(appeals);
+        var items = await _appeals.GetByClaimIdAsync(TenantId, claimId, ct);
+        var decrypted = await Task.WhenAll(items.Select(a => DecryptForResponseAsync(a, ct)));
+        return Ok(new AppealListResponse { Items = decrypted.ToList() });
     }
 
-    /// <summary>
-    /// Search appeals with filters
-    /// </summary>
     [HttpGet("search")]
-    [ProducesResponseType(typeof(IEnumerable<Appeal>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<Appeal>>> SearchAppeals(
+    [ProducesResponseType(typeof(AppealListResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> SearchAppeals(
         [FromQuery] string? memberId,
         [FromQuery] string? providerNPI,
         [FromQuery] DateTime? submittedFrom,
         [FromQuery] DateTime? submittedTo,
         [FromQuery] AppealStatus? status,
+        [FromQuery] AppealClosureReasonCode? closureReasonCode,
         [FromQuery] LineOfBusiness? lineOfBusiness,
+        [FromQuery] string? assignedReviewerId,
         [FromQuery] int page = 1,
-        [FromQuery] int pageSize = 50)
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
     {
-        _logger.LogInformation("Searching appeals: member {Member}, provider {Provider}, status {Status}",
-            SanitizeForLog(memberId), SanitizeForLog(providerNPI), status);
-
-        var appeals = await _appealRepository.SearchAsync(
-            memberId, providerNPI, submittedFrom, submittedTo, status, lineOfBusiness, page, pageSize);
-
-        return Ok(appeals);
-    }
-
-    /// <summary>
-    /// Add attachment to appeal (275 submission)
-    /// </summary>
-    [HttpPost("{id}/attachments")]
-    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> AddAttachment(string id, [FromBody] AppealAttachment attachment)
-    {
-        var appeal = await _appealRepository.GetByIdAsync(id);
-
-        if (appeal == null)
+        var p = new AppealSearchParams
         {
-            return NotFound($"Appeal {id} not found");
-        }
-
-        // Generate 275 control number
-        if (string.IsNullOrEmpty(attachment.ControlNumber))
-        {
-            attachment.ControlNumber = $"275-{DateTime.UtcNow:yyyyMMddHHmmss}-{Guid.NewGuid().ToString("N").Substring(0, 6).ToUpper()}";
-        }
-
-        appeal.Attachments.Add(attachment);
-        appeal.AttachmentControlNumbers.Add(attachment.ControlNumber);
-
-        var updated = await _appealRepository.UpdateAsync(appeal);
-
-        _logger.LogInformation("Added attachment {AttachmentId} to appeal {AppealId}", 
-            SanitizeForLog(attachment.AttachmentId), SanitizeForLog(id));
-
-        return Ok(updated);
-    }
-
-    /// <summary>
-    /// Update attachment status (275 acknowledgment)
-    /// </summary>
-    [HttpPut("{id}/attachments/{attachmentId}")]
-    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> UpdateAttachmentStatus(
-        string id, 
-        string attachmentId, 
-        [FromBody] UpdateAttachmentStatusRequest request)
-    {
-        var appeal = await _appealRepository.GetByIdAsync(id);
-
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {id} not found");
-        }
-
-        var attachment = appeal.Attachments.FirstOrDefault(a => a.AttachmentId == attachmentId);
-        if (attachment == null)
-        {
-            return NotFound($"Attachment {attachmentId} not found");
-        }
-
-        attachment.Status = request.Status;
-        attachment.AcknowledgmentReceived = request.Status == AttachmentStatus.Acknowledged;
-        if (request.Status == AttachmentStatus.Sent)
-        {
-            attachment.SentDate = DateTime.UtcNow;
-        }
-
-        var updated = await _appealRepository.UpdateAsync(appeal);
-
-        return Ok(updated);
-    }
-
-    /// <summary>
-    /// Add note to appeal
-    /// </summary>
-    [HttpPost("{id}/notes")]
-    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> AddNote(string id, [FromBody] AddNoteRequest request)
-    {
-        var appeal = await _appealRepository.GetByIdAsync(id);
-
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {id} not found");
-        }
-
-        appeal.Notes.Add(new AppealNote
-        {
-            NoteText = request.NoteText,
-            CreatedBy = request.CreatedBy,
-            IsInternal = request.IsInternal
-        });
-
-        var updated = await _appealRepository.UpdateAsync(appeal);
-
-        return Ok(updated);
-    }
-
-    /// <summary>
-    /// Submit appeal decision
-    /// </summary>
-    [HttpPost("{id}/decision")]
-    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> SubmitDecision(string id, [FromBody] AppealDecision decision)
-    {
-        var appeal = await _appealRepository.GetByIdAsync(id);
-
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {id} not found");
-        }
-
-        appeal.Decision = decision;
-        appeal.DecisionDate = decision.DecisionDate;
-        appeal.Status = decision.DecisionType switch
-        {
-            AppealDecisionType.Approved => AppealStatus.Approved,
-            AppealDecisionType.Denied => AppealStatus.Denied,
-            AppealDecisionType.PartialApproval => AppealStatus.PartialApproval,
-            _ => appeal.Status
+            MemberId = memberId,
+            ProviderNPI = providerNPI,
+            SubmittedFrom = submittedFrom,
+            SubmittedTo = submittedTo,
+            Status = status,
+            ClosureReasonCode = closureReasonCode,
+            LineOfBusiness = lineOfBusiness,
+            AssignedReviewerId = assignedReviewerId,
+            Page = page,
+            PageSize = pageSize
         };
 
-        var updated = await _appealRepository.UpdateAsync(appeal);
-
-        _logger.LogInformation("Appeal {AppealId} decision: {Decision}", SanitizeForLog(id), decision.DecisionType);
-
-        return Ok(updated);
+        var items = await _appeals.SearchAsync(TenantId, p, ct);
+        var decrypted = await Task.WhenAll(items.Select(a => DecryptForResponseAsync(a, ct)));
+        return Ok(new AppealListResponse { Items = decrypted.ToList() });
     }
 
-    /// <summary>
-    /// Update appeal status
-    /// </summary>
-    [HttpPut("{id}/status")]
-    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Appeal>> UpdateStatus(string id, [FromBody] UpdateStatusRequest request)
-    {
-        var appeal = await _appealRepository.GetByIdAsync(id);
-
-        if (appeal == null)
-        {
-            return NotFound($"Appeal {id} not found");
-        }
-
-        appeal.Status = request.Status;
-
-        var updated = await _appealRepository.UpdateAsync(appeal);
-
-        return Ok(updated);
-    }
-
-    /// <summary>
-    /// Get appeals summary statistics
-    /// </summary>
     [HttpGet("summary")]
     [ProducesResponseType(typeof(AppealsSummary), StatusCodes.Status200OK)]
-    public async Task<ActionResult<AppealsSummary>> GetAppealsSummary(
+    public async Task<IActionResult> GetAppealsSummary(
         [FromQuery] DateTime? from,
-        [FromQuery] DateTime? to)
+        [FromQuery] DateTime? to,
+        CancellationToken ct = default)
     {
         var fromDate = from ?? DateTime.UtcNow.AddMonths(-3);
         var toDate = to ?? DateTime.UtcNow;
 
-        var summary = await _appealRepository.GetAppealsSummaryAsync(fromDate, toDate);
-
+        var summary = await _appeals.GetAppealsSummaryAsync(TenantId, fromDate, toDate, ct);
         return Ok(summary);
     }
 
-    private static string SanitizeForLog(string? value)
+    [HttpGet("{id}/history")]
+    [ProducesResponseType(typeof(AppealHistoryResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetHistory([FromRoute] string id, CancellationToken ct)
     {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        var events = await _events.ListByAppealAsync(TenantId, id, ct);
+        return Ok(new AppealHistoryResponse { Items = events.ToList() });
+    }
+
+    // ── Lifecycle transitions ───────────────────────────────────────────
+
+    [HttpPost("{id}/submit")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<IActionResult> Submit([FromRoute] string id, [FromBody] IdempotencyEnvelope? request, CancellationToken ct)
+        => RunTransitionAsync(id, AppealStatus.Submitted, request?.EventId, ct);
+
+    [HttpPost("{id}/begin-review")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<IActionResult> BeginReview([FromRoute] string id, [FromBody] IdempotencyEnvelope? request, CancellationToken ct)
+        => RunTransitionAsync(id, AppealStatus.InReview, request?.EventId, ct);
+
+    [HttpPost("{id}/resume-review")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public Task<IActionResult> ResumeReview([FromRoute] string id, [FromBody] IdempotencyEnvelope? request, CancellationToken ct)
+        => RunTransitionAsync(id, AppealStatus.InReview, request?.EventId, ct);
+
+    [HttpPost("{id}/request-info")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> RequestInfo(
+        [FromRoute] string id,
+        [FromBody] RequestInfoRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        // Transition to PendingInfo first — this is the state-bearing
+        // operation; a failure surfaces as 409. The note append runs after
+        // successful transition; a crash window between the two leaves the
+        // appeal in PendingInfo without the info-request note, matching
+        // consent/personal-rep's accepted audit-trail-annotation posture.
+        var transitionResult = await RunTransitionAsync(id, AppealStatus.PendingInfo, request.EventId, ct);
+        if (transitionResult is not OkObjectResult okResult || okResult.Value is not Appeal view)
+            return transitionResult;
+
+        if (!string.IsNullOrEmpty(request.Description))
+        {
+            var actor = User.Identity?.Name ?? "System";
+            var note = new AppealNote
+            {
+                CreatedBy = actor,
+                NoteText = await _encryptor.EncryptAsync(request.Description, ct) ?? string.Empty,
+                IsInternal = false
+            };
+
+            // Re-read the appeal in stored (encrypted) form — the note append
+            // repository method expects the stored shape, not the decrypted
+            // view we just returned to the caller.
+            var stored = await _appeals.GetByIdAsync(TenantId, id, ct);
+            if (stored != null)
+            {
+                var noteAudit = BuildEvent(stored, AppealEventType.AppealNoteAdded,
+                    fromStatus: null, toStatus: null, actor, eventId: null);
+                noteAudit.Payload = new JsonObject
+                {
+                    ["noteId"] = note.NoteId,
+                    ["author"] = note.CreatedBy,
+                    ["isInternal"] = note.IsInternal,
+                    ["context"] = "request-info"
+                };
+
+                var withNote = await _appeals.AppendNoteAsync(stored, note, noteAudit, ct);
+                await _publisher.PublishNoteAddedAsync(withNote, note, actor, HttpContext.TraceIdentifier, ct);
+
+                view = await DecryptForResponseAsync(withNote, ct);
+            }
+        }
+
+        return Ok(view);
+    }
+
+    [HttpPost("{id}/withdraw")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Withdraw(
+        [FromRoute] string id,
+        [FromBody] WithdrawRequest? request,
+        CancellationToken ct)
+    {
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        // Idempotent: already closed with reason Withdrawn → 200, no second event.
+        if (appeal.Status == AppealStatus.Closed && appeal.ClosureReasonCode == AppealClosureReasonCode.Withdrawn)
+        {
+            return Ok(await DecryptForResponseAsync(appeal, ct));
+        }
+
+        return await CloseInternalAsync(appeal, AppealClosureReasonCode.Withdrawn,
+            decision: null, request?.EventId, ct);
+    }
+
+    [HttpPost("{id}/close")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Close(
+        [FromRoute] string id,
+        [FromBody] CloseAppealRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        // Idempotent: same reason already closed → 200, no second event.
+        if (appeal.Status == AppealStatus.Closed && appeal.ClosureReasonCode == request.ClosureReasonCode)
+        {
+            return Ok(await DecryptForResponseAsync(appeal, ct));
+        }
+
+        return await CloseInternalAsync(appeal, request.ClosureReasonCode,
+            request.Decision, request.EventId, ct);
+    }
+
+    // ── Notes / Attachments / Assignment ────────────────────────────────
+
+    [HttpPost("{id}/notes")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AddNote(
+        [FromRoute] string id,
+        [FromBody] AddNoteRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        var actor = User.Identity?.Name ?? "System";
+        var note = new AppealNote
+        {
+            CreatedBy = string.IsNullOrEmpty(request.CreatedBy) ? actor : request.CreatedBy,
+            NoteText = await _encryptor.EncryptAsync(request.NoteText, ct) ?? string.Empty,
+            IsInternal = request.IsInternal
+        };
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealNoteAdded,
+            fromStatus: null, toStatus: null, actor, request.EventId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["noteId"] = note.NoteId,
+            ["author"] = note.CreatedBy,
+            ["isInternal"] = note.IsInternal
+        };
+
+        var updated = await _appeals.AppendNoteAsync(appeal, note, auditEvent, ct);
+        await _publisher.PublishNoteAddedAsync(updated, note, actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(updated, ct);
+        return Ok(view);
+    }
+
+    [HttpPost("{id}/attachments")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AddAttachment(
+        [FromRoute] string id,
+        [FromBody] AddAttachmentRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        var actor = User.Identity?.Name ?? "System";
+        var now = DateTime.UtcNow;
+
+        var attachment = new AppealAttachment
+        {
+            ControlNumber = string.IsNullOrEmpty(request.ControlNumber)
+                ? $"275-{now:yyyyMMddHHmmss}-{Guid.NewGuid().ToString("N")[..6].ToUpperInvariant()}"
+                : request.ControlNumber,
+            AttachmentTypeCode = request.AttachmentTypeCode,
+            AttachmentTypeDescription = request.AttachmentTypeDescription,
+            TransmissionCode = string.IsNullOrEmpty(request.TransmissionCode) ? "EL" : request.TransmissionCode,
+            FileName = request.FileName,
+            BlobUrl = request.BlobUrl,
+            ContentType = request.ContentType,
+            FileSizeBytes = request.FileSizeBytes,
+            UploadedAt = now,
+            Description = await _encryptor.EncryptAsync(request.Description, ct)
+        };
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealAttachmentAdded,
+            fromStatus: null, toStatus: null, actor, request.EventId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["attachmentId"] = attachment.AttachmentId,
+            ["attachmentTypeCode"] = attachment.AttachmentTypeCode,
+            ["transmissionCode"] = attachment.TransmissionCode,
+            ["controlNumber"] = attachment.ControlNumber,
+            ["uploadedAt"] = attachment.UploadedAt.ToString("o")
+        };
+
+        var updated = await _appeals.AppendAttachmentAsync(appeal, attachment, auditEvent, ct);
+        await _publisher.PublishAttachmentAddedAsync(updated, attachment, actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(updated, ct);
+        return Ok(view);
+    }
+
+    [HttpPost("{id}/attachments/{attachmentId}/acknowledge")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AcknowledgeAttachment(
+        [FromRoute] string id,
+        [FromRoute] string attachmentId,
+        [FromBody] AcknowledgeAttachmentRequest? request,
+        CancellationToken ct)
+    {
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        var attachment = appeal.Attachments.FirstOrDefault(a => a.AttachmentId == attachmentId);
+        if (attachment == null) return NotFound();
+
+        var acknowledged = request?.AcknowledgmentReceived ?? true;
+        var actor = User.Identity?.Name ?? "System";
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealAttachmentAcknowledged,
+            fromStatus: null, toStatus: null, actor, request?.EventId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["attachmentId"] = attachmentId,
+            ["acknowledgmentReceived"] = acknowledged
+        };
+
+        var updated = await _appeals.AcknowledgeAttachmentAsync(
+            TenantId, id, attachmentId, acknowledged, auditEvent, ct);
+
+        var ackAtt = updated.Attachments.First(a => a.AttachmentId == attachmentId);
+        await _publisher.PublishAttachmentAcknowledgedAsync(
+            updated, ackAtt, actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(updated, ct);
+        return Ok(view);
+    }
+
+    [HttpPost("{id}/assign")]
+    [ProducesResponseType(typeof(Appeal), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AssignReviewer(
+        [FromRoute] string id,
+        [FromBody] AssignReviewerRequest request,
+        CancellationToken ct)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        // Idempotent: same reviewer already assigned → 200, no second event.
+        if (appeal.AssignedReviewerId == request.AssignedReviewerId)
+        {
+            return Ok(await DecryptForResponseAsync(appeal, ct));
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        var previous = appeal.AssignedReviewerId;
+
+        appeal.AssignedReviewerId = request.AssignedReviewerId;
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealAssigned,
+            fromStatus: null, toStatus: null, actor, request.EventId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["assignedReviewerId"] = request.AssignedReviewerId,
+            ["previousReviewerId"] = previous
+        };
+
+        var updated = await _appeals.AssignReviewerAsync(appeal, auditEvent, ct);
+
+        // Optional reassignment reason becomes a note (atomicity: best effort,
+        // same posture as request-info).
+        if (!string.IsNullOrEmpty(request.ReassignmentReason))
+        {
+            var note = new AppealNote
+            {
+                CreatedBy = actor,
+                NoteText = await _encryptor.EncryptAsync(request.ReassignmentReason, ct) ?? string.Empty,
+                IsInternal = true
+            };
+            var noteAudit = BuildEvent(updated, AppealEventType.AppealNoteAdded,
+                fromStatus: null, toStatus: null, actor, eventId: null);
+            noteAudit.Payload = new JsonObject
+            {
+                ["noteId"] = note.NoteId,
+                ["author"] = note.CreatedBy,
+                ["isInternal"] = note.IsInternal,
+                ["context"] = "reassignment-reason"
+            };
+            updated = await _appeals.AppendNoteAsync(updated, note, noteAudit, ct);
+            await _publisher.PublishNoteAddedAsync(updated, note, actor, HttpContext.TraceIdentifier, ct);
+        }
+
+        await _publisher.PublishAssignedAsync(updated, previous, actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(updated, ct);
+        return Ok(view);
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────────
+
+    private async Task<IActionResult> RunTransitionAsync(
+        string id, AppealStatus to, string? eventId, CancellationToken ct)
+    {
+        var appeal = await _appeals.GetByIdAsync(TenantId, id, ct);
+        if (appeal == null) return NotFound();
+
+        appeal = await MaybeObserveOverdueAsync(appeal, ct);
+
+        // Idempotent same-status → 200 no-op. State machine itself rejects
+        // X→X as illegal; the idempotency short-circuit lives here.
+        if (appeal.Status == to)
+        {
+            var view = await DecryptForResponseAsync(appeal, ct);
+            return Ok(view);
+        }
+
+        try
+        {
+            AppealStateMachine.EnsureAllowed(appeal.Status, to);
+        }
+        catch (InvalidAppealTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        var from = appeal.Status;
+        appeal.Status = to;
+        appeal.UpdatedAt = DateTime.UtcNow;
+        appeal.UpdatedBy = actor;
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealStatusChanged,
+            fromStatus: from, toStatus: to, actor, eventId);
+
+        Appeal updated;
+        try
+        {
+            updated = await _appeals.TransitionStatusAsync(appeal, auditEvent, ct);
+        }
+        catch (InvalidAppealTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        await _publisher.PublishStatusChangedAsync(updated, from, to, actor, HttpContext.TraceIdentifier, ct);
+
+        var result = await DecryptForResponseAsync(updated, ct);
+        return Ok(result);
+    }
+
+    private async Task<IActionResult> CloseInternalAsync(
+        Appeal appeal,
+        AppealClosureReasonCode reason,
+        AppealDecisionInput? decision,
+        string? eventId,
+        CancellationToken ct)
+    {
+        if (!AppealStateMachine.IsAllowed(appeal.Status, AppealStatus.Closed))
+        {
+            return ConflictTransition(new InvalidAppealTransitionException(appeal.Status, AppealStatus.Closed));
+        }
+
+        if (!AppealStateMachine.IsClosureReasonAllowed(appeal.Status, reason))
+        {
+            var problem = new ProblemDetails
+            {
+                Status = 409,
+                Title = "Invalid appeal closure reason",
+                Detail = $"Closure reason {reason} is not allowed from status {appeal.Status}.",
+                Type = "https://cloudhealthoffice.com/problems/appeal-closure-reason"
+            };
+            problem.Extensions["fromStatus"] = appeal.Status.ToString();
+            problem.Extensions["closureReasonCode"] = reason.ToString();
+            return Conflict(problem);
+        }
+
+        var actor = User.Identity?.Name ?? "System";
+        var from = appeal.Status;
+        var now = DateTime.UtcNow;
+
+        appeal.Status = AppealStatus.Closed;
+        appeal.ClosureReasonCode = reason;
+        appeal.ClosedAt = now;
+        appeal.ClosedBy = actor;
+        appeal.UpdatedAt = now;
+        appeal.UpdatedBy = actor;
+
+        if (decision != null && reason is AppealClosureReasonCode.Approved
+                                 or AppealClosureReasonCode.Denied
+                                 or AppealClosureReasonCode.PartialApproval)
+        {
+            appeal.Decision = new AppealDecision
+            {
+                DecisionType = decision.DecisionType,
+                ApprovedAmount = decision.ApprovedAmount,
+                DecisionReason = await _encryptor.EncryptAsync(decision.DecisionReason, ct),
+                ReviewerNotes = await _encryptor.EncryptAsync(decision.ReviewerNotes, ct),
+                DecisionMaker = string.IsNullOrEmpty(decision.DecisionMaker) ? actor : decision.DecisionMaker,
+                DecisionDate = now
+            };
+            appeal.DecisionDate = now;
+        }
+
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealClosed,
+            fromStatus: from, toStatus: AppealStatus.Closed, actor, eventId);
+        auditEvent.Payload = new JsonObject
+        {
+            ["fromStatus"] = from.ToString(),
+            ["closureReasonCode"] = reason.ToString(),
+            ["decisionType"] = appeal.Decision?.DecisionType.ToString(),
+            ["approvedAmount"] = appeal.Decision?.ApprovedAmount
+        };
+
+        Appeal updated;
+        try
+        {
+            updated = await _appeals.TransitionStatusAsync(appeal, auditEvent, ct);
+        }
+        catch (InvalidAppealTransitionException ex)
+        {
+            return ConflictTransition(ex);
+        }
+
+        await _publisher.PublishClosedAsync(updated, from, actor, HttpContext.TraceIdentifier, ct);
+
+        var view = await DecryptForResponseAsync(updated, ct);
+        return Ok(view);
+    }
+
+    private async Task<Appeal> MaybeObserveOverdueAsync(Appeal appeal, CancellationToken ct)
+    {
+        if (!appeal.IsOverdue || appeal.OverdueAuditEmitted) return appeal;
+
+        var actor = "System";
+        var auditEvent = BuildEvent(appeal, AppealEventType.AppealOverdueObserved,
+            fromStatus: null, toStatus: null, actor, eventId: null);
+        auditEvent.Payload = new JsonObject
+        {
+            ["currentStatus"] = appeal.Status.ToString(),
+            ["targetResponseDate"] = appeal.TargetResponseDate?.ToString("o")
+        };
+
+        var persisted = await _appeals.TryTransitionToOverdueAsync(appeal, auditEvent, ct);
+        if (persisted != null)
+        {
+            await _publisher.PublishOverdueObservedAsync(persisted, actor, HttpContext.TraceIdentifier, ct);
+            return persisted;
+        }
+
+        // Lost the race — another reader already emitted. Keep the local
+        // copy's OverdueAuditEmitted flag in sync so we don't retry.
+        appeal.OverdueAuditEmitted = true;
+        return appeal;
+    }
+
+    private static AppealEvent BuildEvent(
+        Appeal appeal,
+        AppealEventType type,
+        AppealStatus? fromStatus,
+        AppealStatus? toStatus,
+        string actor,
+        string? eventId)
+    {
+        return new AppealEvent
+        {
+            TenantId = appeal.TenantId,
+            AppealId = appeal.Id,
+            EventId = string.IsNullOrEmpty(eventId) ? Guid.NewGuid().ToString() : eventId,
+            EventType = type,
+            FromStatus = fromStatus,
+            ToStatus = toStatus,
+            ActorId = actor,
+            OccurredAt = DateTime.UtcNow
+        };
+    }
+
+    private async Task<Appeal> DecryptForResponseAsync(Appeal appeal, CancellationToken ct)
+    {
+        // Shallow copy — leave the stored record untouched; decrypt the
+        // outward-facing view only. Avoids aliasing bugs where a caller
+        // persists the decrypted copy.
+        var view = new Appeal
+        {
+            TenantId = appeal.TenantId,
+            Id = appeal.Id,
+            AppealNumber = appeal.AppealNumber,
+            ClaimId = appeal.ClaimId,
+            ClaimNumber = appeal.ClaimNumber,
+            MemberId = appeal.MemberId,
+            ProviderNPI = appeal.ProviderNPI,
+            ProviderName = appeal.ProviderName,
+            DenialReasonCode = appeal.DenialReasonCode,
+            DeniedAmount = appeal.DeniedAmount,
+            AppealedAmount = appeal.AppealedAmount,
+            AppealType = appeal.AppealType,
+            AppealLevel = appeal.AppealLevel,
+            LineOfBusiness = appeal.LineOfBusiness,
+            Status = appeal.Status,
+            Source = appeal.Source,
+            Attachments = await DecryptAttachmentsAsync(appeal.Attachments, ct),
+            ClinicalDocuments = await DecryptClinicalDocsAsync(appeal.ClinicalDocuments, ct),
+            Decision = await DecryptDecisionAsync(appeal.Decision, ct),
+            SubmittedDate = appeal.SubmittedDate,
+            ReceivedDate = appeal.ReceivedDate,
+            TargetResponseDate = appeal.TargetResponseDate,
+            DecisionDate = appeal.DecisionDate,
+            SubmittedBy = appeal.SubmittedBy,
+            Notes = await DecryptNotesAsync(appeal.Notes, ct),
+            AttachmentControlNumbers = appeal.AttachmentControlNumbers,
+            IsUrgent = appeal.IsUrgent,
+            ServiceDate = appeal.ServiceDate,
+            DiagnosisCodes = appeal.DiagnosisCodes,
+            ProcedureCodes = appeal.ProcedureCodes,
+            AssignedReviewerId = appeal.AssignedReviewerId,
+            CreatedAt = appeal.CreatedAt,
+            CreatedBy = appeal.CreatedBy,
+            UpdatedAt = appeal.UpdatedAt,
+            UpdatedBy = appeal.UpdatedBy,
+            ClosedAt = appeal.ClosedAt,
+            ClosedBy = appeal.ClosedBy,
+            ClosureReasonCode = appeal.ClosureReasonCode,
+            OverdueAuditEmitted = appeal.OverdueAuditEmitted,
+
+            PatientName = await _encryptor.DecryptAsync(appeal.PatientName, ct) ?? string.Empty,
+            AppealReason = await _encryptor.DecryptAsync(appeal.AppealReason, ct) ?? string.Empty,
+            DenialReason = await _encryptor.DecryptAsync(appeal.DenialReason, ct)
+        };
+        return view;
+    }
+
+    private async Task<List<AppealNote>> DecryptNotesAsync(List<AppealNote> notes, CancellationToken ct)
+    {
+        var results = new List<AppealNote>(notes.Count);
+        foreach (var n in notes)
+        {
+            results.Add(new AppealNote
+            {
+                NoteId = n.NoteId,
+                CreatedAt = n.CreatedAt,
+                CreatedBy = n.CreatedBy,
+                NoteText = await _encryptor.DecryptAsync(n.NoteText, ct) ?? string.Empty,
+                IsInternal = n.IsInternal
+            });
+        }
+        return results;
+    }
+
+    private async Task<List<AppealAttachment>> DecryptAttachmentsAsync(List<AppealAttachment> attachments, CancellationToken ct)
+    {
+        var results = new List<AppealAttachment>(attachments.Count);
+        foreach (var a in attachments)
+        {
+            results.Add(new AppealAttachment
+            {
+                AttachmentId = a.AttachmentId,
+                ControlNumber = a.ControlNumber,
+                AttachmentTypeCode = a.AttachmentTypeCode,
+                AttachmentTypeDescription = a.AttachmentTypeDescription,
+                TransmissionCode = a.TransmissionCode,
+                FileName = a.FileName,
+                BlobUrl = a.BlobUrl,
+                ContentType = a.ContentType,
+                FileSizeBytes = a.FileSizeBytes,
+                UploadedAt = a.UploadedAt,
+                Description = await _encryptor.DecryptAsync(a.Description, ct),
+                Status = a.Status,
+                SentDate = a.SentDate,
+                AcknowledgmentReceived = a.AcknowledgmentReceived
+            });
+        }
+        return results;
+    }
+
+    private async Task<List<ClinicalDocument>> DecryptClinicalDocsAsync(List<ClinicalDocument> docs, CancellationToken ct)
+    {
+        var results = new List<ClinicalDocument>(docs.Count);
+        foreach (var d in docs)
+        {
+            results.Add(new ClinicalDocument
+            {
+                DocumentId = d.DocumentId,
+                DocumentType = d.DocumentType,
+                DocumentDate = d.DocumentDate,
+                Provider = d.Provider,
+                BlobUrl = d.BlobUrl,
+                Summary = await _encryptor.DecryptAsync(d.Summary, ct)
+            });
+        }
+        return results;
+    }
+
+    private async Task<AppealDecision?> DecryptDecisionAsync(AppealDecision? decision, CancellationToken ct)
+    {
+        if (decision == null) return null;
+        return new AppealDecision
+        {
+            DecisionType = decision.DecisionType,
+            ApprovedAmount = decision.ApprovedAmount,
+            DecisionReason = await _encryptor.DecryptAsync(decision.DecisionReason, ct),
+            ReviewerNotes = await _encryptor.DecryptAsync(decision.ReviewerNotes, ct),
+            DecisionMaker = decision.DecisionMaker,
+            DecisionDate = decision.DecisionDate
+        };
+    }
+
+    private IActionResult ConflictTransition(InvalidAppealTransitionException ex)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = 409,
+            Title = "Invalid appeal transition",
+            Detail = ex.Message,
+            Type = "https://cloudhealthoffice.com/problems/appeal-transition"
+        };
+        problem.Extensions["fromStatus"] = ex.FromStatus.ToString();
+        problem.Extensions["toStatus"] = ex.ToStatus.ToString();
+        return Conflict(problem);
     }
 }
 
-public class UpdateAttachmentStatusRequest
+// ── Request / response DTOs ─────────────────────────────────────────────
+
+public class CreateAppealRequest
 {
-    public AttachmentStatus Status { get; set; }
+    [StringLength(50)]
+    public string? AppealNumber { get; set; }
+
+    [Required] [StringLength(50)]
+    public string ClaimId { get; set; } = string.Empty;
+
+    [Required] [StringLength(50)]
+    public string ClaimNumber { get; set; } = string.Empty;
+
+    [Required] [StringLength(50)]
+    public string MemberId { get; set; } = string.Empty;
+
+    [Required] [StringLength(200)]
+    public string PatientName { get; set; } = string.Empty;
+
+    [Required] [StringLength(10)]
+    public string ProviderNPI { get; set; } = string.Empty;
+
+    [StringLength(300)]
+    public string? ProviderName { get; set; }
+
+    [StringLength(5)]
+    public string? DenialReasonCode { get; set; }
+
+    [StringLength(4000)]
+    public string? DenialReason { get; set; }
+
+    public decimal DeniedAmount { get; set; }
+    public decimal AppealedAmount { get; set; }
+
+    [Required] public AppealType AppealType { get; set; } = AppealType.Reconsideration;
+
+    [Required] public AppealLevel AppealLevel { get; set; } = AppealLevel.FirstLevel;
+
+    [Required] public LineOfBusiness LineOfBusiness { get; set; }
+
+    [Required] [StringLength(8000)]
+    public string AppealReason { get; set; } = string.Empty;
+
+    public AppealSource Source { get; set; } = AppealSource.ProviderPortal;
+
+    public DateTime? TargetResponseDate { get; set; }
+
+    [StringLength(100)]
+    public string? SubmittedBy { get; set; }
+
+    public bool IsUrgent { get; set; }
+    public DateTime? ServiceDate { get; set; }
+
+    public List<string>? DiagnosisCodes { get; set; }
+    public List<string>? ProcedureCodes { get; set; }
+
+    [StringLength(200)]
+    public string? AssignedReviewerId { get; set; }
+
+    /// <summary>Optional client-supplied idempotency key for the audit event.</summary>
+    public string? EventId { get; set; }
+}
+
+public class CloseAppealRequest
+{
+    [Required]
+    public AppealClosureReasonCode ClosureReasonCode { get; set; }
+
+    public AppealDecisionInput? Decision { get; set; }
+
+    public string? EventId { get; set; }
+}
+
+public class AppealDecisionInput
+{
+    [Required] public AppealDecisionType DecisionType { get; set; }
+
+    public decimal? ApprovedAmount { get; set; }
+
+    [StringLength(8000)]
+    public string? DecisionReason { get; set; }
+
+    [StringLength(8000)]
+    public string? ReviewerNotes { get; set; }
+
+    [StringLength(100)]
+    public string? DecisionMaker { get; set; }
+}
+
+public class WithdrawRequest
+{
+    public string? EventId { get; set; }
+}
+
+public class RequestInfoRequest
+{
+    [Required] [StringLength(4000)]
+    public string Description { get; set; } = string.Empty;
+
+    public string? EventId { get; set; }
+}
+
+public class IdempotencyEnvelope
+{
+    public string? EventId { get; set; }
 }
 
 public class AddNoteRequest
 {
+    [Required] [StringLength(8000)]
     public string NoteText { get; set; } = string.Empty;
-    public string CreatedBy { get; set; } = string.Empty;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
     public bool IsInternal { get; set; } = true;
+
+    public string? EventId { get; set; }
 }
 
-public class UpdateStatusRequest
+public class AddAttachmentRequest
 {
-    public AppealStatus Status { get; set; }
+    [Required] [StringLength(2)]
+    public string AttachmentTypeCode { get; set; } = string.Empty;
+
+    public string? AttachmentTypeDescription { get; set; }
+
+    [StringLength(2)]
+    public string? TransmissionCode { get; set; }
+
+    [StringLength(50)]
+    public string? ControlNumber { get; set; }
+
+    [StringLength(300)]
+    public string? FileName { get; set; }
+
+    public string? BlobUrl { get; set; }
+
+    [StringLength(50)]
+    public string? ContentType { get; set; }
+
+    public long? FileSizeBytes { get; set; }
+
+    [StringLength(2000)]
+    public string? Description { get; set; }
+
+    public string? EventId { get; set; }
 }
 
+public class AcknowledgeAttachmentRequest
+{
+    public bool AcknowledgmentReceived { get; set; } = true;
+    public string? EventId { get; set; }
+}
+
+public class AssignReviewerRequest
+{
+    [Required] [StringLength(200)]
+    public string AssignedReviewerId { get; set; } = string.Empty;
+
+    [StringLength(4000)]
+    public string? ReassignmentReason { get; set; }
+
+    public string? EventId { get; set; }
+}
+
+public class AppealListResponse
+{
+    public List<Appeal> Items { get; set; } = new();
+}
+
+public class AppealHistoryResponse
+{
+    public List<AppealEvent> Items { get; set; } = new();
+}

--- a/src/services/appeals-service/HostedServices/AppealIndexInitializer.cs
+++ b/src/services/appeals-service/HostedServices/AppealIndexInitializer.cs
@@ -1,0 +1,101 @@
+using AppealsService.Models;
+using AppealsService.Repositories;
+using MongoDB.Driver;
+
+namespace AppealsService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the Appeals and AppealEvents
+/// collections once at startup. Idempotent — Mongo silently no-ops an
+/// index that already exists with the same spec.
+///
+/// Registered AFTER <see cref="AppealStatusMigrationHostedService"/> so
+/// any pre-modernization records are rewritten to the current schema
+/// before the unique <c>ux_tenant_appeal_number</c> index is built —
+/// otherwise a duplicate <c>AppealNumber</c> under the same tenant would
+/// fail index creation and block service startup. The migration service
+/// logs any duplicates as warnings before this initializer runs.
+/// </summary>
+public sealed class AppealIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly ILogger<AppealIndexInitializer> _logger;
+
+    public AppealIndexInitializer(IMongoDatabase db, ILogger<AppealIndexInitializer> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var appeals = _db.GetCollection<Appeal>(AppealRepositoryMongo.AppealsCollectionName);
+
+        await appeals.Indexes.CreateOneAsync(
+            new CreateIndexModel<Appeal>(
+                Builders<Appeal>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.Id),
+                new CreateIndexOptions { Name = "ux_tenant_id", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await appeals.Indexes.CreateOneAsync(
+            new CreateIndexModel<Appeal>(
+                Builders<Appeal>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.AppealNumber),
+                new CreateIndexOptions { Name = "ux_tenant_appeal_number", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await appeals.Indexes.CreateOneAsync(
+            new CreateIndexModel<Appeal>(
+                Builders<Appeal>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.ClaimId)
+                    .Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "ix_tenant_claim_created" }),
+            cancellationToken: cancellationToken);
+
+        await appeals.Indexes.CreateOneAsync(
+            new CreateIndexModel<Appeal>(
+                Builders<Appeal>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.Status)
+                    .Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "ix_tenant_status_created" }),
+            cancellationToken: cancellationToken);
+
+        await appeals.Indexes.CreateOneAsync(
+            new CreateIndexModel<Appeal>(
+                Builders<Appeal>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.MemberId)
+                    .Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "ix_tenant_member_created" }),
+            cancellationToken: cancellationToken);
+
+        var events = _db.GetCollection<AppealEvent>(AppealEventRepositoryMongo.AppealEventsCollectionName);
+
+        await events.Indexes.CreateOneAsync(
+            new CreateIndexModel<AppealEvent>(
+                Builders<AppealEvent>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.AppealId)
+                    .Ascending(x => x.EventId),
+                new CreateIndexOptions { Name = "ux_tenant_appeal_event", Unique = true }),
+            cancellationToken: cancellationToken);
+
+        await events.Indexes.CreateOneAsync(
+            new CreateIndexModel<AppealEvent>(
+                Builders<AppealEvent>.IndexKeys
+                    .Ascending(x => x.TenantId)
+                    .Ascending(x => x.AppealId)
+                    .Ascending(x => x.OccurredAt),
+                new CreateIndexOptions { Name = "ix_tenant_appeal_occurred" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation("Appeal, AppealEvent indexes ensured.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/appeals-service/HostedServices/AppealStatusMigrationHostedService.cs
+++ b/src/services/appeals-service/HostedServices/AppealStatusMigrationHostedService.cs
@@ -1,0 +1,261 @@
+using AppealsService.Models;
+using AppealsService.Repositories;
+using AppealsService.Services;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace AppealsService.HostedServices;
+
+/// <summary>
+/// One-shot migration: rewrite any pre-modernization appeal records that
+/// carry a legacy terminal <c>Status</c> value (Approved, Denied,
+/// PartialApproval, Withdrawn) into the new shape
+/// <c>Status=Closed</c> + <see cref="Appeal.ClosureReasonCode"/>, and
+/// append an <c>AppealStatusMigrated</c> audit event per record.
+///
+/// Idempotent — re-running finds zero eligible records and exits cleanly.
+/// Bounded batches (100 per scan, configurable via
+/// <c>AppealMigration:BatchSize</c>). Runs in <see cref="StartAsync"/> so
+/// the subsequent <see cref="AppealIndexInitializer"/> sees a consistent
+/// schema — the unique <c>ux_tenant_appeal_number</c> index would
+/// otherwise fail to build if duplicate AppealNumbers exist.
+///
+/// Also scans for duplicate <c>AppealNumber</c> values under the same
+/// tenant and logs them as warnings BEFORE the index initializer attempts
+/// the unique-index build. Operators must resolve dupes manually and
+/// re-deploy if the warning fires.
+///
+/// Cosmos deployments: this service is a no-op (the scan runs against
+/// Mongo's BsonDocument collection). Cosmos-side migration ships as a
+/// separate admin script if that deployment path is used in production.
+/// The status-enum consolidation only affects records written by the
+/// pre-addendum code path.
+/// </summary>
+public sealed class AppealStatusMigrationHostedService : IHostedService
+{
+    public const string LegacyStatusApproved = "Approved";
+    public const string LegacyStatusDenied = "Denied";
+    public const string LegacyStatusPartialApproval = "PartialApproval";
+    public const string LegacyStatusWithdrawn = "Withdrawn";
+
+    private static readonly string[] LegacyTerminalStatuses =
+    {
+        LegacyStatusApproved,
+        LegacyStatusDenied,
+        LegacyStatusPartialApproval,
+        LegacyStatusWithdrawn
+    };
+
+    private readonly IMongoDatabase _db;
+    private readonly IAppealEventSink _events;
+    private readonly IAppealEventPublisher _publisher;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AppealStatusMigrationHostedService> _logger;
+
+    public AppealStatusMigrationHostedService(
+        IMongoDatabase db,
+        IAppealEventSink events,
+        IAppealEventPublisher publisher,
+        IConfiguration configuration,
+        ILogger<AppealStatusMigrationHostedService> logger)
+    {
+        _db = db;
+        _events = events;
+        _publisher = publisher;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var batchSize = _configuration.GetValue<int?>("AppealMigration:BatchSize") ?? 100;
+        var raw = _db.GetCollection<BsonDocument>(AppealRepositoryMongo.AppealsCollectionName);
+
+        await WarnDuplicateAppealNumbersAsync(raw, cancellationToken);
+
+        var found = 0;
+        var migrated = 0;
+        var errors = 0;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var filter = BuildLegacyStatusFilter();
+            var batch = await raw.Find(filter).Limit(batchSize).ToListAsync(cancellationToken);
+            if (batch.Count == 0) break;
+
+            found += batch.Count;
+            foreach (var doc in batch)
+            {
+                try
+                {
+                    await MigrateOneAsync(raw, doc, cancellationToken);
+                    migrated++;
+                }
+                catch (Exception ex)
+                {
+                    errors++;
+                    _logger.LogError(ex,
+                        "Failed to migrate appeal {AppealId} for tenant {TenantId}",
+                        LogSanitizer.SafeForLog(doc.GetValue("_id", BsonNull.Value).ToString()),
+                        LogSanitizer.SafeForLog(doc.GetValue("tenantId", BsonNull.Value).ToString()));
+                }
+            }
+
+            if (batch.Count < batchSize) break;
+        }
+
+        _logger.LogInformation(
+            "AppealStatusMigration complete: found={Found} migrated={Migrated} errors={Errors}",
+            found, migrated, errors);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static FilterDefinition<BsonDocument> BuildLegacyStatusFilter()
+    {
+        // Matches records whose status is any of the four legacy terminal
+        // strings. Enum representation may be configured as integers in
+        // pre-modernization deployments; include integer equivalents too.
+        // Old enum was 0-indexed: Draft=0, Submitted=1, InReview=2,
+        // PendingInfo=3, Approved=4, Denied=5, PartialApproval=6, Withdrawn=7.
+        var stringMatches = LegacyTerminalStatuses
+            .SelectMany(s => new BsonValue[] { s, s.ToLowerInvariant() })
+            .ToArray();
+        var intMatches = new BsonValue[] { 4, 5, 6, 7 };
+        return Builders<BsonDocument>.Filter.In("status",
+            stringMatches.Concat(intMatches));
+    }
+
+    private async Task MigrateOneAsync(IMongoCollection<BsonDocument> raw, BsonDocument doc, CancellationToken ct)
+    {
+        var tenantId = doc.GetValue("tenantId", BsonNull.Value).ToString() ?? string.Empty;
+        var appealId = doc.GetValue("_id", BsonNull.Value).ToString() ?? string.Empty;
+        if (string.IsNullOrEmpty(tenantId) || string.IsNullOrEmpty(appealId))
+            throw new InvalidOperationException("Appeal document missing tenantId or _id.");
+
+        var rawStatus = doc.GetValue("status", BsonNull.Value);
+        var legacyLabel = rawStatus.BsonType == BsonType.Int32
+            ? rawStatus.AsInt32 switch
+              {
+                  4 => LegacyStatusApproved,
+                  5 => LegacyStatusDenied,
+                  6 => LegacyStatusPartialApproval,
+                  7 => LegacyStatusWithdrawn,
+                  _ => rawStatus.ToString() ?? "Unknown"
+              }
+            : rawStatus.ToString() ?? "Unknown";
+
+        var mappedReason = MapLegacyStatus(legacyLabel);
+        var now = DateTime.UtcNow;
+
+        var update = Builders<BsonDocument>.Update
+            .Set("status", AppealStatus.Closed.ToString())
+            .Set("closureReasonCode", mappedReason.ToString())
+            .Set("closedAt", now)
+            .Set("closedBy", "system:migration")
+            .Set("updatedAt", now)
+            .Set("updatedBy", "system:migration");
+
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", doc.GetValue("_id"));
+        await raw.UpdateOneAsync(filter, update, cancellationToken: ct);
+
+        // Build the audit event and the Kafka event from a typed snapshot of
+        // the post-migration record. We populate a minimal Appeal instance
+        // for envelope/headers — the payload only carries legacy/mapped data.
+        var snapshot = new Appeal
+        {
+            TenantId = tenantId,
+            Id = appealId,
+            AppealNumber = doc.GetValue("appealNumber", BsonNull.Value).ToString() ?? string.Empty,
+            ClaimId = doc.GetValue("claimId", BsonNull.Value).ToString() ?? string.Empty,
+            ClaimNumber = doc.GetValue("claimNumber", BsonNull.Value).ToString() ?? string.Empty,
+            MemberId = doc.GetValue("memberId", BsonNull.Value).ToString() ?? string.Empty,
+            PatientName = string.Empty,
+            ProviderNPI = doc.GetValue("providerNPI", BsonNull.Value).ToString() ?? string.Empty,
+            AppealReason = string.Empty,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            Status = AppealStatus.Closed,
+            ClosureReasonCode = mappedReason
+        };
+
+        var auditEvent = new AppealEvent
+        {
+            TenantId = tenantId,
+            AppealId = appealId,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealStatusMigrated,
+            FromStatus = null,
+            ToStatus = AppealStatus.Closed,
+            ActorId = "system:migration",
+            OccurredAt = now,
+            Payload = new System.Text.Json.Nodes.JsonObject
+            {
+                ["legacyStatus"] = legacyLabel,
+                ["mappedReasonCode"] = mappedReason.ToString()
+            }
+        };
+
+        await _events.AppendAsync(auditEvent, ct);
+        await _publisher.PublishStatusMigratedAsync(
+            snapshot, legacyLabel, mappedReason, "system:migration", correlationId: null, ct);
+
+        _logger.LogInformation(
+            "Migrated appeal {AppealId} tenant {TenantId} from legacy status {Legacy} -> Closed + {Reason}",
+            LogSanitizer.SafeForLog(appealId), LogSanitizer.SafeForLog(tenantId),
+            LogSanitizer.SafeForLog(legacyLabel), LogSanitizer.SafeForLog(mappedReason.ToString()));
+    }
+
+    /// <summary>
+    /// Maps a legacy-status string to the new closure reason code.
+    /// Internal so <c>AppealStatusMigrationTests</c> can assert the mapping.
+    /// </summary>
+    internal static AppealClosureReasonCode MapLegacyStatus(string legacy) => legacy switch
+    {
+        LegacyStatusApproved => AppealClosureReasonCode.Approved,
+        LegacyStatusDenied => AppealClosureReasonCode.Denied,
+        LegacyStatusPartialApproval => AppealClosureReasonCode.PartialApproval,
+        LegacyStatusWithdrawn => AppealClosureReasonCode.Withdrawn,
+        _ => AppealClosureReasonCode.Other
+    };
+
+    private async Task WarnDuplicateAppealNumbersAsync(
+        IMongoCollection<BsonDocument> raw, CancellationToken ct)
+    {
+        // Run a light aggregation to surface any (tenantId, appealNumber)
+        // pairs that appear more than once. If any exist, the subsequent
+        // unique-index build WILL FAIL and block service startup —
+        // operators must resolve dupes manually and re-deploy.
+        try
+        {
+            var pipeline = new[]
+            {
+                new BsonDocument("$group", new BsonDocument
+                {
+                    { "_id", new BsonDocument { { "tenantId", "$tenantId" }, { "appealNumber", "$appealNumber" } } },
+                    { "count", new BsonDocument("$sum", 1) }
+                }),
+                new BsonDocument("$match", new BsonDocument("count", new BsonDocument("$gt", 1)))
+            };
+
+            using var cursor = await raw.AggregateAsync<BsonDocument>(pipeline, cancellationToken: ct);
+            while (await cursor.MoveNextAsync(ct))
+            {
+                foreach (var dup in cursor.Current)
+                {
+                    var key = dup.GetValue("_id", BsonNull.Value);
+                    var count = dup.GetValue("count", BsonNull.Value);
+                    _logger.LogWarning(
+                        "Duplicate AppealNumber detected pre-index-build: {Key} count={Count}. " +
+                        "ux_tenant_appeal_number unique index creation WILL FAIL until manually resolved.",
+                        LogSanitizer.SafeForLog(key.ToString()),
+                        LogSanitizer.SafeForLog(count.ToString()));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Duplicate-AppealNumber pre-scan failed — continuing. The index build may still fail if duplicates exist.");
+        }
+    }
+}

--- a/src/services/appeals-service/Middleware/TenantMiddleware.cs
+++ b/src/services/appeals-service/Middleware/TenantMiddleware.cs
@@ -1,18 +1,22 @@
+using System.Security.Claims;
+
 namespace AppealsService.Middleware;
 
 /// <summary>
-/// Middleware to extract TenantId from JWT claims or headers
-/// Multi-tenant SaaS isolation: each tenant's appeals are partitioned by TenantId
+/// Extracts tenant context from JWT tokens or headers for multi-tenant
+/// isolation. Reconciled with consent-service / personal-rep-service
+/// during modernization: returns 401 on missing context rather than
+/// silently defaulting to a shared "default-tenant" (which was a prior
+/// multi-tenancy violation — any unauthenticated request would read that
+/// tenant's data).
 /// </summary>
 public class TenantMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly ILogger<TenantMiddleware> _logger;
 
-    public TenantMiddleware(RequestDelegate next, ILogger<TenantMiddleware> logger)
+    public TenantMiddleware(RequestDelegate next)
     {
         _next = next;
-        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -23,56 +27,66 @@ public class TenantMiddleware
             return;
         }
 
-        string? tenantId = null;
+        var tenantId = ExtractTenantId(context);
 
-        // 1. Try to get from JWT claims (production)
-        if (context.User.Identity?.IsAuthenticated == true)
-        {
-            // Azure AD B2C or custom JWT
-            tenantId = context.User.FindFirst("tenant_id")?.Value
-                      ?? context.User.FindFirst("extension_TenantId")?.Value;
-        }
-
-        // 2. Fallback to headers (development/testing)
         if (string.IsNullOrEmpty(tenantId))
         {
-            tenantId = context.Request.Headers["X-Tenant-ID"].FirstOrDefault()
-                      ?? context.Request.Headers["X-Dev-Tenant-ID"].FirstOrDefault();
+            context.Response.StatusCode = 401;
+            await context.Response.WriteAsync("Missing tenant context. Provide X-Tenant-ID header or valid JWT with tenant claim.");
+            return;
         }
 
-        // 3. Default for local development
-        if (string.IsNullOrEmpty(tenantId))
-        {
-            tenantId = "default-tenant";
-            _logger.LogWarning("No TenantId found in JWT or headers, using default: {TenantId}", SanitizeForLog(tenantId));
-        }
-
-        // Store in HttpContext for repository access
         context.Items["TenantId"] = tenantId;
-
-        _logger.LogDebug("Request TenantId: {TenantId}", SanitizeForLog(tenantId));
-
         await _next(context);
     }
 
     private static bool IsHealthCheckPath(PathString path)
     {
-        return path.StartsWithSegments("/health") 
+        return path.StartsWithSegments("/health")
+            || path.StartsWithSegments("/ready")
+            || path.StartsWithSegments("/live")
             || path.StartsWithSegments("/swagger");
     }
 
-    private static string SanitizeForLog(string? value)
+    private static string? ExtractTenantId(HttpContext context)
     {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        var user = context.User;
+        if (user?.Identity?.IsAuthenticated == true)
+        {
+            var tenantClaim = user.FindFirst("tenant_id")?.Value
+                           ?? user.FindFirst("extension_TenantId")?.Value
+                           ?? user.FindFirst(ClaimTypes.GroupSid)?.Value;
+
+            if (!string.IsNullOrEmpty(tenantClaim))
+            {
+                return tenantClaim;
+            }
+        }
+
+        if (context.Request.Headers.TryGetValue("X-Tenant-ID", out var headerValue))
+        {
+            return headerValue.FirstOrDefault();
+        }
+
+        if (context.Request.Headers.TryGetValue("X-Dev-Tenant-ID", out var devHeaderValue))
+        {
+            return devHeaderValue.FirstOrDefault();
+        }
+
+        return null;
     }
 }
 
 public static class TenantMiddlewareExtensions
 {
-    public static IApplicationBuilder UseTenantMiddleware(this IApplicationBuilder builder)
+    public static IApplicationBuilder UseTenantContext(this IApplicationBuilder builder)
     {
         return builder.UseMiddleware<TenantMiddleware>();
+    }
+
+    public static string GetTenantId(this HttpContext context)
+    {
+        return context.Items["TenantId"]?.ToString()
+            ?? throw new InvalidOperationException("Tenant context not found. Ensure TenantMiddleware is registered.");
     }
 }

--- a/src/services/appeals-service/Models/Appeal.cs
+++ b/src/services/appeals-service/Models/Appeal.cs
@@ -1,401 +1,452 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
-using System.Collections.Generic;
+using MongoDB.Bson.Serialization.Attributes;
+
+// TODO(appeals-followup-pr3): FHIR Task / Communication / DocumentReference /
+// ClaimResponse rendering belongs in fhir-service via the existing
+// IFhirDataAdapter pattern — not here. appeals-service owns the bespoke
+// domain model.
 
 namespace AppealsService.Models;
 
 /// <summary>
-/// Represents a claim appeal request with 275 attachment support
-/// Appeals are submitted when claims are denied and require additional documentation
+/// A claim appeal request with 275 attachment support. Appeals are submitted
+/// when claims are denied and require additional documentation. Appeals are
+/// never hard-deleted; lifecycle transitions (Draft → Submitted → InReview →
+/// PendingInfo → Closed) are captured through
+/// <see cref="Repositories.IAppealRepository.TransitionStatusAsync"/> with a
+/// matching <see cref="AppealEvent"/> appended atomically for audit.
+///
+/// PHI-adjacent free-text fields (<see cref="PatientName"/>,
+/// <see cref="AppealReason"/>, <see cref="DenialReason"/>, note text, decision
+/// reasons, reviewer notes, clinical document summaries, attachment
+/// descriptions) are stored as ciphertext; encryption is applied by the
+/// controller layer before persistence, decryption on read-back. The fields
+/// are always accessed through the entity in ciphertext form — repositories
+/// do not decrypt.
 /// </summary>
+[BsonIgnoreExtraElements]
 public class Appeal
 {
-    /// <summary>
-    /// Multi-tenant partition key (required for Cosmos DB isolation)
-    /// </summary>
+    /// <summary>Multi-tenant partition key.</summary>
     [Required]
     public string TenantId { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Unique appeal identifier (Cosmos DB document id)
-    /// </summary>
+    /// <summary>Stable appeal id. Cosmos document id and Mongo `_id`.</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
-    /// <summary>
-    /// Appeal tracking number (user-facing)
-    /// </summary>
+    /// <summary>User-facing tracking number. Unique within tenant.</summary>
     [Required]
     [StringLength(50)]
     public string AppealNumber { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Original claim ID being appealed
-    /// </summary>
     [Required]
     [StringLength(50)]
     public string ClaimId { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Original claim number
-    /// </summary>
     [Required]
     [StringLength(50)]
     public string ClaimNumber { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Member ID
-    /// </summary>
     [Required]
     [StringLength(50)]
     public string MemberId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Patient name
+    /// Patient name. Encrypted at rest via
+    /// <see cref="Services.IAppealFieldEncryptor"/>.
     /// </summary>
     [Required]
     [StringLength(200)]
     public string PatientName { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Provider NPI submitting appeal
-    /// </summary>
     [Required]
     [StringLength(10)]
     public string ProviderNPI { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Provider name
-    /// </summary>
     [StringLength(300)]
     public string? ProviderName { get; set; }
 
-    /// <summary>
-    /// Original denial reason code
-    /// </summary>
+    /// <summary>Original denial reason code from the claim. Not PHI.</summary>
     [StringLength(5)]
     public string? DenialReasonCode { get; set; }
 
     /// <summary>
-    /// Original denial reason description
+    /// Original denial reason description from the claim. Free text —
+    /// encrypted at rest.
     /// </summary>
+    [StringLength(4000)]
     public string? DenialReason { get; set; }
 
-    /// <summary>
-    /// Original denied amount
-    /// </summary>
     public decimal DeniedAmount { get; set; }
 
-    /// <summary>
-    /// Amount being appealed
-    /// </summary>
     public decimal AppealedAmount { get; set; }
 
-    /// <summary>
-    /// Appeal type
-    /// </summary>
     [Required]
     public AppealType AppealType { get; set; } = AppealType.Reconsideration;
 
-    /// <summary>
-    /// Appeal level (first, second, external review)
-    /// </summary>
     [Required]
     public AppealLevel AppealLevel { get; set; } = AppealLevel.FirstLevel;
 
-    /// <summary>
-    /// Line of Business
-    /// </summary>
     [Required]
     public LineOfBusiness LineOfBusiness { get; set; }
 
-    /// <summary>
-    /// Appeal status
-    /// </summary>
     [Required]
-    public AppealStatus Status { get; set; } = AppealStatus.Submitted;
+    public AppealStatus Status { get; set; } = AppealStatus.Draft;
 
     /// <summary>
-    /// Reason for appeal (provider's argument)
+    /// The provider's argument for the appeal. Free text — encrypted at
+    /// rest.
     /// </summary>
     [Required]
+    [StringLength(8000)]
     public string AppealReason { get; set; } = string.Empty;
 
     /// <summary>
-    /// Supporting documentation/attachments (275 transaction references)
+    /// Ingress channel. Defaults to <see cref="AppealSource.ProviderPortal"/>.
+    /// Future ingress channels (Availity 275, CSR transcription, internal
+    /// retro review, external review) come in follow-up PRs.
     /// </summary>
+    public AppealSource Source { get; set; } = AppealSource.ProviderPortal;
+
     public List<AppealAttachment> Attachments { get; set; } = new();
 
-    /// <summary>
-    /// Clinical documentation references
-    /// </summary>
     public List<ClinicalDocument> ClinicalDocuments { get; set; } = new();
 
     /// <summary>
-    /// Appeal decision outcome
+    /// Decision outcome. Populated when <see cref="Status"/> transitions to
+    /// <see cref="AppealStatus.Closed"/> with a decision-bearing
+    /// <see cref="ClosureReasonCode"/>.
     /// </summary>
     public AppealDecision? Decision { get; set; }
 
-    /// <summary>
-    /// Date appeal submitted
-    /// </summary>
+    // ── Lifecycle timestamps ────────────────────────────────────────────
+
     [Required]
     public DateTime SubmittedDate { get; set; } = DateTime.UtcNow;
 
-    /// <summary>
-    /// Date appeal was received by payer
-    /// </summary>
     public DateTime? ReceivedDate { get; set; }
 
-    /// <summary>
-    /// Target response date (regulatory deadline)
-    /// </summary>
+    /// <summary>Regulatory deadline. Drives the read-time overdue projection.</summary>
     public DateTime? TargetResponseDate { get; set; }
 
-    /// <summary>
-    /// Date decision was made
-    /// </summary>
     public DateTime? DecisionDate { get; set; }
 
     /// <summary>
-    /// User who submitted the appeal
+    /// User who submitted the appeal.
+    /// TODO(appeals-followup-personal-rep-integration): When filed on behalf
+    /// of a member by a Personal Representative, the SubmittedBy field
+    /// should resolve to a personal-rep-service reference. Not this PR.
+    /// TODO(appeals-followup-consent-integration): When filed on behalf of
+    /// a member who granted §164.508 authorization, the chain should be
+    /// recorded via consent-service. Not this PR.
     /// </summary>
     [StringLength(100)]
     public string? SubmittedBy { get; set; }
 
-    /// <summary>
-    /// Internal notes
-    /// </summary>
     public List<AppealNote> Notes { get; set; } = new();
 
-    /// <summary>
-    /// 275 attachment transaction control numbers
-    /// </summary>
+    /// <summary>275 attachment transaction control numbers.</summary>
     public List<string> AttachmentControlNumbers { get; set; } = new();
 
-    /// <summary>
-    /// Priority flag
-    /// </summary>
-    public bool IsUrgent { get; set; } = false;
+    public bool IsUrgent { get; set; }
 
-    /// <summary>
-    /// Service date from original claim
-    /// </summary>
     public DateTime? ServiceDate { get; set; }
 
     /// <summary>
-    /// Diagnosis codes from original claim
+    /// Diagnosis codes from the original claim. Plain-stored for
+    /// queryability — matches the claims-service posture. Legal review to
+    /// confirm for the PCHP tenant before merge.
     /// </summary>
     public List<string> DiagnosisCodes { get; set; } = new();
 
     /// <summary>
-    /// Procedure codes from original claim
+    /// Procedure codes from the original claim. Plain-stored for
+    /// queryability — matches the claims-service posture. Legal review to
+    /// confirm for the PCHP tenant before merge.
     /// </summary>
     public List<string> ProcedureCodes { get; set; } = new();
+
+    /// <summary>
+    /// Assigned reviewer id (plain-stored, not encrypted). Mutated only via
+    /// the <c>POST /{id}/assign</c> endpoint, which writes an
+    /// <c>AppealAssigned</c> audit event.
+    /// TODO(appeals-followup-work-queue): Auto-assignment rules and
+    /// workload balancing live in a future work-queue service.
+    /// </summary>
+    [StringLength(200)]
+    public string? AssignedReviewerId { get; set; }
+
+    // ── Audit timestamps ────────────────────────────────────────────────
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
+    [StringLength(200)]
+    public string? UpdatedBy { get; set; }
+
+    public DateTime? ClosedAt { get; set; }
+
+    [StringLength(200)]
+    public string? ClosedBy { get; set; }
+
+    /// <summary>
+    /// Controlled reason code for closure. Safe to include in event payload
+    /// (enum-valued). Populated when <see cref="Status"/> is
+    /// <see cref="AppealStatus.Closed"/>. See
+    /// <see cref="AppealClosureReasonCode"/>.
+    /// </summary>
+    public AppealClosureReasonCode? ClosureReasonCode { get; set; }
+
+    /// <summary>
+    /// One-shot marker for the read-time overdue observer. Set to
+    /// <c>true</c> by
+    /// <see cref="Repositories.IAppealRepository.TryTransitionToOverdueAsync"/>
+    /// when the first read past <see cref="TargetResponseDate"/> emits an
+    /// <c>AppealOverdueObserved</c> audit event. Prevents duplicate overdue
+    /// events for the same appeal.
+    /// </summary>
+    public bool OverdueAuditEmitted { get; set; }
+
+    /// <summary>
+    /// Projects the persisted status into the status the caller observes —
+    /// the raw <see cref="Status"/> today; overdue is NOT a status (it's a
+    /// read-time projection on <see cref="IsOverdue"/>). This method is
+    /// kept for symmetry with consent-service/personal-rep-service and will
+    /// gain responsibilities if a future status (e.g. a review-pending
+    /// state) joins the lifecycle.
+    /// </summary>
+    public AppealStatus ObservedStatus(DateTime? asOf = null) => Status;
+
+    /// <summary>
+    /// Read-time projection: <c>true</c> when the appeal is in a
+    /// non-terminal status and <see cref="TargetResponseDate"/> has passed.
+    /// </summary>
+    [BsonIgnore]
+    public bool IsOverdue =>
+        TargetResponseDate.HasValue &&
+        TargetResponseDate.Value <= DateTime.UtcNow &&
+        Status != AppealStatus.Draft &&
+        Status != AppealStatus.Closed;
 }
 
 /// <summary>
-/// 275 attachment submission record
-/// 275: Attachment/additional documentation transaction
+/// 275 attachment submission record. The <see cref="BlobUrl"/> is a
+/// member-document-service reference — appeals-service does NOT store blob
+/// bytes.
 /// </summary>
+[BsonIgnoreExtraElements]
 public class AppealAttachment
 {
-    /// <summary>
-    /// Attachment ID
-    /// </summary>
     [Required]
     public string AttachmentId { get; set; } = Guid.NewGuid().ToString();
 
-    /// <summary>
-    /// 275 transaction control number
-    /// </summary>
+    /// <summary>275 transaction control number (PWK06 equivalent).</summary>
     [StringLength(50)]
     public string? ControlNumber { get; set; }
 
-    /// <summary>
-    /// Attachment type code (275: PWK01)
-    /// </summary>
+    /// <summary>Attachment type code (275: PWK01).</summary>
     [Required]
     [StringLength(2)]
     public string AttachmentTypeCode { get; set; } = string.Empty;
 
-    /// <summary>
-    /// Attachment type description
-    /// </summary>
     public string? AttachmentTypeDescription { get; set; }
 
     /// <summary>
-    /// Transmission code (275: PWK02) - AA=Available, BM=By Mail, EL=Electronically, etc.
+    /// Transmission code (275: PWK02). AA=Available, BM=By Mail,
+    /// EL=Electronically, etc.
     /// </summary>
     [Required]
     [StringLength(2)]
     public string TransmissionCode { get; set; } = "EL";
 
-    /// <summary>
-    /// File name or document reference
-    /// </summary>
     [StringLength(300)]
     public string? FileName { get; set; }
 
     /// <summary>
-    /// Blob storage URL for uploaded document
+    /// Reference into member-document-service where the document bytes live.
+    /// appeals-service does NOT store blobs.
     /// </summary>
     public string? BlobUrl { get; set; }
 
-    /// <summary>
-    /// Content type (PDF, TIFF, etc.)
-    /// </summary>
     [StringLength(50)]
     public string? ContentType { get; set; }
 
-    /// <summary>
-    /// File size in bytes
-    /// </summary>
     public long? FileSizeBytes { get; set; }
 
-    /// <summary>
-    /// Upload timestamp
-    /// </summary>
     public DateTime UploadedAt { get; set; } = DateTime.UtcNow;
 
     /// <summary>
-    /// Description/notes about this attachment
+    /// Free-text description. May contain PHI — encrypted at rest.
     /// </summary>
+    [StringLength(2000)]
     public string? Description { get; set; }
 
-    /// <summary>
-    /// 275 submission status
-    /// </summary>
     public AttachmentStatus Status { get; set; } = AttachmentStatus.Pending;
 
-    /// <summary>
-    /// Date attachment was sent via 275 transaction
-    /// </summary>
     public DateTime? SentDate { get; set; }
 
-    /// <summary>
-    /// Acknowledgment received
-    /// </summary>
-    public bool AcknowledgmentReceived { get; set; } = false;
+    public bool AcknowledgmentReceived { get; set; }
 }
 
-/// <summary>
-/// Clinical documentation reference
-/// </summary>
+/// <summary>Clinical documentation reference.</summary>
+[BsonIgnoreExtraElements]
 public class ClinicalDocument
 {
     public string DocumentId { get; set; } = Guid.NewGuid().ToString();
-    public string DocumentType { get; set; } = string.Empty; // Progress Note, Operative Report, Lab Results, etc.
+    public string DocumentType { get; set; } = string.Empty;
     public string? DocumentDate { get; set; }
     public string? Provider { get; set; }
     public string? BlobUrl { get; set; }
+
+    /// <summary>Free-text clinical summary. PHI — encrypted at rest.</summary>
+    [StringLength(4000)]
     public string? Summary { get; set; }
 }
 
-/// <summary>
-/// Appeal decision outcome
-/// </summary>
+/// <summary>Appeal decision outcome.</summary>
+[BsonIgnoreExtraElements]
 public class AppealDecision
 {
-    /// <summary>
-    /// Decision code (Approved, Denied, Partial)
-    /// </summary>
     [Required]
     public AppealDecisionType DecisionType { get; set; }
 
-    /// <summary>
-    /// Approved amount (if approved/partial)
-    /// </summary>
     public decimal? ApprovedAmount { get; set; }
 
-    /// <summary>
-    /// Decision reason/rationale
-    /// </summary>
+    /// <summary>Decision rationale. Free text — encrypted at rest.</summary>
+    [StringLength(8000)]
     public string? DecisionReason { get; set; }
 
-    /// <summary>
-    /// Decision maker (reviewer name/ID)
-    /// </summary>
     [StringLength(100)]
     public string? DecisionMaker { get; set; }
 
-    /// <summary>
-    /// Date decision was made
-    /// </summary>
     public DateTime DecisionDate { get; set; } = DateTime.UtcNow;
 
     /// <summary>
-    /// Additional reviewer notes
+    /// Additional reviewer notes. Free text — encrypted at rest.
     /// </summary>
+    [StringLength(8000)]
     public string? ReviewerNotes { get; set; }
 }
 
-/// <summary>
-/// Appeal note/comment
-/// </summary>
+/// <summary>Appeal note / comment.</summary>
+[BsonIgnoreExtraElements]
 public class AppealNote
 {
     public string NoteId { get; set; } = Guid.NewGuid().ToString();
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
     public string CreatedBy { get; set; } = string.Empty;
+
+    /// <summary>Note body. Free text — encrypted at rest.</summary>
+    [StringLength(8000)]
     public string NoteText { get; set; } = string.Empty;
+
     public bool IsInternal { get; set; } = true;
 }
 
 public enum AppealType
 {
-    Reconsideration,  // Standard appeal review
-    PeerReview,       // Clinical peer-to-peer review
-    ExternalReview,   // Independent external review
-    Grievance         // Member-initiated grievance
+    Reconsideration = 1,
+    PeerReview = 2,
+    ExternalReview = 3,
+    Grievance = 4
 }
 
 public enum AppealLevel
 {
-    FirstLevel,      // Initial appeal review
-    SecondLevel,     // Second-level appeal
-    ExternalReview   // State/Federal external review
+    FirstLevel = 1,
+    SecondLevel = 2,
+    ExternalReview = 3
 }
 
+/// <summary>
+/// Appeal lifecycle state. See <c>Services.AppealStateMachine</c> for the
+/// allowed transitions. The four historical terminal values (Approved,
+/// Denied, PartialApproval, Withdrawn) consolidate into
+/// <see cref="Closed"/> plus an <see cref="AppealClosureReasonCode"/>
+/// discriminator — mirrors the pattern
+/// <c>PersonalRepInactivationReasonCode</c> established.
+/// </summary>
 public enum AppealStatus
 {
-    Draft,           // Being prepared
-    Submitted,       // Submitted to payer
-    InReview,        // Under review by payer
-    PendingInfo,     // Waiting for additional information
-    Approved,        // Appeal approved
-    Denied,          // Appeal denied
-    PartialApproval, // Partially approved
-    Withdrawn        // Withdrawn by provider
+    Draft = 1,
+    Submitted = 2,
+    InReview = 3,
+    PendingInfo = 4,
+    Closed = 5
 }
 
 public enum AppealDecisionType
 {
-    Approved,
-    Denied,
-    PartialApproval
+    Approved = 1,
+    Denied = 2,
+    PartialApproval = 3
 }
 
 public enum AttachmentStatus
 {
-    Pending,      // Not yet sent
-    Sent,         // 275 transaction sent
-    Acknowledged, // Payer acknowledged receipt
-    Rejected,     // Payer rejected attachment
-    Error         // Transmission error
+    Pending = 1,
+    Sent = 2,
+    Acknowledged = 3,
+    Rejected = 4,
+    Error = 5
 }
 
 public enum LineOfBusiness
 {
-    Commercial,
-    Medicare,
-    Medicaid,
-    Marketplace
+    Commercial = 1,
+    Medicare = 2,
+    Medicaid = 3,
+    Marketplace = 4
 }
 
 /// <summary>
-/// Appeals summary statistics
+/// Controlled closure reasons. Safe to include in event payloads (no PHI).
+/// Unlike consent-service which models Expired as a distinct terminal
+/// status, appeals collapses all termination reasons into
+/// <see cref="AppealStatus.Closed"/> with a discriminator here — see
+/// <c>Services.AppealStateMachine</c> remarks for rationale.
+/// </summary>
+public enum AppealClosureReasonCode
+{
+    Approved = 1,
+    Denied = 2,
+    PartialApproval = 3,
+    Withdrawn = 4,
+    Expired = 5,
+    AdminError = 6,
+    Other = 99
+}
+
+/// <summary>
+/// Ingress channel for an appeal. Zero-cost foresight for PR 4's 275
+/// consumer and future ingress work — default today is
+/// <see cref="ProviderPortal"/>; no behavior branches on this yet.
+/// </summary>
+public enum AppealSource
+{
+    ProviderPortal = 1,
+    Availity275 = 2,
+    CsrTranscription = 3,
+    InternalRetroReview = 4,
+    ExternalReview = 5
+}
+
+/// <summary>
+/// Appeals summary statistics. Wire shape is stable — the four portal-
+/// observed buckets (<see cref="OpenAppeals"/>, <see cref="UrgentExpedited"/>,
+/// <see cref="DueThisWeek"/>, <see cref="OverturnedRate"/>) are preserved
+/// across the status-enum consolidation by recomputing over
+/// <c>Status + ClosureReasonCode</c>.
 /// </summary>
 public class AppealsSummary
 {
@@ -404,10 +455,56 @@ public class AppealsSummary
     public int Approved { get; set; }
     public int Denied { get; set; }
     public int PartialApprovals { get; set; }
+    public int Withdrawn { get; set; }
     public decimal TotalAppealedAmount { get; set; }
     public decimal TotalApprovedAmount { get; set; }
     public double AverageDecisionTimeDays { get; set; }
     public double ApprovalRate { get; set; }
+
+    // ── Portal-observed wire-shape buckets ──────────────────────────────
+    /// <summary>
+    /// Appeals in a non-terminal status (Submitted, InReview, PendingInfo).
+    /// Draft is excluded — a draft is not yet an open appeal from the
+    /// payer's perspective.
+    /// </summary>
+    public int OpenAppeals { get; set; }
+
+    /// <summary>Open appeals flagged urgent.</summary>
+    public int UrgentExpedited { get; set; }
+
+    /// <summary>
+    /// Open appeals with <c>TargetResponseDate</c> within the next 7 days
+    /// (including already-overdue).
+    /// </summary>
+    public int DueThisWeek { get; set; }
+
+    /// <summary>
+    /// Percentage of Closed appeals with
+    /// <c>ClosureReasonCode ∈ {Approved, PartialApproval}</c> — the rate at
+    /// which original denials were overturned on appeal. 0–100.
+    /// </summary>
+    public double OverturnedRate { get; set; }
+
     public Dictionary<AppealStatus, int> AppealsByStatus { get; set; } = new();
     public Dictionary<AppealLevel, int> AppealsByLevel { get; set; } = new();
+}
+
+/// <summary>
+/// Thrown when a caller attempts an appeal lifecycle transition that is not
+/// allowed by <c>Services.AppealStateMachine</c>. Distinct from a generic
+/// <see cref="InvalidOperationException"/> so the controller layer can map
+/// it to a 409 Conflict with <see cref="FromStatus"/>/<see cref="ToStatus"/>
+/// in ProblemDetails rather than a 500.
+/// </summary>
+public sealed class InvalidAppealTransitionException : InvalidOperationException
+{
+    public AppealStatus FromStatus { get; }
+    public AppealStatus ToStatus { get; }
+
+    public InvalidAppealTransitionException(AppealStatus from, AppealStatus to)
+        : base($"Appeal transition {from} -> {to} is not allowed.")
+    {
+        FromStatus = from;
+        ToStatus = to;
+    }
 }

--- a/src/services/appeals-service/Models/AppealEvent.cs
+++ b/src/services/appeals-service/Models/AppealEvent.cs
@@ -1,0 +1,102 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace AppealsService.Models;
+
+/// <summary>
+/// Append-only audit row for <see cref="Appeal"/>. One row per lifecycle
+/// action (created, status-changed, closed, note-added, attachment-added,
+/// attachment-acknowledged, overdue-observed, assigned, migrated from
+/// pre-modernization status values). Partition key is
+/// <c>{tenantId}:{appealId}</c> so the full audit trail for an appeal lives
+/// in a single partition and scans cheaply.
+/// </summary>
+[BsonIgnoreExtraElements]
+public class AppealEvent
+{
+    /// <summary>Cosmos document id + Mongo `_id`. Defaults to <see cref="EventId"/>.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Cosmos partition key. Derived via <see cref="BuildPartitionKey"/>.</summary>
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    public string AppealId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client-supplied idempotency key. Duplicate appends with the same
+    /// <c>EventId</c> are silently ignored at the repository layer.
+    /// </summary>
+    [Required]
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public AppealEventType EventType { get; set; }
+
+    public AppealStatus? FromStatus { get; set; }
+    public AppealStatus? ToStatus { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string ActorId { get; set; } = string.Empty;
+
+    [StringLength(200)]
+    public string? CorrelationId { get; set; }
+
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Structured, non-PHI payload. Free-form JSON so new event types can
+    /// carry whatever context they need without a model change — keep PHI-
+    /// adjacent fields OUT of this payload (those live encrypted on the
+    /// <see cref="Appeal"/> aggregate). Field-whitelist tests in
+    /// AppealsService.Tests enforce the invariant.
+    /// </summary>
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    /// <summary>
+    /// Mongo-facing mirror of <see cref="Payload"/>. Not emitted by
+    /// System.Text.Json (Cosmos path) — used only by the BSON driver.
+    /// </summary>
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string appealId) =>
+        $"{tenantId}:{appealId}";
+}
+
+public enum AppealEventType
+{
+    AppealCreated = 1,
+    AppealStatusChanged = 2,
+    AppealClosed = 3,
+    AppealNoteAdded = 4,
+    AppealAttachmentAdded = 5,
+    AppealAttachmentAcknowledged = 6,
+    AppealOverdueObserved = 7,
+    AppealAssigned = 8,
+    /// <summary>
+    /// Emitted by <c>HostedServices.AppealStatusMigrationHostedService</c>
+    /// for records that carried pre-modernization terminal status values
+    /// (Approved/Denied/PartialApproval/Withdrawn) and were rewritten to
+    /// <c>Status=Closed</c> + <see cref="Appeal.ClosureReasonCode"/>. One
+    /// row per migrated record. The <c>Payload</c> carries the legacy
+    /// status as <c>legacyStatus</c> and the mapped reason code as
+    /// <c>mappedReasonCode</c> so the audit trail remains coherent after
+    /// the migration.
+    /// </summary>
+    AppealStatusMigrated = 9
+}

--- a/src/services/appeals-service/Program.cs
+++ b/src/services/appeals-service/Program.cs
@@ -1,14 +1,35 @@
-using Microsoft.Azure.Cosmos;
-using Microsoft.OpenApi.Models;
+using AppealsService.HostedServices;
 using AppealsService.Middleware;
 using AppealsService.Repositories;
-using CloudHealthOffice.Infrastructure.HealthChecks;
+using AppealsService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
+using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Json;
+using CloudHealthOffice.Infrastructure.Messaging;
 using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.OpenApi.Models;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Conventions;
+
+// ── BSON convention: enums stored as strings ─────────────────────────
+// Register BEFORE any IMongoClient is constructed. Ensures enum values on
+// Appeal (Status, ClosureReasonCode, AppealType, etc.) are persisted as
+// human-readable strings rather than integers. Matches the Cosmos
+// serializer's enum representation (JsonStringEnumConverter), so the two
+// storage backends produce comparable shapes. Also future-proofs against
+// enum-value reordering: adding a new status value doesn't silently
+// re-map existing data.
+MongoDB.Bson.Serialization.Conventions.ConventionRegistry.Register(
+    "appeals-enums-as-strings",
+    new ConventionPack { new EnumRepresentationConvention(BsonType.String) },
+    _ => true);
 
 var builder = WebApplication.CreateBuilder(args);
-// Secret provider (Azure Key Vault / none)
+
+// Secret provider (Azure Key Vault / none) — same bootstrap shape as
+// consent-service / personal-rep-service.
 builder.Services.AddSecretProvider(builder.Configuration);
 builder.Configuration.AddAzureKeyVaultConfiguration(builder.Configuration);
 
@@ -19,71 +40,122 @@ builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo
     {
-        Title = "Appeals Service API",
+        Title = "Cloud Health Office - Appeals Service API",
         Version = "v1",
-        Description = "Claim appeals processing with 275 attachment support for Cloud Health Office. " +
-                     "Handles appeal workflow, documentation submission, and decision tracking."
+        Description = "Claim appeals processing with 275 attachment support. "
+                    + "State-machine lifecycle, append-only audit trail, field-level encryption."
     });
 });
 
-// Database Configuration
+// ── Database Configuration ───────────────────────────────────────────
 var mongoConnectionString = builder.Configuration["MongoDb:ConnectionString"];
 
 if (!string.IsNullOrEmpty(mongoConnectionString))
 {
-    builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(sp =>
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoClient>(_ =>
         new MongoDB.Driver.MongoClient(mongoConnectionString));
 
-    builder.Services.AddScoped<MongoDB.Driver.IMongoDatabase>(sp =>
+    builder.Services.AddSingleton<MongoDB.Driver.IMongoDatabase>(sp =>
     {
         var client = sp.GetRequiredService<MongoDB.Driver.IMongoClient>();
         var databaseName = builder.Configuration["MongoDb:DatabaseName"] ?? "CloudHealthOffice";
         return client.GetDatabase(databaseName);
     });
 
-    builder.Services.AddScoped<IAppealRepository, AppealRepositoryMongo>();
-    Console.WriteLine("Using MongoDB database provider");
+    builder.Services.AddSingleton<IAppealEventRepository, AppealEventRepositoryMongo>();
+    builder.Services.AddSingleton<IAppealEventSink>(sp => (IAppealEventSink)sp.GetRequiredService<IAppealEventRepository>());
+    builder.Services.AddSingleton<IAppealRepository, AppealRepositoryMongo>();
+
+    // Registration order matters for IHostedService.StartAsync sequencing:
+    // migration runs first so the index initializer sees a consistent
+    // schema and duplicate-AppealNumber warnings fire before the unique
+    // index build.
+    builder.Services.AddHostedService<AppealStatusMigrationHostedService>();
+    builder.Services.AddHostedService<AppealIndexInitializer>();
+
+    Console.WriteLine("[appeals-service] Using MongoDB database provider");
 }
 else
 {
     builder.Services.AddSingleton<CosmosClient>(sp =>
     {
-        var config = sp.GetRequiredService<IConfiguration>();
-        var endpoint = config["CosmosDb:Endpoint"];
-        var key = config["CosmosDb:Key"];
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var endpoint = configuration["CosmosDb:Endpoint"]
+            ?? configuration["CosmosDb:AccountEndpoint"]
+            ?? throw new InvalidOperationException("CosmosDb:Endpoint configuration missing");
+        var key = configuration["CosmosDb:Key"]
+            ?? configuration["CosmosDb:AccountKey"]
+            ?? throw new InvalidOperationException("CosmosDb:Key configuration missing");
 
-        if (string.IsNullOrEmpty(endpoint) || string.IsNullOrEmpty(key))
-        {
-            throw new InvalidOperationException("CosmosDb:Endpoint and CosmosDb:Key must be configured");
-        }
-
-        var options = new CosmosClientOptions
+        return new CosmosClient(endpoint, key, new CosmosClientOptions
         {
             Serializer = new CosmosSystemTextJsonSerializer()
-        };
-        return new CosmosClient(endpoint, key, options);
+        });
     });
 
-    builder.Services.AddScoped<IAppealRepository, AppealRepository>();
-    Console.WriteLine("Using Cosmos DB database provider");
+    builder.Services.AddScoped<IAppealEventRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        return new AppealEventRepository(cosmosClient, databaseName);
+    });
+    builder.Services.AddScoped<IAppealEventSink>(sp => (IAppealEventSink)sp.GetRequiredService<IAppealEventRepository>());
+    builder.Services.AddScoped<IAppealRepository>(sp =>
+    {
+        var cosmosClient = sp.GetRequiredService<CosmosClient>();
+        var configuration = sp.GetRequiredService<IConfiguration>();
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        var sink = sp.GetRequiredService<IAppealEventSink>();
+        return new AppealRepository(cosmosClient, databaseName, sink);
+    });
+
+    Console.WriteLine("[appeals-service] Using Cosmos DB database provider");
 }
 
-// HTTP context accessor (for tenant middleware)
-builder.Services.AddHttpContextAccessor();
-
-// Health checks (MongoDB or Cosmos DB)
-builder.Services.AddChoHealthChecks(options =>
+// ── Appeal body encryption ───────────────────────────────────────────
+// Non-dev startup guard: no AppealEncryption section = startup error.
+// Only IsDevelopment() falls back to the no-op encryptor.
+var appealEncryptionSection = builder.Configuration.GetSection(AppealEncryptionOptions.SectionName);
+if (appealEncryptionSection.Exists())
 {
-    options.MongoDbConnectionString = builder.Configuration["MongoDb:ConnectionString"];
-    options.CosmosDbConnectionString = builder.Configuration["CosmosDb:ConnectionString"];
-    options.CosmosDbEndpoint = builder.Configuration["CosmosDb:Endpoint"];
-    options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
-});
+    var options = appealEncryptionSection.Get<AppealEncryptionOptions>() ?? new AppealEncryptionOptions();
+    builder.Services.AddSingleton(options);
+    builder.Services.AddSingleton<IAppealFieldEncryptor>(sp =>
+        new AppealFieldEncryptor(
+            sp.GetRequiredService<RotatingKeyProvider>(),
+            sp.GetRequiredService<ILogger<AppealFieldEncryptor>>(),
+            options));
 
-// CORS (for development)
+    Console.WriteLine(
+        $"[appeals-service] IAppealFieldEncryptor = KeyVault (rotating) — current: {options.CurrentKeyVersion}; " +
+        $"accepted: [{string.Join(", ", options.AcceptedKeyVersions)}]");
+}
+else
+{
+    if (!builder.Environment.IsDevelopment())
+    {
+        throw new InvalidOperationException(
+            "AppealEncryption must be configured in non-development environments. " +
+            "Publish the appeal-body-encryption-key-v1 secret and set AppealEncryption:KeySecretPrefix / CurrentKeyVersion.");
+    }
+    builder.Services.AddSingleton(new AppealEncryptionOptions());
+    builder.Services.AddSingleton<IAppealFieldEncryptor, NoOpAppealFieldEncryptor>();
+    Console.WriteLine("[dev] IAppealFieldEncryptor = NoOp (appeal body fields stored plaintext). Configure AppealEncryption to enable.");
+}
+
+// ── Kafka producer (appeal lifecycle events) ─────────────────────────
+// Always registered; degraded-mode-silent if Kafka:BootstrapServers is unset.
+builder.Services.AddSingleton<AppealEventPublisher>();
+builder.Services.AddSingleton<IAppealEventPublisher>(sp => sp.GetRequiredService<AppealEventPublisher>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<AppealEventPublisher>());
+
+// IMessageBus — registered for future consumers; no-op cost today.
+builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
+
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowAll", policy =>
+    options.AddDefaultPolicy(policy =>
     {
         policy.AllowAnyOrigin()
               .AllowAnyMethod()
@@ -91,34 +163,42 @@ builder.Services.AddCors(options =>
     });
 });
 
+// Health checks: Mongo / Cosmos via the shared bootstrap, plus the
+// local appeal-encryption-key readiness check.
+builder.Services.AddChoHealthChecks(options =>
+{
+    options.MongoDbConnectionString = builder.Configuration["MongoDb:ConnectionString"];
+    options.CosmosDbConnectionString = builder.Configuration["CosmosDb:ConnectionString"];
+    options.CosmosDbEndpoint = builder.Configuration["CosmosDb:Endpoint"];
+    options.CosmosDbKey = builder.Configuration["CosmosDb:Key"];
+})
+.AddCheck<AppealEncryptionKeyHealthCheck>(
+    "appeal-encryption-key",
+    failureStatus: HealthStatus.Unhealthy,
+    tags: new[] { "ready" });
+
 builder.Services.AddChoObservability(builder.Configuration);
 
 var app = builder.Build();
 
 app.UseChoObservability();
 
-// Configure the HTTP request pipeline
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "Appeals Service API v1");
-        c.RoutePrefix = string.Empty; // Swagger at root
     });
 }
 
-app.UseMiddleware<CloudHealthOffice.Infrastructure.Middleware.ExceptionHandlingMiddleware>();
-app.UseHttpsRedirection();
-
-// Multi-tenant middleware (extract TenantId from JWT or headers)
-app.UseTenantMiddleware();
-
-app.UseCors("AllowAll");
-
+app.UseCors();
+app.UseTenantContext();
 app.UseAuthorization();
-
 app.MapControllers();
 app.MapChoHealthChecks();
 
 app.Run();
+
+// Required so WebApplicationFactory<Program> works in the test project.
+public partial class Program { }

--- a/src/services/appeals-service/Repositories/AppealEventRepository.cs
+++ b/src/services/appeals-service/Repositories/AppealEventRepository.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using AppealsService.Models;
+using Microsoft.Azure.Cosmos;
+
+namespace AppealsService.Repositories;
+
+/// <summary>
+/// Cosmos DB implementation of <see cref="IAppealEventRepository"/> and
+/// <see cref="IAppealEventSink"/>. Partition key: <c>/partitionKey</c>
+/// (<c>{tenantId}:{appealId}</c>) so the full audit trail for an appeal
+/// lives in a single partition and scans cheaply.
+///
+/// Writes are idempotent: the Cosmos document id is
+/// <see cref="AppealEvent.EventId"/>, so a duplicate append with the same
+/// EventId returns a 409 that we treat as a no-op — safe under retry from
+/// Kafka / controller layers.
+/// </summary>
+public sealed class AppealEventRepository : IAppealEventRepository, IAppealEventSink
+{
+    public const string AppealEventsContainerName = "AppealEvents";
+
+    private readonly Container _container;
+
+    public AppealEventRepository(CosmosClient cosmosClient, string databaseName)
+    {
+        _container = cosmosClient.GetDatabase(databaseName).GetContainer(AppealEventsContainerName);
+    }
+
+    public async Task AppendAsync(AppealEvent evt, CancellationToken ct = default)
+    {
+        NormalizeEnvelope(evt);
+        try
+        {
+            await _container.CreateItemAsync(evt, new PartitionKey(evt.PartitionKey), cancellationToken: ct);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+        {
+            // Idempotent append: duplicate EventId = same append, ignore.
+        }
+    }
+
+    public async Task<IReadOnlyList<AppealEvent>> ListByAppealAsync(
+        string tenantId, string appealId, CancellationToken ct = default)
+    {
+        var partitionKey = AppealEvent.BuildPartitionKey(tenantId, appealId);
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.partitionKey = @pk ORDER BY c.occurredAt ASC")
+            .WithParameter("@pk", partitionKey);
+
+        var iterator = _container.GetItemQueryIterator<AppealEvent>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(partitionKey) });
+
+        var results = new List<AppealEvent>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    internal static void NormalizeEnvelope(AppealEvent evt)
+    {
+        if (string.IsNullOrEmpty(evt.EventId))
+            throw new ArgumentException("EventId is required (client-supplied idempotency key)");
+        if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.AppealId))
+            throw new ArgumentException("TenantId and AppealId are required");
+
+        if (string.IsNullOrEmpty(evt.Id))
+            evt.Id = evt.EventId;
+        if (string.IsNullOrEmpty(evt.PartitionKey))
+            evt.PartitionKey = AppealEvent.BuildPartitionKey(evt.TenantId, evt.AppealId);
+    }
+}

--- a/src/services/appeals-service/Repositories/AppealEventRepositoryMongo.cs
+++ b/src/services/appeals-service/Repositories/AppealEventRepositoryMongo.cs
@@ -1,0 +1,44 @@
+using AppealsService.Models;
+using MongoDB.Driver;
+
+namespace AppealsService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IAppealEventRepository"/> and
+/// <see cref="IAppealEventSink"/>. Append is idempotent via the unique
+/// index on <c>(tenantId, appealId, eventId)</c> created at startup by
+/// <c>HostedServices.AppealIndexInitializer</c>.
+/// </summary>
+public sealed class AppealEventRepositoryMongo : IAppealEventRepository, IAppealEventSink
+{
+    public const string AppealEventsCollectionName = "AppealEvents";
+
+    private readonly IMongoCollection<AppealEvent> _collection;
+
+    public AppealEventRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<AppealEvent>(AppealEventsCollectionName);
+    }
+
+    public async Task AppendAsync(AppealEvent evt, CancellationToken ct = default)
+    {
+        AppealEventRepository.NormalizeEnvelope(evt);
+        try
+        {
+            await _collection.InsertOneAsync(evt, cancellationToken: ct);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Duplicate EventId — idempotent replay, drop silently.
+        }
+    }
+
+    public async Task<IReadOnlyList<AppealEvent>> ListByAppealAsync(
+        string tenantId, string appealId, CancellationToken ct = default)
+    {
+        var filter = Builders<AppealEvent>.Filter.Eq(e => e.TenantId, tenantId)
+                   & Builders<AppealEvent>.Filter.Eq(e => e.AppealId, appealId);
+        var results = await _collection.Find(filter).ToListAsync(ct);
+        return results.OrderBy(e => e.OccurredAt).ToList();
+    }
+}

--- a/src/services/appeals-service/Repositories/AppealRepository.cs
+++ b/src/services/appeals-service/Repositories/AppealRepository.cs
@@ -1,286 +1,374 @@
-using Microsoft.Azure.Cosmos;
+using System.Net;
 using AppealsService.Models;
+using Microsoft.Azure.Cosmos;
 
 namespace AppealsService.Repositories;
 
-public interface IAppealRepository
+/// <summary>
+/// Cosmos DB implementation of <see cref="IAppealRepository"/>.
+/// Partition key: <c>/tenantId</c>. Audit-trail atomicity for
+/// <see cref="TransitionStatusAsync"/> / <see cref="TryTransitionToOverdueAsync"/>
+/// follows the same pattern as consent-service and personal-rep-service:
+/// conditional ReplaceItem with ETag precondition on the appeal entity;
+/// the audit event is appended after the conditional replace succeeds.
+/// Event writes are idempotent (unique key on EventId) so a retry is safe.
+/// </summary>
+public sealed class AppealRepository : IAppealRepository
 {
-    Task<Appeal?> GetByIdAsync(string id);
-    Task<Appeal?> GetByAppealNumberAsync(string appealNumber);
-    Task<IEnumerable<Appeal>> GetByClaimIdAsync(string claimId);
-    Task<IEnumerable<Appeal>> SearchAsync(
-        string? memberId,
-        string? providerNPI,
-        DateTime? submittedFrom,
-        DateTime? submittedTo,
-        AppealStatus? status,
-        LineOfBusiness? lineOfBusiness,
-        int page = 1,
-        int pageSize = 50);
-    Task<AppealsSummary> GetAppealsSummaryAsync(DateTime from, DateTime to);
-    Task<Appeal> CreateAsync(Appeal appeal);
-    Task<Appeal> UpdateAsync(Appeal appeal);
-    Task DeleteAsync(string id);
-}
+    public const string AppealsContainerName = "Appeals";
 
-public class AppealRepository : IAppealRepository
-{
-    private readonly Container _container;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILogger<AppealRepository> _logger;
+    private readonly Container _appeals;
+    private readonly IAppealEventSink _events;
 
-    public AppealRepository(
-        CosmosClient cosmosClient,
-        IConfiguration configuration,
-        IHttpContextAccessor httpContextAccessor,
-        ILogger<AppealRepository> logger)
+    public AppealRepository(CosmosClient cosmosClient, string databaseName, IAppealEventSink events)
     {
-        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
-        var containerName = configuration["CosmosDb:ContainerName"] ?? "Appeals";
-
-        _container = cosmosClient.GetContainer(databaseName, containerName);
-        _httpContextAccessor = httpContextAccessor;
-        _logger = logger;
+        _appeals = cosmosClient.GetDatabase(databaseName).GetContainer(AppealsContainerName);
+        _events = events;
     }
 
-    private string GetTenantId()
+    public async Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default)
     {
-        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
-        if (string.IsNullOrEmpty(tenantId))
-        {
-            throw new InvalidOperationException("TenantId not found in request context");
-        }
-        return tenantId;
+        if (string.IsNullOrEmpty(appeal.Id)) appeal.Id = Guid.NewGuid().ToString();
+        if (appeal.CreatedAt == default) appeal.CreatedAt = DateTime.UtcNow;
+
+        var response = await _appeals.CreateItemAsync(appeal, new PartitionKey(appeal.TenantId), cancellationToken: ct);
+        await _events.AppendAsync(genesisEvent, ct);
+        return response.Resource;
     }
 
-    public async Task<Appeal?> GetByIdAsync(string id)
+    public async Task<Appeal?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-
         try
         {
-            var response = await _container.ReadItemAsync<Appeal>(
-                id,
-                new PartitionKey(tenantId));
+            var response = await _appeals.ReadItemAsync<Appeal>(id, new PartitionKey(tenantId), cancellationToken: ct);
             return response.Resource;
         }
-        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             return null;
         }
     }
 
-    public async Task<Appeal?> GetByAppealNumberAsync(string appealNumber)
+    public async Task<Appeal?> GetByAppealNumberAsync(string tenantId, string appealNumber, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-
         var query = new QueryDefinition(
             "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.appealNumber = @appealNumber")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@appealNumber", appealNumber);
 
-        var iterator = _container.GetItemQueryIterator<Appeal>(query);
-        var results = new List<Appeal>();
+        var iterator = _appeals.GetItemQueryIterator<Appeal>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
 
         while (iterator.HasMoreResults)
         {
-            var response = await iterator.ReadNextAsync();
-            results.AddRange(response);
+            var page = await iterator.ReadNextAsync(ct);
+            foreach (var item in page) return item;
         }
-
-        return results.FirstOrDefault();
+        return null;
     }
 
-    public async Task<IEnumerable<Appeal>> GetByClaimIdAsync(string claimId)
+    public async Task<IReadOnlyList<Appeal>> GetByClaimIdAsync(string tenantId, string claimId, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-
         var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.claimId = @claimId ORDER BY c.submittedDate DESC")
+            "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.claimId = @claimId ORDER BY c.createdAt DESC")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@claimId", claimId);
 
-        var iterator = _container.GetItemQueryIterator<Appeal>(query);
-        var results = new List<Appeal>();
+        var iterator = _appeals.GetItemQueryIterator<Appeal>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
 
+        var results = new List<Appeal>();
         while (iterator.HasMoreResults)
         {
-            var response = await iterator.ReadNextAsync();
-            results.AddRange(response);
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
         }
-
         return results;
     }
 
-    public async Task<IEnumerable<Appeal>> SearchAsync(
-        string? memberId,
-        string? providerNPI,
-        DateTime? submittedFrom,
-        DateTime? submittedTo,
-        AppealStatus? status,
-        LineOfBusiness? lineOfBusiness,
-        int page = 1,
-        int pageSize = 50)
+    public async Task<IReadOnlyList<Appeal>> SearchAsync(
+        string tenantId, AppealSearchParams p, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
+        var page = Math.Max(1, p.Page);
+        var pageSize = Math.Clamp(p.PageSize, 1, 100);
 
         var queryText = "SELECT * FROM c WHERE c.tenantId = @tenantId";
         var parameters = new List<(string, object)> { ("@tenantId", tenantId) };
 
-        if (!string.IsNullOrEmpty(memberId))
+        if (!string.IsNullOrEmpty(p.MemberId))
         {
             queryText += " AND c.memberId = @memberId";
-            parameters.Add(("@memberId", memberId));
+            parameters.Add(("@memberId", p.MemberId));
         }
-
-        if (!string.IsNullOrEmpty(providerNPI))
+        if (!string.IsNullOrEmpty(p.ProviderNPI))
         {
             queryText += " AND c.providerNPI = @providerNPI";
-            parameters.Add(("@providerNPI", providerNPI));
+            parameters.Add(("@providerNPI", p.ProviderNPI));
         }
-
-        if (submittedFrom.HasValue)
+        if (p.SubmittedFrom.HasValue)
         {
             queryText += " AND c.submittedDate >= @submittedFrom";
-            parameters.Add(("@submittedFrom", submittedFrom.Value));
+            parameters.Add(("@submittedFrom", p.SubmittedFrom.Value));
         }
-
-        if (submittedTo.HasValue)
+        if (p.SubmittedTo.HasValue)
         {
             queryText += " AND c.submittedDate <= @submittedTo";
-            parameters.Add(("@submittedTo", submittedTo.Value));
+            parameters.Add(("@submittedTo", p.SubmittedTo.Value));
         }
-
-        if (status.HasValue)
+        if (p.Status.HasValue)
         {
             queryText += " AND c.status = @status";
-            parameters.Add(("@status", (int)status.Value));
+            parameters.Add(("@status", p.Status.Value.ToString()));
         }
-
-        if (lineOfBusiness.HasValue)
+        if (p.ClosureReasonCode.HasValue)
+        {
+            queryText += " AND c.closureReasonCode = @closureReasonCode";
+            parameters.Add(("@closureReasonCode", p.ClosureReasonCode.Value.ToString()));
+        }
+        if (p.LineOfBusiness.HasValue)
         {
             queryText += " AND c.lineOfBusiness = @lineOfBusiness";
-            parameters.Add(("@lineOfBusiness", (int)lineOfBusiness.Value));
+            parameters.Add(("@lineOfBusiness", p.LineOfBusiness.Value.ToString()));
+        }
+        if (!string.IsNullOrEmpty(p.AssignedReviewerId))
+        {
+            queryText += " AND c.assignedReviewerId = @assignedReviewerId";
+            parameters.Add(("@assignedReviewerId", p.AssignedReviewerId));
         }
 
-        queryText += " ORDER BY c.submittedDate DESC";
+        queryText += " ORDER BY c.createdAt DESC";
+        // page and pageSize are bounded integers — no injection surface.
         queryText += $" OFFSET {(page - 1) * pageSize} LIMIT {pageSize}";
 
-        var queryDefinition = new QueryDefinition(queryText);
-        foreach (var param in parameters)
-        {
-            queryDefinition = queryDefinition.WithParameter(param.Item1, param.Item2);
-        }
+        var query = new QueryDefinition(queryText);
+        foreach (var (name, value) in parameters) query = query.WithParameter(name, value);
 
-        var iterator = _container.GetItemQueryIterator<Appeal>(queryDefinition);
+        var iterator = _appeals.GetItemQueryIterator<Appeal>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
         var results = new List<Appeal>();
-
         while (iterator.HasMoreResults)
         {
-            var response = await iterator.ReadNextAsync();
-            results.AddRange(response);
+            var pageResults = await iterator.ReadNextAsync(ct);
+            results.AddRange(pageResults);
         }
-
         return results;
     }
 
-    public async Task<AppealsSummary> GetAppealsSummaryAsync(DateTime from, DateTime to)
+    public async Task<AppealsSummary> GetAppealsSummaryAsync(
+        string tenantId, DateTime from, DateTime to, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
+        // TODO(appeals-followup-summary-perf): scan-all + in-memory aggregation
+        // scales poorly. Migrate to a Cosmos GROUP BY in a follow-up PR.
+        var results = await SearchAsync(
+            tenantId,
+            new AppealSearchParams { SubmittedFrom = from, SubmittedTo = to, Page = 1, PageSize = 100 },
+            ct);
 
-        var appeals = await SearchAsync(null, null, from, to, null, null, 1, 10000);
-        var appealsList = appeals.ToList();
-
-        var summary = new AppealsSummary
+        // Paginate — SearchAsync caps at 100/page. Keep reading for the summary.
+        var all = new List<Appeal>(results);
+        var page = 2;
+        while (results.Count == 100)
         {
-            TotalAppeals = appealsList.Count,
-            InReview = appealsList.Count(a => a.Status == AppealStatus.InReview),
-            Approved = appealsList.Count(a => a.Status == AppealStatus.Approved),
-            Denied = appealsList.Count(a => a.Status == AppealStatus.Denied),
-            PartialApprovals = appealsList.Count(a => a.Status == AppealStatus.PartialApproval),
-            TotalAppealedAmount = appealsList.Sum(a => a.AppealedAmount),
-            TotalApprovedAmount = appealsList
-                .Where(a => a.Decision != null && a.Decision.ApprovedAmount.HasValue)
-                .Sum(a => a.Decision!.ApprovedAmount!.Value)
-        };
-
-        // Calculate average decision time
-        var decidedAppeals = appealsList.Where(a => a.DecisionDate.HasValue).ToList();
-        if (decidedAppeals.Any())
-        {
-            summary.AverageDecisionTimeDays = decidedAppeals
-                .Average(a => (a.DecisionDate!.Value - a.SubmittedDate).TotalDays);
+            results = await SearchAsync(
+                tenantId,
+                new AppealSearchParams { SubmittedFrom = from, SubmittedTo = to, Page = page, PageSize = 100 },
+                ct);
+            all.AddRange(results);
+            page++;
         }
 
-        // Calculate approval rate
-        var totalDecided = appealsList.Count(a => a.Status == AppealStatus.Approved || 
-                                                  a.Status == AppealStatus.Denied || 
-                                                  a.Status == AppealStatus.PartialApproval);
-        if (totalDecided > 0)
+        return SummaryBuilder.Build(all);
+    }
+
+    public async Task<Appeal> TransitionStatusAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        if (!auditEvent.FromStatus.HasValue)
         {
-            summary.ApprovalRate = ((double)(summary.Approved + summary.PartialApprovals) / totalDecided) * 100;
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
         }
+        var expectedFromStatus = auditEvent.FromStatus.Value;
 
-        // Group by status
-        foreach (var appeal in appealsList)
+        try
         {
-            if (!summary.AppealsByStatus.ContainsKey(appeal.Status))
-                summary.AppealsByStatus[appeal.Status] = 0;
-            summary.AppealsByStatus[appeal.Status]++;
+            var fresh = await _appeals.ReadItemAsync<Appeal>(
+                appeal.Id, new PartitionKey(appeal.TenantId), cancellationToken: ct);
 
-            if (!summary.AppealsByLevel.ContainsKey(appeal.AppealLevel))
-                summary.AppealsByLevel[appeal.AppealLevel] = 0;
-            summary.AppealsByLevel[appeal.AppealLevel]++;
+            if (fresh.Resource.Status != expectedFromStatus)
+            {
+                throw new InvalidAppealTransitionException(fresh.Resource.Status, appeal.Status);
+            }
+
+            appeal.UpdatedAt = DateTime.UtcNow;
+            var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+            var response = await _appeals.ReplaceItemAsync(
+                appeal, appeal.Id, new PartitionKey(appeal.TenantId), options, ct);
+
+            await _events.AppendAsync(auditEvent, ct);
+            return response.Resource;
         }
-
-        return summary;
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            throw new InvalidAppealTransitionException(expectedFromStatus, appeal.Status);
+        }
     }
 
-    public async Task<Appeal> CreateAsync(Appeal appeal)
+    public async Task<Appeal?> TryTransitionToOverdueAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        appeal.TenantId = GetTenantId();
-        appeal.SubmittedDate = DateTime.UtcNow;
+        try
+        {
+            var fresh = await _appeals.ReadItemAsync<Appeal>(
+                appeal.Id, new PartitionKey(appeal.TenantId), cancellationToken: ct);
 
-        // Calculate target response date (typically 30-60 days)
-        appeal.TargetResponseDate = appeal.SubmittedDate.AddDays(appeal.IsUrgent ? 30 : 60);
+            if (fresh.Resource.OverdueAuditEmitted) return null;
+            if (fresh.Resource.Status != AppealStatus.Submitted &&
+                fresh.Resource.Status != AppealStatus.InReview &&
+                fresh.Resource.Status != AppealStatus.PendingInfo)
+            {
+                return null;
+            }
 
-        var response = await _container.CreateItemAsync(
-            appeal,
-            new PartitionKey(appeal.TenantId));
+            var mutated = fresh.Resource;
+            mutated.OverdueAuditEmitted = true;
+            mutated.UpdatedAt = DateTime.UtcNow;
 
-        _logger.LogInformation("Created appeal {AppealId} for claim {ClaimId}",
-            SanitizeForLog(appeal.Id), SanitizeForLog(appeal.ClaimId));
+            var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+            var response = await _appeals.ReplaceItemAsync(
+                mutated, mutated.Id, new PartitionKey(mutated.TenantId), options, ct);
 
-        return response.Resource;
+            await _events.AppendAsync(auditEvent, ct);
+            return response.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+        {
+            return null;
+        }
     }
 
-    public async Task<Appeal> UpdateAsync(Appeal appeal)
+    public async Task<Appeal> AppendNoteAsync(Appeal appeal, AppealNote note, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        var response = await _container.ReplaceItemAsync(
-            appeal,
-            appeal.Id,
-            new PartitionKey(appeal.TenantId));
+        // Cosmos has no native array-push operator for arbitrary depth. We
+        // re-read with ETag and do a conditional ReplaceItem. Contention on
+        // the same appeal's notes is rare; on 412 we retry once. A third
+        // conflicting writer is extremely unlikely in practice.
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var fresh = await _appeals.ReadItemAsync<Appeal>(
+                    appeal.Id, new PartitionKey(appeal.TenantId), cancellationToken: ct);
+                var mutated = fresh.Resource;
+                mutated.Notes.Add(note);
+                mutated.UpdatedAt = DateTime.UtcNow;
 
-        _logger.LogInformation("Updated appeal {AppealId}", SanitizeForLog(appeal.Id));
+                var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+                var response = await _appeals.ReplaceItemAsync(
+                    mutated, mutated.Id, new PartitionKey(mutated.TenantId), options, ct);
 
-        return response.Resource;
+                await _events.AppendAsync(auditEvent, ct);
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                if (attempt == 1) throw;
+            }
+        }
+        throw new InvalidOperationException("AppendNoteAsync retry budget exhausted.");
     }
 
-    public async Task DeleteAsync(string id)
+    public async Task<Appeal> AppendAttachmentAsync(Appeal appeal, AppealAttachment attachment, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var fresh = await _appeals.ReadItemAsync<Appeal>(
+                    appeal.Id, new PartitionKey(appeal.TenantId), cancellationToken: ct);
+                var mutated = fresh.Resource;
+                mutated.Attachments.Add(attachment);
+                if (!string.IsNullOrEmpty(attachment.ControlNumber))
+                    mutated.AttachmentControlNumbers.Add(attachment.ControlNumber);
+                mutated.UpdatedAt = DateTime.UtcNow;
 
-        await _container.DeleteItemAsync<Appeal>(
-            id,
-            new PartitionKey(tenantId));
+                var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+                var response = await _appeals.ReplaceItemAsync(
+                    mutated, mutated.Id, new PartitionKey(mutated.TenantId), options, ct);
 
-        _logger.LogInformation("Deleted appeal {AppealId}", SanitizeForLog(id));
+                await _events.AppendAsync(auditEvent, ct);
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                if (attempt == 1) throw;
+            }
+        }
+        throw new InvalidOperationException("AppendAttachmentAsync retry budget exhausted.");
     }
 
-    private static string SanitizeForLog(string? value)
+    public async Task<Appeal> AcknowledgeAttachmentAsync(
+        string tenantId, string appealId, string attachmentId, bool acknowledgmentReceived,
+        AppealEvent auditEvent, CancellationToken ct = default)
     {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var fresh = await _appeals.ReadItemAsync<Appeal>(
+                    appealId, new PartitionKey(tenantId), cancellationToken: ct);
+                var mutated = fresh.Resource;
+                var attachment = mutated.Attachments.FirstOrDefault(a => a.AttachmentId == attachmentId)
+                    ?? throw new InvalidOperationException(
+                        $"Attachment {attachmentId} not found on appeal {appealId} for tenant {tenantId}.");
+
+                attachment.AcknowledgmentReceived = acknowledgmentReceived;
+                attachment.Status = acknowledgmentReceived ? AttachmentStatus.Acknowledged : AttachmentStatus.Sent;
+                if (acknowledgmentReceived) attachment.SentDate = DateTime.UtcNow;
+                mutated.UpdatedAt = DateTime.UtcNow;
+
+                var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+                var response = await _appeals.ReplaceItemAsync(
+                    mutated, mutated.Id, new PartitionKey(mutated.TenantId), options, ct);
+
+                await _events.AppendAsync(auditEvent, ct);
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                if (attempt == 1) throw;
+            }
+        }
+        throw new InvalidOperationException("AcknowledgeAttachmentAsync retry budget exhausted.");
+    }
+
+    public async Task<Appeal> AssignReviewerAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var fresh = await _appeals.ReadItemAsync<Appeal>(
+                    appeal.Id, new PartitionKey(appeal.TenantId), cancellationToken: ct);
+                var mutated = fresh.Resource;
+                mutated.AssignedReviewerId = appeal.AssignedReviewerId;
+                mutated.UpdatedAt = DateTime.UtcNow;
+
+                var options = new ItemRequestOptions { IfMatchEtag = fresh.ETag };
+                var response = await _appeals.ReplaceItemAsync(
+                    mutated, mutated.Id, new PartitionKey(mutated.TenantId), options, ct);
+
+                await _events.AppendAsync(auditEvent, ct);
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                if (attempt == 1) throw;
+            }
+        }
+        throw new InvalidOperationException("AssignReviewerAsync retry budget exhausted.");
     }
 }

--- a/src/services/appeals-service/Repositories/AppealRepositoryMongo.cs
+++ b/src/services/appeals-service/Repositories/AppealRepositoryMongo.cs
@@ -1,172 +1,258 @@
-using MongoDB.Driver;
 using AppealsService.Models;
+using MongoDB.Driver;
 
 namespace AppealsService.Repositories;
 
-public class AppealRepositoryMongo : IAppealRepository
+/// <summary>
+/// MongoDB implementation of <see cref="IAppealRepository"/>. The
+/// transition-and-append shape is not truly atomic across the Appeals and
+/// AppealEvents collections — Mongo multi-collection transactions require
+/// a replica-set primary, which our dev and many production deployments do
+/// not guarantee. Operationally we accept that a transition-then-event
+/// crash window can drop a single audit row; the appeal record update is
+/// still conditional (filter on current Status) so the status invariant
+/// holds. If operations observe a gap, the source of truth is the appeal
+/// row itself — the event log is an audit annotation, not the authoritative
+/// lifecycle store. Same inherited posture as consent-service and
+/// personal-representative-service.
+/// </summary>
+public sealed class AppealRepositoryMongo : IAppealRepository
 {
-    private readonly IMongoCollection<Appeal> _collection;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILogger<AppealRepositoryMongo> _logger;
+    public const string AppealsCollectionName = "Appeals";
 
-    public AppealRepositoryMongo(
-        IMongoDatabase database,
-        IHttpContextAccessor httpContextAccessor,
-        ILogger<AppealRepositoryMongo> logger)
+    private readonly IMongoCollection<Appeal> _appeals;
+    private readonly IAppealEventSink _events;
+
+    public AppealRepositoryMongo(IMongoDatabase database, IAppealEventSink events)
     {
-        _collection = database.GetCollection<Appeal>("appeals");
-        _httpContextAccessor = httpContextAccessor;
-        _logger = logger;
+        _appeals = database.GetCollection<Appeal>(AppealsCollectionName);
+        _events = events;
     }
 
-    private string GetTenantId()
+    /// <summary>
+    /// Internal test seam for the migration hosted service — exposes the
+    /// raw collection so a one-shot batch scan can rewrite legacy-status
+    /// records. Not part of <see cref="IAppealRepository"/>.
+    /// </summary>
+    internal IMongoCollection<Appeal> AppealsCollection => _appeals;
+
+    public async Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default)
     {
-        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
-        if (string.IsNullOrEmpty(tenantId))
-            throw new InvalidOperationException("TenantId not found in request context");
-        return tenantId;
+        if (string.IsNullOrEmpty(appeal.Id)) appeal.Id = Guid.NewGuid().ToString();
+        if (appeal.CreatedAt == default) appeal.CreatedAt = DateTime.UtcNow;
+        await _appeals.InsertOneAsync(appeal, cancellationToken: ct);
+        await _events.AppendAsync(genesisEvent, ct);
+        return appeal;
     }
 
-    public async Task<Appeal?> GetByIdAsync(string id)
+    public async Task<Appeal?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-        var filter = Builders<Appeal>.Filter.And(
-            Builders<Appeal>.Filter.Eq(x => x.Id, id),
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, tenantId));
-        return await _collection.Find(filter).FirstOrDefaultAsync();
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, id);
+        return await _appeals.Find(filter).FirstOrDefaultAsync(ct);
     }
 
-    public async Task<Appeal?> GetByAppealNumberAsync(string appealNumber)
+    public async Task<Appeal?> GetByAppealNumberAsync(string tenantId, string appealNumber, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-        var filter = Builders<Appeal>.Filter.And(
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, tenantId),
-            Builders<Appeal>.Filter.Eq(x => x.AppealNumber, appealNumber));
-        return await _collection.Find(filter).FirstOrDefaultAsync();
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.AppealNumber, appealNumber);
+        return await _appeals.Find(filter).FirstOrDefaultAsync(ct);
     }
 
-    public async Task<IEnumerable<Appeal>> GetByClaimIdAsync(string claimId)
+    public async Task<IReadOnlyList<Appeal>> GetByClaimIdAsync(string tenantId, string claimId, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-        var filter = Builders<Appeal>.Filter.And(
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, tenantId),
-            Builders<Appeal>.Filter.Eq(x => x.ClaimId, claimId));
-        return await _collection.Find(filter)
-            .SortByDescending(x => x.SubmittedDate)
-            .ToListAsync();
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.ClaimId, claimId);
+        return await _appeals.Find(filter)
+            .SortByDescending(a => a.CreatedAt)
+            .ToListAsync(ct);
     }
 
-    public async Task<IEnumerable<Appeal>> SearchAsync(
-        string? memberId,
-        string? providerNPI,
-        DateTime? submittedFrom,
-        DateTime? submittedTo,
-        AppealStatus? status,
-        LineOfBusiness? lineOfBusiness,
-        int page = 1,
-        int pageSize = 50)
+    public async Task<IReadOnlyList<Appeal>> SearchAsync(
+        string tenantId, AppealSearchParams p, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
         var filters = new List<FilterDefinition<Appeal>>
         {
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, tenantId)
+            Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
         };
 
-        if (!string.IsNullOrEmpty(memberId))
-            filters.Add(Builders<Appeal>.Filter.Eq(x => x.MemberId, memberId));
-        if (!string.IsNullOrEmpty(providerNPI))
-            filters.Add(Builders<Appeal>.Filter.Eq(x => x.ProviderNPI, providerNPI));
-        if (submittedFrom.HasValue)
-            filters.Add(Builders<Appeal>.Filter.Gte(x => x.SubmittedDate, submittedFrom.Value));
-        if (submittedTo.HasValue)
-            filters.Add(Builders<Appeal>.Filter.Lte(x => x.SubmittedDate, submittedTo.Value));
-        if (status.HasValue)
-            filters.Add(Builders<Appeal>.Filter.Eq(x => x.Status, status.Value));
-        if (lineOfBusiness.HasValue)
-            filters.Add(Builders<Appeal>.Filter.Eq(x => x.LineOfBusiness, lineOfBusiness.Value));
+        if (!string.IsNullOrEmpty(p.MemberId))
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.MemberId, p.MemberId));
+        if (!string.IsNullOrEmpty(p.ProviderNPI))
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.ProviderNPI, p.ProviderNPI));
+        if (p.SubmittedFrom.HasValue)
+            filters.Add(Builders<Appeal>.Filter.Gte(a => a.SubmittedDate, p.SubmittedFrom.Value));
+        if (p.SubmittedTo.HasValue)
+            filters.Add(Builders<Appeal>.Filter.Lte(a => a.SubmittedDate, p.SubmittedTo.Value));
+        if (p.Status.HasValue)
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.Status, p.Status.Value));
+        if (p.ClosureReasonCode.HasValue)
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.ClosureReasonCode, p.ClosureReasonCode.Value));
+        if (p.LineOfBusiness.HasValue)
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.LineOfBusiness, p.LineOfBusiness.Value));
+        if (!string.IsNullOrEmpty(p.AssignedReviewerId))
+            filters.Add(Builders<Appeal>.Filter.Eq(a => a.AssignedReviewerId, p.AssignedReviewerId));
 
-        return await _collection
+        var page = Math.Max(1, p.Page);
+        var pageSize = Math.Clamp(p.PageSize, 1, 100);
+
+        return await _appeals
             .Find(Builders<Appeal>.Filter.And(filters))
-            .SortByDescending(x => x.SubmittedDate)
+            .SortByDescending(a => a.CreatedAt)
             .Skip((page - 1) * pageSize)
             .Limit(pageSize)
-            .ToListAsync();
+            .ToListAsync(ct);
     }
 
-    public async Task<AppealsSummary> GetAppealsSummaryAsync(DateTime from, DateTime to)
+    public async Task<AppealsSummary> GetAppealsSummaryAsync(
+        string tenantId, DateTime from, DateTime to, CancellationToken ct = default)
     {
-        var appeals = (await SearchAsync(null, null, from, to, null, null, 1, 10000)).ToList();
-
-        var summary = new AppealsSummary
-        {
-            TotalAppeals = appeals.Count,
-            InReview = appeals.Count(a => a.Status == AppealStatus.InReview),
-            Approved = appeals.Count(a => a.Status == AppealStatus.Approved),
-            Denied = appeals.Count(a => a.Status == AppealStatus.Denied),
-            PartialApprovals = appeals.Count(a => a.Status == AppealStatus.PartialApproval),
-            TotalAppealedAmount = appeals.Sum(a => a.AppealedAmount),
-            TotalApprovedAmount = appeals
-                .Where(a => a.Decision != null && a.Decision.ApprovedAmount.HasValue)
-                .Sum(a => a.Decision!.ApprovedAmount!.Value)
-        };
-
-        var decidedAppeals = appeals.Where(a => a.DecisionDate.HasValue).ToList();
-        if (decidedAppeals.Any())
-        {
-            summary.AverageDecisionTimeDays = decidedAppeals
-                .Average(a => (a.DecisionDate!.Value - a.SubmittedDate).TotalDays);
-        }
-
-        var totalDecided = appeals.Count(a => a.Status == AppealStatus.Approved ||
-                                              a.Status == AppealStatus.Denied ||
-                                              a.Status == AppealStatus.PartialApproval);
-        if (totalDecided > 0)
-        {
-            summary.ApprovalRate = ((double)(summary.Approved + summary.PartialApprovals) / totalDecided) * 100;
-        }
-
-        foreach (var appeal in appeals)
-        {
-            if (!summary.AppealsByStatus.ContainsKey(appeal.Status))
-                summary.AppealsByStatus[appeal.Status] = 0;
-            summary.AppealsByStatus[appeal.Status]++;
-
-            if (!summary.AppealsByLevel.ContainsKey(appeal.AppealLevel))
-                summary.AppealsByLevel[appeal.AppealLevel] = 0;
-            summary.AppealsByLevel[appeal.AppealLevel]++;
-        }
-
-        return summary;
+        // TODO(appeals-followup-summary-perf): in-memory aggregation over all
+        // rows scans poorly at scale. A follow-up PR will migrate this to a
+        // Mongo aggregation pipeline / Cosmos GROUP BY. Correctness is fine;
+        // only performance is deferred.
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Gte(a => a.SubmittedDate, from)
+                   & Builders<Appeal>.Filter.Lte(a => a.SubmittedDate, to);
+        var appeals = await _appeals.Find(filter).ToListAsync(ct);
+        return SummaryBuilder.Build(appeals);
     }
 
-    public async Task<Appeal> CreateAsync(Appeal appeal)
+    public async Task<Appeal> TransitionStatusAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        appeal.TenantId = GetTenantId();
-        appeal.SubmittedDate = DateTime.UtcNow;
-        appeal.TargetResponseDate = appeal.SubmittedDate.AddDays(appeal.IsUrgent ? 30 : 60);
+        if (!auditEvent.FromStatus.HasValue)
+        {
+            throw new ArgumentException(
+                "TransitionStatusAsync requires auditEvent.FromStatus to be set.",
+                nameof(auditEvent));
+        }
+        var expectedFromStatus = auditEvent.FromStatus.Value;
 
-        await _collection.InsertOneAsync(appeal);
-        _logger.LogInformation("Created appeal {AppealId} for claim {ClaimId}", appeal.Id, appeal.ClaimId);
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, appeal.TenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appeal.Id)
+                   & Builders<Appeal>.Filter.Eq(a => a.Status, expectedFromStatus);
+
+        appeal.UpdatedAt = DateTime.UtcNow;
+        var replaceResult = await _appeals.ReplaceOneAsync(filter, appeal, cancellationToken: ct);
+        if (replaceResult.MatchedCount == 0)
+        {
+            throw new InvalidAppealTransitionException(expectedFromStatus, appeal.Status);
+        }
+
+        await _events.AppendAsync(auditEvent, ct);
         return appeal;
     }
 
-    public async Task<Appeal> UpdateAsync(Appeal appeal)
+    public async Task<Appeal?> TryTransitionToOverdueAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        var filter = Builders<Appeal>.Filter.And(
-            Builders<Appeal>.Filter.Eq(x => x.Id, appeal.Id),
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, appeal.TenantId));
-        await _collection.ReplaceOneAsync(filter, appeal);
-        _logger.LogInformation("Updated appeal {AppealId}", appeal.Id);
-        return appeal;
+        var nonTerminalStatuses = new[] { AppealStatus.Submitted, AppealStatus.InReview, AppealStatus.PendingInfo };
+
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, appeal.TenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appeal.Id)
+                   & Builders<Appeal>.Filter.Eq(a => a.OverdueAuditEmitted, false)
+                   & Builders<Appeal>.Filter.In(a => a.Status, nonTerminalStatuses);
+
+        var update = Builders<Appeal>.Update
+            .Set(a => a.OverdueAuditEmitted, true)
+            .Set(a => a.UpdatedAt, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<Appeal> { ReturnDocument = ReturnDocument.After };
+
+        var updated = await _appeals.FindOneAndUpdateAsync(filter, update, options, ct);
+        if (updated is null) return null;
+
+        await _events.AppendAsync(auditEvent, ct);
+        return updated;
     }
 
-    public async Task DeleteAsync(string id)
+    public async Task<Appeal> AppendNoteAsync(Appeal appeal, AppealNote note, AppealEvent auditEvent, CancellationToken ct = default)
     {
-        var tenantId = GetTenantId();
-        var filter = Builders<Appeal>.Filter.And(
-            Builders<Appeal>.Filter.Eq(x => x.Id, id),
-            Builders<Appeal>.Filter.Eq(x => x.TenantId, tenantId));
-        await _collection.DeleteOneAsync(filter);
-        _logger.LogInformation("Deleted appeal {AppealId}", id);
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, appeal.TenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appeal.Id);
+
+        var update = Builders<Appeal>.Update
+            .Push(a => a.Notes, note)
+            .Set(a => a.UpdatedAt, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<Appeal> { ReturnDocument = ReturnDocument.After };
+
+        var updated = await _appeals.FindOneAndUpdateAsync(filter, update, options, ct)
+            ?? throw new InvalidOperationException(
+                $"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+
+        await _events.AppendAsync(auditEvent, ct);
+        return updated;
+    }
+
+    public async Task<Appeal> AppendAttachmentAsync(Appeal appeal, AppealAttachment attachment, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, appeal.TenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appeal.Id);
+
+        var updateBuilder = Builders<Appeal>.Update
+            .Push(a => a.Attachments, attachment)
+            .Set(a => a.UpdatedAt, DateTime.UtcNow);
+
+        if (!string.IsNullOrEmpty(attachment.ControlNumber))
+        {
+            updateBuilder = updateBuilder.Push(a => a.AttachmentControlNumbers, attachment.ControlNumber);
+        }
+
+        var options = new FindOneAndUpdateOptions<Appeal> { ReturnDocument = ReturnDocument.After };
+
+        var updated = await _appeals.FindOneAndUpdateAsync(filter, updateBuilder, options, ct)
+            ?? throw new InvalidOperationException(
+                $"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+
+        await _events.AppendAsync(auditEvent, ct);
+        return updated;
+    }
+
+    public async Task<Appeal> AcknowledgeAttachmentAsync(
+        string tenantId, string appealId, string attachmentId, bool acknowledgmentReceived,
+        AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appealId)
+                   & Builders<Appeal>.Filter.ElemMatch(
+                         a => a.Attachments,
+                         att => att.AttachmentId == attachmentId);
+
+        var newStatus = acknowledgmentReceived ? AttachmentStatus.Acknowledged : AttachmentStatus.Sent;
+        var update = Builders<Appeal>.Update
+            .Set("attachments.$.acknowledgmentReceived", acknowledgmentReceived)
+            .Set("attachments.$.status", newStatus)
+            .Set(a => a.UpdatedAt, DateTime.UtcNow);
+
+        if (acknowledgmentReceived)
+        {
+            update = update.Set("attachments.$.sentDate", DateTime.UtcNow);
+        }
+
+        var options = new FindOneAndUpdateOptions<Appeal> { ReturnDocument = ReturnDocument.After };
+        var updated = await _appeals.FindOneAndUpdateAsync(filter, update, options, ct)
+            ?? throw new InvalidOperationException(
+                $"Appeal {appealId} with attachment {attachmentId} not found for tenant {tenantId}.");
+
+        await _events.AppendAsync(auditEvent, ct);
+        return updated;
+    }
+
+    public async Task<Appeal> AssignReviewerAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default)
+    {
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, appeal.TenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.Id, appeal.Id);
+
+        var update = Builders<Appeal>.Update
+            .Set(a => a.AssignedReviewerId, appeal.AssignedReviewerId)
+            .Set(a => a.UpdatedAt, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<Appeal> { ReturnDocument = ReturnDocument.After };
+        var updated = await _appeals.FindOneAndUpdateAsync(filter, update, options, ct)
+            ?? throw new InvalidOperationException(
+                $"Appeal {appeal.Id} not found for tenant {appeal.TenantId}.");
+
+        await _events.AppendAsync(auditEvent, ct);
+        return updated;
     }
 }

--- a/src/services/appeals-service/Repositories/IAppealRepository.cs
+++ b/src/services/appeals-service/Repositories/IAppealRepository.cs
@@ -1,0 +1,103 @@
+using AppealsService.Models;
+
+namespace AppealsService.Repositories;
+
+/// <summary>
+/// Repository surface for <see cref="Appeal"/>. Mirrors the shape
+/// <c>IConsentRepository</c> / <c>IPersonalRepRepository</c> established:
+/// tenantId is always the first positional argument on reads; lifecycle
+/// methods are verb-named (no generic <c>UpdateAsync</c>, no
+/// <c>DeleteAsync</c>). Every mutation bundles the entity update with an
+/// <see cref="AppealEvent"/> append — the audit-trail invariant is
+/// enforced structurally.
+/// </summary>
+public interface IAppealRepository
+{
+    Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default);
+
+    Task<Appeal?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default);
+
+    Task<Appeal?> GetByAppealNumberAsync(string tenantId, string appealNumber, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Appeal>> GetByClaimIdAsync(string tenantId, string claimId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<Appeal>> SearchAsync(string tenantId, AppealSearchParams p, CancellationToken ct = default);
+
+    Task<AppealsSummary> GetAppealsSummaryAsync(string tenantId, DateTime from, DateTime to, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomic: persist the new status on <paramref name="appeal"/> AND
+    /// append <paramref name="auditEvent"/>. Caller must set
+    /// <c>appeal.Status</c> to the new value and populate any lifecycle
+    /// fields (ClosedAt, ClosedBy, ClosureReasonCode, etc.) before calling.
+    /// Callers MUST have validated the transition via
+    /// <c>AppealStateMachine</c>. Conditional on persisted status still
+    /// matching <c>auditEvent.FromStatus</c> — a mismatch throws
+    /// <see cref="InvalidAppealTransitionException"/>.
+    /// </summary>
+    Task<Appeal> TransitionStatusAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Race-safe one-shot overdue observer. Conditional on
+    /// <c>OverdueAuditEmitted == false</c> AND
+    /// <c>Status ∈ {Submitted, InReview, PendingInfo}</c>. Returns the
+    /// updated appeal on win (audit event appended). Returns <c>null</c>
+    /// on loss — another caller already emitted. Callers that get
+    /// <c>null</c> must NOT retry with a different event.
+    /// </summary>
+    Task<Appeal?> TryTransitionToOverdueAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default);
+
+    /// <summary>Atomic note append + audit event.</summary>
+    Task<Appeal> AppendNoteAsync(Appeal appeal, AppealNote note, AppealEvent auditEvent, CancellationToken ct = default);
+
+    /// <summary>Atomic attachment append + audit event.</summary>
+    Task<Appeal> AppendAttachmentAsync(Appeal appeal, AppealAttachment attachment, AppealEvent auditEvent, CancellationToken ct = default);
+
+    /// <summary>Atomic attachment-ack mutation + audit event.</summary>
+    Task<Appeal> AcknowledgeAttachmentAsync(
+        string tenantId, string appealId, string attachmentId, bool acknowledgmentReceived,
+        AppealEvent auditEvent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomic reviewer assignment + audit event. Caller sets
+    /// <c>appeal.AssignedReviewerId</c> (and optionally appends a note
+    /// separately via <see cref="AppendNoteAsync"/> for reassignment
+    /// reason) before calling.
+    /// </summary>
+    Task<Appeal> AssignReviewerAsync(Appeal appeal, AppealEvent auditEvent, CancellationToken ct = default);
+}
+
+/// <summary>Search filters — bag of optional query parameters.</summary>
+public sealed record AppealSearchParams
+{
+    public string? MemberId { get; init; }
+    public string? ProviderNPI { get; init; }
+    public DateTime? SubmittedFrom { get; init; }
+    public DateTime? SubmittedTo { get; init; }
+    public AppealStatus? Status { get; init; }
+    public AppealClosureReasonCode? ClosureReasonCode { get; init; }
+    public LineOfBusiness? LineOfBusiness { get; init; }
+    public string? AssignedReviewerId { get; init; }
+    public int Page { get; init; } = 1;
+    public int PageSize { get; init; } = 50;
+}
+
+/// <summary>Repository surface for <see cref="AppealEvent"/> (audit trail reads).</summary>
+public interface IAppealEventRepository
+{
+    Task<IReadOnlyList<AppealEvent>> ListByAppealAsync(
+        string tenantId,
+        string appealId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Repository-local sink for appending <see cref="AppealEvent"/> rows.
+/// Lets the Cosmos and Mongo <see cref="IAppealRepository"/> implementations
+/// share a single transition-and-append shape while keeping their own
+/// storage choice for audit rows.
+/// </summary>
+public interface IAppealEventSink
+{
+    Task AppendAsync(AppealEvent evt, CancellationToken ct = default);
+}

--- a/src/services/appeals-service/Repositories/SummaryBuilder.cs
+++ b/src/services/appeals-service/Repositories/SummaryBuilder.cs
@@ -1,0 +1,90 @@
+using AppealsService.Models;
+
+namespace AppealsService.Repositories;
+
+/// <summary>
+/// Computes <see cref="AppealsSummary"/> from a flat list of appeals.
+/// Extracted so the Cosmos and Mongo repositories share the aggregation
+/// logic verbatim. Preserves the portal's observed 4-bucket wire shape
+/// (<c>OpenAppeals</c>, <c>UrgentExpedited</c>, <c>DueThisWeek</c>,
+/// <c>OverturnedRate</c>) across the status-enum consolidation by
+/// recomputing over <c>Status + ClosureReasonCode</c>.
+/// </summary>
+internal static class SummaryBuilder
+{
+    public static AppealsSummary Build(IReadOnlyList<Appeal> appeals)
+    {
+        var now = DateTime.UtcNow;
+        var weekFromNow = now.AddDays(7);
+
+        var summary = new AppealsSummary
+        {
+            TotalAppeals = appeals.Count,
+            InReview = appeals.Count(a => a.Status == AppealStatus.InReview),
+            Approved = appeals.Count(a => a.Status == AppealStatus.Closed
+                                       && a.ClosureReasonCode == AppealClosureReasonCode.Approved),
+            Denied = appeals.Count(a => a.Status == AppealStatus.Closed
+                                     && a.ClosureReasonCode == AppealClosureReasonCode.Denied),
+            PartialApprovals = appeals.Count(a => a.Status == AppealStatus.Closed
+                                               && a.ClosureReasonCode == AppealClosureReasonCode.PartialApproval),
+            Withdrawn = appeals.Count(a => a.Status == AppealStatus.Closed
+                                        && a.ClosureReasonCode == AppealClosureReasonCode.Withdrawn),
+            TotalAppealedAmount = appeals.Sum(a => a.AppealedAmount),
+            TotalApprovedAmount = appeals
+                .Where(a => a.Decision != null && a.Decision.ApprovedAmount.HasValue)
+                .Sum(a => a.Decision!.ApprovedAmount!.Value),
+            OpenAppeals = appeals.Count(a => a.Status == AppealStatus.Submitted
+                                           || a.Status == AppealStatus.InReview
+                                           || a.Status == AppealStatus.PendingInfo),
+            UrgentExpedited = appeals.Count(a => a.IsUrgent
+                                              && (a.Status == AppealStatus.Submitted
+                                                  || a.Status == AppealStatus.InReview
+                                                  || a.Status == AppealStatus.PendingInfo)),
+            DueThisWeek = appeals.Count(a => (a.Status == AppealStatus.Submitted
+                                               || a.Status == AppealStatus.InReview
+                                               || a.Status == AppealStatus.PendingInfo)
+                                           && a.TargetResponseDate.HasValue
+                                           && a.TargetResponseDate.Value <= weekFromNow)
+        };
+
+        // Decision time: for closed appeals with a DecisionDate, from SubmittedDate.
+        var decidedAppeals = appeals.Where(a => a.DecisionDate.HasValue && a.Status == AppealStatus.Closed).ToList();
+        if (decidedAppeals.Count > 0)
+        {
+            summary.AverageDecisionTimeDays = decidedAppeals
+                .Average(a => (a.DecisionDate!.Value - a.SubmittedDate).TotalDays);
+        }
+
+        // ApprovalRate: fraction of closed-with-decision that were Approved or PartialApproval.
+        var closedWithDecision = appeals.Count(a => a.Status == AppealStatus.Closed
+                                                  && a.ClosureReasonCode.HasValue
+                                                  && (a.ClosureReasonCode == AppealClosureReasonCode.Approved
+                                                      || a.ClosureReasonCode == AppealClosureReasonCode.Denied
+                                                      || a.ClosureReasonCode == AppealClosureReasonCode.PartialApproval));
+        if (closedWithDecision > 0)
+        {
+            summary.ApprovalRate = (double)(summary.Approved + summary.PartialApprovals) / closedWithDecision * 100;
+        }
+
+        // OverturnedRate (portal-observed): fraction of all closed appeals whose
+        // reason code is Approved or PartialApproval. Computed over ALL closed
+        // appeals (including Withdrawn, AdminError, etc.) because portal's
+        // definition is "fraction of terminated appeals whose original denial
+        // was overturned" — denominator is every closed appeal.
+        var totalClosed = appeals.Count(a => a.Status == AppealStatus.Closed);
+        if (totalClosed > 0)
+        {
+            summary.OverturnedRate = (double)(summary.Approved + summary.PartialApprovals) / totalClosed * 100;
+        }
+
+        foreach (var a in appeals)
+        {
+            summary.AppealsByStatus.TryGetValue(a.Status, out var s);
+            summary.AppealsByStatus[a.Status] = s + 1;
+            summary.AppealsByLevel.TryGetValue(a.AppealLevel, out var l);
+            summary.AppealsByLevel[a.AppealLevel] = l + 1;
+        }
+
+        return summary;
+    }
+}

--- a/src/services/appeals-service/Services/AppealEncryptionKeyHealthCheck.cs
+++ b/src/services/appeals-service/Services/AppealEncryptionKeyHealthCheck.cs
@@ -1,0 +1,62 @@
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Readiness check: verify that the CURRENT appeal encryption key can be
+/// resolved from the secret provider. A missing current key means new
+/// appeal writes will fail at encrypt time; surfacing this as a 503 on
+/// <c>/health/ready</c> keeps the service from being rotated into traffic
+/// with a broken encryption path.
+///
+/// Local to appeals-service for now. No shared-infra refactor in this PR —
+/// when a fifth service needs the same check (after member, consent,
+/// personal-rep, appeals), that's the forcing function for promotion.
+/// </summary>
+public sealed class AppealEncryptionKeyHealthCheck : IHealthCheck
+{
+    private readonly RotatingKeyProvider _keys;
+    private readonly AppealEncryptionOptions _options;
+
+    public AppealEncryptionKeyHealthCheck(RotatingKeyProvider keys, AppealEncryptionOptions options)
+    {
+        _keys = keys;
+        _options = options;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var key = await _keys.GetKeyAsync(
+                _options.KeySecretPrefix,
+                _options.CurrentKeyVersion,
+                devConfigFallback: null,
+                cancellationToken);
+
+            if (key.Length != 32)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Appeal encryption key '{_options.KeySecretPrefix}-{_options.CurrentKeyVersion}' must be 32 bytes (AES-256); got {key.Length}.");
+            }
+
+            return HealthCheckResult.Healthy(
+                $"Current appeal encryption key '{_options.CurrentKeyVersion}' resolved.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Current appeal encryption key '{_options.CurrentKeyVersion}' not resolvable from secret provider.",
+                ex);
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(
+                "Unexpected error resolving appeal encryption key.",
+                ex);
+        }
+    }
+}

--- a/src/services/appeals-service/Services/AppealEncryptionOptions.cs
+++ b/src/services/appeals-service/Services/AppealEncryptionOptions.cs
@@ -1,0 +1,17 @@
+namespace AppealsService.Services;
+
+/// <summary>
+/// Config surface for <see cref="AppealFieldEncryptor"/>. appeals-service is
+/// greenfield with respect to field-level encryption — appeals has NEVER
+/// stored envelope-encrypted records before this PR, so the options shape
+/// does NOT carry a <c>LegacyKeySecretName</c>. Only 0x02 envelopes are
+/// read and written.
+/// </summary>
+public sealed record AppealEncryptionOptions
+{
+    public const string SectionName = "AppealEncryption";
+
+    public string KeySecretPrefix { get; init; } = "appeal-body-encryption-key";
+    public string CurrentKeyVersion { get; init; } = "v1";
+    public IReadOnlyList<string> AcceptedKeyVersions { get; init; } = new[] { "v1" };
+}

--- a/src/services/appeals-service/Services/AppealEventPublisher.cs
+++ b/src/services/appeals-service/Services/AppealEventPublisher.cs
@@ -1,0 +1,528 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AppealsService.Models;
+using Confluent.Kafka;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Kafka producer for <c>appeal.status-changed.v1</c>. Mirrors the shape
+/// of <c>ConsentService.Services.ConsentEventPublisher</c> and
+/// <c>PersonalRepresentativeService.Services.PersonalRepEventPublisher</c>:
+/// - <see cref="IHostedService"/> + <see cref="IAsyncDisposable"/>.
+/// - Degraded mode when <c>Kafka:BootstrapServers</c> is unset — publish
+///   becomes a no-op; service still boots. DB is the source of truth.
+/// - Single topic, nine event types distinguished by the <c>event-type</c>
+///   header.
+/// - Partition key = <c>appealId</c> (per-appeal ordering preserved).
+/// - Headers: <c>tenant-id</c>, <c>event-type</c>, <c>event-version</c>.
+/// </summary>
+public sealed class AppealEventPublisher : IAppealEventPublisher, IHostedService, IAsyncDisposable
+{
+    public const string StatusChangedTopic = "appeal.status-changed.v1";
+    public const string EventVersion = "1.0";
+
+    public const string AppealCreatedType = "AppealCreated";
+    public const string AppealStatusChangedType = "AppealStatusChanged";
+    public const string AppealClosedType = "AppealClosed";
+    public const string AppealNoteAddedType = "AppealNoteAdded";
+    public const string AppealAttachmentAddedType = "AppealAttachmentAdded";
+    public const string AppealAttachmentAcknowledgedType = "AppealAttachmentAcknowledged";
+    public const string AppealOverdueObservedType = "AppealOverdueObserved";
+    public const string AppealAssignedType = "AppealAssigned";
+    public const string AppealStatusMigratedType = "AppealStatusMigrated";
+
+    private readonly ILogger<AppealEventPublisher> _logger;
+    private readonly IConfiguration _configuration;
+    private IProducer<string, string>? _producer;
+    private bool _available;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter() },
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    public AppealEventPublisher(ILogger<AppealEventPublisher> logger, IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var bootstrapServers = _configuration["Kafka:BootstrapServers"];
+        if (string.IsNullOrEmpty(bootstrapServers))
+        {
+            _logger.LogWarning("Kafka:BootstrapServers not configured — appeal event publisher disabled");
+            return Task.CompletedTask;
+        }
+
+        var producerConfig = new ProducerConfig
+        {
+            BootstrapServers = bootstrapServers,
+            ClientId = _configuration["Kafka:ClientId"] ?? "appeals-service",
+            MessageTimeoutMs = 10_000,
+            RequestTimeoutMs = 10_000,
+            SocketTimeoutMs = 10_000,
+            EnableIdempotence = true
+        };
+
+        var saslUsername = _configuration["Kafka:SaslUsername"];
+        if (!string.IsNullOrEmpty(saslUsername))
+        {
+            producerConfig.SaslUsername = saslUsername;
+            producerConfig.SaslPassword = _configuration["Kafka:SaslPassword"];
+            producerConfig.SaslMechanism = SaslMechanism.ScramSha512;
+            producerConfig.SecurityProtocol = SecurityProtocol.SaslSsl;
+        }
+
+        try
+        {
+            _producer = new ProducerBuilder<string, string>(producerConfig).Build();
+            _available = true;
+            _logger.LogInformation("Appeal event publisher connected to Kafka at {Servers}",
+                LogSanitizer.SafeForLog(bootstrapServers));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Kafka producer init failed — appeal event publisher running in degraded mode");
+            _producer?.Dispose();
+            _producer = null;
+            _available = false;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            _producer?.Flush(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error flushing Kafka producer on shutdown");
+        }
+        _producer?.Dispose();
+        _producer = null;
+        _available = false;
+        return Task.CompletedTask;
+    }
+
+    public Task PublishCreatedAsync(Appeal appeal, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildCreatedPayload(appeal, actor, correlationId);
+        return ProduceAsync(appeal, AppealCreatedType, evt, ct);
+    }
+
+    public Task PublishStatusChangedAsync(
+        Appeal appeal, AppealStatus fromStatus, AppealStatus toStatus,
+        string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildStatusChangedPayload(appeal, fromStatus, toStatus, actor, correlationId);
+        return ProduceAsync(appeal, AppealStatusChangedType, evt, ct);
+    }
+
+    public Task PublishClosedAsync(
+        Appeal appeal, AppealStatus fromStatus, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildClosedPayload(appeal, fromStatus, actor, correlationId);
+        return ProduceAsync(appeal, AppealClosedType, evt, ct);
+    }
+
+    public Task PublishNoteAddedAsync(
+        Appeal appeal, AppealNote note, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildNoteAddedPayload(appeal, note, actor, correlationId);
+        return ProduceAsync(appeal, AppealNoteAddedType, evt, ct);
+    }
+
+    public Task PublishAttachmentAddedAsync(
+        Appeal appeal, AppealAttachment attachment, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildAttachmentAddedPayload(appeal, attachment, actor, correlationId);
+        return ProduceAsync(appeal, AppealAttachmentAddedType, evt, ct);
+    }
+
+    public Task PublishAttachmentAcknowledgedAsync(
+        Appeal appeal, AppealAttachment attachment, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildAttachmentAcknowledgedPayload(appeal, attachment, actor, correlationId);
+        return ProduceAsync(appeal, AppealAttachmentAcknowledgedType, evt, ct);
+    }
+
+    public Task PublishOverdueObservedAsync(Appeal appeal, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildOverdueObservedPayload(appeal, actor, correlationId);
+        return ProduceAsync(appeal, AppealOverdueObservedType, evt, ct);
+    }
+
+    public Task PublishAssignedAsync(
+        Appeal appeal, string? previousReviewerId, string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildAssignedPayload(appeal, previousReviewerId, actor, correlationId);
+        return ProduceAsync(appeal, AppealAssignedType, evt, ct);
+    }
+
+    public Task PublishStatusMigratedAsync(
+        Appeal appeal, string legacyStatus, AppealClosureReasonCode mappedReasonCode,
+        string actor, string? correlationId, CancellationToken ct = default)
+    {
+        var evt = BuildStatusMigratedPayload(appeal, legacyStatus, mappedReasonCode, actor, correlationId);
+        return ProduceAsync(appeal, AppealStatusMigratedType, evt, ct);
+    }
+
+    private async Task ProduceAsync<TPayload>(Appeal appeal, string eventType, TPayload payload, CancellationToken ct)
+    {
+        if (!_available || _producer == null)
+        {
+            _logger.LogDebug("Kafka producer unavailable; skipping {EventType} for appeal {AppealId}",
+                LogSanitizer.SafeForLog(eventType), LogSanitizer.SafeForLog(appeal.Id));
+            return;
+        }
+
+        var message = new Message<string, string>
+        {
+            Key = appeal.Id,
+            Value = JsonSerializer.Serialize(payload, JsonOptions),
+            Headers = new Headers
+            {
+                { "tenant-id", Encoding.UTF8.GetBytes(appeal.TenantId) },
+                { "event-type", Encoding.UTF8.GetBytes(eventType) },
+                { "event-version", Encoding.UTF8.GetBytes(EventVersion) }
+            }
+        };
+
+        try
+        {
+            await _producer.ProduceAsync(StatusChangedTopic, message, ct);
+            _logger.LogInformation("Published {EventType} for appeal {AppealId}",
+                LogSanitizer.SafeForLog(eventType), LogSanitizer.SafeForLog(appeal.Id));
+        }
+        catch (ProduceException<string, string> ex)
+        {
+            _logger.LogError(ex, "Failed to publish {EventType} for appeal {AppealId}: {Reason}",
+                LogSanitizer.SafeForLog(eventType), LogSanitizer.SafeForLog(appeal.Id),
+                LogSanitizer.SafeForLog(ex.Error.Reason));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error publishing {EventType} for appeal {AppealId}",
+                LogSanitizer.SafeForLog(eventType), LogSanitizer.SafeForLog(appeal.Id));
+        }
+    }
+
+    // ── Payload builders (internal for field-whitelist tests) ───────────
+
+    internal static AppealCreatedEventPayload BuildCreatedPayload(Appeal a, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealCreatedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        AppealNumber = a.AppealNumber,
+        ClaimId = a.ClaimId,
+        ClaimNumber = a.ClaimNumber,
+        MemberId = a.MemberId,
+        ProviderNPI = a.ProviderNPI,
+        AppealType = a.AppealType.ToString(),
+        AppealLevel = a.AppealLevel.ToString(),
+        LineOfBusiness = a.LineOfBusiness.ToString(),
+        Source = a.Source.ToString(),
+        TargetResponseDate = a.TargetResponseDate,
+        IsUrgent = a.IsUrgent,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealStatusChangedEventPayload BuildStatusChangedPayload(
+        Appeal a, AppealStatus from, AppealStatus to, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealStatusChangedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        FromStatus = from.ToString(),
+        ToStatus = to.ToString(),
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealClosedEventPayload BuildClosedPayload(
+        Appeal a, AppealStatus from, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealClosedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        FromStatus = from.ToString(),
+        ClosureReasonCode = a.ClosureReasonCode?.ToString(),
+        DecisionType = a.Decision?.DecisionType.ToString(),
+        ApprovedAmount = a.Decision?.ApprovedAmount,
+        DecisionDate = a.DecisionDate,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealNoteAddedEventPayload BuildNoteAddedPayload(
+        Appeal a, AppealNote n, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealNoteAddedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        NoteId = n.NoteId,
+        Author = n.CreatedBy,
+        CreatedAt = n.CreatedAt,
+        IsInternal = n.IsInternal,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealAttachmentAddedEventPayload BuildAttachmentAddedPayload(
+        Appeal a, AppealAttachment att, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealAttachmentAddedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        AttachmentId = att.AttachmentId,
+        AttachmentTypeCode = att.AttachmentTypeCode,
+        TransmissionCode = att.TransmissionCode,
+        ControlNumber = att.ControlNumber,
+        UploadedAt = att.UploadedAt,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealAttachmentAcknowledgedEventPayload BuildAttachmentAcknowledgedPayload(
+        Appeal a, AppealAttachment att, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealAttachmentAcknowledgedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        AttachmentId = att.AttachmentId,
+        AcknowledgmentReceived = att.AcknowledgmentReceived,
+        SentDate = att.SentDate,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealOverdueObservedEventPayload BuildOverdueObservedPayload(
+        Appeal a, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealOverdueObservedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        CurrentStatus = a.Status.ToString(),
+        TargetResponseDate = a.TargetResponseDate,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealAssignedEventPayload BuildAssignedPayload(
+        Appeal a, string? previousReviewerId, string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealAssignedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        AssignedReviewerId = a.AssignedReviewerId,
+        PreviousReviewerId = previousReviewerId,
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    internal static AppealStatusMigratedEventPayload BuildStatusMigratedPayload(
+        Appeal a, string legacyStatus, AppealClosureReasonCode mappedReasonCode,
+        string actor, string? correlationId) => new()
+    {
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealStatusMigratedType,
+        EventVersion = EventVersion,
+        OccurredAt = DateTime.UtcNow,
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        LegacyStatus = legacyStatus,
+        MappedReasonCode = mappedReasonCode.ToString(),
+        Actor = actor,
+        CorrelationId = correlationId
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None);
+        GC.SuppressFinalize(this);
+    }
+}
+
+// ── Event payload records (tested by field-whitelist assertion) ─────────
+// Each record defines the COMPLETE wire shape. Adding a field here is a
+// deliberate wire-format change; the field-whitelist tests enforce no
+// encrypted-at-rest value silently leaks onto the event stream.
+
+public sealed record AppealCreatedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string AppealNumber { get; init; } = string.Empty;
+    public string ClaimId { get; init; } = string.Empty;
+    public string ClaimNumber { get; init; } = string.Empty;
+    public string MemberId { get; init; } = string.Empty;
+    public string ProviderNPI { get; init; } = string.Empty;
+    public string AppealType { get; init; } = string.Empty;
+    public string AppealLevel { get; init; } = string.Empty;
+    public string LineOfBusiness { get; init; } = string.Empty;
+    public string Source { get; init; } = string.Empty;
+    public DateTime? TargetResponseDate { get; init; }
+    public bool IsUrgent { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealStatusChangedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string FromStatus { get; init; } = string.Empty;
+    public string ToStatus { get; init; } = string.Empty;
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealClosedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string FromStatus { get; init; } = string.Empty;
+    public string? ClosureReasonCode { get; init; }
+    public string? DecisionType { get; init; }
+    public decimal? ApprovedAmount { get; init; }
+    public DateTime? DecisionDate { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealNoteAddedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string NoteId { get; init; } = string.Empty;
+    public string Author { get; init; } = string.Empty;
+    public DateTime CreatedAt { get; init; }
+    public bool IsInternal { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealAttachmentAddedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string AttachmentId { get; init; } = string.Empty;
+    public string AttachmentTypeCode { get; init; } = string.Empty;
+    public string TransmissionCode { get; init; } = string.Empty;
+    public string? ControlNumber { get; init; }
+    public DateTime UploadedAt { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealAttachmentAcknowledgedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string AttachmentId { get; init; } = string.Empty;
+    public bool AcknowledgmentReceived { get; init; }
+    public DateTime? SentDate { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealOverdueObservedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string CurrentStatus { get; init; } = string.Empty;
+    public DateTime? TargetResponseDate { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealAssignedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string? AssignedReviewerId { get; init; }
+    public string? PreviousReviewerId { get; init; }
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}
+
+public sealed record AppealStatusMigratedEventPayload
+{
+    public string EventId { get; init; } = string.Empty;
+    public string EventType { get; init; } = string.Empty;
+    public string EventVersion { get; init; } = string.Empty;
+    public DateTime OccurredAt { get; init; }
+    public string TenantId { get; init; } = string.Empty;
+    public string AppealId { get; init; } = string.Empty;
+    public string LegacyStatus { get; init; } = string.Empty;
+    public string MappedReasonCode { get; init; } = string.Empty;
+    public string Actor { get; init; } = string.Empty;
+    public string? CorrelationId { get; init; }
+}

--- a/src/services/appeals-service/Services/AppealFieldEncryptor.cs
+++ b/src/services/appeals-service/Services/AppealFieldEncryptor.cs
@@ -1,0 +1,180 @@
+using System.Security.Cryptography;
+using System.Text;
+using CloudHealthOffice.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// AES-256-GCM encryptor for appeal body fields. Fourth consumer of the
+/// <see cref="RotatingKeyProvider"/> pattern after member-service,
+/// consent-service, and personal-representative-service — the A.7.3 payoff
+/// curve is fully realized at this point.
+///
+/// appeals-service has no 0x01 legacy envelopes (field encryption didn't
+/// exist before this PR). Only 0x02 envelopes are read and written.
+///
+/// Envelope format (base64url of):
+///   0x02: [0x02][keyVerLen=1 byte][keyVer UTF-8 bytes][12 IV][16 tag][ciphertext]
+/// </summary>
+public sealed class AppealFieldEncryptor : IAppealFieldEncryptor
+{
+    private const byte FormatV2 = 0x02;
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+
+    private readonly RotatingKeyProvider _keys;
+    private readonly ILogger<AppealFieldEncryptor> _logger;
+    private readonly AppealEncryptionOptions _options;
+
+    public AppealFieldEncryptor(
+        RotatingKeyProvider keys,
+        ILogger<AppealFieldEncryptor> logger,
+        AppealEncryptionOptions options)
+    {
+        _keys = keys;
+        _logger = logger;
+        _options = options;
+
+        if (string.IsNullOrWhiteSpace(options.KeySecretPrefix))
+            throw new ArgumentException("KeySecretPrefix is required", nameof(options));
+        if (string.IsNullOrWhiteSpace(options.CurrentKeyVersion))
+            throw new ArgumentException("CurrentKeyVersion is required", nameof(options));
+        if (options.AcceptedKeyVersions.Count == 0)
+            throw new ArgumentException("AcceptedKeyVersions must contain at least one entry", nameof(options));
+    }
+
+    public async Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(plaintext)) return plaintext;
+
+        var keyVersion = _options.CurrentKeyVersion;
+        var keyVersionBytes = Encoding.UTF8.GetBytes(keyVersion);
+        if (keyVersionBytes.Length == 0 || keyVersionBytes.Length > 255)
+            throw new InvalidOperationException(
+                $"AppealEncryption:CurrentKeyVersion '{keyVersion}' must be 1..255 UTF-8 bytes.");
+
+        var key = await ResolveKeyAsync(keyVersion, ct);
+        EnsureKeyLength(key);
+
+        var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+        var plainBytes = Encoding.UTF8.GetBytes(plaintext);
+        var cipherBytes = new byte[plainBytes.Length];
+        var tag = new byte[TagSize];
+
+        using (var gcm = new AesGcm(key, TagSize))
+        {
+            gcm.Encrypt(nonce, plainBytes, cipherBytes, tag);
+        }
+
+        var envelope = new byte[1 + 1 + keyVersionBytes.Length + NonceSize + TagSize + cipherBytes.Length];
+        var o = 0;
+        envelope[o++] = FormatV2;
+        envelope[o++] = (byte)keyVersionBytes.Length;
+        Buffer.BlockCopy(keyVersionBytes, 0, envelope, o, keyVersionBytes.Length); o += keyVersionBytes.Length;
+        Buffer.BlockCopy(nonce, 0, envelope, o, NonceSize); o += NonceSize;
+        Buffer.BlockCopy(tag, 0, envelope, o, TagSize); o += TagSize;
+        Buffer.BlockCopy(cipherBytes, 0, envelope, o, cipherBytes.Length);
+
+        return Base64UrlEncode(envelope);
+    }
+
+    public async Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(ciphertext)) return ciphertext;
+
+        byte[] envelope;
+        try
+        {
+            envelope = Base64UrlDecode(ciphertext);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogWarning(ex, "Appeal ciphertext is not valid base64url");
+            throw new CryptographicException("Appeal ciphertext is not valid base64url", ex);
+        }
+
+        if (envelope.Length < 1)
+            throw new CryptographicException("Envelope is empty");
+
+        if (envelope[0] != FormatV2)
+            throw new CryptographicException($"Unsupported envelope version 0x{envelope[0]:X2}");
+
+        if (envelope.Length < 1 + 1) throw new CryptographicException("0x02 envelope too short");
+        int keyVerLen = envelope[1];
+        var headerLen = 1 + 1 + keyVerLen;
+        if (envelope.Length < headerLen + NonceSize + TagSize)
+            throw new CryptographicException("0x02 envelope too short for key-version + IV + tag");
+
+        var keyVersion = Encoding.UTF8.GetString(envelope, 2, keyVerLen);
+
+        if (!_options.AcceptedKeyVersions.Contains(keyVersion, StringComparer.OrdinalIgnoreCase))
+            throw new CryptographicException(
+                $"Envelope key version '{keyVersion}' is not in AppealEncryption:AcceptedKeyVersions. " +
+                "Either widen the accepted window or re-encrypt the record.");
+
+        var key = await ResolveKeyAsync(keyVersion, ct);
+        EnsureKeyLength(key);
+
+        var nonce = new byte[NonceSize];
+        var tag = new byte[TagSize];
+        var cipherLen = envelope.Length - headerLen - NonceSize - TagSize;
+        var cipherBytes = new byte[cipherLen];
+        Buffer.BlockCopy(envelope, headerLen, nonce, 0, NonceSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize, tag, 0, TagSize);
+        Buffer.BlockCopy(envelope, headerLen + NonceSize + TagSize, cipherBytes, 0, cipherLen);
+
+        var plainBytes = new byte[cipherLen];
+        using var gcm = new AesGcm(key, TagSize);
+        gcm.Decrypt(nonce, cipherBytes, tag, plainBytes);
+        return Encoding.UTF8.GetString(plainBytes);
+    }
+
+    private async Task<byte[]> ResolveKeyAsync(string version, CancellationToken ct)
+    {
+        try
+        {
+            return await _keys.GetKeyAsync(_options.KeySecretPrefix, version, devConfigFallback: null, ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new StaleEncryptionKeyException(version,
+                $"Key version '{version}' cannot be resolved from the secret provider. " +
+                "Publish the secret or drop the version from AcceptedKeyVersions.",
+                ex);
+        }
+    }
+
+    private static void EnsureKeyLength(byte[] key)
+    {
+        if (key.Length != 32)
+            throw new InvalidOperationException(
+                $"Appeal encryption key must be 32 bytes (AES-256); got {key.Length}.");
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] Base64UrlDecode(string s)
+    {
+        var padded = s.Replace('-', '+').Replace('_', '/');
+        switch (padded.Length % 4)
+        {
+            case 2: padded += "=="; break;
+            case 3: padded += "="; break;
+        }
+        return Convert.FromBase64String(padded);
+    }
+}
+
+/// <summary>
+/// Dev-only passthrough. Used when <see cref="AppealEncryptionOptions"/> is
+/// not configured and the host is <c>IsDevelopment</c>. A non-dev startup
+/// with no <c>AppealEncryption</c> section throws in <c>Program.cs</c>
+/// rather than falling back to plaintext.
+/// </summary>
+public sealed class NoOpAppealFieldEncryptor : IAppealFieldEncryptor
+{
+    public Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default) => Task.FromResult(plaintext);
+    public Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default) => Task.FromResult(ciphertext);
+}

--- a/src/services/appeals-service/Services/AppealStateMachine.cs
+++ b/src/services/appeals-service/Services/AppealStateMachine.cs
@@ -1,0 +1,114 @@
+using AppealsService.Models;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Pure transition validator. No side effects — callers assemble the
+/// <see cref="AppealEvent"/> themselves and pass the (appeal, new-status,
+/// event) triple to the repository, which enforces atomicity.
+///
+/// Allowed transitions:
+///   (none)      -> Draft        (genesis, via CreateAsync)
+///   Draft       -> Submitted    (submit)
+///   Draft       -> Closed       (withdraw from draft)
+///   Submitted   -> InReview     (begin-review)
+///   Submitted   -> Closed       (withdraw from submitted)
+///   InReview    -> PendingInfo  (request-info)
+///   InReview    -> Closed       (close with decision, or withdraw)
+///   PendingInfo -> InReview     (resume-review)
+///   PendingInfo -> Closed       (close, or expire)
+///
+/// Rejected:
+///   Closed      -> anything     (terminal — no re-entry)
+///   *           -> *self        (idempotent no-op handled at controller,
+///                                NOT a legal state-machine transition)
+///   Any         -> Draft        (genesis cannot be re-entered)
+///   Backwards   transitions     (InReview -> Submitted, etc.)
+///
+/// Overdue is NOT a state. It is a read-time projection on
+/// <see cref="Appeal.IsOverdue"/> and drives the one-shot
+/// <c>AppealOverdueObserved</c> audit event via
+/// <c>IAppealRepository.TryTransitionToOverdueAsync</c>. A status transition
+/// is NOT emitted for overdue — the appeal remains in Submitted/InReview/
+/// PendingInfo until an explicit close.
+/// </summary>
+/// <remarks>
+/// Divergence from <c>ConsentStateMachine</c>: consent models Expired as a
+/// distinct terminal status because consent has exactly two termination
+/// reasons (Revoked, Expired). Appeals has six+ termination reasons
+/// (Approved, Denied, PartialApproval, Withdrawn, Expired-by-deadline,
+/// AdminError, Other) and promoting any of them to a status would be
+/// arbitrary. We keep the status enum lean (Draft/Submitted/InReview/
+/// PendingInfo/Closed) and carry the discriminator on
+/// <see cref="AppealClosureReasonCode"/>. Same pattern
+/// <c>PersonalRepStateMachine</c> established for the same reason.
+/// Reviewers coming from consent-service: this is deliberate, not an
+/// oversight.
+///
+/// Idempotent same-status requests (e.g. submit when already Submitted)
+/// are handled at the controller layer by short-circuiting BEFORE calling
+/// <see cref="EnsureAllowed"/> — the state machine rejects X->X as illegal.
+/// This keeps the state machine strict (it is the invariant enforcer) and
+/// puts UX concerns like idempotency where they belong.
+/// </remarks>
+public static class AppealStateMachine
+{
+    /// <summary>Pure check — does NOT throw. Returns true iff the transition is legal.</summary>
+    public static bool IsAllowed(AppealStatus from, AppealStatus to) =>
+        (from, to) switch
+        {
+            (AppealStatus.Draft,       AppealStatus.Submitted)   => true,
+            (AppealStatus.Draft,       AppealStatus.Closed)      => true,
+            (AppealStatus.Submitted,   AppealStatus.InReview)    => true,
+            (AppealStatus.Submitted,   AppealStatus.Closed)      => true,
+            (AppealStatus.InReview,    AppealStatus.PendingInfo) => true,
+            (AppealStatus.InReview,    AppealStatus.Closed)      => true,
+            (AppealStatus.PendingInfo, AppealStatus.InReview)    => true,
+            (AppealStatus.PendingInfo, AppealStatus.Closed)      => true,
+            _ => false
+        };
+
+    /// <summary>
+    /// Validate a transition. Throws
+    /// <see cref="InvalidAppealTransitionException"/> if the transition is
+    /// not allowed. Repositories and controllers call this BEFORE
+    /// persisting; the same check is repeated by the repository's
+    /// conditional write to close a TOCTOU window.
+    /// </summary>
+    public static void EnsureAllowed(AppealStatus from, AppealStatus to)
+    {
+        if (!IsAllowed(from, to))
+            throw new InvalidAppealTransitionException(from, to);
+    }
+
+    /// <summary>
+    /// Valid closure-reason codes for a given source status. Enforces the
+    /// rule that <c>Withdrawn</c> is the only reason valid from Draft or
+    /// Submitted (a withdrawal before review, not a decision); decision-
+    /// bearing reasons are only valid from InReview or PendingInfo; and
+    /// <c>Expired</c> is only valid from PendingInfo (a no-response close).
+    /// </summary>
+    public static bool IsClosureReasonAllowed(AppealStatus from, AppealClosureReasonCode reason) =>
+        (from, reason) switch
+        {
+            (AppealStatus.Draft,       AppealClosureReasonCode.Withdrawn)       => true,
+            (AppealStatus.Submitted,   AppealClosureReasonCode.Withdrawn)       => true,
+
+            (AppealStatus.InReview,    AppealClosureReasonCode.Approved)        => true,
+            (AppealStatus.InReview,    AppealClosureReasonCode.Denied)          => true,
+            (AppealStatus.InReview,    AppealClosureReasonCode.PartialApproval) => true,
+            (AppealStatus.InReview,    AppealClosureReasonCode.Withdrawn)       => true,
+            (AppealStatus.InReview,    AppealClosureReasonCode.AdminError)      => true,
+            (AppealStatus.InReview,    AppealClosureReasonCode.Other)           => true,
+
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.Approved)        => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.Denied)          => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.PartialApproval) => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.Withdrawn)       => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.Expired)         => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.AdminError)      => true,
+            (AppealStatus.PendingInfo, AppealClosureReasonCode.Other)           => true,
+
+            _ => false
+        };
+}

--- a/src/services/appeals-service/Services/IAppealEventPublisher.cs
+++ b/src/services/appeals-service/Services/IAppealEventPublisher.cs
@@ -1,0 +1,88 @@
+using AppealsService.Models;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Emits appeal lifecycle events to Kafka. The DB is source of truth — a
+/// Kafka failure is logged but never propagated.
+/// </summary>
+public interface IAppealEventPublisher
+{
+    /// <summary>Genesis event. <paramref name="fromStatus"/> is always null.</summary>
+    Task PublishCreatedAsync(
+        Appeal appeal,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>Any transition except genesis and close.</summary>
+    Task PublishStatusChangedAsync(
+        Appeal appeal,
+        AppealStatus fromStatus,
+        AppealStatus toStatus,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Terminal →Closed transition. Includes structured decision data
+    /// (decisionType, approvedAmount) when a decision is present. Decision
+    /// free-text fields (rationale, reviewer notes) remain encrypted at
+    /// rest and are NOT in the payload.
+    /// </summary>
+    Task PublishClosedAsync(
+        Appeal appeal,
+        AppealStatus fromStatus,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    Task PublishNoteAddedAsync(
+        Appeal appeal,
+        AppealNote note,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    Task PublishAttachmentAddedAsync(
+        Appeal appeal,
+        AppealAttachment attachment,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    Task PublishAttachmentAcknowledgedAsync(
+        Appeal appeal,
+        AppealAttachment attachment,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>Read-time one-shot when an appeal first passes TargetResponseDate.</summary>
+    Task PublishOverdueObservedAsync(
+        Appeal appeal,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    Task PublishAssignedAsync(
+        Appeal appeal,
+        string? previousReviewerId,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Emitted by the status-migration hosted service for records
+    /// carrying pre-modernization terminal status values that were rewritten
+    /// to <c>Status=Closed</c> + <see cref="Appeal.ClosureReasonCode"/>. One
+    /// event per migrated record.
+    /// </summary>
+    Task PublishStatusMigratedAsync(
+        Appeal appeal,
+        string legacyStatus,
+        AppealClosureReasonCode mappedReasonCode,
+        string actor,
+        string? correlationId,
+        CancellationToken ct = default);
+}

--- a/src/services/appeals-service/Services/IAppealFieldEncryptor.cs
+++ b/src/services/appeals-service/Services/IAppealFieldEncryptor.cs
@@ -1,0 +1,16 @@
+namespace AppealsService.Services;
+
+/// <summary>
+/// Encrypts and decrypts PHI-adjacent free-text fields on an appeal record
+/// (<c>PatientName</c>, <c>AppealReason</c>, <c>DenialReason</c>,
+/// <c>AppealNote.NoteText</c>, <c>AppealDecision.DecisionReason</c>,
+/// <c>AppealDecision.ReviewerNotes</c>, <c>ClinicalDocument.Summary</c>,
+/// <c>AppealAttachment.Description</c>). Null/empty values pass through
+/// unchanged so partial records — a draft appeal created without a denial
+/// reason, for example — do not force spurious ciphertext.
+/// </summary>
+public interface IAppealFieldEncryptor
+{
+    Task<string?> EncryptAsync(string? plaintext, CancellationToken ct = default);
+    Task<string?> DecryptAsync(string? ciphertext, CancellationToken ct = default);
+}

--- a/src/services/appeals-service/Services/LogSanitizer.cs
+++ b/src/services/appeals-service/Services/LogSanitizer.cs
@@ -1,0 +1,38 @@
+namespace AppealsService.Services;
+
+/// <summary>
+/// Strips control characters (CR/LF/tab/NUL/etc.) from user-supplied
+/// strings before they go into log messages. CodeQL's
+/// <c>cs/log-forging</c> rule flags any logged value that originates from
+/// request data because a newline in a tenant id, correlation id, or
+/// appeal id lets an attacker inject synthetic log entries that corrupt
+/// parsing and triage workflows. All CHO repositories, controllers, and
+/// publishers that log user-originated fields (<c>TenantId</c>,
+/// <c>AppealId</c>, <c>ClaimId</c>, <c>EventId</c>, <c>CorrelationId</c>,
+/// external error reasons) MUST route them through
+/// <see cref="SafeForLog"/> first.
+///
+/// Kept local to appeals-service; mirrors the shape personal-rep-service
+/// established. Promotes to shared infra when a third service needs it.
+/// </summary>
+internal static class LogSanitizer
+{
+    /// <summary>
+    /// Returns <paramref name="value"/> with all control characters replaced
+    /// by <c>?</c>. Truncates to <paramref name="maxLength"/> (default 256)
+    /// so a pathological value cannot blow up log storage or flood the
+    /// downstream log pipeline.
+    /// </summary>
+    public static string SafeForLog(string? value, int maxLength = 256)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var capped = value.Length > maxLength ? value[..maxLength] : value;
+        var chars = capped.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (char.IsControl(chars[i])) chars[i] = '?';
+        }
+        return new string(chars);
+    }
+}

--- a/src/services/appeals-service/Services/StaleEncryptionKeyException.cs
+++ b/src/services/appeals-service/Services/StaleEncryptionKeyException.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Thrown when an envelope references a key version that is listed in the
+/// service's <c>AcceptedKeyVersions</c> window but whose underlying secret
+/// cannot be resolved from the
+/// <see cref="CloudHealthOffice.Infrastructure.Configuration.ISecretProvider"/>.
+/// Distinct from a plain <see cref="CryptographicException"/> (which
+/// indicates tampered ciphertext or the wrong key) so that callers can
+/// distinguish "rotation migration failure — page ops" from "possible
+/// tamper — audit the caller".
+/// </summary>
+public sealed class StaleEncryptionKeyException : CryptographicException
+{
+    public string KeyVersion { get; }
+
+    public StaleEncryptionKeyException(string keyVersion, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        KeyVersion = keyVersion;
+    }
+}

--- a/src/services/appeals-service/appeals-service.csproj
+++ b/src/services/appeals-service/appeals-service.csproj
@@ -10,10 +10,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="AppealsService.Tests/**" />
+    <Content Remove="AppealsService.Tests/**" />
+    <None Remove="AppealsService.Tests/**" />
+    <EmbeddedResource Remove="AppealsService.Tests/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AppealsService.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
+    <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/appeals-service/appsettings.Development.json
+++ b/src/services/appeals-service/appsettings.Development.json
@@ -9,11 +9,12 @@
     "AccountEndpoint": "https://localhost:8081",
     "AccountKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
   },
-  "AzureStorage": {
-    "ConnectionString": "UseDevelopmentStorage=true"
-  },
   "ClaimsService": {
     "BaseUrl": "http://localhost:5003"
+  },
+  "Kafka": {
+    "BootstrapServers": "",
+    "ClientId": "appeals-service"
   },
   "Observability": {
     "OtlpEndpoint": null,

--- a/src/services/appeals-service/appsettings.json
+++ b/src/services/appeals-service/appsettings.json
@@ -11,10 +11,6 @@
     "AccountKey": "",
     "DatabaseName": "CloudHealthOffice"
   },
-  "AzureStorage": {
-    "ConnectionString": "",
-    "ContainerName": "appeal-attachments"
-  },
   "ClaimsService": {
     "BaseUrl": "http://claims-service:8080"
   },
@@ -30,6 +26,18 @@
       ".xml"
     ],
     "DefaultAppealLevelTimeLimitDays": 60
+  },
+  "AppealEncryption": {
+    "KeySecretPrefix": "appeal-body-encryption-key",
+    "CurrentKeyVersion": "v1",
+    "AcceptedKeyVersions": [ "v1" ]
+  },
+  "Kafka": {
+    "BootstrapServers": "",
+    "ClientId": "appeals-service"
+  },
+  "AppealMigration": {
+    "BatchSize": 100
   },
   "Observability": {
     "ServiceName": "appeals-service",

--- a/src/services/appeals-service/k8s/appeals-service-deployment.yaml
+++ b/src/services/appeals-service/k8s/appeals-service-deployment.yaml
@@ -6,8 +6,12 @@ metadata:
 data:
   ASPNETCORE_ENVIRONMENT: "Production"
   CosmosDb__DatabaseName: "CloudHealthOffice"
-  AzureStorage__ContainerName: "appeal-attachments"
   ClaimsService__BaseUrl: "http://claims-service.cloudhealthoffice"
+  AppealEncryption__KeySecretPrefix: "appeal-body-encryption-key"
+  AppealEncryption__CurrentKeyVersion: "v1"
+  AppealEncryption__AcceptedKeyVersions__0: "v1"
+  Kafka__ClientId: "appeals-service"
+  AppealMigration__BatchSize: "100"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -57,16 +61,6 @@ spec:
             configMapKeyRef:
               name: appeals-service-config
               key: CosmosDb__DatabaseName
-        - name: AzureStorage__ConnectionString
-          valueFrom:
-            secretKeyRef:
-              name: azure-storage-secret
-              key: connectionString
-        - name: AzureStorage__ContainerName
-          valueFrom:
-            configMapKeyRef:
-              name: appeals-service-config
-              key: AzureStorage__ContainerName
         - name: ClaimsService__BaseUrl
           valueFrom:
             configMapKeyRef:
@@ -79,6 +73,44 @@ spec:
               key: connectionString
         - name: MongoDb__DatabaseName
           value: "cloudhealthoffice"
+        # Appeal body encryption — key material is in Key Vault under
+        # appeal-body-encryption-key-v1. Must be provisioned BEFORE first
+        # deployment; otherwise the readiness check fails and the pod is
+        # not rotated into traffic. See rotate-secret.sh.
+        - name: AppealEncryption__KeySecretPrefix
+          valueFrom:
+            configMapKeyRef:
+              name: appeals-service-config
+              key: AppealEncryption__KeySecretPrefix
+        - name: AppealEncryption__CurrentKeyVersion
+          valueFrom:
+            configMapKeyRef:
+              name: appeals-service-config
+              key: AppealEncryption__CurrentKeyVersion
+        - name: AppealEncryption__AcceptedKeyVersions__0
+          valueFrom:
+            configMapKeyRef:
+              name: appeals-service-config
+              key: AppealEncryption__AcceptedKeyVersions__0
+        # Kafka — empty BootstrapServers puts the publisher in degraded
+        # mode (service boots, publishes are silent no-ops). Populate the
+        # secret when the broker is ready for appeal.status-changed.v1.
+        - name: Kafka__BootstrapServers
+          valueFrom:
+            secretKeyRef:
+              name: kafka-secret
+              key: bootstrapServers
+              optional: true
+        - name: Kafka__ClientId
+          valueFrom:
+            configMapKeyRef:
+              name: appeals-service-config
+              key: Kafka__ClientId
+        - name: AppealMigration__BatchSize
+          valueFrom:
+            configMapKeyRef:
+              name: appeals-service-config
+              key: AppealMigration__BatchSize
         resources:
           requests:
             cpu: 100m

--- a/src/services/consent-service/ConsentService.Tests/Controllers/ConsentsControllerTests.cs
+++ b/src/services/consent-service/ConsentService.Tests/Controllers/ConsentsControllerTests.cs
@@ -2,6 +2,8 @@ using System.Security.Claims;
 using ConsentService.Controllers;
 using ConsentService.Middleware;
 using ConsentService.Models;
+using ConsentService.Repositories;
+using ConsentService.Services;
 using ConsentService.Tests.Fakes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/services/consent-service/ConsentService.Tests/Fakes/InMemoryConsentRepository.cs
+++ b/src/services/consent-service/ConsentService.Tests/Fakes/InMemoryConsentRepository.cs
@@ -71,7 +71,7 @@ public sealed class InMemoryConsentRepository : IConsentRepository, IConsentEven
             if (!_consents.TryGetValue(key, out var current) || current.Status != expectedFromStatus)
             {
                 var actual = current?.Status ?? consent.Status;
-                throw new Models.InvalidConsentTransitionException(actual, consent.Status);
+                throw new InvalidConsentTransitionException(actual, consent.Status);
             }
 
             _consents[key] = Clone(consent);


### PR DESCRIPTION
## Summary

Fixes the `.NET Unit Tests` failure on [run 24814338291](https://github.com/aurelianware/cloudhealthoffice/actions/runs/24814338291/job/72625422936) for PR #678 (appeals-service modernization).

The two failing tests — `AppealLifecycleSmokeTests.FullLifecycle_Create_Submit_BeginReview_RequestInfo_ResumeReview_Close_Approved` (empty events collection) and `AppealLifecycleSmokeTests.Overdue_EmitsExactlyOneObservedEvent_AcrossConcurrentReads` (`NullReferenceException`) — share a root cause in `AppealsWebApplicationFactory.Reset()`.

## Root cause

`Reset()` assigned **new** `InMemoryAppealRepository` / `RecordingAppealEventPublisher` instances to the factory's public properties. But `WebApplicationFactory<Program>` builds its host + DI container on the first `CreateClient()` call and caches them, so the DI container's `AddSingleton(Repo)` / `AddSingleton(Publisher)` registrations captured the **original** instances.

From the second test onward:

- The app (controllers → repo → publisher) kept writing to the original singletons held by DI.
- `_factory.Repo` / `_factory.Publisher` pointed to freshly-constructed, empty instances.
- `_factory.Repo.SnapshotEvents()` therefore returned an empty list → `ContainInOrder(...)` assertions failed.
- `_factory.Repo.PeekStored("tenant-a", appeal.Id)!` returned `null` → NRE on the next property access (line 265 of `AppealLifecycleSmokeTests.cs`).

## Fix

- Add `Clear()` to `InMemoryAppealRepository` (resets `_appeals`, `_events`, and the `_failAuditAppendOnce` flag under `_sync`).
- Add `Clear()` to `RecordingAppealEventPublisher` (clears all nine `ConcurrentQueue` recorders).
- Make `Repo` / `Publisher` get-only properties and change `Reset()` to call `Clear()` on the existing instances — so the DI-held singletons and the property references stay the same object for the lifetime of the `IClassFixture`.

## Test plan

- [ ] `AppealLifecycleSmokeTests` all 5 integration tests green on CI.
- [ ] `AppealAtomicityTests` (which construct their own `InMemoryAppealRepository` per test) unaffected.
- [ ] No other tests read `_factory.Repo` / `_factory.Publisher` as reassignable — they're all field accesses on the same reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jjqwt42FJ926rve7qEonSy)_