### PR TITLE
ci: close production deploy gap (5 missing services + base-image fix)

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -175,6 +175,11 @@ jobs:
           - CHO.TerminologyService
           - CloudHealthOffice.PricingApi
           - consent-service
+          - accumulator-service
+          - capitation-service
+          - encounter-submission-service
+          - member-document-service
+          - personal-representative-service
         include:
           # All .NET services need repo root as context to reach
           # src/services/shared/CloudHealthOffice.Infrastructure/ and/or src/engines/.
@@ -235,6 +240,16 @@ jobs:
             build_context: '.'
             image_name: cloudhealthoffice-pricing-api
           - service: consent-service
+            build_context: '.'
+          - service: accumulator-service
+            build_context: '.'
+          - service: capitation-service
+            build_context: '.'
+          - service: encounter-submission-service
+            build_context: '.'
+          - service: member-document-service
+            build_context: '.'
+          - service: personal-representative-service
             build_context: '.'
 
     steps:

--- a/docs/deployment/KNOWN-GAPS.md
+++ b/docs/deployment/KNOWN-GAPS.md
@@ -1,0 +1,13 @@
+# Known Build Gaps
+
+This file documents services or components in the repository that
+exist but are not yet included in CI build/deploy workflows. Canonical
+build matrix lives in `.github/workflows/deploy-azure-aks.yml`.
+
+## `ffs-service`
+
+Service exists at `src/services/ffs-service/` (csproj, Program.cs,
+Models/) but does not yet have a `Dockerfile`. Excluded from
+`.github/workflows/deploy-azure-aks.yml` and
+`.github/workflows/docker-build.yml` matrices. Will be added once
+the service is containerized.

--- a/src/services/encounter-submission-service/Dockerfile
+++ b/src/services/encounter-submission-service/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 
 # Copy csproj files and restore (preserves layer caching)
@@ -16,7 +17,7 @@ FROM build AS publish
 RUN dotnet publish src/services/encounter-submission-service/encounter-submission-service.csproj -c Release -o /app/publish /p:UseAppHost=false --no-restore --no-build
 
 # Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM ${REGISTRY}/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
 RUN apt-get update \


### PR DESCRIPTION
## Summary

Closes the genuine production-deploy gap surfaced during the C3b plan-phase audit. `deploy-azure-aks.yml` (the workflow that actually builds + pushes + deploys on every main push) was missing 5 services that have Dockerfiles. They were silently being skipped from production CI. This PR adds them. In the same change, fixes `encounter-submission-service`'s Dockerfile to use the ACR-mirrored base images per the workflow's required pattern, and documents `ffs-service` (no Dockerfile yet) as a known build gap.

## Scope reframe vs. the original C3b plan

The original C3b plan was framed as "expand `docker-build.yml` from 18 to 35 services." Mid-execution, an audit revealed that **`deploy-azure-aks.yml` already builds 28 services** — most of the 17 the original plan targeted were already in production CI, just via a different workflow. The actual production gap was 5 services missing from BOTH workflows.

