### PR TITLE
feat(appeals-service): X12 275 Kafka consumer for appeal attachments

### DIFF
--- a/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/InMemoryAppealRepository.cs
@@ -79,6 +79,18 @@ public sealed class InMemoryAppealRepository : IAppealRepository, IAppealEventRe
         return Task.FromResult<IReadOnlyList<Appeal>>(results);
     }
 
+    public Task<Appeal?> GetMostRecentAppealByClaimIdAsync(
+        string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var match = _appeals.Values
+            .Where(a => a.TenantId == tenantId
+                     && a.ClaimId == claimId
+                     && a.Status != AppealStatus.Closed)
+            .OrderByDescending(a => a.SubmittedDate)
+            .FirstOrDefault();
+        return Task.FromResult<Appeal?>(match is null ? null : Clone(match));
+    }
+
     public Task<IReadOnlyList<Appeal>> SearchAsync(string tenantId, AppealSearchParams p, CancellationToken ct = default)
     {
         var query = _appeals.Values.Where(a => a.TenantId == tenantId);

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAttachment275DeadLetterSink.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAttachment275DeadLetterSink.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+using AppealsService.Models;
+using AppealsService.Services;
+
+namespace AppealsService.Tests.Fakes;
+
+/// <summary>
+/// Captures every dead-letter call so consumer tests can assert
+/// the routing decision tree. Mirrors the queue-per-call shape that
+/// <see cref="RecordingAppealEventPublisher"/> uses.
+/// </summary>
+public sealed class RecordingAttachment275DeadLetterSink : IAttachment275DeadLetterSink
+{
+    public readonly ConcurrentQueue<EnvelopeCall> Envelopes = new();
+    public readonly ConcurrentQueue<MalformedCall> Malformed = new();
+
+    public Task DeadLetterAsync(Attachment275EnvelopeDto envelope, string reason, CancellationToken ct = default)
+    {
+        Envelopes.Enqueue(new EnvelopeCall(envelope.TenantId, envelope.ClaimId, envelope.ControlNumber, reason));
+        return Task.CompletedTask;
+    }
+
+    public Task DeadLetterMalformedAsync(string rawMessage, string reason, CancellationToken ct = default)
+    {
+        Malformed.Enqueue(new MalformedCall(rawMessage?.Length ?? 0, reason));
+        return Task.CompletedTask;
+    }
+
+    public sealed record EnvelopeCall(string TenantId, string? ClaimId, string? ControlNumber, string Reason);
+    public sealed record MalformedCall(int RawByteCount, string Reason);
+}

--- a/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAttachment275DeadLetterSink.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Fakes/RecordingAttachment275DeadLetterSink.cs
@@ -27,5 +27,5 @@ public sealed class RecordingAttachment275DeadLetterSink : IAttachment275DeadLet
     }
 
     public sealed record EnvelopeCall(string TenantId, string? ClaimId, string? ControlNumber, string Reason);
-    public sealed record MalformedCall(int RawByteCount, string Reason);
+    public sealed record MalformedCall(int RawCharLength, string Reason);
 }

