### PR TITLE
feat(benefit-plan-service): plan-year definition foundation (5.3)

### DIFF
--- a/docs/architecture/plan-year-definition.md
+++ b/docs/architecture/plan-year-definition.md
@@ -1,0 +1,180 @@
+# Plan-Year Definition (Foundation)
+
+Status: 5.3 — initial implementation (Phase 1: event emission)
+Service: `src/services/benefit-plan-service`
+Companion: `src/services/accumulator-service` (subscriber, idempotent)
+
+## Why
+
+Until 5.3, plan-year boundaries were implicit. `BenefitPlan.EffectiveDate`
+and `BenefitPlan.TerminationDate` told consumers when a plan was active,
+but not how it renewed: was the plan a calendar year, an employer
+contract year, a CMS fiscal year, or a per-member enrollment
+anniversary? Each downstream service (accumulator-service, benefit
+engine, member portal) had to infer the type from naming conventions or
+out-of-band tenant config — and any disagreement led to accumulators
+resetting on the wrong day.
+
+5.3 makes the plan-year a **first-class declarative concept** so every
+consumer derives the same window from the same field.
+
+## Scope
+
+**Phase 1 (this PR):** model + scheduler + event emission only. No
+accumulator orchestration; subscribers receive events but are not yet
+required to act on them.
+
+**Phase 3 (separate prompt):** accumulator-service consumes the events
+and applies `PlanYearResetBehavior` per `AccumulatorTarget`.
+
+`BenefitPlan.EffectiveDate` / `TerminationDate` are preserved verbatim;
+they remain authoritative for plan activation. `PlanYearDefinition` is
+optional — plans created before this feature deserialize with a null
+definition, which the scheduler treats as opt-out (no events emitted).
+
+## Model
+
+```csharp
+class BenefitPlan {
+    // ... existing fields preserved ...
+    PlanYearDefinition? PlanYearDefinition { get; set; }
+    List<AccumulatorTarget> AccumulatorTargets { get; set; }
+}
+
+class PlanYearDefinition {
+    DateTime PlanYearStart;
+    DateTime PlanYearEnd;
+    PlanYearType PlanYearType;     // Calendar | Contract | Fiscal | EnrollmentAnniversary
+    int CarryoverDays;             // retro-claim grace window
+    int? AnnualResetDay;
+}
+
+class AccumulatorTarget {
+    string BenefitCategory;
+    string Unit;                   // USD | Visits | Days | Units
+    decimal Limit;
+    PlanYearResetBehavior ResetBehavior;
+    decimal? RolloverCap;          // RolloverWithCap only
+}
+```
+
+`PlanYearResetBehavior` values:
+
+| Value | Meaning |
+| ----- | ------- |
+| `ResetAtPlanYearEnd` | Zero the counter at `PlanYearEnd`. Default. |
+| `NoReset` | Carry across boundaries unchanged (lifetime maximums). |
+| `RolloverWithCap` | Roll up to `RolloverCap`; discard remainder. |
+| `InheritFromPredecessorPlan` | Start at predecessor plan's closing balance. |
+
+## Window computation
+
+`PlanYearDefinition.ComputeWindow(asOf)` returns the inclusive
+(start, end) window containing `asOf`:
+
+- **CalendarYear** — snaps to January 1 → December 31 of `asOf.Year`.
+  The persisted anchor's year is intentionally ignored: a plan declared
+  in 2020 is still a calendar plan in 2026.
+- **ContractYear / FiscalYear / EnrollmentAnniversary** — rolls the
+  persisted anchor forward (or backward) in 1-year hops until the
+  window contains `asOf`. A 200-iteration safety cap defends against
+  pathological inputs.
+
+## Event stream
+
+Two event types land in the append-only `PlanYearTransitionEvents`
+collection (Mongo today; Cosmos when cross-store consistency is
+needed — same trajectory as `PlanVersionEvents`):
+
+| Type | Fired when | Purpose |
+| ---- | ---------- | ------- |
+| `ApproachingTransition` | `now` is within `PlanYearScheduler:ApproachingDays` of `PlanYearEnd` (default 30) | Warm caches; member-portal notifications. |
+| `Transition` | `now > PlanYearEnd + CarryoverDays` | Trigger reset / rollover work in accumulator-service (Phase 3). |
+
+Both types share the `PlanVersionEvent` envelope: monotonic `Version`
+per `(TenantId, PlanId)`, partition key `{TenantId}:{PlanId}`,
+deterministic `EventId`.
+
+### Idempotency
+
+`EventId` is computed deterministically:
+
+```
+{transitionType}:{tenantId}:{planId}:{planYearEnd:yyyyMMdd}
+```
+
+Two scheduler replicas racing (or a single scheduler running on every
+tick) collapse to a single row via the unique index on
+`(TenantId, PlanId, EventId)`. The publisher's pre-insert lookup
+short-circuits the duplicate so we don't pay for a write that will be
+rejected; the unique index is the safety net for two replicas hitting
+the lookup-then-insert window simultaneously.
+
+`PlanYearTransitionEventIndexInitializer` ensures both
+`(TenantId, PlanId, EventId)` and `(TenantId, PlanId, Version)`
+unique indexes exist on startup.
+
+## Scheduler
+
+`PlanYearScheduler` is a `BackgroundService` that periodically:
+
+1. Enumerates plans via `IPlanYearScheduleSource` (Mongo prod /
+   in-memory tests).
+2. Computes the current plan-year window for each plan with a
+   `PlanYearDefinition`.
+3. Decides which event (if any) to emit:
+   - `now > PlanYearEnd + CarryoverDays` → `Transition`.
+   - `now ≥ PlanYearEnd − ApproachingDays` and `now ≤ PlanYearEnd` →
+     `ApproachingTransition`.
+4. Calls `IPlanYearTransitionPublisher`. Idempotency guarantees the
+   publisher does the right thing on reruns.
+
+### Tunables (`appsettings.json` / `PlanYearScheduler:`)
+
+| Key | Default | Notes |
+| --- | ------- | ----- |
+| `IntervalMinutes` | 360 (6h) | How often the sweep runs. |
+| `ApproachingDays` | 30 | 0 disables approaching events. |
+| `StartupDelaySeconds` | 30 | Stagger so we don't fight other init. |
+
+### Multi-replica safety
+
+The scheduler is safe to run on every replica. Idempotency lives in the
+publisher's deterministic `EventId`; two replicas computing the same
+`(planId, planYearEnd, type)` produce one row. This matches the
+operational posture of `PlanVersionEventPublisher`.
+
+### Failure handling
+
+A failed sweep logs and retries on the next tick — never takes the host
+down. Events are idempotent, so any sweep that partially completed will
+be reconciled on the next pass.
+
+## Subscriber contract (Phase 3 — for reference)
+
+`accumulator-service` subscribes to the event stream. Per the existing
+[accumulator architecture](accumulator-service.md), the subscriber must
+be idempotent: re-delivery of a `Transition` event for the same
+`{planId, planYearEnd}` must not double-reset or double-roll. The
+subscriber will key on `(TenantId, PlanId, EventId)` (already the
+publisher's idempotency key) and persist the high-water mark in its own
+`ProcessedPlanYearTransition` store, mirroring `ProcessedClaim`.
+
+## Backward compatibility
+
+- `BenefitPlan.EffectiveDate` and `BenefitPlan.TerminationDate` are
+  unchanged in shape and semantics.
+- `PlanYearDefinition` is optional. Legacy plans that never set it are
+  invisible to the scheduler.
+- `AccumulatorTargets` defaults to an empty list. The accumulator-service
+  retains its existing behavior (calendar-year reset on snapshot
+  rollover) for plans without explicit targets.
+
+## What's *not* in this PR
+
+- No accumulator orchestration. Phase 1 emits events only.
+- No bus fan-out. The Mongo stream is the system of record;
+  Service Bus / Kafka decorators land alongside Phase 3.
+- No member-anniversary fan-out. `EnrollmentAnniversary` plans emit
+  one event per plan, not per member — Phase 3 will resolve members
+  from coverage-service when applying the transition.

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -205,6 +205,71 @@ public sealed class InMemoryPlanVersionTransitionRepository : IPlanVersionTransi
     }
 }
 
