### PR TITLE
feat(benefit-plan-service): declarative benefit model (5.4)

### DIFF
--- a/docs/architecture/declarative-benefit-model.md
+++ b/docs/architecture/declarative-benefit-model.md
@@ -1,0 +1,210 @@
+# Declarative Benefit Model (5.4)
+
+> **Status:** Phase 1, capability 5.4. Establishes the discriminated-union
+> shape and the predicate evaluator. Type-aware engine paths arrive in
+> capability 5.7+ (preventive zero-cost-share, embedded vs non-embedded
+> OOP) and 5.14 (formulary resolution).
+
+## Why
+
+The original `Benefit` class was a flat bag of fields covering every kind
+of benefit a plan can carry — medical, dental, pharmacy, behavioral,
+vision, DME, maternity, preventive. Type-specific facets (formulary tier,
+ACA preventive grade, MHPAEA parity flag, orthodontic lifetime maximum)
+either lived nowhere or were inferred from `ServiceCategory` substring
+matches at the call site (see the pharmacy branch in
+`Services/BenefitViewService.cs:102-117` before this change).
+
+That shape made every new capability harder:
+
+- 5.7 (embedded / non-embedded OOP) needs to know whether a benefit is
+  preventive without re-parsing the service category string.
+- 5.14 (formulary service) needs structured tier / specialty / step-therapy
+  metadata, not "Tier 1 (Specialty)" as a category label.
+- 5.17 (MHPAEA attestation) needs an explicit parity flag per benefit, not
+  a `ServiceCategory.Contains("Mental Health")` heuristic.
+- External adapters (QNXT, Facets, HealthEdge — capability 5.2 stubs)
+  need to know which fields a vendor API maps to, and that's much easier
+  with a typed model than a flat bag.
+
+5.4 introduces a discriminated-union `Benefit` hierarchy so each of those
+capabilities can extend the right subclass without touching unrelated code,
+while preserving full backward compatibility with rows persisted before
+the discriminator existed.
+
+## Shape
+
+The base `Benefit` class continues to carry every facet that applies to
+every benefit (cost-sharing, prior-auth, visit limits, deductibles, OOP
+behavior, annual / lifetime maximums, the new optional `Rules` predicate
+list). Type-specific facets live on subclasses under
+`Models/Benefits/`:
+
+| Subclass                   | Adds                                                         |
+| -------------------------- | ------------------------------------------------------------ |
+| `MedicalBenefit`           | nothing — catch-all default                                  |
+| `DentalBenefit`            | `IsOrthodontic`, `IsImplant`, `LifetimeBenefitMaximum`       |
+| `PharmacyBenefit`          | `FormularyTier`, `IsSpecialtyDrug`, `RequiresStepTherapy`, `QuantityLimit`, `DaysSupply` |
+| `BehavioralHealthBenefit`  | `IsParityProtected` (default `true`), `ParityCategory`       |
+| `VisionBenefit`            | `IsRoutineExam`, `FrameAllowance`, `LensCoverageType`        |
+| `DMEBenefit`               | `RequiresFitting`, `FittingPeriodDays`, `IsRental`, `MaxRentalMonths` |
+| `MaternityBenefit`         | `CoversPrenatal`, `CoversDelivery`, `CoversPostpartum`, `CoversNICU` |
+| `PreventiveBenefit`        | `IsAcaPreventive`, `UspstfRecommendationGrade`               |
+
+Each subclass overrides a `BenefitType` virtual property whose value is
+written to the wire as the `"benefitType"` discriminator. Discriminator
+constants live in `BenefitTypeDiscriminators` so call sites never spell a
+discriminator string by hand.
+
+## Wire format and the catch-all-as-Medical hydration rule
+
+The `Benefit` base class is decorated with
+`[JsonConverter(typeof(BenefitJsonConverter))]`. The custom converter
+peeks at the JSON object's `"benefitType"` property and dispatches:
+
+- `"dental"`, `"pharmacy"`, `"behavioralHealth"`, `"vision"`, `"dme"`,
+  `"maternity"`, `"preventive"` (case-insensitive) → matching subclass.
+- `"medical"`, missing, empty, or any unrecognized value → `MedicalBenefit`.
+
+The "missing or unknown ⇒ `MedicalBenefit`" rule is the backward
+compatibility seam. Every benefit row that was persisted before 5.4 has
+the legacy flat shape — no `benefitType` property at all. After this
+change, those rows hydrate as `MedicalBenefit` with every common field
+populated from the JSON. There is no migration; legacy data continues to
+work indefinitely. Unknown discriminators (e.g. a future
+`"telehealth"` value emitted by a payer ahead of our schema) also fall
+back to `MedicalBenefit` so deserialization never throws on read.
+
+On write, the converter delegates to `JsonSerializer` with the runtime
+type, so each subclass emits its `BenefitType` override and its
+type-specific facets. A round trip through `JsonSerializer.Serialize` /
+`JsonSerializer.Deserialize` preserves the concrete type — verified by
+`TypedBenefitSerializationTests` and `LegacyBenefitHydrationTests`.
+
+### Serializer-config scope
+
+This change relies on `System.Text.Json` polymorphism, which is the
+serializer used by:
+
+- ASP.NET Core's HTTP MVC pipeline (configured in `Program.cs` via
+  `AddCloudHealthOfficeJsonOptions`).
+- The in-memory test fake `InMemoryBenefitPlanRepository`, which clones
+  every store / fetch with `JsonSerializerOptions(JsonSerializerDefaults.Web)`.
+
+Real Cosmos (uses Newtonsoft.Json by default) and real Mongo (uses BSON,
+not System.Text.Json) **do not** pick up `[JsonConverter]` attributes on
+their own. The test scaffolding exercises the polymorphic round-trip via
+the in-memory fake, which uses the same wire format the API surface and
+the future System.Text.Json-on-Cosmos path will use; the real-infrastructure
+serializer registration (`CosmosSystemTextJsonSerializer` and
+`BsonClassMap.RegisterClassMap`) is a follow-up before the typed model
+is exercised in production. Until that follow-up lands, real Cosmos /
+Mongo continue to round-trip the **flat** shape — which then hydrates
+through this converter as `MedicalBenefit`, the same way any pre-5.4 row
+does. No data loss; the typed-facet write path simply isn't exercised in
+prod yet.
+
+## Predicate evaluation strategy
+
+`BenefitRulePredicate` is the declarative gate that restricts when a
+benefit applies to a member encounter. Facets:
+
+- `MemberAgeMin` / `MemberAgeMax` — inclusive age range.
+- `MemberGender` — `Female` / `Male` / `NonBinary` / `Any`. `Any` skips
+  the check.
+- `RequiredDiagnosisCodes` — list of ICD-10 codes; the encounter must
+  carry at least one (case-insensitive OR semantics).
+- `RequiresRelatedEncounter` + `RelatedEncounterLookbackDays` — gate the
+  benefit on a qualifying earlier encounter, evaluated through a caller-
+  supplied `Func<int, bool>` so the predicate stays in-process.
+
+Evaluation rules:
+
+- An unset facet is "no opinion" and never blocks the benefit.
+- Every set facet must match for the predicate to evaluate `true`.
+- A null `BenefitRuleEvaluationContext` evaluates `false` — predicates
+  refuse to gate without information.
+- A `RequiresRelatedEncounter` predicate without a supplied
+  `HasRelatedEncounter` source fails closed: we'd rather decline a
+  benefit than admit one we can't verify.
+
+5.4 establishes the predicate type and its in-process evaluator. The
+calculation engine doesn't read the predicate yet (Strategy A — see
+below); 5.7 / 5.10 will wire the predicate into the adjudication hot
+path so age- and diagnosis-restricted benefits are evaluated correctly.
+
+## Engine integration: Strategy A (deferred type-awareness)
+
+`BenefitCalculationEngine` and the prior-auth rule engine continue to
+read the base `Benefit` class verbatim. Every field they need —
+`ServiceCategory`, `CptCodes`, `InNetworkCopay`, `CoinsurancePercentage`,
+`DeductibleApplies`, `OopApplies`, `PriorAuthRequired`,
+`RequiresPriorAuth`, `VisitLimit`, `AnnualMaximum`, `LifetimeMaximum` —
+remains on the base class. The new typed facets are silently ignored by
+the engine in this PR.
+
+Type-aware engine paths arrive in subsequent capabilities:
+
+- **5.7** — embedded vs non-embedded OOP rules. The engine becomes
+  preventive-aware (`benefit is PreventiveBenefit { IsAcaPreventive: true }`
+  + grade A/B ⇒ zero member liability).
+- **5.14** — formulary service. The engine resolves
+  `PharmacyBenefit.FormularyTier` against the formulary doc to land
+  benefits on the correct tier.
+- **5.17** — MHPAEA attestation. The engine cross-checks
+  `BehavioralHealthBenefit.IsParityProtected` and `ParityCategory`
+  against the medical/surgical analog when running parity analysis.
+
+Strategy A keeps this PR additive and reversible: any regression on the
+adjudication hot path is, by construction, a serialization issue
+(verified by the round-trip tests), not a calculation issue.
+
+## Adapter integration
+
+`AdapterBenefit` mirrors the discriminated-union shape of `Benefit` —
+one `Adapter…Benefit` subclass per concrete `Benefit` subclass. The DTO
+hierarchy uses `[JsonPolymorphic]` + `[JsonDerivedType]` directly because
+adapter response payloads are constructed only by `AdapterBenefit.From`
+(the runtime-type-dispatching factory) and never by deserializing legacy
+data — there is no flat-shape legacy at the adapter layer.
+
+`AdapterBenefit.From(typed)` ⇒ `AdapterBenefit.ToBenefit()` round-trips
+without field loss. External adapters (today CHO; 5.2 stubs for QNXT,
+Facets, HealthEdge) populate the matching subclass; legacy / unknown
+benefits map to `AdapterMedicalBenefit`.
+
+## What this PR doesn't touch
+
+- Versioning (5.1) — `BenefitPlan` identity, `VersionId`, `VersionState`,
+  `PublishAndSupersedeAsync`. Verified by the round-trip tests under
+  `Repositories/`.
+- Adapter factory routing (5.2) — `BenefitPlanAdapterFactory`, tenant
+  config cache, the QNXT/Facets/HealthEdge stubs. Stubs continue to
+  throw `NotImplementedException`.
+- Plan-year (5.3) — `PlanYearDefinition`, `PlanYearScheduler`,
+  `PlanYearTransitionPublisher`. No coupling.
+- `AdjudicationController` and the six adjudication endpoints — no
+  contract change.
+- `formulary-service` (5.14) and ACA preventive zero-cost-share (5.7 /
+  5.16) — typed-shape work only.
+
+## Testing
+
+Five new test files cover the contract:
+
+- `Models/Benefits/TypedBenefitSerializationTests.cs` — round-trip every
+  typed benefit through `JsonSerializer`.
+- `Models/Benefits/LegacyBenefitHydrationTests.cs` — legacy flat-shape
+  JSON deserializes as `MedicalBenefit`; unknown discriminators fall back.
+- `Models/Benefits/BenefitRulePredicateTests.cs` — predicate evaluation
+  per facet.
+- `Repositories/TypedBenefitRoundTripTests.cs` — typed benefits survive
+  the publish / amend / publish v2 lifecycle through the in-memory fake.
+- `Adapters/AdapterTypedBenefitRoundTripTests.cs` — `AdapterBenefit.From`
+  + `ToBenefit` round-trip every typed shape.
+
+Existing test suites (`BenefitPlanServiceVersionTests`,
+`BenefitPlanRepositoryVersionChainTests`,
+`PlanYearTransitionPublisherTests`, `ChoBenefitPlanAdapterTests`,
+`BenefitViewServiceTests`, the `PriorAuthRuleEngine.Tests` suite) pass
+unchanged.

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/AdapterTypedBenefitRoundTripTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Adapters/AdapterTypedBenefitRoundTripTests.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+
+namespace BenefitPlanService.Tests.Adapters;
+
+/// <summary>
+/// Lossless round-trip across the adapter seam:
+/// <c>typed Benefit ⇒ AdapterBenefit.From ⇒ ToBenefit ⇒ typed Benefit</c>.
+/// External adapters (today CHO; tomorrow QNXT, Facets, HealthEdge) emit
+/// <see cref="AdapterBenefit"/> on their member-view APIs, so the
+/// discriminator and every type-specific facet must survive both directions.
+/// </summary>
+public class AdapterTypedBenefitRoundTripTests
+{
+    private static readonly JsonSerializerOptions Opts = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void From_dispatches_pharmacy_to_AdapterPharmacyBenefit()
+    {
+        Benefit src = new PharmacyBenefit
+        {
+            Id = "p1",
+            ServiceCategory = "Pharmacy",
+            FormularyTier = "Tier 2",
+            IsSpecialtyDrug = true,
+            QuantityLimit = 30,
+            DaysSupply = 90,
+            CopayAmount = 15m,
+        };
+
+        var dto = AdapterBenefit.From(src);
+
+        dto.Should().BeOfType<AdapterPharmacyBenefit>();
+        var pharmacy = (AdapterPharmacyBenefit)dto;
+        pharmacy.FormularyTier.Should().Be("Tier 2");
+        pharmacy.IsSpecialtyDrug.Should().BeTrue();
+        pharmacy.QuantityLimit.Should().Be(30);
+        pharmacy.DaysSupply.Should().Be(90);
+        pharmacy.CopayAmount.Should().Be(15m);
+    }
+
+    [Fact]
+    public void Base_Benefit_From_returns_AdapterMedicalBenefit_legacy_default()
+    {
+        var src = new Benefit { Id = "leg", ServiceCategory = "Primary Care", InNetworkCopay = 25m };
+
+        var dto = AdapterBenefit.From(src);
+
+        dto.Should().BeOfType<AdapterMedicalBenefit>();
+        dto.InNetworkCopay.Should().Be(25m);
+    }
+
+    [Theory]
+    [MemberData(nameof(EachTypedBenefit))]
+    public void Typed_benefit_round_trips_through_adapter_without_field_loss(Benefit src)
+    {
+        var dto = AdapterBenefit.From(src);
+        var back = dto.ToBenefit();
+
+        back.Should().BeOfType(src.GetType());
+        back.ServiceCategory.Should().Be(src.ServiceCategory);
+        back.Id.Should().Be(src.Id);
+    }
+
+    public static IEnumerable<object[]> EachTypedBenefit() => new[]
+    {
+        new object[] { new MedicalBenefit { Id = "m", ServiceCategory = "Primary Care", InNetworkCopay = 25m } },
+        new object[] { new DentalBenefit { Id = "d", ServiceCategory = "Dental", IsOrthodontic = true, LifetimeBenefitMaximum = 1500m } },
+        new object[] { new PharmacyBenefit { Id = "p", ServiceCategory = "Pharmacy", FormularyTier = "Tier 1", DaysSupply = 30 } },
+        new object[] { new BehavioralHealthBenefit { Id = "bh", ServiceCategory = "Mental Health", ParityCategory = "Outpatient" } },
+        new object[] { new VisionBenefit { Id = "v", ServiceCategory = "Vision", FrameAllowance = 200m, LensCoverageType = "Single Vision" } },
+        new object[] { new DMEBenefit { Id = "dme", ServiceCategory = "DME", IsRental = true, MaxRentalMonths = 12 } },
+        new object[] { new MaternityBenefit { Id = "mat", ServiceCategory = "Maternity", CoversPrenatal = true, CoversDelivery = true } },
+        new object[] { new PreventiveBenefit { Id = "prev", ServiceCategory = "Preventive", IsAcaPreventive = true, UspstfRecommendationGrade = "A" } },
+    };
+
+    [Fact]
+    public void AdapterPharmacyBenefit_serializes_with_pharmacy_discriminator()
+    {
+        AdapterBenefit dto = AdapterBenefit.From(new PharmacyBenefit
+        {
+            ServiceCategory = "Pharmacy",
+            FormularyTier = "Tier 1",
+        });
+
+        var json = JsonSerializer.Serialize(dto, Opts);
+
+        json.Should().Contain("\"benefitType\":\"pharmacy\"");
+        json.Should().Contain("\"formularyTier\":\"Tier 1\"");
+    }
+
+    [Fact]
+    public void AdapterBenefit_deserializes_to_correct_subclass_by_discriminator()
+    {
+        const string json = """
+        {
+            "benefitType": "behavioralHealth",
+            "id": "bh1",
+            "serviceCategory": "Mental Health",
+            "isParityProtected": true,
+            "parityCategory": "InpatientInNetwork"
+        }
+        """;
+
+        var dto = JsonSerializer.Deserialize<AdapterBenefit>(json, Opts);
+
+        dto.Should().BeOfType<AdapterBehavioralHealthBenefit>();
+        var bh = (AdapterBehavioralHealthBenefit)dto!;
+        bh.IsParityProtected.Should().BeTrue();
+        bh.ParityCategory.Should().Be("InpatientInNetwork");
+    }
+
+    [Fact]
+    public void AdapterBenefit_round_trip_via_Json_preserves_typed_facets()
+    {
+        Benefit src = new DMEBenefit
+        {
+            ServiceCategory = "DME",
+            RequiresFitting = true,
+            FittingPeriodDays = 14,
+            IsRental = true,
+            MaxRentalMonths = 6,
+            CoinsurancePercentage = 20m,
+        };
+
+        var dto = AdapterBenefit.From(src);
+        var json = JsonSerializer.Serialize(dto, Opts);
+        var rebuilt = JsonSerializer.Deserialize<AdapterBenefit>(json, Opts);
+        var back = rebuilt!.ToBenefit();
+
+        back.Should().BeOfType<DMEBenefit>();
+        var dme = (DMEBenefit)back;
+        dme.RequiresFitting.Should().BeTrue();
+        dme.FittingPeriodDays.Should().Be(14);
+        dme.IsRental.Should().BeTrue();
+        dme.MaxRentalMonths.Should().Be(6);
+        dme.CoinsurancePercentage.Should().Be(20m);
+    }
+
+    [Fact]
+    public void AdapterBenefitPlan_From_preserves_mixed_typed_benefits()
+    {
+        var plan = new BenefitPlan
+        {
+            Id = "plan-x",
+            TenantId = "t",
+            PlanId = "P",
+            PlanName = "Mixed",
+            Payer = "Acme",
+            EffectiveDate = new DateTime(2026, 1, 1),
+            PlanType = PlanType.PPO,
+            Benefits =
+            {
+                new MedicalBenefit { ServiceCategory = "Primary Care", CopayAmount = 25m },
+                new PharmacyBenefit { ServiceCategory = "Pharmacy", FormularyTier = "Tier 1" },
+                new PreventiveBenefit { ServiceCategory = "Preventive", IsAcaPreventive = true },
+            }
+        };
+
+        var dto = AdapterBenefitPlan.From(plan);
+
+        dto.Benefits.Should().HaveCount(3);
+        dto.Benefits[0].Should().BeOfType<AdapterMedicalBenefit>();
+        dto.Benefits[1].Should().BeOfType<AdapterPharmacyBenefit>();
+        dto.Benefits[2].Should().BeOfType<AdapterPreventiveBenefit>();
+
+        var back = dto.ToBenefitPlan();
+        back.Benefits[0].Should().BeOfType<MedicalBenefit>();
+        back.Benefits[1].Should().BeOfType<PharmacyBenefit>();
+        back.Benefits[2].Should().BeOfType<PreventiveBenefit>();
+        ((PharmacyBenefit)back.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/BenefitRulePredicateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/BenefitRulePredicateTests.cs
@@ -1,0 +1,188 @@
+using BenefitPlanService.Models.Benefits;
+
+namespace BenefitPlanService.Tests.Models.Benefits;
+
+/// <summary>
+/// Contract tests for <see cref="BenefitRulePredicate.Evaluate"/>: each
+/// facet is independent and an unset facet is "no opinion". A predicate
+/// gates the benefit only when every set facet matches the supplied
+/// <see cref="BenefitRuleEvaluationContext"/>.
+/// </summary>
+public class BenefitRulePredicateTests
+{
+    [Fact]
+    public void Empty_predicate_evaluates_to_true()
+    {
+        var pred = new BenefitRulePredicate();
+        var ctx = new BenefitRuleEvaluationContext();
+
+        pred.Evaluate(ctx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Null_context_evaluates_to_false()
+    {
+        var pred = new BenefitRulePredicate();
+
+        pred.Evaluate(null!).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(17, false)]
+    [InlineData(18, true)]
+    [InlineData(64, true)]
+    [InlineData(65, false)]
+    public void Age_range_inclusive_at_both_ends(int age, bool expected)
+    {
+        var pred = new BenefitRulePredicate { MemberAgeMin = 18, MemberAgeMax = 64 };
+        var ctx = new BenefitRuleEvaluationContext { MemberAgeYears = age };
+
+        pred.Evaluate(ctx).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Age_range_with_missing_age_in_context_fails()
+    {
+        var pred = new BenefitRulePredicate { MemberAgeMin = 18 };
+        var ctx = new BenefitRuleEvaluationContext { MemberAgeYears = null };
+
+        pred.Evaluate(ctx).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Gender_match_passes_when_equal()
+    {
+        var pred = new BenefitRulePredicate { MemberGender = BenefitMemberGender.Female };
+        var ctx = new BenefitRuleEvaluationContext { MemberGender = BenefitMemberGender.Female };
+
+        pred.Evaluate(ctx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Gender_match_fails_when_different()
+    {
+        var pred = new BenefitRulePredicate { MemberGender = BenefitMemberGender.Female };
+        var ctx = new BenefitRuleEvaluationContext { MemberGender = BenefitMemberGender.Male };
+
+        pred.Evaluate(ctx).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Gender_Any_in_predicate_skips_the_check()
+    {
+        var pred = new BenefitRulePredicate { MemberGender = BenefitMemberGender.Any };
+        var ctx = new BenefitRuleEvaluationContext { MemberGender = BenefitMemberGender.Male };
+
+        pred.Evaluate(ctx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Diagnosis_match_uses_case_insensitive_OR_semantics()
+    {
+        var pred = new BenefitRulePredicate
+        {
+            RequiredDiagnosisCodes = new List<string> { "E11.9", "E10.9" }
+        };
+        var ctx = new BenefitRuleEvaluationContext
+        {
+            DiagnosisCodes = new[] { "I10", "e11.9" } // any-of, case-insensitive
+        };
+
+        pred.Evaluate(ctx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Diagnosis_match_fails_when_none_present()
+    {
+        var pred = new BenefitRulePredicate
+        {
+            RequiredDiagnosisCodes = new List<string> { "E11.9" }
+        };
+        var ctx = new BenefitRuleEvaluationContext
+        {
+            DiagnosisCodes = new[] { "I10" }
+        };
+
+        pred.Evaluate(ctx).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_required_diagnosis_list_is_no_opinion()
+    {
+        var pred = new BenefitRulePredicate
+        {
+            RequiredDiagnosisCodes = new List<string>()
+        };
+        var ctx = new BenefitRuleEvaluationContext { DiagnosisCodes = Array.Empty<string>() };
+
+        pred.Evaluate(ctx).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Related_encounter_lookback_uses_supplied_predicate()
+    {
+        var seenLookback = -1;
+        var pred = new BenefitRulePredicate
+        {
+            RequiresRelatedEncounter = true,
+            RelatedEncounterLookbackDays = 90,
+        };
+        var ctx = new BenefitRuleEvaluationContext
+        {
+            HasRelatedEncounter = days =>
+            {
+                seenLookback = days;
+                return true;
+            }
+        };
+
+        pred.Evaluate(ctx).Should().BeTrue();
+        seenLookback.Should().Be(90);
+    }
+
+    [Fact]
+    public void Related_encounter_required_but_predicate_returns_false_fails()
+    {
+        var pred = new BenefitRulePredicate { RequiresRelatedEncounter = true };
+        var ctx = new BenefitRuleEvaluationContext { HasRelatedEncounter = _ => false };
+
+        pred.Evaluate(ctx).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Related_encounter_required_but_no_source_supplied_fails_closed()
+    {
+        var pred = new BenefitRulePredicate { RequiresRelatedEncounter = true };
+        var ctx = new BenefitRuleEvaluationContext { HasRelatedEncounter = null };
+
+        pred.Evaluate(ctx).Should().BeFalse(
+            "the predicate is conservative — without a related-encounter source it refuses to gate the benefit through");
+    }
+
+    [Fact]
+    public void All_facets_must_match_for_predicate_to_pass()
+    {
+        var pred = new BenefitRulePredicate
+        {
+            MemberAgeMin = 50,
+            MemberGender = BenefitMemberGender.Female,
+            RequiredDiagnosisCodes = new List<string> { "Z12.31" }, // mammogram screening
+        };
+
+        var passing = new BenefitRuleEvaluationContext
+        {
+            MemberAgeYears = 55,
+            MemberGender = BenefitMemberGender.Female,
+            DiagnosisCodes = new[] { "Z12.31" }
+        };
+        var wrongAge = new BenefitRuleEvaluationContext
+        {
+            MemberAgeYears = 40,
+            MemberGender = BenefitMemberGender.Female,
+            DiagnosisCodes = new[] { "Z12.31" }
+        };
+
+        pred.Evaluate(passing).Should().BeTrue();
+        pred.Evaluate(wrongAge).Should().BeFalse();
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/LegacyBenefitHydrationTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/LegacyBenefitHydrationTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+
+namespace BenefitPlanService.Tests.Models.Benefits;
+
+/// <summary>
+/// Backward-compatibility contract for the discriminated-union refactor:
+/// every benefit row that was persisted before 5.4 carries no
+/// <c>"benefitType"</c> property on the wire, and every such row must
+/// hydrate as <see cref="MedicalBenefit"/> with all common fields populated.
+/// Unknown discriminators must also fall back to MedicalBenefit so future
+/// payer-specific extensions never throw on read.
+/// </summary>
+public class LegacyBenefitHydrationTests
+{
+    private static readonly JsonSerializerOptions Opts = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Flat_shape_without_discriminator_hydrates_as_MedicalBenefit()
+    {
+        const string legacyJson = """
+        {
+            "id": "legacy-1",
+            "serviceCategory": "Primary Care",
+            "description": "Office visit",
+            "cptCodes": ["99213", "99214"],
+            "inNetworkCopay": 25,
+            "deductibleApplies": false,
+            "oopApplies": true,
+            "priorAuthRequired": false,
+            "requiresPriorAuth": false,
+            "visitLimit": 10,
+            "visitLimitPeriod": "annual",
+            "annualMaximum": 5000
+        }
+        """;
+
+        var hydrated = JsonSerializer.Deserialize<Benefit>(legacyJson, Opts);
+
+        hydrated.Should().BeOfType<MedicalBenefit>();
+        hydrated!.Id.Should().Be("legacy-1");
+        hydrated.ServiceCategory.Should().Be("Primary Care");
+        hydrated.Description.Should().Be("Office visit");
+        hydrated.CptCodes.Should().BeEquivalentTo(new[] { "99213", "99214" });
+        hydrated.InNetworkCopay.Should().Be(25m);
+        hydrated.DeductibleApplies.Should().BeFalse();
+        hydrated.VisitLimit.Should().Be(10);
+        hydrated.AnnualMaximum.Should().Be(5000m);
+    }
+
+    [Fact]
+    public void Empty_string_discriminator_hydrates_as_MedicalBenefit()
+    {
+        const string json = """
+        { "id": "x", "benefitType": "", "serviceCategory": "Primary Care" }
+        """;
+
+        var hydrated = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        hydrated.Should().BeOfType<MedicalBenefit>();
+        hydrated!.ServiceCategory.Should().Be("Primary Care");
+    }
+
+    [Fact]
+    public void Unknown_discriminator_falls_back_to_MedicalBenefit()
+    {
+        const string json = """
+        { "id": "x", "benefitType": "telehealth-future-shape", "serviceCategory": "Primary Care" }
+        """;
+
+        var hydrated = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        hydrated.Should().BeOfType<MedicalBenefit>();
+        hydrated!.ServiceCategory.Should().Be("Primary Care");
+    }
+
+    [Fact]
+    public void Discriminator_is_case_insensitive()
+    {
+        const string json = """
+        { "benefitType": "Pharmacy", "serviceCategory": "Pharmacy", "formularyTier": "Tier 1" }
+        """;
+
+        var hydrated = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        hydrated.Should().BeOfType<PharmacyBenefit>();
+        ((PharmacyBenefit)hydrated!).FormularyTier.Should().Be("Tier 1");
+    }
+
+    [Fact]
+    public void Legacy_BenefitPlan_with_flat_benefits_hydrates_each_as_MedicalBenefit()
+    {
+        const string planJson = """
+        {
+            "id": "plan-1",
+            "tenantId": "t",
+            "planId": "p",
+            "planName": "Legacy Plan",
+            "payer": "Acme",
+            "effectiveDate": "2025-01-01T00:00:00Z",
+            "planType": "PPO",
+            "lineOfBusiness": "Commercial",
+            "benefits": [
+                { "id": "b1", "serviceCategory": "Primary Care", "inNetworkCopay": 25 },
+                { "id": "b2", "serviceCategory": "Pharmacy", "inNetworkCopay": 10 },
+                { "id": "b3", "serviceCategory": "DME", "inNetworkCoinsurance": 0.20 }
+            ]
+        }
+        """;
+
+        var plan = JsonSerializer.Deserialize<BenefitPlan>(planJson, Opts)!;
+
+        plan.Benefits.Should().HaveCount(3);
+        plan.Benefits.Should().AllBeOfType<MedicalBenefit>(
+            "legacy rows lack the benefitType discriminator and the catch-all default is MedicalBenefit");
+    }
+
+    [Fact]
+    public void Mutating_a_hydrated_legacy_benefit_writes_medical_discriminator_back()
+    {
+        const string legacyJson = """
+        { "serviceCategory": "Primary Care", "inNetworkCopay": 25 }
+        """;
+        var hydrated = JsonSerializer.Deserialize<Benefit>(legacyJson, Opts)!;
+        hydrated.InNetworkCopay = 30m;
+
+        var rewritten = JsonSerializer.Serialize(hydrated, Opts);
+
+        rewritten.Should().Contain("\"benefitType\":\"medical\"",
+            "the hydrated MedicalBenefit instance now carries the discriminator on write");
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
@@ -1,0 +1,260 @@
+using System.Text.Json;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+
+namespace BenefitPlanService.Tests.Models.Benefits;
+
+/// <summary>
+/// Round-trip every typed benefit subclass through System.Text.Json with the
+/// Web defaults (the same options used by repositories and the in-memory
+/// fake). Each test asserts that the discriminator <c>"benefitType"</c> is
+/// emitted on write and dispatched on read so the concrete subclass and
+/// every type-specific facet survive the round-trip.
+/// </summary>
+public class TypedBenefitSerializationTests
+{
+    private static readonly JsonSerializerOptions Opts = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void MedicalBenefit_round_trips_with_medical_discriminator()
+    {
+        Benefit src = new MedicalBenefit
+        {
+            Id = "b1",
+            ServiceCategory = "Primary Care",
+            InNetworkCopay = 25m,
+            DeductibleApplies = false,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        json.Should().Contain("\"benefitType\":\"medical\"");
+
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+        back.Should().BeOfType<MedicalBenefit>();
+        back!.Id.Should().Be("b1");
+        back.InNetworkCopay.Should().Be(25m);
+    }
+
+    [Fact]
+    public void DentalBenefit_round_trips_orthodontic_facets()
+    {
+        Benefit src = new DentalBenefit
+        {
+            ServiceCategory = "Orthodontics",
+            IsOrthodontic = true,
+            IsImplant = false,
+            LifetimeBenefitMaximum = 1500m,
+            CopayAmount = 0m,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        json.Should().Contain("\"benefitType\":\"dental\"");
+        json.Should().Contain("\"lifetimeBenefitMaximum\":1500");
+
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+        back.Should().BeOfType<DentalBenefit>();
+        var dental = (DentalBenefit)back!;
+        dental.IsOrthodontic.Should().BeTrue();
+        dental.LifetimeBenefitMaximum.Should().Be(1500m);
+    }
+
+    [Fact]
+    public void PharmacyBenefit_round_trips_formulary_facets()
+    {
+        Benefit src = new PharmacyBenefit
+        {
+            ServiceCategory = "Pharmacy",
+            FormularyTier = "Tier 2",
+            IsSpecialtyDrug = true,
+            RequiresStepTherapy = true,
+            QuantityLimit = 30,
+            DaysSupply = 90,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        json.Should().Contain("\"benefitType\":\"pharmacy\"");
+
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+        back.Should().BeOfType<PharmacyBenefit>();
+        var pharmacy = (PharmacyBenefit)back!;
+        pharmacy.FormularyTier.Should().Be("Tier 2");
+        pharmacy.IsSpecialtyDrug.Should().BeTrue();
+        pharmacy.RequiresStepTherapy.Should().BeTrue();
+        pharmacy.QuantityLimit.Should().Be(30);
+        pharmacy.DaysSupply.Should().Be(90);
+    }
+
+    [Fact]
+    public void PharmacyBenefit_with_null_FormularyTier_is_still_pharmacy()
+    {
+        Benefit src = new PharmacyBenefit
+        {
+            ServiceCategory = "Pharmacy",
+            FormularyTier = null,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        back.Should().BeOfType<PharmacyBenefit>();
+        ((PharmacyBenefit)back!).FormularyTier.Should().BeNull();
+    }
+
+    [Fact]
+    public void BehavioralHealthBenefit_defaults_parity_to_true()
+    {
+        var src = new BehavioralHealthBenefit
+        {
+            ServiceCategory = "Mental Health",
+            ParityCategory = "OutpatientInNetwork",
+        };
+        src.IsParityProtected.Should().BeTrue();
+
+        var json = JsonSerializer.Serialize<Benefit>(src, Opts);
+        json.Should().Contain("\"benefitType\":\"behavioralHealth\"");
+
+        var back = (BehavioralHealthBenefit)JsonSerializer.Deserialize<Benefit>(json, Opts)!;
+        back.IsParityProtected.Should().BeTrue();
+        back.ParityCategory.Should().Be("OutpatientInNetwork");
+    }
+
+    [Fact]
+    public void VisionBenefit_round_trips_frame_allowance()
+    {
+        Benefit src = new VisionBenefit
+        {
+            ServiceCategory = "Vision",
+            IsRoutineExam = true,
+            FrameAllowance = 200m,
+            LensCoverageType = "Progressive",
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        back.Should().BeOfType<VisionBenefit>();
+        var vision = (VisionBenefit)back!;
+        vision.IsRoutineExam.Should().BeTrue();
+        vision.FrameAllowance.Should().Be(200m);
+        vision.LensCoverageType.Should().Be("Progressive");
+    }
+
+    [Fact]
+    public void DMEBenefit_round_trips_rental_facets()
+    {
+        Benefit src = new DMEBenefit
+        {
+            ServiceCategory = "DME",
+            RequiresFitting = true,
+            FittingPeriodDays = 14,
+            IsRental = true,
+            MaxRentalMonths = 12,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        back.Should().BeOfType<DMEBenefit>();
+        var dme = (DMEBenefit)back!;
+        dme.RequiresFitting.Should().BeTrue();
+        dme.FittingPeriodDays.Should().Be(14);
+        dme.IsRental.Should().BeTrue();
+        dme.MaxRentalMonths.Should().Be(12);
+    }
+
+    [Fact]
+    public void MaternityBenefit_round_trips_episode_flags()
+    {
+        Benefit src = new MaternityBenefit
+        {
+            ServiceCategory = "Maternity",
+            CoversPrenatal = true,
+            CoversDelivery = true,
+            CoversPostpartum = true,
+            CoversNICU = false,
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        back.Should().BeOfType<MaternityBenefit>();
+        var maternity = (MaternityBenefit)back!;
+        maternity.CoversPrenatal.Should().BeTrue();
+        maternity.CoversDelivery.Should().BeTrue();
+        maternity.CoversPostpartum.Should().BeTrue();
+        maternity.CoversNICU.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PreventiveBenefit_round_trips_aca_grade()
+    {
+        Benefit src = new PreventiveBenefit
+        {
+            ServiceCategory = "Preventive",
+            IsAcaPreventive = true,
+            UspstfRecommendationGrade = "A",
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts);
+
+        back.Should().BeOfType<PreventiveBenefit>();
+        var prev = (PreventiveBenefit)back!;
+        prev.IsAcaPreventive.Should().BeTrue();
+        prev.UspstfRecommendationGrade.Should().Be("A");
+    }
+
+    [Fact]
+    public void Mixed_benefits_in_a_plan_each_round_trip_to_their_concrete_type()
+    {
+        var plan = new BenefitPlan
+        {
+            TenantId = "t",
+            PlanId = "p",
+            PlanName = "Mixed",
+            Payer = "Acme",
+            EffectiveDate = new DateTime(2026, 1, 1),
+            PlanType = PlanType.PPO,
+            Benefits =
+            {
+                new MedicalBenefit { ServiceCategory = "Primary Care", CopayAmount = 25m },
+                new PharmacyBenefit { ServiceCategory = "Pharmacy", FormularyTier = "Tier 1" },
+                new BehavioralHealthBenefit { ServiceCategory = "Mental Health", ParityCategory = "Outpatient" },
+                new PreventiveBenefit { ServiceCategory = "Preventive", IsAcaPreventive = true, UspstfRecommendationGrade = "A" },
+            }
+        };
+
+        var json = JsonSerializer.Serialize(plan, Opts);
+        var back = JsonSerializer.Deserialize<BenefitPlan>(json, Opts)!;
+
+        back.Benefits.Should().HaveCount(4);
+        back.Benefits[0].Should().BeOfType<MedicalBenefit>();
+        back.Benefits[1].Should().BeOfType<PharmacyBenefit>();
+        back.Benefits[2].Should().BeOfType<BehavioralHealthBenefit>();
+        back.Benefits[3].Should().BeOfType<PreventiveBenefit>();
+
+        ((PharmacyBenefit)back.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+        ((PreventiveBenefit)back.Benefits[3]).UspstfRecommendationGrade.Should().Be("A");
+    }
+
+    [Fact]
+    public void Rules_list_round_trips_on_base_class()
+    {
+        Benefit src = new MedicalBenefit
+        {
+            ServiceCategory = "Primary Care",
+            Rules = new List<BenefitRulePredicate>
+            {
+                new() { MemberAgeMin = 18, MemberAgeMax = 64, MemberGender = BenefitMemberGender.Any }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(src, Opts);
+        var back = JsonSerializer.Deserialize<Benefit>(json, Opts)!;
+
+        back.Rules.Should().NotBeNull();
+        back.Rules!.Should().HaveCount(1);
+        back.Rules[0].MemberAgeMin.Should().Be(18);
+        back.Rules[0].MemberAgeMax.Should().Be(64);
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
@@ -1,0 +1,134 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Repositories;
+
+/// <summary>
+/// End-to-end round-trip of typed benefits through the repository contract
+/// and the version-chain lifecycle, exercised via
+/// <see cref="InMemoryBenefitPlanRepository"/>. The fake clones via the
+/// same System.Text.Json Web options that real Cosmos / Mongo wire formats
+/// will go through, so the discriminator and every type-specific facet
+/// must survive store-and-fetch and the <c>amend → publish v2</c> path.
+/// </summary>
+public class TypedBenefitRoundTripTests
+{
+    private const string Tenant = "tenant-typed";
+    private const string Actor = "user-typed";
+
+    private static (BenefitPlanServiceImpl service,
+                    InMemoryBenefitPlanRepository repo,
+                    InMemoryPlanVersionTransitionRepository transitions,
+                    FakePlanVersionEventPublisher events) Build()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var transitions = new InMemoryPlanVersionTransitionRepository();
+        var events = new FakePlanVersionEventPublisher();
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, NullLogger<BenefitPlanServiceImpl>.Instance);
+        return (service, repo, transitions, events);
+    }
+
+    private static BenefitPlan PlanWithTypedBenefits(string planId = "plan-typed") => new()
+    {
+        TenantId = Tenant,
+        PlanId = planId,
+        PlanName = "Mixed Typed",
+        Payer = "Acme",
+        EffectiveDate = new DateTime(2026, 1, 1),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        Benefits =
+        {
+            new MedicalBenefit { ServiceCategory = "Primary Care", CopayAmount = 25m },
+            new PharmacyBenefit
+            {
+                ServiceCategory = "Pharmacy",
+                FormularyTier = "Tier 1",
+                IsSpecialtyDrug = false,
+                DaysSupply = 30,
+            },
+            new BehavioralHealthBenefit
+            {
+                ServiceCategory = "Mental Health",
+                ParityCategory = "OutpatientInNetwork",
+            },
+            new PreventiveBenefit
+            {
+                ServiceCategory = "Preventive",
+                IsAcaPreventive = true,
+                UspstfRecommendationGrade = "A",
+            },
+        }
+    };
+
+    [Fact]
+    public async Task Round_trip_preserves_subclass_identity_through_repository()
+    {
+        var (service, _, _, _) = Build();
+
+        var draft = await service.CreateDraftAsync(PlanWithTypedBenefits(), Tenant, Actor);
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor);
+
+        var reloaded = await service.GetVersionAsync(v1.PlanId, v1.VersionId, Tenant);
+
+        reloaded.Should().NotBeNull();
+        reloaded!.Benefits.Should().HaveCount(4);
+        reloaded.Benefits[0].Should().BeOfType<MedicalBenefit>();
+        reloaded.Benefits[1].Should().BeOfType<PharmacyBenefit>();
+        reloaded.Benefits[2].Should().BeOfType<BehavioralHealthBenefit>();
+        reloaded.Benefits[3].Should().BeOfType<PreventiveBenefit>();
+
+        ((PharmacyBenefit)reloaded.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+        ((BehavioralHealthBenefit)reloaded.Benefits[2]).IsParityProtected.Should().BeTrue();
+        ((PreventiveBenefit)reloaded.Benefits[3]).UspstfRecommendationGrade.Should().Be("A");
+    }
+
+    [Fact]
+    public async Task AmendPublishedPlan_clones_typed_benefits_into_v2_draft()
+    {
+        var (service, repo, _, _) = Build();
+
+        var draft = await service.CreateDraftAsync(PlanWithTypedBenefits(), Tenant, Actor);
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor);
+
+        var v2Draft = await service.AmendPublishedPlanAsync(v1.PlanId, Tenant, Actor);
+
+        v2Draft.Benefits.Should().HaveCount(4);
+        v2Draft.Benefits[1].Should().BeOfType<PharmacyBenefit>(
+            "the amend flow uses CloneBenefit which JSON-round-trips the polymorphic shape");
+        ((PharmacyBenefit)v2Draft.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+
+        // mutate the typed facet on v2 only and publish
+        var pharmacy = (PharmacyBenefit)v2Draft.Benefits[1];
+        pharmacy.FormularyTier = "Tier 2";
+        await repo.UpdateDraftAsync(v2Draft);
+        var v2 = await service.PublishVersionAsync(v2Draft.PlanId, v2Draft.VersionId, Tenant, Actor);
+
+        // v1 still has Tier 1, v2 has Tier 2 — version isolation holds for typed facets.
+        var v1Reloaded = await service.GetVersionAsync(v1.PlanId, v1.VersionId, Tenant);
+        ((PharmacyBenefit)v1Reloaded!.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+        ((PharmacyBenefit)v2.Benefits[1]).FormularyTier.Should().Be("Tier 2");
+    }
+
+    [Fact]
+    public async Task Repository_returned_benefit_is_independent_of_stored_instance()
+    {
+        // The fake clones on read; mutating a returned typed benefit must
+        // not bleed into the stored document.
+        var (_, repo, _, _) = Build();
+        var plan = PlanWithTypedBenefits();
+        plan.VersionId = "vid";
+        plan.VersionNumber = 1;
+        plan.VersionState = PlanVersionState.Published;
+        await repo.CreateAsync(plan);
+
+        var read = await repo.GetByIdAsync(plan.Id, Tenant);
+        ((PharmacyBenefit)read!.Benefits[1]).FormularyTier = "MUTATED";
+
+        var reread = await repo.GetByIdAsync(plan.Id, Tenant);
+        ((PharmacyBenefit)reread!.Benefits[1]).FormularyTier.Should().Be("Tier 1");
+    }
+}

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using BenefitPlanService.Models.Benefits;
 
 namespace BenefitPlanService.Models;
 
@@ -175,12 +176,48 @@ public class BenefitPlan
 }
 
 /// <summary>
-/// Individual benefit within a plan
+/// Individual benefit within a plan.
+///
+/// <para>
+/// Phase 1 / 5.4 — Declarative Benefit Model. This base type carries every
+/// facet that applies to every benefit (cost-sharing, prior-auth flags,
+/// visit limits, etc.). Type-specific facets live on the concrete subclasses
+/// in <c>BenefitPlanService.Models.Benefits</c>: <see cref="MedicalBenefit"/>,
+/// <see cref="DentalBenefit"/>, <see cref="PharmacyBenefit"/>,
+/// <see cref="BehavioralHealthBenefit"/>, <see cref="VisionBenefit"/>,
+/// <see cref="DMEBenefit"/>, <see cref="MaternityBenefit"/>,
+/// <see cref="PreventiveBenefit"/>.
+/// </para>
+///
+/// <para>
+/// Wire format: a polymorphic discriminator <c>"benefitType"</c> selects the
+/// concrete subclass during deserialization. Legacy rows persisted before
+/// 5.4 carry no discriminator; they hydrate as <see cref="MedicalBenefit"/>
+/// (the catch-all default) so existing data continues to work without a
+/// migration. See <c>docs/architecture/declarative-benefit-model.md</c>.
+/// </para>
+///
+/// <para>
+/// Engine integration: <c>BenefitCalculationEngine</c> and the prior-auth
+/// rule engine continue to read this base class verbatim (Strategy A).
+/// Type-aware engine paths (e.g. preventive zero-cost-share, formulary
+/// resolution) arrive in subsequent capability prompts.
+/// </para>
 /// </summary>
+[JsonConverter(typeof(BenefitJsonConverter))]
 public class Benefit
 {
     [JsonPropertyName("id")]
     public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Discriminator written to the wire so the polymorphic converter can
+    /// reconstruct the correct subclass. Each concrete subclass overrides
+    /// this; the base default is <c>"medical"</c> so legacy rows that lack
+    /// the property hydrate as <see cref="MedicalBenefit"/>.
+    /// </summary>
+    [JsonPropertyName("benefitType")]
+    public virtual string BenefitType => BenefitTypeDiscriminators.Medical;
 
     [Required]
     [JsonPropertyName("serviceCategory")]
@@ -241,6 +278,15 @@ public class Benefit
 
     [JsonPropertyName("lifetimeMaximum")]
     public decimal? LifetimeMaximum { get; set; }
+
+    /// <summary>
+    /// Optional declarative gates that restrict when this benefit applies
+    /// to a given member encounter (age range, gender, required diagnosis
+    /// codes, related-encounter lookback). Predicates are evaluated by
+    /// callers; <c>null</c> or empty means the benefit always applies.
+    /// </summary>
+    [JsonPropertyName("rules")]
+    public List<BenefitRulePredicate>? Rules { get; set; }
 }
 
 /// <summary>

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -264,7 +264,7 @@ public class AdapterBenefit
         Limitations = b.Limitations;
         AnnualMaximum = b.AnnualMaximum;
         LifetimeMaximum = b.LifetimeMaximum;
-        Rules = b.Rules?.Select(r => r).ToList();
+        Rules = b.Rules?.Select(r => r.Clone()).ToList();
     }
 }
 
@@ -451,6 +451,10 @@ public sealed class AdapterMaternityBenefit : AdapterBenefit
     public bool CoversPrenatal { get; set; }
     public bool CoversDelivery { get; set; }
     public bool CoversPostpartum { get; set; }
+
+    // Explicit camelCase wire name so the all-caps C# acronym doesn't leak
+    // through and produce `coversNICU` on the wire — matches the model.
+    [JsonPropertyName("coversNicu")]
     public bool CoversNICU { get; set; }
 
     public static AdapterMaternityBenefit FromTyped(MaternityBenefit src)

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using BenefitPlanService.Models.Benefits;
+
 namespace BenefitPlanService.Models;
 
 /// <summary>
@@ -142,6 +145,25 @@ public class AdapterBenefitPlan
     };
 }
 
+/// <summary>
+/// Vendor-neutral benefit DTO. Mirrors the discriminated-union shape of
+/// <see cref="Benefit"/> so external adapters (today CHO; tomorrow QNXT,
+/// Facets, HealthEdge) can populate the typed facets that line up with
+/// each vendor's API. <see cref="From"/> dispatches on the runtime type of
+/// the source <see cref="Benefit"/>; <see cref="ToBenefit"/> reconstructs
+/// the matching subclass.
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "benefitType",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType,
+    IgnoreUnrecognizedTypeDiscriminators = true)]
+[JsonDerivedType(typeof(AdapterMedicalBenefit), BenefitTypeDiscriminators.Medical)]
+[JsonDerivedType(typeof(AdapterDentalBenefit), BenefitTypeDiscriminators.Dental)]
+[JsonDerivedType(typeof(AdapterPharmacyBenefit), BenefitTypeDiscriminators.Pharmacy)]
+[JsonDerivedType(typeof(AdapterBehavioralHealthBenefit), BenefitTypeDiscriminators.BehavioralHealth)]
+[JsonDerivedType(typeof(AdapterVisionBenefit), BenefitTypeDiscriminators.Vision)]
+[JsonDerivedType(typeof(AdapterDMEBenefit), BenefitTypeDiscriminators.DME)]
+[JsonDerivedType(typeof(AdapterMaternityBenefit), BenefitTypeDiscriminators.Maternity)]
+[JsonDerivedType(typeof(AdapterPreventiveBenefit), BenefitTypeDiscriminators.Preventive)]
 public class AdapterBenefit
 {
     public string Id { get; set; } = string.Empty;
@@ -163,52 +185,327 @@ public class AdapterBenefit
     public string? Limitations { get; set; }
     public decimal? AnnualMaximum { get; set; }
     public decimal? LifetimeMaximum { get; set; }
+    public List<BenefitRulePredicate>? Rules { get; set; }
 
-    public static AdapterBenefit From(Benefit b) => new()
+    /// <summary>
+    /// Dispatch on the runtime type of <paramref name="b"/> and return the
+    /// matching adapter subclass with all common-plus-typed facets copied.
+    /// A base-class <see cref="Benefit"/> (legacy / pre-5.4 shape) maps to
+    /// <see cref="AdapterMedicalBenefit"/>.
+    /// </summary>
+    public static AdapterBenefit From(Benefit b) => b switch
     {
-        Id = b.Id,
-        ServiceCategory = b.ServiceCategory,
-        Description = b.Description,
-        CptCodes = b.CptCodes.ToList(),
-        InNetworkCopay = b.InNetworkCopay,
-        OutNetworkCopay = b.OutNetworkCopay,
-        InNetworkCoinsurance = b.InNetworkCoinsurance,
-        OutNetworkCoinsurance = b.OutNetworkCoinsurance,
-        DeductibleApplies = b.DeductibleApplies,
-        OopApplies = b.OopApplies,
-        PriorAuthRequired = b.PriorAuthRequired,
-        CopayAmount = b.CopayAmount,
-        CoinsurancePercentage = b.CoinsurancePercentage,
-        RequiresPriorAuth = b.RequiresPriorAuth,
-        VisitLimit = b.VisitLimit,
-        VisitLimitPeriod = b.VisitLimitPeriod,
-        Limitations = b.Limitations,
-        AnnualMaximum = b.AnnualMaximum,
-        LifetimeMaximum = b.LifetimeMaximum,
+        DentalBenefit dental => AdapterDentalBenefit.FromTyped(dental),
+        PharmacyBenefit pharmacy => AdapterPharmacyBenefit.FromTyped(pharmacy),
+        BehavioralHealthBenefit bh => AdapterBehavioralHealthBenefit.FromTyped(bh),
+        VisionBenefit vision => AdapterVisionBenefit.FromTyped(vision),
+        DMEBenefit dme => AdapterDMEBenefit.FromTyped(dme),
+        MaternityBenefit maternity => AdapterMaternityBenefit.FromTyped(maternity),
+        PreventiveBenefit preventive => AdapterPreventiveBenefit.FromTyped(preventive),
+        MedicalBenefit medical => AdapterMedicalBenefit.FromTyped(medical),
+        _ => AdapterMedicalBenefit.FromTyped(b), // base-class Benefit ⇒ medical (legacy default)
     };
 
-    public Benefit ToBenefit() => new()
+    /// <summary>
+    /// Reconstruct the matching <see cref="Benefit"/> subclass. Override
+    /// in each concrete adapter type to populate the type-specific facets.
+    /// </summary>
+    public virtual Benefit ToBenefit()
     {
-        Id = Id,
-        ServiceCategory = ServiceCategory,
-        Description = Description,
-        CptCodes = CptCodes.ToList(),
-        InNetworkCopay = InNetworkCopay,
-        OutNetworkCopay = OutNetworkCopay,
-        InNetworkCoinsurance = InNetworkCoinsurance,
-        OutNetworkCoinsurance = OutNetworkCoinsurance,
-        DeductibleApplies = DeductibleApplies,
-        OopApplies = OopApplies,
-        PriorAuthRequired = PriorAuthRequired,
-        CopayAmount = CopayAmount,
-        CoinsurancePercentage = CoinsurancePercentage,
-        RequiresPriorAuth = RequiresPriorAuth,
-        VisitLimit = VisitLimit,
-        VisitLimitPeriod = VisitLimitPeriod,
-        Limitations = Limitations,
-        AnnualMaximum = AnnualMaximum,
-        LifetimeMaximum = LifetimeMaximum,
-    };
+        var medical = new MedicalBenefit();
+        CopyCommonTo(medical);
+        return medical;
+    }
+
+    /// <summary>Copy common facets from this DTO onto a <see cref="Benefit"/>.</summary>
+    protected void CopyCommonTo(Benefit b)
+    {
+        b.Id = Id;
+        b.ServiceCategory = ServiceCategory;
+        b.Description = Description;
+        b.CptCodes = CptCodes.ToList();
+        b.InNetworkCopay = InNetworkCopay;
+        b.OutNetworkCopay = OutNetworkCopay;
+        b.InNetworkCoinsurance = InNetworkCoinsurance;
+        b.OutNetworkCoinsurance = OutNetworkCoinsurance;
+        b.DeductibleApplies = DeductibleApplies;
+        b.OopApplies = OopApplies;
+        b.PriorAuthRequired = PriorAuthRequired;
+        b.CopayAmount = CopayAmount;
+        b.CoinsurancePercentage = CoinsurancePercentage;
+        b.RequiresPriorAuth = RequiresPriorAuth;
+        b.VisitLimit = VisitLimit;
+        b.VisitLimitPeriod = VisitLimitPeriod;
+        b.Limitations = Limitations;
+        b.AnnualMaximum = AnnualMaximum;
+        b.LifetimeMaximum = LifetimeMaximum;
+        b.Rules = Rules?.Select(r => r).ToList();
+    }
+
+    /// <summary>Copy common facets from a <see cref="Benefit"/> onto this DTO.</summary>
+    protected void CopyCommonFrom(Benefit b)
+    {
+        Id = b.Id;
+        ServiceCategory = b.ServiceCategory;
+        Description = b.Description;
+        CptCodes = b.CptCodes.ToList();
+        InNetworkCopay = b.InNetworkCopay;
+        OutNetworkCopay = b.OutNetworkCopay;
+        InNetworkCoinsurance = b.InNetworkCoinsurance;
+        OutNetworkCoinsurance = b.OutNetworkCoinsurance;
+        DeductibleApplies = b.DeductibleApplies;
+        OopApplies = b.OopApplies;
+        PriorAuthRequired = b.PriorAuthRequired;
+        CopayAmount = b.CopayAmount;
+        CoinsurancePercentage = b.CoinsurancePercentage;
+        RequiresPriorAuth = b.RequiresPriorAuth;
+        VisitLimit = b.VisitLimit;
+        VisitLimitPeriod = b.VisitLimitPeriod;
+        Limitations = b.Limitations;
+        AnnualMaximum = b.AnnualMaximum;
+        LifetimeMaximum = b.LifetimeMaximum;
+        Rules = b.Rules?.Select(r => r).ToList();
+    }
+}
+
+public sealed class AdapterMedicalBenefit : AdapterBenefit
+{
+    public static AdapterMedicalBenefit FromTyped(Benefit src)
+    {
+        var dto = new AdapterMedicalBenefit();
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new MedicalBenefit();
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterDentalBenefit : AdapterBenefit
+{
+    public bool IsOrthodontic { get; set; }
+    public bool IsImplant { get; set; }
+    public decimal? LifetimeBenefitMaximum { get; set; }
+
+    public static AdapterDentalBenefit FromTyped(DentalBenefit src)
+    {
+        var dto = new AdapterDentalBenefit
+        {
+            IsOrthodontic = src.IsOrthodontic,
+            IsImplant = src.IsImplant,
+            LifetimeBenefitMaximum = src.LifetimeBenefitMaximum,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new DentalBenefit
+        {
+            IsOrthodontic = IsOrthodontic,
+            IsImplant = IsImplant,
+            LifetimeBenefitMaximum = LifetimeBenefitMaximum,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterPharmacyBenefit : AdapterBenefit
+{
+    public string? FormularyTier { get; set; }
+    public bool IsSpecialtyDrug { get; set; }
+    public bool RequiresStepTherapy { get; set; }
+    public int? QuantityLimit { get; set; }
+    public int? DaysSupply { get; set; }
+
+    public static AdapterPharmacyBenefit FromTyped(PharmacyBenefit src)
+    {
+        var dto = new AdapterPharmacyBenefit
+        {
+            FormularyTier = src.FormularyTier,
+            IsSpecialtyDrug = src.IsSpecialtyDrug,
+            RequiresStepTherapy = src.RequiresStepTherapy,
+            QuantityLimit = src.QuantityLimit,
+            DaysSupply = src.DaysSupply,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new PharmacyBenefit
+        {
+            FormularyTier = FormularyTier,
+            IsSpecialtyDrug = IsSpecialtyDrug,
+            RequiresStepTherapy = RequiresStepTherapy,
+            QuantityLimit = QuantityLimit,
+            DaysSupply = DaysSupply,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterBehavioralHealthBenefit : AdapterBenefit
+{
+    public bool IsParityProtected { get; set; } = true;
+    public string? ParityCategory { get; set; }
+
+    public static AdapterBehavioralHealthBenefit FromTyped(BehavioralHealthBenefit src)
+    {
+        var dto = new AdapterBehavioralHealthBenefit
+        {
+            IsParityProtected = src.IsParityProtected,
+            ParityCategory = src.ParityCategory,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new BehavioralHealthBenefit
+        {
+            IsParityProtected = IsParityProtected,
+            ParityCategory = ParityCategory,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterVisionBenefit : AdapterBenefit
+{
+    public bool IsRoutineExam { get; set; }
+    public decimal? FrameAllowance { get; set; }
+    public string? LensCoverageType { get; set; }
+
+    public static AdapterVisionBenefit FromTyped(VisionBenefit src)
+    {
+        var dto = new AdapterVisionBenefit
+        {
+            IsRoutineExam = src.IsRoutineExam,
+            FrameAllowance = src.FrameAllowance,
+            LensCoverageType = src.LensCoverageType,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new VisionBenefit
+        {
+            IsRoutineExam = IsRoutineExam,
+            FrameAllowance = FrameAllowance,
+            LensCoverageType = LensCoverageType,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterDMEBenefit : AdapterBenefit
+{
+    public bool RequiresFitting { get; set; }
+    public int? FittingPeriodDays { get; set; }
+    public bool IsRental { get; set; }
+    public int? MaxRentalMonths { get; set; }
+
+    public static AdapterDMEBenefit FromTyped(DMEBenefit src)
+    {
+        var dto = new AdapterDMEBenefit
+        {
+            RequiresFitting = src.RequiresFitting,
+            FittingPeriodDays = src.FittingPeriodDays,
+            IsRental = src.IsRental,
+            MaxRentalMonths = src.MaxRentalMonths,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new DMEBenefit
+        {
+            RequiresFitting = RequiresFitting,
+            FittingPeriodDays = FittingPeriodDays,
+            IsRental = IsRental,
+            MaxRentalMonths = MaxRentalMonths,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterMaternityBenefit : AdapterBenefit
+{
+    public bool CoversPrenatal { get; set; }
+    public bool CoversDelivery { get; set; }
+    public bool CoversPostpartum { get; set; }
+    public bool CoversNICU { get; set; }
+
+    public static AdapterMaternityBenefit FromTyped(MaternityBenefit src)
+    {
+        var dto = new AdapterMaternityBenefit
+        {
+            CoversPrenatal = src.CoversPrenatal,
+            CoversDelivery = src.CoversDelivery,
+            CoversPostpartum = src.CoversPostpartum,
+            CoversNICU = src.CoversNICU,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new MaternityBenefit
+        {
+            CoversPrenatal = CoversPrenatal,
+            CoversDelivery = CoversDelivery,
+            CoversPostpartum = CoversPostpartum,
+            CoversNICU = CoversNICU,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
+}
+
+public sealed class AdapterPreventiveBenefit : AdapterBenefit
+{
+    public bool IsAcaPreventive { get; set; }
+    public string? UspstfRecommendationGrade { get; set; }
+
+    public static AdapterPreventiveBenefit FromTyped(PreventiveBenefit src)
+    {
+        var dto = new AdapterPreventiveBenefit
+        {
+            IsAcaPreventive = src.IsAcaPreventive,
+            UspstfRecommendationGrade = src.UspstfRecommendationGrade,
+        };
+        dto.CopyCommonFrom(src);
+        return dto;
+    }
+
+    public override Benefit ToBenefit()
+    {
+        var b = new PreventiveBenefit
+        {
+            IsAcaPreventive = IsAcaPreventive,
+            UspstfRecommendationGrade = UspstfRecommendationGrade,
+        };
+        CopyCommonTo(b);
+        return b;
+    }
 }
 
 public class AdapterNetworkTier

--- a/src/services/benefit-plan-service/Models/Benefits/BehavioralHealthBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BehavioralHealthBenefit.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Behavioral health (mental health + substance-use disorder) benefit.
+/// Carries the MHPAEA parity flag and parity-category label so the
+/// non-quantitative-treatment-limitation analyser introduced in capability
+/// 5.17 can reason over the plan without inferring from
+/// <see cref="Benefit.ServiceCategory"/> strings.
+///
+/// <para>
+/// Defaults are MHPAEA-safe: <see cref="IsParityProtected"/> is <c>true</c>
+/// out of the box. 5.4 establishes the shape only; the full attestation
+/// pipeline lands in 5.17.
+/// </para>
+/// </summary>
+public class BehavioralHealthBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.BehavioralHealth;
+
+    /// <summary>
+    /// True when this benefit is subject to MHPAEA parity rules (no more
+    /// restrictive than the medical/surgical analog). Defaults to
+    /// <c>true</c> because parity is the regulatory floor.
+    /// </summary>
+    [JsonPropertyName("isParityProtected")]
+    public bool IsParityProtected { get; set; } = true;
+
+    /// <summary>
+    /// MHPAEA parity classification (e.g. "InpatientInNetwork",
+    /// "OutpatientOutOfNetwork", "PrescriptionDrugs", "EmergencyCare"). Free
+    /// form for now; 5.17 will introduce a canonical enum.
+    /// </summary>
+    [JsonPropertyName("parityCategory")]
+    public string? ParityCategory { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitJsonConverter.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitJsonConverter.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Polymorphic <see cref="JsonConverter{T}"/> for <see cref="Benefit"/> and
+/// its typed subclasses (<see cref="MedicalBenefit"/>,
+/// <see cref="DentalBenefit"/>, <see cref="PharmacyBenefit"/>, etc).
+///
+/// <para>
+/// On read, peeks at the <c>benefitType</c> discriminator and dispatches to
+/// the matching concrete subclass. A missing or empty discriminator — which
+/// is the shape every <see cref="Benefit"/> persisted before 5.4 has on the
+/// wire — hydrates as <see cref="MedicalBenefit"/>, the catch-all default.
+/// An unknown discriminator value also falls back to <see cref="MedicalBenefit"/>
+/// so we never throw on legacy or unfamiliar data.
+/// </para>
+///
+/// <para>
+/// On write, serializes using the runtime type so the type-specific facets
+/// of subclasses are preserved on the wire. The discriminator is emitted
+/// via the virtual <see cref="Benefit.BenefitType"/> property each subclass
+/// overrides.
+/// </para>
+///
+/// <para>
+/// Implementation note: to avoid infinite recursion, the converter strips
+/// itself from a copy of the active <see cref="JsonSerializerOptions"/>
+/// before delegating to <see cref="JsonSerializer"/> for the inner work.
+/// </para>
+/// </summary>
+public sealed class BenefitJsonConverter : JsonConverter<Benefit>
+{
+    public override Benefit Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null!;
+        }
+
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+
+        var discriminator = ReadDiscriminator(root);
+        var concreteType = ResolveConcreteType(discriminator);
+
+        var rawJson = root.GetRawText();
+        var inner = WithoutSelf(options);
+        var result = JsonSerializer.Deserialize(rawJson, concreteType, inner);
+        return (Benefit)result!;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Benefit value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        var inner = WithoutSelf(options);
+        JsonSerializer.Serialize(writer, value, value.GetType(), inner);
+    }
+
+    private static string ReadDiscriminator(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return BenefitTypeDiscriminators.Medical;
+        }
+
+        if (!root.TryGetProperty("benefitType", out var prop))
+        {
+            return BenefitTypeDiscriminators.Medical;
+        }
+
+        if (prop.ValueKind != JsonValueKind.String)
+        {
+            return BenefitTypeDiscriminators.Medical;
+        }
+
+        var value = prop.GetString();
+        return string.IsNullOrWhiteSpace(value) ? BenefitTypeDiscriminators.Medical : value;
+    }
+
+    private static Type ResolveConcreteType(string discriminator)
+    {
+        // Comparison is case-insensitive so e.g. "BehavioralHealth", "behavioralhealth",
+        // and "behavioralHealth" all resolve to the same type. Unknown values fall
+        // back to MedicalBenefit — we never throw on read.
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.Dental, StringComparison.OrdinalIgnoreCase))
+            return typeof(DentalBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.Pharmacy, StringComparison.OrdinalIgnoreCase))
+            return typeof(PharmacyBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.BehavioralHealth, StringComparison.OrdinalIgnoreCase))
+            return typeof(BehavioralHealthBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.Vision, StringComparison.OrdinalIgnoreCase))
+            return typeof(VisionBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.DME, StringComparison.OrdinalIgnoreCase))
+            return typeof(DMEBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.Maternity, StringComparison.OrdinalIgnoreCase))
+            return typeof(MaternityBenefit);
+        if (string.Equals(discriminator, BenefitTypeDiscriminators.Preventive, StringComparison.OrdinalIgnoreCase))
+            return typeof(PreventiveBenefit);
+        return typeof(MedicalBenefit);
+    }
+
+    private static JsonSerializerOptions WithoutSelf(JsonSerializerOptions options)
+    {
+        var copy = new JsonSerializerOptions(options);
+        for (var i = copy.Converters.Count - 1; i >= 0; i--)
+        {
+            if (copy.Converters[i] is BenefitJsonConverter)
+            {
+                copy.Converters.RemoveAt(i);
+            }
+        }
+        return copy;
+    }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitJsonConverter.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitJsonConverter.cs
@@ -70,17 +70,28 @@ public sealed class BenefitJsonConverter : JsonConverter<Benefit>
             return BenefitTypeDiscriminators.Medical;
         }
 
-        if (!root.TryGetProperty("benefitType", out var prop))
+        // Property-name lookup is case-insensitive so payloads that arrive
+        // with "BenefitType" / "BENEFITTYPE" / "benefittype" all dispatch
+        // the same way. STJ's JsonElement.TryGetProperty is case-sensitive
+        // and ignores PropertyNameCaseInsensitive on the options, so we
+        // enumerate explicitly. Discriminator value comparison further down
+        // (ResolveConcreteType) is also case-insensitive for the same reason.
+        JsonElement? prop = null;
+        foreach (var p in root.EnumerateObject())
+        {
+            if (string.Equals(p.Name, "benefitType", StringComparison.OrdinalIgnoreCase))
+            {
+                prop = p.Value;
+                break;
+            }
+        }
+
+        if (prop is null || prop.Value.ValueKind != JsonValueKind.String)
         {
             return BenefitTypeDiscriminators.Medical;
         }
 
-        if (prop.ValueKind != JsonValueKind.String)
-        {
-            return BenefitTypeDiscriminators.Medical;
-        }
-
-        var value = prop.GetString();
+        var value = prop.Value.GetString();
         return string.IsNullOrWhiteSpace(value) ? BenefitTypeDiscriminators.Medical : value;
     }
 

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitRulePredicate.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitRulePredicate.cs
@@ -1,0 +1,141 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Declarative gate that restricts when a <see cref="Benefit"/> applies to
+/// a given member encounter. All facets are optional — an unset facet is
+/// "no opinion" and never blocks the benefit. A predicate evaluates to
+/// true (benefit applies) only when every set facet matches the supplied
+/// <see cref="BenefitRuleEvaluationContext"/>.
+///
+/// <para>
+/// 5.4 introduces the predicate shape and its in-process evaluator.
+/// Wiring it into the <c>BenefitCalculationEngine</c> hot path is deferred
+/// (Strategy A); 5.7 / 5.10 will exercise predicates during adjudication.
+/// </para>
+/// </summary>
+public class BenefitRulePredicate
+{
+    /// <summary>Inclusive lower age bound, in years.</summary>
+    [JsonPropertyName("memberAgeMin")]
+    public int? MemberAgeMin { get; set; }
+
+    /// <summary>Inclusive upper age bound, in years.</summary>
+    [JsonPropertyName("memberAgeMax")]
+    public int? MemberAgeMax { get; set; }
+
+    /// <summary>Required member gender, when the benefit is sex-specific.</summary>
+    [JsonPropertyName("memberGender")]
+    public BenefitMemberGender? MemberGender { get; set; }
+
+    /// <summary>
+    /// ICD-10 codes that gate this benefit. When set and non-empty, the
+    /// member encounter must include at least one of these diagnoses for
+    /// the benefit to apply.
+    /// </summary>
+    [JsonPropertyName("requiredDiagnosisCodes")]
+    public List<string>? RequiredDiagnosisCodes { get; set; }
+
+    /// <summary>
+    /// True when the benefit is only available if a qualifying related
+    /// encounter exists in <see cref="RelatedEncounterLookbackDays"/>. The
+    /// caller supplies the related-encounter source via the evaluation
+    /// context.
+    /// </summary>
+    [JsonPropertyName("requiresRelatedEncounter")]
+    public bool RequiresRelatedEncounter { get; set; }
+
+    /// <summary>Lookback window in days for the related-encounter check.</summary>
+    [JsonPropertyName("relatedEncounterLookbackDays")]
+    public int? RelatedEncounterLookbackDays { get; set; }
+
+    /// <summary>
+    /// Evaluate the predicate against <paramref name="context"/>. Returns
+    /// true when every set facet matches; an unset facet contributes no
+    /// constraint. A predicate with no facets at all evaluates to true.
+    /// </summary>
+    public bool Evaluate(BenefitRuleEvaluationContext context)
+    {
+        if (context is null)
+        {
+            // No context to evaluate against — refuse to gate the benefit.
+            return false;
+        }
+
+        if (MemberAgeMin.HasValue && (!context.MemberAgeYears.HasValue || context.MemberAgeYears.Value < MemberAgeMin.Value))
+        {
+            return false;
+        }
+
+        if (MemberAgeMax.HasValue && (!context.MemberAgeYears.HasValue || context.MemberAgeYears.Value > MemberAgeMax.Value))
+        {
+            return false;
+        }
+
+        if (MemberGender.HasValue && MemberGender.Value != BenefitMemberGender.Any)
+        {
+            if (!context.MemberGender.HasValue) return false;
+            if (context.MemberGender.Value != BenefitMemberGender.Any && context.MemberGender.Value != MemberGender.Value)
+            {
+                return false;
+            }
+        }
+
+        if (RequiredDiagnosisCodes is { Count: > 0 } required)
+        {
+            var presented = context.DiagnosisCodes ?? Array.Empty<string>();
+            var anyMatch = required.Any(req => presented.Any(p => string.Equals(p, req, StringComparison.OrdinalIgnoreCase)));
+            if (!anyMatch) return false;
+        }
+
+        if (RequiresRelatedEncounter)
+        {
+            if (context.HasRelatedEncounter is null)
+            {
+                // Caller hasn't wired a related-encounter source; treat
+                // as not satisfied rather than silently passing.
+                return false;
+            }
+
+            var lookback = RelatedEncounterLookbackDays ?? 0;
+            if (!context.HasRelatedEncounter(lookback))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/// <summary>Member-gender enum for <see cref="BenefitRulePredicate.MemberGender"/>.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum BenefitMemberGender
+{
+    Any = 0,
+    Female = 1,
+    Male = 2,
+    NonBinary = 3,
+}
+
+/// <summary>
+/// Inputs for <see cref="BenefitRulePredicate.Evaluate"/>. Constructed at
+/// the call site (typically by the calculation engine) from member
+/// demographics, the encounter under adjudication, and an optional related-
+/// encounter source.
+/// </summary>
+public sealed class BenefitRuleEvaluationContext
+{
+    public int? MemberAgeYears { get; init; }
+    public BenefitMemberGender? MemberGender { get; init; }
+    public IReadOnlyCollection<string>? DiagnosisCodes { get; init; }
+
+    /// <summary>
+    /// Function that answers "does the member have a qualifying related
+    /// encounter within <paramref name="lookbackDays"/>?" — supplied by
+    /// callers that have access to encounter history. Null when the caller
+    /// can't answer; predicates that need a related encounter then fail closed.
+    /// </summary>
+    public Func<int, bool>? HasRelatedEncounter { get; init; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitRulePredicate.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitRulePredicate.cs
@@ -51,6 +51,23 @@ public class BenefitRulePredicate
     public int? RelatedEncounterLookbackDays { get; set; }
 
     /// <summary>
+    /// Deep-copy of the predicate. <see cref="RequiredDiagnosisCodes"/>
+    /// gets its own list (strings are immutable, so element references are
+    /// safe to share); every other field is a value type or string and
+    /// copies cleanly. Used at the adapter seam so a mutation on one side
+    /// can't bleed across.
+    /// </summary>
+    public BenefitRulePredicate Clone() => new()
+    {
+        MemberAgeMin = MemberAgeMin,
+        MemberAgeMax = MemberAgeMax,
+        MemberGender = MemberGender,
+        RequiredDiagnosisCodes = RequiredDiagnosisCodes is null ? null : new List<string>(RequiredDiagnosisCodes),
+        RequiresRelatedEncounter = RequiresRelatedEncounter,
+        RelatedEncounterLookbackDays = RelatedEncounterLookbackDays,
+    };
+
+    /// <summary>
     /// Evaluate the predicate against <paramref name="context"/>. Returns
     /// true when every set facet matches; an unset facet contributes no
     /// constraint. A predicate with no facets at all evaluates to true.
@@ -59,7 +76,7 @@ public class BenefitRulePredicate
     {
         if (context is null)
         {
-            // No context to evaluate against — refuse to gate the benefit.
+            // No context to evaluate against — fail closed, so the benefit does not apply.
             return false;
         }
 

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitTypeDiscriminators.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitTypeDiscriminators.cs
@@ -2,9 +2,9 @@ namespace BenefitPlanService.Models.Benefits;
 
 /// <summary>
 /// Wire values for the <c>benefitType</c> discriminator used by
-/// <see cref="Benefit"/> and <see cref="AdapterBenefit"/>. CamelCase by
-/// convention so the discriminator matches the rest of the JSON envelope
-/// emitted by this service.
+/// <see cref="Benefit"/> and <see cref="BenefitPlanService.Models.AdapterBenefit"/>.
+/// CamelCase by convention so the discriminator matches the rest of the
+/// JSON envelope emitted by this service.
 /// </summary>
 public static class BenefitTypeDiscriminators
 {

--- a/src/services/benefit-plan-service/Models/Benefits/BenefitTypeDiscriminators.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/BenefitTypeDiscriminators.cs
@@ -1,0 +1,19 @@
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Wire values for the <c>benefitType</c> discriminator used by
+/// <see cref="Benefit"/> and <see cref="AdapterBenefit"/>. CamelCase by
+/// convention so the discriminator matches the rest of the JSON envelope
+/// emitted by this service.
+/// </summary>
+public static class BenefitTypeDiscriminators
+{
+    public const string Medical = "medical";
+    public const string Dental = "dental";
+    public const string Pharmacy = "pharmacy";
+    public const string BehavioralHealth = "behavioralHealth";
+    public const string Vision = "vision";
+    public const string DME = "dme";
+    public const string Maternity = "maternity";
+    public const string Preventive = "preventive";
+}

--- a/src/services/benefit-plan-service/Models/Benefits/DMEBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/DMEBenefit.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Durable Medical Equipment benefit. Captures the fitting-required and
+/// rental-vs-purchase facets that gate DME adjudication.
+/// </summary>
+public class DMEBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.DME;
+
+    /// <summary>True when the equipment must be fitted by a qualifying provider.</summary>
+    [JsonPropertyName("requiresFitting")]
+    public bool RequiresFitting { get; set; }
+
+    /// <summary>Days within which the fitting must occur after the order.</summary>
+    [JsonPropertyName("fittingPeriodDays")]
+    public int? FittingPeriodDays { get; set; }
+
+    /// <summary>True when the equipment is dispensed as a rental rather than a purchase.</summary>
+    [JsonPropertyName("isRental")]
+    public bool IsRental { get; set; }
+
+    /// <summary>Rental cap in months. Null when uncapped or not a rental.</summary>
+    [JsonPropertyName("maxRentalMonths")]
+    public int? MaxRentalMonths { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/DentalBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/DentalBenefit.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Dental benefit. Adds the orthodontic / implant flags and the
+/// orthodontic-specific lifetime maximum that dental plans typically carry
+/// alongside the shared <see cref="Benefit"/> facets.
+/// </summary>
+public class DentalBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Dental;
+
+    /// <summary>True when this benefit covers orthodontic services.</summary>
+    [JsonPropertyName("isOrthodontic")]
+    public bool IsOrthodontic { get; set; }
+
+    /// <summary>True when this benefit covers dental implants.</summary>
+    [JsonPropertyName("isImplant")]
+    public bool IsImplant { get; set; }
+
+    /// <summary>
+    /// Orthodontic-specific lifetime maximum. Distinct from
+    /// <see cref="Benefit.LifetimeMaximum"/> (which is the medical lifetime cap)
+    /// so dental benefits can carry both without collision.
+    /// </summary>
+    [JsonPropertyName("lifetimeBenefitMaximum")]
+    public decimal? LifetimeBenefitMaximum { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/MaternityBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/MaternityBenefit.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Maternity benefit. Splits coverage along the prenatal / delivery /
+/// postpartum / NICU axes that the Newborns' and Mothers' Health Protection
+/// Act and downstream analytics treat as separate episodes of care.
+/// </summary>
+public class MaternityBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Maternity;
+
+    [JsonPropertyName("coversPrenatal")]
+    public bool CoversPrenatal { get; set; }
+
+    [JsonPropertyName("coversDelivery")]
+    public bool CoversDelivery { get; set; }
+
+    [JsonPropertyName("coversPostpartum")]
+    public bool CoversPostpartum { get; set; }
+
+    /// <summary>True when neonatal intensive care unit charges are covered under this benefit.</summary>
+    [JsonPropertyName("coversNICU")]
+    public bool CoversNICU { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/MaternityBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/MaternityBenefit.cs
@@ -22,6 +22,6 @@ public class MaternityBenefit : Benefit
     public bool CoversPostpartum { get; set; }
 
     /// <summary>True when neonatal intensive care unit charges are covered under this benefit.</summary>
-    [JsonPropertyName("coversNICU")]
+    [JsonPropertyName("coversNicu")]
     public bool CoversNICU { get; set; }
 }

--- a/src/services/benefit-plan-service/Models/Benefits/MedicalBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/MedicalBenefit.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// The catch-all medical benefit shape — adds no facets beyond
+/// <see cref="Benefit"/>. <c>MedicalBenefit</c> is the hydration default for
+/// legacy rows that predate the discriminator (<c>"benefitType"</c> missing
+/// or empty), and the safe choice for any benefit that doesn't fit a more
+/// specific subclass.
+/// </summary>
+public class MedicalBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Medical;
+}

--- a/src/services/benefit-plan-service/Models/Benefits/PharmacyBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/PharmacyBenefit.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Pharmacy benefit. Carries formulary metadata (tier, specialty flag,
+/// step-therapy gate, quantity / days-supply limits) so the pharmacy view
+/// can render without inferring from <see cref="Benefit.ServiceCategory"/>
+/// substring matches.
+///
+/// <para>
+/// 5.4 establishes the shape only — the full formulary-resolution service
+/// arrives in capability 5.14. Today's <c>BenefitCalculationEngine</c> reads
+/// the base-class fields (Strategy A) and ignores these typed facets.
+/// </para>
+/// </summary>
+public class PharmacyBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Pharmacy;
+
+    /// <summary>
+    /// Formulary tier label (e.g. "Tier 1", "Generic", "Preferred Brand").
+    /// Free-form so payer-specific tier nomenclatures round-trip cleanly;
+    /// 5.14 will introduce a canonical tier resolver.
+    /// </summary>
+    [JsonPropertyName("formularyTier")]
+    public string? FormularyTier { get; set; }
+
+    /// <summary>True when the drug is on a specialty-pharmacy tier.</summary>
+    [JsonPropertyName("isSpecialtyDrug")]
+    public bool IsSpecialtyDrug { get; set; }
+
+    /// <summary>True when step therapy must be exhausted before coverage.</summary>
+    [JsonPropertyName("requiresStepTherapy")]
+    public bool RequiresStepTherapy { get; set; }
+
+    /// <summary>Maximum dispensable quantity per fill.</summary>
+    [JsonPropertyName("quantityLimit")]
+    public int? QuantityLimit { get; set; }
+
+    /// <summary>Days-supply per fill (e.g. 30, 90).</summary>
+    [JsonPropertyName("daysSupply")]
+    public int? DaysSupply { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/PreventiveBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/PreventiveBenefit.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Preventive-care benefit. Carries the ACA preventive flag and the USPSTF
+/// recommendation grade that determine whether the service is subject to
+/// zero-cost-share rules.
+///
+/// <para>
+/// 5.4 establishes the shape only — the ACA zero-cost-share calculation
+/// arrives in capability 5.7 / 5.16, where the <c>BenefitCalculationEngine</c>
+/// will check <see cref="IsAcaPreventive"/> and the recommendation grade
+/// (A or B = full coverage, no member liability).
+/// </para>
+/// </summary>
+public class PreventiveBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Preventive;
+
+    /// <summary>
+    /// True when this benefit qualifies under the ACA preventive-services
+    /// mandate (zero member cost-share, in-network, when delivered per
+    /// USPSTF / HRSA / ACIP guidelines).
+    /// </summary>
+    [JsonPropertyName("isAcaPreventive")]
+    public bool IsAcaPreventive { get; set; }
+
+    /// <summary>
+    /// USPSTF recommendation grade: <c>"A"</c>, <c>"B"</c>, or any other
+    /// label (C, D, I, or payer-specific). A and B are the grades that
+    /// trigger ACA zero-cost-share.
+    /// </summary>
+    [JsonPropertyName("uspstfRecommendationGrade")]
+    public string? UspstfRecommendationGrade { get; set; }
+}

--- a/src/services/benefit-plan-service/Models/Benefits/VisionBenefit.cs
+++ b/src/services/benefit-plan-service/Models/Benefits/VisionBenefit.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Models.Benefits;
+
+/// <summary>
+/// Vision benefit. Carries the routine-exam flag, frame allowance, and lens
+/// coverage type that vision plans typically gate independently from
+/// medical cost-sharing.
+/// </summary>
+public class VisionBenefit : Benefit
+{
+    [JsonPropertyName("benefitType")]
+    public override string BenefitType => BenefitTypeDiscriminators.Vision;
+
+    /// <summary>True when this benefit covers routine eye exams.</summary>
+    [JsonPropertyName("isRoutineExam")]
+    public bool IsRoutineExam { get; set; }
+
+    /// <summary>Periodic dollar allowance toward eyeglass frames.</summary>
+    [JsonPropertyName("frameAllowance")]
+    public decimal? FrameAllowance { get; set; }
+
+    /// <summary>
+    /// Lens coverage classification (e.g. "Single Vision", "Bifocal",
+    /// "Progressive", "Photochromic"). Free form.
+    /// </summary>
+    [JsonPropertyName("lensCoverageType")]
+    public string? LensCoverageType { get; set; }
+}

--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BenefitPlanService.Models;
 using BenefitPlanService.Repositories;
 
@@ -493,27 +494,21 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         Documents = src.Documents.Select(CloneDocument).ToList(),
     };
 
-    private static Benefit CloneBenefit(Benefit b) => new()
-    {
-        ServiceCategory = b.ServiceCategory,
-        Description = b.Description,
-        CptCodes = b.CptCodes.ToList(),
-        InNetworkCopay = b.InNetworkCopay,
-        OutNetworkCopay = b.OutNetworkCopay,
-        InNetworkCoinsurance = b.InNetworkCoinsurance,
-        OutNetworkCoinsurance = b.OutNetworkCoinsurance,
-        DeductibleApplies = b.DeductibleApplies,
-        OopApplies = b.OopApplies,
-        PriorAuthRequired = b.PriorAuthRequired,
-        CopayAmount = b.CopayAmount,
-        CoinsurancePercentage = b.CoinsurancePercentage,
-        RequiresPriorAuth = b.RequiresPriorAuth,
-        VisitLimit = b.VisitLimit,
-        VisitLimitPeriod = b.VisitLimitPeriod,
-        Limitations = b.Limitations,
-        AnnualMaximum = b.AnnualMaximum,
-        LifetimeMaximum = b.LifetimeMaximum
-    };
+    // Shared options for the polymorphic benefit clone path. JsonSerializerDefaults.Web
+    // matches the wire format used by repositories and the in-memory fake, so a clone
+    // through these options preserves the subclass discriminator end-to-end.
+    private static readonly JsonSerializerOptions _benefitCloneOpts = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Deep-clones a <see cref="Benefit"/> through a polymorphic JSON
+    /// round-trip so typed subclasses (<c>PharmacyBenefit</c>,
+    /// <c>BehavioralHealthBenefit</c>, …) survive the
+    /// <c>AmendPublishedPlanAsync</c> flow. A manual property-by-property
+    /// clone would silently downgrade every subclass to base
+    /// <see cref="Benefit"/> on amendment.
+    /// </summary>
+    private static Benefit CloneBenefit(Benefit b)
+        => JsonSerializer.Deserialize<Benefit>(JsonSerializer.Serialize(b, _benefitCloneOpts), _benefitCloneOpts)!;
 
     private static NetworkTier CloneNetworkTier(NetworkTier n) => new()
     {


### PR DESCRIPTION
## Summary

Refactors `Benefit` (in `BenefitPlanService.Models`) into a discriminated-union typed hierarchy. Eight typed subclasses live under `Models/Benefits/`: `MedicalBenefit` (catch-all default), `DentalBenefit`, `PharmacyBenefit`, `BehavioralHealthBenefit`, `VisionBenefit`, `DMEBenefit`, `MaternityBenefit`, `PreventiveBenefit`. `BenefitRulePredicate` introduces declarative gates (age range, gender, required diagnosis codes, related-encounter lookback) with an in-process evaluator.

Backward compatibility is non-negotiable and preserved end-to-end: a custom `BenefitJsonConverter` defaults missing or unrecognized `benefitType` discriminators to `MedicalBenefit`, so every benefit row persisted before 5.4 (which lacks the discriminator) hydrates as `MedicalBenefit` with all common fields populated. `BenefitPlanServiceImpl.CloneBenefit` switches to a JSON round-trip so typed subclass identity survives the `AmendPublishedPlanAsync` flow.

`AdapterBenefit` mirrors the discriminated union (`AdapterMedicalBenefit`, `AdapterPharmacyBenefit`, …) so external adapters (today CHO; tomorrow QNXT, Facets, HealthEdge) can populate the typed facets that line up with each vendor's API. The existing `AdapterBenefit.From` seam keeps a single dispatch point on the runtime type of the source `Benefit`.

## Plan-First survey results

- **Engine consumption**: `BenefitCalculationEngine` has its own internal `Benefit` model and is decoupled from `BenefitPlanService.Models.Benefit`. `ChoBenefitPlanProvider` reads only base-class fields (`ServiceCategory`, `Description`, `PriorAuthRequired`, `RequiresPriorAuth`, `VisitLimit`, `AnnualMaximum`, `LifetimeMaximum`, `InNetworkCopay`, `CopayAmount`, `CoinsurancePercentage`, `DeductibleApplies`, `OopApplies`). Strategy A is structural here — no engine changes needed.
- **PriorAuthRuleEngine**: Zero direct reads of `BenefitPlanService.Models.Benefit`. The engine consumes `PaRuleDocument` config; no regression vector.
- **Cosmos / Mongo serializers**: Cosmos defaults to Newtonsoft.Json; Mongo uses BSON. Neither honors `[JsonConverter]` attributes by default. The in-memory test fake uses `JsonSerializerOptions(JsonSerializerDefaults.Web)` (System.Text.Json), which exercises the polymorphic round-trip end-to-end. Real-infrastructure registration (`CosmosSystemTextJsonSerializer`, `BsonClassMap.RegisterClassMap`) is a follow-up; until that lands, real Cosmos/Mongo continue to round-trip the flat shape, which then hydrates as `MedicalBenefit` (the same path any pre-5.4 row takes).
- **`AdapterBenefit` instantiation**: Single seam at `AdapterBenefit.From()` (no scattered `new` sites).
- **`MemberBenefitView` propagation**: Categorized to `CategorizedBenefit` — typed shape doesn't need to survive there.

## Decisions surfaced

| Decision | Choice |
| --- | --- |
| Engine integration | **Strategy A** — engine reads base-class fields. Type-aware paths land in 5.7+. |
| Adapter shape | **Discriminated union** matching the model. |
| Hydration mechanism | Custom `JsonConverter<Benefit>` with missing/unknown discriminator → `MedicalBenefit`. |
| Wire-format discriminator | `benefitType` (camelCase). |
| Real Cosmos/Mongo serializer config | **Deferred** to follow-up (matches "additive, fast revert" recovery posture in the prompt). |
| `BenefitPlanServiceImpl.CloneBenefit` | Switched to JSON-based clone to preserve subclass identity through `AmendPublishedPlanAsync`. |

## Test plan

- [ ] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests` — verify all existing tests pass and the 5 new test files (TypedBenefitSerializationTests, LegacyBenefitHydrationTests, BenefitRulePredicateTests, TypedBenefitRoundTripTests, AdapterTypedBenefitRoundTripTests) are green.
- [ ] `dotnet test tests/CloudHealthOffice.BenefitPlanService.Tests` — verify outer test project (BenefitViewServiceTests, ObservabilityTests, PlanDocumentValidationTests) still passes.
- [ ] `dotnet test tests/CloudHealthOffice.PriorAuthRuleEngine.Tests` — confirm prior-auth engine tests pass (no regression; engine is decoupled).
- [ ] `dotnet build cloudhealthoffice-main.sln` — full solution build clean.
- [ ] Manually verify the JSON wire format on a `BenefitPlan` GET — `benefitType` discriminator present on each benefit; legacy stored plans hydrate as `MedicalBenefit`.

## Out of scope (verified)

- Versioning logic (5.1) — round-trip tests confirm no behavior change.
- Adapter factory routing (5.2) — QNXT/Facets/HealthEdge stubs untouched.
- Plan-year scheduling (5.3) — no coupling.
- `AdjudicationController` — no contract change.
- `formulary-service` (5.14), MHPAEA attestation (5.17), ACA preventive zero-cost-share (5.7/5.16) — typed-shape work only; engine paths land in those subsequent capabilities.

## Recovery posture

Polymorphic-serialization issue → fast follow-up; legacy data remains readable via the catch-all. Adapter or repository round-trip loss → fast follow-up with serializer fix. Worst-case rollback is a single PR revert; downstream capabilities don't strictly require this PR to be merged first.

https://claude.ai/code/session_01HUUSd4Sd4Wus6iRvEK4gbd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUUSd4Sd4Wus6iRvEK4gbd)_