### PR TITLE
ci: refactor deploy-azure-aks.yml build-push-services to call reusable workflow (delta-2)

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -137,7 +137,6 @@ jobs:
 
   build-push-services:
     name: Build & Push Services (${{ matrix.service }})
-    runs-on: ubuntu-latest
     needs: ensure-base-images
     permissions:
       id-token: write
@@ -146,6 +145,11 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
+        # All 33 .NET services need repo root as context (build_context: '.')
+        # to reach src/services/shared/CloudHealthOffice.Infrastructure/
+        # and/or src/engines/. Passed inline via the with: block below
+        # for every entry — replaces the per-entry include: overrides
+        # that previously carried the same value 33 times.
         service:
           - member-service
           - coverage-service
@@ -181,105 +185,24 @@ jobs:
           - member-document-service
           - personal-representative-service
         include:
-          # All .NET services need repo root as context to reach
-          # src/services/shared/CloudHealthOffice.Infrastructure/ and/or src/engines/.
-          - service: claims-scrubbing-service
-            build_context: '.'
-          - service: member-service
-            build_context: '.'
-          - service: coverage-service
-            build_context: '.'
-          - service: claims-service
-            build_context: '.'
-          - service: eligibility-service
-            build_context: '.'
-          - service: authorization-service
-            build_context: '.'
-          - service: attachment-service
-            build_context: '.'
-          - service: benefit-plan-service
-            build_context: '.'
-          - service: enrollment-import-service
-            build_context: '.'
-          - service: tenant-service
-            build_context: '.'
-          - service: provider-service
-            build_context: '.'
-          - service: sponsor-service
-            build_context: '.'
-          - service: trading-partner-service
-            build_context: '.'
-          - service: reference-data-service
-            build_context: '.'
-          - service: premium-billing-service
-            build_context: '.'
-          - service: appeals-service
-            build_context: '.'
-          - service: rfai-service
-            build_context: '.'
-          - service: payment-service
-            build_context: '.'
-          - service: fhir-service
-            build_context: '.'
-          - service: smart-auth-service
-            build_context: '.'
-          - service: risk-adjustment-service
-            build_context: '.'
-          - service: encounter-service
-            build_context: '.'
-          - service: provider-contracts-service
-            build_context: '.'
-          - service: ar-service
-            build_context: '.'
-          - service: claims-examiner-service
-            build_context: '.'
+          # Image name overrides for the two PascalCase services. Repo
+          # convention treats the override value verbatim — no double
+          # prefixing. All other services fall through to the reusable
+          # workflow's default ${image_prefix}-${service} naming.
           - service: CHO.TerminologyService
-            build_context: '.'
             image_name: cloudhealthoffice-terminology-service
           - service: CloudHealthOffice.PricingApi
-            build_context: '.'
             image_name: cloudhealthoffice-pricing-api