+/// <summary>
+/// In-memory <see cref="IPlanYearTransitionPublisher"/> with the same
+/// idempotency contract as the Mongo implementation: re-emitting an
+/// EventId is a no-op rather than a duplicate row.
+/// </summary>
+public sealed class FakePlanYearTransitionPublisher : IPlanYearTransitionPublisher
+{
+    public List<PlanYearTransitionEvent> Events { get; } = new();
+
+    public Task<PlanYearTransitionEvent> PublishApproachingAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+        => AppendOrReturnExisting(Build(plan, PlanYearTransitionType.ApproachingTransition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId));
+
+    public Task<PlanYearTransitionEvent> PublishTransitionAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+        => AppendOrReturnExisting(Build(plan, PlanYearTransitionType.Transition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId));
+
+    private Task<PlanYearTransitionEvent> AppendOrReturnExisting(PlanYearTransitionEvent e)
+    {
+        var existing = Events.FirstOrDefault(x =>
+            x.TenantId == e.TenantId && x.PlanId == e.PlanId && x.EventId == e.EventId);
+        if (existing != null) return Task.FromResult(existing);
+
+        e.Version = Events.Count(x => x.TenantId == e.TenantId && x.PlanId == e.PlanId) + 1;
+        Events.Add(e);
+        return Task.FromResult(e);
+    }
+
+    private static PlanYearTransitionEvent Build(
+        BenefitPlan plan, PlanYearTransitionType type,
+        DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId) => new()
+        {
+            EventId = PlanYearTransitionEvent.BuildEventId(type, plan.TenantId, plan.PlanId, planYearEnd),
+            TransitionType = type,
+            TenantId = plan.TenantId,
+            PlanId = plan.PlanId,
+            FromPlanYearEnd = planYearEnd,
+            ToPlanYearStart = nextPlanYearStart,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            OccurredAt = DateTime.UtcNow
+        };
+}
+
+public sealed class FakePlanYearScheduleSource : IPlanYearScheduleSource
+{
+    public List<BenefitPlan> Plans { get; } = new();
+
+    public async IAsyncEnumerable<BenefitPlan> EnumeratePlansAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (var p in Plans)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return p;
+            await Task.Yield();
+        }
+    }
+}
+
 public sealed class FakePlanVersionEventPublisher : IPlanVersionEventPublisher
 {
     public List<PlanVersionEvent> Events { get; } = new();

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/PlanYearDefinitionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/PlanYearDefinitionTests.cs
@@ -1,0 +1,115 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Tests.Models;
+
+public class PlanYearDefinitionTests
+{
+    [Fact]
+    public void CalendarYear_window_snaps_to_jan1_regardless_of_anchor()
+    {
+        var def = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2020, 1, 1),
+            PlanYearEnd = new DateTime(2020, 12, 31),
+            PlanYearType = PlanYearType.CalendarYear
+        };
+
+        var (start, end) = def.ComputeWindow(new DateTime(2026, 7, 15));
+
+        start.Should().Be(new DateTime(2026, 1, 1));
+        end.Should().Be(new DateTime(2026, 12, 31));
+    }
+
+    [Fact]
+    public void ContractYear_window_rolls_forward_to_contain_asOf()
+    {
+        // Contract anchor: April 1 2024. As-of mid-2026 should land in
+        // the 2026-04-01 → 2027-03-31 window.
+        var def = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2024, 4, 1),
+            PlanYearEnd = new DateTime(2025, 3, 31),
+            PlanYearType = PlanYearType.ContractYear
+        };
+
+        var (start, end) = def.ComputeWindow(new DateTime(2026, 7, 15));
+
+        start.Should().Be(new DateTime(2026, 4, 1));
+        end.Should().Be(new DateTime(2027, 3, 31));
+    }
+
+    [Fact]
+    public void FiscalYear_window_anchored_to_payer_fiscal_start()
+    {
+        // Federal fiscal year: October 1 → September 30.
+        var def = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2023, 10, 1),
+            PlanYearEnd = new DateTime(2024, 9, 30),
+            PlanYearType = PlanYearType.FiscalYear
+        };
+
+        var (start, end) = def.ComputeWindow(new DateTime(2026, 4, 26));
+
+        start.Should().Be(new DateTime(2025, 10, 1));
+        end.Should().Be(new DateTime(2026, 9, 30));
+    }
+
+    [Fact]
+    public void EnrollmentAnniversary_window_rolls_per_member_anchor()
+    {
+        // Member enrolled August 12, 2024. As-of April 26 2026 should
+        // sit in the 2025-08-12 → 2026-08-11 window.
+        var def = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2024, 8, 12),
+            PlanYearEnd = new DateTime(2025, 8, 11),
+            PlanYearType = PlanYearType.EnrollmentAnniversary
+        };
+
+        var (start, end) = def.ComputeWindow(new DateTime(2026, 4, 26));
+
+        start.Should().Be(new DateTime(2025, 8, 12));
+        end.Should().Be(new DateTime(2026, 8, 11));
+    }
+
+    [Fact]
+    public void Window_rolls_backward_when_asOf_precedes_anchor()
+    {
+        // Defensive: scheduler should still produce a stable window even
+        // if it runs against a stale snapshot.
+        var def = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2030, 1, 1),
+            PlanYearEnd = new DateTime(2030, 12, 31),
+            PlanYearType = PlanYearType.ContractYear
+        };
+
+        var (start, end) = def.ComputeWindow(new DateTime(2026, 4, 26));
+
+        start.Should().Be(new DateTime(2026, 1, 1));
+        end.Should().Be(new DateTime(2026, 12, 31));
+    }
+
+    [Fact]
+    public void EventId_builder_produces_deterministic_idempotency_key()
+    {
+        var planYearEnd = new DateTime(2026, 12, 31);
+
+        var id1 = PlanYearTransitionEvent.BuildEventId(
+            PlanYearTransitionType.Transition, "tenant-1", "plan-A", planYearEnd);
+        var id2 = PlanYearTransitionEvent.BuildEventId(
+            PlanYearTransitionType.Transition, "tenant-1", "plan-A", planYearEnd);
+
+        id1.Should().Be(id2);
+        id1.Should().Be("transition:tenant-1:plan-A:20261231");
+    }
+
+    [Fact]
+    public void AccumulatorTarget_defaults_to_ResetAtPlanYearEnd()
+    {
+        var t = new AccumulatorTarget { BenefitCategory = "Deductible", Limit = 1500m };
+        t.ResetBehavior.Should().Be(PlanYearResetBehavior.ResetAtPlanYearEnd);
+        t.Unit.Should().Be("USD");
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearSchedulerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearSchedulerTests.cs
@@ -58,8 +58,8 @@ public class PlanYearSchedulerTests
 
         var result = await scheduler.SweepOnceAsync(CancellationToken.None);
 
-        result.ApproachingEmitted.Should().Be(1);
-        result.TransitionsEmitted.Should().Be(0);
+        result.ApproachingAttempted.Should().Be(1);
+        result.TransitionsAttempted.Should().Be(0);
         pub.Events.Should().HaveCount(1);
         pub.Events[0].TransitionType.Should().Be(PlanYearTransitionType.ApproachingTransition);
         pub.Events[0].FromPlanYearEnd.Should().Be(new DateTime(2026, 12, 31));
@@ -87,8 +87,8 @@ public class PlanYearSchedulerTests
 
         var result = await scheduler.SweepOnceAsync(CancellationToken.None);
 
-        result.TransitionsEmitted.Should().Be(1);
-        result.ApproachingEmitted.Should().Be(0);
+        result.TransitionsAttempted.Should().Be(1);
+        result.ApproachingAttempted.Should().Be(0);
         pub.Events.Should().ContainSingle(e => e.TransitionType == PlanYearTransitionType.Transition);
     }
 
@@ -111,8 +111,8 @@ public class PlanYearSchedulerTests
 
         var result = await scheduler.SweepOnceAsync(CancellationToken.None);
 
-        result.TransitionsEmitted.Should().Be(0);
-        result.ApproachingEmitted.Should().Be(0);
+        result.TransitionsAttempted.Should().Be(0);
+        result.ApproachingAttempted.Should().Be(0);
         pub.Events.Should().BeEmpty();
     }
 
@@ -158,8 +158,8 @@ public class PlanYearSchedulerTests
         var result = await scheduler.SweepOnceAsync(CancellationToken.None);
 
         result.Inspected.Should().Be(1);
-        result.ApproachingEmitted.Should().Be(0);
-        result.TransitionsEmitted.Should().Be(0);
+        result.ApproachingAttempted.Should().Be(0);
+        result.TransitionsAttempted.Should().Be(0);
         pub.Events.Should().BeEmpty();
     }
 
@@ -168,9 +168,8 @@ public class PlanYearSchedulerTests
     [InlineData(PlanYearType.ContractYear, "2024-04-01", "2025-03-31", "2026-03-20")]
     [InlineData(PlanYearType.FiscalYear, "2023-10-01", "2024-09-30", "2026-09-15")]
     [InlineData(PlanYearType.EnrollmentAnniversary, "2024-08-12", "2025-08-11", "2026-07-25")]
-    public async Task Sweep_handles_each_plan_year_type(string planYearType, string anchorStart, string anchorEnd, string asOf)
+    public async Task Sweep_handles_each_plan_year_type(PlanYearType planYearType, string anchorStart, string anchorEnd, string asOf)
     {
-        var type = Enum.Parse<PlanYearType>(planYearType);
         var now = DateTime.SpecifyKind(DateTime.Parse(asOf), DateTimeKind.Utc);
         var (scheduler, pub, src) = BuildScheduler(now);
 
@@ -178,12 +177,12 @@ public class PlanYearSchedulerTests
         {
             PlanYearStart = DateTime.Parse(anchorStart),
             PlanYearEnd = DateTime.Parse(anchorEnd),
-            PlanYearType = type
-        }, planId: $"plan-{type}"));
+            PlanYearType = planYearType
+        }, planId: $"plan-{planYearType}"));
 
         var result = await scheduler.SweepOnceAsync(CancellationToken.None);
 
