### PR TITLE
docs: W2.1 — README + site/index.html v2 framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CMS-0057-F compliance, real-time EDI, FHIR R4 APIs, and claims adjudication engi
 Deploy alongside your existing Core Admin Processing System (CAPS) today. Migrate workloads on your timeline.
 
 [![Version](https://img.shields.io/badge/version-v4.2.0-blue)](https://github.com/aurelianware/cloudhealthoffice/releases/tag/v4.2.0)
-[![Tests](https://img.shields.io/badge/tests-2%2C800%2B%20passing-brightgreen)](./tests/) <!-- auto-updated by test-metrics workflow -->
+[![Tests](https://img.shields.io/badge/tests-2800%20passing-brightgreen)](./tests/) <!-- auto-updated by test-metrics workflow -->
 [![Test Projects](https://img.shields.io/badge/test%20projects-44-brightgreen)](./tests/)
 [![Security](https://img.shields.io/badge/vulnerabilities-0-brightgreen)](./SECURITY.md)
 [![License](https://img.shields.io/badge/license-BSL%201.1-orange.svg)](./LICENSE)
@@ -65,7 +65,8 @@ Customers enter at any product line and expand over time. See
 |Portal Pages         |50       |Blazor Server + MudBlazor, Microsoft Entra ID (multi-tenant)                                                |
 |CI/CD Workflows      |18       |GitHub Actions — build, test, deploy, security scan                                                         |
 |Claims Scrubbing     |20+ rules|Data completeness, ICD-10/CPT format, NPI Luhn, POS, filing limits                                         |
-|Automated Tests      |~2,800 across 44 projects|C# xUnit, TypeScript Jest, Python pytest                                                  |
+|Automated Tests      |2800     |C# xUnit, TypeScript Jest, Python pytest                                                                    |
+|Test Projects        |44       |Repositories and suites covered by automated test execution                                                |
 
 ### Services
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![Cloud Health Office](docs/images/logo-cloudhealthoffice-sentinel-primary.svg)
 
-**The payer platform that starts where your core admin stops — and grows from there.**
+**A cloud-native portfolio for healthcare claims administration — from free public tools to full payer-scale platform engagement.**
 
 CMS-0057-F compliance, real-time EDI, FHIR R4 APIs, and claims adjudication engines.
 Deploy alongside your existing Core Admin Processing System (CAPS) today. Migrate workloads on your timeline.
 
 [![Version](https://img.shields.io/badge/version-v4.2.0-blue)](https://github.com/aurelianware/cloudhealthoffice/releases/tag/v4.2.0)
-[![Tests](https://img.shields.io/badge/tests-973%20passing-brightgreen)](./tests/) <!-- auto-updated by test-metrics workflow -->
-[![Coverage](https://img.shields.io/badge/coverage-85.93%25-green)](https://codecov.io/gh/aurelianware/cloudhealthoffice) <!-- auto-updated by test-metrics workflow -->
+[![Tests](https://img.shields.io/badge/tests-2%2C800%2B%20passing-brightgreen)](./tests/) <!-- auto-updated by test-metrics workflow -->
+[![Test Projects](https://img.shields.io/badge/test%20projects-44-brightgreen)](./tests/)
 [![Security](https://img.shields.io/badge/vulnerabilities-0-brightgreen)](./SECURITY.md)
 [![License](https://img.shields.io/badge/license-BSL%201.1-orange.svg)](./LICENSE)
 
@@ -26,6 +26,25 @@ Health plans face a January 2027 CMS-0057-F compliance deadline. The typical pat
 Cloud Health Office is a different approach. It deploys alongside your existing core admin system and handles the workloads that legacy platforms weren’t built for: real-time EDI routing, FHIR R4 APIs, prior authorization automation, and medical attachment workflows. Every module is designed to either augment or replace the corresponding function in your core system — you decide which workloads to migrate and when.
 
 Start with compliance. Expand into claims. Move at your own pace.
+
+## Product Lines
+
+Cloud Health Office is a portfolio of four complementary product lines —
+each a coherent offering on its own, each connecting naturally to the next:
+
+- **Public Tools** — free utilities (fee schedule lookup, free-tier claims
+  repricing) that establish credibility and seed the commercial funnel.
+- **Transactional Services** — per-call APIs (Claims Repricing API, Pricing
+  API) on self-serve subscription. Developer- and integrator-accessible.
+- **Managed Data Services** — subscription services for healthcare data that
+  changes constantly: state Medicaid compliance updates, CMS fee schedule
+  updates, provider verification, terminology mapping.
+- **Platform Engagement** — payer-scale relationships priced per member per
+  month (PMPM), across three layers: Compliance Accelerator, Progressive
+  Modernization, and Full CAPS Platform.
+
+Customers enter at any product line and expand over time. See
+[docs/POSITIONING.md](docs/POSITIONING.md) for the canonical framing.
 
 ## How It Works
 
@@ -46,8 +65,7 @@ Start with compliance. Expand into claims. Move at your own pace.
 |Portal Pages         |50       |Blazor Server + MudBlazor, Microsoft Entra ID (multi-tenant)                                                |
 |CI/CD Workflows      |18       |GitHub Actions — build, test, deploy, security scan                                                         |
 |Claims Scrubbing     |20+ rules|Data completeness, ICD-10/CPT format, NPI Luhn, POS, filing limits                                         |
-|Automated Tests      |973      |C# xUnit, TypeScript Jest, Python pytest                                                                    |
-|Lines of Code        |~204,000 |C#, TypeScript, Razor, Python, YAML, Shell, PowerShell (excludes docs)                                      |
+|Automated Tests      |~2,800 across 44 projects|C# xUnit, TypeScript Jest, Python pytest                                                  |
 
 ### Services
 
@@ -277,7 +295,7 @@ cloudhealthoffice/
 |Documentation    |150,000  |Architecture, ADRs, deployment guides, features, security, sales|
 |**Total**        |**~500,000+**|                                                             |
 
-3K+ automated tests across C# (xUnit), TypeScript (Jest), and Python (pytest).
+~2,800 automated tests across 44 test projects in C# (xUnit), TypeScript (Jest), and Python (pytest).
 Built by a solo founder with 25+ years of payer IT experience and AI-assisted development.
 
 ## Deployment Options

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -111,7 +111,7 @@
              alt="Cloud Health Office The Sentinel"
              class="hero-logo" />
 
-        <div class="hero-badge">v4.0.0 &nbsp;&middot;&nbsp; Production SaaS &nbsp;&middot;&nbsp; 2,661 Tests &nbsp;&middot;&nbsp; Zero Vulnerabilities</div>
+        <div class="hero-badge">v4.0.0 &nbsp;&middot;&nbsp; Production SaaS &nbsp;&middot;&nbsp; 2,800+ Tests &nbsp;&middot;&nbsp; Zero Vulnerabilities</div>
 
         <h1 class="hero-headline">
           CMS-0057-F Compliance<br>
@@ -150,13 +150,58 @@
       <div class="hero-scroll-hint" aria-hidden="true">&darr; SCROLL</div>
     </section>
 
+    <!-- ===== PORTFOLIO ===== -->
+    <section aria-label="Four product lines portfolio">
+      <div class="section-wrapper">
+        <div class="section-header">
+          <span class="section-eyebrow">The Portfolio</span>
+          <h2 class="section-title">Four product lines.<br><span>One platform.</span></h2>
+          <p class="section-subtitle">Cloud Health Office engages customers across four complementary product lines, each a coherent offering on its own, each connecting naturally to the next. Enter at any line and expand over time.</p>
+        </div>
+
+        <div class="feature-grid">
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#128221;</div>
+            <h3>Public Tools</h3>
+            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Free utilities. No signup.</strong></p>
+            <p>Fee schedule lookup and free-tier claims repricing. Verify the calculation engines before any commercial conversation begins.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#128640;</div>
+            <h3>Transactional Services</h3>
+            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Per-call APIs. Self-serve subscription.</strong></p>
+            <p>Claims Repricing API and Pricing API for developers, billing companies, TPAs, and integrators. Free tier flows to paid tier on usage.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#128202;</div>
+            <h3>Managed Data Services</h3>
+            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Subscription data. Recurring value.</strong></p>
+            <p>State Medicaid compliance updates, CMS fee schedule updates, provider verification, terminology mapping. Healthcare data that changes constantly &mdash; tracked for you.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#127970;</div>
+            <h3>Platform Engagement</h3>
+            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Payer-scale. Priced PMPM.</strong></p>
+            <p>Multi-year relationships priced per member per month, across three layers: Compliance Accelerator, Progressive Modernization, and Full CAPS Platform.</p>
+          </div>
+        </div>
+
+        <p style="text-align:center; margin-top:32px; font-size:0.95rem; color:rgba(176,176,176,0.7);">
+          See <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">POSITIONING.md</a> for the canonical four-product-line framing.
+        </p>
+      </div>
+    </section>
+
     <!-- ===== CHOOSE YOUR ENTRY POINT ===== -->
-    <section aria-label="Three-layer engagement model">
+    <section aria-label="Platform Engagement three-layer structure">
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow">Choose your entry point</span>
-          <h2 class="section-title">Three layers.<br><span>One platform.</span></h2>
-          <p class="section-subtitle">Cloud Health Office engages customers at three layers, each a coherent product on its own, each containing the previous. Meet us where you are &mdash; expand when you&rsquo;re ready.</p>
+          <h2 class="section-title">Three layers.<br><span>One Platform Engagement.</span></h2>
+          <p class="section-subtitle">Within Platform Engagement, Cloud Health Office engages customers at three layers, each a coherent product on its own, each containing the previous. Meet us where you are &mdash; expand when you&rsquo;re ready.</p>
         </div>
 
         <div class="feature-grid">
@@ -304,7 +349,7 @@
       <div class="ticker-track" aria-hidden="true">
         <span class="ticker-item"><span>250,000+ Repository Clones</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Zero Security Vulnerabilities</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>2,661 Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
+        <span class="ticker-item"><span>2,800+ Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>CMS-0057-F Compliant &mdash; 18 Months Early</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Production SaaS Live</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
@@ -313,7 +358,7 @@
         <!-- Repeat for seamless loop -->
         <span class="ticker-item"><span>250,000+ Repository Clones</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Zero Security Vulnerabilities</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>2,661 Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
+        <span class="ticker-item"><span>2,800+ Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>CMS-0057-F Compliant &mdash; 18 Months Early</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Production SaaS Live</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
@@ -338,8 +383,8 @@
           <span class="stat-label">Production<br>Deployment</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">2,661</span>
-          <span class="stat-label">Tests,<br>85.93% Coverage</span>
+          <span class="stat-number">2,800+</span>
+          <span class="stat-label">Tests Across<br>44 Projects</span>
         </div>
       </div>
     </section>
@@ -419,7 +464,7 @@
 
         <p style="text-align:center; font-size:1.05rem; color:rgba(176,176,176,0.8); max-width:600px; margin:0 auto 36px auto; line-height:1.7;">
           Transform X12 EDI (270/837/278/835) to FHIR R4 with zero external dependencies.<br>
-          2,661 comprehensive tests. 85.93% coverage. v4.0.0 production-ready.
+          2,800+ tests across 44 test projects. v4.0.0 production-ready.
         </p>
 
         <div style="text-align:center;">

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -111,7 +111,7 @@
              alt="Cloud Health Office The Sentinel"
              class="hero-logo" />
 
-        <div class="hero-badge">v4.0.0 &nbsp;&middot;&nbsp; Production SaaS &nbsp;&middot;&nbsp; 2,800+ Tests &nbsp;&middot;&nbsp; Zero Vulnerabilities</div>
+        <div class="hero-badge">v4.0.0 &nbsp;&middot;&nbsp; Production SaaS &nbsp;&middot;&nbsp; 2,800 Tests &nbsp;&middot;&nbsp; Zero Vulnerabilities</div>
 
         <h1 class="hero-headline">
           CMS-0057-F Compliance<br>
@@ -349,7 +349,7 @@
       <div class="ticker-track" aria-hidden="true">
         <span class="ticker-item"><span>250,000+ Repository Clones</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Zero Security Vulnerabilities</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>2,800+ Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
+        <span class="ticker-item"><span>2,800 Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>CMS-0057-F Compliant &mdash; 18 Months Early</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Production SaaS Live</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
@@ -358,7 +358,7 @@
         <!-- Repeat for seamless loop -->
         <span class="ticker-item"><span>250,000+ Repository Clones</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Zero Security Vulnerabilities</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>2,800+ Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
+        <span class="ticker-item"><span>2,800 Tests Passing</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>CMS-0057-F Compliant &mdash; 18 Months Early</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Production SaaS Live</span><span class="ticker-dot">&#9670;</span></span>
         <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
@@ -383,8 +383,8 @@
           <span class="stat-label">Production<br>Deployment</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">2,800+</span>
-          <span class="stat-label">Tests Across<br>44 Projects</span>
+          <span class="stat-number">2,800</span>
+          <span class="stat-label">Tests<br>Across 44 Projects</span>
         </div>
       </div>
     </section>
@@ -464,7 +464,7 @@
 
         <p style="text-align:center; font-size:1.05rem; color:rgba(176,176,176,0.8); max-width:600px; margin:0 auto 36px auto; line-height:1.7;">
           Transform X12 EDI (270/837/278/835) to FHIR R4 with zero external dependencies.<br>
-          2,800+ tests across 44 test projects. v4.0.0 production-ready.
+          2,800 comprehensive tests across 44 test projects. v4.0.0 production-ready.
         </p>
 
         <div style="text-align:center;">


### PR DESCRIPTION
First PR in Wave 2 — cascading the **POSITIONING.md v2** four-product-line framing (merged in P2 / #694) into the two highest-traffic entry points: `README.md` (GitHub) and `src/site/index.html` (cloudhealthoffice.com).

## Summary

- **README.md**
  - New "Product Lines" section between "Why This Exists" and "How It Works", linking to `docs/POSITIONING.md`.
  - Hero tagline reframed to portfolio breadth: *"A cloud-native portfolio for healthcare claims administration — from free public tools to full payer-scale platform engagement."*
  - Tests badge `973` → `2,800+` (Canonical Facts).
  - Coverage badge `85.93%` replaced with **Test Projects: 44** badge.
  - Platform table: Tests row `973` → `~2,800 across 44 projects`; Lines of Code row dropped (Codebase Scale table later in the README remains, providing a fuller multi-language view).
  - Prose `3K+ automated tests` → `~2,800 ... across 44 test projects`.

- **src/site/index.html**
  - New **"Portfolio"** section between hero and "Choose your entry point", with four feature-cards (Public Tools / Transactional Services / Managed Data Services / Platform Engagement) using existing `feature-grid` / `feature-card` CSS classes. Closes with link to `POSITIONING.md`.
  - Existing **Layer 1/2/3 cards preserved unchanged**. Their section title and subtitle were reframed to position the three layers as Platform Engagement's sub-structure rather than the company-wide engagement model.
  - Stale `2,661` test references replaced with `2,800+` in: hero badge, ticker (×2 for the seamless-loop repeat), stats panel, CMS-0057-F prose.
  - Coverage `85.93%` removed from stats panel and CMS-0057-F prose; replaced with structural counts (44 test projects).

## Stale claims reconciled

| Location | Before | After |
| --- | --- | --- |
| README L11 badge | `tests-973%20passing` | `tests-2,800+ passing` |
| README L12 badge | `coverage-85.93%` | dropped → `Test Projects: 44` badge |
| README Platform table | `Automated Tests \| 973` | `~2,800 across 44 projects` |
| README Platform table | `Lines of Code \| ~204,000 \| C#, TS, Razor, Python, YAML…` | dropped (Codebase Scale table at L290+ retained) |
| README L280 prose | `3K+ automated tests` | `~2,800 automated tests across 44 test projects` |
| site hero badge | `2,661 Tests` | `2,800+ Tests` |
| site ticker (×2) | `2,661 Tests Passing` | `2,800+ Tests Passing` |
| site stats panel | `2,661 / Tests, 85.93% Coverage` | `2,800+ / Tests Across 44 Projects` |
| site CMS-0057-F prose | `2,661 comprehensive tests. 85.93% coverage.` | `2,800+ tests across 44 test projects.` |

## Coverage figure decision: Option (a) — removed

The repo-wide 85.93% coverage claim cannot be reconciled with POSITIONING.md v2's honest disclosure that `claims-service`, `provider-service`, and `sponsor-service` sit at roughly 24% / 12% / 13% line coverage. No CI artifact was found that substantiates the 85.93% figure. Structural counts (44 test projects, ~2,800 test methods) are anchored to Canonical Facts and defensible under diligence.

## Preserved (no edits)

- JSON-LD structured data and all meta tags (title, description, og:*, twitter:*) in `src/site/index.html`
- Navigation, footer, hero CTAs, all images, all existing feature/case/deploy cards
- Existing **Layer 1/2/3 feature-card markup** in `src/site/index.html` (only the surrounding section eyebrow/title/subtitle reframed)
- README service inventory table, adjudication engines table, supporting projects table, provider verification, CMS-0057-F compliance table, augment/replace, operations portal, typical adoption path
- README quick start, project structure, tech stack, deployment options, documentation, who-this-is-for, channel partners, pricing, licensing, links, footer
- All POSITIONING.md Canonical Facts (canonical anchor preserved by design)

## Deferred to later PRs

- **W2.2** — `src/site/pricing.html` (Starter/Professional/Enterprise tier surgery)
- **W2.3** — `docs/sales-materials/`
- **W2.4** — `docs/fundraising/`
- **Wave 3** — site marketing pages (`cho-*-marketing.html`, `solutions-*.html`, `platform.html`, etc.)
- **Wave 4** — `src/site/docs/` technical docs
- **C4** (separate, optional) — solution file project-reference reconciliation
- **Future PR** — `MODULE-STATUS.md` / per-service maturity tagging

## Adjacent drift noticed (not fixed here)

- `README.md` L18: orphan `</div>` with no opening tag.
- `README.md` "Codebase Scale" table (~L290): Application Code row "300,000" with a sub-breakdown summing to ~140K; Total row "~500,000+" doesn't quite match the column sums.
- `src/site/index.html` references `v4.0.0` in multiple places (hero badge, hero logo alt, ticker context, JSON-LD softwareVersion) while `README.md` is on `v4.2.0`. Version cascade should be its own PR.

## Diff size

```
README.md           | 30 ++++++++++++++++++++-----
src/site/index.html | 63 +++++++++++++++++++++++++++++++++++++++++++++--------
2 files changed, 78 insertions(+), 15 deletions(-)
```

## Before requesting review

- [x] All four product lines mentioned in `README.md` (Product Lines section)
- [x] All four product lines mentioned in `src/site/index.html` (Portfolio section)
- [x] Stale test-count claims reconciled to `~2,800` / `44 test projects` (Canonical Facts)
- [x] Stale `85.93%` coverage claim removed (Option a) from all three locations
- [x] Layer 1/2/3 cards preserved verbatim in `src/site/index.html`
- [x] Service inventory, engine, and supporting-projects tables preserved verbatim in `README.md`
- [x] JSON-LD structured data and all meta tags untouched
- [x] No CSS or image changes
- [x] Both files contain a link to `docs/POSITIONING.md` (README: relative path; site: existing GitHub blob URL — both reference the v2 framing)
- [x] File diffs show only intended changes (verified via `git diff --stat`)

## Test plan

- [ ] Markdown render check on `README.md` in GitHub web UI
- [ ] Visual check on `src/site/index.html` (Portfolio section renders with same card style as Layer 1/2/3 section; sections in correct order; no layout regressions)
- [ ] Confirm `docs/POSITIONING.md` link from README resolves
- [ ] Confirm POSITIONING.md anchor link in site Portfolio section resolves


---
_Generated by [Claude Code](https://claude.ai/code/session_01SU7oMMGxKAVcrRaTZSXWXW)_