Switched to Option β (minimum-blast-radius fix) per [the revised plan](https://github.com/aurelianware/cloudhealthoffice/pull/689) discussion. Workflow consolidation between `docker-build.yml` and `deploy-azure-aks.yml` (Option δ) is real technical debt but deferred to a separate planning conversation — bundling it here would expand scope right when we're trying to stay surgical.

## Changes

### 1. `.github/workflows/deploy-azure-aks.yml`

5 new entries appended to the `service:` matrix and 5 corresponding `include:` entries with `build_context: '.'`:

| Service | Cross-directory dependency | Override |
|---------|---------------------------|----------|
| `accumulator-service` | `Infrastructure` + `Events` shared libs | `build_context: '.'` |
| `capitation-service` | `Infrastructure` | `build_context: '.'` |
| `encounter-submission-service` | `Infrastructure` | `build_context: '.'` |
| `member-document-service` | `Infrastructure` | `build_context: '.'` |
| `personal-representative-service` | `Infrastructure` | `build_context: '.'` |

All 5 follow the exact pattern of every other `.NET` service entry. No new conventions introduced.

### 2. `src/services/encounter-submission-service/Dockerfile`

Three-line fix to use the ACR-mirrored .NET base images:

```diff
+ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 ...
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM ${REGISTRY}/dotnet/aspnet:8.0 AS runtime
```

The MCR-direct `FROM` lines bypassed the workflow's stated invariant that PR builds and main deploys exercise the same registry — the exact failure mode commit `71c9d37` caused for 5 days in April 2026 (when 28 Dockerfiles were repointed to ACR without populating the mirror). After this fix, encounter-submission-service uses the same `ARG REGISTRY` + `\${REGISTRY}/dotnet/...` pattern as every other `.NET` service.

### 3. `docs/deployment/KNOWN-GAPS.md` (new file)

Short, single-purpose file documenting `ffs-service` as a known build gap. Opens with a one-line statement of purpose and points to `deploy-azure-aks.yml` as the canonical build matrix.

Did not append to `DOCKER-BUILD-STATUS.md` because that doc is wildly stale (claims 10 services, GHCR registry, Mar/Apr 2025-era snapshot) — appending would propagate the staleness. DOCKER-BUILD-STATUS.md cleanup is a separate follow-up.

## Adjacent drift noticed (flagged, not fixed)

While editing `encounter-submission-service/Dockerfile`, observed two patterns that diverge from sibling services. Both look intentional (security/healthcheck hardening) so preserved them; flagging for a future reviewer's awareness:

- **Explicit `apt-get install -y --no-install-recommends curl`** at lines 22-24. Sibling services rely on the base image's bundled tools. Possibly added to make the `HEALTHCHECK CMD curl -f` work reliably on minimal base images.
- **Explicit `groupadd/useradd appuser`** at lines 28-30. Sibling services use the base image's implicit `\$APP_UID`. Possibly added for explicit non-root enforcement.

Neither is obviously wrong. Either pattern could be standardized across all services in a future cleanup PR, but doing so requires understanding the rationale for the deviation — which isn't documented anywhere in the repo. Out of scope for this PR.

## Validation strategy

⚠️ **First-on-main validation** — `deploy-azure-aks.yml` does not run on pull requests (it's `on: push: branches: [\"main\"]` + `workflow_dispatch` only). Verified that `workflow_dispatch` against this branch is **not safe**: the `PROD` environment used by `deploy-site` and `deploy-aks` jobs has no protection rules and no deployment branch policy, so `gh workflow run` from this branch would actually deploy from the branch.

Falling back to **merge-as-draft + first-on-main validation** with these safeguards:

- `build-push-services` has `fail-fast: false` (line 146) — if any of the 5 new entries fail, all 33 will report so we see all failures at once rather than aborting on the first.
- The 5 newly-added Dockerfiles were inspected during plan phase. All COPY paths verified to resolve under repo-root context.
- The `encounter-submission-service` base-image change is a 3-line edit matching the pattern proven by the other ~33 services.
- `docker-build.yml` runs on this PR (because of the `src/services/**` path filter) and exercises its 18-service matrix unchanged. Won't validate the new 5 or the encounter-submission-service fix, but provides smoke coverage that nothing in the broader Dockerfile flow regressed.

If first-on-main reveals a build failure, the recovery path is a fast follow-up PR. The blast radius is limited because `fail-fast: false` means broken services don't block the deploy of healthy ones.

## Test plan

- [x] `git diff --stat main...HEAD` shows exactly 3 files (deploy-azure-aks.yml, encounter-submission-service/Dockerfile, KNOWN-GAPS.md).
- [x] All 5 new `service:` matrix entries have matching `include:` entries with `build_context: '.'`.
- [x] `encounter-submission-service/Dockerfile` shows only the 3-line ARG/FROM diff; everything else preserved.
- [x] `KNOWN-GAPS.md` opens with the purpose-statement sentence pointing to `deploy-azure-aks.yml` as canonical.
- [x] No edits to `docker-build.yml`, `RELEASE-v4.0.0.md`, `DOCKER-BUILD-STATUS.md`, the hardcoded summary block, or the dead-code `build_context: '.'` overrides.
- [ ] **Manual: post-merge** — verify `deploy-azure-aks.yml` runs green on main with all 33 service matrix entries (28 existing + 5 new) building+pushing successfully. Specifically watch encounter-submission-service since it has both a new matrix entry AND the base-image change.

## Out of scope (deferred)

- `docker-build.yml` — untouched. Its role (PR-validation subset) is defensible even after this PR; consolidation question deferred.
- `docs/features/RELEASE-v4.0.0.md` line 129 wording (`(builds container images for the core service set)`) — saying \"builds all 36 services\" wouldn't be accurate to either workflow individually post-β. Defer until workflow consolidation resolves the canonical-builder question.
- `DOCKER-BUILD-STATUS.md` broader staleness — separate cleanup.
- Hardcoded summary block in `docker-build.yml` lines 525-541 — deferred.
- Dead-code `build_context: '.'` overrides in `docker-build.yml` lines 61-67 — deferred.
- Image-name override pattern reconciliation between the two workflows — deferred to consolidation conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)