-        result.ApproachingEmitted.Should().Be(1, $"asOf {asOf} sits inside the 30-day approach window for {type}");
+        result.ApproachingAttempted.Should().Be(1, $"asOf {asOf} sits inside the 30-day approach window for {planYearType}");
         pub.Events.Should().ContainSingle();
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearSchedulerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearSchedulerTests.cs
@@ -1,0 +1,196 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Services;
+
+public class PlanYearSchedulerTests
+{
+    private static (PlanYearScheduler scheduler, FakePlanYearTransitionPublisher pub, FakePlanYearScheduleSource src)
+        BuildScheduler(DateTime now, int approachingDays = 30)
+    {
+        var pub = new FakePlanYearTransitionPublisher();
+        var src = new FakePlanYearScheduleSource();
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanYearTransitionPublisher>(pub);
+        services.AddSingleton<IPlanYearScheduleSource>(src);
+        var sp = services.BuildServiceProvider();
+        var clock = new FakeTimeProvider(now);
+        var scheduler = new PlanYearScheduler(
+            sp,
+            new PlanYearSchedulerOptions { IntervalMinutes = 60, ApproachingDays = approachingDays, StartupDelaySeconds = 0 },
+            clock,
+            NullLogger<PlanYearScheduler>.Instance);
+        return (scheduler, pub, src);
+    }
+
+    private static BenefitPlan PlanWith(PlanYearDefinition def, string planId = "plan-1", string tenantId = "tenant-1")
+        => new()
+        {
+            TenantId = tenantId,
+            PlanId = planId,
+            PlanName = "Test Plan",
+            Payer = "Test Payer",
+            EffectiveDate = def.PlanYearStart,
+            PlanType = PlanType.PPO,
+            VersionId = $"v-{planId}",
+            VersionNumber = 1,
+            VersionState = PlanVersionState.Published,
+            PlanYearDefinition = def
+        };
+
+    [Fact]
+    public async Task Sweep_emits_ApproachingTransition_when_within_window()
+    {
+        // Plan year ends Dec 31 2026; today is Dec 10 2026 → 21 days out, inside the
+        // 30-day approaching window.
+        var now = new DateTime(2026, 12, 10, 0, 0, 0, DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        src.Plans.Add(PlanWith(new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            PlanYearType = PlanYearType.CalendarYear
+        }));
+
+        var result = await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        result.ApproachingEmitted.Should().Be(1);
+        result.TransitionsEmitted.Should().Be(0);
+        pub.Events.Should().HaveCount(1);
+        pub.Events[0].TransitionType.Should().Be(PlanYearTransitionType.ApproachingTransition);
+        pub.Events[0].FromPlanYearEnd.Should().Be(new DateTime(2026, 12, 31));
+        pub.Events[0].ToPlanYearStart.Should().Be(new DateTime(2027, 1, 1));
+    }
+
+    [Fact]
+    public async Task Sweep_emits_Transition_after_planYearEnd_passes()
+    {
+        // Plan year ended Dec 31 2025; today is Jan 5 2026 → past end, no carryover.
+        var now = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        // Anchor at 2025-01-01 so the window containing now (Jan 5 2026)
+        // is the 2026 calendar year — but ComputeWindow snaps calendar
+        // plans to asOf's year. To exercise the post-end transition we
+        // use a contract-year plan whose end falls just before now.
+        src.Plans.Add(PlanWith(new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2025, 1, 1),
+            PlanYearEnd = new DateTime(2025, 12, 31),
+            PlanYearType = PlanYearType.ContractYear,
+            CarryoverDays = 0
+        }));
+
+        var result = await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        result.TransitionsEmitted.Should().Be(1);
+        result.ApproachingEmitted.Should().Be(0);
+        pub.Events.Should().ContainSingle(e => e.TransitionType == PlanYearTransitionType.Transition);
+    }
+
+    [Fact]
+    public async Task Sweep_respects_CarryoverDays_before_emitting_Transition()
+    {
+        // Plan year ended 2025-12-31 with 30-day carryover. Today is
+        // 2026-01-15 → 15 days into carryover → must NOT yet emit
+        // Transition (retro claims still allowed).
+        var now = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        src.Plans.Add(PlanWith(new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2025, 1, 1),
+            PlanYearEnd = new DateTime(2025, 12, 31),
+            PlanYearType = PlanYearType.ContractYear,
+            CarryoverDays = 30
+        }));
+
+        var result = await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        result.TransitionsEmitted.Should().Be(0);
+        result.ApproachingEmitted.Should().Be(0);
+        pub.Events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Sweep_is_idempotent_on_rerun()
+    {
+        var now = new DateTime(2026, 12, 15, 0, 0, 0, DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        src.Plans.Add(PlanWith(new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            PlanYearType = PlanYearType.CalendarYear
+        }));
+
+        await scheduler.SweepOnceAsync(CancellationToken.None);
+        await scheduler.SweepOnceAsync(CancellationToken.None);
+        await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        // Three sweeps, one event — publisher dedups on EventId.
+        pub.Events.Should().HaveCount(1);
+        pub.Events[0].Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Sweep_skips_plans_without_PlanYearDefinition()
+    {
+        var now = new DateTime(2026, 12, 15, 0, 0, 0, DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        src.Plans.Add(new BenefitPlan
+        {
+            TenantId = "t",
+            PlanId = "p",
+            PlanName = "Legacy",
+            Payer = "X",
+            EffectiveDate = new DateTime(2026, 1, 1),
+            PlanType = PlanType.HMO,
+            PlanYearDefinition = null
+        });
+
+        var result = await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        result.Inspected.Should().Be(1);
+        result.ApproachingEmitted.Should().Be(0);
+        result.TransitionsEmitted.Should().Be(0);
+        pub.Events.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(PlanYearType.CalendarYear, "2026-01-01", "2026-12-31", "2026-12-15")]
+    [InlineData(PlanYearType.ContractYear, "2024-04-01", "2025-03-31", "2026-03-20")]
+    [InlineData(PlanYearType.FiscalYear, "2023-10-01", "2024-09-30", "2026-09-15")]
+    [InlineData(PlanYearType.EnrollmentAnniversary, "2024-08-12", "2025-08-11", "2026-07-25")]
+    public async Task Sweep_handles_each_plan_year_type(string planYearType, string anchorStart, string anchorEnd, string asOf)
+    {
+        var type = Enum.Parse<PlanYearType>(planYearType);
+        var now = DateTime.SpecifyKind(DateTime.Parse(asOf), DateTimeKind.Utc);
+        var (scheduler, pub, src) = BuildScheduler(now);
+
+        src.Plans.Add(PlanWith(new PlanYearDefinition
+        {
+            PlanYearStart = DateTime.Parse(anchorStart),
+            PlanYearEnd = DateTime.Parse(anchorEnd),
+            PlanYearType = type
+        }, planId: $"plan-{type}"));
+
+        var result = await scheduler.SweepOnceAsync(CancellationToken.None);
+
+        result.ApproachingEmitted.Should().Be(1, $"asOf {asOf} sits inside the 30-day approach window for {type}");
+        pub.Events.Should().ContainSingle();
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _now;
+        public FakeTimeProvider(DateTime utcNow) => _now = new DateTimeOffset(utcNow, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearTransitionPublisherTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanYearTransitionPublisherTests.cs
@@ -1,0 +1,77 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Tests.Fakes;
+
+namespace BenefitPlanService.Tests.Services;
+
+public class FakePlanYearTransitionPublisherTests
+{
+    private static BenefitPlan SamplePlan(string planId = "plan-A") => new()
+    {
+        TenantId = "tenant-1",
+        PlanId = planId,
+        PlanName = "Test",
+        Payer = "Test",
+        EffectiveDate = new DateTime(2026, 1, 1),
+        PlanType = PlanType.PPO,
+        VersionId = "v-1",
+        VersionNumber = 1,
+        VersionState = PlanVersionState.Published,
+        PlanYearDefinition = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+            PlanYearType = PlanYearType.CalendarYear
+        }
+    };
+
+    [Fact]
+    public async Task PublishApproaching_then_PublishTransition_uses_monotonic_versions()
+    {
+        var sut = new FakePlanYearTransitionPublisher();
+        var plan = SamplePlan();
+        var end = new DateTime(2026, 12, 31);
+        var nextStart = end.AddDays(1);
+
+        var a = await sut.PublishApproachingAsync(plan, end, nextStart, "scheduler", null);
+        var t = await sut.PublishTransitionAsync(plan, end, nextStart, "scheduler", null);
+
+        sut.Events.Should().HaveCount(2);
+        a.Version.Should().Be(1);
+        t.Version.Should().Be(2);
+        a.TransitionType.Should().Be(PlanYearTransitionType.ApproachingTransition);
+        t.TransitionType.Should().Be(PlanYearTransitionType.Transition);
+    }
+
+    [Fact]
+    public async Task Republishing_same_transition_is_idempotent()
+    {
+        // Two scheduler replicas racing — both compute the same EventId
+        // and the publisher must collapse them to one row.
+        var sut = new FakePlanYearTransitionPublisher();
+        var plan = SamplePlan();
+        var end = new DateTime(2026, 12, 31);
+        var nextStart = end.AddDays(1);
+
+        var first = await sut.PublishTransitionAsync(plan, end, nextStart, "scheduler", "corr-1");
+        var second = await sut.PublishTransitionAsync(plan, end, nextStart, "scheduler", "corr-2");
+
+        sut.Events.Should().ContainSingle();
+        first.EventId.Should().Be(second.EventId);
+        // First write wins — second call returns the original row, so
+        // the original CorrelationId is preserved.
+        second.CorrelationId.Should().Be("corr-1");
+    }
+
+    [Fact]
+    public async Task Different_planYearEnds_produce_distinct_events()
+    {
+        var sut = new FakePlanYearTransitionPublisher();
+        var plan = SamplePlan();
+
+        await sut.PublishTransitionAsync(plan, new DateTime(2025, 12, 31), new DateTime(2026, 1, 1), null, null);
+        await sut.PublishTransitionAsync(plan, new DateTime(2026, 12, 31), new DateTime(2027, 1, 1), null, null);
+
+        sut.Events.Should().HaveCount(2);
+        sut.Events.Select(e => e.EventId).Should().OnlyHaveUniqueItems();
+    }
+}

--- a/src/services/benefit-plan-service/HostedServices/PlanYearTransitionEventIndexInitializer.cs
+++ b/src/services/benefit-plan-service/HostedServices/PlanYearTransitionEventIndexInitializer.cs
@@ -1,0 +1,74 @@
+using BenefitPlanService.Models;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.HostedServices;
+
+/// <summary>
+/// Creates Mongo indexes used by the
+/// <c>PlanYearTransitionEvents</c> stream once at startup. Mirrors
+/// <see cref="PlanVersionEventIndexInitializer"/> in this service and
+/// <c>MemberEventIndexInitializer</c> in member-service.
+///
+/// The indexes are what make
+/// <see cref="Services.MongoPlanYearTransitionPublisher"/>'s retry loop
+/// correct — without the unique index on
+/// <c>(TenantId, PlanId, Version)</c>, two scheduler replicas racing
+/// could each insert with the same <c>Version</c> and the
+/// duplicate-key catch never fires.
+///
+/// Idempotent: Mongo silently no-ops an index that already exists with
+/// the same spec.
+/// </summary>
+public sealed class PlanYearTransitionEventIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly string _collectionName;
+    private readonly ILogger<PlanYearTransitionEventIndexInitializer> _logger;
+
+    public PlanYearTransitionEventIndexInitializer(
+        IMongoDatabase db,
+        IConfiguration configuration,
+        ILogger<PlanYearTransitionEventIndexInitializer> logger)
+    {
+        _db = db;
+        _collectionName = configuration["CosmosDb:PlanYearTransitionEventsContainer"]
+            ?? "PlanYearTransitionEvents";
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<PlanYearTransitionEvent>(_collectionName);
+
+        // (TenantId, PlanId, EventId) — idempotency key. The publisher's
+        // pre-insert lookup uses this; the unique constraint is what
+        // makes "scheduler runs twice" a no-op.
+        var idemKeys = Builders<PlanYearTransitionEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.PlanId)
+            .Ascending(x => x.EventId);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<PlanYearTransitionEvent>(
+                idemKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_plan_event" }),
+            cancellationToken: cancellationToken);
+
+        // (TenantId, PlanId, Version) — monotonic-ordering invariant.
+        var orderKeys = Builders<PlanYearTransitionEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.PlanId)
+            .Ascending(x => x.Version);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<PlanYearTransitionEvent>(
+                orderKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_plan_version" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation(
+            "PlanYearTransitionEvent indexes ensured on collection '{Collection}'.",
+            _collectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -155,6 +155,23 @@ public class BenefitPlan
 
     [JsonPropertyName("supersededByVersionId")]
     public string? SupersededByVersionId { get; set; }
+
+    // ---------------------------------------------------------------------
+    // Plan-Year Definition (5.3 — Plan-Year Definition Foundation)
+    //
+    // Optional. Plans created before this feature deserialize with a null
+    // definition and an empty accumulator-target list, which the
+    // PlanYearScheduler treats as opt-out (no events emitted).
+    // EffectiveDate / TerminationDate above are preserved verbatim and
+    // remain authoritative for plan activation. See
+    // docs/architecture/plan-year-definition.md.
+    // ---------------------------------------------------------------------
+
+    [JsonPropertyName("planYearDefinition")]
+    public PlanYearDefinition? PlanYearDefinition { get; set; }
+
+    [JsonPropertyName("accumulatorTargets")]
+    public List<AccumulatorTarget> AccumulatorTargets { get; set; } = new();
 }
 
 /// <summary>

--- a/src/services/benefit-plan-service/Models/PlanYearDefinition.cs
+++ b/src/services/benefit-plan-service/Models/PlanYearDefinition.cs
@@ -1,0 +1,214 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Declarative description of a plan's renewal cycle (5.3 — Plan-Year
+/// Definition). Until now <see cref="BenefitPlan.EffectiveDate"/> and
+/// <see cref="BenefitPlan.TerminationDate"/> were the only signals about
+/// when a plan year started or ended; downstream consumers had to infer
+/// the type (calendar / contract / fiscal / anniversary) from naming
+/// conventions or out-of-band config. This makes the type a first-class
+/// declarative field so the scheduler, accumulator-service, and benefit
+/// engine all derive the same window deterministically.
+///
+/// <para>
+/// Backward compatibility: <see cref="BenefitPlan.EffectiveDate"/> and
+/// <see cref="BenefitPlan.TerminationDate"/> are preserved verbatim and
+/// remain authoritative for plan activation. PlanYearDefinition is
+/// optional — plans created before this feature deserialize with a null
+/// definition, which the scheduler treats as opt-out.
+/// </para>
+/// </summary>
+public class PlanYearDefinition
+{
+    /// <summary>
+    /// Anchor date for the current plan year. For
+    /// <see cref="PlanYearType.CalendarYear"/> this is January 1; for
+    /// <see cref="PlanYearType.ContractYear"/> and
+    /// <see cref="PlanYearType.FiscalYear"/> it is the contract / fiscal
+    /// start; for <see cref="PlanYearType.EnrollmentAnniversary"/> it is
+    /// the member's enrollment effective date.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("planYearStart")]
+    public DateTime PlanYearStart { get; set; }
+
+    /// <summary>
+    /// Inclusive end of the current plan year. Computed by the publisher
+    /// when <see cref="ComputeWindow"/> runs, but persisted here so the
+    /// authoritative value travels with the plan and downstream consumers
+    /// never have to recompute.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("planYearEnd")]
+    public DateTime PlanYearEnd { get; set; }
+
+    [Required]
+    [JsonPropertyName("planYearType")]
+    public PlanYearType PlanYearType { get; set; } = PlanYearType.CalendarYear;
+
+    /// <summary>
+    /// Number of days after <see cref="PlanYearEnd"/> during which a
+    /// claim with a service date in the closing year may still be
+    /// applied to that year's accumulator. 0 disables carryover (default).
+    /// </summary>
+    [JsonPropertyName("carryoverDays")]
+    public int CarryoverDays { get; set; }
+
+    /// <summary>
+    /// Day-of-year on which non-anniversary plans reset. Matches
+    /// <see cref="PlanYearStart"/> for calendar / contract / fiscal
+    /// plans; ignored for anniversary plans where each member rolls on
+    /// their own enrollment date. Persisted explicitly so the scheduler
+    /// does not need to re-derive from the start date on every tick.
+    /// </summary>
+    [JsonPropertyName("annualResetDay")]
+    public int? AnnualResetDay { get; set; }
+
+    /// <summary>
+    /// Computes the plan-year window containing <paramref name="asOf"/>.
+    /// Returns inclusive start and end dates; for calendar / contract /
+    /// fiscal types the window is exactly one year; for anniversary
+    /// plans the window rolls forward from <see cref="PlanYearStart"/>.
+    /// </summary>
+    public (DateTime Start, DateTime End) ComputeWindow(DateTime asOf)
+    {
+        var start = PlanYearStart.Date;
+        if (PlanYearType == PlanYearType.CalendarYear)
+        {
+            // Snap to Jan 1 of asOf's year, regardless of the persisted
+            // PlanYearStart's year — calendar plans always reset Jan 1.
+            start = new DateTime(asOf.Year, 1, 1);
+            return (start, start.AddYears(1).AddDays(-1));
+        }
+
+        // Contract / Fiscal / Anniversary: roll PlanYearStart forward in
+        // 1-year hops until the window contains asOf. Caps the loop at
+        // 200 iterations to defend against pathological inputs.
+        var end = start.AddYears(1).AddDays(-1);
+        var safety = 0;
+        while (asOf > end && safety++ < 200)
+        {
+            start = start.AddYears(1);
+            end = start.AddYears(1).AddDays(-1);
+        }
+        // Roll backward when asOf precedes the persisted anchor (rare —
+        // happens only when the scheduler runs against an old snapshot).
+        while (asOf < start && safety++ < 200)
+        {
+            start = start.AddYears(-1);
+            end = start.AddYears(1).AddDays(-1);
+        }
+        return (start, end);
+    }
+}
+
+/// <summary>
+/// Enumerates the four plan-year shapes the platform supports. Used by
+/// <see cref="PlanYearDefinition.ComputeWindow"/> and by the scheduler
+/// to decide when to emit transition events.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PlanYearType
+{
+    /// <summary>January 1 – December 31. The most common shape.</summary>
+    CalendarYear = 1,
+
+    /// <summary>
+    /// Anchored to a contract effective date. Common for self-funded
+    /// employer plans. Resets on the contract anniversary.
+    /// </summary>
+    ContractYear = 2,
+
+    /// <summary>
+    /// Anchored to the payer's fiscal year (often July 1 or October 1).
+    /// </summary>
+    FiscalYear = 3,
+
+    /// <summary>
+    /// Each member rolls on their own enrollment effective date.
+    /// Common for individual market and Medicare Advantage SEPs.
+    /// </summary>
+    EnrollmentAnniversary = 4
+}
+
+/// <summary>
+/// Plan-level accumulator declaration. Lets the plan author tell the
+/// accumulator-service which counters to maintain and how each one
+/// behaves at plan-year boundaries. The accumulator-service is the
+/// runtime owner of the actual numbers; this type is authoring metadata
+/// only.
+///
+/// <para>
+/// A plan may declare zero or more <see cref="AccumulatorTarget"/>s.
+/// When the scheduler emits a <see cref="PlanYearTransitionEvent"/>, the
+/// downstream subscriber inspects each target's
+/// <see cref="ResetBehavior"/> to decide whether to zero, roll over, or
+/// ignore the corresponding accumulator. The subscriber must remain
+/// idempotent — see docs/architecture/plan-year-definition.md.
+/// </para>
+/// </summary>
+public class AccumulatorTarget
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Benefit category this counter is keyed on (free-form; matches
+    /// <c>ServiceAccumulator.BenefitCategory</c> in accumulator-service).
+    /// "Deductible" / "OOP" are reserved for the cost-share rollups.
+    /// </summary>
+    [Required]
+    [JsonPropertyName("benefitCategory")]
+    public string BenefitCategory { get; set; } = string.Empty;
+
+    /// <summary>USD | Visits | Days | Units. Matches accumulator-service.</summary>
+    [JsonPropertyName("unit")]
+    public string Unit { get; set; } = "USD";
+
+    [JsonPropertyName("limit")]
+    public decimal Limit { get; set; }
+
+    [Required]
+    [JsonPropertyName("resetBehavior")]
+    public PlanYearResetBehavior ResetBehavior { get; set; } = PlanYearResetBehavior.ResetAtPlanYearEnd;
+
+    /// <summary>
+    /// Maximum amount that may carry over when
+    /// <see cref="ResetBehavior"/> is <see cref="PlanYearResetBehavior.RolloverWithCap"/>.
+    /// Ignored for the other behaviors.
+    /// </summary>
+    [JsonPropertyName("rolloverCap")]
+    public decimal? RolloverCap { get; set; }
+}
+
+/// <summary>
+/// How an <see cref="AccumulatorTarget"/> behaves when the plan year
+/// rolls over. Consumed by the accumulator-service when it processes a
+/// <see cref="PlanYearTransitionEvent"/>.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PlanYearResetBehavior
+{
+    /// <summary>Zero the counter at <see cref="PlanYearDefinition.PlanYearEnd"/>.</summary>
+    ResetAtPlanYearEnd = 1,
+
+    /// <summary>Carry the counter across boundaries unchanged (e.g. lifetime maximums).</summary>
+    NoReset = 2,
+
+    /// <summary>
+    /// Carry up to <see cref="AccumulatorTarget.RolloverCap"/> into the
+    /// new year; discard the remainder. Common for HSA-style funds.
+    /// </summary>
+    RolloverWithCap = 3,
+
+    /// <summary>
+    /// New plan starts at the closing balance of the predecessor plan.
+    /// Used when a plan replaces another mid-stream (mergers, plan
+    /// switches) — the accumulator-service resolves the predecessor via
+    /// the version chain.
+    /// </summary>
+    InheritFromPredecessorPlan = 4
+}

--- a/src/services/benefit-plan-service/Models/PlanYearDefinition.cs
+++ b/src/services/benefit-plan-service/Models/PlanYearDefinition.cs
@@ -69,37 +69,49 @@ public class PlanYearDefinition
 
     /// <summary>
     /// Computes the plan-year window containing <paramref name="asOf"/>.
-    /// Returns inclusive start and end dates; for calendar / contract /
-    /// fiscal types the window is exactly one year; for anniversary
-    /// plans the window rolls forward from <see cref="PlanYearStart"/>.
+    /// Returns inclusive start and end dates.
+    ///
+    /// <para>
+    /// For calendar plans the window snaps to Jan 1 – Dec 31 of
+    /// <paramref name="asOf"/>'s year. For contract / fiscal /
+    /// anniversary plans both <see cref="PlanYearStart"/> and
+    /// <see cref="PlanYearEnd"/> roll forward (or backward) in
+    /// 1-year hops until the window contains <paramref name="asOf"/>.
+    /// Honoring the persisted end keeps day-of-year boundaries
+    /// authoritative — leap years and explicit terminus dates survive
+    /// the rollover without drift.
+    /// </para>
     /// </summary>
     public (DateTime Start, DateTime End) ComputeWindow(DateTime asOf)
     {
-        var start = PlanYearStart.Date;
         if (PlanYearType == PlanYearType.CalendarYear)
         {
-            // Snap to Jan 1 of asOf's year, regardless of the persisted
-            // PlanYearStart's year — calendar plans always reset Jan 1.
-            start = new DateTime(asOf.Year, 1, 1);
-            return (start, start.AddYears(1).AddDays(-1));
+            // Calendar plans always reset Jan 1, regardless of the
+            // persisted anchor's year.
+            var calStart = new DateTime(asOf.Year, 1, 1);
+            return (calStart, calStart.AddYears(1).AddDays(-1));
         }
 
-        // Contract / Fiscal / Anniversary: roll PlanYearStart forward in
-        // 1-year hops until the window contains asOf. Caps the loop at
+        // Contract / Fiscal / Anniversary: roll the persisted
+        // (start, end) pair forward together so the persisted end's
+        // day-of-year is preserved across rollovers. Caps the loop at
         // 200 iterations to defend against pathological inputs.
-        var end = start.AddYears(1).AddDays(-1);
+        var start = PlanYearStart.Date;
+        var end = PlanYearEnd.Date;
+        // Defensive: if end was never set or is malformed, derive the
+        // canonical 1-year-minus-a-day window from start.
+        if (end < start) end = start.AddYears(1).AddDays(-1);
+
         var safety = 0;
         while (asOf > end && safety++ < 200)
         {
             start = start.AddYears(1);
-            end = start.AddYears(1).AddDays(-1);
+            end = end.AddYears(1);
         }
-        // Roll backward when asOf precedes the persisted anchor (rare —
-        // happens only when the scheduler runs against an old snapshot).
         while (asOf < start && safety++ < 200)
         {
             start = start.AddYears(-1);
-            end = start.AddYears(1).AddDays(-1);
+            end = end.AddYears(-1);
         }
         return (start, end);
     }

--- a/src/services/benefit-plan-service/Models/PlanYearTransitionEvent.cs
+++ b/src/services/benefit-plan-service/Models/PlanYearTransitionEvent.cs
@@ -51,9 +51,12 @@ public class PlanYearTransitionEvent
     /// Deterministic idempotency key:
     /// <c>{transitionType}:{tenantId}:{planId}:{planYearEnd:yyyyMMdd}</c>.
     /// Re-running the scheduler will not insert a duplicate row.
+    /// Sized at 256 to accommodate the full deterministic format using
+    /// the model's allowed <see cref="TenantId"/> and <see cref="PlanId"/>
+    /// lengths (each up to 100 chars).
     /// </summary>
     [Required]
-    [StringLength(160)]
+    [StringLength(256)]
     public string EventId { get; set; } = string.Empty;
 
     [Required]

--- a/src/services/benefit-plan-service/Models/PlanYearTransitionEvent.cs
+++ b/src/services/benefit-plan-service/Models/PlanYearTransitionEvent.cs
@@ -1,0 +1,114 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Append-only event for the plan-year transition stream
+/// (5.3 — Plan-Year Definition Foundation). Mirrors
+/// <see cref="PlanVersionEvent"/>: deterministic <see cref="EventId"/>
+/// for idempotency, monotonic per-aggregate <see cref="Version"/>,
+/// partition key <c>{TenantId}:{PlanId}</c>.
+///
+/// <para>
+/// Two event types are emitted by <see cref="Services.PlanYearScheduler"/>:
+/// <list type="bullet">
+///   <item><see cref="PlanYearTransitionType.ApproachingTransition"/> — fires
+///   once per plan-year-end when within the configured window (default 30
+///   days). Lets accumulator-service warm caches and notify members.</item>
+///   <item><see cref="PlanYearTransitionType.Transition"/> — fires once
+///   when the plan-year-end has passed. Triggers reset / rollover work
+///   in accumulator-service.</item>
+/// </list>
+/// Idempotency lives in the deterministic
+/// <see cref="EventId"/> (<c>{type}:{tenantId}:{planId}:{yyyyMMdd}</c>),
+/// so re-running the scheduler — or two replicas racing — produces a
+/// single row in the stream.
+/// </para>
+/// </summary>
+[BsonIgnoreExtraElements]
+public class PlanYearTransitionEvent
+{
+    [Required]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary><c>{TenantId}:{PlanId}</c> — first-class so Cosmos and Mongo both see it.</summary>
+    [Required]
+    [StringLength(256)]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string PlanId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Deterministic idempotency key:
+    /// <c>{transitionType}:{tenantId}:{planId}:{planYearEnd:yyyyMMdd}</c>.
+    /// Re-running the scheduler will not insert a duplicate row.
+    /// </summary>
+    [Required]
+    [StringLength(160)]
+    public string EventId { get; set; } = string.Empty;
+
+    [Required]
+    public PlanYearTransitionType TransitionType { get; set; }
+
+    [Required]
+    public DateTime FromPlanYearEnd { get; set; }
+
+    [Required]
+    public DateTime ToPlanYearStart { get; set; }
+
+    /// <summary>1-based monotonic sequence per <c>(TenantId, PlanId)</c>.</summary>
+    [Required]
+    public int Version { get; set; }
+
+    public int SchemaVersion { get; set; } = 1;
+
+    [Required]
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? ActorId { get; set; }
+
+    [StringLength(128)]
+    public string? CorrelationId { get; set; }
+
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string planId) => $"{tenantId}:{planId}";
+
+    public static string BuildEventId(PlanYearTransitionType type, string tenantId, string planId, DateTime planYearEnd) =>
+        $"{type.ToString().ToLowerInvariant()}:{tenantId}:{planId}:{planYearEnd:yyyyMMdd}";
+}
+
+public enum PlanYearTransitionType
+{
+    /// <summary>
+    /// Plan-year-end is within the configured warning window (default 30
+    /// days). One event per plan-year boundary; idempotent on reruns.
+    /// </summary>
+    ApproachingTransition = 1,
+
+    /// <summary>
+    /// Plan-year-end has passed. The accumulator-service is expected to
+    /// reset / roll over targets per their <c>PlanYearResetBehavior</c>.
+    /// </summary>
+    Transition = 2
+}

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -41,6 +41,8 @@ if (useMongo)
     builder.Services.AddScoped<IAccumulatorRepository, AccumulatorRepositoryMongo>();
     builder.Services.AddScoped<IPlanVersionTransitionRepository, MongoPlanVersionTransitionRepository>();
     builder.Services.AddScoped<IPlanVersionEventPublisher, MongoPlanVersionEventPublisher>();
+    builder.Services.AddScoped<IPlanYearTransitionPublisher, MongoPlanYearTransitionPublisher>();
+    builder.Services.AddScoped<IPlanYearScheduleSource, MongoPlanYearScheduleSource>();
     // Ensures (TenantId, PlanId, EventId) and (TenantId, PlanId, Version)
     // unique indexes exist on the events collection — the publisher's
     // retry-on-duplicate loop depends on them.
@@ -53,6 +55,16 @@ if (useMongo)
               .GetDatabase(builder.Configuration["MongoDb:DatabaseName"]),
             sp.GetRequiredService<IConfiguration>(),
             sp.GetRequiredService<ILogger<BenefitPlanService.HostedServices.PlanVersionEventIndexInitializer>>()));