--- a/src/services/appeals-service/AppealsService.Tests/HostedServices/Attachment275ConsumerTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/HostedServices/Attachment275ConsumerTests.cs
@@ -1,0 +1,364 @@
+using AppealsService.HostedServices;
+using AppealsService.Models;
+using AppealsService.Services;
+using AppealsService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppealsService.Tests.HostedServices;
+
+/// <summary>
+/// Handler-level tests for
+/// <see cref="Attachment275ConsumerHostedService.HandleMessageAsync"/>.
+/// Drives the internal test constructor path so the 5-collaborator
+/// handler can be exercised without standing up Kafka or a fake
+/// <see cref="IServiceProvider"/>. Covers every branch of the routing
+/// decision tree plus the PHI-safety log posture.
+/// </summary>
+public class Attachment275ConsumerTests
+{
+    private static readonly DateTime FixtureSubmittedDate =
+        new(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
+
+    private sealed record Harness(
+        Attachment275ConsumerHostedService Consumer,
+        InMemoryAppealRepository Repository,
+        RecordingAppealEventPublisher Publisher,
+        ReversibleAppealFieldEncryptor Encryptor,
+        RecordingAttachment275DeadLetterSink DeadLetterSink,
+        Attachment275EnvelopeMapper Mapper);
+
+    private static Harness NewHarness()
+    {
+        var repository = new InMemoryAppealRepository();
+        var publisher = new RecordingAppealEventPublisher();
+        var encryptor = new ReversibleAppealFieldEncryptor();
+        var deadLetterSink = new RecordingAttachment275DeadLetterSink();
+        var mapper = new Attachment275EnvelopeMapper();
+        var consumer = new Attachment275ConsumerHostedService(
+            repository, publisher, encryptor, deadLetterSink, mapper,
+            NullLogger<Attachment275ConsumerHostedService>.Instance);
+        return new Harness(consumer, repository, publisher, encryptor, deadLetterSink, mapper);
+    }
+
+    private static async Task<Appeal> SeedOpenAppealAsync(
+        InMemoryAppealRepository repository,
+        string tenantId = "tenant-a",
+        string claimId = "claim-1",
+        AppealStatus status = AppealStatus.Submitted)
+    {
+        var appeal = new Appeal
+        {
+            TenantId = tenantId,
+            Id = Guid.NewGuid().ToString(),
+            AppealNumber = "APL-" + Guid.NewGuid().ToString("N")[..6],
+            ClaimId = claimId,
+            ClaimNumber = "CLM-" + claimId,
+            MemberId = "m1",
+            PatientName = "enc::patient",
+            ProviderNPI = "1234567890",
+            AppealReason = "enc::reason",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            AppealType = AppealType.Reconsideration,
+            AppealLevel = AppealLevel.FirstLevel,
+            Status = status,
+            SubmittedDate = DateTime.UtcNow.AddDays(-1),
+            CreatedAt = DateTime.UtcNow.AddDays(-1)
+        };
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId,
+            AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealCreated,
+            FromStatus = null,
+            ToStatus = status,
+            ActorId = "seed"
+        };
+        return await repository.CreateAsync(appeal, genesis);
+    }
+
+    private static string EnvelopeJson(
+        string? context = "appeal",
+        string? tenantId = "tenant-a",
+        string? claimId = "claim-1",
+        string? rawX12 = "ISA*00*...",
+        string? controlNumber = "BHT-12345",
+        string? notes = "Attached records",
+        string? documentType = "Medical Records",
+        string? documentFormat = "PDF") =>
+        System.Text.Json.JsonSerializer.Serialize(new
+        {
+            tenantId,
+            context,
+            claimId,
+            authorizationId = "auth-xyz",
+            payerId = "P1",
+            payerName = "Payer",
+            providerId = "PR1",
+            providerName = "Provider",
+            subscriberId = "SUB1",
+            patientFirstName = "Jane",
+            patientLastName = "Doe",
+            documentType,
+            documentFormat,
+            rawX12,
+            submittedDate = FixtureSubmittedDate,
+            notes,
+            controlNumber
+        });
+
+    // ── Routing branches ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleMessage_SkipsAndCommits_WhenContextNotAppeal()
+    {
+        var h = NewHarness();
+        var json = EnvelopeJson(context: "authorization");
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.SkippedNonAppealContext);
+        h.DeadLetterSink.Envelopes.Should().BeEmpty();
+        h.DeadLetterSink.Malformed.Should().BeEmpty();
+        h.Publisher.AttachmentsAdded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleMessage_SkipsAndCommits_WhenContextNull_PreArgoReality()
+    {
+        // The pre-Argo-PR production reality: messages arrive without
+        // a "context" field. The consumer must not log-spam or
+        // dead-letter on this path.
+        var h = NewHarness();
+        var json = EnvelopeJson(context: null);
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.SkippedNonAppealContext);
+        h.DeadLetterSink.Envelopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenJsonMalformed()
+    {
+        var h = NewHarness();
+
+        var outcome = await h.Consumer.HandleMessageAsync("{ not valid json", CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredMalformedJson);
+        h.DeadLetterSink.Malformed.Should().ContainSingle();
+        h.DeadLetterSink.Malformed.Single().Reason.Should().Be("json-deserialization-failed");
+        h.DeadLetterSink.Envelopes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenTenantIdMissing()
+    {
+        var h = NewHarness();
+        var json = EnvelopeJson(tenantId: "");
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredMissingRequiredField);
+        h.DeadLetterSink.Envelopes.Should().ContainSingle(e => e.Reason == "missing-tenantId");
+    }
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenClaimIdMissing()
+    {
+        var h = NewHarness();
+        var json = EnvelopeJson(claimId: null);
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredMissingRequiredField);
+        h.DeadLetterSink.Envelopes.Should().ContainSingle(e => e.Reason == "missing-claimId");
+    }
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenRawX12Missing()
+    {
+        var h = NewHarness();
+        var json = EnvelopeJson(rawX12: null);
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredMissingRequiredField);
+        h.DeadLetterSink.Envelopes.Should().ContainSingle(e => e.Reason == "missing-rawX12");
+    }
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenNoOpenAppealMatches()
+    {
+        var h = NewHarness();
+        // Nothing seeded — lookup returns null.
+        var json = EnvelopeJson(claimId: "orphan-claim");
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredNoOpenAppeal);
+        h.DeadLetterSink.Envelopes.Should().ContainSingle(e => e.Reason == "no-open-appeal-for-claim");
+    }
+
+    [Fact]
+    public async Task HandleMessage_AppendsAttachment_WhenOpenAppealFound()
+    {
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        var json = EnvelopeJson(tenantId: appeal.TenantId, claimId: appeal.ClaimId);
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.Routed);
+        var stored = h.Repository.PeekStored(appeal.TenantId, appeal.Id);
+        stored.Should().NotBeNull();
+        stored!.Attachments.Should().ContainSingle();
+        stored.Attachments[0].ControlNumber.Should().Be("BHT-12345");
+        stored.Attachments[0].AttachmentTypeCode.Should().Be("OZ"); // Medical Records → OZ
+        stored.AttachmentControlNumbers.Should().Contain("BHT-12345");
+    }
+
+    // ── Correlation + audit-event shape ─────────────────────────────────
+
+    [Fact]
+    public async Task HandleMessage_SetsCorrelationIdFromControlNumber()
+    {
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        var json = EnvelopeJson(
+            tenantId: appeal.TenantId, claimId: appeal.ClaimId,
+            controlNumber: "BHT-99999");
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        var auditEvents = await h.Repository.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        var attachmentEvent = auditEvents.Single(e => e.EventType == AppealEventType.AppealAttachmentAdded);
+        attachmentEvent.CorrelationId.Should().Be("BHT-99999");
+    }
+
+    [Fact]
+    public async Task HandleMessage_FallsBackToUnknownCorrelation_WhenControlNumberAbsent()
+    {
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        var json = EnvelopeJson(
+            tenantId: appeal.TenantId, claimId: appeal.ClaimId,
+            controlNumber: null);
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        var auditEvents = await h.Repository.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        var attachmentEvent = auditEvents.Single(e => e.EventType == AppealEventType.AppealAttachmentAdded);
+        attachmentEvent.CorrelationId.Should().Be(Attachment275ConsumerHostedService.UnknownCorrelationId);
+    }
+
+    [Fact]
+    public async Task HandleMessage_AuditEventPayload_IncludesIngressSourceAvaility275()
+    {
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        var json = EnvelopeJson(tenantId: appeal.TenantId, claimId: appeal.ClaimId);
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        var auditEvents = await h.Repository.ListByAppealAsync(appeal.TenantId, appeal.Id);
+        var attachmentEvent = auditEvents.Single(e => e.EventType == AppealEventType.AppealAttachmentAdded);
+        attachmentEvent.Payload.Should().NotBeNull();
+        attachmentEvent.Payload![Attachment275ConsumerHostedService.IngressSourcePayloadKey]!.GetValue<string>()
+            .Should().Be(Attachment275ConsumerHostedService.IngressSourcePayloadValue);
+    }
+
+    [Fact]
+    public async Task HandleMessage_DescriptionPersistedAsCiphertext_NotPlaintextNotes()
+    {
+        // Structural guard: the consumer routes envelope.Notes through
+        // IAppealFieldEncryptor before persistence — same posture as
+        // AppealsController.AddAttachment. With the reversible test
+        // encryptor, "ciphertext" deliberately wraps the plaintext
+        // (so round-trip decryption tests can assert equality), so we
+        // assert the encryption *call* happened (LooksEncrypted) and the
+        // stored value is not the raw plaintext.
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        const string sensitiveNote = "Patient reports migraine Tuesday morning";
+        var json = EnvelopeJson(
+            tenantId: appeal.TenantId, claimId: appeal.ClaimId,
+            notes: sensitiveNote);
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        var stored = h.Repository.PeekStored(appeal.TenantId, appeal.Id);
+        var attachment = stored!.Attachments.Single();
+        ReversibleAppealFieldEncryptor.LooksEncrypted(attachment.Description).Should().BeTrue(
+            "the consumer must encrypt envelope.Notes via IAppealFieldEncryptor before persistence");
+        attachment.Description.Should().NotBe(sensitiveNote,
+            "the raw plaintext note value must not be the stored value");
+    }
+
+    [Fact]
+    public async Task HandleMessage_PublishesAppealAttachmentAddedEvent_WithCorrelationId()
+    {
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        var json = EnvelopeJson(
+            tenantId: appeal.TenantId, claimId: appeal.ClaimId,
+            controlNumber: "BHT-PUBLISH-TEST");
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        h.Publisher.AttachmentsAdded.Should().ContainSingle();
+        var call = h.Publisher.AttachmentsAdded.Single();
+        call.AppealId.Should().Be(appeal.Id);
+        call.ControlNumber.Should().Be("BHT-PUBLISH-TEST");
+        call.CorrelationId.Should().Be("BHT-PUBLISH-TEST");
+        call.Actor.Should().Be(Attachment275ConsumerHostedService.IngressActor);
+    }
+
+    // ── Exception branch ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HandleMessage_DeadLettersAndCommits_WhenRepositoryAppendThrows()
+    {
+        // Seed an open appeal, then force the next audit-append to fail.
+        // The consumer should catch, dead-letter with reason handler-exception,
+        // and NOT crash.
+        var h = NewHarness();
+        var appeal = await SeedOpenAppealAsync(h.Repository);
+        h.Repository.FailAuditAppendOnce(); // will be triggered by the genesis-already-done; next append fails
+        var json = EnvelopeJson(tenantId: appeal.TenantId, claimId: appeal.ClaimId);
+
+        var outcome = await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredHandlerException);
+        h.DeadLetterSink.Envelopes.Should().ContainSingle(e => e.Reason == "handler-exception");
+    }
+
+    // ── PHI-safety (log surface) ────────────────────────────────────────
+
+    [Fact]
+    public async Task DeadLetterSink_NeverReceivesRawX12OrPatientNames()
+    {
+        // Structural guard: the IAttachment275DeadLetterSink contract
+        // surfaces only non-PHI fields (tenantId, claimId, controlNumber,
+        // reason). Patient names and rawX12 live only on the envelope
+        // DTO that the sink receives — the sink's default
+        // (LoggingAttachment275DeadLetterSink) is already proven not to
+        // log them. This test reinforces that the RecordingSink — the
+        // artifact tests rely on — likewise only captures the whitelisted
+        // tuple.
+        var h = NewHarness();
+        var json = EnvelopeJson(claimId: null); // force dead-letter
+
+        await h.Consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        h.DeadLetterSink.Envelopes.Should().ContainSingle();
+        var captured = h.DeadLetterSink.Envelopes.Single();
+        // Assert the recording fields structurally: TenantId + ClaimId +
+        // ControlNumber + Reason, no PatientFirstName / PatientLastName /
+        // RawX12 field on the record type.
+        typeof(RecordingAttachment275DeadLetterSink.EnvelopeCall)
+            .GetProperties()
+            .Select(p => p.Name)
+            .Should().BeEquivalentTo(new[] { "TenantId", "ClaimId", "ControlNumber", "Reason" });
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Integration/Attachment275ConsumerIntegrationTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Integration/Attachment275ConsumerIntegrationTests.cs
@@ -1,0 +1,228 @@
+using AppealsService.HostedServices;
+using AppealsService.Models;
+using AppealsService.Services;
+using AppealsService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace AppealsService.Tests.Integration;
+
+/// <summary>
+/// End-to-end integration tests for the X12 275 ingress path. Uses the
+/// in-memory repository as the storage substrate (mirrors Mongo + Cosmos
+/// behavior per the
+/// <c>AppealRepositoryClaimLookupTests</c> contract) and drives the
+/// consumer's <c>HandleMessageAsync</c> directly with the JSON shapes
+/// the Argo workflow does (and will) publish.
+///
+/// Two fixtures:
+/// <list type="bullet">
+///   <item><description><see cref="AppealContextFixtureTemplate"/> — the
+///   post-Argo-PR shape with <c>context: "appeal"</c>, <c>claimId</c>, and
+///   <c>controlNumber</c> populated. Asserts the full happy path.</description></item>
+///   <item><description><see cref="CanonicalSolicitedFixture"/> — today's
+///   canonical solicited fixture (no <c>context</c>, no <c>claimId</c>).
+///   Asserts the consumer skips it cleanly: no repository write, no
+///   dead-letter, no audit event.</description></item>
+/// </list>
+/// </summary>
+public class Attachment275ConsumerIntegrationTests
+{
+    /// <summary>
+    /// Synthesized post-Argo-PR envelope. Substitutes
+    /// <c>{CLAIM_ID}</c> and <c>{CONTROL_NUMBER}</c> at test time. Mirrors
+    /// the canonical
+    /// <c>docs/testing/test-attachment-275-solicited.json</c> shape with
+    /// the three new fields the Argo workflow update will introduce
+    /// (see PR 4 plan, deferred item #10).
+    /// </summary>
+    private const string AppealContextFixtureTemplate = """
+        {
+          "tenantId": "tenant-pchp",
+          "context": "appeal",
+          "claimId": "{CLAIM_ID}",
+          "authorizationId": "auth-20260207-001",
+          "rfaiReference": "RFAI-2026-12345",
+          "payerId": "BSCA123456789",
+          "payerName": "Blue Shield of California",
+          "providerId": "1234567890",
+          "providerName": "City Medical Center",
+          "subscriberId": "BSCA987654321",
+          "patientFirstName": "John",
+          "patientLastName": "Doe",
+          "documentType": "Medical Records",
+          "documentFormat": "PDF",
+          "rawX12": "ISA*00*REDACTED*00*REDACTED*ZZ*SENDER*ZZ*RECEIVER*260207*1430*^*00501*000000001*0*P*:~",
+          "submittedDate": "2026-02-07T14:30:00Z",
+          "controlNumber": "{CONTROL_NUMBER}"
+        }
+        """;
+
+    /// <summary>
+    /// Canonical solicited fixture today
+    /// (<c>docs/testing/test-attachment-275-solicited.json</c>) — no
+    /// <c>context</c>, no <c>claimId</c>, no <c>controlNumber</c>.
+    /// Represents the production envelope shape until the Argo
+    /// follow-up ships.
+    /// </summary>
+    private const string CanonicalSolicitedFixture = """
+        {
+          "tenantId": "blueshield-ca",
+          "authorizationId": "auth-20260207-001",
+          "rfaiReference": "RFAI-2026-12345",
+          "payerId": "BSCA123456789",
+          "payerName": "Blue Shield of California",
+          "providerId": "1234567890",
+          "providerName": "City Medical Center",
+          "subscriberId": "BSCA987654321",
+          "patientFirstName": "John",
+          "patientLastName": "Doe",
+          "documentType": "Medical Records",
+          "documentFormat": "PDF",
+          "rawX12": "ISA*00*REDACTED~",
+          "submittedDate": "2026-02-07T14:30:00Z"
+        }
+        """;
+
+    private static (Attachment275ConsumerHostedService Consumer,
+        InMemoryAppealRepository Repository,
+        RecordingAppealEventPublisher Publisher,
+        RecordingAttachment275DeadLetterSink Sink) BuildHarness()
+    {
+        var repository = new InMemoryAppealRepository();
+        var publisher = new RecordingAppealEventPublisher();
+        var encryptor = new ReversibleAppealFieldEncryptor();
+        var sink = new RecordingAttachment275DeadLetterSink();
+        var mapper = new Attachment275EnvelopeMapper();
+        var consumer = new Attachment275ConsumerHostedService(
+            repository, publisher, encryptor, sink, mapper,
+            NullLogger<Attachment275ConsumerHostedService>.Instance);
+        return (consumer, repository, publisher, sink);
+    }
+
+    private static async Task<Appeal> SeedOpenAppeal(
+        InMemoryAppealRepository repository, string tenantId, string claimId)
+    {
+        var appeal = new Appeal
+        {
+            TenantId = tenantId,
+            Id = Guid.NewGuid().ToString(),
+            AppealNumber = "APL-" + Guid.NewGuid().ToString("N")[..6],
+            ClaimId = claimId,
+            ClaimNumber = "CLM-" + claimId,
+            MemberId = "m1",
+            PatientName = "enc::patient",
+            ProviderNPI = "1234567890",
+            AppealReason = "enc::reason",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            AppealType = AppealType.Reconsideration,
+            AppealLevel = AppealLevel.FirstLevel,
+            Status = AppealStatus.Submitted,
+            SubmittedDate = DateTime.UtcNow.AddDays(-2),
+            CreatedAt = DateTime.UtcNow.AddDays(-2)
+        };
+        var genesis = new AppealEvent
+        {
+            TenantId = appeal.TenantId,
+            AppealId = appeal.Id,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealCreated,
+            FromStatus = null,
+            ToStatus = AppealStatus.Submitted,
+            ActorId = "seed"
+        };
+        return await repository.CreateAsync(appeal, genesis);
+    }
+
+    [Fact]
+    public async Task AppealContextFixture_RoutesToSeededAppeal_WithFullAuditLineage()
+    {
+        var (consumer, repository, publisher, sink) = BuildHarness();
+        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-pchp", claimId: "claim-PCHP-9001");
+        var bht03 = "BHT03-2026-04-23-XYZ";
+        var json = AppealContextFixtureTemplate
+            .Replace("{CLAIM_ID}", seeded.ClaimId)
+            .Replace("{CONTROL_NUMBER}", bht03);
+
+        var outcome = await consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.Routed);
+
+        var stored = repository.PeekStored(seeded.TenantId, seeded.Id);
+        stored.Should().NotBeNull();
+        stored!.Attachments.Should().ContainSingle();
+        stored.Attachments[0].ControlNumber.Should().Be(bht03);
+        stored.Attachments[0].AttachmentTypeCode.Should().Be("OZ"); // Medical Records
+        stored.Attachments[0].TransmissionCode.Should().Be("EL");   // default
+        stored.AttachmentControlNumbers.Should().Contain(bht03);
+
+        var auditEvents = await repository.ListByAppealAsync(seeded.TenantId, seeded.Id);
+        var attachmentEvent = auditEvents.Single(e => e.EventType == AppealEventType.AppealAttachmentAdded);
+        attachmentEvent.CorrelationId.Should().Be(bht03,
+            "the BHT03 control number is the correlation key payer responses echo back");
+        attachmentEvent.ActorId.Should().Be(Attachment275ConsumerHostedService.IngressActor);
+        attachmentEvent.Payload!["ingressSource"]!.GetValue<string>().Should().Be("Availity275");
+
+        publisher.AttachmentsAdded.Should().ContainSingle();
+        publisher.AttachmentsAdded.Single().CorrelationId.Should().Be(bht03);
+
+        sink.Envelopes.Should().BeEmpty();
+        sink.Malformed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CanonicalSolicitedFixture_SkipsCleanly_PreArgoBaseline()
+    {
+        // Today's canonical envelope shape: no "context" field. Until
+        // the Argo workflow follow-up ships, every production message
+        // takes this branch. Must not dead-letter, must not write to
+        // the repository, must not emit an audit event.
+        var (consumer, repository, publisher, sink) = BuildHarness();
+        // Seed an appeal so a "happy" lookup would succeed if we accidentally
+        // tried to route — that way the assertion has teeth.
+        var seeded = await SeedOpenAppeal(repository, tenantId: "blueshield-ca", claimId: "claim-1");
+
+        var outcome = await consumer.HandleMessageAsync(CanonicalSolicitedFixture, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.SkippedNonAppealContext);
+
+        var stored = repository.PeekStored(seeded.TenantId, seeded.Id);
+        stored!.Attachments.Should().BeEmpty("no attachment must be written for a non-appeal-context envelope");
+
+        var auditEvents = await repository.ListByAppealAsync(seeded.TenantId, seeded.Id);
+        auditEvents.Should().NotContain(e => e.EventType == AppealEventType.AppealAttachmentAdded);
+
+        publisher.AttachmentsAdded.Should().BeEmpty();
+        sink.Envelopes.Should().BeEmpty();
+        sink.Malformed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppealContextFixture_DeadLetters_WhenSeededAppealIsClosed()
+    {
+        var (consumer, repository, publisher, sink) = BuildHarness();
+        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-pchp", claimId: "claim-closed-x");
+        // Move the appeal to Closed via the repository's transition path
+        // so the next 275 has nothing to land on.
+        var transition = new AppealEvent
+        {
+            TenantId = seeded.TenantId,
+            AppealId = seeded.Id,
+            EventId = Guid.NewGuid().ToString(),
+            EventType = AppealEventType.AppealClosed,
+            FromStatus = AppealStatus.Submitted,
+            ToStatus = AppealStatus.Closed,
+            ActorId = "seed"
+        };
+        seeded.Status = AppealStatus.Closed;
+        await repository.TransitionStatusAsync(seeded, transition);
+
+        var json = AppealContextFixtureTemplate
+            .Replace("{CLAIM_ID}", seeded.ClaimId)
+            .Replace("{CONTROL_NUMBER}", "BHT-doesnt-matter");
+
+        var outcome = await consumer.HandleMessageAsync(json, CancellationToken.None);
+
+        outcome.Should().Be(Attachment275HandleOutcome.DeadLetteredNoOpenAppeal);
+        sink.Envelopes.Should().ContainSingle(e => e.Reason == "no-open-appeal-for-claim");
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Repositories/AppealRepositoryClaimLookupTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Repositories/AppealRepositoryClaimLookupTests.cs
@@ -1,0 +1,145 @@
+using AppealsService.Models;
+using AppealsService.Tests.Fakes;
+
+namespace AppealsService.Tests.Repositories;
+
+/// <summary>
+/// Behavioral spec for <c>GetMostRecentAppealByClaimIdAsync</c>. Exercised
+/// against <see cref="InMemoryAppealRepository"/>, which mirrors the
+/// Cosmos + Mongo filter and ordering semantics. The production
+/// implementations carry the same invariants; this suite documents and
+/// guards them in a reproducible form.
+/// </summary>
+public class AppealRepositoryClaimLookupTests
+{
+    private static Appeal NewAppeal(
+        string tenantId = "tenant-a",
+        string claimId = "claim-1",
+        AppealStatus status = AppealStatus.Submitted,
+        DateTime? submittedDate = null) => new()
+    {
+        TenantId = tenantId,
+        Id = Guid.NewGuid().ToString(),
+        AppealNumber = "APL-" + Guid.NewGuid().ToString("N")[..6],
+        ClaimId = claimId,
+        ClaimNumber = "CLM-" + claimId,
+        MemberId = "m1",
+        PatientName = "enc::patient",
+        ProviderNPI = "1234567890",
+        AppealReason = "enc::reason",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        AppealType = AppealType.Reconsideration,
+        AppealLevel = AppealLevel.FirstLevel,
+        Status = status,
+        SubmittedDate = submittedDate ?? DateTime.UtcNow,
+        CreatedAt = DateTime.UtcNow
+    };
+
+    private static AppealEvent Genesis(Appeal a) => new()
+    {
+        TenantId = a.TenantId,
+        AppealId = a.Id,
+        EventId = Guid.NewGuid().ToString(),
+        EventType = AppealEventType.AppealCreated,
+        FromStatus = null,
+        ToStatus = a.Status,
+        ActorId = "test"
+    };
+
+    [Fact]
+    public async Task ReturnsNull_WhenNoAppealsExist()
+    {
+        var repo = new InMemoryAppealRepository();
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync("tenant-a", "claim-missing");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReturnsNull_WhenAllAppealsForClaimAreClosed()
+    {
+        var repo = new InMemoryAppealRepository();
+        var closed = NewAppeal(status: AppealStatus.Closed);
+        await repo.CreateAsync(closed, Genesis(closed));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync(closed.TenantId, closed.ClaimId);
+
+        result.Should().BeNull("a Closed appeal must not satisfy the open-appeal lookup");
+    }
+
+    [Fact]
+    public async Task ReturnsMostRecentlySubmitted_AmongMultipleOpen()
+    {
+        var repo = new InMemoryAppealRepository();
+        var older = NewAppeal(status: AppealStatus.Submitted, submittedDate: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var newer = NewAppeal(status: AppealStatus.InReview, submittedDate: new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc));
+        var middle = NewAppeal(status: AppealStatus.PendingInfo, submittedDate: new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+        await repo.CreateAsync(older, Genesis(older));
+        await repo.CreateAsync(newer, Genesis(newer));
+        await repo.CreateAsync(middle, Genesis(middle));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync("tenant-a", "claim-1");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(newer.Id);
+    }
+
+    [Fact]
+    public async Task DoesNotCrossTenants()
+    {
+        var repo = new InMemoryAppealRepository();
+        var other = NewAppeal(tenantId: "tenant-b", claimId: "claim-1", status: AppealStatus.Submitted);
+        await repo.CreateAsync(other, Genesis(other));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync("tenant-a", "claim-1");
+
+        result.Should().BeNull("an appeal in a different tenant must not satisfy the lookup");
+    }
+
+    [Fact]
+    public async Task FiltersOutClosed_AmongMixedStatus()
+    {
+        var repo = new InMemoryAppealRepository();
+        // Closed but newer than any open appeal — must NOT win.
+        var closedNewest = NewAppeal(status: AppealStatus.Closed, submittedDate: new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc));
+        var openOlder = NewAppeal(status: AppealStatus.Submitted, submittedDate: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        await repo.CreateAsync(closedNewest, Genesis(closedNewest));
+        await repo.CreateAsync(openOlder, Genesis(openOlder));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync("tenant-a", "claim-1");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(openOlder.Id, "Closed appeals are excluded regardless of recency");
+    }
+
+    [Fact]
+    public async Task DoesNotMatchDifferentClaim()
+    {
+        var repo = new InMemoryAppealRepository();
+        var other = NewAppeal(claimId: "claim-other", status: AppealStatus.Submitted);
+        await repo.CreateAsync(other, Genesis(other));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync(other.TenantId, "claim-1");
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(AppealStatus.Draft)]
+    [InlineData(AppealStatus.Submitted)]
+    [InlineData(AppealStatus.InReview)]
+    [InlineData(AppealStatus.PendingInfo)]
+    public async Task ReturnsAppeal_ForEveryNonClosedStatus(AppealStatus status)
+    {
+        var repo = new InMemoryAppealRepository();
+        var appeal = NewAppeal(status: status);
+        await repo.CreateAsync(appeal, Genesis(appeal));
+
+        var result = await repo.GetMostRecentAppealByClaimIdAsync(appeal.TenantId, appeal.ClaimId);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(appeal.Id);
+        result.Status.Should().Be(status);
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Services/Attachment275EnvelopeMapperTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Services/Attachment275EnvelopeMapperTests.cs
@@ -1,0 +1,187 @@
+using AppealsService.Models;
+using AppealsService.Services;
+
+namespace AppealsService.Tests.Services;
+
+/// <summary>
+/// Pure-mapping unit tests for <see cref="Attachment275EnvelopeMapper"/>.
+/// Encryption is the consumer's responsibility — the mapper takes
+/// already-encrypted ciphertext via its <c>encryptedDescription</c>
+/// argument, so these tests only verify pass-through and structural
+/// shape.
+/// </summary>
+public class Attachment275EnvelopeMapperTests
+{
+    private static Attachment275EnvelopeDto NewEnvelope(
+        string? controlNumber = "BHT-12345",
+        string? documentType = "Medical Records",
+        string? documentFormat = "PDF",
+        string? transmissionCode = null,
+        DateTime? submittedDate = null) => new()
+    {
+        TenantId = "tenant-a",
+        Context = "appeal",
+        ClaimId = "claim-1",
+        DocumentType = documentType,
+        DocumentFormat = documentFormat,
+        ControlNumber = controlNumber,
+        TransmissionCode = transmissionCode,
+        SubmittedDate = submittedDate ?? new DateTime(2026, 2, 7, 14, 0, 0, DateTimeKind.Utc),
+        Notes = "plain note text" // not used by the mapper directly
+    };
+
+    [Fact]
+    public void ToAppealAttachment_PopulatesControlNumberFromEnvelope()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(controlNumber: "BHT-XYZ-789");
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        result.ControlNumber.Should().Be("BHT-XYZ-789");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_DefaultsTransmissionCodeToEL_WhenEnvelopeMissing()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(transmissionCode: null);
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        result.TransmissionCode.Should().Be("EL");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_PassesEncryptedDescriptionThrough()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope();
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: "enc::ciphertext::abc");
+
+        result.Description.Should().Be("enc::ciphertext::abc",
+            "the mapper must not re-encrypt or transform the ciphertext supplied by the consumer");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_DerivesDeterministicFileName()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(
+            controlNumber: "BHT-12345",
+            documentFormat: "PDF",
+            submittedDate: new DateTime(2026, 2, 7, 14, 0, 0, DateTimeKind.Utc));
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        result.FileName.Should().Be("275-BHT-12345-20260207140000.pdf");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_FileName_FallsBackForUnknownControlAndFormat()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(
+            controlNumber: null,
+            documentFormat: null,
+            submittedDate: new DateTime(2026, 3, 15, 9, 30, 0, DateTimeKind.Utc));
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        result.FileName.Should().Be("275-unknown-20260315093000.bin");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_AttachmentTypeDescription_PreservesOriginalDocumentType()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(documentType: "Medical Records");
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        result.AttachmentTypeDescription.Should().Be("Medical Records");
+    }
+
+    [Fact]
+    public void ToAppealAttachment_StatusIsSent_WhenIngressedFrom275()
+    {
+        // Difference vs. the controller's POST /attachments path, which
+        // creates Pending: a 275 received over Kafka has, by definition,
+        // already been transmitted over the X12 network.
+        var mapper = new Attachment275EnvelopeMapper();
+
+        var result = mapper.ToAppealAttachment(NewEnvelope(), encryptedDescription: null);
+
+        result.Status.Should().Be(AttachmentStatus.Sent);
+    }
+
+    [Fact]
+    public void ToAppealAttachment_UploadedAt_FallsBackToUtcNow_WhenEnvelopeDateMissing()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(submittedDate: default(DateTime));
+
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+        var after = DateTime.UtcNow.AddSeconds(1);
+
+        result.UploadedAt.Should().BeAfter(before).And.BeBefore(after);
+    }
+
+    [Theory]
+    [InlineData("Medical Records", "OZ")]
+    [InlineData("Lab Results", "LA")]
+    [InlineData("Discharge Summary", "DS")]
+    [InlineData("Operative Report", "OB")]
+    [InlineData("Radiology Report", "RR")]
+    public void MapDocumentTypeToAttachmentTypeCode_ReturnsExpected_ForKnownTypes(string documentType, string expected)
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+
+        mapper.MapDocumentTypeToAttachmentTypeCode(documentType).Should().Be(expected);
+    }
+
+    [Fact]
+    public void MapDocumentTypeToAttachmentTypeCode_ReturnsOZ_ForUnknownType()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+
+        mapper.MapDocumentTypeToAttachmentTypeCode("Some Unmapped Type").Should().Be("OZ");
+    }
+
+    [Fact]
+    public void MapDocumentTypeToAttachmentTypeCode_ReturnsOZ_ForNullOrEmpty()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+
+        mapper.MapDocumentTypeToAttachmentTypeCode(null).Should().Be("OZ");
+        mapper.MapDocumentTypeToAttachmentTypeCode(string.Empty).Should().Be("OZ");
+    }
+
+    [Theory]
+    [InlineData("AA")]
+    [InlineData("BM")]
+    [InlineData("EL")]
+    [InlineData("FT")]
+    [InlineData("FX")]
+    [InlineData("IL")]
+    [InlineData("OZ")]
+    public void ResolveTransmissionCode_AcceptsAllSevenCodeSystemEntries(string code)
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+
+        mapper.ResolveTransmissionCode(code).Should().Be(code);
+    }
+
+    [Fact]
+    public void ResolveTransmissionCode_DefaultsToEL_ForUnrecognized()
+    {
+        var mapper = new Attachment275EnvelopeMapper();
+
+        mapper.ResolveTransmissionCode("ZZ").Should().Be("EL");
+        mapper.ResolveTransmissionCode("not-a-code").Should().Be("EL");
+        mapper.ResolveTransmissionCode(null).Should().Be("EL");
+        mapper.ResolveTransmissionCode(string.Empty).Should().Be("EL");
+    }
+}

--- a/src/services/appeals-service/AppealsService.Tests/Services/Attachment275EnvelopeMapperTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Services/Attachment275EnvelopeMapperTests.cs
@@ -129,6 +129,24 @@ public class Attachment275EnvelopeMapperTests
         result.UploadedAt.Should().BeAfter(before).And.BeBefore(after);
     }
 
