### PR TITLE
docs: factual corrections — pricing, service count, engine count, test count, docs volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Start with compliance. Expand into claims. Move at your own pace.
 
 |Component           |Count    |Details                                                                                                    |
 |---------------------|---------|-----------------------------------------------------------------------------------------------------------|
-|Microservices        |29       |C# / .NET 8, multi-tenant, Cosmos + MongoDB dual-repo                                                      |
-|Calculation Engines  |10       |Benefit, Fee Schedule, NCCI, COB, Risk Adj, Encounter, Claims Scrub, Operating Mode, Document Store, Provider Verification|
+|Microservices        |36       |C# / .NET 8, multi-tenant, Cosmos + MongoDB dual-repo                                                      |
+|Adjudication Engines |9        |Benefit, Fee Schedule, NCCI, COB, Risk Adj, Encounter, Claims Scrub, Prior Auth Rule, Provider Verification|
+|Supporting Projects  |4        |Operating Mode, Document Store, Provider Enrollment, enrollment-wiring                                     |
 |X12 Parsers          |5        |275, 276, 277, 278 (Python), 834 (Node.js)                                                                 |
 |FHIR APIs            |5        |Patient Access, Provider Access, Payer-to-Payer, Prior Auth, Provider Directory                            |
 |Argo Workflows       |17       |Claims adjudication, EDI ingest, enrollment import, RFAI                                                    |
@@ -84,26 +85,36 @@ Start with compliance. Expand into claims. Move at your own pace.
 |provider-verification-service|Multi-source provider verification & integrity scoring|—         |
 |ffs-service              |Fee-for-service rate configuration            |—               |
 
-### Calculation Engines
+### Adjudication Engines
 
 ![Calculation Engines](docs/images/calculation-engines.svg)
 
-|Engine              |Purpose                                                                                                     |
-|--------------------|------------------------------------------------------------------------------------------------------------|
-|BenefitEngine       |Cost-sharing calculation (deductible, copay, coinsurance), accumulator tracking, service category resolution|
-|FeeScheduleEngine   |Rate resolution against contracted fee schedules, allowed amount calculation                                |
-|NcciEngine          |CCI procedure-to-procedure edits, medically unlikely edits (MUE), modifier adjudication                     |
-|CobEngine           |Coordination of benefits, payer order determination, primary/secondary/tertiary payment split               |
-|RiskAdjustmentEngine|ICD-10 to HCC mapping, hierarchy resolution, CMS-HCC risk score calculation                                 |
-|EncounterEngine     |Encounter data transformation and batch submission for Medicaid/MA reporting                                |
-|ClaimsScrubEngine   |Pre-adjudication validation: 20+ rules across 6 categories (data completeness, code validation, date logic, amount logic, provider validation, modifier validation)|
-|OperatingMode       |Per-engine, per-tenant Augment/Replace mode toggle with AugmentResult&lt;T&gt; for parallel-run comparison against legacy CAPS|
-|DocumentStore       |IDocumentStore abstraction with Azure Blob Storage + InMemory providers for attachment and document management|
+|Engine                    |Purpose                                                                                                     |
+|--------------------------|------------------------------------------------------------------------------------------------------------|
+|BenefitEngine             |Cost-sharing calculation (deductible, copay, coinsurance), accumulator tracking, service category resolution|
+|FeeScheduleEngine         |Rate resolution against contracted fee schedules, allowed amount calculation                                |
+|NcciEngine                |CCI procedure-to-procedure edits, medically unlikely edits (MUE), modifier adjudication                     |
+|CobEngine                 |Coordination of benefits, payer order determination, primary/secondary/tertiary payment split               |
+|RiskAdjustmentEngine      |ICD-10 to HCC mapping, hierarchy resolution, CMS-HCC risk score calculation                                 |
+|EncounterEngine           |Encounter data transformation and batch submission for Medicaid/MA reporting                                |
+|ClaimsScrubEngine         |Pre-adjudication validation: 20+ rules across 6 categories (data completeness, code validation, date logic, amount logic, provider validation, modifier validation)|
+|PriorAuthRuleEngine       |CRD → DTR → PAS prior-authorization rule evaluation and decision orchestration                              |
 |ProviderVerificationEngine|Multi-source provider verification: NPPES, OIG/LEIE, PECOS, Open Payments, Medicare Utilization, FSMB. Composite 0–100 integrity scoring with configurable dimension weights|
+
+### Supporting Projects
+
+Additional projects under `src/engines/` that are not adjudication engines:
+
+|Project                 |Purpose                                                                                                     |
+|------------------------|------------------------------------------------------------------------------------------------------------|
+|OperatingMode           |Per-engine, per-tenant Augment/Replace mode toggle with AugmentResult&lt;T&gt; for parallel-run comparison against legacy CAPS|
+|DocumentStore           |IDocumentStore abstraction with Azure Blob Storage + InMemory providers for attachment and document management|
+|ProviderEnrollmentService|Provider enrollment workflow coordination                                                                  |
+|cho-enrollment-wiring   |Enrollment import orchestration wiring for 834 EDI processing                                               |
 
 ### Provider Verification
 