+    builder.Services.AddSingleton<IHostedService>(sp =>
+        new BenefitPlanService.HostedServices.PlanYearTransitionEventIndexInitializer(
+            sp.GetRequiredService<IMongoClient>()
+              .GetDatabase(builder.Configuration["MongoDb:DatabaseName"]),
+            sp.GetRequiredService<IConfiguration>(),
+            sp.GetRequiredService<ILogger<BenefitPlanService.HostedServices.PlanYearTransitionEventIndexInitializer>>()));
+    // PlanYearScheduler periodically scans plans and emits Approaching /
+    // Transition events. Idempotency lives in the publisher (deterministic
+    // EventId), so running on multiple replicas is safe.
+    builder.Services.AddHostedService<PlanYearScheduler>();
     Console.WriteLine("Using MongoDB repository");
 }
 else
@@ -77,6 +89,17 @@ else
             ? new NoopPlanVersionEventPublisher(sp.GetRequiredService<ILogger<NoopPlanVersionEventPublisher>>())
             : new MongoPlanVersionEventPublisher(mongo, sp.GetRequiredService<IConfiguration>(),
                 sp.GetRequiredService<ILogger<MongoPlanVersionEventPublisher>>());
+    });
+    // Cosmos-only deployments get the no-op publisher and no scheduler —
+    // the events stream lives in Mongo today (consistent with
+    // PlanVersionEvent). See docs/architecture/plan-year-definition.md.
+    builder.Services.AddScoped<IPlanYearTransitionPublisher>(sp =>
+    {
+        var mongo = sp.GetService<IMongoDatabase>();
+        return mongo == null
+            ? new NoopPlanYearTransitionPublisher(sp.GetRequiredService<ILogger<NoopPlanYearTransitionPublisher>>())
+            : new MongoPlanYearTransitionPublisher(mongo, sp.GetRequiredService<IConfiguration>(),
+                sp.GetRequiredService<ILogger<MongoPlanYearTransitionPublisher>>());
     });
     Console.WriteLine("Using Cosmos DB repository");
 }