+    [Fact]
+    public void ToAppealAttachment_FileNameStamp_AgreesWithUploadedAt_WhenSubmittedDateMissing()
+    {
+        // Regression: when envelope.SubmittedDate is default, both
+        // UploadedAt and the filename's timestamp segment used to call
+        // DateTime.UtcNow independently and could drift by milliseconds —
+        // producing a record where the filename stamp does not match the
+        // persisted UploadedAt. Mapper must compute the effective date
+        // once and reuse it.
+        var mapper = new Attachment275EnvelopeMapper();
+        var envelope = NewEnvelope(controlNumber: "BHT-CONSISTENCY", submittedDate: default(DateTime));
+
+        var result = mapper.ToAppealAttachment(envelope, encryptedDescription: null);
+
+        var expectedStamp = result.UploadedAt.ToString("yyyyMMddHHmmss");
+        result.FileName.Should().Be($"275-BHT-CONSISTENCY-{expectedStamp}.{envelope.DocumentFormat!.ToLowerInvariant()}");
+    }
+
     [Theory]
     [InlineData("Medical Records", "OZ")]
     [InlineData("Lab Results", "LA")]

--- a/src/services/appeals-service/HostedServices/Attachment275ConsumerHostedService.cs
+++ b/src/services/appeals-service/HostedServices/Attachment275ConsumerHostedService.cs
@@ -1,0 +1,380 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AppealsService.Models;
+using AppealsService.Repositories;
+using AppealsService.Services;
+using Confluent.Kafka;
+
+namespace AppealsService.HostedServices;
+
+/// <summary>
+/// Background consumer for the X12 275 Kafka topic
+/// (default <c>"attachments-in"</c>). Filters for messages whose
+/// envelope <c>context</c> field equals <c>"appeal"</c>, locates the
+/// open appeal in the tenant via
+/// <see cref="IAppealRepository.GetMostRecentAppealByClaimIdAsync"/>,
+/// and routes the 275 into the existing
+/// <see cref="IAppealRepository.AppendAttachmentAsync"/> path. Mirrors
+/// the structure of <c>ClaimsExaminerService.Services.Kafka.ClaimPendedConsumer</c>:
+/// degraded-mode no-op when <c>Kafka:BootstrapServers</c> is empty,
+/// 1-second poll loop, commit offset regardless of handler outcome so
+/// poison messages do not block the queue.
+///
+/// Adopts the dual-constructor pattern from
+/// <c>AuthorizationService.Consumers.RfaiDocsReceivedConsumer</c> so the
+/// per-message handler is exercisable from the test project without
+/// standing up a fake <see cref="IServiceProvider"/>.
+/// </summary>
+public sealed class Attachment275ConsumerHostedService : BackgroundService
+{
+    public const string AppealContext = "appeal";
+    public const string IngressActor = "appeals-service:275-consumer";
+    public const string UnknownCorrelationId = "x12-275-unknown";
+    public const string DefaultTopic = "attachments-in";
+    public const string DefaultGroupId = "appeals-service-275-consumer";
+    public const string IngressSourcePayloadKey = "ingressSource";
+    public const string IngressSourcePayloadValue = "Availity275";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IServiceProvider? _services;
+    private readonly IConfiguration? _configuration;
+    private readonly ILogger<Attachment275ConsumerHostedService> _logger;
+
+    // Test-mode collaborators. When non-null, HandleMessageAsync uses
+    // these directly instead of resolving from a per-message scope. Keeps
+    // the hosted service's message-handling logic exercisable without a
+    // fake IServiceProvider.
+    private readonly IAppealRepository? _testRepository;
+    private readonly IAppealEventPublisher? _testPublisher;
+    private readonly IAppealFieldEncryptor? _testEncryptor;
+    private readonly IAttachment275DeadLetterSink? _testDeadLetterSink;
+    private readonly Attachment275EnvelopeMapper? _testMapper;
+
+    public Attachment275ConsumerHostedService(
+        IServiceProvider services,
+        IConfiguration configuration,
+        ILogger<Attachment275ConsumerHostedService> logger)
+    {
+        _services = services;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    internal Attachment275ConsumerHostedService(
+        IAppealRepository repository,
+        IAppealEventPublisher publisher,
+        IAppealFieldEncryptor encryptor,
+        IAttachment275DeadLetterSink deadLetterSink,
+        Attachment275EnvelopeMapper mapper,
+        ILogger<Attachment275ConsumerHostedService> logger)
+    {
+        _testRepository = repository;
+        _testPublisher = publisher;
+        _testEncryptor = encryptor;
+        _testDeadLetterSink = deadLetterSink;
+        _testMapper = mapper;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Yield before the synchronous Consume loop so BackgroundService.StartAsync
+        // can return and let Kestrel + sibling hosted services initialize.
+        // Same rationale as ClaimPendedConsumer.cs:55.
+        await Task.Yield();
+
+        if (_configuration is null)
+        {
+            // Test-ctor instances do not run the consume loop; tests drive
+            // HandleMessageAsync directly.
+            return;
+        }
+
+        var bootstrap = _configuration["Kafka:BootstrapServers"];
+        if (string.IsNullOrEmpty(bootstrap))
+        {
+            _logger.LogWarning("Kafka:BootstrapServers not configured — 275 attachment consumer disabled");
+            return;
+        }
+
+        var topic = _configuration["Kafka:AttachmentsInTopic"] ?? DefaultTopic;
+        var groupId = _configuration["Kafka:Attachment275ConsumerGroupId"] ?? DefaultGroupId;
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = bootstrap,
+            GroupId = groupId,
+            ClientId = _configuration["Kafka:ClientId"] ?? "appeals-service",
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = false,
+            SessionTimeoutMs = 45_000
+        };
+
+        var saslUsername = _configuration["Kafka:SaslUsername"];
+        if (!string.IsNullOrEmpty(saslUsername))
+        {
+            config.SaslUsername = saslUsername;
+            config.SaslPassword = _configuration["Kafka:SaslPassword"];
+            config.SaslMechanism = SaslMechanism.ScramSha512;
+            config.SecurityProtocol = SecurityProtocol.SaslSsl;
+        }
+
+        IConsumer<string, string>? consumer = null;
+        try
+        {
+            consumer = new ConsumerBuilder<string, string>(config).Build();
+            consumer.Subscribe(topic);
+            _logger.LogInformation(
+                "275 attachment consumer subscribed to {Topic} (group={Group}, bootstrap={Bootstrap})",
+                LogSanitizer.SafeForLog(topic),
+                LogSanitizer.SafeForLog(groupId),
+                LogSanitizer.SafeForLog(bootstrap));
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                ConsumeResult<string, string>? result;
+                try
+                {
+                    result = consumer.Consume(TimeSpan.FromSeconds(1));
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ConsumeException ex)
+                {
+                    _logger.LogError(ex, "Kafka consume error: {Reason}",
+                        LogSanitizer.SafeForLog(ex.Error.Reason));
+                    continue;
+                }
+
+                if (result?.Message is null)
+                {
+                    continue;
+                }
+
+                // HandleMessageAsync is allowed to throw only in pathological
+                // cases (e.g. DI scope creation failure). Catch at the outer
+                // boundary so the offset still advances and the queue drains.
+                try
+                {
+                    await HandleMessageAsync(result.Message.Value, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Unhandled error in 275 message handler at {Topic} {Partition} {Offset}; advancing offset",
+                        result.Topic, result.Partition.Value, result.Offset.Value);
+                }
+
+                try
+                {
+                    consumer.Commit(result);
+                }
+                catch (KafkaException ex)
+                {
+                    _logger.LogError(ex, "Failed to commit offset for {Topic} {Partition} {Offset}",
+                        result.Topic, result.Partition.Value, result.Offset.Value);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "275 attachment consumer crashed");
+        }
+        finally
+        {
+            try { consumer?.Close(); } catch { /* ignore on shutdown */ }
+            consumer?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Process a single Kafka message value (envelope JSON). Returns the
+    /// outcome so tests can assert each branch of the routing decision tree.
+    /// </summary>
+    internal async Task<Attachment275HandleOutcome> HandleMessageAsync(
+        string messageValue, CancellationToken ct)
+    {
+        Attachment275EnvelopeDto? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<Attachment275EnvelopeDto>(messageValue, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex,
+                "275 envelope deserialization failed; dead-lettering raw message ({Bytes} bytes)",
+                messageValue?.Length ?? 0);
+            await ResolveDeadLetterSink().DeadLetterMalformedAsync(
+                messageValue ?? string.Empty, "json-deserialization-failed", ct);
+            return Attachment275HandleOutcome.DeadLetteredMalformedJson;
+        }
+
+        if (envelope is null)
+        {
+            _logger.LogWarning("275 envelope deserialized to null; dead-lettering");
+            await ResolveDeadLetterSink().DeadLetterMalformedAsync(
+                messageValue ?? string.Empty, "envelope-null", ct);
+            return Attachment275HandleOutcome.DeadLetteredMalformedJson;
+        }
+
+        if (!string.Equals(envelope.Context, AppealContext, StringComparison.Ordinal))
+        {
+            // Not an appeal-context message. Skipped; not a failure.
+            // Pre-Argo-PR, this is the expected fall-through for every
+            // production message — keep at debug to avoid log spam.
+            _logger.LogDebug(
+                "275 envelope context={Context} is not '{AppealContext}'; skipping",
+                LogSanitizer.SafeForLog(envelope.Context),
+                AppealContext);
+            return Attachment275HandleOutcome.SkippedNonAppealContext;
+        }
+
+        if (string.IsNullOrEmpty(envelope.TenantId))
+        {
+            await ResolveDeadLetterSink().DeadLetterAsync(envelope, "missing-tenantId", ct);
+            return Attachment275HandleOutcome.DeadLetteredMissingRequiredField;
+        }
+        if (string.IsNullOrEmpty(envelope.ClaimId))
+        {
+            await ResolveDeadLetterSink().DeadLetterAsync(envelope, "missing-claimId", ct);
+            return Attachment275HandleOutcome.DeadLetteredMissingRequiredField;
+        }
+        if (string.IsNullOrEmpty(envelope.RawX12))
+        {
+            await ResolveDeadLetterSink().DeadLetterAsync(envelope, "missing-rawX12", ct);
+            return Attachment275HandleOutcome.DeadLetteredMissingRequiredField;
+        }
+
+        if (_testRepository is not null)
+        {
+            return await RouteAsync(
+                envelope,
+                _testRepository,
+                _testPublisher!,
+                _testEncryptor!,
+                _testDeadLetterSink!,
+                _testMapper!,
+                ct);
+        }
+
+        // Per-message DI scope so scoped collaborators (Cosmos repository,
+        // encryptor key handles, etc.) get fresh lifetimes per envelope.
+        using var scope = _services!.CreateScope();
+        var sp = scope.ServiceProvider;
+        return await RouteAsync(
+            envelope,
+            sp.GetRequiredService<IAppealRepository>(),
+            sp.GetRequiredService<IAppealEventPublisher>(),
+            sp.GetRequiredService<IAppealFieldEncryptor>(),
+            sp.GetRequiredService<IAttachment275DeadLetterSink>(),
+            sp.GetRequiredService<Attachment275EnvelopeMapper>(),
+            ct);
+    }
+
+    private async Task<Attachment275HandleOutcome> RouteAsync(
+        Attachment275EnvelopeDto envelope,
+        IAppealRepository repository,
+        IAppealEventPublisher publisher,
+        IAppealFieldEncryptor encryptor,
+        IAttachment275DeadLetterSink deadLetterSink,
+        Attachment275EnvelopeMapper mapper,
+        CancellationToken ct)
+    {
+        try
+        {
+            var appeal = await repository.GetMostRecentAppealByClaimIdAsync(
+                envelope.TenantId, envelope.ClaimId!, ct);
+            if (appeal is null)
+            {
+                _logger.LogWarning(
+                    "275 envelope: no open appeal for tenantId={TenantId} claimId={ClaimId} controlNumber={ControlNumber}",
+                    LogSanitizer.SafeForLog(envelope.TenantId),
+                    LogSanitizer.SafeForLog(envelope.ClaimId),
+                    LogSanitizer.SafeForLog(envelope.ControlNumber));
+                await deadLetterSink.DeadLetterAsync(envelope, "no-open-appeal-for-claim", ct);
+                return Attachment275HandleOutcome.DeadLetteredNoOpenAppeal;
+            }
+
+            var encryptedDescription = await encryptor.EncryptAsync(envelope.Notes, ct);
+            var attachment = mapper.ToAppealAttachment(envelope, encryptedDescription);
+
+            var correlationId = string.IsNullOrEmpty(envelope.ControlNumber)
+                ? UnknownCorrelationId
+                : envelope.ControlNumber;
+
+            var auditEvent = new AppealEvent
+            {
+                TenantId = appeal.TenantId,
+                AppealId = appeal.Id,
+                EventId = Guid.NewGuid().ToString(),
+                EventType = AppealEventType.AppealAttachmentAdded,
+                ActorId = IngressActor,
+                CorrelationId = correlationId,
+                OccurredAt = DateTime.UtcNow,
+                Payload = new JsonObject
+                {
+                    ["attachmentId"] = attachment.AttachmentId,
+                    ["attachmentTypeCode"] = attachment.AttachmentTypeCode,
+                    ["transmissionCode"] = attachment.TransmissionCode,
+                    ["controlNumber"] = attachment.ControlNumber,
+                    ["uploadedAt"] = attachment.UploadedAt.ToString("o"),
+                    [IngressSourcePayloadKey] = IngressSourcePayloadValue
+                }
+            };
+
+            var updated = await repository.AppendAttachmentAsync(appeal, attachment, auditEvent, ct);
+            await publisher.PublishAttachmentAddedAsync(updated, attachment, IngressActor, correlationId, ct);
+
+            _logger.LogInformation(
+                "275 attachment routed: tenantId={TenantId} appealId={AppealId} attachmentId={AttachmentId} controlNumber={ControlNumber}",
+                LogSanitizer.SafeForLog(updated.TenantId),
+                LogSanitizer.SafeForLog(updated.Id),
+                LogSanitizer.SafeForLog(attachment.AttachmentId),
+                LogSanitizer.SafeForLog(envelope.ControlNumber));
+
+            return Attachment275HandleOutcome.Routed;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "275 envelope routing failed: tenantId={TenantId} claimId={ClaimId} controlNumber={ControlNumber}; dead-lettering and advancing offset",
+                LogSanitizer.SafeForLog(envelope.TenantId),
+                LogSanitizer.SafeForLog(envelope.ClaimId),
+                LogSanitizer.SafeForLog(envelope.ControlNumber));
+            await deadLetterSink.DeadLetterAsync(envelope, "handler-exception", ct);
+            return Attachment275HandleOutcome.DeadLetteredHandlerException;
+        }
+    }
+
+    private IAttachment275DeadLetterSink ResolveDeadLetterSink()
+    {
+        if (_testDeadLetterSink is not null) return _testDeadLetterSink;
+        // For the pre-route paths (deserialization failure, missing
+        // required fields) we resolve a transient sink without holding
+        // a full per-message scope open — the sink is a singleton.
+        return _services!.GetRequiredService<IAttachment275DeadLetterSink>();
+    }
+}
+
+/// <summary>
+/// Outcome of one
+/// <see cref="Attachment275ConsumerHostedService.HandleMessageAsync"/> call.
+/// Internal because it's a test-only assertion target — the production
+/// path commits the offset regardless of which value is returned.
+/// </summary>
+internal enum Attachment275HandleOutcome
+{
+    Routed,
+    SkippedNonAppealContext,
+    DeadLetteredMalformedJson,
+    DeadLetteredMissingRequiredField,
+    DeadLetteredNoOpenAppeal,
+    DeadLetteredHandlerException
+}

