### PR TITLE
ci: replace docker-build.yml service builds with pr-validation.yml (delta-3)

### DIFF
--- a/.github/paths-filter.yml
+++ b/.github/paths-filter.yml
@@ -32,7 +32,10 @@
 # a δ3 concern.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# ── Per-service filters (alphabetical, case-insensitive) ────────────────────
+# ── Per-service filters (alphabetical) ──────────────────────────────────────
+# Filter NAMES match dorny output names verbatim and are case-sensitive;
+# the two PascalCase entries (CHO.TerminologyService, CloudHealthOffice.PricingApi)
+# sort against the rest by lowercase order purely for human readability.
 accumulator-service:           ['src/services/accumulator-service/**']
 appeals-service:               ['src/services/appeals-service/**']
 ar-service:                    ['src/services/ar-service/**']

--- a/.github/paths-filter.yml
+++ b/.github/paths-filter.yml
@@ -1,0 +1,102 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# dorny/paths-filter configuration consumed by .github/workflows/pr-validation.yml.
+#
+# Two filter classes live here:
+#
+#   1. Per-service filters — one entry per CHO microservice with a Dockerfile.
+#      A PR that touches files under the service's directory triggers the
+#      reusable build workflow for THAT service only. The filter name MUST
+#      match the on-disk service directory name and the matrix entry name
+#      that pr-validation.yml emits, since the same string is fed back as
+#      the `service:` input to _build-service-image.yml.
+#
+#   2. Meta filters — shared-libs / engines / build-config / workflows.
+#      Any one of these matching means "the change could affect every
+#      service's build," so pr-validation.yml's detect-changes job promotes
+#      to the full-matrix (validate-all) branch instead of the per-service
+#      branch. This eliminates a class of false negatives where a shared
+#      lib change builds clean against one service but breaks another.
+#
+# Intentionally excluded:
+#
+#   * ffs-service — has no Dockerfile (see docs/deployment/KNOWN-GAPS.md).
+#     The directory exists with a csproj but the service is not yet
+#     containerized, so a "build" filter would never have a matching
+#     Dockerfile to invoke.
+#
+# Service set: 35 services = 33 currently in deploy-azure-aks.yml's matrix
+# plus idcard-service and provider-verification-service (both already
+# PR-validated by docker-build.yml today; preserved here so δ3 doesn't
+# regress existing coverage). Both services have a separate doc-gap on
+# main: they build but don't deploy. That's a pre-existing condition, not
+# a δ3 concern.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Per-service filters (alphabetical, case-insensitive) ────────────────────
+accumulator-service:           ['src/services/accumulator-service/**']
+appeals-service:               ['src/services/appeals-service/**']
+ar-service:                    ['src/services/ar-service/**']
+attachment-service:            ['src/services/attachment-service/**']
+authorization-service:         ['src/services/authorization-service/**']
+benefit-plan-service:          ['src/services/benefit-plan-service/**']
+capitation-service:            ['src/services/capitation-service/**']
+CHO.TerminologyService:        ['src/services/CHO.TerminologyService/**']
+claims-examiner-service:       ['src/services/claims-examiner-service/**']
+claims-scrubbing-service:      ['src/services/claims-scrubbing-service/**']
+claims-service:                ['src/services/claims-service/**']
+CloudHealthOffice.PricingApi:  ['src/services/CloudHealthOffice.PricingApi/**']
+consent-service:               ['src/services/consent-service/**']
+coverage-service:              ['src/services/coverage-service/**']
+eligibility-service:           ['src/services/eligibility-service/**']
+encounter-service:             ['src/services/encounter-service/**']
+encounter-submission-service:  ['src/services/encounter-submission-service/**']
+enrollment-import-service:     ['src/services/enrollment-import-service/**']
+fhir-service:                  ['src/services/fhir-service/**']
+idcard-service:                ['src/services/idcard-service/**']
+member-document-service:       ['src/services/member-document-service/**']
+member-service:                ['src/services/member-service/**']
+payment-service:               ['src/services/payment-service/**']
+personal-representative-service: ['src/services/personal-representative-service/**']
+premium-billing-service:       ['src/services/premium-billing-service/**']
+provider-contracts-service:    ['src/services/provider-contracts-service/**']
+provider-service:              ['src/services/provider-service/**']
+provider-verification-service: ['src/services/provider-verification-service/**']
+reference-data-service:        ['src/services/reference-data-service/**']
+rfai-service:                  ['src/services/rfai-service/**']
+risk-adjustment-service:       ['src/services/risk-adjustment-service/**']
+smart-auth-service:            ['src/services/smart-auth-service/**']
+sponsor-service:               ['src/services/sponsor-service/**']
+tenant-service:                ['src/services/tenant-service/**']
+trading-partner-service:       ['src/services/trading-partner-service/**']
+
+# ── Meta filters (any match → validate ALL services) ────────────────────────
+# shared-libs: src/services/shared/ contains CloudHealthOffice.Infrastructure,
+# CloudHealthOffice.Events, CloudHealthOffice.Appeals.Contracts — every
+# service's Dockerfile COPYs from here, so any change can break every build.
+shared-libs:
+  - 'src/services/shared/**'
+
+# engines: src/engines/ contains BenefitEngine, ClaimsScrubEngine, CobEngine,
+# EncounterEngine, FeeScheduleEngine, NcciEngine, PriorAuthRuleEngine,
+# ProviderEnrollmentService, ProviderVerificationEngine, RiskAdjustmentEngine,
+# DocumentStore, OperatingMode. Several services COPY from here and the
+# coupling isn't easy to enumerate per-service, so any engine change fans
+# out to all builds.
+engines:
+  - 'src/engines/**'
+
+# build-config: root-level MSBuild artifacts that affect every project's
+# compilation. Today this is just the solution file (no Directory.Build.props
+# at root yet); add Directory.Build.props / Directory.Build.targets here if
+# they are introduced later.
+build-config:
+  - 'cloudhealthoffice-main.sln'
+
+# workflows: self-edits to the CI workflow files that drive PR validation.
+# Including this file in its own filter means any path-filter config change
+# triggers a full-matrix run on the same PR — config errors surface
+# immediately instead of going green here and breaking on a future PR.
+workflows:
+  - '.github/workflows/_build-service-image.yml'
+  - '.github/workflows/pr-validation.yml'
+  - '.github/paths-filter.yml'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -382,4 +382,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
-

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,11 +1,19 @@
-name: Build and Push Docker Images
+name: Build Portal / Site / Utility Containers
+
+# Service-image builds moved out of this workflow as part of the δ-series
+# consolidation (PRs #691, #692, and the δ3 PR introducing pr-validation.yml).
+# Production service builds run via deploy-azure-aks.yml; PR validation runs
+# via pr-validation.yml. This workflow now covers only the non-service
+# concerns: the Blazor portal, the static marketing site, and the utility
+# containers under containers/. The service trigger path 'src/services/**'
+# is intentionally absent below; service-only changes should NOT spin this
+# workflow up.
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'src/services/**'
       - 'src/portal/**'
       - 'src/site/**'
       - 'containers/**'