-The Provider Verification Service (service #29) aggregates six federal and licensed data sources to produce a composite integrity score for every provider in your network. The score is cached on the `Provider` and `ProviderContract` entities for sub-millisecond claims adjudication gating.
+The Provider Verification Service aggregates six federal and licensed data sources to produce a composite integrity score for every provider in your network. The score is cached on the `Provider` and `ProviderContract` entities for sub-millisecond claims adjudication gating.
 
 |Data Source         |Purpose                                                                                                     |
 |--------------------|------------------------------------------------------------------------------------------------------------|
@@ -195,7 +206,7 @@ curl http://localhost:5000/health
 
 ### Full Development Stack
 
-To bring up the complete backend (all 28 services + MongoDB + Redis + seed data):
+To bring up the complete backend (all 36 services + MongoDB + Redis + seed data):
 
 ```bash
 # Start everything
@@ -220,8 +231,8 @@ Or deploy to Azure:
 ```
 cloudhealthoffice/
 ├── src/
-│   ├── services/           # 28 C# microservices
-│   ├── engines/            # Calculation engines (Benefit, Fee Schedule, NCCI, COB, Risk Adj, Encounter)
+│   ├── services/           # 36 C# microservices
+│   ├── engines/            # 9 adjudication engines + supporting projects
 │   ├── portal/             # Blazor Server portal (50 pages, MudBlazor, Entra ID multi-tenant)
 │   ├── site/               # Marketing site (cloudhealthoffice.com)
 │   ├── fhir/               # FHIR R4 APIs and X12→FHIR mappers

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -182,6 +182,25 @@ Layer 3 entry — full platform, day one. The reference-customer gap is real and
 
 Layer 2 entry typically, with Layer 3 visible on the horizon. State-specific compliance variations (FL-AHCA-SMMC, Texas TMPPM, and similar) are handled through per-tenant configuration rather than per-customer code forks.
 
+## Canonical Facts
+
+*Last verified: April 2026*
+
+These are the ground-truth numbers for CHO as of the most recent verification. Any artifact citing service counts, engine counts, test counts, or documentation volume should reconcile to this section. When these numbers drift from reality, update this section first; derivative artifacts then reconcile to it.
+
+| Metric | Value | Source |
+| --- | --- | --- |
+| Services | 36 | `src/services/*/` excluding `shared/` |
+| Adjudication/rules engines | 9 | BenefitEngine, FeeScheduleEngine, NcciEngine, CobEngine, RiskAdjustmentEngine, EncounterEngine, ClaimsScrubEngine, PriorAuthRuleEngine, ProviderVerificationEngine |
+| Supporting engine projects | 4 | DocumentStore, OperatingMode, ProviderEnrollmentService, enrollment-wiring |
+| Test projects | 44 | `*.Tests.csproj` files |
+| Test methods | ~2,800 | xUnit Facts + Theories |
+| Production C# lines | ~136,000 | Excluding tests, bin, obj |
+| Documentation lines | ~94,000 | Markdown under `docs/` |
+| Pricing framework | PMPM-based, pilot-specific | See FINANCIAL-MODEL.md for indicative ranges |
+
+Verification procedure documented at `scripts/verify-canonical-facts.sh` (to be created in a follow-up PR). Numbers should be re-verified at each major release and when the Canonical Facts section is cited by another artifact.
+
 ## Governance
 
 This document is the source of truth for CHO positioning. Every other CHO-facing artifact — site pages, pitch deck, sales materials, compliance docs, technical documentation — should derive from and not contradict this document.

--- a/docs/announcements/v3.0.0-announcement.md
+++ b/docs/announcements/v3.0.0-announcement.md
@@ -39,7 +39,7 @@ With v3.0.0, we're not just updating software; we're **redefining what's possibl
 | **HashiCorp Vault** | Open-source secrets management as an alternative to proprietary solutions |
 | **OpenTelemetry** | Distributed tracing across microservices for superior observability |
 | **Infrastructure as Code** | Complete Bicep/Helm templates for reproducible deployments |
-| **424 Passing Tests** | Comprehensive test coverage ensures reliability |
+| **~2,800 test methods across 44 test projects** | Comprehensive test coverage ensures reliability |
 
 ### 📊 For Finance Teams
 

--- a/docs/fundraising/DUE-DILIGENCE-CHECKLIST.md
+++ b/docs/fundraising/DUE-DILIGENCE-CHECKLIST.md
@@ -235,7 +235,7 @@ full checklist.
   - Unit test coverage report
   - Integration test coverage
   - End-to-end test suite
-  - Current: 193 tests passing
+  - Current: ~2,800 test methods across 44 test projects
   - **Status**: ✅ Complete
 
 - [ ] **CI/CD Pipeline**

--- a/docs/fundraising/INVESTOR-MEETING-SCRIPT.md
+++ b/docs/fundraising/INVESTOR-MEETING-SCRIPT.md
@@ -30,7 +30,7 @@ This script provides a structured framework for 30-minute investor meetings. Ada
 > "In [X] days, 900 health plans face a compliance cliff that could cost them up to $10,000 per day in penalties and potential exclusion from Medicare and Medicaid programs. Most of them have no viable path to compliance—and that's the problem we've solved."
 
 **Option B: Time-to-Value**
-> "Traditional healthcare EDI implementations take 6-18 months and cost $500K to $2M. We've reduced Layer 1 CMS-0057-F compliance to weeks-to-deploy and ~$36K/year blended (tiers from $11K–$86K) — with 100% capability coverage of the mandate. Layer 2 progressive modernization (appeals shipped as the reference domain) and Layer 3 full-CAPS are the expansion path."
+> "Traditional healthcare EDI implementations take 6-18 months and cost $500K to $2M. We've reduced Layer 1 CMS-0057-F compliance to weeks-to-deploy with PMPM-based pricing and pilot-custom terms for founding partners — with 100% capability coverage of the mandate. Layer 2 progressive modernization (appeals shipped as the reference domain) and Layer 3 full-CAPS are the expansion path."
 
 **Option C: Market Transformation**
 > "The healthcare EDI market is $8 billion and hasn't seen meaningful innovation in 20 years. The CMS-0057-F mandate is forcing every health plan in America to modernize—and we're the only source-available, cloud-native solution ready to help them."
@@ -156,15 +156,9 @@ npm run generate -- interactive --output demo-config.json --generate
 
 ### Revenue Model (90 seconds)
 
-> "We have a straightforward SaaS subscription model with three tiers:
+> "We have a SaaS subscription model priced per member per month (PMPM), with indicative market-rate PMPM per layer — Layer 1 compliance surface, Layer 2 progressive modernization, Layer 3 full-CAPS. Specific terms are pilot-scoped; founding partners receive preferential terms.
 >
-> | Tier | Annual | Target |
-> |------|--------|--------|
-> | Starter | $11K | Regional payers, evaluation |
-> | Professional | $32K | Mid-market, production |
-> | Enterprise | $86K | Large plans, unlimited scale |
->
-> Our blended average revenue per customer is $36K in Year 1, growing to $45K by Year 3 through tier upgrades and add-on services.
+> Our Year 1 ARR target is $1.8M across ~50 customers, growing to $13.5M ARR across 300 customers by Year 3 as customers expand from Layer 1 into Layer 2 and Layer 3 engagements.
 >
 > We also have professional services revenue for complex implementations and premium support, which together represent about 17% of revenue."
 

--- a/docs/fundraising/INVESTOR-ONE-PAGER.md
+++ b/docs/fundraising/INVESTOR-ONE-PAGER.md
@@ -44,7 +44,7 @@
 | Provider Access API | ✅ Production Ready (Layer 1) |
 | Prior Authorization API (72hr/7-day) | ✅ Automated (Layer 1) |
 | Payer-to-Payer API | ✅ Ready (Layer 1) |
-| Complete X12 ↔ FHIR Transformation | ✅ 45 transformation tests (193 total suite) |
+| Complete X12 ↔ FHIR Transformation | ✅ 45 transformation tests (part of ~2,800-method suite across 44 test projects) |
 | Configuration Wizard | **< 5 min per tenant** |
 
 *Layer 1 = CMS-0057-F compliance surface. Layer 2 (appeals re-foundation) also production-ready. See [POSITIONING.md](../POSITIONING.md) §Layer 3 for full-CAPS honest today-state.*
@@ -68,7 +68,7 @@
 | Metric | Current | Year 1 Target |
 |--------|---------|---------------|
 | Platform Status | ✅ 100% CMS-Ready | Maintained |
-| Test Suite | 193 tests passing | 250+ |
+| Test Suite | ~2,800 test methods across 44 test projects | Maintain coverage |
 | Pilot Pipeline | Active conversations | 25 customers |
 | GitHub Stars | Growing | 1,000 |
 

--- a/docs/fundraising/WARM-INTRO-REQUEST.md
+++ b/docs/fundraising/WARM-INTRO-REQUEST.md
@@ -96,7 +96,7 @@ I wanted to introduce you to [Your Name], founder of Cloud Health Office.
 They've built a source-available, Azure-native EDI platform that helps health plans achieve CMS-0057-F compliance in under 5 minutes—compared to 6-18 months with traditional vendors. With the January 2027 deadline approaching, 900+ health plans face mandatory compliance, and there's no comparable solution in market.
 
 I've been advising them for [X months/time] and have been impressed by:
-• Technical execution (100% CMS-compliant, 193 tests passing)
+• Technical execution (100% CMS-compliant, ~2,800 test methods across 44 test projects)
 • Market timing (regulatory deadline creates urgent demand)
 • Capital efficiency (LTV:CAC of 25:1)
 
@@ -123,7 +123,7 @@ A few quick highlights:
 • 900+ health plans must comply by January 1, 2027
 • Traditional implementations take 6-18 months and $500K+
 • We deploy in <5 minutes at 85% lower cost
-• 100% compliant, 193 tests passing, production-ready
+• 100% compliant, ~2,800 test methods across 44 test projects, production-ready
 
 I've attached our one-pager and would be happy to send our full deck if helpful. Would [specific times] work for a call?
 
@@ -188,8 +188,8 @@ Thanks for connecting us, [Existing Investor Name].
 Quick context:
 • $8B healthcare EDI market with regulatory forcing function
 • 900+ health plans must comply with CMS-0057-F by January 2027
-• Traditional vendors: 6-18 months, $500K-$2M
-• Cloud Health Office: <5 minutes, $36K/year
+• Traditional vendors: 6-18 months, $500K–$2M implementation + annual licensing
+• Cloud Health Office: Layer 1 compliance surface deployable in weeks, PMPM-based pricing, pilot-custom terms for founding partners
 • Unit economics: LTV:CAC of 25:1, 6-month CAC payback
 
 I'd love to find 30 minutes to walk through our platform and market opportunity. Would [specific times] work?
@@ -258,7 +258,7 @@ Thank you, [Customer Name], for the kind introduction.
 
 • Deploy CMS-0057-F compliance in under 5 minutes
 • 85% cost reduction vs. enterprise vendors
-• 100% compliant infrastructure, 193 tests passing
+• 100% compliant infrastructure, ~2,800 test methods across 44 test projects
 • Zero-code configuration for payer-specific needs
 
 We're raising a $2M seed round to scale from pilot customers like [Customer Company] to 50+ customers by end of Year 1.

--- a/docs/sales-materials/FINANCIAL-MODEL.md
+++ b/docs/sales-materials/FINANCIAL-MODEL.md
@@ -8,6 +8,18 @@
 
 This financial model outlines Cloud Health Office's path to profitability as a SaaS platform serving the healthcare payer market. With a **$1.8M Year 1 ARR target** growing to **$13.5M ARR by Year 3**, the model demonstrates a capital-efficient approach to capturing the $8B+ healthcare EDI market segment facing CMS-0057-F compliance mandates.
 
+---
+
+## Pricing Framework
+
+Cloud Health Office is priced **per member per month (PMPM)** across the Platform Engagement layers. Pricing is indicative market-rate within each layer; specific terms are negotiated per pilot.
+
+- **Layer 1 — Compliance Accelerator.** Entry pricing for the CMS-0057-F compliance surface. Indicative market-rate PMPM; founding-partner terms available for first pilot engagements.
+- **Layer 2 — Progressive Modernization.** PMPM expands per domain migrated. Appeals shipped as the first reference domain; additional domains (capitation, claims, others) activated per pilot scope.
+- **Layer 3 — Full CAPS Platform.** PMPM for end-to-end platform engagement. Pricing aspires to incumbent CAPS market range as the platform matures and production references accumulate; founding partners receive preferential terms.
+
+The per-customer dollar figures in the tables below are **internal modeled ARPU figures** used to produce 3-year ARR and unit-economics projections. They represent weighted averages of pilot-scenario pricing, not list prices or customer-quotable rates. Customer-facing artifacts cite PMPM framing; specific PMPM ranges per layer are negotiated per pilot and are not published.
+
 ### Key Financial Highlights
 
 | Metric | Year 1 | Year 2 | Year 3 |
@@ -32,8 +44,10 @@ This financial model outlines Cloud Health Office's path to profitability as a S
 
 ### Tier Distribution Assumptions
 
-| Year | Starter | Professional | Enterprise | Blended ARPU |
-|------|---------|--------------|------------|--------------|
+*Blended ARPU figures below are internal modeled projections (weighted averages of pilot-scenario pricing), used to produce 3-year ARR targets. Not list prices or customer-quotable rates.*
+
+| Year | Starter | Professional | Enterprise | Blended ARPU (modeled) |
+|------|---------|--------------|------------|------------------------|
 | Year 1 | 50% | 40% | 10% | $36,000 |
 | Year 2 | 40% | 45% | 15% | $40,000 |
 | Year 3 | 30% | 50% | 20% | $45,000 |
@@ -105,8 +119,10 @@ This financial model outlines Cloud Health Office's path to profitability as a S
 
 ### Customer Segmentation
 
-| Segment | Year 1 | Year 2 | Year 3 | ARPU |
-|---------|--------|--------|--------|------|
+*ARPU figures below are internal modeled projections by segment, used to produce 3-year revenue forecasts. Not list prices or customer-quotable rates.*
+
+| Segment | Year 1 | Year 2 | Year 3 | Modeled ARPU |
+|---------|--------|--------|--------|--------------|
 | **Regional Health Plans** | 25 | 75 | 150 | $36,000 |
 | **TPAs** | 15 | 45 | 90 | $32,000 |
 | **Medicaid MCOs** | 8 | 24 | 48 | $72,000 |
@@ -132,7 +148,7 @@ This financial model outlines Cloud Health Office's path to profitability as a S
 
 | Metric | Year 1 | Year 2 | Year 3 |
 |--------|--------|--------|--------|
-| **ARPU** | $36,000 | $40,000 | $45,000 |
+| **ARPU (modeled)** | $36,000 | $40,000 | $45,000 |
 | **Gross Margin** | 75% | 78% | 82% |
 | **Churn Rate** | 8% | 6% | 5% |
 | **Customer Lifetime** | 12.5 years | 16.7 years | 20 years |
@@ -161,7 +177,7 @@ This financial model outlines Cloud Health Office's path to profitability as a S
 | **Starter** | $10,788 | $2,500 | 77% |
 | **Professional** | $32,388 | $6,500 | 80% |
 | **Enterprise** | $86,388 | $14,000 | 84% |
-| **Blended (Year 1)** | $36,000 | $9,000 | **75%** |
+| **Blended (Year 1, modeled)** | $36,000 | $9,000 | **75%** |
 | **Blended (Year 3)** | $45,000 | $8,100 | **82%** |
 
 ### Cost of Goods Sold (COGS)

--- a/docs/sales-materials/PITCH-DECK-CONTENT.md
+++ b/docs/sales-materials/PITCH-DECK-CONTENT.md
@@ -142,8 +142,8 @@
 
 | Metric | Before Cloud Health Office | After |
 |--------|---------------------------|-------|
-| Deployment Time | 6-18 months | **< 5 minutes** |
-| Implementation Cost | $500K - $2M | **$36K/year** |
+| Deployment Time | 6-18 months | **Weeks to deploy (Layer 1)** |
+| Implementation Cost | $500K - $2M | **PMPM-based, pilot-custom** |
 | Compliance Readiness | Uncertain | **100%** |
 | Source Code Access | None | **Full (BSL 1.1)** |
 
@@ -413,11 +413,13 @@ npm run generate -- interactive --output my-config.json --generate
 
 | Metric | Value |
 |--------|-------|
-| **ARPU** | $36,000 - $45,000 |
+| **Pricing Model** | PMPM (per member per month), indicative market-rate per layer |
 | **Gross Margin** | 75% - 82% |
 | **LTV:CAC** | 25:1 - 43:1 |
 | **CAC Payback** | 6 months |
 | **Net Revenue Retention** | 115% - 125% |
+
+*See [FINANCIAL-MODEL.md](./FINANCIAL-MODEL.md) for indicative PMPM framing per layer and 3-year ARR projections.*
 
 ---
 
@@ -437,8 +439,8 @@ npm run generate -- interactive --output my-config.json --generate
 |--------|---------|-----------------|
 | **GitHub Stars** | [PLACEHOLDER] | 1,000 |
 | **Contributors** | [PLACEHOLDER] | 30 |
-| **Test Suite** | 193 tests passing | 250+ |
-| **Documentation** | 20,000+ lines | 30,000+ |
+| **Test Suite** | ~2,800 test methods across 44 test projects | Maintain coverage |
+| **Documentation** | ~94,000 lines of markdown | Maintain coverage |
 | **CMS Compliance** | 100% | Maintained |
 
 ### Product Milestones Achieved
@@ -540,7 +542,7 @@ Reference: [ROADMAP-2026.md](../ROADMAP-2026.md)
 
 | Assumption | Value |
 |------------|-------|
-| **Blended ARPU** | $36K → $45K |
+| **Pricing Framework** | PMPM-based, pilot-specific (see FINANCIAL-MODEL.md) |
 | **Annual Churn** | 8% → 5% |
 | **Net Revenue Retention** | 115% → 125% |
 | **CAC Payback** | 6 months |

--- a/docs/sales-materials/SALES-EMAIL-TEMPLATES.md
+++ b/docs/sales-materials/SALES-EMAIL-TEMPLATES.md
@@ -116,10 +116,12 @@ I'm reaching out because Cloud Health Office can reduce your EDI platform costs 
 
 | Cost Category | Current (Estimated) | With Cloud Health Office |
 |---------------|---------------------|--------------------------|
-| Annual Platform | $[X]00,000 | $36,000 |
-| Implementation | $[X]00,000 | $5,000 |
+| Annual Platform | $[X]00,000 | PMPM (pilot-custom) |
+| Implementation | $[X]00,000 | Pilot-scoped |
 | Support | $[X]0,000 | Included |
-| **3-Year TCO** | **$[X]M** | **$169,000** |
+| **3-Year TCO** | **$[X]M** | **Pilot-scoped; see FINANCIAL-MODEL.md** |
+
+**Pricing:** PMPM-based, pilot-custom terms for founding partners. Happy to scope specifics on a discovery call.
 
 **Why the difference?**
 • Source-available platform (BSL 1.1) - no vendor lock-in

--- a/docs/sales-materials/SALES-ROI-CALCULATOR.md
+++ b/docs/sales-materials/SALES-ROI-CALCULATOR.md
@@ -16,20 +16,18 @@ This ROI calculator enables healthcare organizations to quantify the financial i
 
 | Cost Category | Custom Development | Enterprise Vendor | Cloud Health Office |
 |---------------|-------------------|-------------------|---------------------|
-| **Year 1 Implementation** | $1,500,000 | $250,000 | $15,000 |
-| **Year 1 Licensing/Subscription** | $0 | $180,000 | $36,000 |
-| **Year 1 Support & Maintenance** | $150,000 | $45,000 | $0 (included) |
-| **Year 2 Licensing/Subscription** | $0 | $180,000 | $36,000 |
-| **Year 2 Support & Maintenance** | $300,000 | $45,000 | $0 (included) |
-| **Year 3 Licensing/Subscription** | $0 | $180,000 | $36,000 |
-| **Year 3 Support & Maintenance** | $300,000 | $45,000 | $0 (included) |
-| **Compliance Updates** | $200,000 | $50,000 | $0 (included) |
-| **Infrastructure (3-year)** | $180,000 | $90,000 | $36,000 |
-| **Total 3-Year TCO** | **$2,630,000** | **$1,065,000** | **$159,000** |
-| **Additional Cost vs. Cloud Health Office** | $2,471,000 | $906,000 | — |
-| **Savings with Cloud Health Office** | **94%** | **85%** | — |
+| **Year 1 Implementation** | $1,500,000 | $250,000 | Pilot-scoped |
+| **Year 1 Licensing/Subscription** | $0 | $180,000 | PMPM (indicative market-rate) |
+| **Year 1 Support & Maintenance** | $150,000 | $45,000 | Included |
+| **Year 2 Licensing/Subscription** | $0 | $180,000 | PMPM (expands by layer) |
+| **Year 2 Support & Maintenance** | $300,000 | $45,000 | Included |
+| **Year 3 Licensing/Subscription** | $0 | $180,000 | PMPM (expands by layer) |
+| **Year 3 Support & Maintenance** | $300,000 | $45,000 | Included |
+| **Compliance Updates** | $200,000 | $50,000 | Included |
+| **Infrastructure (3-year)** | $180,000 | $90,000 | Customer-deployed |
+| **Total 3-Year TCO (indicative)** | **$2,630,000** | **$1,065,000** | **Pilot-scoped; see FINANCIAL-MODEL.md** |
 
-> **Note:** The Cost Comparison Matrix uses conservative estimates for Custom Development. The Detailed Cost Breakdown reflects typical implementation costs, including common overruns and delays observed in real-world payer integrations. This distinction ensures transparent, future-proof financial modeling for decision-makers.
+> **Note:** Cost Comparison Matrix uses conservative estimates for Custom Development and Enterprise Vendor paths. Cloud Health Office pricing is PMPM-based (per member per month) and pilot-scoped. Specific three-year TCO for Cloud Health Office depends on layer mix (Layer 1 compliance surface vs. Layer 2 progressive modernization vs. Layer 3 full-CAPS) and member count. See [FINANCIAL-MODEL.md](./FINANCIAL-MODEL.md) for indicative PMPM framing per layer.
 
 ### Detailed Cost Breakdown
 

--- a/docs/sales-materials/pitch-deck-v4.md
+++ b/docs/sales-materials/pitch-deck-v4.md
@@ -510,7 +510,7 @@ This is the precedent that every subsequent Layer 2 domain follows (capitation, 
 | **Beta Launch** | ✅ Live | First 10 customers |
 | **Eligibility Microservice v2.0** | ✅ Complete | 50K req/sec, <100ms latency |
 | **Security Hardening** | ✅ Complete | Zero vulnerabilities (CodeQL) |
-| **Documentation Overhaul** | ✅ Complete | 20K+ lines of docs |
+| **Documentation Overhaul** | ✅ Complete | ~94,000 lines of markdown documentation |
 
 ### Q2 2026: Azure Marketplace + AI
 

--- a/src/site/cms-0057f-compliance.html
+++ b/src/site/cms-0057f-compliance.html
@@ -641,7 +641,7 @@
 <text x="185" y="1228" text-anchor="middle" font-size="12" fill="rgba(0,255,255,0.5)" font-family="-apple-system, sans-serif">85.93% coverage</text>
 
 <rect x="340" y="1185" width="250" height="56" rx="8" fill="rgba(0,255,136,0.04)" stroke="rgba(0,255,136,0.12)" stroke-width="0.5"/>
-<text x="465" y="1208" text-anchor="middle" font-size="18" font-weight="700" fill="#00ff88" font-family="-apple-system, sans-serif">29 microservices</text>
+<text x="465" y="1208" text-anchor="middle" font-size="18" font-weight="700" fill="#00ff88" font-family="-apple-system, sans-serif">36 microservices</text>
 <text x="465" y="1228" text-anchor="middle" font-size="12" fill="rgba(0,255,136,0.5)" font-family="-apple-system, sans-serif">9 engines · 6 parsers</text>
 
 <rect x="620" y="1185" width="250" height="56" rx="8" fill="rgba(0,255,255,0.04)" stroke="rgba(0,255,255,0.12)" stroke-width="0.5"/>

--- a/src/site/docs/architecture.html
+++ b/src/site/docs/architecture.html
@@ -64,7 +64,7 @@
 
         <h2 id="platform">Platform Components</h2>
 
-        <h3>Microservices (29)</h3>
+        <h3>Microservices (36)</h3>
         <p>Member, Coverage, Claims, Eligibility, Authorization, Provider, Benefit Plan, Reference Data, Sponsor, Claims Scrubbing, Capitation, Payment, Pricing API, Terminology Service, Provider Verification, and more. Each service owns its domain data and communicates via Azure Service Bus messaging. The Terminology Service provides FHIR <code>ConceptMap/$translate</code> for SNOMED CT &harr; CPT/ICD-10-CM crosswalk — required for Da Vinci CRD, DTR, and PAS workflows. The Provider Verification Service aggregates NPPES, OIG/LEIE, PECOS, CMS Open Payments, and FSMB data into a composite integrity score per NPI.</p>
 
         <h3>Calculation Engines (9)</h3>

--- a/src/site/docs/architecture.html
+++ b/src/site/docs/architecture.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Architecture — Cloud Health Office Documentation</title>
-  <meta name="description" content="Cloud Health Office platform architecture. Multi-tenant SaaS, Kubernetes-native with Argo Workflows, 29 microservices, 9 calculation engines, configuration-driven deployment for healthcare payers." />
+  <meta name="description" content="Cloud Health Office platform architecture. Multi-tenant SaaS, Kubernetes-native with Argo Workflows, 36 microservices, 9 adjudication engines, configuration-driven deployment for healthcare payers." />
   <meta name="keywords" content="healthcare payer platform architecture, Kubernetes healthcare, multi-tenant claims processing, Argo Workflows EDI, FHIR R4 architecture, healthcare microservices, claims adjudication pipeline" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/architecture" />
   <meta property="og:type" content="article" />
@@ -43,8 +43,8 @@
         <p class="docs-subtitle">Cloud Health Office is a cloud-native multi-tenant SaaS platform that processes healthcare EDI transactions for unlimited health plans. Configuration-driven, backend-agnostic, and deployable to any Kubernetes cluster.</p>
 
         <figure class="docs-diagram">
-          <img src="/graphics/platform-overview.svg" alt="Cloud Health Office platform overview showing 29 microservices, 9 calculation engines, 7 FHIR R4 APIs, and multi-cloud deployment" />
-          <figcaption>Platform overview — 29 microservices, 9 engines, 6 parsers, 7 FHIR APIs, 17 Argo Workflows</figcaption>
+          <img src="/graphics/platform-overview.svg" alt="Cloud Health Office platform overview showing 36 microservices, 9 adjudication engines, 7 FHIR R4 APIs, and multi-cloud deployment" />
+          <figcaption>Platform overview — 36 microservices, 9 engines, 6 parsers, 7 FHIR APIs, 17 Argo Workflows</figcaption>
         </figure>
 
         <h2 id="overview">Overview</h2>

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -165,7 +165,7 @@
           <a href="/docs/architecture" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F3D7;&#xFE0F;</span>
             <h3>Architecture</h3>
-            <p>Multi-tenant SaaS platform architecture. Kubernetes-native with Argo Workflows, 29 microservices, 9 calculation engines, and configuration-driven deployment.</p>
+            <p>Multi-tenant SaaS platform architecture. Kubernetes-native with Argo Workflows, 36 microservices, 9 adjudication engines, and configuration-driven deployment.</p>
             <span class="card-arrow">Explore &rarr;</span>
           </a>
 

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
   <meta property="og:title" content="Kubernetes Quick Start — Cloud Health Office" />
-  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production. 29 microservices, MongoDB, Redis — identical to Azure AKS." />
+  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production. 36 microservices, MongoDB, Redis — identical to Azure AKS." />
 
   <script type="application/ld+json">
   {

--- a/src/site/release-notes.html
+++ b/src/site/release-notes.html
@@ -308,7 +308,7 @@
       <h1>Cloud Health Office V4</h1>
       <p style="font-size: 1.5rem; max-width: 800px; margin: 0 auto;">
         Production SaaS. Zero Vulnerabilities.<br>
-        29 Microservices. 6 Calculation Engines.<br>
+        36 Microservices. 9 Adjudication Engines.<br>
         <strong>CMS-0057-F Compliant &mdash; 10 Months Early</strong>
       </p>
     </div>
@@ -319,12 +319,12 @@
         <h2>V4 At A Glance</h2>
         <div class="metrics-grid">
           <div class="metric-card">
-            <div class="metric-value">29</div>
+            <div class="metric-value">36</div>
             <div class="metric-label">Microservices</div>
           </div>
           <div class="metric-card">
-            <div class="metric-value">6</div>
-            <div class="metric-label">Calculation Engines</div>
+            <div class="metric-value">9</div>
+            <div class="metric-label">Adjudication Engines</div>
           </div>
           <div class="metric-card">
             <div class="metric-value">1,740</div>
@@ -707,7 +707,7 @@ npm install &amp;&amp; npm test
       <section class="cta-section" style="text-align: center; margin: 60px 0;">
         <h2>Production-Ready Payer Platform</h2>
         <p style="font-size: 1.2rem; max-width: 700px; margin: 20px auto;">
-          29 microservices. 6 calculation engines. 5 FHIR R4 APIs.<br>
+          36 microservices. 9 adjudication engines. 5 FHIR R4 APIs.<br>
           CMS-0057-F compliant. Zero vulnerabilities. Deploy anywhere.
         </p>
         <div style="margin-top: 30px;">
@@ -721,7 +721,7 @@ npm install &amp;&amp; npm test
   <footer>
     <p>
       <strong>Cloud Health Office V4 &mdash; Production SaaS</strong><br>
-      22 Microservices. 9 Engines. 5 FHIR R4 APIs. Zero Vulnerabilities.
+      36 Microservices. 9 Engines. 5 FHIR R4 APIs. Zero Vulnerabilities.
     </p>
     <p>
       BSL 1.1 Licensed &bull; Actively maintained by Aurelianware<br>


### PR DESCRIPTION
## Summary

Second PR in the Phase 1 foundation sequence. Reconciles stale factual claims across the repo to verified ground truth. Follows PR C1 (repo neutralization, merged) and precedes PR P2 (POSITIONING.md v2 with four-product-line framing).

**Purpose:** the repo currently contains factual drift points that damage credibility with technically-literate evaluators — pricing cited as a committed rate that is actually an internal modeled ARPU, service counts understated by 7–14, test counts understated by ~15×, documentation volume understated by ~5×. This PR reconciles all in-scope drift to the verified ground-truth numbers while leaving tier architecture and historical release notes intact for later waves.

## Ground-truth numbers (verified against current main)

| Metric | Value | Source |
|---|---|---|
| Services | **36** | `src/services/*/` excluding `shared/` |
| Adjudication/rules engines | **9** | BenefitEngine, FeeScheduleEngine, NcciEngine, CobEngine, RiskAdjustmentEngine, EncounterEngine, ClaimsScrubEngine, PriorAuthRuleEngine, ProviderVerificationEngine |
| Supporting engine projects | **4** | DocumentStore, OperatingMode, ProviderEnrollmentService, cho-enrollment-wiring |
| Test projects | **44** | `*.Tests.csproj` files |
| Test methods | **~2,800** | xUnit `[Fact]` + `[Theory]` = 2,809 |
| Documentation lines | **~94,000** | `find docs -name "*.md" \| xargs wc -l` = 94,655 |
| Pricing framework | PMPM-based, pilot-specific | See FINANCIAL-MODEL.md for indicative ranges per layer |

## Concerns reconciled

**A. Pricing ($36K → PMPM framing) — 6 files:**
- `docs/sales-materials/FINANCIAL-MODEL.md` — added **Pricing Framework** section articulating PMPM-per-layer (Layer 1/2/3). Internal modeled ARPU figures preserved in downstream tables with explicit `(modeled)` labeling. Year-1/2/3 ARR targets ($1.8M/$6.0M/$13.5M) preserved intact.
- `docs/sales-materials/SALES-ROI-CALCULATOR.md` — TCO-comparison table CHO column reframed to PMPM + pilot-scoped.
- `docs/sales-materials/PITCH-DECK-CONTENT.md` — Transformation table + Unit Economics + Key Assumptions reframed.
- `docs/sales-materials/SALES-EMAIL-TEMPLATES.md` — outreach pricing table.
- `docs/fundraising/INVESTOR-MEETING-SCRIPT.md` — two residual $36K refs (not cleaned in Wave 1b) reframed.
- `docs/fundraising/WARM-INTRO-REQUEST.md` — bullet-list pitch summary.

**B. Service count (29/28/22 → 36) — 7 files:**
- `README.md` (4 locations: Component table, Provider Verification paragraph ordinal dropped, Full Dev Stack, project-structure tree).
- `src/site/release-notes.html` (hero, metric cards, CTA, footer).
- `src/site/cms-0057f-compliance.html` (SVG callout).
- `src/site/docs/architecture.html` (meta description, image alt, figcaption, h3).
- `src/site/docs/index.html` (Architecture card copy).
- `src/site/docs/quickstart-kubernetes.html` (meta description).

**C. Engine count (10 mixed → 9 adjudication + 4 supporting) — 2 files:**
- `README.md` — Component table relabeled; Calculation Engines subsection → Adjudication Engines with 9 engines including previously-missing `PriorAuthRuleEngine`; new Supporting Projects subsection lists the 4 non-adjudication projects.
- `src/site/release-notes.html` — body references reconciled (footer already said 9).

**D. Test count (193 / 424 → ~2,800 across 44 projects) — 5 files:**
- `docs/fundraising/INVESTOR-ONE-PAGER.md` (Traction table + Solution-row subset-claim reframing: scoped "45 transformation tests" preserved, unscoped "193 total suite" replaced).
- `docs/fundraising/DUE-DILIGENCE-CHECKLIST.md`.
- `docs/fundraising/WARM-INTRO-REQUEST.md` (3 instances).
- `docs/announcements/v3.0.0-announcement.md` ("424 Passing Tests").
- `docs/sales-materials/PITCH-DECK-CONTENT.md` (Traction table; scoped "45 Tests Passing" subset claim preserved).
- `docs/sales-materials/pitch-deck-v4.md` — scoped subset claim preserved.

**E. Documentation volume (20K+ → ~94,000) — 2 files:**
- `docs/sales-materials/pitch-deck-v4.md`.
- `docs/sales-materials/PITCH-DECK-CONTENT.md` (opportunistically corrected; same file already in scope).

**Canonical Facts footer:** appended to `docs/POSITIONING.md` as a new section before Governance, dated April 2026, containing the verified metrics and sources for derivative artifacts to reconcile against.

## Zero invented replacement numbers

Every correction either (a) uses the verified ground truth, (b) uses directional framing (PMPM, indicative market-rate, pilot-custom), or (c) scopes the claim to where it holds true (e.g., preserving "45 transformation tests" as an X12↔FHIR subset claim). No dollar figures or test counts were invented.

## Out-of-scope (deliberately deferred)

- **`docs/features/RELEASE-v4.0.0.md` "22 microservices"** — left intact per user direction: preserve historical release-time counts rather than overwrite historical release notes with current state.
- **Starter/Professional/Enterprise tier architecture** — Wave 2 restructures customer-facing pricing around PMPM + four product lines. This PR only replaces literal `$36K` dollar figures and leaves tier names in place.
- **Internal tier infrastructure** (`MULTI-TENANT-SAAS-ARCHITECTURE.md`, `ONBOARDING.md`, Stripe scripts) — internal taxonomy, not customer-facing pricing.
- **`docs/status/POSITIONING-AUDIT.md`** — historical audit record of the drift this PR fixes; updating it would misrepresent the audit.
- **Test layout normalization, Logic Apps scrub, new ADRs/runbooks, archive content** — later waves.

## Adjacent drift noticed (flagged for Wave 2, not fixed here)

- `docs/images/services-overview.svg:31` — SVG text label "28 Services" (asset may need regeneration).
- `src/site/platform.html:920` — "29 Microservices. One Adjudication Pipeline."
- `docs/sales-materials/MARKETING-LANDING-PAGE-COPY.md:250` — "193 Tests" in BSL footer line.
- `docs/features/RELEASE_NOTES.md:83` — "424 passing" in a release-notes table (distinct from the v4.0.0 file; if Wave 2 treats all historical release notes as in-scope for update, this becomes editable; otherwise leave as historical).
- `README.md:11` badge `tests-973 passing` — auto-updated by the `test-metrics` workflow; 973 likely reflects the test *run* count vs. the 2,800 method-attribute count. Different metric, worth a reconciliation pass but out of scope here.

## Before requesting review

- [x] Repo-wide grep `(29|28|22) (microservice\|[Ss]ervices)` outside archive/audit/RELEASE-v4.0.0 → only the 2 flagged adjacent-drift matches remain.
- [x] Repo-wide grep `(6|10) [Cc]alculation [Ee]ngine\|6 engines\|10 engines` → zero matches.
- [x] Repo-wide grep `193 [Tt]est\|424 [Pp]assing` outside archive/audit/RELEASE-v4.0.0 → only the 2 flagged adjacent-drift matches remain.
- [x] Every PMPM reference in customer-facing text is directional ("indicative market-rate", "pilot-custom"); specific per-PMPM numbers not leaked into customer-facing content.
- [x] FINANCIAL-MODEL.md ARR targets ($1.8M / $6.0M / $13.5M) preserved — only the ARPU-per-tier math now carries explicit `(modeled)` labeling and a top-of-document clarifier explaining they are internal projections, not list prices.
- [x] Canonical Facts footer added to POSITIONING.md before Governance section.

## Test plan

- [ ] Visual review of `src/site/release-notes.html`, `cms-0057f-compliance.html`, and `docs/architecture.html` rendering (counts in hero, metric cards, figcaption, h3, SVG callout).
- [ ] Read-through of `FINANCIAL-MODEL.md` Pricing Framework section and `(modeled)` labeling to confirm internal-modeled vs. customer-facing distinction is clear.
- [ ] Spot-check WARM-INTRO-REQUEST.md, SALES-EMAIL-TEMPLATES.md, and INVESTOR-MEETING-SCRIPT.md for residual PMPM-unfriendly phrasing.
- [ ] Confirm scoped subset claims ("45 transformation tests") still present in PITCH-DECK-CONTENT.md:136, pitch-deck-v4.md:106, INVESTOR-ONE-PAGER.md:47 and carry clear X12↔FHIR scoping.

https://claude.ai/code/session_01DovWighznzQWosCnuL5wmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DovWighznzQWosCnuL5wmL)_