--- a/src/services/appeals-service/Models/Attachment275EnvelopeDto.cs
+++ b/src/services/appeals-service/Models/Attachment275EnvelopeDto.cs
@@ -1,0 +1,86 @@
+using System.Text.Json.Serialization;
+
+namespace AppealsService.Models;
+
+/// <summary>
+/// Envelope shape published by the
+/// <c>infrastructure/argo-workflows/x12-275-ingest.yaml</c> workflow onto
+/// the <c>attachments-in</c> Kafka topic. Argo parses the X12 envelope
+/// and emits this JSON; appeals-service consumes it without re-parsing
+/// the EDI.
+///
+/// <see cref="Context"/>, <see cref="ClaimId"/>, and <see cref="ControlNumber"/>
+/// are populated by the Argo workflow follow-up that ships alongside
+/// this consumer (tracked separately under
+/// <c>infrastructure/argo-workflows/</c>). Until that ships, every
+/// production message will be skipped (<c>Context</c> absent) or
+/// dead-lettered (<c>ClaimId</c> absent) — see
+/// <see cref="HostedServices.Attachment275ConsumerHostedService"/> for
+/// the routing decision tree.
+/// </summary>
+public sealed class Attachment275EnvelopeDto
+{
+    /// <summary>Tenant the attachment belongs to. Required for routing.</summary>
+    [JsonPropertyName("tenantId")]
+    public required string TenantId { get; init; }
+
+    /// <summary>
+    /// Routing discriminator. <c>"appeal"</c> for appeal-context 275s.
+    /// Other values (including <c>null</c>) are skipped at the consumer
+    /// for routing to a future authorization-service consumer of the same
+    /// topic.
+    /// </summary>
+    [JsonPropertyName("context")]
+    public string? Context { get; init; }
+
+    /// <summary>
+    /// Claim identifier the 275 references. Used by
+    /// <c>IAppealRepository.GetMostRecentAppealByClaimIdAsync</c> to
+    /// locate the open appeal. Required for appeal-context routing;
+    /// absence triggers dead-letter.
+    /// </summary>
+    [JsonPropertyName("claimId")]
+    public string? ClaimId { get; init; }
+
+    [JsonPropertyName("authorizationId")] public string? AuthorizationId { get; init; }
+    [JsonPropertyName("rfaiReference")]   public string? RfaiReference { get; init; }
+    [JsonPropertyName("payerId")]         public string? PayerId { get; init; }
+    [JsonPropertyName("payerName")]       public string? PayerName { get; init; }
+    [JsonPropertyName("providerId")]      public string? ProviderId { get; init; }
+    [JsonPropertyName("providerName")]    public string? ProviderName { get; init; }
+    [JsonPropertyName("subscriberId")]    public string? SubscriberId { get; init; }
+    [JsonPropertyName("patientFirstName")] public string? PatientFirstName { get; init; }
+    [JsonPropertyName("patientLastName")]  public string? PatientLastName { get; init; }
+    [JsonPropertyName("documentType")]    public string? DocumentType { get; init; }
+    [JsonPropertyName("documentFormat")]  public string? DocumentFormat { get; init; }
+
+    /// <summary>
+    /// Raw X12 envelope as published by Argo. Carried opaquely through
+    /// this consumer — appeals-service does NOT parse X12. May contain
+    /// PHI; never log this field.
+    /// </summary>
+    [JsonPropertyName("rawX12")]          public string? RawX12 { get; init; }
+
+    [JsonPropertyName("submittedDate")]   public DateTime SubmittedDate { get; init; }
+
+    /// <summary>
+    /// Free-text supplementary notes from the upstream submitter.
+    /// May contain PHI; encrypted at rest before persistence and never
+    /// logged.
+    /// </summary>
+    [JsonPropertyName("notes")]           public string? Notes { get; init; }
+
+    /// <summary>
+    /// 275 transaction-set reference (X12 BHT03). Used as
+    /// <c>AppealEvent.CorrelationId</c> on the resulting audit event so
+    /// downstream payer responses (277CA, 824) that echo BHT03 correlate
+    /// end-to-end.
+    /// </summary>
+    [JsonPropertyName("controlNumber")]   public string? ControlNumber { get; init; }
+
+    /// <summary>
+    /// X12 PWK02 transmission code when surfaced by the Argo extractor.
+    /// Defaults to <c>"EL"</c> at the mapper when absent or unrecognized.
+    /// </summary>
+    [JsonPropertyName("transmissionCode")] public string? TransmissionCode { get; init; }
+}

