### PR TITLE
feat(benefit-plan-service): adapter pattern foundation (5.2)

### DIFF
--- a/docs/architecture/benefit-plan-adapter-pattern.md
+++ b/docs/architecture/benefit-plan-adapter-pattern.md
@@ -1,0 +1,163 @@
+# Benefit Plan Adapter Pattern
+
+## Why
+
+Some tenants will eventually source their benefit plan data from external
+core platforms (QNXT, Facets, HealthEdge) instead of CHO's internal
+`benefit-plan-service`. This pattern introduces a thin abstraction
+(`IBenefitPlanAdapter`) selected at request time by tenant configuration,
+mirroring the existing `IEligibilityAdapter` surface used by
+`eligibility-service`.
+
+For every tenant currently in production the factory resolves to the
+default `ChoBenefitPlanAdapter`, which is a near pass-through over the
+existing `IBenefitPlanService` and `IBenefitViewService` — so this PR
+introduces the seam without changing observable behavior.
+
+## Topology
+
+```
+           ┌──────────────────────┐
+GET /plans │ BenefitPlansController│   GET /benefit-plans
+GET /...   │ MemberViewController  │
+           └──────────┬────────────┘
+                      │ (every request)
+              ┌───────▼───────┐
+              │   Factory     │  ── reads tenant cfg ──▶  tenant-service
+              └───────┬───────┘     (cached 5 min)
+                      │
+       ┌──────────────┼──────────────┬──────────────┐
+       ▼              ▼              ▼              ▼
+   Cho (active)    QNXT (stub)   Facets (stub)   HealthEdge (stub)
+```
+
+## Interface
+
+```csharp
+public interface IBenefitPlanAdapter
+{
+    string Platform { get; }
+    Task<BenefitPlanAdapterResponse>       GetPlanAsync(...);
+    Task<BenefitPlanAdapterResponse>       GetPlanVersionAsync(...);
+    Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(...);
+}
+```
+
+The two response envelopes carry a `Platform` string, an optional
+`RawResponse` audit string, and a normalized payload (`AdapterBenefitPlan`
+or `AdapterMemberBenefitView`). Payload shape mirrors the existing
+`BenefitPlan` / `MemberBenefitView` so the CHO pass-through is lossless,
+and is structurally compatible with the planned FHIR `InsurancePlan`
+projection (Section 5.8 of the migration spec).
+
+## Routing & Tenant Configuration
+
+The factory consults tenant-service via HTTP at request time and reads:
+
+```
+GET /api/v1/tenants/{tenantId}
+  → response.configuration.benefitPlanPlatform.platform        (string)
+  → response.configuration.benefitPlanPlatform.platformSettings (object)
+```
+
+The matching adapter is selected case-insensitively by its `Platform`
+property. Allowed values today:
+
+| Platform string | Adapter                       | Status |
+|-----------------|-------------------------------|--------|
+| `cho`           | `ChoBenefitPlanAdapter`       | Active |
+| `qnxt`          | `QnxtBenefitPlanAdapter`      | Stub — `NotImplementedException` |
+| `facets`        | `FacetsBenefitPlanAdapter`    | Stub — `NotImplementedException` |
+| `healthedge`    | `HealthEdgeBenefitPlanAdapter`| Stub — `NotImplementedException` |
+
+On any failure (HTTP error, JSON parse error, unknown platform) the factory
+warns and falls back to `cho`. A per-tenant `(platform, settings)` tuple
+is cached in the singleton `BenefitPlanTenantConfigCache` for 5 minutes
+(thread-safe via `ConcurrentDictionary`).
+
+Tenant-service schema lives in
+`src/services/tenant-service/Models/Tenant.cs::BenefitPlanConfig` —
+parallel to the existing `EligibilityConfig`.
+
+## DI lifetimes
+
+```csharp
+// Singleton — must outlive a single request so the TTL cache survives.
+services.AddSingleton<BenefitPlanTenantConfigCache>();
+
+// Scoped — Cho wraps the scoped IBenefitPlanService / IBenefitViewService.
+services.AddScoped<IBenefitPlanAdapter, ChoBenefitPlanAdapter>();
+services.AddScoped<IBenefitPlanAdapter, QnxtBenefitPlanAdapter>();
+services.AddScoped<IBenefitPlanAdapter, FacetsBenefitPlanAdapter>();
+services.AddScoped<IBenefitPlanAdapter, HealthEdgeBenefitPlanAdapter>();
+services.AddScoped<BenefitPlanAdapterFactory>();
+
+services.AddHttpClient(BenefitPlanTenantConfigCache.HttpClientName)
+        .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+```
+
+This differs from `eligibility-service`, where adapters are stateless and
+all registered as singletons. The benefit-plan CHO adapter has to be
+scoped because it composes scoped business services; we keep the cache
+lifecycle separate.
+
+## Refactored controller endpoints
+
+Only the three GET endpoints that map 1:1 onto the interface route through
+the factory:
+
+| Endpoint                                                      | Adapter method              |
+|---------------------------------------------------------------|-----------------------------|
+| `GET /api/v1/plans/{id}`                                      | `GetPlanAsync`              |
+| `GET /api/v1/plans/{id}/versions/{versionId}`                 | `GetPlanVersionAsync`       |
+| `GET /api/v1/benefit-plans/{planId}/member-view`              | `GetMemberBenefitViewAsync` |
+
+All other endpoints (search, list versions, accumulation, draft/publish/
+amend/supersede, benefit add/remove) keep calling `IBenefitPlanService`
+directly. Writes are CHO-internal; expanding adapter coverage to writes
+is a future PR.
+
+## Adding a new adapter
+
+1. Implement `IBenefitPlanAdapter` with a unique `Platform` string.
+2. Register `services.AddScoped<IBenefitPlanAdapter, MyAdapter>()` in
+   `Program.cs` next to the others.
+3. Add the platform string to the table above and to the comment in
+   `BenefitPlanConfig.Platform` in tenant-service.
+4. Configure tenants via `PUT /api/v1/tenants/{id}` with
+   `configuration.benefitPlanPlatform.platform = "my-platform"`.
+5. Write factory + adapter tests under
+   `BenefitPlanService.Tests/Adapters/`.
+
+## Migration TODOs
+
+- **QNXT** (`TODO(qnxt-benefit-plan)`): integrate with the QNXT plan
+  inquiry API (BENEFIT_PLAN_INQ on the QNXT benefits stack).
+- **Facets** (`TODO(facets-benefit-plan)`): integrate with the Facets
+  benefit / product inquiry interface (Open Access XML or Workflow REST).
+- **HealthEdge** (`TODO(healthedge-benefit-plan)`): integrate with the
+  HealthRules Payer plan inquiry API (HRP REST surface).
+
+Until those land the stubs surface a clear `NotImplementedException`
+containing the TODO marker so any tenant misconfigured to point at one of
+them fails loudly rather than silently degrading.
+
+## FHIR alignment (Section 5.8)
+
+`AdapterBenefitPlan` and `AdapterMemberBenefitView` were intentionally
+shaped so a future FHIR projection layer can map them onto FHIR
+`InsurancePlan` without a model redesign. Field-level mapping notes:
+
+| Adapter field                  | FHIR `InsurancePlan` location                |
+|--------------------------------|----------------------------------------------|
+| `EffectiveDate` / `TerminationDate` | `period`                                |
+| `PlanType`                     | `type.coding`                                |
+| `Payer`                        | `ownedBy` (org reference)                    |
+| `NetworkTiers[]`               | `network[]`                                  |
+| `CostSharing.*`                | `plan.specificCost[]`                        |
+| `Documents[]`                  | contained `DocumentReference` resources      |
+| `VersionId` / `VersionNumber`  | `meta.versionId` / extension                 |
+
+The CHO adapter today returns the existing model unchanged via the
+mapper; the QNXT/Facets/HealthEdge adapters will populate the same shape
+when implemented.