--- a/src/services/benefit-plan-service/Services/PlanYearScheduler.cs
+++ b/src/services/benefit-plan-service/Services/PlanYearScheduler.cs
@@ -1,0 +1,241 @@
+using BenefitPlanService.Models;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Source of plans to evaluate on each scheduler tick. Kept as a small
+/// seam so the scheduler can be unit-tested against an in-memory list
+/// without standing up Mongo. Production binds
+/// <see cref="MongoPlanYearScheduleSource"/>.
+/// </summary>
+public interface IPlanYearScheduleSource
+{
+    /// <summary>
+    /// Yields every plan with a non-null <see cref="PlanYearDefinition"/>
+    /// in any tenant. Implementations should not page — the call site is
+    /// a periodic background sweep, not a hot path. Streaming via
+    /// <see cref="IAsyncEnumerable{T}"/> keeps memory bounded.
+    /// </summary>
+    IAsyncEnumerable<BenefitPlan> EnumeratePlansAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Mongo-backed source. Reads from the BenefitPlans collection and
+/// filters to rows that have a PlanYearDefinition set. Cosmos is not
+/// supported in Phase 1 — the events stream lives in Mongo today
+/// (consistent with PlanVersionEvent).
+/// </summary>
+public sealed class MongoPlanYearScheduleSource : IPlanYearScheduleSource
+{
+    private readonly IMongoCollection<BenefitPlan> _collection;
+
+    public MongoPlanYearScheduleSource(IMongoDatabase database, IConfiguration configuration)
+    {
+        var collectionName = configuration["CosmosDb:ContainerName"] ?? "BenefitPlans";
+        _collection = database.GetCollection<BenefitPlan>(collectionName);
+    }
+
+    public async IAsyncEnumerable<BenefitPlan> EnumeratePlansAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var b = Builders<BenefitPlan>.Filter;
+        // Only Published versions are scheduler-relevant. Drafts have no
+        // accumulator activity; Superseded versions have already been
+        // replaced by a successor whose PlanYearDefinition is the source
+        // of truth going forward.
+        var filter = b.And(
+            b.Exists(x => x.PlanYearDefinition, true),
+            b.Ne(x => x.PlanYearDefinition, null!),
+            b.Or(
+                b.Eq(x => x.VersionState, PlanVersionState.Published),
+                b.Exists(x => x.VersionState, false)));
+
+        using var cursor = await _collection.Find(filter).ToCursorAsync(ct);
+        while (await cursor.MoveNextAsync(ct))
+        {
+            foreach (var plan in cursor.Current)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return plan;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Tunables for <see cref="PlanYearScheduler"/>. Lives in
+/// <c>appsettings.json</c> under <c>PlanYearScheduler:</c>.
+/// </summary>
+public sealed class PlanYearSchedulerOptions
+{
+    /// <summary>How often the scheduler scans plans. Default 6 hours.</summary>
+    public int IntervalMinutes { get; set; } = 360;
+
+    /// <summary>
+    /// How many days before <see cref="PlanYearDefinition.PlanYearEnd"/>
+    /// the scheduler emits an <see cref="PlanYearTransitionType.ApproachingTransition"/>.
+    /// Default 30. Set to 0 to disable approaching events.
+    /// </summary>
+    public int ApproachingDays { get; set; } = 30;
+
+    /// <summary>
+    /// Cosmetic startup delay so the scheduler doesn't fight other
+    /// hosted services for the connection pool on cold start.
+    /// </summary>
+    public int StartupDelaySeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Emit-window tail for <see cref="PlanYearTransitionType.Transition"/>:
+    /// once carryover has elapsed, the scheduler keeps trying to publish
+    /// for this many days. Bounds how far back ancient transitions are
+    /// re-checked on every sweep (the publisher would dedup them anyway,
+    /// but each re-check still costs a point lookup). Default 90 days.
+    /// </summary>
+    public int TransitionEmitWindowDays { get; set; } = 90;
+}
+
+/// <summary>
+/// Background sweep that detects approaching and just-ended plan years,
+/// then emits <see cref="PlanYearTransitionEvent"/>s through
+/// <see cref="IPlanYearTransitionPublisher"/>. Phase 1 ships event
+/// emission only — accumulator orchestration ships in Phase 3.
+///
+/// <para>
+/// The scheduler is safe to run on multiple replicas: idempotency lives
+/// in the publisher, which keys on a deterministic
+/// <see cref="PlanYearTransitionEvent.EventId"/>
+/// (<c>{type}:{tenantId}:{planId}:{planYearEnd:yyyyMMdd}</c>). Two
+/// replicas racing produce one row.
+/// </para>
+/// </summary>
+public sealed class PlanYearScheduler : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly PlanYearSchedulerOptions _options;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<PlanYearScheduler> _logger;
+
+    public PlanYearScheduler(
+        IServiceProvider services,
+        IConfiguration configuration,
+        ILogger<PlanYearScheduler> logger)
+        : this(services, BindOptions(configuration), TimeProvider.System, logger) { }
+
+    // Test-friendly constructor: lets tests inject a fake clock and an
+    // explicit options instance without touching IConfiguration.
+    internal PlanYearScheduler(
+        IServiceProvider services,
+        PlanYearSchedulerOptions options,
+        TimeProvider clock,
+        ILogger<PlanYearScheduler> logger)
+    {
+        _services = services;
+        _options = options;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    private static PlanYearSchedulerOptions BindOptions(IConfiguration configuration)
+    {
+        var opts = new PlanYearSchedulerOptions();
+        configuration.GetSection("PlanYearScheduler").Bind(opts);
+        return opts;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_options.StartupDelaySeconds > 0)
+        {
+            try { await Task.Delay(TimeSpan.FromSeconds(_options.StartupDelaySeconds), stoppingToken); }
+            catch (OperationCanceledException) { return; }
+        }
+
+        var interval = TimeSpan.FromMinutes(Math.Max(1, _options.IntervalMinutes));
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                // One bad sweep must not take the host down. Log and try
+                // again on the next tick — events are idempotent.
+                _logger.LogError(ex, "PlanYearScheduler sweep failed; retrying after {Interval}", interval);
+            }
+
+            try { await Task.Delay(interval, stoppingToken); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    /// <summary>
+    /// Runs a single pass over the source. Public so tests and an
+    /// optional admin endpoint can trigger it on demand.
+    /// </summary>
+    public async Task<SweepResult> SweepOnceAsync(CancellationToken ct)
+    {
+        using var scope = _services.CreateScope();
+        var source = scope.ServiceProvider.GetRequiredService<IPlanYearScheduleSource>();
+        var publisher = scope.ServiceProvider.GetRequiredService<IPlanYearTransitionPublisher>();
+
+        var now = _clock.GetUtcNow().UtcDateTime;
+        var approaching = 0;
+        var transitions = 0;
+        var inspected = 0;
+
+        await foreach (var plan in source.EnumeratePlansAsync(ct))
+        {
+            inspected++;
+            if (plan.PlanYearDefinition is null) continue;
+
+            var def = plan.PlanYearDefinition;
+            var (currentStart, currentEnd) = def.ComputeWindow(now);
+            var nextStart = currentEnd.AddDays(1);
+            // ComputeWindow always returns the window CONTAINING now, so
+            // the just-closed plan-year-end is one day before the
+            // current window's start.
+            var previousEnd = currentStart.AddDays(-1);
+
+            // Transition: emit once carryover has elapsed for the
+            // just-closed year. Bounded by TransitionEmitWindowDays so
+            // ancient transitions don't cost a point lookup on every
+            // sweep — the publisher would dedup them, but the lookup
+            // still costs a roundtrip.
+            var emitFrom = previousEnd.AddDays(def.CarryoverDays + 1);
+            var emitUntil = emitFrom.AddDays(_options.TransitionEmitWindowDays);
+            if (now.Date >= emitFrom.Date && now.Date <= emitUntil.Date)
+            {
+                await publisher.PublishTransitionAsync(plan, previousEnd, currentStart,
+                    actorId: "scheduler", correlationId: null, ct);
+                transitions++;
+            }
+
+            // Approaching: within ApproachingDays of the CURRENT
+            // window's end. Members and accumulator caches need warning
+            // before the boundary, not after.
+            if (_options.ApproachingDays > 0)
+            {
+                var approachingFrom = currentEnd.AddDays(-_options.ApproachingDays);
+                if (now.Date >= approachingFrom.Date && now.Date <= currentEnd.Date)
+                {
+                    await publisher.PublishApproachingAsync(plan, currentEnd, nextStart,
+                        actorId: "scheduler", correlationId: null, ct);
+                    approaching++;
+                }
+            }
+        }
+
+        _logger.LogInformation(
+            "PlanYearScheduler sweep complete: inspected={Inspected} approaching={Approaching} transitions={Transitions}",
+            inspected, approaching, transitions);
+        return new SweepResult(inspected, approaching, transitions);
+    }
+
+    public readonly record struct SweepResult(int Inspected, int ApproachingEmitted, int TransitionsEmitted);
+}

--- a/src/services/benefit-plan-service/Services/PlanYearScheduler.cs
+++ b/src/services/benefit-plan-service/Services/PlanYearScheduler.cs
@@ -185,8 +185,13 @@ public sealed class PlanYearScheduler : BackgroundService
         var publisher = scope.ServiceProvider.GetRequiredService<IPlanYearTransitionPublisher>();
 
         var now = _clock.GetUtcNow().UtcDateTime;
-        var approaching = 0;
-        var transitions = 0;
+        // The scheduler only counts *attempts*. The publisher's
+        // idempotency contract means a publish call can be a no-op
+        // (returns an existing row); distinguishing that here would
+        // require extending the publisher contract, so we name the
+        // counters honestly instead.
+        var approachingAttempted = 0;
+        var transitionsAttempted = 0;
         var inspected = 0;
 
         await foreach (var plan in source.EnumeratePlansAsync(ct))
@@ -213,7 +218,7 @@ public sealed class PlanYearScheduler : BackgroundService
             {
                 await publisher.PublishTransitionAsync(plan, previousEnd, currentStart,
                     actorId: "scheduler", correlationId: null, ct);
-                transitions++;
+                transitionsAttempted++;
             }
 
             // Approaching: within ApproachingDays of the CURRENT
@@ -226,16 +231,21 @@ public sealed class PlanYearScheduler : BackgroundService
                 {
                     await publisher.PublishApproachingAsync(plan, currentEnd, nextStart,
                         actorId: "scheduler", correlationId: null, ct);
-                    approaching++;
+                    approachingAttempted++;
                 }
             }
         }
 
         _logger.LogInformation(
-            "PlanYearScheduler sweep complete: inspected={Inspected} approaching={Approaching} transitions={Transitions}",
-            inspected, approaching, transitions);
-        return new SweepResult(inspected, approaching, transitions);
+            "PlanYearScheduler sweep complete: inspected={Inspected} approachingAttempted={ApproachingAttempted} transitionsAttempted={TransitionsAttempted}",
+            inspected, approachingAttempted, transitionsAttempted);
+        return new SweepResult(inspected, approachingAttempted, transitionsAttempted);
     }
 