-          - service: consent-service
-            build_context: '.'
-          - service: accumulator-service
-            build_context: '.'
-          - service: capitation-service
-            build_context: '.'
-          - service: encounter-submission-service
-            build_context: '.'
-          - service: member-document-service
-            build_context: '.'
-          - service: personal-representative-service
-            build_context: '.'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Azure Login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Login to ACR
-        run: az acr login --name ${{ vars.ACR_NAME }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push ${{ matrix.service }}
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.build_context || format('./src/services/{0}', matrix.service) }}
-          file: ./src/services/${{ matrix.service }}/Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ matrix.image_name || format('{0}-{1}', env.IMAGE_PREFIX, matrix.service) }}:latest
-            ${{ env.REGISTRY }}/${{ matrix.image_name || format('{0}-{1}', env.IMAGE_PREFIX, matrix.service) }}:sha-${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
+    uses: ./.github/workflows/_build-service-image.yml
+    with:
+      service: ${{ matrix.service }}
+      build_context: '.'
+      image_name: ${{ matrix.image_name || '' }}
+      push: true
+    secrets:
+      azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   build-push-containers:
     name: Build & Push Containers (${{ matrix.container }})

--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -199,6 +199,8 @@ jobs:
       build_context: '.'
       image_name: ${{ matrix.image_name || '' }}
       push: true
+      registry: ${{ vars.ACR_LOGIN_SERVER }}
+      registry_name: ${{ vars.ACR_NAME }}
     secrets:
       azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
       azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

Second of three sequential PRs in the δ-series workflow consolidation.

- **δ1 (#691, merged 2026-04-25):** Created `.github/workflows/_build-service-image.yml` reusable workflow.
- **δ2 (this PR):** Refactor `deploy-azure-aks.yml`'s `build-push-services` job to call `_build-service-image.yml` instead of inlining the build steps. Production deploy path for service images now flows through the reusable workflow.
- **δ3 (next):** Replace `docker-build.yml` with `pr-validation.yml` that also calls `_build-service-image.yml`.

After δ2 lands, the inline `docker/build-push-action@v6` invocation in deploy-azure-aks.yml is gone, replaced by a `uses: ./.github/workflows/_build-service-image.yml` job that calls the reusable workflow per matrix entry.

## Why δ2 is the highest-risk PR of the three

δ1 was safe because nothing called the new file. δ3 will be safe because PR-validation failures are caught pre-merge. **δ2 is different — it modifies the production deploy path itself.**

- `deploy-azure-aks.yml` runs on `push: branches: [main]`, not on PRs
- The `PROD` environment used by downstream `deploy-site` and `deploy-aks` jobs has no protection rules and no deployment branch policy (verified during PR #690)
- `workflow_dispatch` from a non-main branch would actually push to ACR and deploy to AKS

**First real validation happens post-merge on main**, same posture as #690.

## Validation strategy: first-on-main with blast-radius containment

Pre-merge validation is not viable (above). Post-merge:

- `fail-fast: false` ensures broken services don't cascade — healthy ones still push
- `max-parallel: 4` paces the rollout
- Recovery via fast follow-up PR if anything fails — **do not revert δ2** (that loses the consolidation work)

Most likely failure modes (decreasing probability):
1. Caller passing input with wrong type/case
2. Reusable workflow expecting a secret the caller didn't pass
3. Permissions misalignment between caller and reusable workflow

## What changed

The `build-push-services` job's three concerns separated cleanly:

- **Matrix definition** stays in deploy-azure-aks.yml (caller's responsibility)
- **Auth setup** (Azure OIDC + `az acr login` + Buildx) moves into the reusable workflow
- **Build invocation** (`docker/build-push-action@v6`) moves into the reusable workflow

`runs-on: ubuntu-latest` and the entire `steps:` block are replaced by `uses:`/`with:`/`secrets:`.

## Service inventory: 33 services (corrected from prompt's stale "28")

The original δ2 prompt cited "28 services" — that count was from before #690, which added 5 services (`accumulator-service`, `capitation-service`, `encounter-submission-service`, `member-document-service`, `personal-representative-service`). The actual matrix on main has **33 services**, and δ2 preserves all 33 in current order. No service is added or removed by this PR.

The two PascalCase services keep their `image_name` overrides:

- `CHO.TerminologyService` → `cloudhealthoffice-terminology-service`
- `CloudHealthOffice.PricingApi` → `cloudhealthoffice-pricing-api`

## Cleanup: 31 dead-code include entries removed

Of the 33 `include:` entries previously in the matrix, 31 carried only `build_context: '.'`. Those are pure dead code post-refactor — every matrix entry now receives `build_context: '.'` through the caller's `with:` block. The 2 `image_name`-override entries lose their redundant `build_context: '.'` line but keep the override.

## Preserved on the caller job

- `name: Build & Push Services (${{ matrix.service }})`
- `needs: ensure-base-images`
- `permissions: id-token: write` + `contents: read`
- `strategy: fail-fast: false` + `max-parallel: 4`
- All 33 service names in current order

## Adjacent drift noticed (deferred from δ2)

While editing the file, four items surfaced — all out of scope for δ2:

1. **`build-push-containers` mirrors the same inline pattern.** Future sibling `_build-container-image.yml` work; different path convention (`containers/<name>/Dockerfile`), no shared-lib COPY pattern.
2. **`build-push-acr` (portal + site) also mirrors the same inline pattern.** Same potential consolidation target; different path conventions.
3. **Header comment on `build-push-services`** ("Build all images and push to ACR" at line 88 pre-δ2) is generic — applies to all three build jobs. Tolerable; not worth fixing in δ2.
4. **`include:` block ordering didn't match `service:` list ordering** pre-δ2. YAML matrix matches by key; ordering didn't affect execution. Now moot — the `include:` block is reduced to 2 entries.

(1) and (2) are genuine future-work breadcrumbs for whoever extends the δ-series. (3) and (4) are micro-cosmetic.

## δ1 post-merge manual tests (deferred from #691, run after δ2 ships)

GitHub Actions blocked workflow_dispatch from non-default branches for new workflow files until #691 merged. Now `_build-service-image.yml` exists on main, so the dispatch tests can run:

```
gh workflow run _build-service-image.yml --ref main \
  -f service=CHO.TerminologyService \
  -f image_name=cloudhealthoffice-terminology-service \
  -f build_context=. -f push=false

gh workflow run _build-service-image.yml --ref main \
  -f service=appeals-service \
  -f build_context=. -f push=false
```

Both should pass `push: false` smoke tests against main.

## Test plan

- [ ] YAML validates (no Actions parse errors) — verified locally with `python3 -c 'import yaml; yaml.safe_load(...)'`
- [ ] `git diff --stat main...HEAD` shows exactly 1 file modified
- [ ] Reusable workflow file (`_build-service-image.yml`) NOT modified
- [ ] `build-push-containers` job NOT modified
- [ ] `ensure-base-images` job NOT modified
- [ ] `build-push-acr` job NOT modified
- [ ] `deploy-site` and `deploy-aks` jobs NOT modified
- [ ] Matrix has same 33 service entries as before in same order
- [ ] Both `image_name` overrides preserved (CHO.TerminologyService, CloudHealthOffice.PricingApi)
- [ ] **First-on-main validation:** all 33 service builds pass in the first deploy-azure-aks.yml run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)