### PR TITLE
ci: add reusable _build-service-image.yml workflow (delta-1)

### DIFF
--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -183,8 +183,10 @@ on:
 
 jobs:
   build:
-    name: Build ${{ inputs.service }}${{ inputs.push && ' (push)' || ' (no-push)' }}
+    name: Build ${{ inputs.service }}${{ (inputs.push == true || inputs.push == 'true') && ' (push)' || ' (no-push)' }}
     runs-on: ubuntu-latest
+    env:
+      PUSH_ENABLED: ${{ inputs.push == true || inputs.push == 'true' }}
     permissions:
       # Read-only checkout of the repository.
       contents: read
@@ -282,7 +284,7 @@ jobs:
       # GitHub mints a short-lived token bound to this workflow's subject.
       # ───────────────────────────────────────────────────────────────────
       - name: Azure Login (OIDC) — push mode
-        if: inputs.push
+        if: env.PUSH_ENABLED == 'true'
         uses: azure/login@v2
         with:
           # secrets.X || secrets.Y pattern: in workflow_call mode the lowercase
@@ -295,7 +297,7 @@ jobs:
           subscription-id: ${{ secrets.azure_subscription_id || secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Log in to ACR — push mode
-        if: inputs.push
+        if: env.PUSH_ENABLED == 'true'
         run: az acr login --name "${{ steps.params.outputs.registry_name }}"
 
       # ───────────────────────────────────────────────────────────────────
@@ -314,7 +316,7 @@ jobs:
       # ───────────────────────────────────────────────────────────────────
       - name: Check ACR read-token availability — non-push mode
         id: check-acr-token
-        if: inputs.push == false
+        if: env.PUSH_ENABLED != 'true'
         env:
           # Same secrets.X || secrets.Y pattern as the OIDC step — works for
           # both workflow_call (caller-provided) and workflow_dispatch (repo
@@ -330,7 +332,7 @@ jobs:
 
       - name: Log in to ACR for base-image pulls — non-push mode
         id: acr-pr-login
-        if: inputs.push == false && steps.check-acr-token.outputs.available == 'true'
+        if: env.PUSH_ENABLED != 'true' && steps.check-acr-token.outputs.available == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ steps.params.outputs.registry }}
@@ -342,7 +344,7 @@ jobs:
         # login step was skipped, OR (b) the login step ran and failed.
         # Either way, proceeding silently would let the build pull base
         # images from MCR — exactly what 71c9d37 did, undetected for 5 days.
-        if: inputs.push == false && steps.acr-pr-login.outcome != 'success'
+        if: env.PUSH_ENABLED != 'true' && steps.acr-pr-login.outcome != 'success'
         env:
           ACR_SHORT_NAME: ${{ steps.params.outputs.registry_name }}
         run: |
@@ -367,7 +369,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and ${{ inputs.push && 'push' || 'check' }} ${{ inputs.service }}
+      - name: Build and ${{ env.PUSH_ENABLED == 'true' && 'push' || 'check' }} ${{ inputs.service }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ steps.params.outputs.build_context }}
@@ -393,6 +395,6 @@ jobs:
           # cache-to (write) is gated on push: true. Non-push builds skip
           # cache writes to avoid polluting the cache namespace shared with
           # main builds. See header item 3.
-          cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+          cache-to: ${{ env.PUSH_ENABLED == 'true' && 'type=gha,mode=max' || '' }}
           # All CHO services target linux/amd64. Multi-arch is not in scope.
           platforms: linux/amd64

