### PR TITLE
feat(provider-service): network as first-class organization (5.3)

### DIFF
--- a/docs/architecture/network-as-organization.md
+++ b/docs/architecture/network-as-organization.md
@@ -18,9 +18,11 @@ facility — hospital, clinic, group practice). The two co-exist:
 - `Provider` (`ProviderType=Organization`) — *one facility*.
 - `Organization` (this doc) — *one payer-defined network*.
 
-Downstream services reference networks by `Organization.Id` once they need
-network-tier semantics (capability 5.5) or FHIR `Organization` projections
-(capabilities 5.7+).
+Downstream services reference networks by `OrganizationId`, the stable
+chain key, once they need network-tier semantics (capability 5.5) or FHIR
+`Organization` projections (capabilities 5.7+). The per-version `Id` is
+internal to the version chain and is never used as a cross-version
+reference.
 
 ## Topology
 
@@ -89,10 +91,16 @@ public enum NetworkType
 }
 ```
 
-Every value is explicitly numbered, `Unknown=0` is the default, and the
-converter is `JsonStringEnumConverter` (string-only, no integer parsing) so
-on-the-wire payloads stay self-describing. `OrganizationStatus` follows
-the same pattern.
+Every value is explicitly numbered and `Unknown=0` is the default.
+String-only enforcement (rejecting integer enum payloads) is delegated
+to the shared MVC JSON options registered by
+`AddCloudHealthOfficeJsonOptions`, which constructs a
+`JsonStringEnumConverter(allowIntegerValues: false)`. The new enums in
+this capability deliberately do **not** carry a type-level
+`[JsonConverter(typeof(JsonStringEnumConverter))]` attribute, because
+that constructor defaults to `allowIntegerValues: true` and would
+override the strict global converter. `OrganizationStatus` and
+`OrganizationVersionState` follow the same pattern.
 
 ## REST Surface
 
@@ -111,6 +119,13 @@ middleware to populate `HttpContext.Items["TenantId"]`.
 `PUT` always advances the version chain — it never mutates an Active row
 in place. `DELETE` does not remove documents; it flips the head to
 `Terminated` and preserves the historical chain.
+
+**PUT is RESTful full-replacement.** Callers must submit the full network
+body on every update; any field omitted from the request becomes its
+default on the new version (`Identifiers` → empty list, `ContactInfo` →
+null, etc.). Partial-update semantics are intentionally out of scope for
+this capability — they would require a separate `PATCH` endpoint with
+explicit "fields the client touched" tracking.
 
 ## partOf Hierarchy
 

--- a/docs/architecture/network-as-organization.md
+++ b/docs/architecture/network-as-organization.md
@@ -1,0 +1,190 @@
+# Network as First-Class Organization (Capability 5.3)
+
+## Why
+
+Until now, the only structure resembling a payer network in CHO was a list
+of `NetworkParticipation` records hanging off each `Provider`. That worked
+for "is provider X in plan Y?" lookups but meant the network itself had no
+identity, no metadata, no lifecycle, and no way to describe a hierarchy
+(parent ⇄ sub-network) — all of which are first-class concepts in FHIR R4
+`Organization`, in benefit-plan tier definitions, and in how payers
+actually shape their products.
+
+This capability introduces a real `Organization` entity in `provider-service`
+that represents a payer-defined network. It is **distinct** from a
+`Provider` whose `ProviderType=Organization` (which represents a single
+facility — hospital, clinic, group practice). The two co-exist:
+
+- `Provider` (`ProviderType=Organization`) — *one facility*.
+- `Organization` (this doc) — *one payer-defined network*.
+
+Downstream services reference networks by `Organization.Id` once they need
+network-tier semantics (capability 5.5) or FHIR `Organization` projections
+(capabilities 5.7+).
+
+## Topology
+
+```
+                         ┌─────────────────────────────┐
+GET /api/v1/networks*    │      NetworksController      │
+                         └──────────────┬───────────────┘
+                              writes ↓        ↑ reads
+                         ┌──────────────────────────────┐
+                         │     IOrganizationService     │
+                         └──────────────┬───────────────┘
+                                        │
+                ┌───────────────────────┴───────────────────────┐
+                ▼                                               ▼
+        IOrganizationRepository              OrganizationAdapterFactory
+        (Cosmos | Mongo)                          │
+                                ┌─────────────────┼─────────────────┐
+                                ▼                 ▼                 ▼
+                         Cho (active)        QNXT (stub)       Facets (stub)
+```
+
+Reads route through `IOrganizationAdapter` so a tenant whose network
+catalog lives in QNXT or Facets can plug in a real adapter later without
+controller changes. Writes always go through `IOrganizationService` /
+`IOrganizationRepository` for the CHO-owned data store; vendor-platform
+write paths are intentionally out of scope for this capability.
+
+## Entity Shape
+
+`Organization` is FHIR-aligned:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `TenantId` | string | Cosmos partition key. |
+| `Id` | string | Per-version document id. |
+| `OrganizationId` | string | Stable chain key (preserved across versions). |
+| `Name` | string | Human-readable network name. |
+| `NetworkType` | enum | PPO / HMO / EPO / POS / Indemnity / Custom (Unknown=0 default). |
+| `LineOfBusiness` | enum | Preserved from `Provider.NetworkParticipation.LineOfBusiness`. |
+| `ParentOrganizationId` | string? | partOf hierarchy → FHIR `Organization.partOf`. |
+| `Identifiers` | list | External identifiers (TAX, PRN, NIIP, ...). |
+| `EffectiveDate` / `TerminationDate` | datetime | Period of validity. |
+| `ContactInfo` | object | Admin contact + address. |
+| `Status` | enum | Operational status. |
+| Version-chain fields | various | `VersionId` / `VersionNumber` / `VersionState` / `PredecessorVersionId` / `Activated*` / `Suspended*` / `Superseded*`. |
+
+The version-chain semantics mirror **capability 5.1** (Provider Identity &
+Versioning): every row is one immutable version, the chain is keyed on
+`(TenantId, OrganizationId)`, and default reads resolve to the latest
+non-Draft head.
+
+### Enum Defaults — PR #705
+
+`NetworkType` follows the PR #705 enum-handling pattern:
+
+```csharp
+public enum NetworkType
+{
+    Unknown = 0,   // safe default for hydrated documents that predate the field
+    PPO = 1,
+    HMO = 2,
+    EPO = 3,
+    POS = 4,
+    Indemnity = 5,
+    Custom = 99
+}
+```
+
+Every value is explicitly numbered, `Unknown=0` is the default, and the
+converter is `JsonStringEnumConverter` (string-only, no integer parsing) so
+on-the-wire payloads stay self-describing. `OrganizationStatus` follows
+the same pattern.
+
+## REST Surface
+
+All routes live under `/api/v1/networks` and require the standard tenant
+middleware to populate `HttpContext.Items["TenantId"]`.
+
+| Verb | Path | Purpose |
+|------|------|---------|
+| `GET` | `/api/v1/networks` | Paginated list. Query filters: `networkType`, `lineOfBusiness`, `parentOrganizationId`, `page`, `pageSize`. |
+| `GET` | `/api/v1/networks/{id}` | Fetch a single network's current head. |
+| `GET` | `/api/v1/networks/{id}/children` | List children of a parent network (partOf traversal). |
+| `POST` | `/api/v1/networks` | Create + activate v1. |
+| `PUT` | `/api/v1/networks/{id}` | Amend: clones the head into a new Active version, supersedes the prior. |
+| `DELETE` | `/api/v1/networks/{id}` | Soft-delete via `Terminate` transition on the head. |
+
+`PUT` always advances the version chain — it never mutates an Active row
+in place. `DELETE` does not remove documents; it flips the head to
+`Terminated` and preserves the historical chain.
+
+## partOf Hierarchy
+
+`ParentOrganizationId` is optional and references another network's
+`OrganizationId` (the chain key, not a per-version `Id`). Use cases:
+
+- A regional HMO sub-network (`HMO Florida North`) referencing its parent
+  product (`Aetna HMO Florida 2025`).
+- Tier groupings inside a tiered PPO.
+
+The repository ships an indexed `GetByParentAsync` that pages through
+children of a given parent, and `NetworksController.GetChildren` exposes
+that as `GET /api/v1/networks/{id}/children`.
+
+## Adapter Pattern
+
+`IOrganizationAdapter` mirrors `IProviderAdapter`:
+
+```csharp
+public interface IOrganizationAdapter
+{
+    string Platform { get; }
+    Task<OrganizationAdapterResponse>     GetOrganizationAsync(...);
+    Task<OrganizationListAdapterResponse> GetByParentAsync(...);
+    Task<OrganizationListAdapterResponse> ListAsync(...);
+}
+```
+
+Selection happens via `OrganizationAdapterFactory`, which **reuses
+`ProviderTenantConfigCache`** — networks live in `provider-service` and
+share the same `providerPlatform` block in tenant config:
+
+```
+GET /api/v1/tenants/{tenantId}
+  → response.configuration.providerPlatform.platform        (string)
+  → response.configuration.providerPlatform.platformSettings (object)
+```
+
+Sharing the cache keeps the TTL semantics (5 minutes) consistent across
+provider and organization reads — one cache miss, two adapter selections.
+
+| Platform | Adapter | Status |
+|----------|---------|--------|
+| `cho` | `ChoOrganizationAdapter` | Active (default). |
+| `qnxt` | `QnxtOrganizationAdapter` | Stub — `NotImplementedException` with `TODO(qnxt-organization)`. |
+| `facets` | `FacetsOrganizationAdapter` | Stub — `NotImplementedException` with `TODO(facets-organization)`. |
+
+On any failure (HTTP error, JSON parse, unknown platform) the factory
+falls back to `cho`.
+
+## Storage
+
+The `Organizations` collection lives alongside `Providers` in the same
+database (`ProviderDB` / `CloudHealthOffice` for Mongo). Mongo indexes:
+
+- `(TenantId, OrganizationId, VersionNumber)` — chain head lookup.
+- `(TenantId, OrganizationId, VersionId)` — exact-version fetch.
+- `(TenantId, NetworkType)` / `(TenantId, LineOfBusiness)` — list filters.
+- `(TenantId, ParentOrganizationId)` — partOf traversal.
+- `(TenantId, VersionState)` — head/draft separation.
+
+Cosmos uses `TenantId` as the partition key; queries are scoped to the
+partition for tenant isolation.
+
+## Hand-off to benefit-plan-service (Capability 5.5)
+
+Once this PR merges, `benefit-plan-service` capability 5.5 (Network Tiers
++ FHIR Organization) is unblocked:
+
+1. `BenefitPlan.NetworkTier` records reference `Organization` by
+   `OrganizationId` (chain key).
+2. `benefit-plan-service` resolves the network through a new
+   `IOrganizationAdapter` consumer that lives in `benefit-plan-service`
+   and calls `provider-service` over HTTP — no direct DB coupling.
+3. FHIR projections (`5.7+`) render `Organization.partOf` directly from
+   `ParentOrganizationId` and use the `Identifiers` list as
+   `Organization.identifier`.

--- a/src/services/provider-service/Adapters/ChoOrganizationAdapter.cs
+++ b/src/services/provider-service/Adapters/ChoOrganizationAdapter.cs
@@ -1,0 +1,88 @@
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Default <see cref="IOrganizationAdapter"/> using CHO's internal
+/// <see cref="IOrganizationRepository"/>. For every tenant currently in
+/// production the factory resolves to this adapter and reads the rows
+/// the repository returns directly (post-hydration), with no translation.
+/// </summary>
+public class ChoOrganizationAdapter : IOrganizationAdapter
+{
+    private readonly IOrganizationRepository _repository;
+    private readonly ILogger<ChoOrganizationAdapter> _logger;
+
+    public string Platform => "cho";
+
+    public ChoOrganizationAdapter(
+        IOrganizationRepository repository,
+        ILogger<ChoOrganizationAdapter> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<OrganizationAdapterResponse> GetOrganizationAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.OrganizationId))
+        {
+            throw new ArgumentException(
+                "OrganizationId is required for GetOrganizationAsync.", nameof(request));
+        }
+
+        Organization? org;
+        if (!string.IsNullOrEmpty(request.VersionId))
+        {
+            org = await _repository.GetVersionAsync(request.OrganizationId, request.VersionId);
+        }
+        else
+        {
+            org = await _repository.GetByIdAsync(request.OrganizationId);
+        }
+
+        return new OrganizationAdapterResponse
+        {
+            Platform = Platform,
+            Organization = org is null ? null : AdapterOrganization.From(org),
+        };
+    }
+
+    public async Task<OrganizationListAdapterResponse> GetByParentAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.ParentOrganizationId))
+        {
+            throw new ArgumentException(
+                "ParentOrganizationId is required for GetByParentAsync.", nameof(request));
+        }
+
+        var children = await _repository.GetByParentAsync(request.ParentOrganizationId);
+        return new OrganizationListAdapterResponse
+        {
+            Platform = Platform,
+            Organizations = children.Select(AdapterOrganization.From).ToList(),
+            TotalCount = children.Count,
+        };
+    }
+
+    public async Task<OrganizationListAdapterResponse> ListAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+    {
+        var (items, total) = await _repository.ListAsync(
+            networkType: request.NetworkType,
+            lineOfBusiness: request.LineOfBusiness,
+            parentOrganizationId: request.ParentOrganizationId,
+            page: request.Page,
+            pageSize: request.PageSize);
+
+        return new OrganizationListAdapterResponse
+        {
+            Platform = Platform,
+            Organizations = items.Select(AdapterOrganization.From).ToList(),
+            TotalCount = total,
+        };
+    }
+}

--- a/src/services/provider-service/Adapters/FacetsOrganizationAdapter.cs
+++ b/src/services/provider-service/Adapters/FacetsOrganizationAdapter.cs
@@ -1,0 +1,36 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Stub <see cref="IOrganizationAdapter"/> for tenants whose network
+/// directory lives in TriZetto Facets. Every method throws
+/// <see cref="NotImplementedException"/> with a clear migration TODO
+/// until the Facets integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(facets-organization): integrate with the Facets network setup
+/// interface (typically the Facets Open Access XML or Workflow service).
+/// Reference doc: docs/architecture/network-as-organization.md.
+/// </remarks>
+public class FacetsOrganizationAdapter : IOrganizationAdapter
+{
+    private const string Todo =
+        "Facets organization adapter not yet implemented. " +
+        "TODO(facets-organization): integrate with the Facets network setup interface. " +
+        "See docs/architecture/network-as-organization.md.";
+
+    public string Platform => "facets";
+
+    public Task<OrganizationAdapterResponse> GetOrganizationAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<OrganizationListAdapterResponse> GetByParentAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<OrganizationListAdapterResponse> ListAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/provider-service/Adapters/IOrganizationAdapter.cs
+++ b/src/services/provider-service/Adapters/IOrganizationAdapter.cs
@@ -1,0 +1,37 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Tenant-routed abstraction over the network <see cref="Organization"/>
+/// surface. Mirrors <see cref="IProviderAdapter"/>: each tenant is mapped
+/// (via <see cref="ProviderTenantConfigCache"/>) to one adapter
+/// implementation and the factory selects it case-insensitively by the
+/// <see cref="Platform"/> property.
+///
+/// <para>
+/// The DTO shape (<see cref="AdapterOrganization"/>) is FHIR-aligned so a
+/// later projection layer (capabilities 5.5 / 5.7+) can render the same
+/// object as a FHIR <c>Organization</c> resource without translation.
+/// </para>
+/// </summary>
+public interface IOrganizationAdapter
+{
+    /// <summary>Platform identifier matching tenant config (e.g. <c>cho</c>, <c>qnxt</c>).</summary>
+    string Platform { get; }
+
+    /// <summary>Fetch a network by chain key (or by VersionId when supplied).</summary>
+    Task<OrganizationAdapterResponse> GetOrganizationAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>Children of a parent network for partOf hierarchy traversal.</summary>
+    Task<OrganizationListAdapterResponse> GetByParentAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Paginated list filtered by <see cref="OrganizationAdapterRequest.NetworkType"/>
+    /// and/or <see cref="OrganizationAdapterRequest.LineOfBusiness"/>.
+    /// </summary>
+    Task<OrganizationListAdapterResponse> ListAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default);
+}

--- a/src/services/provider-service/Adapters/OrganizationAdapterFactory.cs
+++ b/src/services/provider-service/Adapters/OrganizationAdapterFactory.cs
@@ -1,0 +1,55 @@
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Resolves the correct <see cref="IOrganizationAdapter"/> at runtime
+/// from tenant configuration. Reuses <see cref="ProviderTenantConfigCache"/>
+/// — networks live in provider-service and share the same
+/// <c>providerPlatform</c> tenant config block, so the cache (and its
+/// 5-minute TTL) is shared across both adapter families.
+/// </summary>
+public class OrganizationAdapterFactory
+{
+    private readonly IEnumerable<IOrganizationAdapter> _adapters;
+    private readonly ProviderTenantConfigCache _cache;
+    private readonly ILogger<OrganizationAdapterFactory> _logger;
+
+    public OrganizationAdapterFactory(
+        IEnumerable<IOrganizationAdapter> adapters,
+        ProviderTenantConfigCache cache,
+        ILogger<OrganizationAdapterFactory> logger)
+    {
+        _adapters = adapters;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<IOrganizationAdapter> GetAdapterAsync(string tenantId, CancellationToken ct = default)
+    {
+        var (platform, _) = await _cache.GetAsync(tenantId, ct);
+        return ResolveAdapter(platform);
+    }
+
+    public async Task<(IOrganizationAdapter Adapter, Dictionary<string, string> Settings)> GetAdapterWithSettingsAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        var (platform, settings) = await _cache.GetAsync(tenantId, ct);
+        return (ResolveAdapter(platform), new Dictionary<string, string>(settings));
+    }
+
+    private IOrganizationAdapter ResolveAdapter(string platform)
+    {
+        var adapter = _adapters.FirstOrDefault(a =>
+            string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase));
+
+        if (adapter == null)
+        {
+            _logger.LogWarning(
+                "No organization adapter found for platform '{Platform}', falling back to 'cho'",
+                platform);
+            adapter = _adapters.First(a =>
+                string.Equals(a.Platform, ProviderTenantConfigCache.DefaultPlatform, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return adapter;
+    }
+}

--- a/src/services/provider-service/Adapters/QnxtOrganizationAdapter.cs
+++ b/src/services/provider-service/Adapters/QnxtOrganizationAdapter.cs
@@ -1,0 +1,36 @@
+using ProviderService.Models;
+
+namespace ProviderService.Adapters;
+
+/// <summary>
+/// Stub <see cref="IOrganizationAdapter"/> for tenants whose network
+/// directory lives in QNXT (TriZetto / Cognizant). Every method throws
+/// <see cref="NotImplementedException"/> with a clear migration TODO
+/// until the QNXT integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(qnxt-organization): integrate with the QNXT network configuration
+/// surface (NETWORK_INQ on the QNXT network stack). Reference doc:
+/// docs/architecture/network-as-organization.md.
+/// </remarks>
+public class QnxtOrganizationAdapter : IOrganizationAdapter
+{
+    private const string Todo =
+        "QNXT organization adapter not yet implemented. " +
+        "TODO(qnxt-organization): integrate with the QNXT network configuration API. " +
+        "See docs/architecture/network-as-organization.md.";
+
+    public string Platform => "qnxt";
+
+    public Task<OrganizationAdapterResponse> GetOrganizationAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<OrganizationListAdapterResponse> GetByParentAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<OrganizationListAdapterResponse> ListAsync(
+        OrganizationAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -1,0 +1,204 @@
+using Microsoft.AspNetCore.Mvc;
+using ProviderService.Adapters;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace ProviderService.Controllers;
+
+/// <summary>
+/// REST surface for payer-defined provider networks (the
+/// <see cref="Organization"/> entity from capability 5.3). Reads route
+/// through <see cref="IOrganizationAdapter"/> per tenant config; writes
+/// go directly to <see cref="IOrganizationService"/> on the CHO store.
+/// </summary>
+[ApiController]
+[Route("api/v1/networks")]
+[Produces("application/json")]
+public class NetworksController : ControllerBase
+{
+    private readonly IOrganizationService _service;
+    private readonly OrganizationAdapterFactory _adapterFactory;
+    private readonly ILogger<NetworksController> _logger;
+
+    public NetworksController(
+        IOrganizationService service,
+        OrganizationAdapterFactory adapterFactory,
+        ILogger<NetworksController> logger)
+    {
+        _service = service;
+        _adapterFactory = adapterFactory;
+        _logger = logger;
+    }
+
+    private string TenantId =>
+        HttpContext.Items["TenantId"]?.ToString()
+            ?? throw new InvalidOperationException("TenantId not found in request context");
+
+    /// <summary>
+    /// Paginated list of networks. Filters are AND-combined.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(NetworkListResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<NetworkListResponse>> List(
+        [FromQuery] NetworkType? networkType = null,
+        [FromQuery] LineOfBusiness? lineOfBusiness = null,
+        [FromQuery] string? parentOrganizationId = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50)
+    {
+        if (page <= 0) page = 1;
+        if (pageSize <= 0 || pageSize > 200) pageSize = 50;
+
+        _logger.LogInformation(
+            "Listing networks: networkType={NetworkType}, lob={LOB}, parent={Parent}",
+            networkType, lineOfBusiness, SanitizeForLog(parentOrganizationId));
+
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.ListAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            NetworkType = networkType,
+            LineOfBusiness = lineOfBusiness,
+            ParentOrganizationId = parentOrganizationId,
+            Page = page,
+            PageSize = pageSize,
+            PlatformSettings = settings,
+        });
+
+        return Ok(new NetworkListResponse
+        {
+            Items = response.Organizations.Select(o => o.ToOrganization()).ToList(),
+            TotalCount = response.TotalCount,
+            Page = page,
+            PageSize = pageSize,
+        });
+    }
+
+    /// <summary>Get a single network by id.</summary>
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(Organization), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<Organization>> GetById(string id)
+    {
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetOrganizationAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            OrganizationId = id,
+            PlatformSettings = settings,
+        });
+
+        if (response.Organization == null)
+        {
+            return NotFound(new { message = $"Network {id} not found" });
+        }
+
+        return Ok(response.Organization.ToOrganization());
+    }
+
+    /// <summary>Get child networks for a parent (partOf hierarchy traversal).</summary>
+    [HttpGet("{id}/children")]
+    [ProducesResponseType(typeof(IEnumerable<Organization>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<Organization>>> GetChildren(string id)
+    {
+        var (adapter, settings) = await _adapterFactory.GetAdapterWithSettingsAsync(TenantId);
+        var response = await adapter.GetByParentAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            ParentOrganizationId = id,
+            PlatformSettings = settings,
+        });
+
+        return Ok(response.Organizations.Select(o => o.ToOrganization()));
+    }
+
+    /// <summary>Create a new network. Activates v1 in one shot.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(Organization), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<Organization>> Create([FromBody] Organization organization)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        organization.TenantId = TenantId;
+        var created = await _service.CreateAndActivateAsync(organization, ResolveActorId());
+        return CreatedAtAction(nameof(GetById), new { id = created.OrganizationId }, created);
+    }
+
+    /// <summary>
+    /// Update a network. Internally clones the head into a new Active
+    /// version and supersedes the prior one — the chain stays intact and
+    /// addressable under the same <see cref="Organization.OrganizationId"/>.
+    /// </summary>
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(Organization), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<Organization>> Update(string id, [FromBody] Organization organization)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        try
+        {
+            organization.TenantId = TenantId;
+            var updated = await _service.UpdateAsync(id, organization, ResolveActorId());
+            return Ok(updated);
+        }
+        catch (OrganizationVersionStateException ex) when (ex.IsNotFound)
+        {
+            return NotFound(new { message = ex.Message, organizationId = ex.OrganizationId });
+        }
+        catch (OrganizationVersionStateException ex)
+        {
+            return Conflict(new
+            {
+                message = ex.Message,
+                organizationId = ex.OrganizationId,
+                versionId = ex.VersionId,
+                versionState = ex.CurrentState.ToString()
+            });
+        }
+    }
+
+    /// <summary>Soft-delete the network by terminating the current head version.</summary>
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(string id, [FromQuery] string? reason = null)
+    {
+        try
+        {
+            await _service.TerminateAsync(id, reason ?? "deleted via DELETE /api/v1/networks", ResolveActorId());
+            return NoContent();
+        }
+        catch (OrganizationVersionStateException ex) when (ex.IsNotFound)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) && !string.IsNullOrEmpty(header.ToString()))
+            return header.ToString();
+        return "system";
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}
+
+/// <summary>Page envelope for the list endpoint.</summary>
+public sealed class NetworkListResponse
+{
+    public IReadOnlyList<Organization> Items { get; set; } = Array.Empty<Organization>();
+    public int? TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -130,6 +130,15 @@ public class NetworksController : ControllerBase
     /// Update a network. Internally clones the head into a new Active
     /// version and supersedes the prior one — the chain stays intact and
     /// addressable under the same <see cref="Organization.OrganizationId"/>.
+    ///
+    /// <para>
+    /// Standard REST PUT semantics — <b>full replacement</b>. Callers must
+    /// submit the complete network body; any field omitted from the
+    /// request body is treated as "set to default" on the new version
+    /// (e.g. an absent <c>Identifiers</c> array becomes empty, an absent
+    /// <c>ContactInfo</c> becomes null). For partial updates use
+    /// <c>POST</c> against future amendment endpoints rather than PUT.
+    /// </para>
     /// </summary>
     [HttpPut("{id}")]
     [ProducesResponseType(typeof(Organization), StatusCodes.Status200OK)]

--- a/src/services/provider-service/Models/NetworkType.cs
+++ b/src/services/provider-service/Models/NetworkType.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Payer-defined network classification for an <see cref="Organization"/>.
+///
+/// <para>
+/// Follows the PR #705 enum-handling pattern: every value is explicitly
+/// numbered, <c>Unknown = 0</c> is the safe default for documents written
+/// before this enum existed, and the converter is locked to string form
+/// (no integer parsing) so on-the-wire payloads stay self-describing.
+/// </para>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum NetworkType
+{
+    /// <summary>Default for hydrated documents that predate the field.</summary>
+    Unknown = 0,
+
+    /// <summary>Preferred Provider Organization.</summary>
+    PPO = 1,
+
+    /// <summary>Health Maintenance Organization.</summary>
+    HMO = 2,
+
+    /// <summary>Exclusive Provider Organization.</summary>
+    EPO = 3,
+
+    /// <summary>Point of Service.</summary>
+    POS = 4,
+
+    /// <summary>Indemnity / fee-for-service network.</summary>
+    Indemnity = 5,
+
+    /// <summary>Custom payer-defined classification not covered by the canonical list.</summary>
+    Custom = 99
+}

--- a/src/services/provider-service/Models/NetworkType.cs
+++ b/src/services/provider-service/Models/NetworkType.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace ProviderService.Models;
 
 /// <summary>
@@ -7,12 +5,14 @@ namespace ProviderService.Models;
 ///
 /// <para>
 /// Follows the PR #705 enum-handling pattern: every value is explicitly
-/// numbered, <c>Unknown = 0</c> is the safe default for documents written
-/// before this enum existed, and the converter is locked to string form
-/// (no integer parsing) so on-the-wire payloads stay self-describing.
+/// numbered and <c>Unknown = 0</c> is the safe default for documents
+/// written before this enum existed. The string-only / no-integer
+/// enforcement is delegated to the shared MVC JSON options registered by
+/// <c>AddCloudHealthOfficeJsonOptions</c> (which constructs a
+/// <c>JsonStringEnumConverter(allowIntegerValues: false)</c>) — declaring
+/// a type-level converter here would override that with the lax default.
 /// </para>
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum NetworkType
 {
     /// <summary>Default for hydrated documents that predate the field.</summary>

--- a/src/services/provider-service/Models/Organization.cs
+++ b/src/services/provider-service/Models/Organization.cs
@@ -1,0 +1,240 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Payer-defined provider network represented as a first-class entity.
+///
+/// <para>
+/// Distinct from a <see cref="Provider"/> with <c>ProviderType=Organization</c>
+/// (which represents a single facility — hospital, clinic, group practice).
+/// An <see cref="Organization"/> here is the network construct referenced
+/// by claims, benefit plans (network tiers — capability 5.5), and FHIR
+/// <c>Organization</c> projections. The shape is deliberately FHIR-aligned:
+/// <c>Identifiers</c>, <c>Name</c>, <c>PartOf</c> (via <see cref="ParentOrganizationId"/>),
+/// effective <c>Period</c>, and <c>Contact</c> all map cleanly onto
+/// FHIR R4 <c>Organization</c>.
+/// </para>
+///
+/// <para>
+/// Each row is one immutable version. The chain key is
+/// <see cref="OrganizationId"/> (preserved across amendments); each
+/// per-version row carries its own <see cref="Id"/> + <see cref="VersionId"/>,
+/// matching the provider versioning model from capability 5.1.
+/// </para>
+/// </summary>
+public class Organization
+{
+    /// <summary>
+    /// Multi-tenant partition key (required for Cosmos DB isolation).
+    /// </summary>
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-version document id (Cosmos DB document id / Mongo _id).
+    /// </summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Stable chain key — the persistent network identifier preserved
+    /// across every version row. For genesis rows <c>OrganizationId == Id</c>;
+    /// amend versions share the same <c>OrganizationId</c> with a new per-row
+    /// <c>Id</c>. Empty on the wire is the legacy marker; hydration sets
+    /// <c>OrganizationId = Id</c>.
+    /// </summary>
+    public string OrganizationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable network name (e.g. "Aetna Open Access HMO Florida 2025").
+    /// </summary>
+    [Required]
+    [StringLength(300)]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Payer-defined network classification. <see cref="NetworkType.Unknown"/>
+    /// is the safe default for documents written before this field existed.
+    /// </summary>
+    [Required]
+    public NetworkType NetworkType { get; set; } = NetworkType.Unknown;
+
+    /// <summary>
+    /// Line of business this network applies to. Preserved from
+    /// <c>Provider.NetworkParticipation.LineOfBusiness</c> so existing
+    /// search filters and policy checks continue to read the same field
+    /// shape on the network entity.
+    /// </summary>
+    [Required]
+    public LineOfBusiness LineOfBusiness { get; set; }
+
+    /// <summary>
+    /// Optional parent network for partOf hierarchies (e.g. a sub-network
+    /// nested inside a parent group). Maps to FHIR <c>Organization.partOf</c>.
+    /// Null on top-level networks.
+    /// </summary>
+    [StringLength(64)]
+    public string? ParentOrganizationId { get; set; }
+
+    /// <summary>
+    /// External / payer-system identifiers (e.g. trading-partner network
+    /// id, contract id, regulatory filing id). Maps to FHIR
+    /// <c>Organization.identifier</c>.
+    /// </summary>
+    public List<OrganizationIdentifier> Identifiers { get; set; } = new();
+
+    /// <summary>
+    /// Effective date of the network (inclusive). Required.
+    /// </summary>
+    [Required]
+    public DateTime EffectiveDate { get; set; }
+
+    /// <summary>
+    /// Termination date (exclusive). Null while the network is open-ended.
+    /// </summary>
+    public DateTime? TerminationDate { get; set; }
+
+    /// <summary>
+    /// Free-text reason captured when the head version is terminated.
+    /// </summary>
+    [StringLength(500)]
+    public string? TerminationReason { get; set; }
+
+    /// <summary>
+    /// Network operational status — distinct from
+    /// <see cref="VersionState"/>, which describes lifecycle of the row.
+    /// </summary>
+    [Required]
+    public OrganizationStatus Status { get; set; } = OrganizationStatus.Active;
+
+    /// <summary>
+    /// Network contact information (admin contact, support phone, address).
+    /// Maps to FHIR <c>Organization.contact</c> + <c>Organization.address</c>.
+    /// </summary>
+    public OrganizationContactInfo? ContactInfo { get; set; }
+
+    // ---------------------------------------------------------------------
+    // Audit fields
+    // ---------------------------------------------------------------------
+
+    public DateTime CreatedDate { get; set; } = DateTime.UtcNow;
+    public DateTime LastUpdatedDate { get; set; } = DateTime.UtcNow;
+
+    [StringLength(200)]
+    public string? CreatedBy { get; set; }
+
+    [StringLength(200)]
+    public string? LastUpdatedBy { get; set; }
+
+    // ---------------------------------------------------------------------
+    // Version-chain identity (mirrors capability 5.1)
+    //
+    // Every row in the Organizations collection is one immutable version.
+    // The chain is keyed on (TenantId, OrganizationId); VersionId is the
+    // ULID per-row key. Documents written before these fields existed
+    // hydrate as VersionState=Active, VersionNumber=1, OrganizationId=Id.
+    // ---------------------------------------------------------------------
+
+    public string VersionId { get; set; } = string.Empty;
+
+    public int VersionNumber { get; set; }
+
+    public OrganizationVersionState VersionState { get; set; }
+
+    public string? PredecessorVersionId { get; set; }
+
+    public DateTime? ActivatedAt { get; set; }
+
+    [StringLength(200)]
+    public string? ActivatedBy { get; set; }
+
+    public DateTime? SuspendedAt { get; set; }
+
+    [StringLength(500)]
+    public string? SuspensionReason { get; set; }
+
+    public DateTime? SupersededAt { get; set; }
+
+    [StringLength(64)]
+    public string? SupersededByVersionId { get; set; }
+}
+
+/// <summary>
+/// External identifier on an <see cref="Organization"/>. Shape mirrors
+/// FHIR <c>Identifier</c> so projections in capability 5.5 / 5.7+ can
+/// pass the value through without translation.
+/// </summary>
+public class OrganizationIdentifier
+{
+    /// <summary>Issuing system URI (e.g. <c>urn:cho:network</c>, <c>http://hl7.org/fhir/sid/us-npi</c>).</summary>
+    [Required]
+    [StringLength(200)]
+    public string System { get; set; } = string.Empty;
+
+    /// <summary>Identifier value within the issuing system.</summary>
+    [Required]
+    [StringLength(200)]
+    public string Value { get; set; } = string.Empty;
+
+    /// <summary>Identifier type code (e.g. <c>NIIP</c>, <c>TAX</c>, <c>PRN</c>).</summary>
+    [StringLength(50)]
+    public string? Type { get; set; }
+
+    /// <summary>FHIR identifier-use category (<c>usual</c>, <c>official</c>, <c>secondary</c>, ...).</summary>
+    [StringLength(20)]
+    public string? Use { get; set; }
+}
+
+/// <summary>
+/// Contact information on an <see cref="Organization"/>. Kept distinct
+/// from <c>tenant-service</c>'s <c>ContactInfo</c> so the two services
+/// can evolve their shapes independently.
+/// </summary>
+public class OrganizationContactInfo
+{
+    [StringLength(200)]
+    public string? PrimaryContactName { get; set; }
+
+    [Phone]
+    [StringLength(20)]
+    public string? Phone { get; set; }
+
+    [Phone]
+    [StringLength(20)]
+    public string? Fax { get; set; }
+
+    [EmailAddress]
+    [StringLength(200)]
+    public string? Email { get; set; }
+
+    [StringLength(300)]
+    public string? Address { get; set; }
+
+    [StringLength(100)]
+    public string? City { get; set; }
+
+    [StringLength(2)]
+    public string? State { get; set; }
+
+    [StringLength(10)]
+    public string? ZipCode { get; set; }
+
+    [StringLength(500)]
+    public string? Website { get; set; }
+}
+
+/// <summary>
+/// Operational status of an <see cref="Organization"/> network, separate
+/// from row lifecycle (<see cref="OrganizationVersionState"/>).
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum OrganizationStatus
+{
+    Unknown = 0,
+    Active = 1,
+    Inactive = 2,
+    Terminated = 3,
+    Pending = 4
+}

--- a/src/services/provider-service/Models/Organization.cs
+++ b/src/services/provider-service/Models/Organization.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace ProviderService.Models;
 
@@ -228,8 +227,10 @@ public class OrganizationContactInfo
 /// <summary>
 /// Operational status of an <see cref="Organization"/> network, separate
 /// from row lifecycle (<see cref="OrganizationVersionState"/>).
+///
+/// <para>String-only / no-integer enforcement is delegated to the shared
+/// MVC JSON options registered by <c>AddCloudHealthOfficeJsonOptions</c>.</para>
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum OrganizationStatus
 {
     Unknown = 0,

--- a/src/services/provider-service/Models/OrganizationAdapterRequest.cs
+++ b/src/services/provider-service/Models/OrganizationAdapterRequest.cs
@@ -1,0 +1,55 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Vendor-neutral request envelope for any <see cref="Adapters.IOrganizationAdapter"/>.
+/// Mirrors <see cref="ProviderAdapterRequest"/>; per-method required fields
+/// are documented on each property.
+/// </summary>
+public class OrganizationAdapterRequest
+{
+    /// <summary>Tenant id resolved by the request middleware. Required by all methods.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Network chain key (<see cref="Organization.OrganizationId"/>). Required by
+    /// <c>GetOrganizationAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Specific version identifier (ULID). Optional on <c>GetOrganizationAsync</c>
+    /// — when set, adapters return that exact version instead of the latest
+    /// non-Draft head.
+    /// </summary>
+    public string? VersionId { get; set; }
+
+    /// <summary>
+    /// Parent network identifier — used by <c>GetByParentAsync</c> to walk
+    /// the partOf hierarchy. Required by <c>GetByParentAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? ParentOrganizationId { get; set; }
+
+    /// <summary>Optional <see cref="NetworkType"/> filter for list queries.</summary>
+    public NetworkType? NetworkType { get; set; }
+
+    /// <summary>Optional line-of-business filter for list queries.</summary>
+    public LineOfBusiness? LineOfBusiness { get; set; }
+
+    /// <summary>
+    /// Effective date for service-date queries. Optional; when null,
+    /// adapters should treat it as <see cref="DateTime.UtcNow"/>.
+    /// </summary>
+    public DateTime? ServiceDate { get; set; }
+
+    /// <summary>1-based page index for paged list results.</summary>
+    public int Page { get; set; } = 1;
+
+    /// <summary>Page size for paged list results.</summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Platform-specific configuration sourced from tenant config
+    /// (e.g. QNXT base URL). Adapters read what they need.
+    /// </summary>
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}

--- a/src/services/provider-service/Models/OrganizationAdapterResponse.cs
+++ b/src/services/provider-service/Models/OrganizationAdapterResponse.cs
@@ -1,0 +1,138 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Vendor-neutral response envelope for
+/// <see cref="Adapters.IOrganizationAdapter.GetOrganizationAsync"/>.
+/// Shape mirrors <see cref="ProviderAdapterResponse"/> — a Platform tag,
+/// optional raw audit blob, and a normalized <see cref="AdapterOrganization"/>.
+/// </summary>
+public class OrganizationAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Organization payload. Null when not found.</summary>
+    public AdapterOrganization? Organization { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for collection-returning adapter
+/// methods (<see cref="Adapters.IOrganizationAdapter.ListAsync"/> and
+/// <see cref="Adapters.IOrganizationAdapter.GetByParentAsync"/>).
+/// </summary>
+public class OrganizationListAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Page of organizations returned by the adapter (never null; may be empty).</summary>
+    public IReadOnlyList<AdapterOrganization> Organizations { get; set; } = Array.Empty<AdapterOrganization>();
+
+    /// <summary>Total matching count when the platform reports it; null otherwise.</summary>
+    public int? TotalCount { get; set; }
+}
+
+/// <summary>
+/// Normalized organization DTO. Field shape mirrors <see cref="Organization"/>
+/// so the CHO pass-through is lossless and downstream FHIR projections
+/// (capabilities 5.5, 5.7+) can consume the same record.
+/// </summary>
+public class AdapterOrganization
+{
+    public string Id { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+    public NetworkType NetworkType { get; set; }
+    public LineOfBusiness LineOfBusiness { get; set; }
+    public string? ParentOrganizationId { get; set; }
+
+    public List<OrganizationIdentifier> Identifiers { get; set; } = new();
+
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+    public string? TerminationReason { get; set; }
+
+    public OrganizationStatus Status { get; set; }
+    public OrganizationContactInfo? ContactInfo { get; set; }
+
+    public DateTime CreatedDate { get; set; }
+    public DateTime LastUpdatedDate { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? LastUpdatedBy { get; set; }
+
+    // Version-chain identity
+    public string VersionId { get; set; } = string.Empty;
+    public int VersionNumber { get; set; }
+    public OrganizationVersionState VersionState { get; set; }
+    public string? PredecessorVersionId { get; set; }
+    public DateTime? ActivatedAt { get; set; }
+    public string? ActivatedBy { get; set; }
+    public DateTime? SuspendedAt { get; set; }
+    public string? SuspensionReason { get; set; }
+    public DateTime? SupersededAt { get; set; }
+    public string? SupersededByVersionId { get; set; }
+
+    public static AdapterOrganization From(Organization src) => new()
+    {
+        Id = src.Id,
+        TenantId = src.TenantId,
+        OrganizationId = src.OrganizationId,
+        Name = src.Name,
+        NetworkType = src.NetworkType,
+        LineOfBusiness = src.LineOfBusiness,
+        ParentOrganizationId = src.ParentOrganizationId,
+        Identifiers = src.Identifiers.ToList(),
+        EffectiveDate = src.EffectiveDate,
+        TerminationDate = src.TerminationDate,
+        TerminationReason = src.TerminationReason,
+        Status = src.Status,
+        ContactInfo = src.ContactInfo,
+        CreatedDate = src.CreatedDate,
+        LastUpdatedDate = src.LastUpdatedDate,
+        CreatedBy = src.CreatedBy,
+        LastUpdatedBy = src.LastUpdatedBy,
+        VersionId = src.VersionId,
+        VersionNumber = src.VersionNumber,
+        VersionState = src.VersionState,
+        PredecessorVersionId = src.PredecessorVersionId,
+        ActivatedAt = src.ActivatedAt,
+        ActivatedBy = src.ActivatedBy,
+        SuspendedAt = src.SuspendedAt,
+        SuspensionReason = src.SuspensionReason,
+        SupersededAt = src.SupersededAt,
+        SupersededByVersionId = src.SupersededByVersionId,
+    };
+
+    public Organization ToOrganization() => new()
+    {
+        Id = Id,
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Name = Name,
+        NetworkType = NetworkType,
+        LineOfBusiness = LineOfBusiness,
+        ParentOrganizationId = ParentOrganizationId,
+        Identifiers = Identifiers.ToList(),
+        EffectiveDate = EffectiveDate,
+        TerminationDate = TerminationDate,
+        TerminationReason = TerminationReason,
+        Status = Status,
+        ContactInfo = ContactInfo,
+        CreatedDate = CreatedDate,
+        LastUpdatedDate = LastUpdatedDate,
+        CreatedBy = CreatedBy,
+        LastUpdatedBy = LastUpdatedBy,
+        VersionId = VersionId,
+        VersionNumber = VersionNumber,
+        VersionState = VersionState,
+        PredecessorVersionId = PredecessorVersionId,
+        ActivatedAt = ActivatedAt,
+        ActivatedBy = ActivatedBy,
+        SuspendedAt = SuspendedAt,
+        SuspensionReason = SuspensionReason,
+        SupersededAt = SupersededAt,
+        SupersededByVersionId = SupersededByVersionId,
+    };
+}

--- a/src/services/provider-service/Models/OrganizationVersionId.cs
+++ b/src/services/provider-service/Models/OrganizationVersionId.cs
@@ -1,0 +1,51 @@
+using System.Security.Cryptography;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// ULID generator for <see cref="Organization"/> version rows. Mirrors
+/// <c>ProviderVersionId</c> — Crockford base-32, 26 chars, 48-bit timestamp
+/// + 80-bit randomness. Lexicographic ordering tracks creation time so
+/// the latest activated version sorts last under a stable string compare.
+/// </summary>
+internal static class OrganizationVersionId
+{
+    private const string Alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+    public static string NewId() => NewId(DateTimeOffset.UtcNow);
+
+    internal static string NewId(DateTimeOffset timestamp)
+    {
+        var ms = timestamp.ToUnixTimeMilliseconds();
+        if (ms < 0) ms = 0;
+
+        Span<byte> rand = stackalloc byte[10];
+        RandomNumberGenerator.Fill(rand);
+
+        Span<char> chars = stackalloc char[26];
+
+        for (int i = 9; i >= 0; i--)
+        {
+            chars[i] = Alphabet[(int)(ms & 0x1F)];
+            ms >>= 5;
+        }
+
+        ulong hi = ((ulong)rand[0] << 32) | ((ulong)rand[1] << 24) | ((ulong)rand[2] << 16)
+                 | ((ulong)rand[3] << 8) | rand[4];
+        ulong lo = ((ulong)rand[5] << 32) | ((ulong)rand[6] << 24) | ((ulong)rand[7] << 16)
+                 | ((ulong)rand[8] << 8) | rand[9];
+
+        for (int i = 17; i >= 10; i--)
+        {
+            chars[i] = Alphabet[(int)(hi & 0x1F)];
+            hi >>= 5;
+        }
+        for (int i = 25; i >= 18; i--)
+        {
+            chars[i] = Alphabet[(int)(lo & 0x1F)];
+            lo >>= 5;
+        }
+
+        return new string(chars);
+    }
+}

--- a/src/services/provider-service/Models/OrganizationVersionState.cs
+++ b/src/services/provider-service/Models/OrganizationVersionState.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Lifecycle state of a single <see cref="Organization"/> version document.
+/// Mirrors <see cref="ProviderVersionState"/> (capability 5.1) — same Draft →
+/// Active → Suspended → Superseded → Terminated state machine.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum OrganizationVersionState
+{
+    Draft = 0,
+    Active = 1,
+    Suspended = 2,
+    Superseded = 3,
+    Terminated = 4
+}

--- a/src/services/provider-service/Models/OrganizationVersionState.cs
+++ b/src/services/provider-service/Models/OrganizationVersionState.cs
@@ -1,13 +1,15 @@
-using System.Text.Json.Serialization;
-
 namespace ProviderService.Models;
 
 /// <summary>
 /// Lifecycle state of a single <see cref="Organization"/> version document.
 /// Mirrors <see cref="ProviderVersionState"/> (capability 5.1) — same Draft →
 /// Active → Suspended → Superseded → Terminated state machine.
+///
+/// <para>String-only / no-integer enforcement is delegated to the shared
+/// MVC JSON options registered by <c>AddCloudHealthOfficeJsonOptions</c>;
+/// declaring a type-level converter here would override that with the lax
+/// default.</para>
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum OrganizationVersionState
 {
     Draft = 0,

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -48,6 +48,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     });
 
     builder.Services.AddScoped<IProviderRepository, ProviderRepositoryMongo>();
+    builder.Services.AddScoped<IOrganizationRepository, OrganizationRepositoryMongo>();
     builder.Services.AddScoped<IProviderTransitionRepository, MongoProviderTransitionRepository>();
     builder.Services.AddScoped<IProviderVersionEventPublisher, MongoProviderVersionEventPublisher>();
     builder.Services.AddHostedService<ProviderVersionEventIndexInitializer>();
@@ -72,6 +73,7 @@ else
 
     // Repositories
     builder.Services.AddScoped<IProviderRepository, ProviderRepository>();
+    builder.Services.AddScoped<IOrganizationRepository, OrganizationRepository>();
     builder.Services.AddScoped<IProviderTransitionRepository, CosmosProviderTransitionRepository>();
     // Cosmos-only deployments don't have a provisioned events stream; the
     // Noop publisher logs a warning so ops can spot the missing wiring
@@ -99,6 +101,15 @@ builder.Services.AddScoped<IProviderAdapter, QnxtProviderAdapter>();
 builder.Services.AddScoped<IProviderAdapter, FacetsProviderAdapter>();
 builder.Services.AddScoped<IProviderAdapter, HealthEdgeProviderAdapter>();
 builder.Services.AddScoped<ProviderAdapterFactory>();
+
+// Organization (Network) services + adapters (5.3 — network as first-class
+// organization). Reuses ProviderTenantConfigCache because the Network
+// entity lives in provider-service and reads the same tenant config block.
+builder.Services.AddScoped<IOrganizationService, OrganizationService>();
+builder.Services.AddScoped<IOrganizationAdapter, ChoOrganizationAdapter>();
+builder.Services.AddScoped<IOrganizationAdapter, QnxtOrganizationAdapter>();
+builder.Services.AddScoped<IOrganizationAdapter, FacetsOrganizationAdapter>();
+builder.Services.AddScoped<OrganizationAdapterFactory>();
 
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();

--- a/src/services/provider-service/Repositories/OrganizationRepository.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepository.cs
@@ -1,0 +1,400 @@
+using Microsoft.Azure.Cosmos;
+using ProviderService.Models;
+
+namespace ProviderService.Repositories;
+
+/// <summary>
+/// Storage seam for the <see cref="Organization"/> network entity. Each
+/// row is one immutable version; default reads resolve to the latest
+/// non-Draft head, mirroring <see cref="IProviderRepository"/>.
+/// </summary>
+public interface IOrganizationRepository
+{
+    /// <summary>Latest non-Draft version of <paramref name="organizationId"/>.</summary>
+    Task<Organization?> GetByIdAsync(string organizationId);
+
+    /// <summary>
+    /// Look up a single version by <c>VersionId</c>. Returns null when
+    /// either the chain key or the version id does not resolve.
+    /// </summary>
+    Task<Organization?> GetVersionAsync(string organizationId, string versionId);
+
+    /// <summary>
+    /// Latest <see cref="OrganizationVersionState.Active"/> version effective
+    /// at <paramref name="asOf"/>. Returns null when no Active version exists.
+    /// </summary>
+    Task<Organization?> GetLatestActiveAsync(string organizationId, DateTime asOf);
+
+    /// <summary>Newest-first list of every version for a chain.</summary>
+    Task<(IReadOnlyList<Organization> Items, string? ContinuationToken)> ListVersionsAsync(
+        string organizationId, int pageSize, string? continuationToken);
+
+    /// <summary>
+    /// List networks for the current tenant, optionally filtered by
+    /// <see cref="NetworkType"/> and <see cref="LineOfBusiness"/>. Returns
+    /// the head (latest non-Draft) of every chain that matches.
+    /// </summary>
+    Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType,
+        LineOfBusiness? lineOfBusiness,
+        string? parentOrganizationId,
+        int page,
+        int pageSize);
+
+    /// <summary>Children of <paramref name="parentOrganizationId"/> for partOf traversal.</summary>
+    Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId);
+
+    /// <summary>Persist a Draft. Caller sets identity + state.</summary>
+    Task<Organization> CreateDraftAsync(Organization draft);
+
+    /// <summary>Update a Draft. Throws when the row is not Draft.</summary>
+    Task<Organization> UpdateDraftAsync(Organization draft);
+
+    /// <summary>
+    /// Atomic transition: flip <paramref name="draftToActivate"/> to Active
+    /// and (if not null) <paramref name="predecessor"/> to Superseded.
+    /// </summary>
+    Task<Organization> ActivateAndSupersedeAsync(Organization draftToActivate, Organization? predecessor);
+
+    /// <summary>Persist a state-only mutation on an existing version row.</summary>
+    Task<Organization> ReplaceVersionRowAsync(Organization version);
+}
+
+/// <summary>
+/// Thrown when a write violates the version-state invariants on the
+/// network chain. Mirrors <see cref="ProviderVersionStateException"/>.
+/// </summary>
+public sealed class OrganizationVersionStateException : InvalidOperationException
+{
+    public string OrganizationId { get; }
+    public string VersionId { get; }
+    public OrganizationVersionState CurrentState { get; }
+
+    public bool IsNotFound { get; init; }
+
+    public OrganizationVersionStateException(
+        string organizationId, string versionId, OrganizationVersionState currentState, string message)
+        : base(message)
+    {
+        OrganizationId = organizationId;
+        VersionId = versionId;
+        CurrentState = currentState;
+    }
+}
+
+/// <summary>
+/// Cosmos DB implementation of <see cref="IOrganizationRepository"/>.
+/// Mirrors <see cref="ProviderRepository"/> partition / hydration shape.
+/// </summary>
+public class OrganizationRepository : IOrganizationRepository
+{
+    private readonly Container _container;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<OrganizationRepository> _logger;
+
+    public OrganizationRepository(
+        CosmosClient cosmosClient,
+        IConfiguration configuration,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<OrganizationRepository> logger)
+    {
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "ProviderDB";
+        var containerName = configuration["CosmosDb:OrganizationsContainerName"] ?? "Organizations";
+
+        _container = cosmosClient.GetContainer(databaseName, containerName);
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    private string GetTenantId()
+    {
+        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new InvalidOperationException("TenantId not found in request context");
+        }
+        return tenantId;
+    }
+
+    public async Task<Organization?> GetByIdAsync(string organizationId)
+    {
+        var tenantId = GetTenantId();
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.organizationId = @id OR (NOT IS_DEFINED(c.organizationId) AND c.id = @id)) AND " +
+                "(NOT IS_DEFINED(c.versionState) OR c.versionState != @draft) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@id", organizationId)
+            .WithParameter("@draft", OrganizationVersionState.Draft.ToString());
+
+        var iterator = _container.GetItemQueryIterator<Organization>(
+            query, requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            var first = page.FirstOrDefault();
+            if (first != null) return Hydrate(first);
+        }
+        return null;
+    }
+
+    public async Task<Organization?> GetVersionAsync(string organizationId, string versionId)
+    {
+        var tenantId = GetTenantId();
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.organizationId = @id OR (NOT IS_DEFINED(c.organizationId) AND c.id = @id)) AND " +
+                "c.versionId = @versionId")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@id", organizationId)
+            .WithParameter("@versionId", versionId);
+
+        var iterator = _container.GetItemQueryIterator<Organization>(
+            query, requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            var first = page.FirstOrDefault();
+            if (first != null) return Hydrate(first);
+        }
+        return null;
+    }
+
+    public async Task<Organization?> GetLatestActiveAsync(string organizationId, DateTime asOf)
+    {
+        var tenantId = GetTenantId();
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.organizationId = @id OR (NOT IS_DEFINED(c.organizationId) AND c.id = @id)) AND " +
+                "(NOT IS_DEFINED(c.versionState) OR c.versionState = @active) AND " +
+                "(NOT IS_DEFINED(c.terminationDate) OR c.terminationDate = null OR c.terminationDate >= @asOf) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@id", organizationId)
+            .WithParameter("@active", OrganizationVersionState.Active.ToString())
+            .WithParameter("@asOf", asOf);
+
+        var iterator = _container.GetItemQueryIterator<Organization>(
+            query, requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync();
+            var first = page.FirstOrDefault();
+            if (first != null) return Hydrate(first);
+        }
+        return null;
+    }
+
+    public async Task<(IReadOnlyList<Organization> Items, string? ContinuationToken)> ListVersionsAsync(
+        string organizationId, int pageSize, string? continuationToken)
+    {
+        var tenantId = GetTenantId();
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.organizationId = @id OR (NOT IS_DEFINED(c.organizationId) AND c.id = @id)) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@id", organizationId);
+
+        var requestOptions = new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(tenantId),
+            MaxItemCount = pageSize
+        };
+
+        var iterator = _container.GetItemQueryIterator<Organization>(query, continuationToken, requestOptions);
+        if (!iterator.HasMoreResults)
+            return (Array.Empty<Organization>(), null);
+
+        var response = await iterator.ReadNextAsync();
+        var items = response.Select(Hydrate).ToList();
+        return (items, response.ContinuationToken);
+    }
+
+    public async Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType,
+        LineOfBusiness? lineOfBusiness,
+        string? parentOrganizationId,
+        int page,
+        int pageSize)
+    {
+        var tenantId = GetTenantId();
+
+        // Pull all non-Draft rows for the tenant under the requested filters,
+        // then group by chain key in-memory and pick the highest-VersionNumber
+        // row per chain. Cosmos has no GROUP BY support for documents in this
+        // shape, so the de-duplication happens at the application layer.
+        var conditions = new List<string>
+        {
+            "c.tenantId = @tenantId",
+            "(NOT IS_DEFINED(c.versionState) OR c.versionState != @draft)"
+        };
+
+        if (networkType.HasValue) conditions.Add("c.networkType = @networkType");
+        if (lineOfBusiness.HasValue) conditions.Add("c.lineOfBusiness = @lineOfBusiness");
+        if (!string.IsNullOrEmpty(parentOrganizationId)) conditions.Add("c.parentOrganizationId = @parent");
+
+        var queryText = $"SELECT * FROM c WHERE {string.Join(" AND ", conditions)} ORDER BY c.versionNumber DESC";
+        var finalQuery = new QueryDefinition(queryText)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@draft", OrganizationVersionState.Draft.ToString());
+        if (networkType.HasValue)
+            finalQuery = finalQuery.WithParameter("@networkType", networkType.Value.ToString());
+        if (lineOfBusiness.HasValue)
+            finalQuery = finalQuery.WithParameter("@lineOfBusiness", lineOfBusiness.Value.ToString());
+        if (!string.IsNullOrEmpty(parentOrganizationId))
+            finalQuery = finalQuery.WithParameter("@parent", parentOrganizationId);
+
+        var iterator = _container.GetItemQueryIterator<Organization>(
+            finalQuery, requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var rows = new List<Organization>();
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            rows.AddRange(response);
+        }
+
+        var heads = rows
+            .Select(Hydrate)
+            .GroupBy(o => o.OrganizationId)
+            .Select(g => g.OrderByDescending(o => o.VersionNumber).First())
+            .OrderBy(o => o.Name)
+            .ToList();
+
+        var total = heads.Count;
+        var paged = heads.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        return (paged, total);
+    }
+
+    public async Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId)
+    {
+        var (items, _) = await ListAsync(
+            networkType: null,
+            lineOfBusiness: null,
+            parentOrganizationId: parentOrganizationId,
+            page: 1,
+            pageSize: 500);
+        return items;
+    }
+
+    public async Task<Organization> CreateDraftAsync(Organization draft)
+    {
+        var tenantId = GetTenantId();
+        draft.TenantId = tenantId;
+        draft.VersionState = OrganizationVersionState.Draft;
+        if (string.IsNullOrEmpty(draft.Id)) draft.Id = Guid.NewGuid().ToString();
+        if (string.IsNullOrEmpty(draft.OrganizationId)) draft.OrganizationId = draft.Id;
+        draft.LastUpdatedDate = DateTime.UtcNow;
+
+        var response = await _container.CreateItemAsync(draft, new PartitionKey(tenantId));
+        return response.Resource;
+    }
+
+    public async Task<Organization> UpdateDraftAsync(Organization draft)
+    {
+        Organization? existing;
+        try
+        {
+            var read = await _container.ReadItemAsync<Organization>(draft.Id, new PartitionKey(draft.TenantId));
+            existing = Hydrate(read.Resource);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            existing = null;
+        }
+        if (existing == null)
+        {
+            throw new OrganizationVersionStateException(draft.OrganizationId, draft.VersionId, OrganizationVersionState.Draft,
+                $"Draft {draft.VersionId} not found") { IsNotFound = true };
+        }
+        if (existing.VersionState != OrganizationVersionState.Draft)
+        {
+            throw new OrganizationVersionStateException(
+                existing.OrganizationId, existing.VersionId, existing.VersionState,
+                $"Organization version {existing.VersionId} is {existing.VersionState} and cannot be edited.");
+        }
+
+        draft.LastUpdatedDate = DateTime.UtcNow;
+        draft.VersionState = OrganizationVersionState.Draft;
+
+        var response = await _container.ReplaceItemAsync(draft, draft.Id, new PartitionKey(draft.TenantId));
+        return response.Resource;
+    }
+
+    public async Task<Organization> ActivateAndSupersedeAsync(Organization draftToActivate, Organization? predecessor)
+    {
+        if (draftToActivate.VersionState != OrganizationVersionState.Active)
+        {
+            throw new InvalidOperationException(
+                "ActivateAndSupersedeAsync expects draftToActivate to already have VersionState=Active applied by the service layer.");
+        }
+
+        draftToActivate.LastUpdatedDate = DateTime.UtcNow;
+
+        var batch = _container.CreateTransactionalBatch(new PartitionKey(draftToActivate.TenantId))
+            .ReplaceItem(draftToActivate.Id, draftToActivate);
+
+        if (predecessor != null)
+        {
+            predecessor.LastUpdatedDate = DateTime.UtcNow;
+            batch = batch.ReplaceItem(predecessor.Id, predecessor);
+        }
+
+        using var response = await batch.ExecuteAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new OrganizationVersionStateException(
+                draftToActivate.OrganizationId, draftToActivate.VersionId, draftToActivate.VersionState,
+                $"Atomic activate/supersede failed: {response.StatusCode}");
+        }
+
+        return draftToActivate;
+    }
+
+    public async Task<Organization> ReplaceVersionRowAsync(Organization version)
+    {
+        version.LastUpdatedDate = DateTime.UtcNow;
+        var response = await _container.ReplaceItemAsync(
+            version, version.Id, new PartitionKey(version.TenantId));
+        return response.Resource;
+    }
+
+    /// <summary>
+    /// Backfills identity fields on legacy rows that predate the versioning
+    /// fields and keeps <see cref="Organization.Status"/> in sync with
+    /// <see cref="Organization.VersionState"/> for downstream consumers.
+    /// </summary>
+    private static Organization Hydrate(Organization org)
+    {
+        if (string.IsNullOrEmpty(org.OrganizationId))
+        {
+            org.OrganizationId = org.Id;
+        }
+        if (string.IsNullOrEmpty(org.VersionId))
+        {
+            org.VersionId = org.Id;
+            org.VersionNumber = org.VersionNumber <= 0 ? 1 : org.VersionNumber;
+            org.VersionState = org.Status switch
+            {
+                OrganizationStatus.Terminated => OrganizationVersionState.Terminated,
+                OrganizationStatus.Inactive => OrganizationVersionState.Suspended,
+                OrganizationStatus.Pending => OrganizationVersionState.Draft,
+                _ => OrganizationVersionState.Active
+            };
+        }
+
+        org.Status = org.VersionState switch
+        {
+            OrganizationVersionState.Active => OrganizationStatus.Active,
+            OrganizationVersionState.Suspended => OrganizationStatus.Inactive,
+            OrganizationVersionState.Terminated => OrganizationStatus.Terminated,
+            OrganizationVersionState.Superseded => OrganizationStatus.Inactive,
+            OrganizationVersionState.Draft => OrganizationStatus.Pending,
+            _ => org.Status
+        };
+
+        return org;
+    }
+}

--- a/src/services/provider-service/Repositories/OrganizationRepository.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepository.cs
@@ -85,6 +85,21 @@ public sealed class OrganizationVersionStateException : InvalidOperationExceptio
 /// <summary>
 /// Cosmos DB implementation of <see cref="IOrganizationRepository"/>.
 /// Mirrors <see cref="ProviderRepository"/> partition / hydration shape.
+///
+/// <para>
+/// <b>Cosmos enum serialization caveat.</b> The default Cosmos SDK
+/// serializer (Newtonsoft) ignores System.Text.Json
+/// <c>[JsonConverter]</c> attributes and persists enums as integers. The
+/// SQL queries below compare enum fields to <c>Enum.ToString()</c>, which
+/// matches the in-memory representation but not the persisted integer
+/// form. This mirrors the existing <see cref="ProviderRepository"/>
+/// pattern and works in environments that configure <c>CosmosClient</c>
+/// with a System.Text.Json serializer (or where Cosmos is exercised only
+/// via the in-memory test fakes). A platform-wide fix — registering
+/// <c>CosmosClientOptions.UseSystemTextJsonSerializerWithOptions</c> in
+/// Program.cs — would address this for both repositories at once and
+/// remains a follow-up beyond the scope of capability 5.3.
+/// </para>
 /// </summary>
 public class OrganizationRepository : IOrganizationRepository
 {

--- a/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
@@ -1,0 +1,361 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using ProviderService.Models;
+
+namespace ProviderService.Repositories;
+
+/// <summary>
+/// MongoDB implementation of <see cref="IOrganizationRepository"/>.
+/// Mirrors <see cref="ProviderRepositoryMongo"/> partition / hydration shape.
+/// </summary>
+public class OrganizationRepositoryMongo : IOrganizationRepository
+{
+    private readonly IMongoDatabase _database;
+    private readonly IMongoCollection<Organization> _collection;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<OrganizationRepositoryMongo> _logger;
+
+    public OrganizationRepositoryMongo(
+        IMongoDatabase database,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<OrganizationRepositoryMongo> logger)
+    {
+        _database = database;
+        _collection = database.GetCollection<Organization>("Organizations");
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+
+        CreateIndexes();
+    }
+
+    private void CreateIndexes()
+    {
+        var keys = Builders<Organization>.IndexKeys;
+        var models = new List<CreateIndexModel<Organization>>
+        {
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.OrganizationId).Ascending(o => o.VersionNumber)),
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.OrganizationId).Ascending(o => o.VersionId)),
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.NetworkType)),
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.LineOfBusiness)),
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.ParentOrganizationId)),
+            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.VersionState))
+        };
+        _collection.Indexes.CreateMany(models);
+    }
+
+    private string GetTenantId()
+    {
+        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
+        return string.IsNullOrEmpty(tenantId) ? string.Empty : tenantId;
+    }
+
+    private static FilterDefinition<Organization> ChainKeyFilter(string organizationId)
+    {
+        var b = Builders<Organization>.Filter;
+        return b.Or(
+            b.Eq(o => o.OrganizationId, organizationId),
+            b.And(
+                b.Or(b.Eq(o => o.OrganizationId, string.Empty), b.Exists(o => o.OrganizationId, false)),
+                b.Eq(o => o.Id, organizationId)));
+    }
+
+    public async Task<Organization?> GetByIdAsync(string organizationId)
+    {
+        var tenantId = GetTenantId();
+        var b = Builders<Organization>.Filter;
+
+        var notRealDraft = b.Or(
+            b.Ne(o => o.VersionState, OrganizationVersionState.Draft),
+            b.Eq(o => o.VersionId, string.Empty),
+            b.Exists(o => o.VersionId, false));
+
+        var filter = b.And(
+            b.Eq(o => o.TenantId, tenantId),
+            ChainKeyFilter(organizationId),
+            notRealDraft);
+
+        var doc = await _collection.Find(filter)
+            .SortByDescending(o => o.VersionNumber)
+            .FirstOrDefaultAsync();
+        return doc == null ? null : Hydrate(doc);
+    }
+
+    public async Task<Organization?> GetVersionAsync(string organizationId, string versionId)
+    {
+        var tenantId = GetTenantId();
+        var b = Builders<Organization>.Filter;
+        var filter = b.And(
+            b.Eq(o => o.TenantId, tenantId),
+            ChainKeyFilter(organizationId),
+            b.Eq(o => o.VersionId, versionId));
+        var doc = await _collection.Find(filter).FirstOrDefaultAsync();
+        return doc == null ? null : Hydrate(doc);
+    }
+
+    public async Task<Organization?> GetLatestActiveAsync(string organizationId, DateTime asOf)
+    {
+        var tenantId = GetTenantId();
+        var b = Builders<Organization>.Filter;
+
+        var stateFilter = b.Or(
+            b.Eq(o => o.VersionState, OrganizationVersionState.Active),
+            b.Exists(o => o.VersionState, false));
+
+        var filter = b.And(
+            ChainKeyFilter(organizationId),
+            b.Eq(o => o.TenantId, tenantId),
+            stateFilter,
+            b.Or(
+                b.Eq(o => o.TerminationDate, null),
+                b.Gte(o => o.TerminationDate, asOf)));
+
+        var doc = await _collection.Find(filter)
+            .SortByDescending(o => o.VersionNumber)
+            .FirstOrDefaultAsync();
+        return doc == null ? null : Hydrate(doc);
+    }
+
+    public async Task<(IReadOnlyList<Organization> Items, string? ContinuationToken)> ListVersionsAsync(
+        string organizationId, int pageSize, string? continuationToken)
+    {
+        var tenantId = GetTenantId();
+        var skip = 0;
+        if (!string.IsNullOrEmpty(continuationToken) &&
+            int.TryParse(continuationToken, out var parsed) && parsed > 0)
+        {
+            skip = parsed;
+        }
+
+        var b = Builders<Organization>.Filter;
+        var filter = b.And(
+            b.Eq(o => o.TenantId, tenantId),
+            ChainKeyFilter(organizationId));
+
+        var docs = await _collection.Find(filter)
+            .SortByDescending(o => o.VersionNumber)
+            .Skip(skip)
+            .Limit(pageSize + 1)
+            .ToListAsync();
+
+        string? next = null;
+        if (docs.Count > pageSize)
+        {
+            docs.RemoveAt(docs.Count - 1);
+            next = (skip + pageSize).ToString();
+        }
+
+        var hydrated = docs.Select(Hydrate).ToList();
+        return (hydrated, next);
+    }
+
+    public async Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType,
+        LineOfBusiness? lineOfBusiness,
+        string? parentOrganizationId,
+        int page,
+        int pageSize)
+    {
+        var tenantId = GetTenantId();
+        var b = Builders<Organization>.Filter;
+
+        var notRealDraft = b.Or(
+            b.Ne(o => o.VersionState, OrganizationVersionState.Draft),
+            b.Eq(o => o.VersionId, string.Empty),
+            b.Exists(o => o.VersionId, false));
+
+        var filter = b.And(
+            b.Eq(o => o.TenantId, tenantId),
+            notRealDraft);
+
+        if (networkType.HasValue)
+            filter = b.And(filter, b.Eq(o => o.NetworkType, networkType.Value));
+
+        if (lineOfBusiness.HasValue)
+            filter = b.And(filter, b.Eq(o => o.LineOfBusiness, lineOfBusiness.Value));
+
+        if (!string.IsNullOrEmpty(parentOrganizationId))
+            filter = b.And(filter, b.Eq(o => o.ParentOrganizationId, parentOrganizationId));
+
+        // Mongo lacks a single-pass GROUP BY for "head per chain" the way
+        // Cosmos does; pull all matching rows, hydrate, then keep the
+        // highest VersionNumber per OrganizationId.
+        var docs = await _collection.Find(filter)
+            .SortByDescending(o => o.VersionNumber)
+            .ToListAsync();
+
+        var heads = docs
+            .Select(Hydrate)
+            .GroupBy(o => o.OrganizationId)
+            .Select(g => g.OrderByDescending(o => o.VersionNumber).First())
+            .OrderBy(o => o.Name)
+            .ToList();
+
+        var total = heads.Count;
+        var paged = heads.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        return (paged, total);
+    }
+
+    public async Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId)
+    {
+        var (items, _) = await ListAsync(
+            networkType: null,
+            lineOfBusiness: null,
+            parentOrganizationId: parentOrganizationId,
+            page: 1,
+            pageSize: 500);
+        return items;
+    }
+
+    public async Task<Organization> CreateDraftAsync(Organization draft)
+    {
+        var tenantId = GetTenantId();
+        if (string.IsNullOrEmpty(draft.TenantId)) draft.TenantId = tenantId;
+        if (string.IsNullOrEmpty(draft.Id)) draft.Id = Guid.NewGuid().ToString();
+        if (string.IsNullOrEmpty(draft.OrganizationId)) draft.OrganizationId = draft.Id;
+        draft.VersionState = OrganizationVersionState.Draft;
+        draft.LastUpdatedDate = DateTime.UtcNow;
+        await _collection.InsertOneAsync(draft);
+        return draft;
+    }
+
+    public async Task<Organization> UpdateDraftAsync(Organization draft)
+    {
+        var b = Builders<Organization>.Filter;
+        var filter = b.And(
+            b.Eq(o => o.Id, draft.Id),
+            b.Eq(o => o.TenantId, draft.TenantId));
+
+        var existing = await _collection.Find(filter).FirstOrDefaultAsync()
+            ?? throw new OrganizationVersionStateException(draft.OrganizationId, draft.VersionId, OrganizationVersionState.Draft,
+                $"Draft {draft.VersionId} not found") { IsNotFound = true };
+
+        if (existing.VersionState != OrganizationVersionState.Draft)
+        {
+            throw new OrganizationVersionStateException(
+                existing.OrganizationId, existing.VersionId, existing.VersionState,
+                $"Organization version {existing.VersionId} is {existing.VersionState} and cannot be edited.");
+        }
+
+        draft.LastUpdatedDate = DateTime.UtcNow;
+        draft.VersionState = OrganizationVersionState.Draft;
+
+        await _collection.ReplaceOneAsync(filter, draft);
+        return draft;
+    }
+
+    public async Task<Organization> ActivateAndSupersedeAsync(Organization draftToActivate, Organization? predecessor)
+    {
+        if (draftToActivate.VersionState != OrganizationVersionState.Active)
+        {
+            throw new InvalidOperationException(
+                "ActivateAndSupersedeAsync expects draftToActivate to already have VersionState=Active applied by the service layer.");
+        }
+
+        draftToActivate.LastUpdatedDate = DateTime.UtcNow;
+        if (predecessor != null) predecessor.LastUpdatedDate = DateTime.UtcNow;
+
+        var activateFilter = Builders<Organization>.Filter.And(
+            Builders<Organization>.Filter.Eq(o => o.Id, draftToActivate.Id),
+            Builders<Organization>.Filter.Eq(o => o.TenantId, draftToActivate.TenantId));
+
+        try
+        {
+            using var session = await _database.Client.StartSessionAsync();
+            session.StartTransaction();
+            try
+            {
+                await _collection.ReplaceOneAsync(session, activateFilter, draftToActivate);
+
+                if (predecessor != null)
+                {
+                    var predFilter = Builders<Organization>.Filter.And(
+                        Builders<Organization>.Filter.Eq(o => o.Id, predecessor.Id),
+                        Builders<Organization>.Filter.Eq(o => o.TenantId, predecessor.TenantId));
+                    await _collection.ReplaceOneAsync(session, predFilter, predecessor);
+                }
+
+                await session.CommitTransactionAsync();
+                return draftToActivate;
+            }
+            catch
+            {
+                await session.AbortTransactionAsync();
+                throw;
+            }
+        }
+        catch (NotSupportedException)
+        {
+            return await ActivateAndSupersedeWithoutTransactionAsync(draftToActivate, predecessor, activateFilter);
+        }
+        catch (MongoCommandException ex) when (
+            ex.CodeName == "IllegalOperation" || ex.Code == 20 || ex.Code == 263)
+        {
+            return await ActivateAndSupersedeWithoutTransactionAsync(draftToActivate, predecessor, activateFilter);
+        }
+    }
+
+    private async Task<Organization> ActivateAndSupersedeWithoutTransactionAsync(
+        Organization draftToActivate,
+        Organization? predecessor,
+        FilterDefinition<Organization> activateFilter)
+    {
+        _logger.LogWarning(
+            "Mongo deployment does not support transactions; activating organization {OrgId} version {VersionId} non-atomically.",
+            draftToActivate.OrganizationId, draftToActivate.VersionId);
+
+        await _collection.ReplaceOneAsync(activateFilter, draftToActivate);
+
+        if (predecessor != null)
+        {
+            var predFilter = Builders<Organization>.Filter.And(
+                Builders<Organization>.Filter.Eq(o => o.Id, predecessor.Id),
+                Builders<Organization>.Filter.Eq(o => o.TenantId, predecessor.TenantId));
+            await _collection.ReplaceOneAsync(predFilter, predecessor);
+        }
+
+        return draftToActivate;
+    }
+
+    public async Task<Organization> ReplaceVersionRowAsync(Organization version)
+    {
+        version.LastUpdatedDate = DateTime.UtcNow;
+        var filter = Builders<Organization>.Filter.And(
+            Builders<Organization>.Filter.Eq(o => o.Id, version.Id),
+            Builders<Organization>.Filter.Eq(o => o.TenantId, version.TenantId));
+        await _collection.ReplaceOneAsync(filter, version);
+        return version;
+    }
+
+    private static Organization Hydrate(Organization org)
+    {
+        if (string.IsNullOrEmpty(org.OrganizationId))
+        {
+            org.OrganizationId = org.Id;
+        }
+        if (string.IsNullOrEmpty(org.VersionId))
+        {
+            org.VersionId = org.Id;
+            org.VersionNumber = org.VersionNumber <= 0 ? 1 : org.VersionNumber;
+            org.VersionState = org.Status switch
+            {
+                OrganizationStatus.Terminated => OrganizationVersionState.Terminated,
+                OrganizationStatus.Inactive => OrganizationVersionState.Suspended,
+                OrganizationStatus.Pending => OrganizationVersionState.Draft,
+                _ => OrganizationVersionState.Active
+            };
+        }
+
+        org.Status = org.VersionState switch
+        {
+            OrganizationVersionState.Active => OrganizationStatus.Active,
+            OrganizationVersionState.Suspended => OrganizationStatus.Inactive,
+            OrganizationVersionState.Terminated => OrganizationStatus.Terminated,
+            OrganizationVersionState.Superseded => OrganizationStatus.Inactive,
+            OrganizationVersionState.Draft => OrganizationStatus.Pending,
+            _ => org.Status
+        };
+
+        return org;
+    }
+}

--- a/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
@@ -302,7 +302,7 @@ public class OrganizationRepositoryMongo : IOrganizationRepository
     {
         _logger.LogWarning(
             "Mongo deployment does not support transactions; activating organization {OrgId} version {VersionId} non-atomically.",
-            draftToActivate.OrganizationId, draftToActivate.VersionId);
+            SanitizeForLog(draftToActivate.OrganizationId), SanitizeForLog(draftToActivate.VersionId));
 
         await _collection.ReplaceOneAsync(activateFilter, draftToActivate);
 
@@ -315,6 +315,12 @@ public class OrganizationRepositoryMongo : IOrganizationRepository
         }
 
         return draftToActivate;
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
     public async Task<Organization> ReplaceVersionRowAsync(Organization version)

--- a/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
@@ -177,22 +177,28 @@ public class OrganizationRepositoryMongo : IOrganizationRepository
         if (!string.IsNullOrEmpty(parentOrganizationId))
             filter = b.And(filter, b.Eq(o => o.ParentOrganizationId, parentOrganizationId));
 
-        // Mongo lacks a single-pass GROUP BY for "head per chain" the way
-        // Cosmos does; pull all matching rows, hydrate, then keep the
-        // highest VersionNumber per OrganizationId.
-        var docs = await _collection.Find(filter)
+        // Server-side aggregation: $match → $sort → $group ($first per chain)
+        // → $replaceRoot → $sort by name. This avoids transferring every
+        // version document to the app and lets Mongo apply the indexes on
+        // (TenantId, OrganizationId, VersionNumber) for the de-duplication.
+        var heads = _collection.Aggregate()
+            .Match(filter)
             .SortByDescending(o => o.VersionNumber)
+            .Group(
+                o => o.OrganizationId,
+                g => new { Organization = g.First() })
+            .ReplaceRoot(x => x.Organization)
+            .SortBy(o => o.Name);
+
+        var totalDoc = await heads.Count().FirstOrDefaultAsync();
+        var total = (int)(totalDoc?.Count ?? 0);
+
+        var pagedDocs = await heads
+            .Skip((page - 1) * pageSize)
+            .Limit(pageSize)
             .ToListAsync();
 
-        var heads = docs
-            .Select(Hydrate)
-            .GroupBy(o => o.OrganizationId)
-            .Select(g => g.OrderByDescending(o => o.VersionNumber).First())
-            .OrderBy(o => o.Name)
-            .ToList();
-
-        var total = heads.Count;
-        var paged = heads.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        var paged = pagedDocs.Select(Hydrate).ToList();
         return (paged, total);
     }
 

--- a/src/services/provider-service/Services/OrganizationService.cs
+++ b/src/services/provider-service/Services/OrganizationService.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Lifecycle façade over <see cref="IOrganizationRepository"/>. Owns
+/// identity assignment (ULID, version number, predecessor pointer),
+/// state transitions, and amend / activate sequencing.
+/// </summary>
+/// <remarks>
+/// CRUD on <c>NetworksController</c> maps as:
+/// <list type="bullet">
+///   <item><c>POST</c> → <see cref="CreateAndActivateAsync"/> — creates a
+///         genesis Draft and immediately activates it.</item>
+///   <item><c>PUT</c> → <see cref="UpdateAsync"/> — clones the current head
+///         into a new Draft, applies the new field values, and activates it,
+///         superseding the prior head.</item>
+///   <item><c>DELETE</c> → <see cref="TerminateAsync"/> — flips the current
+///         head to <see cref="OrganizationVersionState.Terminated"/>
+///         (soft-delete via versioning).</item>
+/// </list>
+/// </remarks>
+public interface IOrganizationService
+{
+    Task<Organization?> GetByIdAsync(string organizationId);
+    Task<Organization?> GetVersionAsync(string organizationId, string versionId);
+
+    Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType, LineOfBusiness? lineOfBusiness, string? parentOrganizationId, int page, int pageSize);
+
+    Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId);
+
+    Task<Organization> CreateAndActivateAsync(Organization candidate, string actorId);
+
+    Task<Organization> UpdateAsync(string organizationId, Organization candidate, string actorId);
+
+    Task<Organization> TerminateAsync(string organizationId, string reason, string actorId);
+}
+
+public class OrganizationService : IOrganizationService
+{
+    private static readonly JsonSerializerOptions _cloneOpts = new(JsonSerializerDefaults.Web);
+
+    private readonly IOrganizationRepository _repository;
+    private readonly ILogger<OrganizationService> _logger;
+
+    public OrganizationService(
+        IOrganizationRepository repository,
+        ILogger<OrganizationService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public Task<Organization?> GetByIdAsync(string organizationId)
+        => _repository.GetByIdAsync(organizationId);
+
+    public Task<Organization?> GetVersionAsync(string organizationId, string versionId)
+        => _repository.GetVersionAsync(organizationId, versionId);
+
+    public Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType, LineOfBusiness? lineOfBusiness, string? parentOrganizationId, int page, int pageSize)
+        => _repository.ListAsync(networkType, lineOfBusiness, parentOrganizationId, page, pageSize);
+
+    public Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId)
+        => _repository.GetByParentAsync(parentOrganizationId);
+
+    public async Task<Organization> CreateAndActivateAsync(Organization candidate, string actorId)
+    {
+        if (string.IsNullOrEmpty(candidate.Id)) candidate.Id = Guid.NewGuid().ToString();
+        if (string.IsNullOrEmpty(candidate.OrganizationId)) candidate.OrganizationId = candidate.Id;
+
+        candidate.VersionId = OrganizationVersionId.NewId();
+        candidate.VersionNumber = 1;
+        candidate.VersionState = OrganizationVersionState.Draft;
+        candidate.PredecessorVersionId = null;
+        candidate.ActivatedAt = null;
+        candidate.ActivatedBy = null;
+        candidate.SuspendedAt = null;
+        candidate.SuspensionReason = null;
+        candidate.SupersededAt = null;
+        candidate.SupersededByVersionId = null;
+        candidate.CreatedBy = string.IsNullOrEmpty(candidate.CreatedBy) ? actorId : candidate.CreatedBy;
+        candidate.CreatedDate = DateTime.UtcNow;
+        candidate.LastUpdatedDate = DateTime.UtcNow;
+        candidate.LastUpdatedBy = actorId;
+
+        var draft = await _repository.CreateDraftAsync(candidate);
+
+        var now = DateTime.UtcNow;
+        draft.VersionState = OrganizationVersionState.Active;
+        draft.ActivatedAt = now;
+        draft.ActivatedBy = actorId;
+        draft.Status = OrganizationStatus.Active;
+        draft.LastUpdatedBy = actorId;
+
+        return await _repository.ActivateAndSupersedeAsync(draft, predecessor: null);
+    }
+
+    public async Task<Organization> UpdateAsync(string organizationId, Organization candidate, string actorId)
+    {
+        var current = await _repository.GetByIdAsync(organizationId)
+            ?? throw new OrganizationVersionStateException(organizationId, string.Empty, OrganizationVersionState.Active,
+                $"Organization {organizationId} not found") { IsNotFound = true };
+
+        if (current.VersionState == OrganizationVersionState.Terminated)
+        {
+            throw new OrganizationVersionStateException(
+                current.OrganizationId, current.VersionId, current.VersionState,
+                $"Organization {current.OrganizationId} is Terminated and cannot be updated. Reactivate first.");
+        }
+
+        // Build a brand-new draft cloned from the candidate fields, but
+        // wire identity (chain key, predecessor, version number) from the
+        // current head so the versioning chain stays intact.
+        var draft = Clone(candidate);
+        draft.Id = Guid.NewGuid().ToString();
+        draft.TenantId = current.TenantId;
+        draft.OrganizationId = current.OrganizationId;
+        draft.VersionId = OrganizationVersionId.NewId();
+        draft.VersionNumber = current.VersionNumber + 1;
+        draft.VersionState = OrganizationVersionState.Draft;
+        draft.PredecessorVersionId = current.VersionId;
+        draft.ActivatedAt = null;
+        draft.ActivatedBy = null;
+        draft.SuspendedAt = null;
+        draft.SuspensionReason = null;
+        draft.SupersededAt = null;
+        draft.SupersededByVersionId = null;
+        draft.CreatedBy = current.CreatedBy ?? actorId;
+        draft.CreatedDate = current.CreatedDate;
+        draft.LastUpdatedDate = DateTime.UtcNow;
+        draft.LastUpdatedBy = actorId;
+
+        var stored = await _repository.CreateDraftAsync(draft);
+
+        var now = DateTime.UtcNow;
+        stored.VersionState = OrganizationVersionState.Active;
+        stored.ActivatedAt = now;
+        stored.ActivatedBy = actorId;
+        stored.Status = OrganizationStatus.Active;
+        stored.LastUpdatedBy = actorId;
+
+        // Carry the prior head into Superseded atomically.
+        current.VersionState = OrganizationVersionState.Superseded;
+        current.SupersededAt = now;
+        current.SupersededByVersionId = stored.VersionId;
+        current.Status = OrganizationStatus.Inactive;
+
+        return await _repository.ActivateAndSupersedeAsync(stored, current);
+    }
+
+    public async Task<Organization> TerminateAsync(string organizationId, string reason, string actorId)
+    {
+        var current = await _repository.GetByIdAsync(organizationId)
+            ?? throw new OrganizationVersionStateException(organizationId, string.Empty, OrganizationVersionState.Active,
+                $"Organization {organizationId} not found") { IsNotFound = true };
+
+        if (current.VersionState == OrganizationVersionState.Terminated)
+        {
+            // Already terminated — return the existing row instead of churning a no-op write.
+            return current;
+        }
+
+        var now = DateTime.UtcNow;
+        current.VersionState = OrganizationVersionState.Terminated;
+        current.TerminationDate = now;
+        current.Status = OrganizationStatus.Terminated;
+        current.LastUpdatedBy = actorId;
+        current.TerminationReason = string.IsNullOrEmpty(reason) ? current.TerminationReason : reason;
+
+        return await _repository.ReplaceVersionRowAsync(current);
+    }
+
+    private static Organization Clone(Organization src)
+        => JsonSerializer.Deserialize<Organization>(JsonSerializer.Serialize(src, _cloneOpts), _cloneOpts)!;
+}

--- a/src/services/provider-service/Services/OrganizationService.cs
+++ b/src/services/provider-service/Services/OrganizationService.cs
@@ -114,7 +114,10 @@ public class OrganizationService : IOrganizationService
 
         // Build a brand-new draft cloned from the candidate fields, but
         // wire identity (chain key, predecessor, version number) from the
-        // current head so the versioning chain stays intact.
+        // current head so the versioning chain stays intact. This is a
+        // RESTful PUT — full replacement: any field absent from the
+        // candidate is treated as "set to default" on the new version.
+        // See NetworksController.Update XML doc + network-as-organization.md.
         var draft = Clone(candidate);
         draft.Id = Guid.NewGuid().ToString();
         draft.TenantId = current.TenantId;

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ChoOrganizationAdapterTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/ChoOrganizationAdapterTests.cs
@@ -1,0 +1,162 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Adapters;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Verifies the CHO pass-through organization adapter against the
+/// in-memory repository. Mirrors the ChoProviderAdapter regression set.
+/// </summary>
+public class ChoOrganizationAdapterTests
+{
+    private const string TenantId = "tenant-a";
+
+    [Fact]
+    public void Platform_identifier_is_cho()
+    {
+        var adapter = NewAdapter(out _);
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_returns_org_when_found()
+    {
+        var adapter = NewAdapter(out var repo);
+        var seeded = await SeedActive(repo, name: "Aetna PPO FL", networkType: NetworkType.PPO);
+
+        var response = await adapter.GetOrganizationAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            OrganizationId = seeded.OrganizationId,
+        });
+
+        response.Platform.Should().Be("cho");
+        response.Organization.Should().NotBeNull();
+        response.Organization!.OrganizationId.Should().Be(seeded.OrganizationId);
+        response.Organization.NetworkType.Should().Be(NetworkType.PPO);
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_returns_null_when_not_found()
+    {
+        var adapter = NewAdapter(out _);
+
+        var response = await adapter.GetOrganizationAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            OrganizationId = "missing",
+        });
+
+        response.Organization.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_throws_when_id_missing()
+    {
+        var adapter = NewAdapter(out _);
+
+        var act = () => adapter.GetOrganizationAsync(new OrganizationAdapterRequest { TenantId = TenantId });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("OrganizationId is required*");
+    }
+
+    [Fact]
+    public async Task ListAsync_filters_by_network_type()
+    {
+        var adapter = NewAdapter(out var repo);
+        await SeedActive(repo, name: "Aetna PPO", networkType: NetworkType.PPO);
+        await SeedActive(repo, name: "BCBS HMO", networkType: NetworkType.HMO);
+        await SeedActive(repo, name: "Cigna PPO", networkType: NetworkType.PPO);
+
+        var response = await adapter.ListAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            NetworkType = NetworkType.PPO,
+            Page = 1,
+            PageSize = 50,
+        });
+
+        response.Platform.Should().Be("cho");
+        response.Organizations.Should().HaveCount(2);
+        response.Organizations.All(o => o.NetworkType == NetworkType.PPO).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ListAsync_filters_by_lob()
+    {
+        var adapter = NewAdapter(out var repo);
+        await SeedActive(repo, name: "Medicare Net", lob: LineOfBusiness.Medicare);
+        await SeedActive(repo, name: "Commercial Net", lob: LineOfBusiness.Commercial);
+
+        var response = await adapter.ListAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            LineOfBusiness = LineOfBusiness.Medicare,
+            Page = 1,
+            PageSize = 50,
+        });
+
+        response.Organizations.Should().HaveCount(1);
+        response.Organizations.Single().LineOfBusiness.Should().Be(LineOfBusiness.Medicare);
+    }
+
+    [Fact]
+    public async Task GetByParentAsync_returns_children()
+    {
+        var adapter = NewAdapter(out var repo);
+        var parent = await SeedActive(repo, name: "Parent Net");
+        await SeedActive(repo, name: "Child A", parent: parent.OrganizationId);
+        await SeedActive(repo, name: "Child B", parent: parent.OrganizationId);
+        await SeedActive(repo, name: "Unrelated");
+
+        var response = await adapter.GetByParentAsync(new OrganizationAdapterRequest
+        {
+            TenantId = TenantId,
+            ParentOrganizationId = parent.OrganizationId,
+        });
+
+        response.Organizations.Should().HaveCount(2);
+        response.Organizations.All(o => o.ParentOrganizationId == parent.OrganizationId).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByParentAsync_throws_when_parent_missing()
+    {
+        var adapter = NewAdapter(out _);
+
+        var act = () => adapter.GetByParentAsync(new OrganizationAdapterRequest { TenantId = TenantId });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("ParentOrganizationId is required*");
+    }
+
+    private static ChoOrganizationAdapter NewAdapter(out InMemoryOrganizationRepository repo)
+    {
+        repo = new InMemoryOrganizationRepository { TenantId = TenantId };
+        return new ChoOrganizationAdapter(repo, NullLogger<ChoOrganizationAdapter>.Instance);
+    }
+
+    private static async Task<Organization> SeedActive(
+        InMemoryOrganizationRepository repo,
+        string name,
+        NetworkType networkType = NetworkType.PPO,
+        LineOfBusiness lob = LineOfBusiness.Commercial,
+        string? parent = null)
+    {
+        var service = new OrganizationService(repo, NullLogger<OrganizationService>.Instance);
+        return await service.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = name,
+            NetworkType = networkType,
+            LineOfBusiness = lob,
+            EffectiveDate = DateTime.UtcNow.Date,
+            ParentOrganizationId = parent,
+        }, actorId: "test-actor");
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/OrganizationAdapterFactoryTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/OrganizationAdapterFactoryTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using ProviderService.Adapters;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Routing tests for <see cref="OrganizationAdapterFactory"/>. Mirrors the
+/// ProviderAdapterFactory fallback semantics — flaky tenant-service or an
+/// unknown platform must fall back to the CHO adapter so reads keep working.
+/// </summary>
+public class OrganizationAdapterFactoryTests
+{
+    [Fact]
+    public async Task GetAdapterAsync_returns_cho_when_tenant_service_fails()
+    {
+        var factory = NewFactory(out _, simulateFailure: true);
+
+        var adapter = await factory.GetAdapterAsync("tenant-broken");
+
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_returns_cho_for_unknown_platform()
+    {
+        var factory = NewFactory(out _, platform: "doesnotexist");
+
+        var adapter = await factory.GetAdapterAsync("tenant-x");
+
+        adapter.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_routes_to_qnxt_when_configured()
+    {
+        var factory = NewFactory(out _, platform: "qnxt");
+
+        var adapter = await factory.GetAdapterAsync("tenant-qnxt");
+
+        adapter.Platform.Should().Be("qnxt");
+    }
+
+    private static OrganizationAdapterFactory NewFactory(
+        out ProviderTenantConfigCache cache,
+        string? platform = null,
+        bool simulateFailure = false)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        if (simulateFailure)
+        {
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(new HttpRequestException("simulated outage"));
+        }
+        else
+        {
+            var body = new
+            {
+                configuration = new
+                {
+                    providerPlatform = new
+                    {
+                        platform = platform ?? "cho",
+                        platformSettings = new Dictionary<string, string>()
+                    }
+                }
+            };
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(body)
+                });
+        }
+
+        var clientFactory = new Mock<IHttpClientFactory>();
+        clientFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler.Object));
+
+        var configRoot = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Services:TenantService"] = "http://tenant-service.test/api/v1"
+            })
+            .Build();
+
+        cache = new ProviderTenantConfigCache(
+            clientFactory.Object,
+            configRoot,
+            NullLogger<ProviderTenantConfigCache>.Instance);
+
+        var adapters = new IOrganizationAdapter[]
+        {
+            new ChoOrganizationAdapter(
+                new Fakes.InMemoryOrganizationRepository(),
+                NullLogger<ChoOrganizationAdapter>.Instance),
+            new QnxtOrganizationAdapter(),
+            new FacetsOrganizationAdapter(),
+        };
+
+        return new OrganizationAdapterFactory(
+            adapters,
+            cache,
+            NullLogger<OrganizationAdapterFactory>.Instance);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Adapters/StubOrganizationAdaptersTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Adapters/StubOrganizationAdaptersTests.cs
@@ -1,0 +1,49 @@
+using ProviderService.Adapters;
+using ProviderService.Models;
+
+namespace CloudHealthOffice.ProviderService.Tests.Adapters;
+
+/// <summary>
+/// Each stub organization adapter must throw <see cref="NotImplementedException"/>
+/// with a platform-specific TODO marker pointing at the architecture doc,
+/// matching the behaviour of the provider stubs.
+/// </summary>
+public class StubOrganizationAdaptersTests
+{
+    public static IEnumerable<object[]> Stubs => new[]
+    {
+        new object[] { (IOrganizationAdapter)new QnxtOrganizationAdapter(), "qnxt", "TODO(qnxt-organization)" },
+        new object[] { (IOrganizationAdapter)new FacetsOrganizationAdapter(), "facets", "TODO(facets-organization)" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public void Platform_identifier_is_stable(IOrganizationAdapter adapter, string expectedPlatform, string _)
+    {
+        adapter.Platform.Should().Be(expectedPlatform);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task Every_method_throws_with_migration_todo(
+        IOrganizationAdapter adapter, string _, string expectedTodoMarker)
+    {
+        var request = new OrganizationAdapterRequest
+        {
+            TenantId = "tenant-a",
+            OrganizationId = "n-1",
+            ParentOrganizationId = "p-1",
+        };
+
+        await AssertThrows(() => adapter.GetOrganizationAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.GetByParentAsync(request), expectedTodoMarker);
+        await AssertThrows(() => adapter.ListAsync(request), expectedTodoMarker);
+    }
+
+    private static async Task AssertThrows(Func<Task> act, string expectedTodoMarker)
+    {
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(expectedTodoMarker);
+        ex.Which.Message.Should().Contain("docs/architecture/network-as-organization.md");
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryOrganizationRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryOrganizationRepository.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace CloudHealthOffice.ProviderService.Tests.Fakes;
+
+/// <summary>
+/// In-memory fake of <see cref="IOrganizationRepository"/> with full
+/// version-chain semantics. Mirrors <see cref="InMemoryProviderRepository"/>:
+/// every store and fetch round-trips through JSON so callers can mutate
+/// returned objects without corrupting the stored copy.
+/// </summary>
+public sealed class InMemoryOrganizationRepository : IOrganizationRepository
+{
+    private static readonly JsonSerializerOptions _jsonOpts = new(JsonSerializerDefaults.Web);
+    private readonly List<Organization> _docs = new();
+    public IReadOnlyList<Organization> Docs => _docs;
+
+    /// <summary>Tenant context defaults to "tenant-a" for the service tests.</summary>
+    public string TenantId { get; set; } = "tenant-a";
+
+    private static Organization Clone(Organization org)
+        => JsonSerializer.Deserialize<Organization>(JsonSerializer.Serialize(org, _jsonOpts), _jsonOpts)!;
+
+    private static Organization Hydrate(Organization org)
+    {
+        if (string.IsNullOrEmpty(org.OrganizationId))
+        {
+            org.OrganizationId = org.Id;
+        }
+        if (string.IsNullOrEmpty(org.VersionId))
+        {
+            org.VersionId = org.Id;
+            org.VersionNumber = org.VersionNumber <= 0 ? 1 : org.VersionNumber;
+            org.VersionState = org.Status switch
+            {
+                OrganizationStatus.Terminated => OrganizationVersionState.Terminated,
+                OrganizationStatus.Inactive => OrganizationVersionState.Suspended,
+                OrganizationStatus.Pending => OrganizationVersionState.Draft,
+                _ => OrganizationVersionState.Active
+            };
+        }
+        org.Status = org.VersionState switch
+        {
+            OrganizationVersionState.Active => OrganizationStatus.Active,
+            OrganizationVersionState.Suspended => OrganizationStatus.Inactive,
+            OrganizationVersionState.Terminated => OrganizationStatus.Terminated,
+            OrganizationVersionState.Superseded => OrganizationStatus.Inactive,
+            OrganizationVersionState.Draft => OrganizationStatus.Pending,
+            _ => org.Status
+        };
+        return org;
+    }
+
+    private IEnumerable<Organization> HydratedView()
+        => _docs.Select(d => Hydrate(Clone(d)));
+
+    public Task<Organization?> GetByIdAsync(string organizationId)
+    {
+        var match = HydratedView()
+            .Where(o => (o.OrganizationId == organizationId || o.Id == organizationId)
+                && o.TenantId == TenantId
+                && o.VersionState != OrganizationVersionState.Draft)
+            .OrderByDescending(o => o.VersionNumber)
+            .FirstOrDefault();
+        return Task.FromResult<Organization?>(match);
+    }
+
+    public Task<Organization?> GetVersionAsync(string organizationId, string versionId)
+    {
+        var match = HydratedView().FirstOrDefault(o =>
+            (o.OrganizationId == organizationId || o.Id == organizationId)
+            && o.TenantId == TenantId
+            && o.VersionId == versionId);
+        return Task.FromResult<Organization?>(match);
+    }
+
+    public Task<Organization?> GetLatestActiveAsync(string organizationId, DateTime asOf)
+    {
+        var match = HydratedView()
+            .Where(o => (o.OrganizationId == organizationId || o.Id == organizationId)
+                && o.TenantId == TenantId
+                && o.VersionState == OrganizationVersionState.Active
+                && (o.TerminationDate == null || o.TerminationDate >= asOf))
+            .OrderByDescending(o => o.VersionNumber)
+            .FirstOrDefault();
+        return Task.FromResult<Organization?>(match);
+    }
+
+    public Task<(IReadOnlyList<Organization> Items, string? ContinuationToken)> ListVersionsAsync(
+        string organizationId, int pageSize, string? continuationToken)
+    {
+        var skip = 0;
+        if (!string.IsNullOrEmpty(continuationToken) && int.TryParse(continuationToken, out var parsed))
+            skip = parsed;
+
+        var ordered = HydratedView()
+            .Where(o => (o.OrganizationId == organizationId || o.Id == organizationId)
+                && o.TenantId == TenantId)
+            .OrderByDescending(o => o.VersionNumber)
+            .Skip(skip)
+            .ToList();
+
+        var slice = ordered.Take(pageSize).ToList();
+        var next = ordered.Count > pageSize ? (skip + pageSize).ToString() : null;
+        return Task.FromResult<(IReadOnlyList<Organization>, string?)>((slice, next));
+    }
+
+    public Task<(IReadOnlyList<Organization> Items, int? TotalCount)> ListAsync(
+        NetworkType? networkType,
+        LineOfBusiness? lineOfBusiness,
+        string? parentOrganizationId,
+        int page,
+        int pageSize)
+    {
+        var heads = HydratedView()
+            .Where(o => o.TenantId == TenantId && o.VersionState != OrganizationVersionState.Draft)
+            .GroupBy(o => o.OrganizationId)
+            .Select(g => g.OrderByDescending(o => o.VersionNumber).First())
+            .ToList();
+
+        if (networkType.HasValue)
+            heads = heads.Where(o => o.NetworkType == networkType.Value).ToList();
+        if (lineOfBusiness.HasValue)
+            heads = heads.Where(o => o.LineOfBusiness == lineOfBusiness.Value).ToList();
+        if (!string.IsNullOrEmpty(parentOrganizationId))
+            heads = heads.Where(o => o.ParentOrganizationId == parentOrganizationId).ToList();
+
+        heads = heads.OrderBy(o => o.Name).ToList();
+        var total = heads.Count;
+        var paged = heads.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        return Task.FromResult<(IReadOnlyList<Organization>, int?)>((paged, total));
+    }
+
+    public async Task<IReadOnlyList<Organization>> GetByParentAsync(string parentOrganizationId)
+    {
+        var (items, _) = await ListAsync(null, null, parentOrganizationId, 1, 500);
+        return items;
+    }
+
+    public Task<Organization> CreateDraftAsync(Organization draft)
+    {
+        if (string.IsNullOrEmpty(draft.Id)) draft.Id = Guid.NewGuid().ToString();
+        if (string.IsNullOrEmpty(draft.OrganizationId)) draft.OrganizationId = draft.Id;
+        if (string.IsNullOrEmpty(draft.TenantId)) draft.TenantId = TenantId;
+        draft.VersionState = OrganizationVersionState.Draft;
+        _docs.Add(Clone(draft));
+        return Task.FromResult(Clone(draft));
+    }
+
+    public Task<Organization> UpdateDraftAsync(Organization draft)
+    {
+        var existing = _docs.FirstOrDefault(d => d.Id == draft.Id && d.TenantId == draft.TenantId)
+            ?? throw new OrganizationVersionStateException(draft.OrganizationId, draft.VersionId, OrganizationVersionState.Draft,
+                $"Draft {draft.VersionId} not found") { IsNotFound = true };
+        if (existing.VersionState != OrganizationVersionState.Draft)
+            throw new OrganizationVersionStateException(existing.OrganizationId, existing.VersionId, existing.VersionState,
+                $"Organization version {existing.VersionId} is {existing.VersionState} and cannot be edited.");
+        _docs.Remove(existing);
+        _docs.Add(Clone(draft));
+        return Task.FromResult(Clone(draft));
+    }
+
+    public Task<Organization> ActivateAndSupersedeAsync(Organization draftToActivate, Organization? predecessor)
+    {
+        var existingDraft = _docs.FirstOrDefault(d => d.Id == draftToActivate.Id);
+        if (existingDraft != null) _docs.Remove(existingDraft);
+        _docs.Add(Clone(draftToActivate));
+
+        if (predecessor != null)
+        {
+            var existingPred = _docs.FirstOrDefault(d => d.Id == predecessor.Id);
+            if (existingPred != null) _docs.Remove(existingPred);
+            _docs.Add(Clone(predecessor));
+        }
+        return Task.FromResult(Clone(draftToActivate));
+    }
+
+    public Task<Organization> ReplaceVersionRowAsync(Organization version)
+    {
+        var existing = _docs.FirstOrDefault(d => d.Id == version.Id && d.TenantId == version.TenantId);
+        if (existing != null) _docs.Remove(existing);
+        _docs.Add(Clone(version));
+        return Task.FromResult(Clone(version));
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/OrganizationServiceTests.cs
@@ -1,0 +1,242 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Lifecycle tests for <see cref="OrganizationService"/>. Mirrors the
+/// provider-versioning test set: genesis create, amend → supersede,
+/// terminate, partOf hierarchy traversal.
+/// </summary>
+public class OrganizationServiceTests
+{
+    private const string TenantId = "tenant-a";
+
+    [Fact]
+    public async Task CreateAndActivateAsync_persists_active_v1_with_chain_key()
+    {
+        var (svc, repo) = NewService();
+
+        var created = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Aetna PPO FL 2025",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "alice");
+
+        created.OrganizationId.Should().NotBeEmpty();
+        created.OrganizationId.Should().Be(created.Id);
+        created.VersionNumber.Should().Be(1);
+        created.VersionState.Should().Be(OrganizationVersionState.Active);
+        created.ActivatedBy.Should().Be("alice");
+
+        var head = await repo.GetByIdAsync(created.OrganizationId);
+        head.Should().NotBeNull();
+        head!.VersionState.Should().Be(OrganizationVersionState.Active);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_creates_v2_and_supersedes_v1()
+    {
+        var (svc, repo) = NewService();
+
+        var v1 = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "BCBS HMO",
+            NetworkType = NetworkType.HMO,
+            LineOfBusiness = LineOfBusiness.Medicare,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "alice");
+
+        var v2 = await svc.UpdateAsync(v1.OrganizationId, new Organization
+        {
+            Name = "BCBS HMO (renamed)",
+            NetworkType = NetworkType.HMO,
+            LineOfBusiness = LineOfBusiness.Medicare,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "bob");
+
+        v2.OrganizationId.Should().Be(v1.OrganizationId);
+        v2.VersionNumber.Should().Be(2);
+        v2.VersionState.Should().Be(OrganizationVersionState.Active);
+        v2.PredecessorVersionId.Should().Be(v1.VersionId);
+        v2.Name.Should().Be("BCBS HMO (renamed)");
+
+        // The v1 row is still present but Superseded.
+        var v1After = await repo.GetVersionAsync(v1.OrganizationId, v1.VersionId);
+        v1After.Should().NotBeNull();
+        v1After!.VersionState.Should().Be(OrganizationVersionState.Superseded);
+        v1After.SupersededByVersionId.Should().Be(v2.VersionId);
+
+        // GetByIdAsync resolves to the v2 head.
+        var head = await repo.GetByIdAsync(v1.OrganizationId);
+        head!.VersionId.Should().Be(v2.VersionId);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_throws_when_organization_missing()
+    {
+        var (svc, _) = NewService();
+
+        var act = () => svc.UpdateAsync("missing", new Organization
+        {
+            Name = "x",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "actor");
+
+        var ex = await act.Should().ThrowAsync<OrganizationVersionStateException>();
+        ex.Which.IsNotFound.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TerminateAsync_marks_head_as_terminated()
+    {
+        var (svc, repo) = NewService();
+
+        var created = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Gone Fishing PPO",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "alice");
+
+        var terminated = await svc.TerminateAsync(created.OrganizationId, "wind down", "alice");
+
+        terminated.VersionState.Should().Be(OrganizationVersionState.Terminated);
+        terminated.Status.Should().Be(OrganizationStatus.Terminated);
+        terminated.TerminationDate.Should().NotBeNull();
+
+        // GetByIdAsync still returns the terminated row (it's the only non-Draft version).
+        var head = await repo.GetByIdAsync(created.OrganizationId);
+        head!.VersionState.Should().Be(OrganizationVersionState.Terminated);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_rejects_terminated_chain()
+    {
+        var (svc, _) = NewService();
+
+        var created = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Net A",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "alice");
+
+        await svc.TerminateAsync(created.OrganizationId, "done", "alice");
+
+        var act = () => svc.UpdateAsync(created.OrganizationId, new Organization
+        {
+            Name = "Net A v2",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "alice");
+
+        await act.Should().ThrowAsync<OrganizationVersionStateException>()
+            .Where(e => e.CurrentState == OrganizationVersionState.Terminated);
+    }
+
+    [Fact]
+    public async Task ListAsync_returns_only_one_row_per_chain()
+    {
+        var (svc, _) = NewService();
+
+        var v1 = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Tier 1 PPO",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, actorId: "alice");
+        await svc.UpdateAsync(v1.OrganizationId, new Organization
+        {
+            Name = "Tier 1 PPO renamed",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "bob");
+        await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "HMO",
+            NetworkType = NetworkType.HMO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "alice");
+
+        var (items, total) = await svc.ListAsync(null, null, null, 1, 50);
+
+        // Two distinct chains, with the head of each returned.
+        items.Should().HaveCount(2);
+        total.Should().Be(2);
+        items.Select(o => o.VersionState).Should().AllBeEquivalentTo(OrganizationVersionState.Active);
+    }
+
+    [Fact]
+    public async Task GetByParentAsync_returns_only_children_under_parent()
+    {
+        var (svc, _) = NewService();
+
+        var parent = await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Parent",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "alice");
+
+        await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Sub A",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+            ParentOrganizationId = parent.OrganizationId,
+        }, "alice");
+        await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Sub B",
+            NetworkType = NetworkType.PPO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+            ParentOrganizationId = parent.OrganizationId,
+        }, "alice");
+        await svc.CreateAndActivateAsync(new Organization
+        {
+            TenantId = TenantId,
+            Name = "Unrelated",
+            NetworkType = NetworkType.HMO,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            EffectiveDate = DateTime.UtcNow.Date,
+        }, "alice");
+
+        var children = await svc.GetByParentAsync(parent.OrganizationId);
+
+        children.Should().HaveCount(2);
+        children.All(o => o.ParentOrganizationId == parent.OrganizationId).Should().BeTrue();
+    }
+
+    private static (IOrganizationService Service, InMemoryOrganizationRepository Repo) NewService()
+    {
+        var repo = new InMemoryOrganizationRepository { TenantId = TenantId };
+        var svc = new OrganizationService(repo, NullLogger<OrganizationService>.Instance);
+        return (svc, repo);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces an `Organization` entity in `provider-service` representing a payer-defined network as a first-class concept — distinct from a `Provider` with `ProviderType=Organization` (which is a single facility). The entity is FHIR-aligned (Identifiers, partOf via `ParentOrganizationId`, Period, Contact) so that capability 5.5 (Network Tiers) and the FHIR projections in 5.7+ can consume the same record without translation.

- **Models** — `Organization`, `NetworkType` (PR #705 enum pattern: `Unknown=0`, explicit ints, `JsonStringEnumConverter`), `OrganizationVersionState`, `OrganizationVersionId` (ULID), `OrganizationIdentifier`, `OrganizationContactInfo`, `OrganizationStatus`. Full version-chain identity matching capability 5.1.
- **Repositories** — `OrganizationRepository` (Cosmos) + `OrganizationRepositoryMongo`, with hydration, tenant-partitioned reads, version-chain operations, and indexes for partOf hierarchy traversal.
- **Service** — `OrganizationService` façade: create + activate v1, update (amend → activate, supersedes prior head), terminate (soft-delete via versioning), list, `GetByParent` for partOf traversal.
- **Adapters** — `IOrganizationAdapter` mirrors `IProviderAdapter`; `OrganizationAdapterFactory` reuses `ProviderTenantConfigCache` so the two adapter families share TTL on a single tenant-config call. `ChoOrganizationAdapter` is a pass-through; `QnxtOrganizationAdapter` and `FacetsOrganizationAdapter` are stubs throwing `NotImplementedException` with `TODO(qnxt-organization)` / `TODO(facets-organization)` markers pointing at the new architecture doc.
- **REST** — `NetworksController` exposes `GET /api/v1/networks`, `GET /{id}`, `GET /{id}/children`, `POST`, `PUT`, `DELETE` (soft-delete via terminate).
- **Tests** — `InMemoryOrganizationRepository` fake, CHO adapter regressions, stub adapter contract tests, factory routing tests with mocked tenant-service, service lifecycle tests covering CRUD + partOf hierarchy + version-chain semantics.
- **Docs** — `docs/architecture/network-as-organization.md`.

## Hand-off

Once this lands, `benefit-plan-service` capability 5.5 (Network Tiers + FHIR `Organization`) is unblocked: `NetworkTier` records can reference an `Organization` by id through the new `IOrganizationAdapter` contract.

## Test plan

- [ ] `dotnet build src/services/provider-service/provider-service.csproj`
- [ ] `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — all existing tests still pass; new test classes pass:
  - [ ] `OrganizationServiceTests` (CRUD, supersede on update, terminate, partOf, list returns one row per chain)
  - [ ] `ChoOrganizationAdapterTests` (pass-through, filters)
  - [ ] `StubOrganizationAdaptersTests` (NotImplementedException with TODO markers)
  - [ ] `OrganizationAdapterFactoryTests` (cho fallback, qnxt routing)
- [ ] Smoke-test `POST /api/v1/networks` → `GET /api/v1/networks/{id}` → `PUT /api/v1/networks/{id}` → `DELETE /api/v1/networks/{id}` round-trip via Swagger.
- [ ] Verify partOf traversal: create parent + 2 children, `GET /api/v1/networks/{parentId}/children` returns the two children.

https://claude.ai/code/session_01W7SdrqJa875hKLVNcssxyu

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7SdrqJa875hKLVNcssxyu)_