--- a/src/services/benefit-plan-service/Adapters/BenefitPlanAdapterFactory.cs
+++ b/src/services/benefit-plan-service/Adapters/BenefitPlanAdapterFactory.cs
@@ -1,0 +1,68 @@
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Resolves the correct <see cref="IBenefitPlanAdapter"/> at runtime based on
+/// tenant configuration. Mirrors <c>EligibilityService.Adapters.EligibilityAdapterFactory</c>.
+///
+/// <para>
+/// Tenant config is fetched from tenant-service (cached 5 minutes via
+/// <see cref="BenefitPlanTenantConfigCache"/>) and matched against each adapter's
+/// <see cref="IBenefitPlanAdapter.Platform"/> property (case-insensitive).
+/// On any failure or unknown platform the factory falls back to <c>"cho"</c>
+/// so a flaky tenant-service never breaks plan reads.
+/// </para>
+/// </summary>
+public class BenefitPlanAdapterFactory
+{
+    private readonly IEnumerable<IBenefitPlanAdapter> _adapters;
+    private readonly BenefitPlanTenantConfigCache _cache;
+    private readonly ILogger<BenefitPlanAdapterFactory> _logger;
+
+    public BenefitPlanAdapterFactory(
+        IEnumerable<IBenefitPlanAdapter> adapters,
+        BenefitPlanTenantConfigCache cache,
+        ILogger<BenefitPlanAdapterFactory> logger)
+    {
+        _adapters = adapters;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Get the benefit-plan adapter configured for the given tenant.
+    /// Returns the CHO adapter when no specific configuration is found.
+    /// </summary>
+    public async Task<IBenefitPlanAdapter> GetAdapterAsync(string tenantId, CancellationToken ct = default)
+    {
+        var (platform, _) = await _cache.GetAsync(tenantId, ct);
+        return ResolveAdapter(platform);
+    }
+
+    /// <summary>
+    /// Get the adapter and a copy of the tenant's platform-settings dictionary
+    /// (callers may mutate the copy without affecting the cache).
+    /// </summary>
+    public async Task<(IBenefitPlanAdapter Adapter, Dictionary<string, string> Settings)> GetAdapterWithSettingsAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        var (platform, settings) = await _cache.GetAsync(tenantId, ct);
+        return (ResolveAdapter(platform), new Dictionary<string, string>(settings));
+    }
+
+    private IBenefitPlanAdapter ResolveAdapter(string platform)
+    {
+        var adapter = _adapters.FirstOrDefault(a =>
+            string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase));
+
+        if (adapter == null)
+        {
+            _logger.LogWarning(
+                "No benefit-plan adapter found for platform '{Platform}', falling back to 'cho'",
+                platform);
+            adapter = _adapters.First(a =>
+                string.Equals(a.Platform, BenefitPlanTenantConfigCache.DefaultPlatform, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return adapter;
+    }
+}

--- a/src/services/benefit-plan-service/Adapters/BenefitPlanTenantConfigCache.cs
+++ b/src/services/benefit-plan-service/Adapters/BenefitPlanTenantConfigCache.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Singleton cache for per-tenant benefit-plan platform configuration. Holds
+/// state across requests so the factory itself can stay scoped (the CHO
+/// adapter wraps scoped business services, so the factory and adapters must
+/// be scoped — but the cache must outlive a single request).
+/// </summary>
+/// <remarks>
+/// Mirrors the inline cache in <c>EligibilityAdapterFactory</c>: 5-minute TTL,
+/// thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>, and a
+/// graceful fallback to <c>"cho"</c> on any HTTP/JSON failure so a flaky
+/// tenant-service never breaks plan reads.
+/// </remarks>
+public class BenefitPlanTenantConfigCache
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<BenefitPlanTenantConfigCache> _logger;
+
+    private readonly ConcurrentDictionary<string, (string Platform, Dictionary<string, string> Settings, DateTime ExpiresAt)> _cache = new();
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    public const string DefaultPlatform = "cho";
+    public const string HttpClientName = "BenefitPlanDefault";
+
+    public BenefitPlanTenantConfigCache(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<BenefitPlanTenantConfigCache> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolve <c>(platform, platformSettings)</c> for the given tenant, hitting
+    /// tenant-service on cache miss. Defaults to <c>("cho", new())</c> when the
+    /// tenant has no <c>benefitPlanPlatform</c> config or the call fails.
+    /// </summary>
+    public async Task<(string Platform, Dictionary<string, string> Settings)> GetAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(tenantId, out var cached) && cached.ExpiresAt > DateTime.UtcNow)
+        {
+            return (cached.Platform, cached.Settings);
+        }
+
+        try
+        {
+            var tenantUrl = _configuration["Services:TenantService"]
+                ?? "http://tenant-service.cloudhealthoffice/api/v1";
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var response = await httpClient.GetAsync($"{tenantUrl}/tenants/{tenantId}", ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadAsStringAsync(ct);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                if (root.TryGetProperty("configuration", out var config) &&
+                    config.TryGetProperty("benefitPlanPlatform", out var planConfig) &&
+                    planConfig.TryGetProperty("platform", out var platformProp))
+                {
+                    var platform = platformProp.GetString() ?? DefaultPlatform;
+                    var settings = new Dictionary<string, string>();
+
+                    if (planConfig.TryGetProperty("platformSettings", out var settingsProp))
+                    {
+                        foreach (var prop in settingsProp.EnumerateObject())
+                        {
+                            settings[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                        }
+                    }
+
+                    _cache[tenantId] = (platform, settings, DateTime.UtcNow.Add(CacheDuration));
+                    return (platform, settings);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to fetch benefit-plan tenant config for {TenantId}, using default adapter",
+                SanitizeForLog(tenantId));
+        }
+
+        var defaultSettings = new Dictionary<string, string>();
+        _cache[tenantId] = (DefaultPlatform, defaultSettings, DateTime.UtcNow.Add(CacheDuration));
+        return (DefaultPlatform, defaultSettings);
+    }
+
+    /// <summary>Test seam — drops all cached entries.</summary>
+    public void Clear() => _cache.Clear();
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Adapters/ChoBenefitPlanAdapter.cs
+++ b/src/services/benefit-plan-service/Adapters/ChoBenefitPlanAdapter.cs
@@ -1,0 +1,70 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Default benefit-plan adapter using CHO's internal services
+/// (<see cref="IBenefitPlanService"/> + <see cref="IBenefitViewService"/>).
+/// Preserves existing behavior — for the current set of tenants the factory
+/// always resolves to this adapter.
+/// </summary>
+public class ChoBenefitPlanAdapter : IBenefitPlanAdapter
+{
+    private readonly IBenefitPlanService _planService;
+    private readonly IBenefitViewService _viewService;
+    private readonly ILogger<ChoBenefitPlanAdapter> _logger;
+
+    public string Platform => "cho";
+
+    public ChoBenefitPlanAdapter(
+        IBenefitPlanService planService,
+        IBenefitViewService viewService,
+        ILogger<ChoBenefitPlanAdapter> logger)
+    {
+        _planService = planService;
+        _viewService = viewService;
+        _logger = logger;
+    }
+
+    public async Task<BenefitPlanAdapterResponse> GetPlanAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+    {
+        var plan = await _planService.GetPlanAsync(request.PlanId, request.TenantId);
+        return new BenefitPlanAdapterResponse
+        {
+            Platform = Platform,
+            Plan = plan is null ? null : AdapterBenefitPlan.From(plan),
+        };
+    }
+
+    public async Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.VersionId))
+        {
+            throw new ArgumentException(
+                "VersionId is required for GetPlanVersionAsync.", nameof(request));
+        }
+
+        var version = await _planService.GetVersionAsync(
+            request.PlanId, request.VersionId, request.TenantId);
+        return new BenefitPlanAdapterResponse
+        {
+            Platform = Platform,
+            Plan = version is null ? null : AdapterBenefitPlan.From(version),
+        };
+    }
+
+    public async Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+    {
+        var asOf = (request.ServiceDate ?? DateTime.UtcNow).Date;
+        var view = await _viewService.GetMemberViewAsync(request.PlanId, request.TenantId, asOf);
+        return new MemberBenefitViewAdapterResponse
+        {
+            Platform = Platform,
+            View = view is null ? null : AdapterMemberBenefitView.From(view),
+        };
+    }
+}