-    public readonly record struct SweepResult(int Inspected, int ApproachingEmitted, int TransitionsEmitted);
+    /// <summary>
+    /// Counters describe scheduler-side publish *attempts*, not
+    /// publisher-side inserts. The publisher dedups idempotently, so a
+    /// no-op replay still increments these. Naming reflects that.
+    /// </summary>
+    public readonly record struct SweepResult(int Inspected, int ApproachingAttempted, int TransitionsAttempted);
 }

--- a/src/services/benefit-plan-service/Services/PlanYearTransitionPublisher.cs
+++ b/src/services/benefit-plan-service/Services/PlanYearTransitionPublisher.cs
@@ -1,0 +1,205 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Publishes <see cref="PlanYearTransitionEvent"/>s to the append-only
+/// <c>plan-year-transition-events</c> stream. Mirrors
+/// <see cref="MongoPlanVersionEventPublisher"/>: deterministic
+/// <see cref="PlanYearTransitionEvent.EventId"/> for idempotency,
+/// monotonic <see cref="PlanYearTransitionEvent.Version"/> per
+/// <c>(TenantId, PlanId)</c>.
+///
+/// <para>
+/// Bus fan-out is intentionally not wired here. accumulator-service
+/// reads from the Mongo stream today; a Service Bus decorator can layer
+/// on without touching call sites — see Phase 3.
+/// </para>
+/// </summary>
+public interface IPlanYearTransitionPublisher
+{
+    Task<PlanYearTransitionEvent> PublishApproachingAsync(
+        BenefitPlan plan,
+        DateTime planYearEnd,
+        DateTime nextPlanYearStart,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    Task<PlanYearTransitionEvent> PublishTransitionAsync(
+        BenefitPlan plan,
+        DateTime planYearEnd,
+        DateTime nextPlanYearStart,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+}
+
+public sealed class MongoPlanYearTransitionPublisher : IPlanYearTransitionPublisher
+{
+    private const int MaxRetries = 5;
+    private static readonly int[] BackoffMs = { 2, 5, 25, 100, 250 };
+
+    private readonly IMongoCollection<PlanYearTransitionEvent> _collection;
+    private readonly ILogger<MongoPlanYearTransitionPublisher> _logger;
+
+    public MongoPlanYearTransitionPublisher(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<MongoPlanYearTransitionPublisher> logger)
+    {
+        var collectionName = configuration["CosmosDb:PlanYearTransitionEventsContainer"]
+            ?? "PlanYearTransitionEvents";
+        _collection = database.GetCollection<PlanYearTransitionEvent>(collectionName);
+        _logger = logger;
+    }
+
+    public Task<PlanYearTransitionEvent> PublishApproachingAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+        => AppendAsync(Build(plan, PlanYearTransitionType.ApproachingTransition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId), ct);
+
+    public Task<PlanYearTransitionEvent> PublishTransitionAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+        => AppendAsync(Build(plan, PlanYearTransitionType.Transition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId), ct);
+
+    private static PlanYearTransitionEvent Build(
+        BenefitPlan plan, PlanYearTransitionType type,
+        DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId)
+    {
+        var payload = new JsonObject
+        {
+            ["versionId"] = plan.VersionId,
+            ["versionNumber"] = plan.VersionNumber,
+            ["planYearType"] = plan.PlanYearDefinition?.PlanYearType.ToString(),
+            ["carryoverDays"] = plan.PlanYearDefinition?.CarryoverDays
+        };
+        return new PlanYearTransitionEvent
+        {
+            EventId = PlanYearTransitionEvent.BuildEventId(type, plan.TenantId, plan.PlanId, planYearEnd),
+            TransitionType = type,
+            TenantId = plan.TenantId,
+            PlanId = plan.PlanId,
+            FromPlanYearEnd = planYearEnd,
+            ToPlanYearStart = nextPlanYearStart,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = payload
+        };
+    }
+
+    private async Task<PlanYearTransitionEvent> AppendAsync(PlanYearTransitionEvent evt, CancellationToken ct)
+    {
+        evt.PartitionKey = PlanYearTransitionEvent.BuildPartitionKey(evt.TenantId, evt.PlanId);
+        evt.Id = evt.EventId;
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+
+        var existing = await GetByEventIdAsync(evt.TenantId, evt.PlanId, evt.EventId, ct);
+        if (existing != null)
+        {
+            _logger.LogDebug(
+                "PlanYearTransitionEvent {EventId} already present for {Tenant}:{Plan} (idempotent no-op)",
+                Sanitize(evt.EventId), Sanitize(evt.TenantId), Sanitize(evt.PlanId));
+            return existing;
+        }
+
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
+        {
+            evt.Version = await GetNextVersionAsync(evt.TenantId, evt.PlanId, ct);
+            try
+            {
+                await _collection.InsertOneAsync(evt, cancellationToken: ct);
+                return evt;
+            }
+            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                var refetch = await GetByEventIdAsync(evt.TenantId, evt.PlanId, evt.EventId, ct);
+                if (refetch != null) return refetch;
+
+                _logger.LogWarning(
+                    "PlanYearTransitionEvent version {Version} conflict for {Tenant}:{Plan}; retry {Attempt}/{Max}",
+                    evt.Version, Sanitize(evt.TenantId), Sanitize(evt.PlanId), attempt + 1, MaxRetries);
+
+                if (attempt + 1 < MaxRetries)
+                    await Task.Delay(BackoffMs[attempt], ct);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to append PlanYearTransitionEvent for {evt.TenantId}:{evt.PlanId} after {MaxRetries} attempts");
+    }
+
+    private async Task<PlanYearTransitionEvent?> GetByEventIdAsync(string tenantId, string planId, string eventId, CancellationToken ct)
+    {
+        var b = Builders<PlanYearTransitionEvent>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.PlanId, planId), b.Eq(x => x.EventId, eventId));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    private async Task<int> GetNextVersionAsync(string tenantId, string planId, CancellationToken ct)
+    {
+        var b = Builders<PlanYearTransitionEvent>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.PlanId, planId));
+        var latest = await _collection.Find(filter).SortByDescending(x => x.Version).FirstOrDefaultAsync(ct);
+        return (latest?.Version ?? 0) + 1;
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}
+
+/// <summary>
+/// No-op fallback used when Mongo isn't available (Cosmos-only
+/// deployments without the events stream provisioned). Logs a warning
+/// so ops can spot the missing wiring; mirrors
+/// <see cref="NoopPlanVersionEventPublisher"/>.
+/// </summary>
+public sealed class NoopPlanYearTransitionPublisher : IPlanYearTransitionPublisher
+{
+    private readonly ILogger<NoopPlanYearTransitionPublisher> _logger;
+
+    public NoopPlanYearTransitionPublisher(ILogger<NoopPlanYearTransitionPublisher> logger) => _logger = logger;
+
+    public Task<PlanYearTransitionEvent> PublishApproachingAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "PlanYearTransitionPublisher is not configured; dropping ApproachingTransition for plan {PlanId} planYearEnd {PlanYearEnd:yyyy-MM-dd}",
+            plan.PlanId, planYearEnd);
+        return Task.FromResult(BuildShell(plan, PlanYearTransitionType.ApproachingTransition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId));
+    }
+
+    public Task<PlanYearTransitionEvent> PublishTransitionAsync(
+        BenefitPlan plan, DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "PlanYearTransitionPublisher is not configured; dropping Transition for plan {PlanId} planYearEnd {PlanYearEnd:yyyy-MM-dd}",
+            plan.PlanId, planYearEnd);
+        return Task.FromResult(BuildShell(plan, PlanYearTransitionType.Transition,
+            planYearEnd, nextPlanYearStart, actorId, correlationId));
+    }
+
+    private static PlanYearTransitionEvent BuildShell(
+        BenefitPlan plan, PlanYearTransitionType type,
+        DateTime planYearEnd, DateTime nextPlanYearStart,
+        string? actorId, string? correlationId) => new()
+        {
+            EventId = PlanYearTransitionEvent.BuildEventId(type, plan.TenantId, plan.PlanId, planYearEnd),
+            TransitionType = type,
+            TenantId = plan.TenantId,
+            PlanId = plan.PlanId,
+            FromPlanYearEnd = planYearEnd,
+            ToPlanYearStart = nextPlanYearStart,
+            ActorId = actorId,
+            CorrelationId = correlationId
+        };
+}