--- a/src/services/appeals-service/Program.cs
+++ b/src/services/appeals-service/Program.cs
@@ -150,6 +150,16 @@ builder.Services.AddSingleton<AppealEventPublisher>();
 builder.Services.AddSingleton<IAppealEventPublisher>(sp => sp.GetRequiredService<AppealEventPublisher>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<AppealEventPublisher>());
 
+// ── Kafka consumer (X12 275 attachment ingress) ──────────────────────
+// Subscribes to the attachments-in topic, routes appeal-context 275s to
+// the existing AppendAttachmentAsync path. Degraded-mode-silent if
+// Kafka:BootstrapServers is unset. Registered AFTER AppealEventPublisher
+// so the producer's StartAsync runs first — the consumer's per-message
+// publish call expects the producer to already be available.
+builder.Services.AddSingleton<Attachment275EnvelopeMapper>();
+builder.Services.AddSingleton<IAttachment275DeadLetterSink, LoggingAttachment275DeadLetterSink>();
+builder.Services.AddHostedService<Attachment275ConsumerHostedService>();
+
 // IMessageBus — registered for future consumers; no-op cost today.
 builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
 

--- a/src/services/appeals-service/Repositories/AppealRepository.cs
+++ b/src/services/appeals-service/Repositories/AppealRepository.cs
@@ -88,6 +88,31 @@ public sealed class AppealRepository : IAppealRepository
         return results;
     }
 
