### PR TITLE
Provider Adapter Pattern Foundation (5.2)

### DIFF
--- a/docs/architecture/provider-adapter-pattern.md
+++ b/docs/architecture/provider-adapter-pattern.md
@@ -1,0 +1,198 @@
+# Provider Adapter Pattern
+
+## Why
+
+Some tenants will eventually source their provider directory from external
+core platforms (QNXT, Facets, HealthEdge) instead of CHO's internal
+`provider-service`. This pattern introduces a thin abstraction
+(`IProviderAdapter`) selected at request time by tenant configuration,
+mirroring the existing `IBenefitPlanAdapter` and `IEligibilityAdapter`
+surfaces.
+
+For every tenant currently in production the factory resolves to the
+default `ChoProviderAdapter`, which is a near pass-through over the
+existing `IProviderRepository` — so this PR introduces the seam without
+changing observable behavior.
+
+## Topology
+
+```
+                ┌────────────────────────┐
+GET /providers/* │   ProvidersController  │
+                └────────────┬───────────┘
+                             │ (every read request)
+                     ┌───────▼───────┐
+                     │   Factory     │  ── reads tenant cfg ──▶  tenant-service
+                     └───────┬───────┘     (cached 5 min)
+                             │
+              ┌──────────────┼──────────────┬──────────────┐
+              ▼              ▼              ▼              ▼
+          Cho (active)    QNXT (stub)   Facets (stub)   HealthEdge (stub)
+```
+
+## Interface
+
+```csharp
+public interface IProviderAdapter
+{
+    string Platform { get; }
+    Task<ProviderAdapterResponse>       GetProviderAsync(...);
+    Task<ProviderAdapterResponse>       GetProviderByNpiAsync(...);
+    Task<NetworkAdapterResponse>        GetNetworkAsync(...);          // placeholder — capability 5.3
+    Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(...);
+    Task<ProviderRosterAdapterResponse> SearchProvidersAsync(...);
+}
+```
+
+The response envelopes carry a `Platform` string, an optional
+`RawResponse` audit string, and a normalized payload (`AdapterProvider`,
+`IReadOnlyList<AdapterProvider>`, or `AdapterNetwork`). Payload shape
+mirrors the existing `Provider` so the CHO pass-through is lossless, and
+is structurally compatible with the planned FHIR `Practitioner` /
+`Organization` projections (Sections 5.7–5.9 of the migration spec).
+
+`GetNetworkAsync` is a deliberate **placeholder**: the Network entity
+itself ships in capability 5.3. Until then every adapter throws
+`NotImplementedException` from this method so any caller that reaches
+for it before 5.3 lands fails loudly with a `TODO(provider-network-5.3)`
+marker.
+
+## Routing & Tenant Configuration
+
+The factory consults tenant-service via HTTP at request time and reads:
+
+```
+GET /api/v1/tenants/{tenantId}
+  → response.configuration.providerPlatform.platform        (string)
+  → response.configuration.providerPlatform.platformSettings (object)
+```
+
+The matching adapter is selected case-insensitively by its `Platform`
+property. Allowed values today:
+
+| Platform string | Adapter                       | Status |
+|-----------------|-------------------------------|--------|
+| `cho`           | `ChoProviderAdapter`          | Active |
+| `qnxt`          | `QnxtProviderAdapter`         | Stub — `NotImplementedException` |
+| `facets`        | `FacetsProviderAdapter`       | Stub — `NotImplementedException` |
+| `healthedge`    | `HealthEdgeProviderAdapter`   | Stub — `NotImplementedException` |
+
+On any failure (HTTP error, JSON parse error, unknown platform) the factory
+warns and falls back to `cho`. A per-tenant `(platform, settings)` tuple
+is cached in the singleton `ProviderTenantConfigCache` for 5 minutes
+(thread-safe via `ConcurrentDictionary`).
+
+## DI lifetimes
+
+```csharp
+// Singleton — must outlive a single request so the TTL cache survives.
+services.AddSingleton<ProviderTenantConfigCache>();
+
+// Scoped — Cho wraps the scoped IProviderRepository.
+services.AddScoped<IProviderAdapter, ChoProviderAdapter>();
+services.AddScoped<IProviderAdapter, QnxtProviderAdapter>();
+services.AddScoped<IProviderAdapter, FacetsProviderAdapter>();
+services.AddScoped<IProviderAdapter, HealthEdgeProviderAdapter>();
+services.AddScoped<ProviderAdapterFactory>();
+
+services.AddHttpClient(ProviderTenantConfigCache.HttpClientName)
+        .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+```
+
+This matches the benefit-plan adapter wiring. The CHO adapter has to be
+scoped because it composes the scoped `IProviderRepository`; the cache
+lifecycle is kept separate so its TTL window is meaningful across
+requests.
+
+## Refactored controller endpoints
+
+Only the read endpoints that map 1:1 onto the interface route through
+the factory:
+
+| Endpoint                                            | Adapter method            |
+|-----------------------------------------------------|---------------------------|
+| `GET /api/v1/providers/{id}`                        | `GetProviderAsync`        |
+| `GET /api/v1/providers/npi/{npi}`                   | `GetProviderByNpiAsync`   |
+| `GET /api/v1/providers/search`                      | `SearchProvidersAsync`    |
+| `GET /api/v1/providers/list`                        | `SearchProvidersAsync`    |
+| `GET /api/v1/providers/{id}/network-status`         | `GetProviderAsync` (then in-controller participation filter) |
+| `GET /api/v1/providers/{id}/rates`                  | `GetProviderAsync` (then in-controller rate filter)          |
+
+Both the canonical `/api/v1/providers` mount and the legacy `/api/Providers`
+mount are covered (the controller is dual-routed).
+
+All other endpoints — version-chain reads (`GET /{id}/versions`,
+`GET /{id}/versions/{versionId}`), version lifecycle writes
+(`POST /drafts`, `POST /amend`, `POST /{id}/versions/{versionId}/activate`,
+`/suspend`, `/terminate`, `POST /{id}/reactivate`), legacy
+`POST /api/Providers`, `PUT /{id}`, `DELETE /{id}`,
+`POST /{id}/network-participations`, `PUT /{id}/credentialing`, and the
+bank-account endpoints — keep calling `IProviderRepository` and
+`IProviderVersioningService` directly. These are CHO-internal write paths
+and chain reads; expanding adapter coverage to writes is a future PR.
+
+## Adding a new adapter
+
+1. Implement `IProviderAdapter` with a unique `Platform` string.
+2. Register `services.AddScoped<IProviderAdapter, MyAdapter>()` in
+   `Program.cs` next to the others.
+3. Add the platform string to the table above and to the tenant-service
+   `ProviderConfig.Platform` enum / docs.
+4. Configure tenants via `PUT /api/v1/tenants/{id}` with
+   `configuration.providerPlatform.platform = "my-platform"`.
+5. Write factory + adapter tests under
+   `tests/CloudHealthOffice.ProviderService.Tests/Adapters/`.
+
+## Migration TODOs
+
+- **QNXT** (`TODO(qnxt-provider)`): integrate with the QNXT provider
+  directory API (PROVIDER_INQ on the QNXT provider stack).
+- **Facets** (`TODO(facets-provider)`): integrate with the Facets
+  provider inquiry interface (Open Access XML or Workflow REST).
+- **HealthEdge** (`TODO(healthedge-provider)`): integrate with the
+  HealthRules Payer provider inquiry API (HRP REST surface).
+- **Network entity** (`TODO(provider-network-5.3)`): every adapter's
+  `GetNetworkAsync` throws today. Capability 5.3 introduces the Network
+  model + repository and fills in this method on the CHO adapter.
+- **Verification surface** (capability 5.10): the integrity score and
+  rating fields on `AdapterProvider` are populated from the cached
+  values stored on `Provider` itself. The dedicated decoration seam that
+  refreshes these from `ProviderVerificationOrchestrator` runs adjacent
+  to the adapter — keeping the adapter contract orchestrator-free so
+  vendor adapters get the same enrichment without each having to
+  re-implement verification.
+
+Until those land the stubs surface a clear `NotImplementedException`
+containing the platform-specific TODO marker so any tenant misconfigured
+to point at one of them fails loudly rather than silently degrading.
+
+## FHIR alignment (Sections 5.7–5.9)
+
+`AdapterProvider` was intentionally shaped so a future FHIR projection
+layer can map it onto FHIR `Practitioner` (individual NPI Type 1) or
+`Organization` (NPI Type 2) without a model redesign. Field-level mapping
+notes:
+
+| Adapter field                                | FHIR location                          |
+|----------------------------------------------|----------------------------------------|
+| `Npi`                                        | `identifier` (system NPI URI)          |
+| `FirstName` / `MiddleName` / `LastName`      | `Practitioner.name`                    |
+| `OrganizationName` / `DBAName`               | `Organization.name` / `Organization.alias` |
+| `Address` / `City` / `State` / `ZipCode`     | `Practitioner.address` / `Organization.address` |
+| `Phone` / `Email` / `Fax`                    | `telecom`                              |
+| `TaxonomyCode` / `PrimarySpecialty`          | `Practitioner.qualification` (NUCC)    |
+| `BoardCertifications[]`                      | `Practitioner.qualification` repeats   |
+| `NetworkParticipations[]`                    | bound via FHIR `PractitionerRole`      |
+| `IntegrityScore` / `IntegrityRating` / `LastVerifiedAt` | payer-specific verification extension |
+| `VersionId` / `VersionNumber`                | `meta.versionId` / extension           |
+
+The CHO adapter today returns the existing model unchanged via the
+mapper; the QNXT/Facets/HealthEdge adapters will populate the same shape
+when implemented.
+
+## See also
+
+- `docs/architecture/benefit-plan-adapter-pattern.md` — sibling pattern,
+  same shape.
+- `docs/architecture/provider-versioning.md` — version chain identity
+  carried through every adapter response.