### PR DESCRIPTION
## Summary

Phase 1 of the plan-year roadmap (5.3): makes the plan-year a first-class declarative concept on `BenefitPlan` and emits `ApproachingTransition` / `Transition` events on a scheduled sweep. Phase 3 (separate prompt) will land accumulator-service orchestration that consumes these events.

`BenefitPlan.EffectiveDate` and `BenefitPlan.TerminationDate` are preserved verbatim and remain authoritative for plan activation.

## What ships

- **Models**
  - `PlanYearDefinition` — `PlanYearStart`, `PlanYearEnd`, `PlanYearType` (`CalendarYear | ContractYear | FiscalYear | EnrollmentAnniversary`), `CarryoverDays`, `AnnualResetDay`. `ComputeWindow(asOf)` returns the inclusive window containing `asOf` for each type.
  - `AccumulatorTarget` + `PlanYearResetBehavior` (`ResetAtPlanYearEnd | NoReset | RolloverWithCap | InheritFromPredecessorPlan`). Plan authors declare per-counter behavior; accumulator-service consumes in Phase 3.
  - `BenefitPlan.PlanYearDefinition` (optional) and `BenefitPlan.AccumulatorTargets` (defaults to empty).
  - `PlanYearTransitionEvent` — append-only stream, mirrors `PlanVersionEvent` envelope: deterministic `EventId` for idempotency, monotonic `Version` per `(TenantId, PlanId)`, partition key `{TenantId}:{PlanId}`.