@@ -14,10 +22,10 @@ on:
     branches:
       - main
     paths:
-      - 'src/services/**'
       - 'src/portal/**'
       - 'src/site/**'
       - 'containers/**'
+      - '.github/workflows/docker-build.yml'
   workflow_dispatch:
 
 concurrency:
@@ -29,138 +37,6 @@ env:
   IMAGE_PREFIX: cloudhealthoffice
 
 jobs:
-  build-services:
-    name: Build Microservices
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-
-    strategy:
-      fail-fast: false  # Build all services to see all errors
-      matrix:
-        service:
-          - member-service
-          - coverage-service
-          - claims-service
-          - eligibility-service
-          - authorization-service
-          - attachment-service
-          - provider-service
-          - reference-data-service
-          - sponsor-service
-          - claims-scrubbing-service
-          - enrollment-import-service
-          - trading-partner-service
-          - tenant-service
-          - benefit-plan-service
-          - payment-service
-          - provider-verification-service
-          - idcard-service
-          - consent-service
-        include:
-          # provider-verification-service references engine project outside src/services/
-          - service: provider-verification-service
-            build_context: '.'
-          # claims-scrubbing-service is now .NET — needs repo root for shared lib
-          - service: claims-scrubbing-service
-            build_context: '.'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Azure Login (OIDC)
-        if: github.event_name != 'pull_request'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Log in to Azure Container Registry
-        if: github.event_name != 'pull_request'
-        run: az acr login --name ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
-
-      # PR builds cannot use OIDC (no push), but still need ACR access to pull
-      # mirrored .NET base images. Check first whether the read-only ACR token
-      # (ACR_USERNAME / ACR_PASSWORD secrets) is configured so that fork PRs,
-      # where repository secrets are unavailable, truly skip the login rather
-      # than triggering a noisy failed attempt.
-      - name: Check ACR token available
-        id: check-acr-token
-        if: github.event_name == 'pull_request'
-        env:
-          _ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
-        run: |
-          if [ -n "$_ACR_USERNAME" ]; then
-            echo "available=true" >> $GITHUB_OUTPUT
-          else
-            echo "available=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Log in to ACR for PR base-image pulls
-        id: acr-pr-login
-        if: github.event_name == 'pull_request' && steps.check-acr-token.outputs.available == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
-
-      # PR builds must exercise the same ACR path that main deploys do.
-      # The old silent MCR fallback hid commit 71c9d37 for 5 days: PR checks
-      # pulled .NET base images directly from MCR while main deploys tried to
-      # pull from an unpopulated ACR mirror and failed. Fail loudly here
-      # rather than let PR builds and main deploys exercise different
-      # registries — PR-green/main-red regressions must be impossible.
-      - name: Fail if ACR login didn't succeed on PR
-        if: github.event_name == 'pull_request' && steps.acr-pr-login.outcome != 'success'
-        env:
-          ACR_SHORT_NAME: ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
-        run: |
-          echo "::error::PR base-image pulls require the ACR_USERNAME / ACR_PASSWORD repo secrets."
-          echo "::error::Without them, PR builds and main deploys exercise different container"
-          echo "::error::registries, and main-only regressions (like 71c9d37) slip through PR review."
-          echo "::error::Setup (run against the subscription that owns $ACR_SHORT_NAME):"
-          echo "::error::  1. az acr scope-map create --registry $ACR_SHORT_NAME --name cho-ci-dotnet-pull --repository dotnet/sdk content/read --repository dotnet/aspnet content/read"
-          echo "::error::  2. az acr token create --registry $ACR_SHORT_NAME --name cho-ci-readonly --scope-map cho-ci-dotnet-pull"
-          echo "::error::     (this command prints credentials.passwords[0].value once — capture it)"
-          echo "::error::  3. If you missed step 2's output, rotate with: az acr token credential generate --registry $ACR_SHORT_NAME --name cho-ci-readonly --password1"
-          echo "::error::  4. Save username 'cho-ci-readonly' as repo secret ACR_USERNAME"
-          echo "::error::  5. Save password1 value as repo secret ACR_PASSWORD"
-          echo "::error::See docs/security/SECRETS-INVENTORY.md for the rationale."
-          exit 1
-
-      - name: Set effective base-image registry
-        run: echo "BUILD_REGISTRY=${{ env.REGISTRY }}" >> $GITHUB_ENV
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}-${{ matrix.service }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.build_context || '.' }}
-          file: ./src/services/${{ matrix.service }}/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: REGISTRY=${{ env.BUILD_REGISTRY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-
   build-portal:
     name: Build Blazor Portal
     runs-on: ubuntu-latest
@@ -507,51 +383,3 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
-  summary:
-    name: Build Summary
-    runs-on: ubuntu-latest
-    needs: [build-services, build-portal, build-site, deploy-site, build-containers]
-    if: always()
-
-    steps:
-      - name: Check build results
-        run: |
-          echo "## Docker Image Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ **All images built successfully**" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Images pushed to: \`${{ env.REGISTRY }}/cloudhealthoffice-*\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Services Built:" >> $GITHUB_STEP_SUMMARY
-          echo "- member-service" >> $GITHUB_STEP_SUMMARY
-          echo "- coverage-service" >> $GITHUB_STEP_SUMMARY
-          echo "- claims-service" >> $GITHUB_STEP_SUMMARY
-          echo "- eligibility-service" >> $GITHUB_STEP_SUMMARY
-          echo "- authorization-service" >> $GITHUB_STEP_SUMMARY
-          echo "- provider-service" >> $GITHUB_STEP_SUMMARY
-          echo "- benefit-plan-service" >> $GITHUB_STEP_SUMMARY
-          echo "- reference-data-service" >> $GITHUB_STEP_SUMMARY
-          echo "- sponsor-service" >> $GITHUB_STEP_SUMMARY
-          echo "- claims-scrubbing-service" >> $GITHUB_STEP_SUMMARY
-          echo "- tenant-service" >> $GITHUB_STEP_SUMMARY
-          echo "- enrollment-import-service" >> $GITHUB_STEP_SUMMARY
-          echo "- provider-verification-service" >> $GITHUB_STEP_SUMMARY
-          echo "- portal (Blazor)" >> $GITHUB_STEP_SUMMARY
-          echo "- site (Static)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Utility Containers Built:" >> $GITHUB_STEP_SUMMARY
-          echo "- x12-parser (837 claims parsing)" >> $GITHUB_STEP_SUMMARY
-          echo "- x12-276-parser (276 claim status inquiry parsing)" >> $GITHUB_STEP_SUMMARY
-          echo "- x12-834-parser (834 enrollment parsing)" >> $GITHUB_STEP_SUMMARY
-          echo "- claims-publisher (Kafka)" >> $GITHUB_STEP_SUMMARY
-          echo "- kafka-publisher" >> $GITHUB_STEP_SUMMARY
-          echo "- sftp-fetcher" >> $GITHUB_STEP_SUMMARY
-          echo "- x12-encoder" >> $GITHUB_STEP_SUMMARY
-          echo "- metadata-extractor" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Next Steps:" >> $GITHUB_STEP_SUMMARY
-          echo "1. Deploy Kafka topics: \`kubectl apply -f kafka/topics.yaml\`" >> $GITHUB_STEP_SUMMARY
-          echo "2. Deploy Argo workflows: \`kubectl apply -f argo-workflows/\`" >> $GITHUB_STEP_SUMMARY
-          echo "3. Deploy Argo Events: \`kubectl apply -f argo-events/\`" >> $GITHUB_STEP_SUMMARY
-          echo "4. Deploy services: \`kubectl apply -f services/*/k8s/\`" >> $GITHUB_STEP_SUMMARY
-          echo "5. Test 834 pipeline: Upload test-x12-834-enrollment-sample.edi to SFTP" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -93,6 +93,16 @@ concurrency:
   group: pr-validation-${{ github.ref }}
   cancel-in-progress: true
 
+# Workflow-level permissions cap the GITHUB_TOKEN scope for every job below.
+# Defaulting to read-only contents matches the CodeQL "minimal starting
+# point" recommendation. The `build` job needs id-token: write to satisfy
+# the reusable workflow's job-level permission contract (even on push:false
+# runs where OIDC is never exercised — GHA validates the caller's grant
+# against the called workflow's request statically); that's granted at the
+# job level rather than widening this default.
+permissions:
+  contents: read
+
 jobs:
   # ───────────────────────────────────────────────────────────────────────
   # detect-changes: figure out which services the PR affects and emit the
@@ -136,10 +146,19 @@ jobs:
           # Per-filter outputs are 'true' / 'false' strings. dorny exposes
           # these alongside `changes` so callers can branch without parsing
           # the array. We use them to decide selective vs validate-all.
-          SHARED_LIBS: ${{ steps.filter.outputs.shared-libs }}
-          ENGINES: ${{ steps.filter.outputs.engines }}
-          BUILD_CONFIG: ${{ steps.filter.outputs.build-config }}
-          WORKFLOWS: ${{ steps.filter.outputs.workflows }}
+          #
+          # IMPORTANT: hyphenated output names (`shared-libs`, `build-config`)
+          # MUST use bracket notation. The GHA expression parser reads
+          # `steps.filter.outputs.shared-libs` as `outputs.shared - libs`
+          # (subtraction), which evaluates to NaN/empty rather than the
+          # filter's true/false string — silently breaking the validate-all
+          # gate for those two triggers. The unhyphenated outputs (engines,
+          # workflows) are safe with dot notation but use brackets too for
+          # consistency.
+          SHARED_LIBS: ${{ steps.filter.outputs['shared-libs'] }}
+          ENGINES: ${{ steps.filter.outputs['engines'] }}
+          BUILD_CONFIG: ${{ steps.filter.outputs['build-config'] }}
+          WORKFLOWS: ${{ steps.filter.outputs['workflows'] }}
         run: |
           set -euo pipefail
 
@@ -257,6 +276,14 @@ jobs:
     name: Build ${{ matrix.service }}
     needs: detect-changes
     if: needs.detect-changes.outputs.services != '[]'
+    # The reusable workflow's job-level permissions request
+    # (contents: read, id-token: write — see _build-service-image.yml lines
+    # 191-195) must be matched by the caller, otherwise GHA rejects the
+    # workflow_call statically. id-token: write is unused at runtime when
+    # push: false (no OIDC), but the static-grant check fires regardless.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       # fail-fast: false matches the deploy-aks and docker-build conventions
       # — we want every affected service's build status visible in the same

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -136,10 +136,10 @@ jobs:
           # Per-filter outputs are 'true' / 'false' strings. dorny exposes
           # these alongside `changes` so callers can branch without parsing
           # the array. We use them to decide selective vs validate-all.
-          SHARED_LIBS:  ${{ steps.filter.outputs.shared-libs }}
-          ENGINES:      ${{ steps.filter.outputs.engines }}
+          SHARED_LIBS: ${{ steps.filter.outputs.shared-libs }}
+          ENGINES: ${{ steps.filter.outputs.engines }}
           BUILD_CONFIG: ${{ steps.filter.outputs.build-config }}
-          WORKFLOWS:    ${{ steps.filter.outputs.workflows }}
+          WORKFLOWS: ${{ steps.filter.outputs.workflows }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,298 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PR validation: builds CHO microservice container images for whichever
+# services are affected by the pull request. Replaces the build-services
+# job in docker-build.yml as part of the δ-series workflow consolidation
+# (PRs #691, #692 shipped the reusable workflow and refactored the production
+# deploy path; this is δ3, the PR-validation half).
+#
+# Two-job structure
+# ─────────────────
+#
+#   detect-changes  →  uses dorny/paths-filter to inspect which files the
+#                       PR touched, then computes the JSON service list that
+#                       drives the build matrix. Two outcomes:
+#
+#                         • Selective: only the per-service filters that
+#                           matched are built. Common case: a PR scoped to
+#                           one or two services.
+#
+#                         • Validate-all: when any META filter matched
+#                           (shared-libs, engines, build-config, workflows),
+#                           every service in the canonical 35-service list
+#                           is built. The change could affect any build, so
+#                           we don't risk a false negative.
+#
+#                       Both branches emit the SAME output shape: a JSON
+#                       array of {service, image_name?} objects, ready for
+#                       fromJSON() expansion in the downstream matrix.
+#
+#   build           →  consumes detect-changes.outputs.services as
+#                       matrix.include, calling _build-service-image.yml
+#                       once per matrix entry with push: false.
+#
+# Why a single matrix job instead of two (selective + all-services)
+# ─────────────────────────────────────────────────────────────────
+# Either pattern works. Computing the list in detect-changes keeps the
+# build job free of conditional logic — same uses:, same with:, same
+# secrets: regardless of which branch fired. The validate-all decision
+# lives in one bash heredoc instead of two parallel matrix jobs that
+# would otherwise duplicate the reusable-workflow call site.
+#
+# Why image_name lives inside the JSON, not in a static include: block
+# ────────────────────────────────────────────────────────────────────
+# GitHub Actions matrix expansion has a footgun: a static `include:`
+# entry whose key (e.g. service: CHO.TerminologyService) doesn't appear
+# in the dynamic base array CAN be promoted to a NEW matrix combination
+# rather than just adding a field to an existing one. That would build
+# CHO.TerminologyService on every PR, even ones that don't touch it.
+# Encoding image_name into the JSON itself avoids that — the override
+# only exists in the matrix when the service is already present.
+#
+# Cache-write asymmetry (push:false vs push:true)
+# ───────────────────────────────────────────────
+# _build-service-image.yml gates `cache-to: type=gha,mode=max` on
+# push:true (see header item 3 of that file). PR-validation builds
+# therefore READ the GHA cache but don't WRITE back, preventing PR
+# build artifacts from polluting the cache namespace shared with main
+# deploys. This is intentional and a behavioral departure from
+# docker-build.yml, where PR builds wrote cache (line 161 of that file).
+#
+# Tag asymmetry (tag_latest:false, tag_sha:true)
+# ──────────────────────────────────────────────
+# The reusable workflow requires AT LEAST one of tag_latest / tag_sha
+# to be true (see _build-service-image.yml line 261). Because PR builds
+# never push, the tag value is computed but never published — it only
+# satisfies the "must produce a tagged image" check. tag_latest is set
+# to false to make the asymmetry explicit (PR builds don't touch the
+# rolling :latest tag even hypothetically); tag_sha is set to true
+# because it's the cheaper, more inert option to satisfy the constraint.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: PR Validation (Service Images)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Trigger any time a PR could plausibly affect a service build.
+      # The dorny step refines the matrix from there; this list is the
+      # outer gate. Keep it broad to avoid missing legitimate triggers.
+      - 'src/services/**'
+      - 'src/engines/**'
+      - 'cloudhealthoffice-main.sln'
+      - '.github/workflows/_build-service-image.yml'
+      - '.github/workflows/pr-validation.yml'
+      - '.github/paths-filter.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Pattern matches docker-build.yml: superseding pushes on the same PR
+  # branch cancel in-flight runs so we don't pile up duplicate matrix
+  # explosions. PR refs are unique per PR, so this also keeps unrelated
+  # PRs running in parallel.
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────────
+  # detect-changes: figure out which services the PR affects and emit the
+  # build matrix as a JSON array. Output shape:
+  #
+  #   [
+  #     {"service": "appeals-service"},
+  #     {"service": "CHO.TerminologyService", "image_name": "cloudhealthoffice-terminology-service"}
+  #   ]
+  #
+  # Empty array (`[]`) when no per-service filter matched and no meta
+  # filter triggered — the build job's `if:` gate skips in that case.
+  # ───────────────────────────────────────────────────────────────────────
+  detect-changes:
+    name: Detect Affected Services
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.compute.outputs.services }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run path filter
+        id: filter
+        # v4 is the current major (the v3 line stopped at v3.0.3 in March 2023;
+        # v4.0.0/v4.0.1 followed in the same window with a Node 24 runtime
+        # upgrade). Pinned to v4.0.1 — the latest minor in the v4 line.
+        # All other actions in this repo follow the same "current major"
+        # convention (actions/checkout@v4, docker/setup-buildx-action@v3,
+        # docker/build-push-action@v6, docker/metadata-action@v5).
+        uses: dorny/paths-filter@v4.0.1
+        with:
+          filters: .github/paths-filter.yml
+
+      - name: Compute build matrix
+        id: compute
+        env:
+          # outputs.changes is a JSON array of names of all filters that
+          # matched any changed file (e.g. ["appeals-service","shared-libs"]).
+          CHANGES_JSON: ${{ steps.filter.outputs.changes }}
+          # Per-filter outputs are 'true' / 'false' strings. dorny exposes
+          # these alongside `changes` so callers can branch without parsing
+          # the array. We use them to decide selective vs validate-all.
+          SHARED_LIBS:  ${{ steps.filter.outputs.shared-libs }}
+          ENGINES:      ${{ steps.filter.outputs.engines }}
+          BUILD_CONFIG: ${{ steps.filter.outputs.build-config }}
+          WORKFLOWS:    ${{ steps.filter.outputs.workflows }}
+        run: |
+          set -euo pipefail
+
+          # The canonical 35-service list. MUST stay in sync with
+          # .github/paths-filter.yml (per-service filter names) and with
+          # deploy-azure-aks.yml's matrix (33 entries; this list adds
+          # idcard-service and provider-verification-service which are
+          # PR-validated but not yet deploy-targeted). ffs-service is
+          # intentionally absent — see paths-filter.yml header.
+          #
+          # Order doesn't matter for matrix correctness; alphabetical for
+          # readability. The two PascalCase services carry image_name
+          # overrides because the default ${image_prefix}-${service} naming
+          # would produce "cloudhealthoffice-CHO.TerminologyService" instead
+          # of the convention "cloudhealthoffice-terminology-service" that
+          # k8s manifests and ACR repositories expect.
+          FULL_LIST='[
+            {"service":"accumulator-service"},
+            {"service":"appeals-service"},
+            {"service":"ar-service"},
+            {"service":"attachment-service"},
+            {"service":"authorization-service"},
+            {"service":"benefit-plan-service"},
+            {"service":"capitation-service"},
+            {"service":"CHO.TerminologyService","image_name":"cloudhealthoffice-terminology-service"},
+            {"service":"claims-examiner-service"},
+            {"service":"claims-scrubbing-service"},
+            {"service":"claims-service"},
+            {"service":"CloudHealthOffice.PricingApi","image_name":"cloudhealthoffice-pricing-api"},
+            {"service":"consent-service"},
+            {"service":"coverage-service"},
+            {"service":"eligibility-service"},
+            {"service":"encounter-service"},
+            {"service":"encounter-submission-service"},
+            {"service":"enrollment-import-service"},
+            {"service":"fhir-service"},
+            {"service":"idcard-service"},
+            {"service":"member-document-service"},
+            {"service":"member-service"},
+            {"service":"payment-service"},
+            {"service":"personal-representative-service"},
+            {"service":"premium-billing-service"},
+            {"service":"provider-contracts-service"},
+            {"service":"provider-service"},
+            {"service":"provider-verification-service"},
+            {"service":"reference-data-service"},
+            {"service":"rfai-service"},
+            {"service":"risk-adjustment-service"},
+            {"service":"smart-auth-service"},
+            {"service":"sponsor-service"},
+            {"service":"tenant-service"},
+            {"service":"trading-partner-service"}
+          ]'
+
+          # Decide selective vs validate-all. Validate-all means a meta
+          # filter matched — the change is structurally capable of breaking
+          # any service's build, so we exercise every one of them.
+          if [ "$SHARED_LIBS" = "true" ] || \
+             [ "$ENGINES" = "true" ] || \
+             [ "$BUILD_CONFIG" = "true" ] || \
+             [ "$WORKFLOWS" = "true" ]; then
+
+            # Build a human-readable reason string for the diagnostic echo.
+            # Future debuggers reading the workflow log should be able to
+            # answer "why did this PR fan out to 35 builds?" by skimming
+            # this single line, instead of cross-referencing the dorny
+            # output table against the meta-filter names.
+            TRIGGER_REASON=""
+            [ "$SHARED_LIBS" = "true" ]  && TRIGGER_REASON="$TRIGGER_REASON shared-libs"
+            [ "$ENGINES" = "true" ]      && TRIGGER_REASON="$TRIGGER_REASON engines"
+            [ "$BUILD_CONFIG" = "true" ] && TRIGGER_REASON="$TRIGGER_REASON build-config"
+            [ "$WORKFLOWS" = "true" ]    && TRIGGER_REASON="$TRIGGER_REASON workflows"
+            echo "Validate-all triggered by:${TRIGGER_REASON}"
+
+            # Compact the heredoc JSON to a single line — GHA outputs
+            # tolerate multi-line via heredoc syntax but compact is easier
+            # to read in step logs and avoids any whitespace ambiguity
+            # when the downstream job runs fromJSON() against it.
+            RESULT=$(jq -nc --argjson v "$FULL_LIST" '$v')
+          else
+            # Selective: drop meta filter names from CHANGES_JSON, then
+            # transform each remaining entry into {service, image_name?}
+            # with the two PascalCase overrides applied. jq does this
+            # atomically so the output is always valid JSON, even when
+            # CHANGES_JSON is empty (`[]`) or contains only meta filter
+            # names that all get filtered out.
+            RESULT=$(jq -nc --argjson changes "$CHANGES_JSON" '
+              $changes
+              | map(select(. as $name
+                  | ["shared-libs","engines","build-config","workflows"]
+                  | index($name) | not))
+              | map(
+                  if . == "CHO.TerminologyService" then
+                    {service: ., image_name: "cloudhealthoffice-terminology-service"}
+                  elif . == "CloudHealthOffice.PricingApi" then
+                    {service: ., image_name: "cloudhealthoffice-pricing-api"}
+                  else
+                    {service: .}
+                  end
+                )
+            ')
+          fi
+
+          echo "Computed services: $RESULT"
+          echo "services=$RESULT" >> "$GITHUB_OUTPUT"
+
+  # ───────────────────────────────────────────────────────────────────────
+  # build: dispatch to _build-service-image.yml once per matrix entry.
+  # `matrix.include: ${{ fromJSON(...) }}` expands each JSON object as a
+  # matrix combination, with the object's keys becoming matrix variables.
+  # When detect-changes emits an empty array, the `if:` gate skips this
+  # job entirely — GHA does not run a job whose matrix expands to zero.
+  # ───────────────────────────────────────────────────────────────────────
+  build:
+    name: Build ${{ matrix.service }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.services != '[]'
+    strategy:
+      # fail-fast: false matches the deploy-aks and docker-build conventions
+      # — we want every affected service's build status visible in the same
+      # PR check, not a single-failure short-circuit.
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect-changes.outputs.services) }}
+    uses: ./.github/workflows/_build-service-image.yml
+    with:
+      service: ${{ matrix.service }}
+      # When matrix.image_name is absent (most services), pass empty string
+      # — the reusable workflow's resolve-effective-params step then falls
+      # through to ${image_prefix}-${service} naming. The two PascalCase
+      # services carry the override in their JSON entry.
+      image_name: ${{ matrix.image_name || '' }}
+      # All CHO services COPY from src/services/shared/ and several COPY
+      # from src/engines/, so build_context: '.' (repo root) is the only
+      # value that produces working builds. Matches deploy-aks.
+      build_context: '.'
+      # PR validation NEVER pushes to ACR. The reusable workflow's three-
+      # step "check / login / fail-loudly" pattern still runs — it ensures
+      # PR builds pull base images from the same ACR mirror that main
+      # deploys do, which is what catches the regression class behind
+      # incident 71c9d37 in PR review instead of on main.
+      push: false
+      # See the tag-asymmetry section in the header. tag_sha satisfies the
+      # reusable workflow's "must tag at least one of sha/latest" check.
+      # The sha tag is computed but never published in non-push mode, so
+      # PR builds neither pollute :latest nor leak per-PR sha tags.
+      tag_latest: false
+      tag_sha: true
+    secrets:
+      # PR builds need ACR read access for mirrored .NET base image pulls.
+      # AZURE_CLIENT_ID / TENANT / SUBSCRIPTION are deliberately NOT
+      # threaded — push: false means OIDC isn't exercised, and granting
+      # workload identity to PR builds would unnecessarily widen the
+      # secret surface for fork PRs.
+      acr_username: ${{ secrets.ACR_USERNAME }}
+      acr_password: ${{ secrets.ACR_PASSWORD }}


### PR DESCRIPTION
## Summary

Third and final PR in the δ-series workflow consolidation. After this lands, both production deploys (deploy-azure-aks.yml, since #692) and PR validation (pr-validation.yml, this PR) flow through `_build-service-image.yml` as the single source of truth for service container builds. The two-workflow split that motivated δ1/δ2/δ3 is resolved.

Predecessors:
- #691 (δ1): introduced `_build-service-image.yml` reusable workflow.
- #692 (δ2): refactored `deploy-azure-aks.yml`'s `build-push-services` to call the reusable workflow (33 services).

## What this PR does

**Adds `.github/paths-filter.yml`** — `dorny/paths-filter@v4.0.1` config with 35 per-service filters and 4 meta filters (`shared-libs`, `engines`, `build-config`, `workflows`).

**Adds `.github/workflows/pr-validation.yml`** — two-job workflow:
- `detect-changes` runs the path filter, then a bash step computes a JSON matrix list: selective when only per-service filters matched, full 35-service when any meta filter matched.
- `build` consumes that list as `matrix.include` via `fromJSON()` and dispatches to `_build-service-image.yml` with `push: false`, `tag_latest: false`, `tag_sha: true`.

**Edits `.github/workflows/docker-build.yml`** (Option A: surgical replacement):
- Deletes `build-services` job (now in pr-validation.yml + deploy-azure-aks.yml).
- Deletes `summary` job (referenced the deleted job in `needs:`; markdown body had drifted out of sync with the matrix anyway).
- Drops `src/services/**` from `push.paths` and `pull_request.paths` triggers.
- Renames workflow `name:` to **Build Portal / Site / Utility Containers**.

`build-portal`, `build-site`, `deploy-site`, and `build-containers` are preserved unchanged. A future consolidation conversation can address them.

## Path-aware matrix design

Two outcomes for any PR:

| Trigger | Outcome |
|---|---|
| Only `src/services/<svc>/**` changed | Selective: builds only the affected service(s). |
| Any of `src/services/shared/**`, `src/engines/**`, `cloudhealthoffice-main.sln`, or any of `_build-service-image.yml` / `pr-validation.yml` / `paths-filter.yml` changed | Validate-all: builds all 35 services. |

Examples:
- A PR touching only `src/services/appeals-service/Program.cs` → selective, builds appeals-service only.
- A PR touching `src/services/shared/CloudHealthOffice.Infrastructure/` → validate-all, builds all 35.
- A PR touching `src/engines/CloudHealthOffice.NcciEngine/` → validate-all, builds all 35.

The `detect-changes` step emits two diagnostic echoes for future debuggability:
- `Validate-all triggered by:<reason>` when meta filters fired.
- `Computed services: <json>` always, before writing the matrix output.

## Service set: 35 (vs. 33 in deploy-aks)

Matches deploy-aks's matrix plus two services that already had PR validation in `docker-build.yml` and shouldn't regress: `idcard-service` and `provider-verification-service`. `ffs-service` is excluded — no Dockerfile (see `docs/deployment/KNOWN-GAPS.md`).

The other side of that asymmetry — 2 services PR-validated but not deploy-targeted on main — is a pre-existing condition, not a δ3 concern.

## New third-party action

`dorny/paths-filter@v4.0.1` enters the repo with this PR. Active project (canonical paths-filter action in the GitHub Actions ecosystem); v4 is the current major. Pinned to a specific minor in line with the repo's "current major" convention for already-in-use actions.

## Cache-write asymmetry (PR-builds-don't-write)

`_build-service-image.yml` already gates `cache-to: type=gha,mode=max` on `push: true`. PR validation builds therefore READ the GHA cache but don't WRITE — preventing PR build artifacts from polluting the cache namespace shared with main builds. This is a behavioral change from the old docker-build.yml (which wrote cache on PRs at line 161). See `_build-service-image.yml` header item 3.

## Tag asymmetry (`tag_latest: false`, `tag_sha: true`)

The reusable workflow requires at least one of `tag_sha` / `tag_latest` to be true. Because PR builds never push, the tag is computed but never published — it only satisfies the "must produce a tagged image" check. Inline comments in `pr-validation.yml` document this for future readers.

## Pre-merge validation

This PR can only ever exercise the **validate-all** branch on its own runs, because the PR diff itself modifies workflow files (which are in the `workflows` meta filter). That's the harder path to validate in any case — if 35 services build green here, the path filter's selective branch is mechanically simpler than the validate-all branch and was dry-run validated locally with `jq` against representative `changes` JSON arrays.

The selective branch will be exercised on the first regular service-only PR opened after this merges. Reviewers can confirm by watching that PR's `Detect Affected Services` step log for the `Computed services:` line — it should show only the touched service(s).

## Adjacent drift noticed

- **`ffs-service` workflow runs**: pr-validation.yml's trigger paths include `src/services/**`, so a PR editing only `src/services/ffs-service/**` will spin up the workflow even though the build job is then skipped (no filter matches). Wasted CI minutes, but rare. Future cleanup candidate.
- **idcard / provider-verification deploy gap**: both have Dockerfiles and PR validation, but neither is in `deploy-azure-aks.yml`'s production matrix. Pre-existing on main; surfacing for awareness.
- **`docker-build.yml` slimmed but still mixes concerns**: portal, site, and utility containers don't share a reusable-workflow pattern with the service builds. A future δ-style PR could consolidate them similarly, possibly by having `_build-portal.yml` / `_build-site.yml` reusable workflows. Out of scope for δ3.

## Before requesting review

- [x] YAML validates for all three files (paths-filter.yml, pr-validation.yml, docker-build.yml)
- [x] `dorny/paths-filter@v4.0.1` is the current pinned major.minor
- [x] Image-name overrides for `CHO.TerminologyService` and `CloudHealthOffice.PricingApi` carried in JSON (avoids `include:` matrix-promotion footgun)
- [x] Validate-all triggers cover: shared-libs, engines, build-config (`cloudhealthoffice-main.sln`), workflows (self + reusable + paths-filter file)
- [x] Path filter file at `.github/paths-filter.yml`
- [x] `jq` selective-branch transform dry-run validated locally against representative inputs
- [ ] **First CI run on this PR builds all 35 services green via validate-all** (pending verification once Actions catches up)

## Test plan

- [ ] Confirm `Detect Affected Services` step emits `Validate-all triggered by: workflows` (since this PR modifies pr-validation.yml itself)
- [ ] Confirm 35 build matrix entries fan out, all green
- [ ] After merge: open a service-scoped PR (e.g., one-line edit to `src/services/appeals-service/Program.cs`) and confirm `Computed services:` log line shows only `[{"service":"appeals-service"}]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)