--- a/docs/architecture/provider-adapter-pattern.md
+++ b/docs/architecture/provider-adapter-pattern.md
@@ -3,16 +3,16 @@
 ## Why
 
 Some tenants will eventually source their provider directory from external
-core platforms (QNXT, Facets, HealthEdge) instead of CHO's internal
-`provider-service`. This pattern introduces a thin abstraction
+core platforms (QNXT, Facets, HealthEdge) instead of Cloud Health Office's
+internal `provider-service`. This pattern introduces a thin abstraction
 (`IProviderAdapter`) selected at request time by tenant configuration,
 mirroring the existing `IBenefitPlanAdapter` and `IEligibilityAdapter`
 surfaces.
 
 For every tenant currently in production the factory resolves to the
-default `ChoProviderAdapter`, which is a near pass-through over the
-existing `IProviderRepository` — so this PR introduces the seam without
-changing observable behavior.
+default `ChoProviderAdapter` (the Cloud Health Office implementation),
+which is a near pass-through over the existing `IProviderRepository` —
+so this PR introduces the seam without changing observable behavior.
 
 ## Topology
 
@@ -47,7 +47,7 @@ public interface IProviderAdapter
 The response envelopes carry a `Platform` string, an optional
 `RawResponse` audit string, and a normalized payload (`AdapterProvider`,
 `IReadOnlyList<AdapterProvider>`, or `AdapterNetwork`). Payload shape
-mirrors the existing `Provider` so the CHO pass-through is lossless, and
+mirrors the existing `Provider` so the Cloud Health Office pass-through is lossless, and
 is structurally compatible with the planned FHIR `Practitioner` /
 `Organization` projections (Sections 5.7–5.9 of the migration spec).
 