--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -1,0 +1,398 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Reusable workflow: build (and optionally push) a single CHO service image.
+#
+# This file is the single source of truth for "how do CHO microservice container
+# images get built?" — both production deploys (deploy-azure-aks.yml) and PR
+# validation (post-δ3, pr-validation.yml) call into this workflow with different
+# inputs. Treat this file as a canonical reference; future maintainers will read
+# it to understand the conventions baked into CHO's CI build path.
+#
+# Two triggers are declared:
+#   * workflow_call    — the production use case; called as a job by other
+#                        workflows in this repo (δ2 wires deploy-azure-aks.yml,
+#                        δ3 wires pr-validation.yml).
+#   * workflow_dispatch — manual smoke testing from the Actions UI or `gh
+#                        workflow run`. Useful while developing this file
+#                        before any caller exists, and afterwards for one-off
+#                        builds.
+#
+# GitHub Actions requires the input schema to be declared SEPARATELY under
+# each trigger (the schemas don't inherit). Keep the two `inputs:` blocks in
+# sync — if you add or change an input, do it in BOTH places.
+#
+# Key design decisions (see PR δ1 description for full rationale):
+#
+# 1. Registry/registry_name resolution uses a 3-tier fallback in a `steps`
+#    expression, NOT in `default:`. `vars.*` is not resolvable at the
+#    `on.workflow_call.inputs.<name>.default` level — only inside `steps.*`
+#    expressions. The fallback chain is:
+#      caller-provided input → vars.ACR_LOGIN_SERVER → hardcoded literal.
+#    The hardcoded literal exists so this workflow remains functional even on
+#    callers that haven't configured the org-level GitHub variable.
+#
+# 2. `build-args: REGISTRY=<effective>` is always passed. Today's
+#    deploy-azure-aks.yml does NOT set this build-arg and works only because
+#    every CHO service Dockerfile defaults `ARG REGISTRY=<acr-url>`. That's
+#    fragile: a future Dockerfile copying the upstream MCR-default pattern
+#    would build green via docker-build.yml (which DOES set this build-arg)
+#    and fail red on main deploy. Threading it through the reusable workflow
+#    eliminates that drift class. This is the one place δ1 deliberately
+#    deviates from strict deploy-aks fidelity (see incident 71c9d37 for the
+#    real-world precedent).
+#
+# 3. cache-to writes are gated on `push: true`. PR-style builds read the
+#    GHA cache (cache-from) but don't write back. This prevents PR builds
+#    from polluting the cache namespace shared with main builds. Today's
+#    docker-build.yml writes cache on PRs; that behavior changes when δ3
+#    routes PR validation through this workflow.
+#
+# 4. Both push and non-push modes preserve the "fail loudly if ACR login
+#    didn't succeed" pattern from docker-build.yml lines 92-135. Incident
+#    71c9d37 hid a 5-day regression behind a silent MCR fallback when PR
+#    builds and main deploys exercised different registries. The reusable
+#    workflow propagates that safety check to all callers.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Build Service Image (Reusable)
+
+on:
+  # ─────────────────────────────────────────────────────────────────────────
+  # workflow_call: invoked as a job by other workflows in this repo.
+  # δ2 will wire deploy-azure-aks.yml's `build-push-services` job into this.
+  # δ3 will wire pr-validation.yml (replacing docker-build.yml) into this.
+  # ─────────────────────────────────────────────────────────────────────────
+  workflow_call:
+    inputs:
+      service:
+        description: "Service directory name under src/services/ (e.g. appeals-service, CHO.TerminologyService)."
+        type: string
+        required: true
+      build_context:
+        description: "Docker build context. Empty default resolves to ./src/services/<service>; override to '.' for services that reference shared code outside their directory (most CHO services do)."
+        type: string
+        required: false
+        default: ""
+      image_name:
+        description: "FULL image name including prefix (e.g. cloudhealthoffice-terminology-service). Empty default resolves to ${image_prefix}-${service}. When overridden, the value is used as-is — no double prefixing."
+        type: string
+        required: false
+        default: ""
+      push:
+        description: "Whether to push the built image to ACR. true = production deploy mode (OIDC + az acr login). false = build-only (uses ACR_USERNAME/ACR_PASSWORD for read-only base-image pulls)."
+        type: boolean
+        required: false
+        default: false
+      registry:
+        description: "ACR login server (e.g. choacrhy6h2vdulfru6.azurecr.io). Empty default falls back to vars.ACR_LOGIN_SERVER, then to the hardcoded production literal. See header comment item 1 for why default resolution lives in a step, not here."
+        type: string
+        required: false
+        default: ""
+      registry_name:
+        description: "ACR short name used by `az acr login` (e.g. choacrhy6h2vdulfru6). Empty default falls back to vars.ACR_NAME, then to the hardcoded production literal."
+        type: string
+        required: false
+        default: ""
+      image_prefix:
+        description: "Prefix prepended to the default image name. Used only when image_name is not overridden."
+        type: string
+        required: false
+        default: "cloudhealthoffice"
+      tag_sha:
+        description: "Whether to tag the image with sha-<commit-sha>. Useful for production deploy traceability; can be disabled for PR builds that don't need long-lived tags."
+        type: boolean
+        required: false
+        default: true
+      tag_latest:
+        description: "Whether to tag the image with :latest. PR validation may want to disable this to avoid touching the rolling :latest tag."
+        type: boolean
+        required: false
+        default: true
+    secrets:
+      # All secrets are declared optional — runtime checks below enforce
+      # presence when actually needed (push:true requires Azure OIDC; push:false
+      # requires ACR read credentials unless skipped).
+      azure_client_id:
+        required: false
+        description: "OIDC federated identity client ID. Required when push: true."
+      azure_tenant_id:
+        required: false
+        description: "Azure AD tenant ID. Required when push: true."
+      azure_subscription_id:
+        required: false
+        description: "Azure subscription ID. Required when push: true."
+      acr_username:
+        required: false
+        description: "ACR scope-mapped read-only token username (e.g. cho-ci-readonly). Required when push: false to pull mirrored .NET base images. See docs/security/SECRETS-INVENTORY.md for setup."
+      acr_password:
+        required: false
+        description: "ACR scope-mapped read-only token password. Required when push: false."
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # workflow_dispatch: manual one-off invocations from the Actions UI or
+  # `gh workflow run`. Inputs schema mirrors workflow_call exactly. Note that
+  # workflow_dispatch cannot accept a `secrets:` block — secrets used in
+  # dispatch mode are read directly from the repository's secret store via
+  # the `secrets.X || secrets.Y` fallback pattern in step expressions below.
+  # ─────────────────────────────────────────────────────────────────────────
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service directory name under src/services/ (e.g. appeals-service, CHO.TerminologyService)."
+        type: string
+        required: true
+      build_context:
+        description: "Docker build context. Empty default resolves to ./src/services/<service>; override to '.' for repo-root context."
+        type: string
+        required: false
+        default: ""
+      image_name:
+        description: "FULL image name including prefix. Empty default resolves to ${image_prefix}-${service}."
+        type: string
+        required: false
+        default: ""
+      push:
+        description: "Whether to push to ACR. true requires AZURE_* repo secrets to be configured."
+        type: boolean
+        required: false
+        default: false
+      registry:
+        description: "ACR login server. Empty default falls back to vars.ACR_LOGIN_SERVER then to hardcoded production literal."
+        type: string
+        required: false
+        default: ""
+      registry_name:
+        description: "ACR short name. Empty default falls back to vars.ACR_NAME then to hardcoded production literal."
+        type: string
+        required: false
+        default: ""
+      image_prefix:
+        description: "Prefix prepended to default image name."
+        type: string
+        required: false
+        default: "cloudhealthoffice"
+      tag_sha:
+        description: "Whether to tag the image with sha-<commit-sha>."
+        type: boolean
+        required: false
+        default: true
+      tag_latest:
+        description: "Whether to tag the image with :latest."
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  build:
+    name: Build ${{ inputs.service }}${{ inputs.push && ' (push)' || ' (no-push)' }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Read-only checkout of the repository.
+      contents: read
+      # OIDC token issuance for azure/login@v2 (only used when push: true,
+      # but the permission must be granted at the job level regardless).
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ───────────────────────────────────────────────────────────────────
+      # Resolve effective parameters from the input/var/literal fallback
+      # chain. This step exists because GitHub Actions does NOT allow
+      # `vars.*` references in `on.workflow_call.inputs.<name>.default` —
+      # the only way to express the 3-tier fallback chain is here, in a
+      # step expression evaluated at runtime.
+      #
+      # Outputs:
+      #   registry        — the final ACR login server (e.g. xxx.azurecr.io)
+      #   registry_name   — the final ACR short name (for az acr login)
+      #   image_name      — the final image name (with prefix)
+      #   build_context   — the final docker build context path
+      #   tags            — multi-line tag list ready for build-push-action
+      # ───────────────────────────────────────────────────────────────────
+      - name: Resolve effective build parameters
+        id: params
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # 3-tier fallback (see header item 1):
+          #   1. caller's input (if non-empty)
+          #   2. org/repo variable (if set)
+          #   3. hardcoded production literal (last resort)
+          REGISTRY="${{ inputs.registry || vars.ACR_LOGIN_SERVER || 'choacrhy6h2vdulfru6.azurecr.io' }}"
+          REGISTRY_NAME="${{ inputs.registry_name || vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}"
+
+          # image_name: when caller provides one, it's used VERBATIM (no
+          # double-prefixing). This matches the convention deploy-azure-aks.yml
+          # already uses for PascalCase services like CHO.TerminologyService
+          # and CloudHealthOffice.PricingApi (see deploy-azure-aks.yml lines
+          # 236-241). When NOT overridden, default to ${image_prefix}-${service}.
+          IMAGE_NAME="${{ inputs.image_name || format('{0}-{1}', inputs.image_prefix, inputs.service) }}"
+
+          # build_context: default to ./src/services/<service>. In practice
+          # every current caller overrides to '.' because all CHO .NET services
+          # share infrastructure code under src/services/shared/ that lives
+          # outside the per-service directory. The default is preserved for
+          # hypothetical self-contained services.
+          BUILD_CONTEXT="${{ inputs.build_context || format('./src/services/{0}', inputs.service) }}"
+
+          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
+          echo "registry_name=$REGISTRY_NAME" >> "$GITHUB_OUTPUT"
+          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "build_context=$BUILD_CONTEXT" >> "$GITHUB_OUTPUT"
+
+          # Build the multi-line tag list that docker/build-push-action expects.
+          # Each line becomes one tag the image is published under.
+          TAGS=""
+          if [ "${{ inputs.tag_latest }}" = "true" ]; then
+            TAGS="${REGISTRY}/${IMAGE_NAME}:latest"
+          fi
+          if [ "${{ inputs.tag_sha }}" = "true" ]; then
+            if [ -n "$TAGS" ]; then
+              TAGS="${TAGS}"$'\n'
+            fi
+            TAGS="${TAGS}${REGISTRY}/${IMAGE_NAME}:sha-${GITHUB_SHA}"
+          fi
+          if [ -z "$TAGS" ]; then
+            echo "::error::Both tag_sha and tag_latest are false; the build would produce an untagged image. Enable at least one."
+            exit 1
+          fi
+
+          # Multi-line outputs require the heredoc form.
+          {
+            echo "tags<<TAGS_EOF"
+            echo "$TAGS"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved registry:      $REGISTRY"
+          echo "Resolved registry_name: $REGISTRY_NAME"
+          echo "Resolved image_name:    $IMAGE_NAME"
+          echo "Resolved build_context: $BUILD_CONTEXT"
+          echo "Resolved tags:"
+          echo "$TAGS" | sed 's/^/  /'
+
+      # ───────────────────────────────────────────────────────────────────
+      # PUSH MODE: authenticate to Azure via OIDC and `az acr login`. This
+      # is the production deploy path (called by deploy-azure-aks.yml after
+      # δ2). OIDC federated identity means no long-lived credentials live in
+      # the repo — the AZURE_CLIENT_ID identifies the service principal, and
+      # GitHub mints a short-lived token bound to this workflow's subject.
+      # ───────────────────────────────────────────────────────────────────
+      - name: Azure Login (OIDC) — push mode
+        if: inputs.push
+        uses: azure/login@v2
+        with:
+          # secrets.X || secrets.Y pattern: in workflow_call mode the lowercase
+          # form is the caller-passed secret; in workflow_dispatch mode it's
+          # empty (undeclared, resolves to ""), and the uppercase form picks
+          # up the repo secret directly. This makes the same step work for
+          # both triggers without a duplicate-step kludge.
+          client-id: ${{ secrets.azure_client_id || secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.azure_tenant_id || secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.azure_subscription_id || secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to ACR — push mode
+        if: inputs.push
+        run: az acr login --name "${{ steps.params.outputs.registry_name }}"
+
+      # ───────────────────────────────────────────────────────────────────
+      # NON-PUSH MODE: PR-style build that doesn't need OIDC (no push
+      # privilege required) but DOES need ACR read access to pull the
+      # mirrored .NET base images that all service Dockerfiles depend on.
+      #
+      # The 3-step pattern below is a faithful extraction of docker-build.yml
+      # lines 92-135 — preserved deliberately because incident 71c9d37 burned
+      # a 5-day silent regression when PR builds quietly fell through to MCR
+      # while main deploys hit (and missed in) ACR. The "fail loudly" step
+      # makes that whole class of PR-green/main-red regressions impossible:
+      # if the read-only ACR token isn't configured, non-push builds error
+      # out with explicit setup instructions instead of silently using the
+      # wrong registry.
+      # ───────────────────────────────────────────────────────────────────
+      - name: Check ACR read-token availability — non-push mode
+        id: check-acr-token
+        if: inputs.push == false
+        env:
+          # Same secrets.X || secrets.Y pattern as the OIDC step — works for
+          # both workflow_call (caller-provided) and workflow_dispatch (repo
+          # secret). The check looks at the username because (username, password)
+          # are always set as a pair; testing one is sufficient.
+          _ACR_USERNAME: ${{ secrets.acr_username || secrets.ACR_USERNAME }}
+        run: |
+          if [ -n "$_ACR_USERNAME" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log in to ACR for base-image pulls — non-push mode
+        id: acr-pr-login
+        if: inputs.push == false && steps.check-acr-token.outputs.available == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.params.outputs.registry }}
+          username: ${{ secrets.acr_username || secrets.ACR_USERNAME }}
+          password: ${{ secrets.acr_password || secrets.ACR_PASSWORD }}
+
+      - name: Fail loudly if ACR login didn't succeed — non-push mode
+        # Fires when EITHER (a) the read-only token wasn't available so the
+        # login step was skipped, OR (b) the login step ran and failed.
+        # Either way, proceeding silently would let the build pull base
+        # images from MCR — exactly what 71c9d37 did, undetected for 5 days.
+        if: inputs.push == false && steps.acr-pr-login.outcome != 'success'
+        env:
+          ACR_SHORT_NAME: ${{ steps.params.outputs.registry_name }}
+        run: |
+          echo "::error::Non-push base-image pulls require the ACR_USERNAME / ACR_PASSWORD repo secrets."
+          echo "::error::Without them, non-push builds and main deploys exercise different container"
+          echo "::error::registries, and main-only regressions (like 71c9d37) slip through review."
+          echo "::error::Setup (run against the subscription that owns $ACR_SHORT_NAME):"
+          echo "::error::  1. az acr scope-map create --registry $ACR_SHORT_NAME --name cho-ci-dotnet-pull --repository dotnet/sdk content/read --repository dotnet/aspnet content/read"
+          echo "::error::  2. az acr token create --registry $ACR_SHORT_NAME --name cho-ci-readonly --scope-map cho-ci-dotnet-pull"
+          echo "::error::     (this command prints credentials.passwords[0].value once — capture it)"
+          echo "::error::  3. If you missed step 2's output, rotate with: az acr token credential generate --registry $ACR_SHORT_NAME --name cho-ci-readonly --password1"
+          echo "::error::  4. Save username 'cho-ci-readonly' as repo secret ACR_USERNAME"
+          echo "::error::  5. Save password1 value as repo secret ACR_PASSWORD"
+          echo "::error::See docs/security/SECRETS-INVENTORY.md for the rationale."
+          exit 1
+
+      # ───────────────────────────────────────────────────────────────────
+      # Buildx + the actual build. Both modes (push:true, push:false) share
+      # this final stage; the only differences are the `push` parameter and
+      # the cache-to gating.
+      # ───────────────────────────────────────────────────────────────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and ${{ inputs.push && 'push' || 'check' }} ${{ inputs.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ steps.params.outputs.build_context }}
+          # The Dockerfile ALWAYS lives at src/services/<service>/Dockerfile,
+          # even when build_context points to repo root. This is a CHO
+          # convention — the Dockerfile and the service code live together;
+          # the context just controls how much of the tree the build sees.
+          file: ./src/services/${{ inputs.service }}/Dockerfile
+          push: ${{ inputs.push }}
+          tags: ${{ steps.params.outputs.tags }}
+          # Pass REGISTRY as a build-arg so service Dockerfiles' `FROM
+          # ${REGISTRY}/dotnet/...` lines resolve to the ACR mirror that
+          # the deploy workflow's ensure-base-images job pre-populates.
+          # See header item 2 — this is intentionally stricter than today's
+          # deploy-azure-aks.yml (which relies on per-Dockerfile ARG
+          # defaults). Setting it here means a future Dockerfile that forgot
+          # to default ARG REGISTRY can't silently fall through to MCR.
+          build-args: |
+            REGISTRY=${{ steps.params.outputs.registry }}
+          # cache-from is always read-only — both push and non-push builds
+          # benefit from warm cache.
+          cache-from: type=gha
+          # cache-to (write) is gated on push: true. Non-push builds skip
+          # cache writes to avoid polluting the cache namespace shared with
+          # main builds. See header item 3.
+          cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+          # All CHO services target linux/amd64. Multi-arch is not in scope.
+          platforms: linux/amd64


### PR DESCRIPTION
## Summary

First of three sequential workflow-consolidation PRs (δ-series). Adds a single new file `.github/workflows/_build-service-image.yml` that **nothing yet calls** — zero behavior change in production CI.

**Predecessors:** PRs #689 / #690 (production-deploy gap fix). The δ planning conversation reframed C3b's original \"expand docker-build.yml\" framing after discovering deploy-azure-aks.yml is the actual production builder, surfacing the architectural debt this δ-series resolves.

**The three-PR phasing:**

| PR | Scope | Behavior change |
| --- | --- | --- |
| **δ1 (this PR)** | Create reusable workflow file. Don't modify either existing workflow. | None — file is `workflow_call`-only, no caller exists yet. |
| **δ2** | Refactor `deploy-azure-aks.yml`'s `build-push-services` job to call the reusable workflow. Production deploy now flows through it. Preserve `max-parallel: 4`. | Production deploy mechanics change but matrix and triggers stay the same. |
| **δ3** | Replace `docker-build.yml` with `pr-validation.yml`. Path-aware matrix. PR validation flows through the reusable workflow. | PR feedback changes user-visibly. PR builds stop writing GHA cache (read-only). |

## Why δ1 is small and safe

The new file declares **only** `workflow_call` and `workflow_dispatch` triggers — no `on: push` or `on: pull_request`. Until δ2 wires it into deploy-azure-aks.yml, production CI doesn't invoke it. The PR's risk surface is limited to:

1. The new file's YAML must be syntactically valid (already validated locally via `python3 -c \"import yaml; yaml.safe_load(...)\"` — passes)
2. Future callers (δ2, δ3) must invoke it correctly — out of scope for this PR

## Inputs and secrets

### Inputs (declared identically under both `workflow_call` and `workflow_dispatch`)

| Input | Type | Required | Default | Purpose |
| --- | --- | --- | --- | --- |
| \`service\` | string | yes | — | Service directory name under \`src/services/\` |
| \`build_context\` | string | no | \`\"\"\` (resolves to \`./src/services/<service>\`) | Override to \`.\` for repo-root context |
| \`image_name\` | string | no | \`\"\"\` (resolves to \`\${image_prefix}-\${service}\`) | FULL name when overridden — no double-prefixing |
| \`push\` | boolean | no | \`false\` | \`true\` = production deploy mode (OIDC + push) |
| \`registry\` | string | no | \`\"\"\` (3-tier fallback) | ACR login server |
| \`registry_name\` | string | no | \`\"\"\` (3-tier fallback) | ACR short name for \`az acr login\` |
| \`image_prefix\` | string | no | \`cloudhealthoffice\` | Default-name prefix |
| \`tag_sha\` | boolean | no | \`true\` | Adds \`:sha-<sha>\` |
| \`tag_latest\` | boolean | no | \`true\` | Adds \`:latest\` |

### Secrets (workflow_call only; all optional)

| Secret | Required when | Purpose |
| --- | --- | --- |
| \`azure_client_id\` / \`azure_tenant_id\` / \`azure_subscription_id\` | \`push: true\` | OIDC federated identity for \`azure/login@v2\` + \`az acr login\` |
| \`acr_username\` / \`acr_password\` | \`push: false\` | Read-only ACR scope-mapped token for base-image pulls |

For `workflow_dispatch` mode, secrets are read directly from the repo's secret store via the `secrets.acr_username || secrets.ACR_USERNAME` fallback pattern in step expressions.

## Three explicit ratifications (from plan phase)

### 1. Three-tier registry fallback resolved in `steps`, not `default:`

`vars.*` is not resolvable at the `on.workflow_call.inputs.<name>.default` level. The 3-tier chain runs in the `Resolve effective build parameters` step:

```
inputs.registry || vars.ACR_LOGIN_SERVER || 'choacrhy6h2vdulfru6.azurecr.io'
```

The hardcoded literal is intentionally load-bearing — it's the third-tier fallback if both input and var are absent on a future caller.

### 2. Branch cut from `main` (post-#690)

Branch `ci/reusable-build-service-image-d1` cut from current `main`. δ2 cuts from main after δ1 merges. δ3 cuts from main after δ2 merges. Sequential PRs, sequential bases.

### 3. Thread `build-args: REGISTRY=<effective>` through

Today's deploy-aks does NOT pass this build-arg — it works only because every CHO service Dockerfile defaults `ARG REGISTRY=<acr-url>`. That's fragile: a future Dockerfile copying the upstream MCR-default pattern would build green via docker-build.yml (which DOES set this build-arg) and fail red on main deploy — exactly the 71c9d37 incident class. Threading the build-arg through the reusable workflow eliminates that drift class.

This is the one place δ1 deliberately deviates from strict deploy-aks fidelity. Inline file comments explain the rationale.

## Action versions (faithful extraction; no upgrades)

| Action | Pinned to |
| --- | --- |
| \`actions/checkout\` | \`@v4\` |
| \`docker/setup-buildx-action\` | \`@v3\` |
| \`azure/login\` | \`@v2\` |
| \`docker/build-push-action\` | \`@v6\` |
| \`docker/login-action\` | \`@v3\` |

Matches what both `docker-build.yml` and `deploy-azure-aks.yml` already use today. δ1 is faithful extraction, not opportunistic upgrade.

## Manual test plan

**GitHub Actions limitation surfaced during execution:** `workflow_dispatch` cannot fire on a non-default branch until the workflow file exists on the default branch. `gh workflow run --ref ci/reusable-build-service-image-d1 ...` returns `HTTP 404: workflow _build-service-image.yml not found on the default branch`.

This is a fundamental GitHub Actions constraint for first-time workflow files; not a defect in this PR. Two manual tests will run **post-merge** from `main`:

```
gh workflow run _build-service-image.yml --ref main \
  -f service=CHO.TerminologyService \
  -f image_name=cloudhealthoffice-terminology-service \
  -f build_context=. \
  -f push=false
```
(Test 1 — image_name override + custom build_context)

```
gh workflow run _build-service-image.yml --ref main \
  -f service=appeals-service \
  -f build_context=. \
  -f push=false
```
(Test 2 — default naming, default-context-from-service)

Both tests use `push: false`, exercise the ACR-read-credentials path, and confirm that the build succeeds without ACR write access.

`push: true` validation is deferred to δ2 — that PR's deploy-aks refactor exercises the push path against real production tags as a side effect of refactoring the production build job.

## Adjacent drift noticed (not fixed in δ1; informs δ2/δ3 scope)

Found while reading both existing workflows:

1. **Tag-strategy divergence:** `docker-build.yml` uses `docker/metadata-action@v5` (rich tag set: branch, pr, sha, latest). `deploy-aks.yml` hardcodes `:latest` + `:sha-<sha>`. δ1 follows the simpler hardcoded approach via `tag_sha`/`tag_latest` boolean inputs. δ3 may revisit metadata-action when wiring PR validation, or add it caller-side without re-touching the reusable workflow.

2. **Build-context default mismatch:** `docker-build.yml` defaults to `'.'`; `deploy-aks.yml` defaults to `./src/services/<svc>` but every entry overrides to `'.'`. δ1 follows the deploy-aks default; in practice every caller will override to `'.'`.

3. **`docker-build.yml` matrix is stale:** 18 services vs deploy-aks's 33. Missing: premium-billing-service, appeals-service, rfai-service, fhir-service, smart-auth-service, risk-adjustment-service, encounter-service, provider-contracts-service, ar-service, claims-examiner-service, CHO.TerminologyService, CloudHealthOffice.PricingApi, accumulator-service, capitation-service, encounter-submission-service, member-document-service, personal-representative-service. **δ3 fixes this** via path-aware pr-validation.yml.

4. **Hardcoded `'choacrhy6h2vdulfru6.azurecr.io'` fallback:** appears 6× in docker-build.yml (lines 28, 85, 122, 188, 225, 291), absent from deploy-aks. After δ3 replaces docker-build.yml, the literal copies disappear with the file. The reusable workflow keeps it as third-tier fallback (intentional load-bearing — see ratification 1).

5. **`build-push-acr` job in deploy-aks** still builds portal+site (not service images). Not in scope for this service-images-only reusable workflow. δ2 leaves it untouched.

6. **Cache contention behavior change for δ3:** `docker-build.yml` writes GHA cache on PRs today (`cache-to: type=gha,mode=max`). The reusable workflow gates `cache-to` on `push: true`, so when δ3 routes PR validation through here, PR builds stop writing cache. PR builds still benefit from `cache-from: type=gha`. Mention in δ3's PR body so reviewers know why PR cache behavior shifts — this is the right architectural posture (PR builds shouldn't pollute the cache namespace shared with main builds).

7. **`max-parallel: 4` on deploy-aks `build-push-services`:** caller-side concern; reusable workflow can't enforce it. δ2 must explicitly preserve `max-parallel: 4` when refactoring its calling matrix. δ3 sets its own appropriate limit.

8. **`docker-build.yml` lines 525-541 hardcoded summary list:** already stale relative to its own matrix. Disappears with the file in δ3.

9. **`docker-build.yml` lines 61-67 dead-code `build_context: '.'` overrides** for two services (provider-verification-service, claims-scrubbing-service): legacy artifacts. Disappears with the file in δ3.

## Out-of-scope self-check

Confirmed zero edits to:
- \`docker-build.yml\`
- \`deploy-azure-aks.yml\` (any job)
- \`RELEASE-v4.0.0.md\`
- \`KNOWN-GAPS.md\`
- Any other workflow file
- Any service Dockerfile
- Any Helm chart, k8s manifest, or ACA bicep/ARM file

## Test plan

- [x] YAML syntax validated locally (`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/_build-service-image.yml'))\"` → OK)
- [x] `git diff --stat origin/main..HEAD` shows exactly 1 file added, 0 modified (398 insertions(+))
- [x] No edits to `docker-build.yml` or `deploy-azure-aks.yml`
- [x] Both `workflow_call` and `workflow_dispatch` triggers declared with input schema duplicated
- [x] `build-args: REGISTRY=<effective>` threading present and documented inline (per ratification 3)
- [x] Three-tier registry fallback resolved in steps expression (per ratification 1)
- [x] ACR-read-credentials three-step pattern preserved for `push: false` mode (faithful extraction of docker-build.yml lines 92-135)
- [ ] Post-merge: Run Test 1 (`CHO.TerminologyService` with `image_name` override) from `main` — document workflow run URL and result
- [ ] Post-merge: Run Test 2 (`appeals-service` with default naming) from `main` — document workflow run URL and result

🤖 Generated with [Claude Code](https://claude.com/claude-code)