### PR TITLE
docs: repo neutralization — remove named-party references

### DIFF
--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -170,7 +170,7 @@ Customers move outward-to-inward over time. No customer is locked at Layer 1. Ev
 
 ## What this positioning means for our existing and prospective customers
 
-### For existing pilot discussions (e.g. PCHP)
+### For existing pilot discussions
 
 Our primary engagement frame is Layer 2 — progressive modernization, starting with appeals plus the CMS-0057-F compliance surface that Layer 1 already delivers. Layer 1 alone is available if a multi-year commitment is premature. Layer 3 is the aspirational end-state story for the CTO conversation, with honest disclosure of the gaps listed above.
 

--- a/docs/architecture/ADJUDICATION-PIPELINE.md
+++ b/docs/architecture/ADJUDICATION-PIPELINE.md
@@ -175,7 +175,7 @@ The `IClaimTypeRouter` determines how a claim is processed based on its type (Pr
 
 ```json
 {
-  "tenantId": "pchp-texas",
+  "tenantId": "txmco01",
   "engines": {
     "professional-medicaid": "replace",
     "institutional-medicaid": "augment",

--- a/docs/architecture/OPERATING-MODE.md
+++ b/docs/architecture/OPERATING-MODE.md
@@ -59,7 +59,7 @@ Operating mode is stored on the tenant document in tenant-service:
 
 ```json
 {
-  "tenantId": "pchp-texas",
+  "tenantId": "txmco01",
   "operatingMode": {
     "engines": {
       "professional-medicaid": "replace",
@@ -68,7 +68,7 @@ Operating mode is stored on the tenant document in tenant-service:
       "rateResolution": "replace"
     },
     "updatedAt": "2026-04-12T14:30:00Z",
-    "updatedBy": "admin@pchp.com"
+    "updatedBy": "admin@example.com"
   }
 }
 ```

--- a/docs/architecture/shared-cache.md
+++ b/docs/architecture/shared-cache.md
@@ -128,8 +128,8 @@ thousand keys per state.
 Every cache key is mandatorily transformed by `CacheKeyGuard` before
 hitting the backend. Two compliance controls:
 
-1. **Tenant prefixing.** The logical key `enrollment:config:pchp`
-   becomes `{env}:{tenantId}:enrollment:config:pchp`. `tenantId` is
+1. **Tenant prefixing.** The logical key `enrollment:config:txmco01`
+   becomes `{env}:{tenantId}:enrollment:config:txmco01`. `tenantId` is
    resolved from `HttpContext.Items["TenantId"]` (set by
    `TenantMiddleware`). Cross-tenant cache pollution is unreachable by
    construction. The sole escape hatch is `CacheScope.Global`, which
@@ -148,7 +148,7 @@ hitting the backend. Two compliance controls:
 
 | Logical key                                | Scope  | Result |
 |--------------------------------------------|--------|--------|
-| `enrollment:config:pchp`                   | Tenant | ✅ `production:pchp:enrollment:config:pchp` |
+| `enrollment:config:txmco01`                   | Tenant | ✅ `production:txmco01:enrollment:config:txmco01` |
 | `member:memberIdHash:deadbeef`             | Tenant | ✅ allowed — hashed form |
 | `feature-flags:pas-auto`                   | Global | ✅ `production:_global:feature-flags:pas-auto` |
 | `enrollment:memberId:M12345`               | Tenant | ❌ `ArgumentException` — PHI token `memberId` |

--- a/docs/features/CONFIG-TO-WORKFLOW-GENERATOR.md
+++ b/docs/features/CONFIG-TO-WORKFLOW-GENERATOR.md
@@ -739,12 +739,12 @@ node dist/scripts/cli/partner-reporting.js \
 ```json
 {
   "partnerBranding": {
-    "partnerName": "HealthTech Solutions",
-    "logo": "https://healthtech.com/logo.png",
-    "supportEmail": "support@healthtech.com",
+    "partnerName": "Example Partner Inc.",
+    "logo": "https://example-partner.com/logo.png",
+    "supportEmail": "support@example-partner.com",
     "supportPhone": "8005551234",
-    "portalUrl": "https://portal.healthtech.com",
-    "documentationUrl": "https://docs.healthtech.com"
+    "portalUrl": "https://portal.example-partner.com",
+    "documentationUrl": "https://docs.example-partner.com"
   }
 }
 ```

--- a/docs/status/POSITIONING-AUDIT.md
+++ b/docs/status/POSITIONING-AUDIT.md
@@ -19,13 +19,13 @@
 
 Urgency breakdown of findings that need change:
 
-- P0 (public-facing / PCHP- or evaluator-critical): 22
+- P0 (public-facing / evaluator-critical): 22
 - P1 (contributor / partner visible): 36
 - P2 (internal / low-traffic): 12
 
 ## Biggest positioning gaps
 
-### Overclaims — must soften before next PCHP / evaluator / investor engagement
+### Overclaims — must soften before next evaluator / investor engagement
 
 1. **`docs/fundraising/INVESTOR-ONE-PAGER.md`** — frames four FHIR APIs as "Production Ready" with $1.8M ARR Year-1 targets, no disclosure that there is no production customer yet. Phase 2 must add the pre-pilot disclosure block from POSITIONING.md Layer 3 honest-today section, and relabel "Production Ready" → "Production Ready (Layer 1 / Layer 2 appeals)".
 2. **`docs/fundraising/INVESTOR-MEETING-SCRIPT.md`** — claims "100% compliant… in under 5 minutes" and walks through demo as if it were a production deployment at a payer. Phase 2 must qualify the "< 5 minutes" claim to Layer 1 compliance scope only and add a Q&A entry that answers "Are you in production with any customers?" honestly.
@@ -57,7 +57,7 @@ See the MISSING section below. Most consequential: `docs/adr/006-three-layer-pos
 
 ## Full artifact classification
 
-### P0 — public-facing / PCHP- / evaluator- / investor-critical
+### P0 — public-facing / evaluator- / investor-critical
 
 #### `README.md` (repo root)
 - **Layer:** multi
@@ -796,7 +796,7 @@ The term "Operating Mode" (Augment / Replace / Legacy) is the Layer 2 risk-mitig
 
 **Pick: (b) sequenced fix, with two parallel streams inside each phase.**
 
-- **Wave 1 (P0, ~1-2 weeks):** fix every OVERCLAIMS finding before any investor or PCHP-evaluator engagement. This is seven documents (INVESTOR-ONE-PAGER, INVESTOR-MEETING-SCRIPT, pitch-deck-v4 Slide 11, PITCH-DECK-CONTENT Slide 4, SALES-PRODUCT-OVERVIEW, v3.0.0-announcement, v3.0.0-features-overview) plus the solutions-payers and site-index underclaims. Stream it in two parallel PRs: one for public-facing site/sales, one for fundraising materials.
+- **Wave 1 (P0, ~1-2 weeks):** fix every OVERCLAIMS finding before any investor or evaluator engagement. This is seven documents (INVESTOR-ONE-PAGER, INVESTOR-MEETING-SCRIPT, pitch-deck-v4 Slide 11, PITCH-DECK-CONTENT Slide 4, SALES-PRODUCT-OVERVIEW, v3.0.0-announcement, v3.0.0-features-overview) plus the solutions-payers and site-index underclaims. Stream it in two parallel PRs: one for public-facing site/sales, one for fundraising materials.
 
 - **Wave 2 (P1, ~2-3 weeks):** the three-layer framing rollout — each of the ten "compliance layer" framing artifacts gets the POSITIONING.md §Summary insert, plus the Layer 2 / appeals language added to proposal template, demo script, cold-call scripts, email templates. Single PR, reviewed by sales lead.
 

--- a/scripts/setup/seed-demo-data.js
+++ b/scripts/setup/seed-demo-data.js
@@ -1010,7 +1010,7 @@ choDb.Accumulators.insertMany(accumulators);
 print("✓ " + accumulators.length + " Accumulators");
 
 // Override member 1's accumulator with specific demo values
-// (believable partial-year utilisation for Thomas & Victoria demo)
+// (believable partial-year utilisation for the demo member)
 choDb.Accumulators.updateOne(
   { OwnerId: makeId("mbr", 1), TenantId: TENANT_ID },
   { $set: {

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/SyntheticProviderGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/SyntheticProviderGenerator.cs
@@ -39,7 +39,7 @@ public class SyntheticProviderGenerator
         "Regional Medical Center", "Community Hospital", "General Hospital",
         "Memorial Hospital", "Methodist Hospital", "Baptist Hospital",
         "Presbyterian Hospital", "St. Luke's Hospital", "Baylor Medical Center",
-        "Parkland Memorial Hospital", "Children's Medical Center",
+        "Regional County Hospital", "Children's Medical Center",
         "Medical City Hospital", "Texas Health Hospital",
         "JPS Health Network", "Cook Children's Hospital",
     };

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticBenefitPlan.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticBenefitPlan.cs
@@ -12,8 +12,8 @@ public class SyntheticBenefitPlan
     /// <summary>Human-readable plan name.</summary>
     public string PlanName { get; set; } = string.Empty;
 
-    /// <summary>Payer name (e.g., Parkland Community Health Plan).</summary>
-    public string Payer { get; set; } = "Parkland Community Health Plan";
+    /// <summary>Payer name (e.g., Texas Medicaid MCO).</summary>
+    public string Payer { get; set; } = "Texas Medicaid MCO";
 
     /// <summary>Tenant identifier.</summary>
     public string TenantId { get; set; } = "mcc-benchmark";

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Output/X12_834Writer.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Output/X12_834Writer.cs
@@ -95,7 +95,7 @@ public class X12_834Writer
                   $"{ElementSeparator}FI{ElementSeparator}741234567{SegmentTerminator}");
 
         // Loop 1000B - Payer Name
-        sb.Append($"N1{ElementSeparator}IN{ElementSeparator}PARKLAND COMMUNITY HEALTH PLAN" +
+        sb.Append($"N1{ElementSeparator}IN{ElementSeparator}TEXAS MEDICAID MCO" +
                   $"{ElementSeparator}FI{ElementSeparator}752345678{SegmentTerminator}");
 
         int segmentCount = 4; // ST + BGN + 2x N1
@@ -137,7 +137,7 @@ public class X12_834Writer
         sb.Append(ElementSeparator); sb.Append("ZZ");              // ISA05 - Sender Qualifier
         sb.Append(ElementSeparator); sb.Append("MCCBENCHMARK   "); // ISA06 - Sender ID (15 chars)
         sb.Append(ElementSeparator); sb.Append("ZZ");              // ISA07 - Receiver Qualifier
-        sb.Append(ElementSeparator); sb.Append("PCHP           "); // ISA08 - Receiver ID (15 chars)
+        sb.Append(ElementSeparator); sb.Append("TXMCO01        "); // ISA08 - Receiver ID (15 chars)
         sb.Append(ElementSeparator); sb.Append(timestamp.ToString("yyMMdd")); // ISA09 - Date
         sb.Append(ElementSeparator); sb.Append(timestamp.ToString("HHmm"));  // ISA10 - Time
         sb.Append(ElementSeparator); sb.Append("^");               // ISA11 - Repetition Separator
@@ -151,7 +151,7 @@ public class X12_834Writer
 
     private static void WriteGs(StringBuilder sb, string controlNumber, DateTime timestamp)
     {
-        sb.Append($"GS{ElementSeparator}HP{ElementSeparator}MCCBENCHMARK{ElementSeparator}PCHP" +
+        sb.Append($"GS{ElementSeparator}HP{ElementSeparator}MCCBENCHMARK{ElementSeparator}TXMCO01" +
                   $"{ElementSeparator}{timestamp:yyyyMMdd}{ElementSeparator}{timestamp:HHmm}" +
                   $"{ElementSeparator}{controlNumber}{ElementSeparator}X{ElementSeparator}005010X220A1" +
                   $"{SegmentTerminator}");

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/Configuration/ProviderEnrollmentServiceRegistration.cs
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/Configuration/ProviderEnrollmentServiceRegistration.cs
@@ -23,7 +23,7 @@ namespace CloudHealthOffice.ProviderEnrollmentService.Configuration;
 ///
 /// ── Typical usage ─────────────────────────────────────────────────────────
 ///
-/// // PCHP (Texas, Medicaid + Exchange) — v1:
+/// // Texas Medicaid MCO tenant (Medicaid + Exchange) — v1:
 /// builder.Services
 ///     .AddProviderEnrollmentService(builder.Configuration)
 ///     .UseCosmosRepositories()

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/Models/TenantEnrollmentConfig.cs
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/Models/TenantEnrollmentConfig.cs
@@ -105,7 +105,7 @@ public record TenantEnrollmentConfig
     /// <summary>
     /// MCO participant IDs for this plan within each state enrollment system.
     /// Used by the panel reconciliation service to pull the plan's enrolled panel.
-    /// Example: ["PCHP-MCO-TX-001"] for PCHP's PEMS MCO identifier.
+    /// Example: ["TXMCO01-MCO-TX-001"] for the tenant's PEMS MCO identifier.
     /// </summary>
     public IReadOnlyList<string> McoIds { get; init; } = [];
 

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/Workers/NightlyBatchSyncWorker.cs
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/Workers/NightlyBatchSyncWorker.cs
@@ -22,7 +22,7 @@ namespace CloudHealthOffice.ProviderEnrollmentService.Workers;
 ///           end:   "0 4 * * *"     # hard stop at 4:00 AM CT
 ///
 /// State sync order:
-///   1. Texas PEMS (SFTP batch export — highest priority for PCHP)
+///   1. Texas PEMS (SFTP batch export — highest priority for Texas MCO tenants)
 ///   2. Other state sources in registration order
 ///   3. CAQH panel refresh (API fan-out, not a true bulk sync)
 /// </summary>

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/enrollment-service-config.yaml
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/enrollment-service-config.yaml
@@ -21,7 +21,7 @@
 #     "BaseUrl": "https://proview.caqh.org/api",
 #     "Username": "",                        // from AKV: caqh-username
 #     "Password": "",                        // from AKV: caqh-password
-#     "OrganizationId": ""                   // PCHP's CAQH org ID
+#     "OrganizationId": ""                   // Tenant's CAQH org ID
 #   }
 # }
 

--- a/src/engines/cho-enrollment-wiring/fhir-service/PasAutoAdjudicator.cs
+++ b/src/engines/cho-enrollment-wiring/fhir-service/PasAutoAdjudicator.cs
@@ -285,7 +285,7 @@ public class PasAutoAdjudicator : IPasAutoAdjudicator
             "MEDICAID" or "STAR" or "STARPLUS" or "STARKIDS" => PaLineOfBusiness.Medicaid,
             "EXCHANGE" or "QHP" or "MARKETPLACE"             => PaLineOfBusiness.Exchange,
             "MEDICARE" or "MA"                               => PaLineOfBusiness.Medicare,
-            _                                                => PaLineOfBusiness.Medicaid // default for PCHP
+            _                                                => PaLineOfBusiness.Medicaid // default for Texas Medicaid MCO tenants
         };
     }
 

--- a/src/services/appeals-service/AppealsService.Tests/Integration/Attachment275ConsumerIntegrationTests.cs
+++ b/src/services/appeals-service/AppealsService.Tests/Integration/Attachment275ConsumerIntegrationTests.cs
@@ -37,7 +37,7 @@ public class Attachment275ConsumerIntegrationTests
     /// </summary>
     private const string AppealContextFixtureTemplate = """
         {
-          "tenantId": "tenant-pchp",
+          "tenantId": "tenant-txmco01",
           "context": "appeal",
           "claimId": "{CLAIM_ID}",
           "authorizationId": "auth-20260207-001",
@@ -137,7 +137,7 @@ public class Attachment275ConsumerIntegrationTests
     public async Task AppealContextFixture_RoutesToSeededAppeal_WithFullAuditLineage()
     {
         var (consumer, repository, publisher, sink) = BuildHarness();
-        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-pchp", claimId: "claim-PCHP-9001");
+        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-txmco01", claimId: "claim-txmco01-9001");
         var bht03 = "BHT03-2026-04-23-XYZ";
         var json = AppealContextFixtureTemplate
             .Replace("{CLAIM_ID}", seeded.ClaimId)
@@ -200,7 +200,7 @@ public class Attachment275ConsumerIntegrationTests
     public async Task AppealContextFixture_DeadLetters_WhenSeededAppealIsClosed()
     {
         var (consumer, repository, publisher, sink) = BuildHarness();
-        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-pchp", claimId: "claim-closed-x");
+        var seeded = await SeedOpenAppeal(repository, tenantId: "tenant-txmco01", claimId: "claim-closed-x");
         // Move the appeal to Closed via the repository's transition path
         // so the next 275 has nothing to land on.
         var transition = new AppealEvent

--- a/src/services/appeals-service/Models/Appeal.cs
+++ b/src/services/appeals-service/Models/Appeal.cs
@@ -159,14 +159,14 @@ public class Appeal
     /// <summary>
     /// Diagnosis codes from the original claim. Plain-stored for
     /// queryability — matches the claims-service posture. Legal review to
-    /// confirm for the PCHP tenant before merge.
+    /// confirm for the deploying tenant before production use.
     /// </summary>
     public List<string> DiagnosisCodes { get; set; } = new();
 
     /// <summary>
     /// Procedure codes from the original claim. Plain-stored for
     /// queryability — matches the claims-service posture. Legal review to
-    /// confirm for the PCHP tenant before merge.
+    /// confirm for the deploying tenant before production use.
     /// </summary>
     public List<string> ProcedureCodes { get; set; } = new();
 

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -784,7 +784,7 @@ public class AdjudicationController : ControllerBase
         3 => PaLineOfBusiness.Medicaid,
         4 => PaLineOfBusiness.Medicaid,  // CHIP → Medicaid rules
         5 => PaLineOfBusiness.Exchange,
-        _ => PaLineOfBusiness.Medicaid   // Default to Medicaid for TX PCHP
+        _ => PaLineOfBusiness.Medicaid   // Default to Medicaid for TX MCO tenants
     };
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/services/fhir-service/Services/PasAutoAdjudicator.cs
+++ b/src/services/fhir-service/Services/PasAutoAdjudicator.cs
@@ -289,7 +289,7 @@ public class PasAutoAdjudicator : IPasAutoAdjudicator
             "MEDICAID" or "STAR" or "STARPLUS" or "STARKIDS" => PaLineOfBusiness.Medicaid,
             "EXCHANGE" or "QHP" or "MARKETPLACE"             => PaLineOfBusiness.Exchange,
             "MEDICARE" or "MA"                               => PaLineOfBusiness.Medicare,
-            _                                                => PaLineOfBusiness.Medicaid // default for PCHP
+            _                                                => PaLineOfBusiness.Medicaid // default for Texas Medicaid MCO tenants
         };
     }
 

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs
@@ -9,11 +9,11 @@ public class CacheKeyGuardTests
     [Fact]
     public void Build_WithTenantContext_PrependsEnvAndTenant()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
-        var key = guard.Build("enrollment:config:pchp");
+        var key = guard.Build("enrollment:config:txmco01");
 
-        Assert.Equal("production:pchp:enrollment:config:pchp", key);
+        Assert.Equal("production:txmco01:enrollment:config:txmco01", key);
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public class CacheKeyGuardTests
     [InlineData("patient:patientId:P99")]        // patientId
     public void Build_RejectsPhiTokens(string badKey)
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
         Assert.Throws<ArgumentException>(() => guard.Build(badKey));
     }
 
@@ -53,28 +53,28 @@ public class CacheKeyGuardTests
         // The hashed form of a member ID is explicitly permitted. Rejecting
         // it would block a large class of legitimate per-member cache keys
         // that have already been pseudonymized.
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
         var key = guard.Build("member:memberIdHash:deadbeef");
 
-        Assert.Equal("production:pchp:member:memberIdHash:deadbeef", key);
+        Assert.Equal("production:txmco01:member:memberIdHash:deadbeef", key);
     }
 
     [Theory]
-    [InlineData("enrollment config pchp")]      // spaces
+    [InlineData("enrollment config txmco01")]      // spaces
     [InlineData("enrollment\tconfig")]            // tab
     [InlineData("enrollment\nconfig")]            // newline
     [InlineData("enrollment\0config")]            // null byte
     public void Build_RejectsControlAndWhitespaceChars(string badKey)
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
         Assert.Throws<ArgumentException>(() => guard.Build(badKey));
     }
 
     [Fact]
     public void Build_NullOrEmptyKey_Throws()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
         Assert.Throws<ArgumentException>(() => guard.Build(""));
         Assert.Throws<ArgumentException>(() => guard.Build(null!));
@@ -86,7 +86,7 @@ public class CacheKeyGuardTests
         // The exception message flows through ExceptionHandlingMiddleware
         // and into production logs; if it echoed the PHI-containing key,
         // the guard would leak the exact value it was designed to reject.
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
         var sensitive = "member:ssn:123-45-6789";
         var ex = Assert.Throws<ArgumentException>(() => guard.Build(sensitive));
@@ -98,7 +98,7 @@ public class CacheKeyGuardTests
     [Fact]
     public void Build_WhitespaceRejectionMessage_DoesNotEchoRawKey()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
         var sensitive = "something member-ssn-123-45-6789";
         var ex = Assert.Throws<ArgumentException>(() => guard.Build(sensitive));
         Assert.DoesNotContain(sensitive, ex.Message);
@@ -108,8 +108,8 @@ public class CacheKeyGuardTests
     [Fact]
     public void BuildPrefix_TenantScope_UsesAmbientTenant()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
-        Assert.Equal("production:pchp:", guard.BuildPrefix());
+        var guard = MakeGuard("Production", tenantId: "txmco01");
+        Assert.Equal("production:txmco01:", guard.BuildPrefix());
     }
 
     [Fact]
@@ -122,17 +122,17 @@ public class CacheKeyGuardTests
     [Fact]
     public void BuildMany_AppliesGuardToEach()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
         var keys = guard.BuildMany(new[] { "a:b", "c:d" });
 
-        Assert.Equal(new[] { "production:pchp:a:b", "production:pchp:c:d" }, keys);
+        Assert.Equal(new[] { "production:txmco01:a:b", "production:txmco01:c:d" }, keys);
     }
 
     [Fact]
     public void BuildMany_OneBadKey_ThrowsAndDoesNotReturnPartial()
     {
-        var guard = MakeGuard("Production", tenantId: "pchp");
+        var guard = MakeGuard("Production", tenantId: "txmco01");
 
         Assert.Throws<ArgumentException>(() =>
             guard.BuildMany(new[] { "ok:one", "bad:ssn:2", "ok:three" }));

--- a/src/site/docs/fee-schedule-engine.html
+++ b/src/site/docs/fee-schedule-engine.html
@@ -192,7 +192,7 @@
           <li>HHSC / TMHP published rates</li>
           <li>STAR, STAR+PLUS, CHIP program-specific schedules</li>
           <li>Rate notices and mid-cycle adjustments</li>
-          <li>Critical for PCHP and any Texas managed care organization</li>
+          <li>Critical for any Texas managed care organization</li>
         </ul>
 
         <h3>Contracted Provider Rates</h3>

--- a/src/site/docs/prior-auth-guide.html
+++ b/src/site/docs/prior-auth-guide.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Prior Authorization Guide — Cloud Health Office</title>
   <meta name="description" content="Complete user guide for prior authorization in Cloud Health Office — X12 278 request/response, decision engine, clinical criteria, Da Vinci CRD/DTR/PAS integration, and authorization lifecycle management." />
-  <meta name="keywords" content="prior authorization engine, healthcare payer prior auth, X12 278 integration, Da Vinci CRD DTR PAS, prior auth decision engine, clinical criteria automation, PCHP prior auth, Texas Medicaid authorization, prior authorization API, CMS-0057-F prior auth" />
+  <meta name="keywords" content="prior authorization engine, healthcare payer prior auth, X12 278 integration, Da Vinci CRD DTR PAS, prior auth decision engine, clinical criteria automation, Texas Medicaid authorization, prior authorization API, CMS-0057-F prior auth" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/prior-auth-guide" />
 
   <meta property="og:type" content="article" />

--- a/src/site/docs/texas-compliance.html
+++ b/src/site/docs/texas-compliance.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Texas State Compliance — Cloud Health Office</title>
   <meta name="description" content="Texas Medicaid managed care compliance for STAR, STAR+PLUS, STAR Kids, and CHIP. TMHP PEMS provider enrollment verification, Gold Card exemption (HB 3229), HHSC UMCM prior authorization rules, and TX-specific fee schedule support." />
-  <meta name="keywords" content="Texas Medicaid, HHSC, TMHP PEMS, STAR, STAR+PLUS, STAR Kids, CHIP, Gold Card, HB 3229, Texas Insurance Code §4201.653, UMCM, prior authorization, MCO compliance, Parkland, Texas managed care" />
+  <meta name="keywords" content="Texas Medicaid, HHSC, TMHP PEMS, STAR, STAR+PLUS, STAR Kids, CHIP, Gold Card, HB 3229, Texas Insurance Code §4201.653, UMCM, prior authorization, MCO compliance, Texas managed care" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/texas-compliance" />
 
   <meta property="og:type" content="article" />

--- a/src/site/docs/texas-tmppm-pa-rules.html
+++ b/src/site/docs/texas-tmppm-pa-rules.html
@@ -211,7 +211,7 @@
         <!-- The Problem -->
         <h2 id="the-problem">The Problem</h2>
 
-        <p>On the March 2024 PCHP interoperability call, Cognizant confirmed their TriZetto EPA has <strong>no Texas Medicaid-specific rules</strong>. Their quote includes 130 custom questionnaires &mdash; but Texas Medicaid exceeds that. Monthly TMPPM maintenance falls entirely on plan staff, who must manually read PDFs, identify changes, and update questionnaires by hand.</p>
+        <p>Manual TMPPM tracking falls entirely on plan staff, who must read PDFs, identify changes, and update prior-authorization questionnaires by hand every month. Generic payer-platform questionnaires are not Texas Medicaid-specific, so plan staff must bridge the gap themselves.</p>
 
         <p>CHO eliminates this manual burden entirely with an automated extraction pipeline that reads the same TMHP PDFs and produces structured, queryable PA rules.</p>
 
@@ -315,7 +315,7 @@
               <tr><td>HCPCS quarterly updates</td><td class="tmppm-cross">&#x2717; Not included</td><td class="tmppm-check">&#x2713; 8 Q1 2026 rules loaded</td></tr>
               <tr><td>SNOMED&#x2194;CPT translation</td><td class="tmppm-cross">&#x2717; &ldquo;Go buy from a vendor&rdquo;</td><td class="tmppm-check">&#x2713; Built-in TerminologyService</td></tr>
               <tr><td>Clinical criteria extraction</td><td class="tmppm-cross">&#x2717; Not digitized</td><td class="tmppm-check">&#x2713; LLM-assisted structured extraction</td></tr>
-              <tr><td>Tenant scoping</td><td>Single-tenant</td><td class="tmppm-check">&#x2713; Per-plan overrides (PCHP, etc.)</td></tr>
+              <tr><td>Tenant scoping</td><td>Single-tenant</td><td class="tmppm-check">&#x2713; Per-plan overrides (tenant-scoped)</td></tr>
               <tr><td>Completed implementations</td><td class="tmppm-cross">&#x2717; Zero as of March 2024</td><td class="tmppm-check">&#x2713; Pipeline running, data in Cosmos</td></tr>
             </tbody>
           </table>
@@ -324,7 +324,7 @@
         <!-- PA Rule Explorer -->
         <h2 id="pa-rule-explorer">PA Rule Explorer</h2>
 
-        <p>The <strong>PA Rule Explorer</strong> is a Blazor Server page in the CHO portal that gives PCHP plan administrators and UM staff direct access to the extracted TMPPM rules:</p>
+        <p>The <strong>PA Rule Explorer</strong> is a Blazor Server page in the CHO portal that gives plan administrators and UM staff direct access to the extracted TMPPM rules:</p>
 
         <ul>
           <li><strong>Search by CPT/HCPCS code</strong> &mdash; type a procedure code and instantly see whether PA is required, the clinical criteria, required documentation, and the TMPPM section reference</li>
@@ -355,7 +355,7 @@
         </div>
 
         <h3>Tenant Scoping</h3>
-        <p>All rules are tenant-scoped with <code>TenantId</code> (e.g., <code>pchp</code>). The CRD server merges global rules with tenant-specific overrides at query time, allowing plans to customize PA requirements while inheriting the platform baseline.</p>
+        <p>All rules are tenant-scoped with <code>TenantId</code> (e.g., <code>txmco01</code>). The CRD server merges global rules with tenant-specific overrides at query time, allowing plans to customize PA requirements while inheriting the platform baseline.</p>
 
         <h3>Extraction Pipeline</h3>
         <p>The <code>TmppmIngestionService</code> is a .NET 8 console application in <code>tools/CloudHealthOffice.TmppmIngestionService</code>:</p>

--- a/tests/CloudHealthOffice.E2E/PriorAuthRuleEngineIntegrationTests.cs
+++ b/tests/CloudHealthOffice.E2E/PriorAuthRuleEngineIntegrationTests.cs
@@ -154,7 +154,7 @@ public class PriorAuthRuleEngineIntegrationTests : IAsyncLifetime
     {
         var context = new PaRuleContext
         {
-            TenantId = "pchp",
+            TenantId = "txmco01",
             StateCode = "TX",
             Lob = PaLineOfBusiness.Medicaid,
             Program = "STARKids",
@@ -182,7 +182,7 @@ public class PriorAuthRuleEngineIntegrationTests : IAsyncLifetime
     {
         var context = new PaRuleContext
         {
-            TenantId = "pchp",
+            TenantId = "txmco01",
             StateCode = "TX",
             Lob = PaLineOfBusiness.Exchange,
             Program = null,
@@ -207,7 +207,7 @@ public class PriorAuthRuleEngineIntegrationTests : IAsyncLifetime
         IReadOnlyList<string>? procedures = null,
         MemberAuthHistory? memberHistory = null) => new()
     {
-        TenantId = "pchp",
+        TenantId = "txmco01",
         StateCode = "TX",
         Lob = PaLineOfBusiness.Medicaid,
         Program = "STAR",

--- a/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
+++ b/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs
@@ -33,9 +33,9 @@ public class RedisPaRuleRepositoryTests
         StateCode = "TX",
         Lob       = PaLineOfBusiness.Medicaid,
         Program   = "STAR",
-        TenantId  = "pchp"
+        TenantId  = "txmco01"
     };
-    private const string TxStarCacheKey = "pa-rules:TX:3:STAR:pchp";
+    private const string TxStarCacheKey = "pa-rules:TX:3:STAR:txmco01";
 
     private readonly CacheKeyGuard _keyGuard = BuildGuard();
 
@@ -174,7 +174,7 @@ public class RedisPaRuleRepositoryTests
             Arg.Any<CommandFlags>())
             .Returns(new RedisKey[]
             {
-                "test:_global:pa-rules:TX:3:STAR:pchp",
+                "test:_global:pa-rules:TX:3:STAR:txmco01",
                 "test:_global:pa-rules:TX:3:any:platform"
             });
 
@@ -232,10 +232,10 @@ public class RedisPaRuleRepositoryTests
         var rules = new List<PaRuleDocument> { MakeRule() };
         _inner.ListAsync(Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>()).Returns(rules);
 
-        var result = await _sut.ListAsync(tenantId: "pchp", stateCode: "TX");
+        var result = await _sut.ListAsync(tenantId: "txmco01", stateCode: "TX");
 
         result.Should().HaveCount(1);
-        await _inner.Received(1).ListAsync("pchp", "TX", Arg.Any<CancellationToken>());
+        await _inner.Received(1).ListAsync("txmco01", "TX", Arg.Any<CancellationToken>());
     }
 
     private static PaRuleDocument MakeRule(
@@ -243,7 +243,7 @@ public class RedisPaRuleRepositoryTests
         string stateCode = "TX",
         PaLineOfBusiness lob = PaLineOfBusiness.Medicaid,
         string? program = "STAR",
-        string? tenantId = "pchp") => new()
+        string? tenantId = "txmco01") => new()
     {
         RuleId    = ruleId,
         RuleName  = $"Rule {ruleId}",

--- a/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/PriorAuthRuleEngineTests.cs
+++ b/tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/PriorAuthRuleEngineTests.cs
@@ -26,7 +26,7 @@ file static class Helpers
         DateOnly? memberDob = null,
         int requestedUnits = 1) => new()
     {
-        TenantId = "pchp",
+        TenantId = "txmco01",
         StateCode = "TX",
         Lob = PaLineOfBusiness.Medicaid,
         Program = "STAR",
@@ -469,10 +469,10 @@ public class PriorAuthRuleEngineServiceTests
     {
         var tenantDoc = new PaRuleDocument
         {
-            RuleId = "PCHP-STAR-PA-001", RuleName = "Tenant PA Rule",
+            RuleId = "TXMCO01-STAR-PA-001", RuleName = "Tenant PA Rule",
             StateCode = "TX", Lob = PaLineOfBusiness.Medicaid,
             Category = RuleCategory.ClinicalCriteria,
-            Scope = RuleScope.Tenant, TenantId = "pchp",
+            Scope = RuleScope.Tenant, TenantId = "txmco01",
             Priority = 10, RuleType = "ProcedureRequiresAuth"
         };
         var platformDoc = new PaRuleDocument
@@ -498,7 +498,7 @@ public class PriorAuthRuleEngineServiceTests
                 Outcome = PaDecisionOutcome.Pend,
                 FiringRuleId = tenantDoc.RuleId,
                 FiringRuleName = tenantDoc.RuleName,
-                ResolvedRuleSetKey = "pchp/TX/Medicaid/any"
+                ResolvedRuleSetKey = "txmco01/TX/Medicaid/any"
             });
         rule.EvaluateAsync(platformDoc, Arg.Any<PaRuleContext>(), Arg.Any<CancellationToken>())
             .Returns((PaRuleDecision?)null);
@@ -508,6 +508,6 @@ public class PriorAuthRuleEngineServiceTests
         var result = await engine.EvaluateAsync(DefaultContext);
 
         result.Outcome.Should().Be(PaDecisionOutcome.Pend);
-        result.FiringRuleId.Should().Be("PCHP-STAR-PA-001", "tenant rule should fire before platform rule at same priority");
+        result.FiringRuleId.Should().Be("TXMCO01-STAR-PA-001", "tenant rule should fire before platform rule at same priority");
     }
 }

--- a/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Cache/RedisTenantEnrollmentConfigRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Cache/RedisTenantEnrollmentConfigRepositoryTests.cs
@@ -21,7 +21,7 @@ public class RedisTenantEnrollmentConfigRepositoryTests
     private readonly ICacheProvider _cache = Substitute.For<ICacheProvider>();
     private readonly RedisTenantEnrollmentConfigRepository _sut;
 
-    private const string TenantId = "pchp";
+    private const string TenantId = "txmco01";
     private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(5);
     private static readonly string ExpectedKey = $"enrollment:config:{TenantId}";
 

--- a/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Gates/StateEnrollmentGateTests.cs
+++ b/tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Gates/StateEnrollmentGateTests.cs
@@ -15,7 +15,7 @@ public class StateEnrollmentGateTests
 {
     private const string Npi = "1234567890";
     private const string StateCode = "TX";
-    private const string TenantId = "pchp";
+    private const string TenantId = "txmco01";
     private const string Taxonomy = "207Q00000X";
 
     private readonly DateOnly _today = DateOnly.FromDateTime(DateTime.Today);

--- a/tools/CloudHealthOffice.TmppmIngestionService/Program.cs
+++ b/tools/CloudHealthOffice.TmppmIngestionService/Program.cs
@@ -13,7 +13,7 @@ namespace CHO.TmppmIngestionService;
 /// 
 /// Usage:
 ///   dotnet run -- ingest 2026 4                    # Full ingestion of April 2026 TMPPM
-///   dotnet run -- ingest 2026 4 --tenant pchp      # With PCHP tenant scoping
+///   dotnet run -- ingest 2026 4 --tenant txmco01   # With tenant scoping
 ///   dotnet run -- parse-section 2_13 9.2.46.14     # Parse a specific section from a chapter
 ///   dotnet run -- diff 2026-03 2026-04             # Diff two editions
 ///   dotnet run -- download 2026 4                  # Download only (no parsing)
@@ -185,7 +185,7 @@ public class Program
             
             Examples:
               dotnet run -- ingest 2026 4                    # Ingest April 2026 TMPPM
-              dotnet run -- ingest 2026 4 --tenant pchp      # Scoped to PCHP tenant
+              dotnet run -- ingest 2026 4 --tenant txmco01   # Scoped to a specific tenant
               dotnet run -- parse-section 2_13 9.2.46.14     # Extract HNS PA rules
               dotnet run -- download 2026 4                  # Download chapters only
             

--- a/tools/CloudHealthOffice.TmppmIngestionService/README.md
+++ b/tools/CloudHealthOffice.TmppmIngestionService/README.md
@@ -143,10 +143,10 @@ Output fields:
 
 ### Run full ingestion pipeline
 
-Downloads chapters, detects changes, parses PA sections, and persists to Cosmos DB with PCHP tenant scoping.
+Downloads chapters, detects changes, parses PA sections, and persists to Cosmos DB with tenant scoping.
 
 ```bash
-dotnet run -- ingest 2026 4 --tenant pchp
+dotnet run -- ingest 2026 4 --tenant txmco01
 ```
 
 This will:
@@ -163,7 +163,7 @@ This will:
 When TMHP publishes a new TMPPM edition (typically the last day of each month):
 
 ```bash
-dotnet run -- ingest 2026 5 --tenant pchp
+dotnet run -- ingest 2026 5 --tenant txmco01
 ```
 
 The pipeline automatically:
@@ -240,15 +240,13 @@ These sections have been tested and confirmed working:
 | §9.2.33.1 | Hyperbaric Oxygen Therapy | 99183 | G0277 | 1,658 chars | Session limits per indication in table |
 | §9.2.51.1 | Organ Transplants (General) | — (category-level) | — | 2,431 chars | Contraindications, 3-day pre/6-week post window |
 
-## Competitive context
+## Why automated extraction
 
-Cognizant told PCHP on the March 2024 interoperability call that they have **no state-specific Medicaid modules**. Their EPA quote includes 130 custom rules/questionnaires, but Texas Medicaid likely exceeds that. Ongoing TMPPM monthly maintenance falls entirely on Parkland staff.
-
-CHO's approach with this service:
+Generic payer-platform prior-auth modules typically ship without state-specific Medicaid rules, leaving plan staff to track TMPPM monthly changes by hand. This service closes that gap:
 
 - **Automated** — TMPPM changes detected and extracted monthly via SHA256 + PDF parsing
 - **Structured** — Rules persisted as FHIR-queryable ConceptMapEntry overrides
-- **Tenant-scoped** — PCHP gets TX-specific rules via `TenantId` + `State=TX` + `IsOverride=true`
+- **Tenant-scoped** — Each Texas MCO tenant gets TX-specific rules via `TenantId` + `State=TX` + `IsOverride=true`
 - **Scalable** — Same architecture replicates to any state (FL, NY, CA) by adding a new state code
 - **LLM-enriched** — Claude API backfills CPT codes for criteria-only sections like bariatric surgery
 
@@ -278,7 +276,7 @@ spec:
           containers:
           - name: tmppm-ingestion
             image: cho.azurecr.io/tmppm-ingestion:latest
-            command: ["dotnet", "TmppmIngestionService.dll", "ingest", "2026", "4", "--tenant", "pchp"]
+            command: ["dotnet", "TmppmIngestionService.dll", "ingest", "2026", "4", "--tenant", "txmco01"]
             env:
             - name: CHO_TMPPM_MONGODB__CONNECTIONSTRING
               valueFrom:


### PR DESCRIPTION
## Purpose

Make the Cloud Health Office repository product-focused and free of references to any specific prospective partner organization or named individuals. No behavioral changes; scope is test data, comments, documentation, and public-site copy only.

Prospective evaluators cloning the repo should see a generic, professional codebase — not one that names a specific third party's relationships.

## Scope

31 files changed, grouped by area:

### Canonical positioning docs (2 files)
- `docs/POSITIONING.md` — genericize a pilot-discussion header
- `docs/status/POSITIONING-AUDIT.md` — genericize four references in the P0 / Overclaims / Wave-1 sections

### Public site pages (4 files)
- `src/site/docs/texas-compliance.html` — removed a named organization from SEO meta keywords
- `src/site/docs/prior-auth-guide.html` — removed a named organization from SEO meta keywords
- `src/site/docs/fee-schedule-engine.html` — removed a named plan from a Texas-managed-care bullet
- `src/site/docs/texas-tmppm-pa-rules.html` — removed a meeting-attributed competitive anecdote and replaced it with a CHO-capability framing (**Cognizant-claim treatment: Option B — drop the claim entirely**); genericized two body-text references and one tenant-ID example

### Tool docs (2 files)
- `tools/CloudHealthOffice.TmppmIngestionService/README.md` — genericized CLI examples, tenant-scoping phrasing, and the competitive-context section
- `tools/CloudHealthOffice.TmppmIngestionService/Program.cs` — genericized two CLI-usage comment lines

### Test data (7 files)
- `src/services/shared/CloudHealthOffice.Infrastructure.Tests/Caching/CacheKeyGuardTests.cs` — tenant ID unified to `txmco01`; all `Assert.Equal` cache-key assertions internally consistent
- `tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/PriorAuthRuleEngineTests.cs` — tenant ID and rule ID unified (bare string → `txmco01`, rule ID → `TXMCO01-STAR-PA-001`); `FiringRuleId.Should().Be(...)` assertion still matches
- `tests/CloudHealthOffice.PriorAuthRuleEngine.Tests/Persistence/RedisPaRuleRepositoryTests.cs` — cache-key literal and tenant ID unified to `txmco01`; Redis SCAN expected-key assertions updated
- `tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Gates/StateEnrollmentGateTests.cs` — tenant ID constant
- `tests/CloudHealthOffice.ProviderEnrollmentService.Tests/Cache/RedisTenantEnrollmentConfigRepositoryTests.cs` — tenant ID constant
- `tests/CloudHealthOffice.E2E/PriorAuthRuleEngineIntegrationTests.cs` — three tenant-ID references
- `src/services/appeals-service/AppealsService.Tests/Integration/Attachment275ConsumerIntegrationTests.cs` — fixture tenant ID (`tenant-txmco01`) and claim ID (`claim-txmco01-9001`) consistent

### Source-code comments (7 files)
- `src/services/appeals-service/Models/Appeal.cs` — two XML doc comments rewritten in clean technical voice
- `src/engines/cho-enrollment-wiring/fhir-service/PasAutoAdjudicator.cs` — switch-default comment genericized
- `src/services/fhir-service/Services/PasAutoAdjudicator.cs` — same
- `src/services/benefit-plan-service/Controllers/AdjudicationController.cs` — mapping-default comment genericized
- `src/engines/CloudHealthOffice.ProviderEnrollmentService/enrollment-service-config.yaml` — config example comment
- `src/engines/CloudHealthOffice.ProviderEnrollmentService/Configuration/ProviderEnrollmentServiceRegistration.cs` — DI-registration example comment
- `src/engines/CloudHealthOffice.ProviderEnrollmentService/Workers/NightlyBatchSyncWorker.cs` — state-sync-order comment
- `src/engines/CloudHealthOffice.ProviderEnrollmentService/Models/TenantEnrollmentConfig.cs` — `McoIds` doc-comment example

### Architecture docs (3 files)
- `docs/architecture/ADJUDICATION-PIPELINE.md` — tenant-ID JSON example
- `docs/architecture/OPERATING-MODE.md` — tenant-ID JSON example + admin email
- `docs/architecture/shared-cache.md` — cache-key prose and worked-example table

### Benchmark generator (3 files)
- `src/CloudHealthOffice.BenchmarkClaimGenerator/Output/X12_834Writer.cs` — N1 payer segment genericized; ISA08 receiver ID (**15-char fixed-width preserved**: `TXMCO01` + 8 spaces); GS04 application receiver code updated
- `src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticBenefitPlan.cs` — default payer string and doc-comment example
- `src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/SyntheticProviderGenerator.cs` — one entry in the synthetic hospital-names list genericized

### Miscellaneous (2 files)
- `scripts/setup/seed-demo-data.js` — comment no longer names demo individuals
- `docs/features/CONFIG-TO-WORKFLOW-GENERATOR.md` — white-label config example uses a generic `"Example Partner Inc."` placeholder with `example-partner.com` URLs

## Replacement convention

- Tenant identifier: unified to `txmco01` across all tests, source comments, and architecture-doc JSON examples. Clearly synthetic, 7 chars, alphanumeric (no hyphens — avoids character-class-validation issues in cache-key contexts).
- Organization references in prose: replaced with generic phrasing such as `Texas Medicaid MCO`, `Texas MCO tenant`, `state Medicaid plan`, or `the deploying tenant`, context-dependent.
- Individual names: dropped; no natural replacement needed.

## Competitive-claim treatment

The meeting-attributed competitive anecdote in `texas-tmppm-pa-rules.html` and `TmppmIngestionService/README.md` has been **removed entirely** (Option B). Replaced with product-capability framing. The generic product-vs-product comparison table in `texas-tmppm-pa-rules.html` is untouched — that was never relationship-specific.

## `docs/archive/` — intentionally untouched

Historical artifacts under `docs/archive/` remain as-is. Rewriting them would be revisionism, and consumers of `main` don't encounter archived content unless they explicitly navigate there.

## SEO impact

Two public pages had terms removed from their `<meta name="keywords">` lists. Both pages will likely de-rank for those specific queries over the next 2–6 weeks as crawlers re-index. This is the desired outcome.

## Before requesting review

- [x] Repo-wide grep for the five named-party strings returns **zero rows** outside `docs/archive/`:
  ```
  grep -rin -E "<five named-party strings>" . --include="*.md" --include="*.html" --include="*.cs" --include="*.yaml" --include="*.yml" --include="*.json" --include="*.csproj" --include="*.sln" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.txt" | grep -v docs/archive | grep -v node_modules | grep -v /bin/ | grep -v /obj/
  # → 0 lines
  ```
- [x] Test-data narratives are internally consistent — every `TenantId` / cache-key / rule-ID pair referenced in an assertion was updated on both sides of the assertion.
- [x] X12 834 writer ISA08 receiver-ID field remains exactly 15 characters (`TXMCO01` + 8 pad spaces); GS04 unchanged structurally.
- [x] HTML body integrity preserved (surgical `<p>` / `<td>` / `<meta>` edits only; no structural changes).
- [ ] **`dotnet build` / `dotnet test` not run** — no .NET SDK available in this environment. Edits are mechanical string substitutions that preserve all assertion pairings. CI must confirm green before merge.

## Adjacent drift noticed (flag for PR C2 — do not fix here)

Things that looked like drift during the edit pass but are **not** neutralization work:
- `texas-tmppm-pa-rules.html` "Validated Extractions — April 2026 TMPPM" section cites specific rule counts; worth re-verifying against current pipeline output.
- `X12_834Writer.cs` uses a hard-coded FEIN `"752345678"` for the payer N1 segment — looks synthetic but worth confirming.
- `TmppmIngestionService/README.md` claims TMHP publishes updates "typically the last day of each month" — verify cadence against actual TMHP schedule.
- `docs/architecture/ADJUDICATION-PIPELINE.md` / `OPERATING-MODE.md` JSON examples would benefit from a brief "example tenant — not a real customer" note to prevent future drift of the same kind.
- `SyntheticProviderGenerator.cs` lists several real Texas hospital names alongside the one that was genericized; PR C2 may want to re-synthesize the full list.

These are documented here so PR C2 can pick them up; intentionally not fixed in this PR to keep the diff surgical.


---
_Generated by [Claude Code](https://claude.ai/code/session_011NMGxsGPK6tLDQoaTqbZY7)_