+    public async Task<Appeal?> GetMostRecentAppealByClaimIdAsync(
+        string tenantId, string claimId, CancellationToken ct = default)
+    {
+        // Status enum is persisted as a string by the System.Text.Json
+        // converter — compare against the enum name, not the integer value.
+        var query = new QueryDefinition(
+            "SELECT * FROM c " +
+            "WHERE c.tenantId = @tenantId AND c.claimId = @claimId AND c.status != @closed " +
+            "ORDER BY c.submittedDate DESC OFFSET 0 LIMIT 1")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@claimId", claimId)
+            .WithParameter("@closed", AppealStatus.Closed.ToString());
+
+        var iterator = _appeals.GetItemQueryIterator<Appeal>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            foreach (var item in page) return item;
+        }
+        return null;
+    }
+
     public async Task<IReadOnlyList<Appeal>> SearchAsync(
         string tenantId, AppealSearchParams p, CancellationToken ct = default)
     {

--- a/src/services/appeals-service/Repositories/AppealRepository.cs
+++ b/src/services/appeals-service/Repositories/AppealRepository.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using AppealsService.Models;
 using Microsoft.Azure.Cosmos;
 
@@ -25,6 +26,18 @@ public sealed class AppealRepository : IAppealRepository
         _appeals = cosmosClient.GetDatabase(databaseName).GetContainer(AppealsContainerName);
         _events = events;
     }