--- a/src/services/benefit-plan-service/Adapters/FacetsBenefitPlanAdapter.cs
+++ b/src/services/benefit-plan-service/Adapters/FacetsBenefitPlanAdapter.cs
@@ -1,0 +1,36 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose benefit plans live in TriZetto Facets.
+/// All methods throw <see cref="NotImplementedException"/> with a clear
+/// migration TODO until the Facets integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(facets-benefit-plan): integrate with the Facets benefit/product
+/// inquiry surface (typically the Open Access XML interface or
+/// Facets Workflow service). Reference doc:
+/// docs/architecture/benefit-plan-adapter-pattern.md.
+/// </remarks>
+public class FacetsBenefitPlanAdapter : IBenefitPlanAdapter
+{
+    private const string Todo =
+        "Facets benefit plan adapter not yet implemented. " +
+        "TODO(facets-benefit-plan): integrate with the Facets benefit/product inquiry interface. " +
+        "See docs/architecture/benefit-plan-adapter-pattern.md.";
+
+    public string Platform => "facets";
+
+    public Task<BenefitPlanAdapterResponse> GetPlanAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/benefit-plan-service/Adapters/HealthEdgeBenefitPlanAdapter.cs
+++ b/src/services/benefit-plan-service/Adapters/HealthEdgeBenefitPlanAdapter.cs
@@ -1,0 +1,35 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose benefit plans live in HealthEdge HealthRules
+/// Payer. All methods throw <see cref="NotImplementedException"/> with a clear
+/// migration TODO until the HealthEdge integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(healthedge-benefit-plan): integrate with the HealthRules Payer plan
+/// inquiry API (HRP REST surface). Reference doc:
+/// docs/architecture/benefit-plan-adapter-pattern.md.
+/// </remarks>
+public class HealthEdgeBenefitPlanAdapter : IBenefitPlanAdapter
+{
+    private const string Todo =
+        "HealthEdge benefit plan adapter not yet implemented. " +
+        "TODO(healthedge-benefit-plan): integrate with the HealthRules Payer plan inquiry API. " +
+        "See docs/architecture/benefit-plan-adapter-pattern.md.";
+
+    public string Platform => "healthedge";
+
+    public Task<BenefitPlanAdapterResponse> GetPlanAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/benefit-plan-service/Adapters/IBenefitPlanAdapter.cs
+++ b/src/services/benefit-plan-service/Adapters/IBenefitPlanAdapter.cs
@@ -1,0 +1,43 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Abstraction for benefit-plan retrieval platforms.
+/// Each tenant can be configured to use a different adapter (CHO, QNXT, Facets, HealthEdge, ...).
+/// The adapter normalizes platform-specific responses into a common, vendor-neutral format
+/// designed to project cleanly onto a future FHIR <c>InsurancePlan</c> resource (Section 5.8).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>EligibilityService.Adapters.IEligibilityAdapter</c>. The selection mechanism
+/// (factory consults tenant-service config and falls back to "cho") is identical.
+/// </remarks>
+public interface IBenefitPlanAdapter
+{
+    /// <summary>
+    /// Platform identifier matching <c>BenefitPlanConfig.Platform</c> on the tenant.
+    /// Resolution by the factory is case-insensitive.
+    /// </summary>
+    string Platform { get; }
+
+    /// <summary>
+    /// Return the canonical (latest published) version of a plan.
+    /// Returns a response with <c>Plan == null</c> when not found so callers can map to 404.
+    /// </summary>
+    Task<BenefitPlanAdapterResponse> GetPlanAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Return a specific version of a plan identified by <see cref="BenefitPlanAdapterRequest.VersionId"/>.
+    /// Returns a response with <c>Plan == null</c> when the version is not found.
+    /// </summary>
+    Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Return a portal-facing categorized view of the plan as of <see cref="BenefitPlanAdapterRequest.ServiceDate"/>.
+    /// Returns a response with <c>View == null</c> when the plan is not found.
+    /// </summary>
+    Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default);
+}

--- a/src/services/benefit-plan-service/Adapters/QnxtBenefitPlanAdapter.cs
+++ b/src/services/benefit-plan-service/Adapters/QnxtBenefitPlanAdapter.cs
@@ -1,0 +1,35 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose benefit plans live in QNXT
+/// (TriZetto / Cognizant). All methods throw <see cref="NotImplementedException"/>
+/// with a clear migration TODO until the QNXT integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(qnxt-benefit-plan): integrate with the QNXT plan inquiry API
+/// (BENEFIT_PLAN_INQ on the QNXT benefits stack). Reference doc:
+/// docs/architecture/benefit-plan-adapter-pattern.md.
+/// </remarks>
+public class QnxtBenefitPlanAdapter : IBenefitPlanAdapter
+{
+    private const string Todo =
+        "QNXT benefit plan adapter not yet implemented. " +
+        "TODO(qnxt-benefit-plan): integrate with the QNXT plan inquiry API. " +
+        "See docs/architecture/benefit-plan-adapter-pattern.md.";
+
+    public string Platform => "qnxt";
+
+    public Task<BenefitPlanAdapterResponse> GetPlanAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(
+        BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/BenefitPlanAdapterFactoryTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/BenefitPlanAdapterFactoryTests.cs
@@ -13,7 +13,7 @@ public class BenefitPlanAdapterFactoryTests
                     StubBenefitPlanAdapter cho,
                     StubBenefitPlanAdapter qnxt) BuildFactory(
         FakeHttpMessageHandler handler,
-        params (string platform, IBenefitPlanAdapter adapter)[] extra)
+        params IBenefitPlanAdapter[] extra)
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
@@ -28,7 +28,7 @@ public class BenefitPlanAdapterFactoryTests
         var cho = new StubBenefitPlanAdapter("cho");
         var qnxt = new StubBenefitPlanAdapter("qnxt");
         var adapters = new List<IBenefitPlanAdapter> { cho, qnxt };
-        adapters.AddRange(extra.Select(e => e.adapter));
+        adapters.AddRange(extra);
 
         var factory = new BenefitPlanAdapterFactory(
             adapters, cache, NullLogger<BenefitPlanAdapterFactory>.Instance);

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/BenefitPlanAdapterFactoryTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/BenefitPlanAdapterFactoryTests.cs
@@ -1,0 +1,151 @@
+using BenefitPlanService.Adapters;
+using BenefitPlanService.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Adapters;
+
+public class BenefitPlanAdapterFactoryTests
+{
+    private static (BenefitPlanAdapterFactory factory,
+                    BenefitPlanTenantConfigCache cache,
+                    FakeHttpMessageHandler handler,
+                    StubBenefitPlanAdapter cho,
+                    StubBenefitPlanAdapter qnxt) BuildFactory(
+        FakeHttpMessageHandler handler,
+        params (string platform, IBenefitPlanAdapter adapter)[] extra)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Services:TenantService"] = "http://tenant-service.test/api/v1",
+        }).Build();
+
+        var cache = new BenefitPlanTenantConfigCache(
+            new StubHttpClientFactory(handler),
+            config,
+            NullLogger<BenefitPlanTenantConfigCache>.Instance);
+
+        var cho = new StubBenefitPlanAdapter("cho");
+        var qnxt = new StubBenefitPlanAdapter("qnxt");
+        var adapters = new List<IBenefitPlanAdapter> { cho, qnxt };
+        adapters.AddRange(extra.Select(e => e.adapter));
+
+        var factory = new BenefitPlanAdapterFactory(
+            adapters, cache, NullLogger<BenefitPlanAdapterFactory>.Instance);
+        return (factory, cache, handler, cho, qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_returns_cho_when_tenant_has_no_platform_config()
+    {
+        var handler = FakeHttpMessageHandler.Json("""{"configuration": {}}""");
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-1");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_returns_configured_platform()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"benefitPlanPlatform": {"platform": "qnxt"}}}""");
+        var (factory, _, _, _, qnxt) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-q");
+
+        adapter.Should().BeSameAs(qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_matches_platform_case_insensitively()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"benefitPlanPlatform": {"platform": "QNXT"}}}""");
+        var (factory, _, _, _, qnxt) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-q");
+
+        adapter.Should().BeSameAs(qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_on_unknown_platform()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"benefitPlanPlatform": {"platform": "unknown-vendor"}}}""");
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-x");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_on_http_failure()
+    {
+        var handler = FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.InternalServerError);
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-y");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_when_http_throws()
+    {
+        var handler = FakeHttpMessageHandler.Throw(new HttpRequestException("network down"));
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-z");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_caches_tenant_lookup()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"benefitPlanPlatform": {"platform": "qnxt"}}}""");
+        var (factory, _, h, _, qnxt) = BuildFactory(handler);
+
+        var first = await factory.GetAdapterAsync("tenant-cache");
+        var second = await factory.GetAdapterAsync("tenant-cache");
+
+        first.Should().BeSameAs(qnxt);
+        second.Should().BeSameAs(qnxt);
+        h.RequestCount.Should().Be(1, "second call should be served from cache");
+    }
+
+    [Fact]
+    public async Task GetAdapterWithSettingsAsync_returns_isolated_copy_of_settings()
+    {
+        var handler = FakeHttpMessageHandler.Json("""
+            {"configuration": {"benefitPlanPlatform": {"platform": "qnxt", "platformSettings": {"qnxt:baseUrl": "https://qnxt.example/"}}}}
+            """);
+        var (factory, _, _, _, _) = BuildFactory(handler);
+
+        var (_, settings) = await factory.GetAdapterWithSettingsAsync("tenant-s");
+        settings["qnxt:baseUrl"].Should().Be("https://qnxt.example/");
+
+        // Mutating the returned dict must not affect the next call.
+        settings["qnxt:baseUrl"] = "https://attacker.example/";
+
+        var (_, fresh) = await factory.GetAdapterWithSettingsAsync("tenant-s");
+        fresh["qnxt:baseUrl"].Should().Be("https://qnxt.example/");
+    }
+
+    private sealed class StubBenefitPlanAdapter : IBenefitPlanAdapter
+    {
+        public string Platform { get; }
+        public StubBenefitPlanAdapter(string platform) { Platform = platform; }
+        public Task<BenefitPlanAdapterResponse> GetPlanAsync(BenefitPlanAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new BenefitPlanAdapterResponse { Platform = Platform });
+        public Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(BenefitPlanAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new BenefitPlanAdapterResponse { Platform = Platform });
+        public Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(BenefitPlanAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new MemberBenefitViewAdapterResponse { Platform = Platform });
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/ChoBenefitPlanAdapterTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/ChoBenefitPlanAdapterTests.cs
@@ -1,0 +1,155 @@
+using BenefitPlanService.Adapters;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Adapters;
+
+public class ChoBenefitPlanAdapterTests
+{
+    private const string Tenant = "tenant-a";
+
+    [Fact]
+    public void Platform_is_cho()
+    {
+        var adapter = new ChoBenefitPlanAdapter(
+            Mock.Of<IBenefitPlanService>(),
+            Mock.Of<IBenefitViewService>(),
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetPlanAsync_delegates_to_plan_service_and_maps_result()
+    {
+        var plan = new BenefitPlan
+        {
+            Id = "id-1",
+            TenantId = Tenant,
+            PlanId = "plan-x",
+            PlanName = "Plan X",
+            Payer = "Acme",
+            EffectiveDate = new DateTime(2026, 1, 1),
+            PlanType = PlanType.PPO,
+        };
+        var planService = new Mock<IBenefitPlanService>();
+        planService.Setup(s => s.GetPlanAsync("id-1", Tenant)).ReturnsAsync(plan);
+
+        var adapter = new ChoBenefitPlanAdapter(
+            planService.Object,
+            Mock.Of<IBenefitViewService>(),
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var response = await adapter.GetPlanAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = Tenant,
+            PlanId = "id-1",
+        });
+
+        response.Platform.Should().Be("cho");
+        response.Plan.Should().NotBeNull();
+        response.Plan!.PlanId.Should().Be("plan-x");
+        response.Plan.PlanName.Should().Be("Plan X");
+    }
+
+    [Fact]
+    public async Task GetPlanAsync_returns_null_payload_when_not_found()
+    {
+        var planService = new Mock<IBenefitPlanService>();
+        planService.Setup(s => s.GetPlanAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync((BenefitPlan?)null);
+
+        var adapter = new ChoBenefitPlanAdapter(
+            planService.Object,
+            Mock.Of<IBenefitViewService>(),
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var response = await adapter.GetPlanAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = Tenant,
+            PlanId = "missing",
+        });
+
+        response.Plan.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPlanVersionAsync_delegates_to_GetVersionAsync()
+    {
+        var plan = new BenefitPlan
+        {
+            Id = "id-2",
+            TenantId = Tenant,
+            PlanId = "plan-y",
+            VersionId = "01HV-VERSION-XYZ",
+            VersionNumber = 3,
+        };
+        var planService = new Mock<IBenefitPlanService>();
+        planService.Setup(s => s.GetVersionAsync("plan-y", "01HV-VERSION-XYZ", Tenant))
+            .ReturnsAsync(plan);
+
+        var adapter = new ChoBenefitPlanAdapter(
+            planService.Object,
+            Mock.Of<IBenefitViewService>(),
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var response = await adapter.GetPlanVersionAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = Tenant,
+            PlanId = "plan-y",
+            VersionId = "01HV-VERSION-XYZ",
+        });
+
+        response.Plan!.VersionId.Should().Be("01HV-VERSION-XYZ");
+        response.Plan.VersionNumber.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetPlanVersionAsync_throws_when_version_id_missing()
+    {
+        var adapter = new ChoBenefitPlanAdapter(
+            Mock.Of<IBenefitPlanService>(),
+            Mock.Of<IBenefitViewService>(),
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var request = new BenefitPlanAdapterRequest { TenantId = Tenant, PlanId = "p" };
+        await adapter.Invoking(a => a.GetPlanVersionAsync(request))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetMemberBenefitViewAsync_delegates_to_view_service_and_uses_service_date()
+    {
+        var view = new MemberBenefitView
+        {
+            PlanId = "plan-z",
+            PlanName = "Plan Z",
+            Payer = "Acme",
+            PlanType = "PPO",
+            EffectiveDate = new DateTime(2026, 1, 1),
+            AsOfDate = new DateTime(2026, 4, 1),
+            PlanVersion = "20260401T000000Z",
+        };
+        var viewService = new Mock<IBenefitViewService>();
+        viewService.Setup(v => v.GetMemberViewAsync("plan-z", Tenant, new DateTime(2026, 4, 1)))
+            .ReturnsAsync(view);
+
+        var adapter = new ChoBenefitPlanAdapter(
+            Mock.Of<IBenefitPlanService>(),
+            viewService.Object,
+            NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var response = await adapter.GetMemberBenefitViewAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = Tenant,
+            PlanId = "plan-z",
+            ServiceDate = new DateTime(2026, 4, 1),
+        });
+
+        response.Platform.Should().Be("cho");
+        response.View.Should().NotBeNull();
+        response.View!.PlanId.Should().Be("plan-z");
+        response.View.PlanVersion.Should().Be("20260401T000000Z");
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/FakeHttpMessageHandler.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/FakeHttpMessageHandler.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Http;
+
+namespace BenefitPlanService.Tests.Adapters;
+
+/// <summary>
+/// Test helper: returns scripted responses for each HTTP call. Tracks the
+/// number of requests so we can assert on cache hits.
+/// </summary>
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+    public int RequestCount { get; private set; }
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder;
+    }
+
+    public static FakeHttpMessageHandler Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(_ => new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        });
+
+    public static FakeHttpMessageHandler Status(HttpStatusCode status)
+        => new(_ => new HttpResponseMessage(status));
+
+    public static FakeHttpMessageHandler Throw(Exception exception)
+        => new(_ => throw exception);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        return Task.FromResult(_responder(request));
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IHttpClientFactory"/> that hands out an
+/// <see cref="HttpClient"/> wrapping the supplied handler.
+/// </summary>
+internal sealed class StubHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpMessageHandler _handler;
+    public StubHttpClientFactory(HttpMessageHandler handler) { _handler = handler; }
+    public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/StubBenefitPlanAdapterTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/StubBenefitPlanAdapterTests.cs
@@ -1,0 +1,57 @@
+using BenefitPlanService.Adapters;
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Tests.Adapters;
+
+public class StubBenefitPlanAdapterTests
+{
+    public static IEnumerable<object[]> Stubs() => new[]
+    {
+        new object[] { new QnxtBenefitPlanAdapter(), "qnxt", "qnxt-benefit-plan" },
+        new object[] { new FacetsBenefitPlanAdapter(), "facets", "facets-benefit-plan" },
+        new object[] { new HealthEdgeBenefitPlanAdapter(), "healthedge", "healthedge-benefit-plan" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public void Platform_returns_expected_string(IBenefitPlanAdapter adapter, string expected, string _)
+    {
+        adapter.Platform.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetPlanAsync_throws_with_migration_TODO(IBenefitPlanAdapter adapter, string _, string todoMarker)
+    {
+        var request = new BenefitPlanAdapterRequest { TenantId = "t", PlanId = "p" };
+        var act = () => adapter.GetPlanAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain("TODO");
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetPlanVersionAsync_throws_with_migration_TODO(IBenefitPlanAdapter adapter, string _, string todoMarker)
+    {
+        var request = new BenefitPlanAdapterRequest { TenantId = "t", PlanId = "p", VersionId = "v" };
+        var act = () => adapter.GetPlanVersionAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain("TODO");
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetMemberBenefitViewAsync_throws_with_migration_TODO(IBenefitPlanAdapter adapter, string _, string todoMarker)
+    {
+        var request = new BenefitPlanAdapterRequest { TenantId = "t", PlanId = "p" };
+        var act = () => adapter.GetMemberBenefitViewAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain("TODO");
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
@@ -1,9 +1,12 @@
+using BenefitPlanService.Adapters;
 using BenefitPlanService.Controllers;
 using BenefitPlanService.Models;
 using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Adapters;
 using BenefitPlanService.Tests.Fakes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BenefitPlanService.Tests.Controllers;
@@ -14,13 +17,29 @@ public class BenefitPlansControllerVersionTests
 
     private static (BenefitPlansController controller,
                     BenefitPlanServiceImpl service,
-                    InMemoryBenefitPlanRepository repo) Build()
+                    InMemoryBenefitPlanRepository repo) Build(
+        Func<IBenefitPlanService, IBenefitViewService, IBenefitPlanAdapter>? adapterFactory = null)
     {
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
         var service = new BenefitPlanServiceImpl(repo, transitions, events, NullLogger<BenefitPlanServiceImpl>.Instance);
-        var controller = new BenefitPlansController(service, NullLogger<BenefitPlansController>.Instance)
+        var viewService = new BenefitViewService(service, NullLogger<BenefitViewService>.Instance);
+
+        // Default adapter: real CHO adapter backed by the in-memory service so
+        // controller GET endpoints behave as before this refactor.
+        var primary = adapterFactory?.Invoke(service, viewService)
+            ?? new ChoBenefitPlanAdapter(service, viewService, NullLogger<ChoBenefitPlanAdapter>.Instance);
+
+        var config = new ConfigurationBuilder().Build();
+        var cache = new BenefitPlanTenantConfigCache(
+            new StubHttpClientFactory(FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.NotFound)),
+            config,
+            NullLogger<BenefitPlanTenantConfigCache>.Instance);
+        var factory = new BenefitPlanAdapterFactory(
+            new[] { primary }, cache, NullLogger<BenefitPlanAdapterFactory>.Instance);
+
+        var controller = new BenefitPlansController(service, factory, NullLogger<BenefitPlansController>.Instance)
         {
             ControllerContext = new ControllerContext
             {
@@ -124,5 +143,79 @@ public class BenefitPlansControllerVersionTests
         var result = await controller.Supersede(v1.PlanId, v1.VersionId,
             new SupersedeRequest { Reason = "test" });
         result.Result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPlan_routes_through_adapter_factory()
+    {
+        RecordingChoAdapter? recording = null;
+        var (controller, service, _) = Build((s, v) =>
+            recording = new RecordingChoAdapter(new ChoBenefitPlanAdapter(s, v, NullLogger<ChoBenefitPlanAdapter>.Instance)));
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, "user");
+
+        var result = await controller.GetPlan(v1.Id);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        recording.Should().NotBeNull();
+        recording!.GetPlanCalls.Should().HaveCount(1);
+        recording.GetPlanCalls[0].PlanId.Should().Be(v1.Id);
+        recording.GetPlanCalls[0].TenantId.Should().Be(Tenant);
+    }
+
+    [Fact]
+    public async Task GetVersion_routes_through_adapter_factory()
+    {
+        RecordingChoAdapter? recording = null;
+        var (controller, service, _) = Build((s, v) =>
+            recording = new RecordingChoAdapter(new ChoBenefitPlanAdapter(s, v, NullLogger<ChoBenefitPlanAdapter>.Instance)));
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, "user");
+
+        var result = await controller.GetVersion(v1.PlanId, v1.VersionId);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        recording.Should().NotBeNull();
+        recording!.GetVersionCalls.Should().HaveCount(1);
+        recording.GetVersionCalls[0].VersionId.Should().Be(v1.VersionId);
+    }
+
+    /// <summary>
+    /// Decorator over <see cref="ChoBenefitPlanAdapter"/> that records every
+    /// invocation so we can assert the controller hit the factory.
+    /// </summary>
+    private sealed class RecordingChoAdapter : IBenefitPlanAdapter
+    {
+        private readonly ChoBenefitPlanAdapter _inner;
+        public RecordingChoAdapter(ChoBenefitPlanAdapter inner) { _inner = inner; }
+
+        public string Platform => "cho";
+        public List<BenefitPlanAdapterRequest> GetPlanCalls { get; } = new();
+        public List<BenefitPlanAdapterRequest> GetVersionCalls { get; } = new();
+
+        public Task<BenefitPlanAdapterResponse> GetPlanAsync(BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        {
+            GetPlanCalls.Add(Clone(request));
+            return _inner.GetPlanAsync(request, ct);
+        }
+
+        public Task<BenefitPlanAdapterResponse> GetPlanVersionAsync(BenefitPlanAdapterRequest request, CancellationToken ct = default)
+        {
+            GetVersionCalls.Add(Clone(request));
+            return _inner.GetPlanVersionAsync(request, ct);
+        }
+
+        public Task<MemberBenefitViewAdapterResponse> GetMemberBenefitViewAsync(BenefitPlanAdapterRequest request, CancellationToken ct = default)
+            => _inner.GetMemberBenefitViewAsync(request, ct);
+
+        private static BenefitPlanAdapterRequest Clone(BenefitPlanAdapterRequest r) => new()
+        {
+            TenantId = r.TenantId,
+            PlanId = r.PlanId,
+            VersionId = r.VersionId,
+            ServiceDate = r.ServiceDate,
+            SubscriberId = r.SubscriberId,
+            PlatformSettings = new(r.PlatformSettings),
+        };
     }
 }

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BenefitPlanService.Models;
 using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
@@ -9,16 +10,29 @@ namespace BenefitPlanService.Tests.Fakes;
 /// version-chain semantics. Used by service- and controller-level tests
 /// to avoid requiring a live Mongo/Cosmos.
 /// </summary>
+/// <remarks>
+/// All store and fetch operations deep-clone via JSON round-trip so that
+/// external mutations of a returned object cannot corrupt the stored document
+/// — matching the behaviour of real Cosmos / Mongo round-trips and preventing
+/// tests from becoming order-dependent due to shared object references.
+/// </remarks>
 public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
 {
+    private static readonly JsonSerializerOptions _jsonOpts = new(JsonSerializerDefaults.Web);
     private readonly List<BenefitPlan> _docs = new();
     public IReadOnlyList<BenefitPlan> Docs => _docs;
 
     /// <summary>Set true to simulate a transactional batch failure.</summary>
     public bool FailNextPublish { get; set; }
 
+    private static BenefitPlan Clone(BenefitPlan plan)
+        => JsonSerializer.Deserialize<BenefitPlan>(JsonSerializer.Serialize(plan, _jsonOpts), _jsonOpts)!;
+
     public Task<BenefitPlan?> GetByIdAsync(string id, string tenantId)
-        => Task.FromResult(_docs.FirstOrDefault(d => d.Id == id && d.TenantId == tenantId));
+    {
+        var doc = _docs.FirstOrDefault(d => d.Id == id && d.TenantId == tenantId);
+        return Task.FromResult(doc is null ? null : Clone(doc));
+    }
 
     public Task<BenefitPlan?> GetByPlanIdAsync(string planId, string tenantId)
         => GetLatestPublishedAsync(planId, tenantId, DateTime.UtcNow);
@@ -33,13 +47,13 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
                 && (d.TerminationDate == null || d.TerminationDate >= asOf))
             .OrderByDescending(d => d.VersionNumber)
             .FirstOrDefault();
-        return Task.FromResult<BenefitPlan?>(match);
+        return Task.FromResult(match is null ? null : Clone(match));
     }
 
     public Task<BenefitPlan?> GetVersionAsync(string planId, string versionId, string tenantId)
     {
         var match = _docs.FirstOrDefault(d => d.TenantId == tenantId && d.PlanId == planId && d.VersionId == versionId);
-        return Task.FromResult<BenefitPlan?>(match);
+        return Task.FromResult(match is null ? null : Clone(match));
     }
 
     public Task<(IReadOnlyList<BenefitPlan> Items, string? ContinuationToken)> ListVersionsAsync(
@@ -55,7 +69,7 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
             .Skip(skip)
             .ToList();
 
-        var slice = ordered.Take(pageSize).ToList();
+        var slice = ordered.Take(pageSize).Select(Clone).ToList();
         var next = ordered.Count > pageSize ? (skip + pageSize).ToString() : null;
         return Task.FromResult<(IReadOnlyList<BenefitPlan>, string?)>((slice, next));
     }
@@ -70,7 +84,7 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
             q = q.Where(d => d.PlanType == pt);
         if (!string.IsNullOrEmpty(metalLevel) && Enum.TryParse<MetalLevel>(metalLevel, true, out var ml))
             q = q.Where(d => d.MetalLevel == ml);
-        return Task.FromResult(q.OrderBy(d => d.PlanName).Skip((page - 1) * pageSize).Take(pageSize));
+        return Task.FromResult(q.OrderBy(d => d.PlanName).Skip((page - 1) * pageSize).Take(pageSize).Select(Clone));
     }
 
     public Task<IEnumerable<Benefit>> GetBenefitsAsync(string planId, string tenantId, string? serviceCategory)
@@ -80,7 +94,8 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
             .OrderByDescending(d => d.VersionNumber)
             .FirstOrDefault();
         if (plan == null) return Task.FromResult(Enumerable.Empty<Benefit>());
-        var benefits = plan.Benefits.AsEnumerable();
+        var cloned = Clone(plan);
+        var benefits = cloned.Benefits.AsEnumerable();
         if (!string.IsNullOrEmpty(serviceCategory))
             benefits = benefits.Where(b => b.ServiceCategory == serviceCategory);
         return Task.FromResult(benefits);
@@ -89,8 +104,8 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
     public Task<BenefitPlan> CreateAsync(BenefitPlan plan)
     {
         if (string.IsNullOrEmpty(plan.Id)) plan.Id = Guid.NewGuid().ToString();
-        _docs.Add(plan);
-        return Task.FromResult(plan);
+        _docs.Add(Clone(plan));
+        return Task.FromResult(Clone(plan));
     }
 
     public Task<BenefitPlan> UpdateAsync(BenefitPlan plan)
@@ -104,8 +119,8 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
                 $"Plan version {existing.VersionId} is Superseded and is read-only.");
 
         if (existing != null) _docs.Remove(existing);
-        _docs.Add(plan);
-        return Task.FromResult(plan);
+        _docs.Add(Clone(plan));
+        return Task.FromResult(Clone(plan));
     }
 
     public Task DeleteAsync(string id, string tenantId)
@@ -118,8 +133,8 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
     {
         if (string.IsNullOrEmpty(draft.Id)) draft.Id = Guid.NewGuid().ToString();
         draft.VersionState = PlanVersionState.Draft;
-        _docs.Add(draft);
-        return Task.FromResult(draft);
+        _docs.Add(Clone(draft));
+        return Task.FromResult(Clone(draft));
     }
 
     public Task<BenefitPlan> UpdateDraftAsync(BenefitPlan draft)
@@ -131,8 +146,8 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
             throw new PlanVersionStateException(existing.PlanId, existing.VersionId, existing.VersionState,
                 $"Plan version {existing.VersionId} is {existing.VersionState} and cannot be edited.");
         _docs.Remove(existing);
-        _docs.Add(draft);
-        return Task.FromResult(draft);
+        _docs.Add(Clone(draft));
+        return Task.FromResult(Clone(draft));
     }
 
     public Task<BenefitPlan> PublishAndSupersedeAsync(BenefitPlan draftToPublish, BenefitPlan? predecessor)
@@ -150,15 +165,15 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
         {
             var existingDraft = _docs.FirstOrDefault(d => d.Id == draftToPublish.Id);
             if (existingDraft != null) _docs.Remove(existingDraft);
-            _docs.Add(draftToPublish);
+            _docs.Add(Clone(draftToPublish));
 
             if (predecessor != null)
             {
                 var existingPred = _docs.FirstOrDefault(d => d.Id == predecessor.Id);
                 if (existingPred != null) _docs.Remove(existingPred);
-                _docs.Add(predecessor);
+                _docs.Add(Clone(predecessor));
             }
-            return Task.FromResult(draftToPublish);
+            return Task.FromResult(Clone(draftToPublish));
         }
         catch
         {

--- a/src/services/benefit-plan-service/Controllers/BenefitPlanMemberViewController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlanMemberViewController.cs
@@ -1,6 +1,6 @@
+using BenefitPlanService.Adapters;
 using BenefitPlanService.Middleware;
 using BenefitPlanService.Models;
-using BenefitPlanService.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BenefitPlanService.Controllers;
@@ -16,14 +16,14 @@ namespace BenefitPlanService.Controllers;
 [Route("api/v1/benefit-plans")]
 public class BenefitPlanMemberViewController : ControllerBase
 {
-    private readonly IBenefitViewService _view;
+    private readonly BenefitPlanAdapterFactory _adapterFactory;
     private readonly ILogger<BenefitPlanMemberViewController> _logger;
 
     public BenefitPlanMemberViewController(
-        IBenefitViewService view,
+        BenefitPlanAdapterFactory adapterFactory,
         ILogger<BenefitPlanMemberViewController> logger)
     {
-        _view = view;
+        _adapterFactory = adapterFactory;
         _logger = logger;
     }
 
@@ -46,13 +46,21 @@ public class BenefitPlanMemberViewController : ControllerBase
             "Building member view for plan {PlanId} tenant {TenantId} as of {ServiceDate:yyyy-MM-dd}",
             SanitizeForLog(planId), SanitizeForLog(TenantId), asOf);
 
-        var view = await _view.GetMemberViewAsync(planId, TenantId, asOf);
-        if (view == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetMemberBenefitViewAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = TenantId,
+            PlanId = planId,
+            ServiceDate = asOf,
+            PlatformSettings = settings,
+        });
+
+        if (response.View == null)
         {
             return NotFound(new { message = $"Benefit plan '{planId}' not found" });
         }
 
-        return Ok(view);
+        return Ok(response.View.ToMemberBenefitView());
     }
 
     private static string SanitizeForLog(string? value)

--- a/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using BenefitPlanService.Adapters;
 using BenefitPlanService.Middleware;
 using BenefitPlanService.Models;
 using BenefitPlanService.Repositories;
@@ -15,11 +16,16 @@ namespace BenefitPlanService.Controllers;
 public class BenefitPlansController : ControllerBase
 {
     private readonly IBenefitPlanService _service;
+    private readonly BenefitPlanAdapterFactory _adapterFactory;
     private readonly ILogger<BenefitPlansController> _logger;
 
-    public BenefitPlansController(IBenefitPlanService service, ILogger<BenefitPlansController> logger)
+    public BenefitPlansController(
+        IBenefitPlanService service,
+        BenefitPlanAdapterFactory adapterFactory,
+        ILogger<BenefitPlansController> logger)
     {
         _service = service;
+        _adapterFactory = adapterFactory;
         _logger = logger;
     }
 
@@ -46,20 +52,30 @@ public class BenefitPlansController : ControllerBase
     }
 
     /// <summary>
-    /// Get a specific benefit plan by ID
+    /// Get a specific benefit plan by ID. Reads route through the
+    /// tenant-resolved <see cref="IBenefitPlanAdapter"/>; for current
+    /// tenants the factory always returns the CHO adapter, preserving
+    /// existing behavior.
     /// </summary>
     [HttpGet("{id}")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<BenefitPlan>> GetPlan(string id)
     {
-        var plan = await _service.GetPlanAsync(id, TenantId);
-        if (plan == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetPlanAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = TenantId,
+            PlanId = id,
+            PlatformSettings = settings,
+        });
+
+        if (response.Plan == null)
         {
             return NotFound(new { message = $"Benefit plan '{id}' not found" });
         }
-        
-        return Ok(plan);
+
+        return Ok(response.Plan.ToBenefitPlan());
     }
 
     /// <summary>
@@ -266,16 +282,27 @@ public class BenefitPlansController : ControllerBase
         return Ok(new PlanVersionPage { Items = items, ContinuationToken = next });
     }
 
-    /// <summary>Get a single version by <c>VersionId</c>.</summary>
+    /// <summary>
+    /// Get a single version by <c>VersionId</c>. Routes through the
+    /// tenant-resolved <see cref="IBenefitPlanAdapter"/>.
+    /// </summary>
     [HttpGet("{id}/versions/{versionId}")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<BenefitPlan>> GetVersion(string id, string versionId)
     {
-        var version = await _service.GetVersionAsync(id, versionId, TenantId);
-        if (version == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetPlanVersionAsync(new BenefitPlanAdapterRequest
+        {
+            TenantId = TenantId,
+            PlanId = id,
+            VersionId = versionId,
+            PlatformSettings = settings,
+        });
+
+        if (response.Plan == null)
             return NotFound(new { message = $"Version '{versionId}' of plan '{id}' not found" });
-        return Ok(version);
+        return Ok(response.Plan.ToBenefitPlan());
     }
 
     /// <summary>Create a Draft v1 of a brand-new plan.</summary>

--- a/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
@@ -107,7 +107,7 @@ public class BenefitPlansController : ControllerBase
     /// <summary>
     /// Update an existing benefit plan. Returns 409 Conflict when the
     /// target version is Published or Superseded — clients must create
-    /// an amendment via <c>POST /api/v1/plans/{id}/amend</c> instead.
+    /// an amendment via <c>POST /api/v1/plans/{planId}/amend</c> instead.
     /// </summary>
     [HttpPut("{id}")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
@@ -264,21 +264,28 @@ public class BenefitPlansController : ControllerBase
 
     // -----------------------------------------------------------------
     // Version chain endpoints (5.1 — Plan Identity & Versioning)
+    //
+    // These endpoints address plans by their business <c>PlanId</c> (the
+    // version-chain key shared across every version of the same plan), as
+    // opposed to <c>GET /{id}</c> / <c>PUT /{id}</c> which address a single
+    // immutable version document by its persistent row <c>Id</c>. The route
+    // token is therefore <c>{planId}</c>, not <c>{id}</c>, to keep the two
+    // identifiers distinct at the API surface.
     // -----------------------------------------------------------------
 
     /// <summary>
     /// Paginated, newest-first list of every version for a plan.
     /// </summary>
-    [HttpGet("{id}/versions")]
+    [HttpGet("{planId}/versions")]
     [ProducesResponseType(typeof(PlanVersionPage), StatusCodes.Status200OK)]
     public async Task<ActionResult<PlanVersionPage>> GetVersions(
-        string id,
+        string planId,
         [FromQuery] int pageSize = 25,
         [FromQuery] string? continuationToken = null)
     {
         if (pageSize <= 0 || pageSize > 200) pageSize = 25;
 
-        var (items, next) = await _service.ListVersionsAsync(id, TenantId, pageSize, continuationToken);
+        var (items, next) = await _service.ListVersionsAsync(planId, TenantId, pageSize, continuationToken);
         return Ok(new PlanVersionPage { Items = items, ContinuationToken = next });
     }
 
@@ -286,22 +293,22 @@ public class BenefitPlansController : ControllerBase
     /// Get a single version by <c>VersionId</c>. Routes through the
     /// tenant-resolved <see cref="IBenefitPlanAdapter"/>.
     /// </summary>
-    [HttpGet("{id}/versions/{versionId}")]
+    [HttpGet("{planId}/versions/{versionId}")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<BenefitPlan>> GetVersion(string id, string versionId)
+    public async Task<ActionResult<BenefitPlan>> GetVersion(string planId, string versionId)
     {
         var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
         var response = await adapter.GetPlanVersionAsync(new BenefitPlanAdapterRequest
         {
             TenantId = TenantId,
-            PlanId = id,
+            PlanId = planId,
             VersionId = versionId,
             PlatformSettings = settings,
         });
 
         if (response.Plan == null)
-            return NotFound(new { message = $"Version '{versionId}' of plan '{id}' not found" });
+            return NotFound(new { message = $"Version '{versionId}' of plan '{planId}' not found" });
         return Ok(response.Plan.ToBenefitPlan());
     }
 
@@ -317,24 +324,24 @@ public class BenefitPlansController : ControllerBase
         catch (ArgumentException ex) { return BadRequest(new { field = ex.ParamName, message = ex.Message }); }
 
         var draft = await _service.CreateDraftAsync(plan, TenantId, ResolveActorId());
-        return CreatedAtAction(nameof(GetVersion), new { id = draft.PlanId, versionId = draft.VersionId }, draft);
+        return CreatedAtAction(nameof(GetVersion), new { planId = draft.PlanId, versionId = draft.VersionId }, draft);
     }
 
     /// <summary>
     /// Move a Draft into Published. If a current Published version exists
     /// for the same <c>PlanId</c>, atomically supersedes it.
     /// </summary>
-    [HttpPost("{id}/versions/{versionId}/publish")]
+    [HttpPost("{planId}/versions/{versionId}/publish")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<BenefitPlan>> Publish(
-        string id, string versionId, [FromBody] PublishRequest? body = null)
+        string planId, string versionId, [FromBody] PublishRequest? body = null)
     {
         try
         {
             var published = await _service.PublishVersionAsync(
-                id, versionId, TenantId, ResolveActorId(), body?.EffectiveDate);
+                planId, versionId, TenantId, ResolveActorId(), body?.EffectiveDate);
             return Ok(published);
         }
         catch (PlanVersionStateException ex) when (ex.IsNotFound)
@@ -351,15 +358,15 @@ public class BenefitPlansController : ControllerBase
     /// Clone the latest Published version into a new Draft (next
     /// <c>VersionNumber</c>, predecessor link set).
     /// </summary>
-    [HttpPost("{id}/amend")]
+    [HttpPost("{planId}/amend")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<BenefitPlan>> Amend(string id)
+    public async Task<ActionResult<BenefitPlan>> Amend(string planId)
     {
         try
         {
-            var draft = await _service.AmendPublishedPlanAsync(id, TenantId, ResolveActorId());
-            return CreatedAtAction(nameof(GetVersion), new { id = draft.PlanId, versionId = draft.VersionId }, draft);
+            var draft = await _service.AmendPublishedPlanAsync(planId, TenantId, ResolveActorId());
+            return CreatedAtAction(nameof(GetVersion), new { planId = draft.PlanId, versionId = draft.VersionId }, draft);
         }
         catch (PlanVersionStateException ex) when (ex.IsNotFound)
         {
@@ -376,17 +383,17 @@ public class BenefitPlansController : ControllerBase
     /// release; this endpoint exists for API parity and currently returns
     /// 409 with an explanation.
     /// </summary>
-    [HttpPost("{id}/versions/{versionId}/supersede")]
+    [HttpPost("{planId}/versions/{versionId}/supersede")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<BenefitPlan>> Supersede(
-        string id, string versionId, [FromBody] SupersedeRequest body)
+        string planId, string versionId, [FromBody] SupersedeRequest body)
     {
         try
         {
             var result = await _service.SupersedeVersionAsync(
-                id, versionId, TenantId, ResolveActorId(), body?.Reason ?? string.Empty,
+                planId, versionId, TenantId, ResolveActorId(), body?.Reason ?? string.Empty,
                 body?.EffectiveDate ?? DateTime.UtcNow);
             return Ok(result);
         }
@@ -421,20 +428,20 @@ public class BenefitPlansController : ControllerBase
     }
 }
 
-/// <summary>Body for POST <c>/{id}/versions/{versionId}/publish</c>.</summary>
+/// <summary>Body for POST <c>/{planId}/versions/{versionId}/publish</c>.</summary>
 public sealed class PublishRequest
 {
     public DateTime? EffectiveDate { get; set; }
 }
 
-/// <summary>Body for POST <c>/{id}/versions/{versionId}/supersede</c>.</summary>
+/// <summary>Body for POST <c>/{planId}/versions/{versionId}/supersede</c>.</summary>
 public sealed class SupersedeRequest
 {
     public string? Reason { get; set; }
     public DateTime? EffectiveDate { get; set; }
 }
 
-/// <summary>Page envelope for <c>GET /{id}/versions</c>.</summary>
+/// <summary>Page envelope for <c>GET /{planId}/versions</c>.</summary>
 public sealed class PlanVersionPage
 {
     public IReadOnlyList<BenefitPlan> Items { get; set; } = Array.Empty<BenefitPlan>();

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
@@ -15,8 +15,8 @@ public class BenefitPlanAdapterRequest
     /// controller / repository conventions:
     /// <list type="bullet">
     ///   <item>
-    ///     <c>GetPlanAsync</c> — the persistent document <c>Id</c> (the row primary key
-    ///     used by <c>GET /api/v1/plans/{id}</c>).
+    ///     <c>GetPlanAsync</c> — the persistent document <c>Id</c> (single-version
+    ///     row primary key used by <c>GET /api/v1/plans/{id}</c>).
     ///   </item>
     ///   <item>
     ///     <c>GetPlanVersionAsync</c> — the business <c>PlanId</c> (version-chain key
@@ -27,9 +27,9 @@ public class BenefitPlanAdapterRequest
     ///     <c>GET /api/v1/benefit-plans/{planId}/member-view</c>).
     ///   </item>
     /// </list>
-    /// Required by all methods. The dual semantics mirror the historical controller
-    /// behaviour and will be consolidated when the version-chain endpoints' <c>{id}</c>
-    /// route token is renamed in a follow-up.
+    /// Required by all methods. Splitting this into two explicit fields
+    /// (<c>DocumentId</c> + <c>PlanId</c>) is tracked as a follow-up; today the
+    /// dual semantics mirror the historical controller and repository behaviour.
     /// </summary>
     public string PlanId { get; set; } = string.Empty;
 

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
@@ -2,14 +2,35 @@ namespace BenefitPlanService.Models;
 
 /// <summary>
 /// Vendor-neutral request envelope passed to any <see cref="Adapters.IBenefitPlanAdapter"/>.
-/// A single shape covers all three read methods; per-method required fields are documented below.
+/// A single shape covers all three read methods; per-method required fields and identifier
+/// semantics are documented on the individual properties below.
 /// </summary>
 public class BenefitPlanAdapterRequest
 {
     /// <summary>Tenant id resolved by the request middleware. Required by all methods.</summary>
     public string TenantId { get; set; } = string.Empty;
 
-    /// <summary>Plan id (the persistent <c>Id</c> on the document, not <c>PlanId</c> business key). Required by all methods.</summary>
+    /// <summary>
+    /// Plan identifier. Semantics differ by adapter method and follow the existing
+    /// controller / repository conventions:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <c>GetPlanAsync</c> — the persistent document <c>Id</c> (the row primary key
+    ///     used by <c>GET /api/v1/plans/{id}</c>).
+    ///   </item>
+    ///   <item>
+    ///     <c>GetPlanVersionAsync</c> — the business <c>PlanId</c> (version-chain key
+    ///     used by <c>GET /api/v1/plans/{planId}/versions/{versionId}</c>).
+    ///   </item>
+    ///   <item>
+    ///     <c>GetMemberBenefitViewAsync</c> — the persistent document <c>Id</c> (matches
+    ///     <c>GET /api/v1/benefit-plans/{planId}/member-view</c>).
+    ///   </item>
+    /// </list>
+    /// Required by all methods. The dual semantics mirror the historical controller
+    /// behaviour and will be consolidated when the version-chain endpoints' <c>{id}</c>
+    /// route token is renamed in a follow-up.
+    /// </summary>
     public string PlanId { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterRequest.cs
@@ -1,0 +1,37 @@
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Vendor-neutral request envelope passed to any <see cref="Adapters.IBenefitPlanAdapter"/>.
+/// A single shape covers all three read methods; per-method required fields are documented below.
+/// </summary>
+public class BenefitPlanAdapterRequest
+{
+    /// <summary>Tenant id resolved by the request middleware. Required by all methods.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Plan id (the persistent <c>Id</c> on the document, not <c>PlanId</c> business key). Required by all methods.</summary>
+    public string PlanId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Specific version identifier (ULID). Required by
+    /// <c>GetPlanVersionAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? VersionId { get; set; }
+
+    /// <summary>Optional subscriber id for member-scoped views.</summary>
+    public string? SubscriberId { get; set; }
+
+    /// <summary>
+    /// Effective date used to resolve which version applies. Used by
+    /// <c>GetMemberBenefitViewAsync</c>; defaults to <see cref="DateTime.UtcNow"/> when null.
+    /// </summary>
+    public DateTime? ServiceDate { get; set; }
+
+    /// <summary>
+    /// Platform-specific configuration sourced from
+    /// <c>BenefitPlanConfig.PlatformSettings</c> (e.g. QNXT base URL,
+    /// Facets credential reference). Adapters read what they need; the
+    /// factory passes the value through unchanged.
+    /// </summary>
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -1,0 +1,512 @@
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Vendor-neutral response envelope returned by <see cref="Adapters.IBenefitPlanAdapter.GetPlanAsync"/>
+/// and <see cref="Adapters.IBenefitPlanAdapter.GetPlanVersionAsync"/>.
+///
+/// <para>
+/// The payload <see cref="Plan"/> is shaped to project cleanly onto a future
+/// FHIR <c>InsurancePlan</c> resource (Section 5.8): the effective/termination
+/// pair maps to <c>InsurancePlan.period</c>, plan-level cost-sharing maps to
+/// <c>InsurancePlan.plan.specificCost</c>, network tiers map to
+/// <c>InsurancePlan.network</c>, and document references map to
+/// contained <c>DocumentReference</c> resources.
+/// </para>
+/// </summary>
+public class BenefitPlanAdapterResponse
+{
+    /// <summary>Adapter that produced the response (e.g. "cho", "qnxt").</summary>
+    public string Platform { get; set; } = string.Empty;
+
+    /// <summary>Optional raw vendor response retained for audit / debugging.</summary>
+    public string? RawResponse { get; set; }
+
+    /// <summary>Plan payload. Null when the requested plan/version is not found.</summary>
+    public AdapterBenefitPlan? Plan { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for <see cref="Adapters.IBenefitPlanAdapter.GetMemberBenefitViewAsync"/>.
+/// </summary>
+public class MemberBenefitViewAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Member view payload. Null when the requested plan is not found.</summary>
+    public AdapterMemberBenefitView? View { get; set; }
+}
+
+/// <summary>
+/// Normalized plan DTO. Field shape mirrors <see cref="BenefitPlan"/> so the
+/// CHO pass-through is lossless; round-trip mappers <see cref="From"/> and
+/// <see cref="ToBenefitPlan"/> let the controller return the existing wire format.
+/// </summary>
+public class AdapterBenefitPlan
+{
+    public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string PlanId { get; set; } = string.Empty;
+    public string PlanName { get; set; } = string.Empty;
+    public string Payer { get; set; } = string.Empty;
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+    public PlanType PlanType { get; set; }
+    public MetalLevel? MetalLevel { get; set; }
+    public LineOfBusiness LineOfBusiness { get; set; } = LineOfBusiness.Commercial;
+
+    public List<AdapterBenefit> Benefits { get; set; } = new();
+    public List<AdapterNetworkTier> NetworkTiers { get; set; } = new();
+    public AdapterCostSharing CostSharing { get; set; } = new();
+    public List<AdapterPlanDocumentReference> Documents { get; set; } = new();
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime CreatedDate { get; set; }
+    public DateTime? ModifiedDate { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public bool IsActive { get; set; } = true;
+
+    // Version-chain identity (5.1)
+    public string VersionId { get; set; } = string.Empty;
+    public int VersionNumber { get; set; }
+    public PlanVersionState VersionState { get; set; }
+    public string? PredecessorVersionId { get; set; }
+    public DateTime? PublishedAt { get; set; }
+    public string? PublishedBy { get; set; }
+    public DateTime? SupersededAt { get; set; }
+    public string? SupersededByVersionId { get; set; }
+
+    public static AdapterBenefitPlan From(BenefitPlan src) => new()
+    {
+        Id = src.Id,
+        TenantId = src.TenantId,
+        PlanId = src.PlanId,
+        PlanName = src.PlanName,
+        Payer = src.Payer,
+        EffectiveDate = src.EffectiveDate,
+        TerminationDate = src.TerminationDate,
+        PlanType = src.PlanType,
+        MetalLevel = src.MetalLevel,
+        LineOfBusiness = src.LineOfBusiness,
+        Benefits = src.Benefits.Select(AdapterBenefit.From).ToList(),
+        NetworkTiers = src.NetworkTiers.Select(AdapterNetworkTier.From).ToList(),
+        CostSharing = AdapterCostSharing.From(src.CostSharing),
+        Documents = src.Documents.Select(AdapterPlanDocumentReference.From).ToList(),
+        CreatedAt = src.CreatedAt,
+        UpdatedAt = src.UpdatedAt,
+        CreatedDate = src.CreatedDate,
+        ModifiedDate = src.ModifiedDate,
+        CreatedBy = src.CreatedBy,
+        IsActive = src.IsActive,
+        VersionId = src.VersionId,
+        VersionNumber = src.VersionNumber,
+        VersionState = src.VersionState,
+        PredecessorVersionId = src.PredecessorVersionId,
+        PublishedAt = src.PublishedAt,
+        PublishedBy = src.PublishedBy,
+        SupersededAt = src.SupersededAt,
+        SupersededByVersionId = src.SupersededByVersionId,
+    };
+
+    public BenefitPlan ToBenefitPlan() => new()
+    {
+        Id = Id,
+        TenantId = TenantId,
+        PlanId = PlanId,
+        PlanName = PlanName,
+        Payer = Payer,
+        EffectiveDate = EffectiveDate,
+        TerminationDate = TerminationDate,
+        PlanType = PlanType,
+        MetalLevel = MetalLevel,
+        LineOfBusiness = LineOfBusiness,
+        Benefits = Benefits.Select(b => b.ToBenefit()).ToList(),
+        NetworkTiers = NetworkTiers.Select(n => n.ToNetworkTier()).ToList(),
+        CostSharing = CostSharing.ToCostSharing(),
+        Documents = Documents.Select(d => d.ToPlanDocumentReference()).ToList(),
+        CreatedAt = CreatedAt,
+        UpdatedAt = UpdatedAt,
+        CreatedDate = CreatedDate,
+        ModifiedDate = ModifiedDate,
+        CreatedBy = CreatedBy,
+        IsActive = IsActive,
+        VersionId = VersionId,
+        VersionNumber = VersionNumber,
+        VersionState = VersionState,
+        PredecessorVersionId = PredecessorVersionId,
+        PublishedAt = PublishedAt,
+        PublishedBy = PublishedBy,
+        SupersededAt = SupersededAt,
+        SupersededByVersionId = SupersededByVersionId,
+    };
+}
+
+public class AdapterBenefit
+{
+    public string Id { get; set; } = string.Empty;
+    public string ServiceCategory { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public List<string> CptCodes { get; set; } = new();
+    public decimal? InNetworkCopay { get; set; }
+    public decimal? OutNetworkCopay { get; set; }
+    public decimal? InNetworkCoinsurance { get; set; }
+    public decimal? OutNetworkCoinsurance { get; set; }
+    public bool DeductibleApplies { get; set; } = true;
+    public bool OopApplies { get; set; } = true;
+    public bool PriorAuthRequired { get; set; }
+    public decimal? CopayAmount { get; set; }
+    public decimal? CoinsurancePercentage { get; set; }
+    public bool RequiresPriorAuth { get; set; }
+    public int? VisitLimit { get; set; }
+    public string? VisitLimitPeriod { get; set; }
+    public string? Limitations { get; set; }
+    public decimal? AnnualMaximum { get; set; }
+    public decimal? LifetimeMaximum { get; set; }
+
+    public static AdapterBenefit From(Benefit b) => new()
+    {
+        Id = b.Id,
+        ServiceCategory = b.ServiceCategory,
+        Description = b.Description,
+        CptCodes = b.CptCodes.ToList(),
+        InNetworkCopay = b.InNetworkCopay,
+        OutNetworkCopay = b.OutNetworkCopay,
+        InNetworkCoinsurance = b.InNetworkCoinsurance,
+        OutNetworkCoinsurance = b.OutNetworkCoinsurance,
+        DeductibleApplies = b.DeductibleApplies,
+        OopApplies = b.OopApplies,
+        PriorAuthRequired = b.PriorAuthRequired,
+        CopayAmount = b.CopayAmount,
+        CoinsurancePercentage = b.CoinsurancePercentage,
+        RequiresPriorAuth = b.RequiresPriorAuth,
+        VisitLimit = b.VisitLimit,
+        VisitLimitPeriod = b.VisitLimitPeriod,
+        Limitations = b.Limitations,
+        AnnualMaximum = b.AnnualMaximum,
+        LifetimeMaximum = b.LifetimeMaximum,
+    };
+
+    public Benefit ToBenefit() => new()
+    {
+        Id = Id,
+        ServiceCategory = ServiceCategory,
+        Description = Description,
+        CptCodes = CptCodes.ToList(),
+        InNetworkCopay = InNetworkCopay,
+        OutNetworkCopay = OutNetworkCopay,
+        InNetworkCoinsurance = InNetworkCoinsurance,
+        OutNetworkCoinsurance = OutNetworkCoinsurance,
+        DeductibleApplies = DeductibleApplies,
+        OopApplies = OopApplies,
+        PriorAuthRequired = PriorAuthRequired,
+        CopayAmount = CopayAmount,
+        CoinsurancePercentage = CoinsurancePercentage,
+        RequiresPriorAuth = RequiresPriorAuth,
+        VisitLimit = VisitLimit,
+        VisitLimitPeriod = VisitLimitPeriod,
+        Limitations = Limitations,
+        AnnualMaximum = AnnualMaximum,
+        LifetimeMaximum = LifetimeMaximum,
+    };
+}
+
+public class AdapterNetworkTier
+{
+    public string Id { get; set; } = string.Empty;
+    public string TierName { get; set; } = string.Empty;
+    public int TierLevel { get; set; }
+    public List<string> ProviderNpis { get; set; } = new();
+
+    public static AdapterNetworkTier From(NetworkTier n) => new()
+    {
+        Id = n.Id,
+        TierName = n.TierName,
+        TierLevel = n.TierLevel,
+        ProviderNpis = n.ProviderNpis.ToList(),
+    };
+
+    public NetworkTier ToNetworkTier() => new()
+    {
+        Id = Id,
+        TierName = TierName,
+        TierLevel = TierLevel,
+        ProviderNpis = ProviderNpis.ToList(),
+    };
+}
+
+public class AdapterCostSharing
+{
+    public decimal IndividualDeductible { get; set; }
+    public decimal FamilyDeductible { get; set; }
+    public decimal IndividualOutOfPocketMax { get; set; }
+    public decimal FamilyOutOfPocketMax { get; set; }
+    public decimal InNetworkDeductible { get; set; }
+    public decimal OutOfNetworkDeductible { get; set; }
+    public decimal InNetworkOutOfPocketMax { get; set; }
+    public decimal OutOfNetworkOutOfPocketMax { get; set; }
+    public decimal? OutNetworkIndividualDeductible { get; set; }
+    public decimal? OutNetworkFamilyDeductible { get; set; }
+    public decimal? OutNetworkIndividualOutOfPocketMax { get; set; }
+    public decimal? OutNetworkFamilyOutOfPocketMax { get; set; }
+
+    public static AdapterCostSharing From(CostSharing c) => new()
+    {
+        IndividualDeductible = c.IndividualDeductible,
+        FamilyDeductible = c.FamilyDeductible,
+        IndividualOutOfPocketMax = c.IndividualOutOfPocketMax,
+        FamilyOutOfPocketMax = c.FamilyOutOfPocketMax,
+        InNetworkDeductible = c.InNetworkDeductible,
+        OutOfNetworkDeductible = c.OutOfNetworkDeductible,
+        InNetworkOutOfPocketMax = c.InNetworkOutOfPocketMax,
+        OutOfNetworkOutOfPocketMax = c.OutOfNetworkOutOfPocketMax,
+        OutNetworkIndividualDeductible = c.OutNetworkIndividualDeductible,
+        OutNetworkFamilyDeductible = c.OutNetworkFamilyDeductible,
+        OutNetworkIndividualOutOfPocketMax = c.OutNetworkIndividualOutOfPocketMax,
+        OutNetworkFamilyOutOfPocketMax = c.OutNetworkFamilyOutOfPocketMax,
+    };
+
+    public CostSharing ToCostSharing() => new()
+    {
+        IndividualDeductible = IndividualDeductible,
+        FamilyDeductible = FamilyDeductible,
+        IndividualOutOfPocketMax = IndividualOutOfPocketMax,
+        FamilyOutOfPocketMax = FamilyOutOfPocketMax,
+        InNetworkDeductible = InNetworkDeductible,
+        OutOfNetworkDeductible = OutOfNetworkDeductible,
+        InNetworkOutOfPocketMax = InNetworkOutOfPocketMax,
+        OutOfNetworkOutOfPocketMax = OutOfNetworkOutOfPocketMax,
+        OutNetworkIndividualDeductible = OutNetworkIndividualDeductible,
+        OutNetworkFamilyDeductible = OutNetworkFamilyDeductible,
+        OutNetworkIndividualOutOfPocketMax = OutNetworkIndividualOutOfPocketMax,
+        OutNetworkFamilyOutOfPocketMax = OutNetworkFamilyOutOfPocketMax,
+    };
+}
+
+public class AdapterPlanDocumentReference
+{
+    public string Id { get; set; } = string.Empty;
+    public PlanDocumentType DocType { get; set; }
+    public string Location { get; set; } = string.Empty;
+    public string? ContentType { get; set; }
+    public long? Size { get; set; }
+    public string? ContentHashSha256 { get; set; }
+    public string? Version { get; set; }
+    public DateTime? EffectiveDate { get; set; }
+    public string? DisplayName { get; set; }
+
+    public static AdapterPlanDocumentReference From(PlanDocumentReference d) => new()
+    {
+        Id = d.Id,
+        DocType = d.DocType,
+        Location = d.Location,
+        ContentType = d.ContentType,
+        Size = d.Size,
+        ContentHashSha256 = d.ContentHashSha256,
+        Version = d.Version,
+        EffectiveDate = d.EffectiveDate,
+        DisplayName = d.DisplayName,
+    };
+
+    public PlanDocumentReference ToPlanDocumentReference() => new()
+    {
+        Id = Id,
+        DocType = DocType,
+        Location = Location,
+        ContentType = ContentType,
+        Size = Size,
+        ContentHashSha256 = ContentHashSha256,
+        Version = Version,
+        EffectiveDate = EffectiveDate,
+        DisplayName = DisplayName,
+    };
+}
+
+/// <summary>
+/// Normalized member-view DTO mirroring <see cref="MemberBenefitView"/>.
+/// </summary>
+public class AdapterMemberBenefitView
+{
+    public string PlanId { get; set; } = string.Empty;
+    public string PlanName { get; set; } = string.Empty;
+    public string Payer { get; set; } = string.Empty;
+    public string PlanType { get; set; } = string.Empty;
+    public string? MetalLevel { get; set; }
+    public string LineOfBusiness { get; set; } = string.Empty;
+    public DateTime AsOfDate { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+    public string PlanVersion { get; set; } = string.Empty;
+    public AdapterCostSharing CostSharing { get; set; } = new();
+    public List<AdapterCategorizedBenefit> Categories { get; set; } = new();
+    public List<AdapterPlanDocumentLink> Documents { get; set; } = new();
+
+    public static AdapterMemberBenefitView From(MemberBenefitView v) => new()
+    {
+        PlanId = v.PlanId,
+        PlanName = v.PlanName,
+        Payer = v.Payer,
+        PlanType = v.PlanType,
+        MetalLevel = v.MetalLevel,
+        LineOfBusiness = v.LineOfBusiness,
+        AsOfDate = v.AsOfDate,
+        EffectiveDate = v.EffectiveDate,
+        TerminationDate = v.TerminationDate,
+        PlanVersion = v.PlanVersion,
+        CostSharing = AdapterCostSharing.From(v.CostSharing),
+        Categories = v.Categories.Select(AdapterCategorizedBenefit.From).ToList(),
+        Documents = v.Documents.Select(AdapterPlanDocumentLink.From).ToList(),
+    };
+
+    public MemberBenefitView ToMemberBenefitView() => new()
+    {
+        PlanId = PlanId,
+        PlanName = PlanName,
+        Payer = Payer,
+        PlanType = PlanType,
+        MetalLevel = MetalLevel,
+        LineOfBusiness = LineOfBusiness,
+        AsOfDate = AsOfDate,
+        EffectiveDate = EffectiveDate,
+        TerminationDate = TerminationDate,
+        PlanVersion = PlanVersion,
+        CostSharing = CostSharing.ToCostSharing(),
+        Categories = Categories.Select(c => c.ToCategorizedBenefit()).ToList(),
+        Documents = Documents.Select(d => d.ToPlanDocumentLink()).ToList(),
+    };
+}
+
+public class AdapterCategorizedBenefit
+{
+    public string Category { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string ServiceCategory { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public AdapterNetworkTierBenefit InNetwork { get; set; } = new();
+    public AdapterNetworkTierBenefit? OutOfNetwork { get; set; }
+    public bool DeductibleApplies { get; set; }
+    public bool OopApplies { get; set; }
+    public bool PriorAuthRequired { get; set; }
+    public int? VisitLimit { get; set; }
+    public string? VisitLimitPeriod { get; set; }
+    public decimal? AnnualMaximum { get; set; }
+    public decimal? LifetimeMaximum { get; set; }
+    public string? Limitations { get; set; }
+    public AdapterPharmacyDetail? Pharmacy { get; set; }
+
+    public static AdapterCategorizedBenefit From(CategorizedBenefit c) => new()
+    {
+        Category = c.Category,
+        DisplayName = c.DisplayName,
+        ServiceCategory = c.ServiceCategory,
+        Description = c.Description,
+        InNetwork = AdapterNetworkTierBenefit.From(c.InNetwork),
+        OutOfNetwork = c.OutOfNetwork is null ? null : AdapterNetworkTierBenefit.From(c.OutOfNetwork),
+        DeductibleApplies = c.DeductibleApplies,
+        OopApplies = c.OopApplies,
+        PriorAuthRequired = c.PriorAuthRequired,
+        VisitLimit = c.VisitLimit,
+        VisitLimitPeriod = c.VisitLimitPeriod,
+        AnnualMaximum = c.AnnualMaximum,
+        LifetimeMaximum = c.LifetimeMaximum,
+        Limitations = c.Limitations,
+        Pharmacy = c.Pharmacy is null ? null : AdapterPharmacyDetail.From(c.Pharmacy),
+    };
+
+    public CategorizedBenefit ToCategorizedBenefit() => new()
+    {
+        Category = Category,
+        DisplayName = DisplayName,
+        ServiceCategory = ServiceCategory,
+        Description = Description,
+        InNetwork = InNetwork.ToNetworkTierBenefit(),
+        OutOfNetwork = OutOfNetwork?.ToNetworkTierBenefit(),
+        DeductibleApplies = DeductibleApplies,
+        OopApplies = OopApplies,
+        PriorAuthRequired = PriorAuthRequired,
+        VisitLimit = VisitLimit,
+        VisitLimitPeriod = VisitLimitPeriod,
+        AnnualMaximum = AnnualMaximum,
+        LifetimeMaximum = LifetimeMaximum,
+        Limitations = Limitations,
+        Pharmacy = Pharmacy?.ToPharmacyDetail(),
+    };
+}
+
+public class AdapterNetworkTierBenefit
+{
+    public string TierName { get; set; } = string.Empty;
+    public decimal? Copay { get; set; }
+    public decimal? Coinsurance { get; set; }
+
+    public static AdapterNetworkTierBenefit From(NetworkTierBenefit n) => new()
+    {
+        TierName = n.TierName,
+        Copay = n.Copay,
+        Coinsurance = n.Coinsurance,
+    };
+
+    public NetworkTierBenefit ToNetworkTierBenefit() => new()
+    {
+        TierName = TierName,
+        Copay = Copay,
+        Coinsurance = Coinsurance,
+    };
+}
+
+public class AdapterPharmacyDetail
+{
+    public string? TierLabel { get; set; }
+    public string? CanonicalTier { get; set; }
+    public bool IsSpecialty { get; set; }
+
+    public static AdapterPharmacyDetail From(PharmacyDetail p) => new()
+    {
+        TierLabel = p.TierLabel,
+        CanonicalTier = p.CanonicalTier,
+        IsSpecialty = p.IsSpecialty,
+    };
+
+    public PharmacyDetail ToPharmacyDetail() => new()
+    {
+        TierLabel = TierLabel,
+        CanonicalTier = CanonicalTier,
+        IsSpecialty = IsSpecialty,
+    };
+}
+
+public class AdapterPlanDocumentLink
+{
+    public string DocType { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Location { get; set; } = string.Empty;
+    public string? ContentType { get; set; }
+    public long? Size { get; set; }
+    public string? ContentHashSha256 { get; set; }
+    public string? Version { get; set; }
+    public DateTime? EffectiveDate { get; set; }
+
+    public static AdapterPlanDocumentLink From(PlanDocumentLink p) => new()
+    {
+        DocType = p.DocType,
+        DisplayName = p.DisplayName,
+        Location = p.Location,
+        ContentType = p.ContentType,
+        Size = p.Size,
+        ContentHashSha256 = p.ContentHashSha256,
+        Version = p.Version,
+        EffectiveDate = p.EffectiveDate,
+    };
+
+    public PlanDocumentLink ToPlanDocumentLink() => new()
+    {
+        DocType = DocType,
+        DisplayName = DisplayName,
+        Location = Location,
+        ContentType = ContentType,
+        Size = Size,
+        ContentHashSha256 = ContentHashSha256,
+        Version = Version,
+        EffectiveDate = EffectiveDate,
+    };
+}

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.Azure.Cosmos;
+using BenefitPlanService.Adapters;
 using BenefitPlanService.Middleware;
 using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
@@ -100,6 +101,25 @@ builder.Services.AddChoCaching(builder.Configuration, builder.Environment);
 builder.Services.AddScoped<IBenefitPlanService, BenefitPlanServiceImpl>();
 builder.Services.AddScoped<IBenefitViewService, BenefitViewService>();
 builder.Services.AddHttpContextAccessor();
+
+// ── Benefit Plan Adapters ─────────────────────────────────────────────────────
+// Tenant-driven routing: each tenant can be configured to read benefit plans
+// from CHO (default) or one of QNXT / Facets / HealthEdge once those adapters
+// are implemented. The factory consults tenant-service config (cached 5 min by
+// BenefitPlanTenantConfigCache) and falls back to "cho" on any failure.
+//
+// All adapters and the factory are scoped because ChoBenefitPlanAdapter wraps
+// scoped business services (IBenefitPlanService / IBenefitViewService). The
+// shared TTL cache lives on the singleton so it survives across requests.
+builder.Services.AddHttpClient(BenefitPlanTenantConfigCache.HttpClientName)
+    .SetHandlerLifetime(TimeSpan.FromMinutes(5))
+    .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+builder.Services.AddSingleton<BenefitPlanTenantConfigCache>();
+builder.Services.AddScoped<IBenefitPlanAdapter, ChoBenefitPlanAdapter>();
+builder.Services.AddScoped<IBenefitPlanAdapter, QnxtBenefitPlanAdapter>();
+builder.Services.AddScoped<IBenefitPlanAdapter, FacetsBenefitPlanAdapter>();
+builder.Services.AddScoped<IBenefitPlanAdapter, HealthEdgeBenefitPlanAdapter>();
+builder.Services.AddScoped<BenefitPlanAdapterFactory>();
 builder.Services.AddScoped<IBenefitEngineTenantContext, HttpContextTenantContext>();
 
 builder.Services.AddHttpClient<IClaimsAccumulatorSource, ClaimsServiceAccumulatorSource>(client =>

--- a/src/services/tenant-service/Models/Tenant.cs
+++ b/src/services/tenant-service/Models/Tenant.cs
@@ -153,6 +153,9 @@ public class TenantConfiguration
     [JsonPropertyName("eligibilityPlatform")]
     public EligibilityConfig? EligibilityPlatform { get; set; }
 
+    [JsonPropertyName("benefitPlanPlatform")]
+    public BenefitPlanConfig? BenefitPlanPlatform { get; set; }
+
     [JsonPropertyName("customSettings")]
     public Dictionary<string, string> CustomSettings { get; set; } = new();
 }
@@ -183,6 +186,32 @@ public class EligibilityConfig
 {
     [JsonPropertyName("platform")]
     public string Platform { get; set; } = "cho"; // cho, availity, change-healthcare, waystar, custom
+
+    [JsonPropertyName("apiEndpoint")]
+    public string? ApiEndpoint { get; set; }
+
+    [JsonPropertyName("keyVaultSecretName")]
+    public string? KeyVaultSecretName { get; set; }
+
+    [JsonPropertyName("timeoutMs")]
+    public int TimeoutMs { get; set; } = 5000;
+
+    [JsonPropertyName("retryCount")]
+    public int RetryCount { get; set; } = 2;
+
+    [JsonPropertyName("platformSettings")]
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration for tenant's benefit-plan source-of-truth platform.
+/// Controls which adapter is used at runtime when reading plans.
+/// Mirrors <see cref="EligibilityConfig"/>.
+/// </summary>
+public class BenefitPlanConfig
+{
+    [JsonPropertyName("platform")]
+    public string Platform { get; set; } = "cho"; // cho, qnxt, facets, healthedge
 
     [JsonPropertyName("apiEndpoint")]
     public string? ApiEndpoint { get; set; }
@@ -272,6 +301,8 @@ public class CreateTenantRequest
     public ClearinghouseConfig? Clearinghouse { get; set; }
 
     public EligibilityConfig? EligibilityPlatform { get; set; }
+
+    public BenefitPlanConfig? BenefitPlanPlatform { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Mirror the `eligibility-service` adapter pattern in `benefit-plan-service` so per-tenant routing to QNXT / Facets / HealthEdge becomes a drop-in registration rather than a service-wide refactor. CHO remains the default for every tenant — the factory consults tenant-service config (cached 5 min) and falls back to `"cho"` on any failure, so observable behavior is unchanged.

- **Adapters/** — `IBenefitPlanAdapter` (`Platform` + `GetPlanAsync` / `GetPlanVersionAsync` / `GetMemberBenefitViewAsync`), `BenefitPlanAdapterFactory`, singleton `BenefitPlanTenantConfigCache`, `ChoBenefitPlanAdapter` (wraps existing `IBenefitPlanService` + `IBenefitViewService`), and Qnxt/Facets/HealthEdge stubs that throw `NotImplementedException` with explicit migration TODOs.
- **Models/** — `BenefitPlanAdapterRequest.cs` and `BenefitPlanAdapterResponse.cs`. Vendor-neutral envelopes whose payloads (`AdapterBenefitPlan`, `AdapterMemberBenefitView`) are shaped to project cleanly onto FHIR `InsurancePlan` (Section 5.8). Round-trip mappers let controllers return the existing wire format unchanged.
- **Controllers** — `GET /api/v1/plans/{id}`, `GET /api/v1/plans/{id}/versions/{versionId}`, and `GET /api/v1/benefit-plans/{planId}/member-view` consult the factory at request entry. All other endpoints stay on `IBenefitPlanService`.
- **tenant-service** — `BenefitPlanConfig` added to `TenantConfiguration` and `CreateTenantRequest`, parallel to `EligibilityConfig`.
- **docs/architecture/benefit-plan-adapter-pattern.md** — topology, routing, DI lifetimes, FHIR alignment, migration TODOs.

## Test plan

- [ ] `dotnet build cloudhealthoffice-main.sln` — solution builds with no new warnings. (Could not run locally — sandbox has no .NET SDK.)
- [ ] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests/BenefitPlanService.Tests.csproj` — existing tests still green; new tests cover:
  - factory routing (CHO default, configured platform, case-insensitive match, unknown-platform fallback, HTTP-error fallback, exception fallback, 5-min cache, settings copy isolation),
  - CHO adapter delegation to `IBenefitPlanService` / `IBenefitViewService`,
  - Qnxt/Facets/HealthEdge stubs throw `NotImplementedException` containing the per-platform TODO marker,
  - `BenefitPlansController.GetPlan` and `GetVersion` actually hit the factory at request entry (recording-decorator test).
- [ ] Smoke: `GET /api/v1/plans/{id}` and `/member-view` return byte-identical payloads pre/post merge for a CHO tenant.
- [ ] Smoke: configure a tenant with `configuration.benefitPlanPlatform.platform = "qnxt"` and confirm the response surfaces the `NotImplementedException` TODO message in logs (proves routing works end-to-end).

## DI lifetime note

All four adapters and the factory are registered as **scoped** because `ChoBenefitPlanAdapter` composes scoped business services. The TTL cache is split out into a dedicated `BenefitPlanTenantConfigCache` registered as **singleton** so it survives across requests. This differs from `eligibility-service`, where adapters are stateless and registered as singletons.

## Out of scope (follow-ups)

- QNXT / Facets / HealthEdge adapter implementations — tracked by `TODO(qnxt-benefit-plan)` / `TODO(facets-benefit-plan)` / `TODO(healthedge-benefit-plan)`.
- Routing additional GET endpoints (`GetPlans` search, `GetPlanBenefits`, `GetVersions` list, `GetAccumulation`) and write paths through the adapter — only the three methods specified for 5.2 are routed today.
- The FHIR `InsurancePlan` projection itself (Section 5.8) — adapter payloads are shaped to receive it without further model changes.

https://claude.ai/code/session_01SCYHLsD7n4hbYD4YY79uQj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCYHLsD7n4hbYD4YY79uQj)_