- **Services**
  - `IPlanYearTransitionPublisher` with Mongo + Noop implementations (Cosmos-only deployments fall back to Noop, mirroring `PlanVersionEventPublisher`).
  - `PlanYearScheduler` (`BackgroundService`) — periodic sweep (default 6h) that emits `ApproachingTransition` within the configured window (default 30d) and `Transition` once carryover has elapsed. Multi-replica safe: idempotency lives in the publisher (`{type}:{tenantId}:{planId}:{yyyyMMdd}` EventId). `IPlanYearScheduleSource` seam keeps it unit-testable.
  - `PlanYearTransitionEventIndexInitializer` — ensures unique indexes on `(TenantId, PlanId, EventId)` and `(TenantId, PlanId, Version)`.
- **DI** — wired in `Program.cs` for both Mongo and Cosmos paths.
- **Tests** — `BenefitPlanService.Tests`:
  - Window computation for each `PlanYearType` (calendar / contract / fiscal / anniversary).
  - Publisher dedup on `EventId`; monotonic versions across distinct events.
  - Scheduler emits Approaching / Transition correctly, respects `CarryoverDays`, skips plans without `PlanYearDefinition`, idempotent on rerun, parametrized over all four plan-year types.
- **Docs** — `docs/architecture/plan-year-definition.md`.

## Acceptance

- [x] Plan declares `PlanYearDefinition`; persisted via existing repository (additive field).
- [x] Scheduled job detects plan-year-end and emits event.
- [x] Event de-duplicated by `EventId` (deterministic, indexed unique).
- [x] All four plan-year types covered (parametrized scheduler test).
- [x] `accumulator-service` subscriber contract preserved (Phase 1 emits only; subscriber stays idempotent — see arch doc).

## Test plan

- [ ] `dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj`
- [ ] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests`
- [ ] Verify `PlanYearTransitionEvents` collection + indexes provision on first Mongo deploy
- [ ] Smoke: with a plan whose `PlanYearDefinition.PlanYearEnd` is set 25 days out, observe one `ApproachingTransition` row per sweep across replicas

https://claude.ai/code/session_01XACGdtx8YcqzAQozmfcENE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XACGdtx8YcqzAQozmfcENE)_