+
+    /// <summary>
+    /// Marshal an enum value into the on-disk Cosmos representation.
+    /// <see cref="Middleware.CosmosSystemTextJsonSerializer"/> registers
+    /// <c>JsonStringEnumConverter(JsonNamingPolicy.CamelCase)</c>, so
+    /// <c>AppealStatus.Closed</c> persists as <c>"closed"</c>, not
+    /// <c>"Closed"</c>. SQL parameters compared against <c>c.status</c>
+    /// (and other enum-valued document fields) MUST use this helper —
+    /// raw <c>.ToString()</c> silently never matches.
+    /// </summary>
+    private static string CosmosEnumValue<TEnum>(TEnum value) where TEnum : struct, Enum =>
+        JsonNamingPolicy.CamelCase.ConvertName(value.ToString());
 
     public async Task<Appeal> CreateAsync(Appeal appeal, AppealEvent genesisEvent, CancellationToken ct = default)
     {
@@ -91,15 +104,13 @@ public sealed class AppealRepository : IAppealRepository
     public async Task<Appeal?> GetMostRecentAppealByClaimIdAsync(
         string tenantId, string claimId, CancellationToken ct = default)
     {
-        // Status enum is persisted as a string by the System.Text.Json
-        // converter — compare against the enum name, not the integer value.
         var query = new QueryDefinition(
             "SELECT * FROM c " +
             "WHERE c.tenantId = @tenantId AND c.claimId = @claimId AND c.status != @closed " +
             "ORDER BY c.submittedDate DESC OFFSET 0 LIMIT 1")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@claimId", claimId)
-            .WithParameter("@closed", AppealStatus.Closed.ToString());
+            .WithParameter("@closed", CosmosEnumValue(AppealStatus.Closed));
 
         var iterator = _appeals.GetItemQueryIterator<Appeal>(
             query,
@@ -145,17 +156,17 @@ public sealed class AppealRepository : IAppealRepository
         if (p.Status.HasValue)
         {
             queryText += " AND c.status = @status";
-            parameters.Add(("@status", p.Status.Value.ToString()));
+            parameters.Add(("@status", CosmosEnumValue(p.Status.Value)));
         }
         if (p.ClosureReasonCode.HasValue)
         {
             queryText += " AND c.closureReasonCode = @closureReasonCode";
-            parameters.Add(("@closureReasonCode", p.ClosureReasonCode.Value.ToString()));
+            parameters.Add(("@closureReasonCode", CosmosEnumValue(p.ClosureReasonCode.Value)));
         }
         if (p.LineOfBusiness.HasValue)
         {
             queryText += " AND c.lineOfBusiness = @lineOfBusiness";
-            parameters.Add(("@lineOfBusiness", p.LineOfBusiness.Value.ToString()));
+            parameters.Add(("@lineOfBusiness", CosmosEnumValue(p.LineOfBusiness.Value)));
         }
         if (!string.IsNullOrEmpty(p.AssignedReviewerId))
         {

--- a/src/services/appeals-service/Repositories/AppealRepositoryMongo.cs
+++ b/src/services/appeals-service/Repositories/AppealRepositoryMongo.cs
@@ -68,6 +68,18 @@ public sealed class AppealRepositoryMongo : IAppealRepository
             .ToListAsync(ct);
     }
 
+    public async Task<Appeal?> GetMostRecentAppealByClaimIdAsync(
+        string tenantId, string claimId, CancellationToken ct = default)
+    {
+        var filter = Builders<Appeal>.Filter.Eq(a => a.TenantId, tenantId)
+                   & Builders<Appeal>.Filter.Eq(a => a.ClaimId, claimId)
+                   & Builders<Appeal>.Filter.Ne(a => a.Status, AppealStatus.Closed);
+        return await _appeals.Find(filter)
+            .SortByDescending(a => a.SubmittedDate)
+            .Limit(1)
+            .FirstOrDefaultAsync(ct);
+    }
+
     public async Task<IReadOnlyList<Appeal>> SearchAsync(
         string tenantId, AppealSearchParams p, CancellationToken ct = default)
     {

--- a/src/services/appeals-service/Repositories/IAppealRepository.cs
+++ b/src/services/appeals-service/Repositories/IAppealRepository.cs
@@ -21,6 +21,27 @@ public interface IAppealRepository
 
     Task<IReadOnlyList<Appeal>> GetByClaimIdAsync(string tenantId, string claimId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Find the most-recently-submitted non-<see cref="AppealStatus.Closed"/>
+    /// appeal for a given claim in a tenant. Returns <c>null</c> when no
+    /// open appeal matches.
+    /// </summary>
+    /// <remarks>
+    /// Used by the X12 275 ingress consumer to route an inbound attachment
+    /// to the correct existing appeal. The consumer dead-letters when this
+    /// returns <c>null</c> rather than fabricating a ghost appeal —
+    /// unsolicited 275s without a linkable open appeal are
+    /// operator-intervention territory.
+    ///
+    /// When multiple open appeals exist for the same claim (rare; a first-
+    /// level appeal can coexist with a second-level on the same denied
+    /// claim), the most-recently-submitted one wins. This matches the
+    /// operational intent: a freshly-arrived 275 supports the most active
+    /// appeal.
+    /// </remarks>
+    Task<Appeal?> GetMostRecentAppealByClaimIdAsync(
+        string tenantId, string claimId, CancellationToken ct = default);
+
     Task<IReadOnlyList<Appeal>> SearchAsync(string tenantId, AppealSearchParams p, CancellationToken ct = default);
 
     Task<AppealsSummary> GetAppealsSummaryAsync(string tenantId, DateTime from, DateTime to, CancellationToken ct = default);

--- a/src/services/appeals-service/Services/Attachment275EnvelopeMapper.cs
+++ b/src/services/appeals-service/Services/Attachment275EnvelopeMapper.cs
@@ -1,0 +1,112 @@
+using AppealsService.Models;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Pure mapping from a Kafka-published <see cref="Attachment275EnvelopeDto"/>
+/// to an <see cref="AppealAttachment"/> ready for repository append.
+/// Stateless and side-effect-free — encryption of the
+/// <see cref="AppealAttachment.Description"/> field is the caller's
+/// responsibility (the consumer resolves
+/// <see cref="IAppealFieldEncryptor"/> from its per-message scope and
+/// passes ciphertext via <paramref name="encryptedDescription"/>).
+/// </summary>
+public sealed class Attachment275EnvelopeMapper
+{
+    /// <summary>X12 PWK02 default per the
+    /// <c>cho-appeal-x12-275-transmission-code</c> CodeSystem
+    /// (electronically transmitted).</summary>
+    public const string DefaultTransmissionCode = "EL";
+
+    /// <summary>X12 PWK01 default per the report-type-code list — used
+    /// when the upstream <c>documentType</c> is null or unmapped.</summary>
+    public const string DefaultAttachmentTypeCode = "OZ";
+
+    /// <summary>
+    /// Codes from the CHO <c>cho-appeal-x12-275-transmission-code</c>
+    /// CodeSystem shipped in PR 1
+    /// (<c>docs/fhir/profiles/CodeSystem-cho-appeal-x12-275-transmission-code.json</c>).
+    /// </summary>
+    private static readonly HashSet<string> ValidTransmissionCodes = new(StringComparer.Ordinal)
+    {
+        "AA", "BM", "EL", "FT", "FX", "IL", "OZ"
+    };
+
+    /// <summary>
+    /// Curated <c>documentType</c> → X12 PWK01 attachment-type-code map.
+    /// Anything not in this table maps to
+    /// <see cref="DefaultAttachmentTypeCode"/>. Codes follow the standard
+    /// X12 005010X215 PWK01 report-type-code list.
+    /// </summary>
+    private static readonly Dictionary<string, string> DocumentTypeMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Medical Records"]   = "OZ",
+        ["Lab Results"]       = "LA",
+        ["Discharge Summary"] = "DS",
+        ["Operative Report"]  = "OB",
+        ["Radiology Report"]  = "RR"
+    };
+
+    public AppealAttachment ToAppealAttachment(
+        Attachment275EnvelopeDto envelope,
+        string? encryptedDescription)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        return new AppealAttachment
+        {
+            ControlNumber = envelope.ControlNumber,
+            AttachmentTypeCode = MapDocumentTypeToAttachmentTypeCode(envelope.DocumentType),
+            AttachmentTypeDescription = envelope.DocumentType,
+            TransmissionCode = ResolveTransmissionCode(envelope.TransmissionCode),
+            FileName = DeriveFileName(envelope),
+            ContentType = MapDocumentFormatToContentType(envelope.DocumentFormat),
+            UploadedAt = envelope.SubmittedDate == default
+                ? DateTime.UtcNow
+                : envelope.SubmittedDate,
+            Description = encryptedDescription,
+            Status = AttachmentStatus.Sent
+        };
+    }
+
+    public string MapDocumentTypeToAttachmentTypeCode(string? documentType)
+    {
+        if (string.IsNullOrEmpty(documentType)) return DefaultAttachmentTypeCode;
+        return DocumentTypeMap.TryGetValue(documentType, out var code)
+            ? code
+            : DefaultAttachmentTypeCode;
+    }
+
+    public string ResolveTransmissionCode(string? envelopeTransmissionCode)
+    {
+        if (string.IsNullOrEmpty(envelopeTransmissionCode)) return DefaultTransmissionCode;
+        return ValidTransmissionCodes.Contains(envelopeTransmissionCode)
+            ? envelopeTransmissionCode
+            : DefaultTransmissionCode;
+    }
+
+    private static string DeriveFileName(Attachment275EnvelopeDto envelope)
+    {
+        var control = string.IsNullOrEmpty(envelope.ControlNumber) ? "unknown" : envelope.ControlNumber;
+        var stamp = (envelope.SubmittedDate == default ? DateTime.UtcNow : envelope.SubmittedDate)
+            .ToString("yyyyMMddHHmmss");
+        var ext = string.IsNullOrEmpty(envelope.DocumentFormat)
+            ? "bin"
+            : envelope.DocumentFormat.ToLowerInvariant();
+        return $"275-{control}-{stamp}.{ext}";
+    }
+
+    private static string? MapDocumentFormatToContentType(string? documentFormat)
+    {
+        if (string.IsNullOrEmpty(documentFormat)) return null;
+        return documentFormat.ToUpperInvariant() switch
+        {
+            "PDF" => "application/pdf",
+            "TIFF" or "TIF" => "image/tiff",
+            "JPG" or "JPEG" => "image/jpeg",
+            "PNG" => "image/png",
+            "XML" => "application/xml",
+            "DCM" => "application/dicom",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/src/services/appeals-service/Services/Attachment275EnvelopeMapper.cs
+++ b/src/services/appeals-service/Services/Attachment275EnvelopeMapper.cs
@@ -52,17 +52,22 @@ public sealed class Attachment275EnvelopeMapper
         string? encryptedDescription)
     {
         ArgumentNullException.ThrowIfNull(envelope);
+        // Compute the effective submitted date once so the persisted
+        // UploadedAt and the file-name timestamp are guaranteed to match
+        // for the same call — multiple DateTime.UtcNow reads inside the
+        // same mapping can drift by milliseconds.
+        var effectiveSubmittedDate = envelope.SubmittedDate == default
+            ? DateTime.UtcNow
+            : envelope.SubmittedDate;
         return new AppealAttachment
         {
             ControlNumber = envelope.ControlNumber,
             AttachmentTypeCode = MapDocumentTypeToAttachmentTypeCode(envelope.DocumentType),
             AttachmentTypeDescription = envelope.DocumentType,
             TransmissionCode = ResolveTransmissionCode(envelope.TransmissionCode),
-            FileName = DeriveFileName(envelope),
+            FileName = DeriveFileName(envelope, effectiveSubmittedDate),
             ContentType = MapDocumentFormatToContentType(envelope.DocumentFormat),
-            UploadedAt = envelope.SubmittedDate == default
-                ? DateTime.UtcNow
-                : envelope.SubmittedDate,
+            UploadedAt = effectiveSubmittedDate,
             Description = encryptedDescription,
             Status = AttachmentStatus.Sent
         };
@@ -84,11 +89,10 @@ public sealed class Attachment275EnvelopeMapper
             : DefaultTransmissionCode;
     }
 
-    private static string DeriveFileName(Attachment275EnvelopeDto envelope)
+    private static string DeriveFileName(Attachment275EnvelopeDto envelope, DateTime effectiveSubmittedDate)
     {
         var control = string.IsNullOrEmpty(envelope.ControlNumber) ? "unknown" : envelope.ControlNumber;
-        var stamp = (envelope.SubmittedDate == default ? DateTime.UtcNow : envelope.SubmittedDate)
-            .ToString("yyyyMMddHHmmss");
+        var stamp = effectiveSubmittedDate.ToString("yyyyMMddHHmmss");
         var ext = string.IsNullOrEmpty(envelope.DocumentFormat)
             ? "bin"
             : envelope.DocumentFormat.ToLowerInvariant();

--- a/src/services/appeals-service/Services/IAttachment275DeadLetterSink.cs
+++ b/src/services/appeals-service/Services/IAttachment275DeadLetterSink.cs
@@ -1,0 +1,41 @@
+using AppealsService.Models;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Records X12 275 envelopes the consumer could not route. The default
+/// implementation
+/// (<see cref="LoggingAttachment275DeadLetterSink"/>) emits a structured
+/// warning with non-PHI fields only. A future production deployment can
+/// substitute a Kafka-DLQ-producing implementation without changing the
+/// consumer's code path — see PR 4 plan, deferred item #8.
+/// </summary>
+public interface IAttachment275DeadLetterSink
+{
+    /// <summary>
+    /// Record an envelope that could not be processed.
+    /// </summary>
+    /// <param name="envelope">The deserialized envelope. Implementations
+    /// MUST NOT log <see cref="Attachment275EnvelopeDto.RawX12"/>,
+    /// <see cref="Attachment275EnvelopeDto.PatientFirstName"/>,
+    /// <see cref="Attachment275EnvelopeDto.PatientLastName"/>, or
+    /// <see cref="Attachment275EnvelopeDto.Notes"/> — those fields are
+    /// PHI-adjacent.</param>
+    /// <param name="reason">Short, controlled vocabulary string describing
+    /// why routing failed. Examples: <c>"missing-tenantId"</c>,
+    /// <c>"no-open-appeal-for-claim"</c>, <c>"handler-exception"</c>.</param>
+    Task DeadLetterAsync(
+        Attachment275EnvelopeDto envelope,
+        string reason,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Record a raw message that failed to deserialize as an envelope.
+    /// Implementations MUST NOT log <paramref name="rawMessage"/> — it
+    /// may contain PHI inside the malformed body.
+    /// </summary>
+    Task DeadLetterMalformedAsync(
+        string rawMessage,
+        string reason,
+        CancellationToken ct = default);
+}

--- a/src/services/appeals-service/Services/LoggingAttachment275DeadLetterSink.cs
+++ b/src/services/appeals-service/Services/LoggingAttachment275DeadLetterSink.cs
@@ -32,8 +32,12 @@ public sealed class LoggingAttachment275DeadLetterSink : IAttachment275DeadLette
 
     public Task DeadLetterMalformedAsync(string rawMessage, string reason, CancellationToken ct = default)
     {
+        // CharLength is UTF-16 code units, not byte length — we deliberately
+        // do not compute UTF-8 byte length here because that requires
+        // touching the (potentially PHI-bearing) raw payload, which we
+        // are explicitly trying to avoid.
         _logger.LogWarning(
-            "275 dead-letter (malformed): bytes={Bytes} reason={Reason}",
+            "275 dead-letter (malformed): charLength={CharLength} reason={Reason}",
             rawMessage?.Length ?? 0,
             LogSanitizer.SafeForLog(reason));
         return Task.CompletedTask;

--- a/src/services/appeals-service/Services/LoggingAttachment275DeadLetterSink.cs
+++ b/src/services/appeals-service/Services/LoggingAttachment275DeadLetterSink.cs
@@ -1,0 +1,41 @@
+using AppealsService.Models;
+
+namespace AppealsService.Services;
+
+/// <summary>
+/// Default <see cref="IAttachment275DeadLetterSink"/> implementation:
+/// emits a structured warning per dead-lettered envelope. The fields it
+/// logs (<c>tenantId</c>, <c>claimId</c>, <c>controlNumber</c>, <c>reason</c>)
+/// are deliberately the non-PHI subset — see
+/// <c>AppealEventPublisherTests</c>'s field-whitelist posture for the
+/// equivalent invariant on the outbound event stream.
+/// </summary>
+public sealed class LoggingAttachment275DeadLetterSink : IAttachment275DeadLetterSink
+{
+    private readonly ILogger<LoggingAttachment275DeadLetterSink> _logger;
+
+    public LoggingAttachment275DeadLetterSink(ILogger<LoggingAttachment275DeadLetterSink> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task DeadLetterAsync(Attachment275EnvelopeDto envelope, string reason, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "275 dead-letter: tenantId={TenantId} claimId={ClaimId} controlNumber={ControlNumber} reason={Reason}",
+            LogSanitizer.SafeForLog(envelope.TenantId),
+            LogSanitizer.SafeForLog(envelope.ClaimId),
+            LogSanitizer.SafeForLog(envelope.ControlNumber),
+            LogSanitizer.SafeForLog(reason));
+        return Task.CompletedTask;
+    }
+
+    public Task DeadLetterMalformedAsync(string rawMessage, string reason, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "275 dead-letter (malformed): bytes={Bytes} reason={Reason}",
+            rawMessage?.Length ?? 0,
+            LogSanitizer.SafeForLog(reason));
+        return Task.CompletedTask;
+    }
+}

--- a/src/services/appeals-service/appsettings.json
+++ b/src/services/appeals-service/appsettings.json
@@ -34,7 +34,9 @@
   },
   "Kafka": {
     "BootstrapServers": "",
-    "ClientId": "appeals-service"
+    "ClientId": "appeals-service",
+    "AttachmentsInTopic": "attachments-in",
+    "Attachment275ConsumerGroupId": "appeals-service-275-consumer"
   },
   "AppealMigration": {
     "BatchSize": 100


### PR DESCRIPTION
## Summary

**PR 4 of 4 in the appeals FHIR re-foundation sequence** — closes out the production ingress channel. Consumes the `attachments-in` Kafka topic populated by the existing Argo ingest pipeline; routes appeal-context 275s into appeals-service via the existing `AppendAttachmentAsync` path.

With this merged, the four-PR sequence is complete: clearinghouse SFTP → Argo parse → Kafka topic → appeals-service consumer → FHIR surface at fhir-service is production-ready for PCHP evaluation.

Sequence context:
- PR 1 (#677) authored the CHO appeal FHIR profiles + the `cho-appeal-x12-275-transmission-code` CodeSystem and `cho-appeal-x12-275-control-number` extension that this PR's audit lineage rides on.
- PR 2 (#678) modernized appeals-service and added the `AppealSource.Availity275` enum value + `AppealEvent.CorrelationId` field this consumer populates.
- PR 3 (#680) established `CorrelationIdPropagationHandler` as the structural pattern this PR extends with the BHT03 control number on the audit event.

## Architectural framing

**First consumer of the `attachments-in` topic in the repo.** Discriminator strategy is **Option B**: the Argo workflow stamps `context: "appeal"` on the envelope for appeal-origin 275s; non-appeal messages are skipped (commit offset, debug-log, no dead-letter) and will be consumed by authorization-service when that wiring lands.

Consumer mirrors `ClaimsExaminerService.Services.Kafka.ClaimPendedConsumer`'s `BackgroundService` shape:
- `Task.Yield()` startup so Kestrel and sibling hosted services initialize on time
- `Kafka:BootstrapServers` empty → degraded-mode warning, no subscribe (matches `AppealEventPublisher`)
- 1-second `Consume` poll with bounded timeout
- **Commit offset regardless of handler outcome.** Poison messages dead-letter and advance; never block the queue.

Adopts `AuthorizationService.Consumers.RfaiDocsReceivedConsumer`'s dual-constructor pattern so `HandleMessageAsync` is exercisable from the test project without standing up a fake `IServiceProvider`.

## Routing decision tree

Per envelope:
1. **Deserialize.** `JsonException` → log warning + `DeadLetterMalformedAsync` + commit offset.
2. **Context filter.** `context != "appeal"` (including `null`) → debug log + skip + commit. **No dead-letter** — these are not failures, they are not-for-this-consumer.
3. **Required fields.** Empty `tenantId` / `claimId` / `rawX12` → dead-letter with the specific reason + commit.
4. **Lookup** via the new `IAppealRepository.GetMostRecentAppealByClaimIdAsync(tenantId, claimId)`. Null → dead-letter `no-open-appeal-for-claim` + commit. **No ghost appeals.**
5. **Encrypt + map.** `IAppealFieldEncryptor.EncryptAsync(envelope.Notes)` → ciphertext into `AppealAttachment.Description`. Pure mapper handles `documentType` → X12 PWK01 lookup, `transmissionCode` defaulting, and deterministic `FileName` derivation.
6. **Append + publish.** `AppendAttachmentAsync` (ETag-conditional with retry, inherited from PR 2) + `IAppealEventPublisher.PublishAttachmentAddedAsync`. Both writes carry the BHT03 control number as `CorrelationId`.
7. **Top-level catch.** Any unhandled exception → log + dead-letter `handler-exception` + commit offset.

## Correlation ID chain

Appeal-context 275 control number (X12 BHT03 — transaction-set reference identification, not ISA13) flows through as the `AppealEvent.CorrelationId`, completing the end-to-end ingress lineage pattern PR 3 established. BHT03 was chosen over ISA13 because downstream payer responses (277CA, 824) typically echo BHT03, so it's the natural correlation key across re-transmissions; ISA13 changes per file.

When `controlNumber` is absent on the envelope (degraded ingress during the Argo rollout window), correlation falls back to `"x12-275-unknown"` so the audit row's `CorrelationId` is never null.

## Audit event payload — `ingressSource` discriminator

The consumer attaches to an existing appeal whose `Source` was set at creation (typically `ProviderPortal`); the consumer does **not** rewrite `AppealSource`. Instead, the audit event's `Payload` carries an explicit `"ingressSource": "Availity275"` discriminator so downstream consumers of the audit log can distinguish portal-uploaded attachments from 275-ingressed ones. One-line addition vs. the controller's existing payload shape.

## Dead-letter behavior

Unroutable 275s (missing claim, no open appeal, malformed envelope, handler exception) are recorded via the new `IAttachment275DeadLetterSink` abstraction. The shipped `LoggingAttachment275DeadLetterSink` emits a structured warning with the non-PHI subset only: `tenantId`, `claimId`, `controlNumber`, `reason`. **Never logs `rawX12`, patient names, or `notes` content.** A future PR can swap in a Kafka-DLQ-producing implementation without touching consumer code.

## Pending operational dependency — Argo workflow follow-up

⚠️ **Production cutover requires a follow-up PR in `infrastructure/argo-workflows/x12-275-ingest.yaml`** that adds three fields to the published envelope:

- `context`: `"appeal"` for appeal-origin 275s, `"authorization"` (default) otherwise
- `claimId`: extracted from the X12 envelope so this consumer can look up the open appeal
- `controlNumber`: extracted from BHT03 for end-to-end correlation

Until that ships, every production message will fall through one of:
- `context` field absent → **skipped** (treated as non-appeal; debug-log only, no dead-letter spam)
- `claimId` field absent → **dead-lettered** with reason `missing-claimId`

The integration test exercises the post-Argo shape via a synthesized fixture template so the consumer's behavior is proven before that follow-up lands.

## Out of scope

1. X12 275 parsing (Argo does this).
2. Outbound 275 generation (trading-partner-service when wired).
3. RFAI (277 response) generation.
4. Azure Logic Apps legacy `ingest275` workflow (already replaced by Argo).
5. 275 validation against 005010X215 (Argo validates pre-publish).
6. Consumer horizontal scaling / partition-strategy tuning (default group semantics fine).
7. Custom Grafana dashboards (standard `AddChoObservability` spans suffice).
8. Kafka-DLQ-producing dead-letter sink (abstraction shipped, logging default; swap is a future PR).
9. fhir-service changes (zero edits).
10. Argo workflow changes (separate follow-up PR — see above).

## Deployment

When `Kafka:BootstrapServers` is configured:
- Topic `attachments-in` exists and is readable by the appeals-service service account
- Consumer group ID `appeals-service-275-consumer` is registered with the cluster
- The Argo workflow follow-up has shipped (otherwise the consumer runs but routes nothing)

Without `Kafka:BootstrapServers`, the consumer logs a degraded-mode warning and the service still boots (no crash, REST surface still serves) — same posture as `AppealEventPublisher`.

## Test plan
- [x] `dotnet build` — appeals-service production project, 0 warnings 0 errors
- [x] `dotnet test src/services/appeals-service/AppealsService.Tests/` — **142/142 passing** (32 new across mapper, consumer-handler, integration; 10 new for repository lookup)
- [x] Mapper unit tests cover the seven CodeSystem transmission codes, all five known documentType→PWK01 mappings, fallback paths, deterministic filename derivation
- [x] Consumer-handler tests cover every branch of the routing decision tree: skip-non-appeal, skip-null-context (pre-Argo reality), dead-letter-malformed-json, dead-letter each missing-required-field, dead-letter no-open-appeal, dead-letter handler-exception, route-on-happy-path, correlation-id from BHT03, fallback to `x12-275-unknown`, audit-event payload includes `ingressSource`, description encrypted before persistence
- [x] Integration tests exercise the post-Argo synthesized envelope (full happy path with audit-lineage assertions) and the canonical pre-Argo solicited fixture (skips cleanly, no dead-letter, no audit row)
- [x] Repository lookup tests cover null-when-missing, all-Closed-returns-null, multi-open-picks-most-recent, tenant isolation, mixed-status filtering, every non-Closed status accepted
- [ ] Manual: run appeals-service locally with `Kafka:BootstrapServers=""` and confirm degraded-mode log + service boot
- [ ] Manual: run with a local Kafka broker, publish a synthesized appeal-context envelope, confirm attachment lands and audit event carries the BHT03 as `CorrelationId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)