@@ -99,10 +99,10 @@ services.AddHttpClient(ProviderTenantConfigCache.HttpClientName)
         .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
 ```
 
-This matches the benefit-plan adapter wiring. The CHO adapter has to be
-scoped because it composes the scoped `IProviderRepository`; the cache
-lifecycle is kept separate so its TTL window is meaningful across
-requests.
+This matches the benefit-plan adapter wiring. The `ChoProviderAdapter`
+has to be scoped because it composes the scoped `IProviderRepository`;
+the cache lifecycle is kept separate so its TTL window is meaningful
+across requests.
 
 ## Refactored controller endpoints
 
@@ -128,8 +128,9 @@ All other endpoints — version-chain reads (`GET /{id}/versions`,
 `POST /api/Providers`, `PUT /{id}`, `DELETE /{id}`,
 `POST /{id}/network-participations`, `PUT /{id}/credentialing`, and the
 bank-account endpoints — keep calling `IProviderRepository` and
-`IProviderVersioningService` directly. These are CHO-internal write paths
-and chain reads; expanding adapter coverage to writes is a future PR.
+`IProviderVersioningService` directly. These are Cloud Health Office
+internal write paths and chain reads; expanding adapter coverage to writes
+is a future PR.
 
 ## Adding a new adapter
 
@@ -153,7 +154,7 @@ and chain reads; expanding adapter coverage to writes is a future PR.
   HealthRules Payer provider inquiry API (HRP REST surface).
 - **Network entity** (`TODO(provider-network-5.3)`): every adapter's
   `GetNetworkAsync` throws today. Capability 5.3 introduces the Network
-  model + repository and fills in this method on the CHO adapter.
+  model + repository and fills in this method on `ChoProviderAdapter`.
 - **Verification surface** (capability 5.10): the integrity score and
   rating fields on `AdapterProvider` are populated from the cached
   values stored on `Provider` itself. The dedicated decoration seam that
@@ -186,9 +187,9 @@ notes:
 | `IntegrityScore` / `IntegrityRating` / `LastVerifiedAt` | payer-specific verification extension |
 | `VersionId` / `VersionNumber`                | `meta.versionId` / extension           |
 
-The CHO adapter today returns the existing model unchanged via the
-mapper; the QNXT/Facets/HealthEdge adapters will populate the same shape
-when implemented.
+The `ChoProviderAdapter` today returns the existing model unchanged via
+the mapper; the QNXT/Facets/HealthEdge adapters will populate the same
+shape when implemented.
 
 ## See also
 

--- a/src/services/provider-service/Adapters/ChoProviderAdapter.cs
+++ b/src/services/provider-service/Adapters/ChoProviderAdapter.cs
@@ -1,0 +1,135 @@
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Default provider adapter using CHO's internal <see cref="IProviderRepository"/>.
+/// Preserves existing behavior — for the current set of tenants the factory
+/// always resolves to this adapter and the read paths return the same rows
+/// (post-hydration) the controller served before the refactor.
+/// </summary>
+/// <remarks>
+/// Provider verification (<c>ProviderVerificationOrchestrator</c>) is intentionally
+/// not wired into the adapter. Verification surfacing is the dedicated work of
+/// capability 5.10 (Integrity Score Surface), which decorates provider responses
+/// with cached integrity projections through a separate seam — adapter-agnostic,
+/// so the same enrichment works equally for CHO/QNXT/Facets sources later.
+/// </remarks>
+public class ChoProviderAdapter : IProviderAdapter
+{
+    private const string NetworkPlaceholderTodo =
+        "GetNetworkAsync is a placeholder — the Network entity arrives in capability 5.3. " +
+        "TODO(provider-network-5.3): implement once the Network model + repository land. " +
+        "See docs/architecture/provider-adapter-pattern.md.";
+
+    private readonly IProviderRepository _repository;
+    private readonly ILogger<ChoProviderAdapter> _logger;
+
+    public string Platform => "cho";
+
+    public ChoProviderAdapter(
+        IProviderRepository repository,
+        ILogger<ChoProviderAdapter> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<ProviderAdapterResponse> GetProviderAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.ProviderId))
+        {
+            throw new ArgumentException(
+                "ProviderId is required for GetProviderAsync.", nameof(request));
+        }
+
+        // Honor an explicit VersionId when supplied, otherwise return the
+        // latest non-Draft head — the same behavior the legacy controller had.
+        Provider? provider;
+        if (!string.IsNullOrEmpty(request.VersionId))
+        {
+            provider = await _repository.GetVersionAsync(request.ProviderId, request.VersionId);
+        }
+        else
+        {
+            provider = await _repository.GetByIdAsync(request.ProviderId);
+        }
+
+        return new ProviderAdapterResponse
+        {
+            Platform = Platform,
+            Provider = provider is null ? null : AdapterProvider.From(provider),
+        };
+    }
+
+    public async Task<ProviderAdapterResponse> GetProviderByNpiAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.Npi))
+        {
+            throw new ArgumentException(
+                "Npi is required for GetProviderByNpiAsync.", nameof(request));
+        }
+
+        var provider = await _repository.GetByNPIAsync(request.Npi);
+        return new ProviderAdapterResponse
+        {
+            Platform = Platform,
+            Provider = provider is null ? null : AdapterProvider.From(provider),
+        };
+    }
+
+    public Task<NetworkAdapterResponse> GetNetworkAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(NetworkPlaceholderTodo);
+
+    public async Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+    {
+        // Until 5.3 lands the Network entity, "roster" is sourced from the
+        // existing provider rows whose NetworkParticipations satisfy the
+        // requested plan/LOB/network scope. The repository's SearchAsync
+        // already pushes plan/LOB filters down to the data store.
+        var providers = await _repository.SearchAsync(
+            name: request.Name,
+            specialty: request.Specialty,
+            zipCode: request.ZipCode,
+            state: request.State,
+            planId: request.PlanId,
+            lineOfBusiness: request.LineOfBusiness,
+            providerType: request.ProviderType,
+            acceptingNewPatients: request.AcceptingNewPatients,
+            page: request.Page,
+            pageSize: request.PageSize);
+
+        return new ProviderRosterAdapterResponse
+        {
+            Platform = Platform,
+            Providers = providers.Select(AdapterProvider.From).ToList(),
+        };
+    }
+
+    public async Task<ProviderRosterAdapterResponse> SearchProvidersAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+    {
+        var providers = await _repository.SearchAsync(
+            name: request.Name,
+            specialty: request.Specialty,
+            zipCode: request.ZipCode,
+            state: request.State,
+            planId: request.PlanId,
+            lineOfBusiness: request.LineOfBusiness,
+            providerType: request.ProviderType,
+            acceptingNewPatients: request.AcceptingNewPatients,
+            page: request.Page,
+            pageSize: request.PageSize);
+
+        return new ProviderRosterAdapterResponse
+        {
+            Platform = Platform,
+            Providers = providers.Select(AdapterProvider.From).ToList(),
+        };
+    }
+}

--- a/src/services/provider-service/Adapters/FacetsProviderAdapter.cs
+++ b/src/services/provider-service/Adapters/FacetsProviderAdapter.cs
@@ -1,0 +1,43 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose provider directory lives in TriZetto Facets.
+/// All methods throw <see cref="NotImplementedException"/> with a clear
+/// migration TODO until the Facets integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(facets-provider): integrate with the Facets provider inquiry surface
+/// (typically the Open Access XML interface or Facets Workflow service).
+/// Reference doc: docs/architecture/provider-adapter-pattern.md.
+/// </remarks>
+public class FacetsProviderAdapter : IProviderAdapter
+{
+    private const string Todo =
+        "Facets provider adapter not yet implemented. " +
+        "TODO(facets-provider): integrate with the Facets provider inquiry interface. " +
+        "See docs/architecture/provider-adapter-pattern.md.";
+
+    public string Platform => "facets";
+
+    public Task<ProviderAdapterResponse> GetProviderAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderAdapterResponse> GetProviderByNpiAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<NetworkAdapterResponse> GetNetworkAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> SearchProvidersAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/provider-service/Adapters/HealthEdgeProviderAdapter.cs
+++ b/src/services/provider-service/Adapters/HealthEdgeProviderAdapter.cs
@@ -1,0 +1,43 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose provider directory lives in HealthEdge
+/// HealthRules Payer. All methods throw <see cref="NotImplementedException"/>
+/// with a clear migration TODO until the HealthEdge integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(healthedge-provider): integrate with the HealthRules Payer provider
+/// inquiry API (HRP REST surface). Reference doc:
+/// docs/architecture/provider-adapter-pattern.md.
+/// </remarks>
+public class HealthEdgeProviderAdapter : IProviderAdapter
+{
+    private const string Todo =
+        "HealthEdge provider adapter not yet implemented. " +
+        "TODO(healthedge-provider): integrate with the HealthRules Payer provider inquiry API. " +
+        "See docs/architecture/provider-adapter-pattern.md.";
+
+    public string Platform => "healthedge";
+
+    public Task<ProviderAdapterResponse> GetProviderAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderAdapterResponse> GetProviderByNpiAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<NetworkAdapterResponse> GetNetworkAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> SearchProvidersAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/provider-service/Adapters/IProviderAdapter.cs
+++ b/src/services/provider-service/Adapters/IProviderAdapter.cs
@@ -1,0 +1,70 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Abstraction for provider directory platforms.
+/// Each tenant can be configured to use a different adapter (CHO, QNXT, Facets, HealthEdge, ...).
+/// The adapter normalizes platform-specific responses into a common, vendor-neutral format
+/// designed to project cleanly onto future FHIR <c>Practitioner</c> / <c>Organization</c>
+/// resources (Sections 5.7–5.9).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>BenefitPlanService.Adapters.IBenefitPlanAdapter</c> and
+/// <c>EligibilityService.Adapters.IEligibilityAdapter</c>. The selection mechanism
+/// (factory consults tenant-service config and falls back to "cho") is identical.
+///
+/// <para>
+/// <see cref="GetNetworkAsync"/> is a deliberate placeholder — the Network entity
+/// itself ships in capability 5.3. Until then every adapter throws
+/// <see cref="NotImplementedException"/> from this method so callers fail loudly
+/// rather than silently degrading.
+/// </para>
+/// </remarks>
+public interface IProviderAdapter
+{
+    /// <summary>
+    /// Platform identifier matching <c>ProviderConfig.Platform</c> on the tenant.
+    /// Resolution by the factory is case-insensitive.
+    /// </summary>
+    string Platform { get; }
+
+    /// <summary>
+    /// Fetch a single provider by chain key (<see cref="ProviderAdapterRequest.ProviderId"/>).
+    /// Returns a response with <c>Provider == null</c> when not found so callers can map to 404.
+    /// </summary>
+    Task<ProviderAdapterResponse> GetProviderAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetch a single provider by NPI (<see cref="ProviderAdapterRequest.Npi"/>).
+    /// Returns a response with <c>Provider == null</c> when not found.
+    /// </summary>
+    Task<ProviderAdapterResponse> GetProviderByNpiAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Placeholder for capability 5.3 (Network entity). Throws
+    /// <see cref="NotImplementedException"/> on every adapter today; the Network
+    /// shape and storage land with 5.3.
+    /// </summary>
+    Task<NetworkAdapterResponse> GetNetworkAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Return providers participating in a given network / plan / line-of-business
+    /// scope as derived from <see cref="ProviderAdapterRequest"/>. Implementations
+    /// filter on <c>NetworkParticipation</c> for CHO; vendor adapters call the
+    /// vendor's roster surface.
+    /// </summary>
+    Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// General provider search (name / specialty / location / type filters).
+    /// Returns the page described by <see cref="ProviderAdapterRequest.Page"/> /
+    /// <see cref="ProviderAdapterRequest.PageSize"/>.
+    /// </summary>
+    Task<ProviderRosterAdapterResponse> SearchProvidersAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default);
+}

--- a/src/services/provider-service/Adapters/ProviderAdapterFactory.cs
+++ b/src/services/provider-service/Adapters/ProviderAdapterFactory.cs
@@ -1,0 +1,68 @@
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Resolves the correct <see cref="IProviderAdapter"/> at runtime based on
+/// tenant configuration. Mirrors <c>BenefitPlanService.Adapters.BenefitPlanAdapterFactory</c>.
+///
+/// <para>
+/// Tenant config is fetched from tenant-service (cached 5 minutes via
+/// <see cref="ProviderTenantConfigCache"/>) and matched against each adapter's
+/// <see cref="IProviderAdapter.Platform"/> property (case-insensitive).
+/// On any failure or unknown platform the factory falls back to <c>"cho"</c>
+/// so a flaky tenant-service never breaks provider reads.
+/// </para>
+/// </summary>
+public class ProviderAdapterFactory
+{
+    private readonly IEnumerable<IProviderAdapter> _adapters;
+    private readonly ProviderTenantConfigCache _cache;
+    private readonly ILogger<ProviderAdapterFactory> _logger;
+
+    public ProviderAdapterFactory(
+        IEnumerable<IProviderAdapter> adapters,
+        ProviderTenantConfigCache cache,
+        ILogger<ProviderAdapterFactory> logger)
+    {
+        _adapters = adapters;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Get the provider adapter configured for the given tenant.
+    /// Returns the CHO adapter when no specific configuration is found.
+    /// </summary>
+    public async Task<IProviderAdapter> GetAdapterAsync(string tenantId, CancellationToken ct = default)
+    {
+        var (platform, _) = await _cache.GetAsync(tenantId, ct);
+        return ResolveAdapter(platform);
+    }
+
+    /// <summary>
+    /// Get the adapter and a copy of the tenant's platform-settings dictionary
+    /// (callers may mutate the copy without affecting the cache).
+    /// </summary>
+    public async Task<(IProviderAdapter Adapter, Dictionary<string, string> Settings)> GetAdapterWithSettingsAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        var (platform, settings) = await _cache.GetAsync(tenantId, ct);
+        return (ResolveAdapter(platform), new Dictionary<string, string>(settings));
+    }
+
+    private IProviderAdapter ResolveAdapter(string platform)
+    {
+        var adapter = _adapters.FirstOrDefault(a =>
+            string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase));
+
+        if (adapter == null)
+        {
+            _logger.LogWarning(
+                "No provider adapter found for platform '{Platform}', falling back to 'cho'",
+                platform);
+            adapter = _adapters.First(a =>
+                string.Equals(a.Platform, ProviderTenantConfigCache.DefaultPlatform, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return adapter;
+    }
+}

--- a/src/services/provider-service/Adapters/ProviderTenantConfigCache.cs
+++ b/src/services/provider-service/Adapters/ProviderTenantConfigCache.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Singleton cache for per-tenant provider-directory platform configuration.
+/// Holds state across requests so the factory itself can stay scoped (the CHO
+/// adapter wraps scoped repository services, so the factory and adapters must
+/// be scoped — but the cache must outlive a single request).
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="BenefitPlanService.Adapters.BenefitPlanTenantConfigCache"/>:
+/// 5-minute TTL, thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>,
+/// and a graceful fallback to <c>"cho"</c> on any HTTP/JSON failure so a flaky
+/// tenant-service never breaks provider reads.
+/// </remarks>
+public class ProviderTenantConfigCache
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ProviderTenantConfigCache> _logger;
+
+    private readonly ConcurrentDictionary<string, (string Platform, Dictionary<string, string> Settings, DateTime ExpiresAt)> _cache = new();
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    public const string DefaultPlatform = "cho";
+    public const string HttpClientName = "ProviderDefault";
+
+    public ProviderTenantConfigCache(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<ProviderTenantConfigCache> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolve <c>(platform, platformSettings)</c> for the given tenant, hitting
+    /// tenant-service on cache miss. Defaults to <c>("cho", new())</c> when the
+    /// tenant has no <c>providerPlatform</c> config or the call fails.
+    /// </summary>
+    public async Task<(string Platform, Dictionary<string, string> Settings)> GetAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(tenantId, out var cached) && cached.ExpiresAt > DateTime.UtcNow)
+        {
+            return (cached.Platform, cached.Settings);
+        }
+
+        try
+        {
+            var tenantUrl = _configuration["Services:TenantService"]
+                ?? "http://tenant-service.cloudhealthoffice/api/v1";
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            var response = await httpClient.GetAsync($"{tenantUrl}/tenants/{tenantId}", ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadAsStringAsync(ct);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                if (root.TryGetProperty("configuration", out var config) &&
+                    config.TryGetProperty("providerPlatform", out var providerConfig) &&
+                    providerConfig.TryGetProperty("platform", out var platformProp))
+                {
+                    var platform = platformProp.GetString() ?? DefaultPlatform;
+                    var settings = new Dictionary<string, string>();
+
+                    if (providerConfig.TryGetProperty("platformSettings", out var settingsProp))
+                    {
+                        foreach (var prop in settingsProp.EnumerateObject())
+                        {
+                            settings[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                        }
+                    }
+
+                    _cache[tenantId] = (platform, settings, DateTime.UtcNow.Add(CacheDuration));
+                    return (platform, settings);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to fetch provider tenant config for {TenantId}, using default adapter",
+                SanitizeForLog(tenantId));
+        }
+
+        var defaultSettings = new Dictionary<string, string>();
+        _cache[tenantId] = (DefaultPlatform, defaultSettings, DateTime.UtcNow.Add(CacheDuration));
+        return (DefaultPlatform, defaultSettings);
+    }
+
+    /// <summary>Test seam — drops all cached entries.</summary>
+    public void Clear() => _cache.Clear();
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/provider-service/Adapters/ProviderTenantConfigCache.cs
+++ b/src/services/provider-service/Adapters/ProviderTenantConfigCache.cs
@@ -10,7 +10,7 @@ namespace ProviderService.Adapters;
 /// be scoped — but the cache must outlive a single request).
 /// </summary>
 /// <remarks>
-/// Mirrors <see cref="BenefitPlanService.Adapters.BenefitPlanTenantConfigCache"/>:
+/// Mirrors <c>BenefitPlanService.Adapters.BenefitPlanTenantConfigCache</c>:
 /// 5-minute TTL, thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>,
 /// and a graceful fallback to <c>"cho"</c> on any HTTP/JSON failure so a flaky
 /// tenant-service never breaks provider reads.
@@ -55,7 +55,11 @@ public class ProviderTenantConfigCache
             var tenantUrl = _configuration["Services:TenantService"]
                 ?? "http://tenant-service.cloudhealthoffice/api/v1";
             var httpClient = _httpClientFactory.CreateClient(HttpClientName);
-            var response = await httpClient.GetAsync($"{tenantUrl}/tenants/{tenantId}", ct);
+            // Encode the tenantId path segment defensively — the value flows
+            // from JWT/header via TenantMiddleware, and a crafted id with '/'
+            // or '?' would otherwise alter the request path or query.
+            var encodedTenantId = Uri.EscapeDataString(tenantId);
+            var response = await httpClient.GetAsync($"{tenantUrl}/tenants/{encodedTenantId}", ct);
 
             if (response.IsSuccessStatusCode)
             {

--- a/src/services/provider-service/Adapters/QnxtProviderAdapter.cs
+++ b/src/services/provider-service/Adapters/QnxtProviderAdapter.cs
@@ -1,0 +1,43 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose provider directory lives in QNXT
+/// (TriZetto / Cognizant). All methods throw <see cref="NotImplementedException"/>
+/// with a clear migration TODO until the QNXT integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(qnxt-provider): integrate with the QNXT provider directory API
+/// (PROVIDER_INQ on the QNXT provider stack). Reference doc:
+/// docs/architecture/provider-adapter-pattern.md.
+/// </remarks>
+public class QnxtProviderAdapter : IProviderAdapter
+{
+    private const string Todo =
+        "QNXT provider adapter not yet implemented. " +
+        "TODO(qnxt-provider): integrate with the QNXT provider directory API. " +
+        "See docs/architecture/provider-adapter-pattern.md.";
+
+    public string Platform => "qnxt";
+
+    public Task<ProviderAdapterResponse> GetProviderAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderAdapterResponse> GetProviderByNpiAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<NetworkAdapterResponse> GetNetworkAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> GetNetworkRosterAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ProviderRosterAdapterResponse> SearchProvidersAsync(
+        ProviderAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using ProviderService.Adapters;
 using ProviderService.Models;
 using ProviderService.Repositories;
 using ProviderService.Services;
@@ -20,17 +21,29 @@ public class ProvidersController : ControllerBase
 {
     private readonly IProviderRepository _providerRepository;
     private readonly IProviderVersioningService _versioning;
+    private readonly ProviderAdapterFactory _adapterFactory;
     private readonly ILogger<ProvidersController> _logger;
 
     public ProvidersController(
         IProviderRepository providerRepository,
         IProviderVersioningService versioning,
+        ProviderAdapterFactory adapterFactory,
         ILogger<ProvidersController> logger)
     {
         _providerRepository = providerRepository;
         _versioning = versioning;
+        _adapterFactory = adapterFactory;
         _logger = logger;
     }
+
+    /// <summary>
+    /// Tenant id resolved by <see cref="Middleware.TenantMiddleware"/>. Throws when
+    /// the middleware did not set it (defensive — the middleware always populates
+    /// the value, defaulting to <c>"default-tenant"</c> in dev).
+    /// </summary>
+    private string TenantId =>
+        HttpContext.Items["TenantId"]?.ToString()
+            ?? throw new InvalidOperationException("TenantId not found in request context");
 
     /// <summary>
     /// Get provider by NPI
@@ -42,13 +55,20 @@ public class ProvidersController : ControllerBase
     {
         _logger.LogInformation("Fetching provider by NPI: {NPI}", SanitizeForLog(npi));
 
-        var provider = await _providerRepository.GetByNPIAsync(npi);
-        if (provider == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetProviderByNpiAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Npi = npi,
+            PlatformSettings = settings,
+        });
+
+        if (response.Provider == null)
         {
             return NotFound($"Provider with NPI {npi} not found");
         }
 
-        return Ok(provider);
+        return Ok(response.Provider.ToProvider());
     }
 
     /// <summary>
@@ -76,10 +96,24 @@ public class ProvidersController : ControllerBase
         // Support 'q' as alias for 'name' (portal autocomplete uses q=)
         var searchName = name ?? q;
 
-        var providers = await _providerRepository.SearchAsync(
-            searchName, specialty, zipCode, state, planId, lineOfBusiness, providerType, acceptingNewPatients, page, pageSize);
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.SearchProvidersAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Name = searchName,
+            Specialty = specialty,
+            ZipCode = zipCode,
+            State = state,
+            PlanId = planId,
+            LineOfBusiness = lineOfBusiness,
+            ProviderType = providerType,
+            AcceptingNewPatients = acceptingNewPatients,
+            Page = page,
+            PageSize = pageSize,
+            PlatformSettings = settings,
+        });
 
-        return Ok(providers);
+        return Ok(response.Providers.Select(p => p.ToProvider()));
     }
 
     /// <summary>
@@ -95,9 +129,20 @@ public class ProvidersController : ControllerBase
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = 50)
     {
-        var providers = await _providerRepository.SearchAsync(
-            null, specialty, null, state, null, null, providerType, acceptingNewPatients, page, pageSize);
-        return Ok(providers);
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.SearchProvidersAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Specialty = specialty,
+            State = state,
+            ProviderType = providerType,
+            AcceptingNewPatients = acceptingNewPatients,
+            Page = page,
+            PageSize = pageSize,
+            PlatformSettings = settings,
+        });
+
+        return Ok(response.Providers.Select(p => p.ToProvider()));
     }
 
     /// <summary>
@@ -140,11 +185,23 @@ public class ProvidersController : ControllerBase
             "Checking network status for provider {Id}, plan={Plan}, lob={LOB}, date={Date}",
             SanitizeForLog(id), SanitizeForLog(planId), lineOfBusiness, checkDate);
 
-        var provider = await _providerRepository.GetByIdAsync(id);
-        if (provider == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var adapterResponse = await adapter.GetProviderAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            ProviderId = id,
+            PlanId = planId,
+            LineOfBusiness = lineOfBusiness,
+            ServiceDate = checkDate,
+            PlatformSettings = settings,
+        });
+
+        if (adapterResponse.Provider == null)
         {
             return NotFound($"Provider {id} not found");
         }
+
+        var provider = adapterResponse.Provider.ToProvider();
 
         // Find active network participation
         var participation = provider.NetworkParticipations
@@ -187,11 +244,22 @@ public class ProvidersController : ControllerBase
             "Fetching contracted rates for provider {Id}, plan={Plan}, lob={LOB}",
             SanitizeForLog(id), SanitizeForLog(planId), lineOfBusiness);
 
-        var provider = await _providerRepository.GetByIdAsync(id);
-        if (provider == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var adapterResponse = await adapter.GetProviderAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            ProviderId = id,
+            PlanId = planId,
+            LineOfBusiness = lineOfBusiness,
+            PlatformSettings = settings,
+        });
+
+        if (adapterResponse.Provider == null)
         {
             return NotFound($"Provider {id} not found");
         }
+
+        var provider = adapterResponse.Provider.ToProvider();
 
         // Find active network participation with rates
         var participation = provider.NetworkParticipations
@@ -398,13 +466,20 @@ public class ProvidersController : ControllerBase
     {
         _logger.LogInformation("Fetching provider by ID: {Id}", SanitizeForLog(id));
 
-        var provider = await _providerRepository.GetByIdAsync(id);
-        if (provider == null)
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetProviderAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            ProviderId = id,
+            PlatformSettings = settings,
+        });
+
+        if (response.Provider == null)
         {
             return NotFound($"Provider {id} not found");
         }
 
-        return Ok(provider);
+        return Ok(response.Provider.ToProvider());
     }
 
     /// <summary>

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -37,9 +37,9 @@ public class ProvidersController : ControllerBase
     }
 
     /// <summary>
-    /// Tenant id resolved by <see cref="Middleware.TenantMiddleware"/>. Throws when
-    /// the middleware did not set it (defensive — the middleware always populates
-    /// the value, defaulting to <c>"default-tenant"</c> in dev).
+    /// Tenant id resolved by <see cref="ProviderService.Middleware.TenantMiddleware"/>.
+    /// Throws when the middleware did not set it (defensive — the middleware always
+    /// populates the value, defaulting to <c>"default-tenant"</c> in dev).
     /// </summary>
     private string TenantId =>
         HttpContext.Items["TenantId"]?.ToString()

--- a/src/services/provider-service/Models/ProviderAdapterRequest.cs
+++ b/src/services/provider-service/Models/ProviderAdapterRequest.cs
@@ -1,0 +1,84 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Vendor-neutral request envelope passed to any
+/// <see cref="Adapters.IProviderAdapter"/>. A single shape covers every read
+/// method on the adapter; per-method required fields are documented on the
+/// individual properties below.
+/// </summary>
+public class ProviderAdapterRequest
+{
+    /// <summary>Tenant id resolved by the request middleware. Required by all methods.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Provider chain key (<see cref="Provider.ProviderId"/>). Required by
+    /// <c>GetProviderAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? ProviderId { get; set; }
+
+    /// <summary>
+    /// Specific version identifier (ULID). Optional on
+    /// <c>GetProviderAsync</c> — when set, adapters return that exact version
+    /// instead of the latest non-Draft head.
+    /// </summary>
+    public string? VersionId { get; set; }
+
+    /// <summary>
+    /// 10-digit National Provider Identifier. Required by <c>GetProviderByNpiAsync</c>;
+    /// ignored otherwise.
+    /// </summary>
+    public string? Npi { get; set; }
+
+    /// <summary>
+    /// Network identifier. Required by <c>GetNetworkAsync</c> /
+    /// <c>GetNetworkRosterAsync</c> once capability 5.3 ships; today the CHO
+    /// adapter treats this as an optional roster scoping hint.
+    /// </summary>
+    public string? NetworkId { get; set; }
+
+    /// <summary>Free-text name fragment used by <c>SearchProvidersAsync</c>.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>NUCC taxonomy fragment (display name or code).</summary>
+    public string? Specialty { get; set; }
+
+    /// <summary>2-letter state code filter for search / roster.</summary>
+    public string? State { get; set; }
+
+    /// <summary>ZIP code filter for search / roster.</summary>
+    public string? ZipCode { get; set; }
+
+    /// <summary>Plan id used to scope <c>SearchProvidersAsync</c> / <c>GetNetworkRosterAsync</c>.</summary>
+    public string? PlanId { get; set; }
+
+    /// <summary>Line of business filter.</summary>
+    public LineOfBusiness? LineOfBusiness { get; set; }
+
+    /// <summary>Provider type (Individual / Organization) filter.</summary>
+    public ProviderType? ProviderType { get; set; }
+
+    /// <summary>Filter to providers accepting new patients.</summary>
+    public bool? AcceptingNewPatients { get; set; }
+
+    /// <summary>1-based page index for paged search / roster results.</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Page size for paged search / roster results.</summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Effective date used to resolve which version applies on
+    /// <c>GetNetworkRosterAsync</c> / network-status checks. Defaults to
+    /// <see cref="DateTime.UtcNow"/> when null.
+    /// </summary>
+    public DateTime? ServiceDate { get; set; }
+
+    /// <summary>
+    /// Platform-specific configuration sourced from
+    /// <c>ProviderConfig.PlatformSettings</c> (e.g. QNXT base URL,
+    /// Facets credential reference). Adapters read what they need; the
+    /// factory passes the value through unchanged.
+    /// </summary>
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}

--- a/src/services/provider-service/Models/ProviderAdapterRequest.cs
+++ b/src/services/provider-service/Models/ProviderAdapterRequest.cs
@@ -69,8 +69,9 @@ public class ProviderAdapterRequest
 
     /// <summary>
     /// Effective date used to resolve which version applies on
-    /// <c>GetNetworkRosterAsync</c> / network-status checks. Defaults to
-    /// <see cref="DateTime.UtcNow"/> when null.
+    /// <c>GetNetworkRosterAsync</c> / network-status checks. Optional; when
+    /// null, callers and adapter implementations should treat it as
+    /// <see cref="DateTime.UtcNow"/> at call time.
     /// </summary>
     public DateTime? ServiceDate { get; set; }
 

--- a/src/services/provider-service/Models/ProviderAdapterResponse.cs
+++ b/src/services/provider-service/Models/ProviderAdapterResponse.cs
@@ -6,10 +6,10 @@ namespace ProviderService.Models;
 /// <see cref="Adapters.IProviderAdapter.GetProviderByNpiAsync"/>.
 ///
 /// <para>
-/// The payload <see cref="Provider"/> is shaped to project cleanly onto future
-/// FHIR <c>Practitioner</c> / <c>Organization</c> resources (Sections 5.7–5.9):
-/// individual-name fields map onto <c>Practitioner.name</c>, organization name
-/// onto <c>Organization.name</c>, address fields onto
+/// The payload <see cref="AdapterProvider"/> is shaped to project cleanly onto
+/// future FHIR <c>Practitioner</c> / <c>Organization</c> resources (Sections
+/// 5.7–5.9): individual-name fields map onto <c>Practitioner.name</c>,
+/// organization name onto <c>Organization.name</c>, address fields onto
 /// <c>Practitioner.address</c> / <c>Organization.address</c>, taxonomy onto
 /// <c>Practitioner.qualification</c>, and the integrity fields onto a
 /// payer-specific verification extension.

--- a/src/services/provider-service/Models/ProviderAdapterResponse.cs
+++ b/src/services/provider-service/Models/ProviderAdapterResponse.cs
@@ -1,0 +1,282 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Vendor-neutral response envelope returned by
+/// <see cref="Adapters.IProviderAdapter.GetProviderAsync"/> and
+/// <see cref="Adapters.IProviderAdapter.GetProviderByNpiAsync"/>.
+///
+/// <para>
+/// The payload <see cref="Provider"/> is shaped to project cleanly onto future
+/// FHIR <c>Practitioner</c> / <c>Organization</c> resources (Sections 5.7–5.9):
+/// individual-name fields map onto <c>Practitioner.name</c>, organization name
+/// onto <c>Organization.name</c>, address fields onto
+/// <c>Practitioner.address</c> / <c>Organization.address</c>, taxonomy onto
+/// <c>Practitioner.qualification</c>, and the integrity fields onto a
+/// payer-specific verification extension.
+/// </para>
+/// </summary>
+public class ProviderAdapterResponse
+{
+    /// <summary>Adapter that produced the response (e.g. "cho", "qnxt").</summary>
+    public string Platform { get; set; } = string.Empty;
+
+    /// <summary>Optional raw vendor response retained for audit / debugging.</summary>
+    public string? RawResponse { get; set; }
+
+    /// <summary>Provider payload. Null when the requested provider is not found.</summary>
+    public AdapterProvider? Provider { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for collection-returning adapter methods
+/// (<see cref="Adapters.IProviderAdapter.SearchProvidersAsync"/> and
+/// <see cref="Adapters.IProviderAdapter.GetNetworkRosterAsync"/>).
+/// </summary>
+public class ProviderRosterAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Page of providers returned by the adapter (never null; may be empty).</summary>
+    public IReadOnlyList<AdapterProvider> Providers { get; set; } = Array.Empty<AdapterProvider>();
+
+    /// <summary>Total matching count when the platform reports it; null otherwise.</summary>
+    public int? TotalCount { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for
+/// <see cref="Adapters.IProviderAdapter.GetNetworkAsync"/>. The
+/// <see cref="AdapterNetwork"/> shape is a deliberate placeholder until
+/// capability 5.3 (Network entity) ships; today every adapter throws
+/// <see cref="NotImplementedException"/> from this call.
+/// </summary>
+public class NetworkAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Network payload. Null today; populated once 5.3 lands.</summary>
+    public AdapterNetwork? Network { get; set; }
+}
+
+/// <summary>
+/// Placeholder Network DTO. Field set will be expanded by capability 5.3.
+/// Kept minimal today so the interface compiles and future fields can be added
+/// without a breaking change to callers that only inspect the envelope.
+/// </summary>
+public class AdapterNetwork
+{
+    public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Free-form status string ("Active", "Inactive", ...). Strict enum follows in 5.3.</summary>
+    public string? Status { get; set; }
+}
+
+/// <summary>
+/// Normalized provider DTO. Field shape mirrors <see cref="Provider"/> so the
+/// CHO pass-through is lossless; round-trip mappers <see cref="From"/> and
+/// <see cref="ToProvider"/> let the controller return the existing wire format
+/// to current consumers without any contract change.
+/// </summary>
+public class AdapterProvider
+{
+    public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string ProviderId { get; set; } = string.Empty;
+
+    public string Npi { get; set; } = string.Empty;
+    public ProviderType ProviderType { get; set; }
+    public string? TaxId { get; set; }
+
+    // Individual name parts
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public string? MiddleName { get; set; }
+    public string? Credentials { get; set; }
+
+    // Organization name parts
+    public string? OrganizationName { get; set; }
+    public string? DBAName { get; set; }
+
+    public string PrimarySpecialty { get; set; } = string.Empty;
+    public string TaxonomyCode { get; set; } = string.Empty;
+    public List<string> SecondarySpecialties { get; set; } = new();
+
+    public string? Address { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+    public string? ZipCode { get; set; }
+    public string? Phone { get; set; }
+    public string? Fax { get; set; }
+    public string? Email { get; set; }
+
+    public List<NetworkParticipation> NetworkParticipations { get; set; } = new();
+
+    public CredentialingStatus CredentialingStatus { get; set; }
+    public DateTime? CredentialingDate { get; set; }
+    public DateTime? RecredentialingDueDate { get; set; }
+    public string? CAQHProviderId { get; set; }
+    public DateTime? LastCAQHSyncDate { get; set; }
+
+    public List<BoardCertification> BoardCertifications { get; set; } = new();
+    public List<HospitalAffiliation> HospitalAffiliations { get; set; } = new();
+
+    public bool AcceptingNewPatients { get; set; } = true;
+    public bool HandicapAccessible { get; set; }
+    public List<string> LanguagesSpoken { get; set; } = new() { "en" };
+
+    public ProviderStatus Status { get; set; } = ProviderStatus.Active;
+    public DateTime? TerminationDate { get; set; }
+    public string? TerminationReason { get; set; }
+
+    public ProviderBankAccount? BankAccount { get; set; }
+
+    public DateTime CreatedDate { get; set; }
+    public DateTime LastUpdatedDate { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? LastUpdatedBy { get; set; }
+
+    /// <summary>
+    /// Cached integrity score from the verification engine. Carried through so
+    /// FHIR projections (5.7–5.9) can surface verification metadata without a
+    /// second round-trip; capability 5.10 owns the read-side decoration that
+    /// keeps this fresh independently of the adapter.
+    /// </summary>
+    public int? IntegrityScore { get; set; }
+    public string? IntegrityRating { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public DateTimeOffset? NextVerificationDue { get; set; }
+
+    // Version-chain identity (5.1)
+    public string VersionId { get; set; } = string.Empty;
+    public int VersionNumber { get; set; }
+    public ProviderVersionState VersionState { get; set; }
+    public string? PredecessorVersionId { get; set; }
+    public DateTime? ActivatedAt { get; set; }
+    public string? ActivatedBy { get; set; }
+    public DateTime? SuspendedAt { get; set; }
+    public string? SuspensionReason { get; set; }
+    public DateTime? SupersededAt { get; set; }
+    public string? SupersededByVersionId { get; set; }
+
+    public static AdapterProvider From(Provider src) => new()
+    {
+        Id = src.Id,
+        TenantId = src.TenantId,
+        ProviderId = src.ProviderId,
+        Npi = src.NPI,
+        ProviderType = src.ProviderType,
+        TaxId = src.TaxId,
+        FirstName = src.FirstName,
+        LastName = src.LastName,
+        MiddleName = src.MiddleName,
+        Credentials = src.Credentials,
+        OrganizationName = src.OrganizationName,
+        DBAName = src.DBAName,
+        PrimarySpecialty = src.PrimarySpecialty,
+        TaxonomyCode = src.TaxonomyCode,
+        SecondarySpecialties = src.SecondarySpecialties.ToList(),
+        Address = src.Address,
+        City = src.City,
+        State = src.State,
+        ZipCode = src.ZipCode,
+        Phone = src.Phone,
+        Fax = src.Fax,
+        Email = src.Email,
+        NetworkParticipations = src.NetworkParticipations.ToList(),
+        CredentialingStatus = src.CredentialingStatus,
+        CredentialingDate = src.CredentialingDate,
+        RecredentialingDueDate = src.RecredentialingDueDate,
+        CAQHProviderId = src.CAQHProviderId,
+        LastCAQHSyncDate = src.LastCAQHSyncDate,
+        BoardCertifications = src.BoardCertifications.ToList(),
+        HospitalAffiliations = src.HospitalAffiliations.ToList(),
+        AcceptingNewPatients = src.AcceptingNewPatients,
+        HandicapAccessible = src.HandicapAccessible,
+        LanguagesSpoken = src.LanguagesSpoken.ToList(),
+        Status = src.Status,
+        TerminationDate = src.TerminationDate,
+        TerminationReason = src.TerminationReason,
+        BankAccount = src.BankAccount,
+        CreatedDate = src.CreatedDate,
+        LastUpdatedDate = src.LastUpdatedDate,
+        CreatedBy = src.CreatedBy,
+        LastUpdatedBy = src.LastUpdatedBy,
+        IntegrityScore = src.IntegrityScore,
+        IntegrityRating = src.IntegrityRating,
+        LastVerifiedAt = src.LastVerifiedAt,
+        NextVerificationDue = src.NextVerificationDue,
+        VersionId = src.VersionId,
+        VersionNumber = src.VersionNumber,
+        VersionState = src.VersionState,
+        PredecessorVersionId = src.PredecessorVersionId,
+        ActivatedAt = src.ActivatedAt,
+        ActivatedBy = src.ActivatedBy,
+        SuspendedAt = src.SuspendedAt,
+        SuspensionReason = src.SuspensionReason,
+        SupersededAt = src.SupersededAt,
+        SupersededByVersionId = src.SupersededByVersionId,
+    };
+
+    public Provider ToProvider() => new()
+    {
+        Id = Id,
+        TenantId = TenantId,
+        ProviderId = ProviderId,
+        NPI = Npi,
+        ProviderType = ProviderType,
+        TaxId = TaxId,
+        FirstName = FirstName,
+        LastName = LastName,
+        MiddleName = MiddleName,
+        Credentials = Credentials,
+        OrganizationName = OrganizationName,
+        DBAName = DBAName,
+        PrimarySpecialty = PrimarySpecialty,
+        TaxonomyCode = TaxonomyCode,
+        SecondarySpecialties = SecondarySpecialties.ToList(),
+        Address = Address,
+        City = City,
+        State = State,
+        ZipCode = ZipCode,
+        Phone = Phone,
+        Fax = Fax,
+        Email = Email,
+        NetworkParticipations = NetworkParticipations.ToList(),
+        CredentialingStatus = CredentialingStatus,
+        CredentialingDate = CredentialingDate,
+        RecredentialingDueDate = RecredentialingDueDate,
+        CAQHProviderId = CAQHProviderId,
+        LastCAQHSyncDate = LastCAQHSyncDate,
+        BoardCertifications = BoardCertifications.ToList(),
+        HospitalAffiliations = HospitalAffiliations.ToList(),
+        AcceptingNewPatients = AcceptingNewPatients,
+        HandicapAccessible = HandicapAccessible,
+        LanguagesSpoken = LanguagesSpoken.ToList(),
+        Status = Status,
+        TerminationDate = TerminationDate,
+        TerminationReason = TerminationReason,
+        BankAccount = BankAccount,
+        CreatedDate = CreatedDate,
+        LastUpdatedDate = LastUpdatedDate,
+        CreatedBy = CreatedBy,
+        LastUpdatedBy = LastUpdatedBy,
+        IntegrityScore = IntegrityScore,
+        IntegrityRating = IntegrityRating,
+        LastVerifiedAt = LastVerifiedAt,
+        NextVerificationDue = NextVerificationDue,
+        VersionId = VersionId,
+        VersionNumber = VersionNumber,
+        VersionState = VersionState,
+        PredecessorVersionId = PredecessorVersionId,
+        ActivatedAt = ActivatedAt,
+        ActivatedBy = ActivatedBy,
+        SuspendedAt = SuspendedAt,
+        SuspensionReason = SuspensionReason,
+        SupersededAt = SupersededAt,
+        SupersededByVersionId = SupersededByVersionId,
+    };
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.Cosmos;
 using Microsoft.OpenApi.Models;
+using ProviderService.Adapters;
 using ProviderService.HostedServices;
 using ProviderService.Middleware;
 using ProviderService.Repositories;
@@ -83,6 +84,21 @@ builder.Services.AddScoped<IProviderVersioningService, ProviderVersioningService
 
 // MPIP rate service (FL SMMC 3.0 physician incentive program)
 builder.Services.AddScoped<IMpipRateService, MpipRateService>();
+
+// Provider adapter pattern (5.2 — tenant-routed provider directory backends).
+// Cache is singleton (TTL across requests); adapters and factory are scoped
+// because the CHO adapter wraps scoped repository services. Tenant-service
+// HTTP client uses a 5-second timeout so a flaky tenant-service can't stall
+// provider reads — the cache falls back to "cho" on any failure.
+builder.Services.AddHttpClient(ProviderTenantConfigCache.HttpClientName)
+    .SetHandlerLifetime(TimeSpan.FromMinutes(5))
+    .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+builder.Services.AddSingleton<ProviderTenantConfigCache>();
+builder.Services.AddScoped<IProviderAdapter, ChoProviderAdapter>();
+builder.Services.AddScoped<IProviderAdapter, QnxtProviderAdapter>();
+builder.Services.AddScoped<IProviderAdapter, FacetsProviderAdapter>();
+builder.Services.AddScoped<IProviderAdapter, HealthEdgeProviderAdapter>();
+builder.Services.AddScoped<ProviderAdapterFactory>();
 
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ChoProviderAdapterTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ChoProviderAdapterTests.cs
@@ -1,0 +1,170 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Adapters;
+using ProviderService.Models;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Verifies the CHO pass-through adapter against the in-memory repository.
+/// These are the regression tests for "no behavior change for current tenants" —
+/// every CHO read path must return the same row shape the controller saw before
+/// the refactor.
+/// </summary>
+public class ChoProviderAdapterTests
+{
+    private const string TenantId = "tenant-a";
+    private const string Npi = "1234567890";
+
+    [Fact]
+    public void Platform_identifier_is_cho()
+    {
+        var adapter = NewAdapter(out _);
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetProviderByNpiAsync_returns_provider_when_found()
+    {
+        var adapter = NewAdapter(out var repo);
+        await Seed(repo, npi: Npi, providerId: "p-1");
+
+        var response = await adapter.GetProviderByNpiAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Npi = Npi,
+        });
+
+        response.Platform.Should().Be("cho");
+        response.Provider.Should().NotBeNull();
+        response.Provider!.Npi.Should().Be(Npi);
+        response.Provider.ProviderId.Should().Be("p-1");
+    }
+
+    [Fact]
+    public async Task GetProviderByNpiAsync_returns_null_provider_when_not_found()
+    {
+        var adapter = NewAdapter(out _);
+
+        var response = await adapter.GetProviderByNpiAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Npi = "0000000000",
+        });
+
+        response.Provider.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetProviderByNpiAsync_throws_when_npi_missing()
+    {
+        var adapter = NewAdapter(out _);
+
+        var act = () => adapter.GetProviderByNpiAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Npi is required*");
+    }
+
+    [Fact]
+    public async Task GetProviderAsync_returns_provider_by_chain_key()
+    {
+        var adapter = NewAdapter(out var repo);
+        await Seed(repo, npi: Npi, providerId: "p-xyz");
+
+        var response = await adapter.GetProviderAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            ProviderId = "p-xyz",
+        });
+
+        response.Provider.Should().NotBeNull();
+        response.Provider!.ProviderId.Should().Be("p-xyz");
+    }
+
+    [Fact]
+    public async Task GetProviderAsync_throws_when_provider_id_missing()
+    {
+        var adapter = NewAdapter(out _);
+
+        var act = () => adapter.GetProviderAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("ProviderId is required*");
+    }
+
+    [Fact]
+    public async Task SearchProvidersAsync_returns_roster_envelope()
+    {
+        var adapter = NewAdapter(out var repo);
+        await Seed(repo, npi: "1111111111", providerId: "p-1", lastName: "Smith");
+        await Seed(repo, npi: "2222222222", providerId: "p-2", lastName: "Jones");
+
+        var response = await adapter.SearchProvidersAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            Page = 1,
+            PageSize = 50,
+        });
+
+        response.Platform.Should().Be("cho");
+        response.Providers.Should().HaveCount(2);
+        response.Providers.Select(p => p.Npi).Should().Contain(new[] { "1111111111", "2222222222" });
+    }
+
+    [Fact]
+    public async Task GetNetworkAsync_throws_until_capability_5_3_lands()
+    {
+        var adapter = NewAdapter(out _);
+
+        var act = () => adapter.GetNetworkAsync(new ProviderAdapterRequest
+        {
+            TenantId = TenantId,
+            NetworkId = "any",
+        });
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain("TODO(provider-network-5.3)");
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static ChoProviderAdapter NewAdapter(out InMemoryProviderRepository repo)
+    {
+        repo = new InMemoryProviderRepository { TenantId = TenantId };
+        return new ChoProviderAdapter(repo, NullLogger<ChoProviderAdapter>.Instance);
+    }
+
+    private static async Task Seed(
+        InMemoryProviderRepository repo,
+        string npi,
+        string providerId,
+        string lastName = "Doe")
+    {
+        await repo.CreateAsync(new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = TenantId,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Jane",
+            LastName = lastName,
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            CredentialingStatus = CredentialingStatus.Approved,
+            Status = ProviderStatus.Active,
+            VersionId = providerId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        });
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ProviderAdapterFactoryTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ProviderAdapterFactoryTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using ProviderService.Adapters;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Verifies that <see cref="ProviderAdapterFactory"/> resolves the correct
+/// adapter by tenant config and that <see cref="ProviderTenantConfigCache"/>
+/// falls back gracefully when tenant-service is unavailable.
+/// </summary>
+public class ProviderAdapterFactoryTests
+{
+    [Fact]
+    public async Task Factory_resolves_cho_adapter_by_default()
+    {
+        var (factory, _) = BuildFactory(stubResponse: null);
+
+        var adapter = await factory.GetAdapterAsync("tenant-without-config");
+
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task Factory_resolves_qnxt_adapter_when_tenant_configured_qnxt()
+    {
+        var json = """
+        {
+          "configuration": {
+            "providerPlatform": {
+              "platform": "qnxt",
+              "platformSettings": {
+                "baseUrl": "https://qnxt.example.com"
+              }
+            }
+          }
+        }
+        """;
+        var (factory, _) = BuildFactory(stubResponse: json);
+
+        var (adapter, settings) = await factory.GetAdapterWithSettingsAsync("tenant-qnxt");
+
+        adapter.Platform.Should().Be("qnxt");
+        settings.Should().ContainKey("baseUrl").WhoseValue.Should().Be("https://qnxt.example.com");
+    }
+
+    [Fact]
+    public async Task Factory_is_case_insensitive_on_platform_match()
+    {
+        var json = """{"configuration":{"providerPlatform":{"platform":"FACETS"}}}""";
+        var (factory, _) = BuildFactory(stubResponse: json);
+
+        var adapter = await factory.GetAdapterAsync("tenant-facets-uppercase");
+
+        adapter.Platform.Should().Be("facets");
+    }
+
+    [Fact]
+    public async Task Factory_falls_back_to_cho_when_platform_unknown()
+    {
+        var json = """{"configuration":{"providerPlatform":{"platform":"unknown-platform"}}}""";
+        var (factory, _) = BuildFactory(stubResponse: json);
+
+        var adapter = await factory.GetAdapterAsync("tenant-bogus");
+
+        // Unknown platform names short-circuit to the CHO adapter so a
+        // misconfigured tenant can't break provider reads.
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task Factory_falls_back_to_cho_when_tenant_service_unreachable()
+    {
+        var (factory, _) = BuildFactory(simulateNetworkFailure: true);
+
+        var adapter = await factory.GetAdapterAsync("tenant-network-error");
+
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task Cache_avoids_second_http_call_within_ttl()
+    {
+        var json = """{"configuration":{"providerPlatform":{"platform":"healthedge"}}}""";
+        var (factory, handler) = BuildFactory(stubResponse: json);
+
+        await factory.GetAdapterAsync("tenant-cached");
+        await factory.GetAdapterAsync("tenant-cached");
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Cache_clear_forces_refetch()
+    {
+        var json = """{"configuration":{"providerPlatform":{"platform":"healthedge"}}}""";
+        var (factory, handler, cache) = BuildFactoryWithCache(stubResponse: json);
+
+        await factory.GetAdapterAsync("tenant-clear");
+        cache.Clear();
+        await factory.GetAdapterAsync("tenant-clear");
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static (ProviderAdapterFactory Factory, Mock<HttpMessageHandler> Handler) BuildFactory(
+        string? stubResponse = null,
+        bool simulateNetworkFailure = false)
+    {
+        var (factory, handler, _) = BuildFactoryWithCache(stubResponse, simulateNetworkFailure);
+        return (factory, handler);
+    }
+
+    private static (ProviderAdapterFactory Factory, Mock<HttpMessageHandler> Handler, ProviderTenantConfigCache Cache) BuildFactoryWithCache(
+        string? stubResponse = null,
+        bool simulateNetworkFailure = false)
+    {
+        // Loose mock — HttpClient may invoke Dispose on the handler during
+        // teardown which would trip strict-mode verification.
+        var handler = new Mock<HttpMessageHandler>();
+        var setup = handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        if (simulateNetworkFailure)
+        {
+            setup.ThrowsAsync(new HttpRequestException("simulated network failure"));
+        }
+        else
+        {
+            setup.ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = stubResponse is null ? HttpStatusCode.NotFound : HttpStatusCode.OK,
+                Content = new StringContent(stubResponse ?? string.Empty, Encoding.UTF8, "application/json"),
+            });
+        }
+
+        var httpClient = new HttpClient(handler.Object);
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory.Setup(f => f.CreateClient(ProviderTenantConfigCache.HttpClientName))
+            .Returns(httpClient);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Services:TenantService"] = "http://tenant-service.test/api/v1",
+            })
+            .Build();
+
+        var cache = new ProviderTenantConfigCache(
+            httpClientFactory.Object,
+            configuration,
+            NullLogger<ProviderTenantConfigCache>.Instance);
+
+        var adapters = new IProviderAdapter[]
+        {
+            new ChoProviderAdapter(new Fakes.InMemoryProviderRepository(), NullLogger<ChoProviderAdapter>.Instance),
+            new QnxtProviderAdapter(),
+            new FacetsProviderAdapter(),
+            new HealthEdgeProviderAdapter(),
+        };
+
+        var factory = new ProviderAdapterFactory(
+            adapters, cache, NullLogger<ProviderAdapterFactory>.Instance);
+
+        return (factory, handler, cache);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/StubProviderAdaptersTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/StubProviderAdaptersTests.cs
@@ -1,0 +1,47 @@
+using ProviderService.Adapters;
+using ProviderService.Models;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Each stub adapter must throw <see cref="NotImplementedException"/> with a
+/// platform-specific TODO marker pointing at the architecture doc, so anyone
+/// following the trace from a stack trace lands directly on the migration plan.
+/// </summary>
+public class StubProviderAdaptersTests
+{
+    public static IEnumerable<object[]> Stubs => new[]
+    {
+        new object[] { (IProviderAdapter)new QnxtProviderAdapter(), "qnxt", "TODO(qnxt-provider)" },
+        new object[] { (IProviderAdapter)new FacetsProviderAdapter(), "facets", "TODO(facets-provider)" },
+        new object[] { (IProviderAdapter)new HealthEdgeProviderAdapter(), "healthedge", "TODO(healthedge-provider)" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public void Platform_identifier_is_stable(IProviderAdapter adapter, string expectedPlatform, string _)
+    {
+        adapter.Platform.Should().Be(expectedPlatform);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task Every_method_throws_with_migration_todo(
+        IProviderAdapter adapter, string _, string expectedTodoMarker)
+    {
+        var request = new ProviderAdapterRequest { TenantId = "tenant-a", Npi = "1234567890", ProviderId = "p-1" };
+
+        await AssertThrows(() => adapter.GetProviderAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.GetProviderByNpiAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.GetNetworkAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.GetNetworkRosterAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.SearchProvidersAsync(request), expectedTodoMarker);
+    }
+
+    private static async Task AssertThrows(Func<Task> act, string expectedTodoMarker)
+    {
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(expectedTodoMarker);
+        ex.Which.Message.Should().Contain("docs/architecture/provider-adapter-pattern.md");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `IProviderAdapter` so provider directory reads can be routed to alternate platforms (QNXT, Facets, HealthEdge) per tenant configuration. Mirrors the benefit-plan-service adapter pattern shipped in 5.2.

For every tenant currently in production the factory resolves to `ChoProviderAdapter`, a near pass-through over `IProviderRepository` — **no observable behavior change**.

## What's in scope

| File | Purpose |
|---|---|
| `src/services/provider-service/Adapters/IProviderAdapter.cs` | Interface — `Platform`, `GetProviderAsync`, `GetProviderByNpiAsync`, `GetNetworkAsync` (placeholder), `GetNetworkRosterAsync`, `SearchProvidersAsync`. |
| `src/services/provider-service/Adapters/ProviderAdapterFactory.cs` | Resolves adapter by tenant config; case-insensitive; falls back to `cho` on unknown platform. |
| `src/services/provider-service/Adapters/ProviderTenantConfigCache.cs` | Singleton 5-min TTL cache around `GET tenant-service/tenants/{id}`; reads `configuration.providerPlatform.platform` + `.platformSettings`. |
| `src/services/provider-service/Adapters/ChoProviderAdapter.cs` | Active adapter — pass-through over `IProviderRepository`. |
| `src/services/provider-service/Adapters/{Qnxt,Facets,HealthEdge}ProviderAdapter.cs` | Stubs throwing `NotImplementedException` with platform-specific TODO markers. |
| `src/services/provider-service/Models/ProviderAdapterRequest.cs` | Vendor-neutral request envelope. |
| `src/services/provider-service/Models/ProviderAdapterResponse.cs` | Response envelopes (`ProviderAdapterResponse`, `ProviderRosterAdapterResponse`, `NetworkAdapterResponse`) + `AdapterProvider`/`AdapterNetwork` DTOs with FHIR-friendly shape. |
| `src/services/provider-service/Controllers/ProvidersController.cs` | GET reads dispatch via factory; writes/version-chain stay direct. |
| `src/services/provider-service/Program.cs` | DI wiring: cache singleton, adapters + factory scoped, named `HttpClient` with 5s timeout. |
| `tests/CloudHealthOffice.ProviderService.Tests/Adapters/` | Factory routing + cache TTL + CHO pass-through + stub TODO-marker tests. |
| `docs/architecture/provider-adapter-pattern.md` | Pattern walk-through, FHIR mapping (5.7–5.9), migration TODOs. |

## Deliberate non-scope

- **`GetNetworkAsync`** is a placeholder — every adapter throws with a `TODO(provider-network-5.3)` marker. The Network entity itself ships with capability 5.3.
- **Verification surfacing** stays out of `IProviderAdapter`. The `AdapterProvider` carries the cached `IntegrityScore` / `IntegrityRating` / `LastVerifiedAt` fields that `Provider` already exposes; capability **5.10** owns the dedicated decoration seam that refreshes these from `ProviderVerificationOrchestrator` — adapter-agnostic, so vendor adapters get the same enrichment for free.
- **Controller refactor is GET-only.** Endpoints routed through the factory: `GET /{id}`, `GET /npi/{npi}`, `GET /search`, `GET /list`, `GET /{id}/network-status`, `GET /{id}/rates` (covering both `/api/v1/providers` and `/api/Providers` mounts). Writes (POST/PUT/DELETE), version-chain reads/lifecycle, network-participation, credentialing, and bank-account endpoints stay direct on `IProviderRepository` / `IProviderVersioningService` — these are CHO-internal write paths and chain reads. Matches the benefit-plan precedent.

## Acceptance

- All CHO read paths return the same row shape (post-hydration) the controller served pre-refactor.
- Factory selects correct adapter per tenant config; falls back to `cho` on HTTP error / JSON parse error / unknown platform.
- Stub adapters throw with grep-able `TODO(qnxt-provider)` / `TODO(facets-provider)` / `TODO(healthedge-provider)` markers pointing at the architecture doc.
- No existing test class instantiates `ProvidersController`, so the new ctor parameter is safe.

## Test plan

- [ ] `dotnet test tests/CloudHealthOffice.ProviderService.Tests/` — all adapter tests green
- [ ] `dotnet test tests/CloudHealthOffice.ProviderService.Tests/` — pre-existing `ProviderRepositoryVersionChainTests`, `ProviderVersioningServiceTests`, `ProviderVersionEventPublisherTests`, `MpipRateServiceTests` still green
- [ ] Manual: `GET /api/v1/providers/npi/{npi}` against a CHO tenant returns the same payload as `main`
- [ ] Manual: `GET /api/v1/providers/{id}/network-status` returns the same `NetworkStatusResponse` as `main`
- [ ] Confirm tenant-service config with `providerPlatform.platform = "qnxt"` causes `NotImplementedException` (not a 500 with a stack trace into adapter internals — the TODO marker should be visible in the error body)

https://claude.ai/code/session_011F6Wfhbo2UzYoxgTCU47VC

---
_Generated by [Claude Code](https://claude.ai/code/session_011F6Wfhbo2UzYoxgTCU47VC)_