### PR TITLE
Network Roster API

### DIFF
--- a/docs/architecture/network-roster-api.md
+++ b/docs/architecture/network-roster-api.md
@@ -1,0 +1,272 @@
+# Network Roster API (Capability 5.4)
+
+## Why
+
+Capability 5.3 introduced `Organization` as the first-class network entity
+(see `network-as-organization.md`). 5.4 turns that entity into something
+operationally useful: **for a given network, return the providers that
+participate in it**, with the filters payer ops actually use day-to-day.
+
+Until now there was no roster endpoint. Provider directory lookups went
+through `GET /api/v1/providers/search` with a `planId` filter, which
+worked only when callers happened to know plan IDs. The new endpoint
+operates at the network level — the same level callers reason about
+when they ask "who's in this product?".
+
+## Endpoint
+
+```
+GET /api/v1/networks/{id}/roster
+```
+
+`{id}` is the chain key (`Organization.OrganizationId`) — never a
+per-version `Id`.
+
+### Query parameters
+
+| Name | Type | Notes |
+|------|------|-------|
+| `lineOfBusiness` | enum | Filters participations matching this LOB. |
+| `specialty` | string | NUCC taxonomy code or specialty substring. Case-insensitive match against `PrimarySpecialty` and `TaxonomyCode`. |
+| `tier` | string | Network tier exact match (e.g. `Tier1`). |
+| `acceptingNewPatients` | bool | Filters both the provider flag and the matched participation. |
+| `asOfDate` | datetime | Snapshot date. Defaults to `DateTime.UtcNow`. |
+| `page` | int | 1-based. Used only when `cursor` is null. |
+| `pageSize` | int | Defaults to **100**, hard cap **1000** (`Math.Clamp`). |
+| `sortBy` | string | `name` (default) or `integrityScore`. `distance` is reserved — see "Deferred — distance sort". |
+| `sortDirection` | string | `asc` or `desc`. Default depends on `sortBy`. |
+| `cursor` | string | Opaque pagination token from a prior response's `nextCursor`. Overrides `page`. |
+
+Filters AND-combine. `asOfDate` applies to both the provider chain (the
+matched row must have `(TerminationDate is null OR TerminationDate >= asOf)`)
+and the matching participation (`EffectiveDate <= asOf` AND
+`(TerminationDate is null OR TerminationDate >= asOf)`).
+
+### Response shape
+
+```jsonc
+{
+  "items": [
+    {
+      "providerId": "p-...",
+      "versionId": "...",
+      "provider": {
+        "npi": "1234567890",
+        "providerType": "Individual",
+        "displayName": "Test Adams MD",
+        "primarySpecialty": "207R00000X",
+        "taxonomyCode": "207R00000X",
+        "address": "...",
+        "city": "...",
+        "state": "FL",
+        "zipCode": "33101",
+        "acceptingNewPatients": true
+      },
+      "participation": {
+        "planId": "...",
+        "lineOfBusiness": "Medicare",
+        "networkTier": "Tier1",
+        "acceptingNewPatients": true,
+        "effectiveDate": "2024-01-01T00:00:00Z",
+        "terminationDate": null,
+        "panelGating": {
+          "panelLimit": 1500,
+          "panelAccepted": false,
+          "acceptedLobs": ["Medicare"],
+          "minAcceptedAgeYears": 18,
+          "maxAcceptedAgeYears": 64
+        }
+      },
+      "integrityScore": {
+        "score": 88,
+        "rating": "Clear",
+        "lastVerifiedAt": "2025-01-01T00:00:00Z"
+      }
+    }
+  ],
+  "nextCursor": "eyJPZmZ...",
+  "pageSize": 100
+}
+```
+
+### Status codes
+
+| Code | When |
+|------|------|
+| `200` | Success. |
+| `400` | Cursor invalid / cursor filter mismatch / unsupported `sortBy` / `sortBy=distance`. Body is `{ error, message }`. |
+| `404` | Network does not exist in the caller's tenant. |
+
+## Tenant scope
+
+Roster results only include providers in the same tenant as the network.
+Two layers enforce this:
+
+1. The controller asserts `network = OrganizationService.GetByIdAsync(id)`
+   under the request's `TenantId` — a foreign tenant's network 404s
+   before the provider collection is touched.
+2. `IProviderRepository.ListNetworkRosterAsync` always passes
+   `TenantId = query.TenantId` into every backend query (Cosmos partition
+   key, Mongo filter equality).
+
+## Linkage: how a provider appears in a roster
+
+A provider participates in a network when they have at least one
+`NetworkParticipation` row with `NetworkId == OrganizationId`. The
+`NetworkId` field was added in this capability; legacy participations
+written before 5.4 carry no link to the `Organization` chain.
+
+> **Migration semantic.** Legacy participations without `NetworkId` are
+> **invisible to `GET /api/v1/networks/{id}/roster` by design** — this is
+> the expected behavior, not a bug. Plan-level lookups
+> (`GET /api/v1/providers/search?planId=...`) keep working unchanged.
+> The migration path is **per-tenant backfill**: as `Organization` rows
+> are authored, the responsible team (network ops) populates
+> `NetworkParticipation.NetworkId` against existing provider records.
+> No automated backfill ships in this PR — that's a separate task driven
+> by tenant onboarding readiness.
+
+## Sort orders
+
+| `sortBy` | Direction | Behaviour |
+|----------|-----------|-----------|
+| `name` | `asc` (default) / `desc` | Sorts by `lastName`, then `organizationName`, then `id` for stability. |
+| `integrityScore` | `desc` (folded) | Highest score first. **Nulls last.** Any explicit direction is folded to `desc` (ascending makes no operational sense). |
+| `distance` | — | **Deferred** — see below. Returns 400 with `error=distance_sort_unsupported`. |
+
+### Nulls-last for `integrityScore`
+
+Cosmos and Mongo disagree on null sort order on descending. The
+repository emits a deterministic backend-native order; the service then
+reorders the page-sized slice to push providers with no
+`IntegrityScore` to the tail. Implemented in
+`NetworkRosterService.ApplyNullsLastForIntegrityScore`.
+
+## Pagination cursor
+
+Cursor is **opaque** and URL-safe base64 of:
+
+```jsonc
+{ "Offset": 100, "AsOfDate": "...", "FilterHash": "ab12..." }
+```
+
+**Filter-hash binding.** `FilterHash` is the SHA-256/128-bit hex of the
+canonicalized filter set + sort. Reusing a cursor with mutated filters
+returns 400 (`cursor_filter_mismatch`) — callers must restart from page
+1 when filters change.
+
+`AsOfDate` is locked into the cursor on first decode so re-paging
+doesn't drift if the wall clock advances between pages.
+
+A short page (items count < `pageSize`) implies the result set is
+exhausted; `nextCursor` is null. We don't peek ahead — the price is one
+spurious empty round-trip when the total is exactly a multiple of
+`pageSize`. Trade-off documented; revisit if it shows up in metrics.
+
+## Performance
+
+Target: **P95 < 400 ms** for standard pagination (100-row page,
+single-network filter, partition-scoped query).
+
+Backing this:
+
+- Cosmos: queries are partition-scoped on `TenantId`. The
+  `EXISTS(... networkParticipations WHERE n.networkId = @networkId)`
+  pattern matches the existing `c.networkParticipations` array shape
+  used by `SearchAsync` and is multikey-covered.
+- Mongo: a new compound index
+  `(TenantId, NetworkParticipations.NetworkId)` is provisioned by
+  `ProviderRepositoryMongo.CreateIndexes()`. The common
+  `(network + tier)` combo is covered by an additional
+  `(TenantId, NetworkParticipations.NetworkId, NetworkParticipations.NetworkTier)`
+  index.
+
+The roster path **never** invokes
+`ProviderVerificationOrchestrator`. `IntegrityScore` is read directly
+from the cached column on the Provider row. This satisfies the "no
+real-time multi-source call on the roster query path" constraint.
+
+## Known gap — verification write-back
+
+`Provider.IntegrityScore`, `IntegrityRating`, and `LastVerifiedAt` exist
+as columns on the Provider entity (see `Models/Provider.cs`). They are
+**not** currently written by `provider-verification-service` —
+verification runs end-to-end and exposes the score via a live HTTP
+endpoint, but no path persists the score back onto the Provider row.
+
+Practical impact for this endpoint: until verification write-back lands,
+`integrityScore` is `null` for ~all roster rows. The nulls-last sort
+handles it gracefully; the field surface is forward-compatible.
+
+Tracked as a separate capability — see the verification roadmap. A
+candidate implementation:
+
+1. Add a hosted projection in `provider-service` that subscribes to
+   verification events and patches `Provider.IntegrityScore` /
+   `IntegrityRating` / `LastVerifiedAt` on the head Active version.
+2. Or extend `provider-verification-service` to call back into
+   `provider-service` after each verification.
+
+Either approach is out of scope for 5.4.
+
+## Deferred — distance sort
+
+`sortBy=distance` is reserved but **not yet supported**. The roster
+endpoint returns `400 distance_sort_unsupported` when called.
+
+Reason: a meaningful "distance" sort needs a geospatial index on
+provider addresses (`Cosmos geospatial query` / `Mongo 2dsphere`). An
+in-memory implementation that pulls a candidate window and sorts
+client-side has scaling limits (large networks won't fit the window)
+and correctness gaps (the ordering is wrong as soon as the window
+truncates results below the desired cut-off).
+
+Follow-up plan:
+
+1. Add `lat`/`lng` (or geocoded `nearZip`) on `NetworkRosterQuery`.
+2. Add a `GeoPoint` projection on `Provider` (lat/lng for the practice
+   address), populated by the address-validation pipeline.
+3. Provision Cosmos geospatial index / Mongo 2dsphere on that field.
+4. Extend `ListNetworkRosterAsync` to accept a geo predicate and emit a
+   distance projection on each row (`DistanceMiles`).
+5. Lift the `400 distance_sort_unsupported` guard.
+
+Tracked separately to keep this PR focused on the roster surface.
+
+## Storage indices
+
+Mongo (added in this PR):
+
+```
+(TenantId, NetworkParticipations.NetworkId)
+(TenantId, NetworkParticipations.NetworkId, NetworkParticipations.NetworkTier)
+```
+
+Cosmos: relies on the default container indexing policy (full indexing
+on all properties) plus partition-scoped queries. No new index
+provisioning required.
+
+## Testing
+
+Coverage in `tests/CloudHealthOffice.ProviderService.Tests/Services`:
+
+- `NetworkRosterServiceTests` — paging across cursor pages, filter
+  composition (LOB + specialty + acceptingNewPatients), `asOfDate`
+  edges, tenant isolation, sort orders, page-size clamping, panel
+  gating projection, integrity envelope projection, terminated chain
+  exclusion, multi-participation row selection, cursor-mismatch
+  rejection, invalid-cursor handling.
+- `NetworkRosterCursorTests` — filter-hash stability + divergence,
+  `ResolveSort` table, nulls-last reordering helper.
+
+The in-memory `InMemoryProviderRepository` implements the same contract
+(`ListNetworkRosterAsync`) so tests run without spinning Cosmos or
+Mongo.
+
+## Capability hand-off
+
+- benefit-plan-service can now render network rosters under a
+  `BenefitPlan.NetworkTier` reference (capability 5.5) by joining the
+  tier's `NetworkId` against this endpoint.
+- FHIR projections (5.7+) can render `PractitionerRole` collections
+  scoped to a network using the same query path.

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -130,31 +130,14 @@ public class NetworksController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<NetworkRosterResponse>> GetRoster(
         string id,
-        [FromQuery] LineOfBusiness? lineOfBusiness = null,
-        [FromQuery] string? specialty = null,
-        [FromQuery] string? tier = null,
-        [FromQuery] bool? acceptingNewPatients = null,
-        [FromQuery] DateTime? asOfDate = null,
-        [FromQuery] int page = 1,
-        [FromQuery] int pageSize = NetworkRosterDefaults.DefaultPageSize,
-        [FromQuery] string? sortBy = null,
-        [FromQuery] string? sortDirection = null,
-        [FromQuery] string? cursor = null,
+        [FromQuery] NetworkRosterQuery query,
         CancellationToken ct = default)
     {
-        // Length guards on the raw query-string values. ASP.NET binds
-        // these as scalar parameters, so the [StringLength] attributes
-        // on NetworkRosterQuery don't apply via [ApiController]
-        // validation. We reject oversized inputs explicitly to keep
-        // log volume and downstream regex / SQL evaluation bounded.
-        if (TryRejectOversize(specialty, 50, "specialty", out var problem)
-            || TryRejectOversize(tier, 20, "tier", out problem)
-            || TryRejectOversize(sortBy, 32, "sortBy", out problem)
-            || TryRejectOversize(sortDirection, 8, "sortDirection", out problem)
-            || TryRejectOversize(cursor, 2048, "cursor", out problem))
-        {
-            return BadRequest(problem);
-        }
+        // [ApiController] runs [StringLength] / [Range] validation on the
+        // bound DTO before this action body executes, so oversized or
+        // out-of-range inputs are already rejected with a 400 at that
+        // point. TenantId and NetworkId carry [BindNever] and are set
+        // from context / route here — never from the wire.
 
         // Tenant-scope guard: if the network isn't in this tenant we 404
         // before touching the provider collection. The OrganizationService
@@ -165,24 +148,8 @@ public class NetworksController : ControllerBase
             return NotFound(new { message = $"Network {id} not found" });
         }
 
-        var query = new NetworkRosterQuery
-        {
-            TenantId = TenantId,
-            NetworkId = id,
-            LineOfBusiness = lineOfBusiness,
-            Specialty = specialty,
-            Tier = tier,
-            AcceptingNewPatients = acceptingNewPatients,
-            AsOfDate = asOfDate,
-            Page = page <= 0 ? 1 : page,
-            PageSize = Math.Clamp(
-                pageSize <= 0 ? NetworkRosterDefaults.DefaultPageSize : pageSize,
-                1,
-                NetworkRosterDefaults.MaxPageSize),
-            SortBy = sortBy,
-            SortDirection = sortDirection,
-            Cursor = cursor,
-        };
+        query.TenantId = TenantId;
+        query.NetworkId = id;
 
         try
         {
@@ -285,22 +252,6 @@ public class NetworksController : ControllerBase
     {
         if (string.IsNullOrEmpty(value)) return string.Empty;
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
-    }
-
-    private static bool TryRejectOversize(string? value, int maxLength, string fieldName, out object problem)
-    {
-        if (value != null && value.Length > maxLength)
-        {
-            problem = new
-            {
-                error = "value_too_long",
-                field = fieldName,
-                message = $"'{fieldName}' exceeds the {maxLength}-character limit.",
-            };
-            return true;
-        }
-        problem = null!;
-        return false;
     }
 }
 

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -19,15 +19,18 @@ public class NetworksController : ControllerBase
 {
     private readonly IOrganizationService _service;
     private readonly OrganizationAdapterFactory _adapterFactory;
+    private readonly INetworkRosterService _rosterService;
     private readonly ILogger<NetworksController> _logger;
 
     public NetworksController(
         IOrganizationService service,
         OrganizationAdapterFactory adapterFactory,
+        INetworkRosterService rosterService,
         ILogger<NetworksController> logger)
     {
         _service = service;
         _adapterFactory = adapterFactory;
+        _rosterService = rosterService;
         _logger = logger;
     }
 
@@ -111,6 +114,74 @@ public class NetworksController : ControllerBase
         });
 
         return Ok(response.Organizations.Select(o => o.ToOrganization()));
+    }
+
+    /// <summary>
+    /// Paginated, filterable roster of providers in this network
+    /// (capability 5.4). Filters AND-combine. <c>asOfDate</c> selects a
+    /// snapshot date — both the provider chain and the participation
+    /// must be in effect on that date. Tenant scope is enforced by the
+    /// repository — the roster only includes providers in the same
+    /// tenant as the network.
+    /// </summary>
+    [HttpGet("{id}/roster")]
+    [ProducesResponseType(typeof(NetworkRosterResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<NetworkRosterResponse>> GetRoster(
+        string id,
+        [FromQuery] LineOfBusiness? lineOfBusiness = null,
+        [FromQuery] string? specialty = null,
+        [FromQuery] string? tier = null,
+        [FromQuery] bool? acceptingNewPatients = null,
+        [FromQuery] DateTime? asOfDate = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = NetworkRosterDefaults.DefaultPageSize,
+        [FromQuery] string? sortBy = null,
+        [FromQuery] string? sortDirection = null,
+        [FromQuery] string? cursor = null,
+        CancellationToken ct = default)
+    {
+        // Tenant-scope guard: if the network isn't in this tenant we 404
+        // before touching the provider collection. The OrganizationService
+        // honors the tenant context via IHttpContextAccessor.
+        var network = await _service.GetByIdAsync(id);
+        if (network == null)
+        {
+            return NotFound(new { message = $"Network {id} not found" });
+        }
+
+        var query = new NetworkRosterQuery
+        {
+            TenantId = TenantId,
+            NetworkId = id,
+            LineOfBusiness = lineOfBusiness,
+            Specialty = specialty,
+            Tier = tier,
+            AcceptingNewPatients = acceptingNewPatients,
+            AsOfDate = asOfDate,
+            Page = page <= 0 ? 1 : page,
+            PageSize = Math.Clamp(
+                pageSize <= 0 ? NetworkRosterDefaults.DefaultPageSize : pageSize,
+                1,
+                NetworkRosterDefaults.MaxPageSize),
+            SortBy = sortBy,
+            SortDirection = sortDirection,
+            Cursor = cursor,
+        };
+
+        try
+        {
+            var response = await _rosterService.GetRosterAsync(query, ct);
+            return Ok(response);
+        }
+        catch (NetworkRosterValidationException ex)
+        {
+            _logger.LogInformation(
+                "Roster query rejected: code={Code} network={Network} tenant={Tenant}",
+                ex.ErrorCode, SanitizeForLog(id), SanitizeForLog(TenantId));
+            return BadRequest(new { error = ex.ErrorCode, message = ex.Message });
+        }
     }
 
     /// <summary>Create a new network. Activates v1 in one shot.</summary>

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -142,6 +142,20 @@ public class NetworksController : ControllerBase
         [FromQuery] string? cursor = null,
         CancellationToken ct = default)
     {
+        // Length guards on the raw query-string values. ASP.NET binds
+        // these as scalar parameters, so the [StringLength] attributes
+        // on NetworkRosterQuery don't apply via [ApiController]
+        // validation. We reject oversized inputs explicitly to keep
+        // log volume and downstream regex / SQL evaluation bounded.
+        if (TryRejectOversize(specialty, 50, "specialty", out var problem)
+            || TryRejectOversize(tier, 20, "tier", out problem)
+            || TryRejectOversize(sortBy, 32, "sortBy", out problem)
+            || TryRejectOversize(sortDirection, 8, "sortDirection", out problem)
+            || TryRejectOversize(cursor, 2048, "cursor", out problem))
+        {
+            return BadRequest(problem);
+        }
+
         // Tenant-scope guard: if the network isn't in this tenant we 404
         // before touching the provider collection. The OrganizationService
         // honors the tenant context via IHttpContextAccessor.
@@ -271,6 +285,22 @@ public class NetworksController : ControllerBase
     {
         if (string.IsNullOrEmpty(value)) return string.Empty;
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+
+    private static bool TryRejectOversize(string? value, int maxLength, string fieldName, out object problem)
+    {
+        if (value != null && value.Length > maxLength)
+        {
+            problem = new
+            {
+                error = "value_too_long",
+                field = fieldName,
+                message = $"'{fieldName}' exceeds the {maxLength}-character limit.",
+            };
+            return true;
+        }
+        problem = null!;
+        return false;
     }
 }
 

--- a/src/services/provider-service/Models/NetworkRosterEntry.cs
+++ b/src/services/provider-service/Models/NetworkRosterEntry.cs
@@ -1,0 +1,103 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Single row in the <c>GET /api/v1/networks/{id}/roster</c> response.
+/// Composed from the matching <see cref="Provider"/> and the specific
+/// <see cref="NetworkParticipation"/> that linked the provider to the
+/// roster's network.
+/// </summary>
+public sealed class NetworkRosterEntry
+{
+    /// <summary>Provider chain key.</summary>
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>Per-version document id of the head Active version.</summary>
+    public string VersionId { get; set; } = string.Empty;
+
+    /// <summary>Provider summary (NPI, name, specialty, address).</summary>
+    public RosterProviderSummary Provider { get; set; } = new();
+
+    /// <summary>The participation that matched the roster filter.</summary>
+    public RosterParticipationSummary Participation { get; set; } = new();
+
+    /// <summary>
+    /// Cached integrity score copied from <see cref="Models.Provider.IntegrityScore"/>.
+    /// Null when the provider has not yet been verified (or when
+    /// verification write-back has not run yet — see network-roster-api.md
+    /// "Known gap").
+    /// </summary>
+    public RosterIntegrityScore? IntegrityScore { get; set; }
+}
+
+/// <summary>
+/// Provider identity + display fields surfaced on a roster row.
+/// </summary>
+public sealed class RosterProviderSummary
+{
+    public string Npi { get; set; } = string.Empty;
+    public ProviderType ProviderType { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string PrimarySpecialty { get; set; } = string.Empty;
+    public string TaxonomyCode { get; set; } = string.Empty;
+    public string? Address { get; set; }
+    public string? City { get; set; }
+    public string? State { get; set; }
+    public string? ZipCode { get; set; }
+    public bool AcceptingNewPatients { get; set; }
+}
+
+/// <summary>
+/// Subset of <see cref="NetworkParticipation"/> safe to expose on the
+/// roster. Includes the panel-gating summary (PCP-assignment fields
+/// from capability 5.7 / pcp-assignment.md) when populated.
+/// </summary>
+public sealed class RosterParticipationSummary
+{
+    public string? PlanId { get; set; }
+    public LineOfBusiness LineOfBusiness { get; set; }
+    public string NetworkTier { get; set; } = string.Empty;
+    public bool AcceptingNewPatients { get; set; }
+    public DateTime EffectiveDate { get; set; }
+    public DateTime? TerminationDate { get; set; }
+    public RosterPanelGating? PanelGating { get; set; }
+}
+
+/// <summary>
+/// PCP-assignment panel-gating summary. Mirrors the nullable fields on
+/// <see cref="NetworkParticipation"/>. Null on the wire when every
+/// underlying field is null (fully unconstrained / not backfilled).
+/// </summary>
+public sealed class RosterPanelGating
+{
+    public int? PanelLimit { get; set; }
+    public bool? PanelAccepted { get; set; }
+    public List<LineOfBusiness>? AcceptedLobs { get; set; }
+    public int? MinAcceptedAgeYears { get; set; }
+    public int? MaxAcceptedAgeYears { get; set; }
+}
+
+/// <summary>
+/// Cached integrity-score envelope. Read directly from the Provider
+/// row — the roster path does not call <c>ProviderVerificationOrchestrator</c>.
+/// </summary>
+public sealed class RosterIntegrityScore
+{
+    public int? Score { get; set; }
+    public string? Rating { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+}
+
+/// <summary>Page envelope for the roster endpoint. Cursor-paginated.</summary>
+public sealed class NetworkRosterResponse
+{
+    public IReadOnlyList<NetworkRosterEntry> Items { get; set; } = Array.Empty<NetworkRosterEntry>();
+
+    /// <summary>
+    /// Opaque token to fetch the next page. Null when this page is the last.
+    /// Bound to the originating filter set via an internal hash; reusing
+    /// a cursor with different filters produces a 400.
+    /// </summary>
+    public string? NextCursor { get; set; }
+
+    public int PageSize { get; set; }
+}

--- a/src/services/provider-service/Models/NetworkRosterQuery.cs
+++ b/src/services/provider-service/Models/NetworkRosterQuery.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace ProviderService.Models;
 
@@ -6,16 +7,20 @@ namespace ProviderService.Models;
 /// Filters, paging, and sort applied to <c>GET /api/v1/networks/{id}/roster</c>.
 ///
 /// <para>
-/// Bound from the query string by ASP.NET model binding. The route's
-/// <c>{id}</c> populates <see cref="NetworkId"/>; remaining fields come
-/// from <c>?lineOfBusiness=...&amp;specialty=...</c>. <see cref="TenantId"/>
-/// is set by the controller from <c>HttpContext.Items["TenantId"]</c>
-/// — never trusted from the wire.
+/// Bound directly from the query string as a DTO via
+/// <c>[FromQuery] NetworkRosterQuery query</c> so that
+/// <c>[ApiController]</c> model validation enforces <see cref="StringLengthAttribute"/>
+/// and <see cref="RangeAttribute"/> constraints automatically. Server-side
+/// fields that must not be bound from the wire are annotated with
+/// <c>[BindNever]</c>: <see cref="TenantId"/> (set from
+/// <c>HttpContext.Items["TenantId"]</c>) and <see cref="NetworkId"/>
+/// (set from the <c>{id}</c> route segment).
 /// </para>
 /// </summary>
 public sealed class NetworkRosterQuery
 {
     /// <summary>Tenant scope. Set by the controller, not by the caller.</summary>
+    [BindNever]
     public string TenantId { get; set; } = string.Empty;
 
     /// <summary>
@@ -23,6 +28,7 @@ public sealed class NetworkRosterQuery
     /// roster is being requested for. Set from the route, not the query
     /// string.
     /// </summary>
+    [BindNever]
     public string NetworkId { get; set; } = string.Empty;
 
     /// <summary>Optional LOB filter. ANDed with all other filters.</summary>
@@ -59,7 +65,8 @@ public sealed class NetworkRosterQuery
 
     /// <summary>
     /// Page size. Defaults to 100 (set in <c>NetworkRosterDefaults</c>);
-    /// hard cap of 1000 enforced by the controller via <c>Math.Clamp</c>.
+    /// hard cap of 1000 enforced via <see cref="RangeAttribute"/> by
+    /// <c>[ApiController]</c> model validation.
     /// </summary>
     [Range(1, 1000)]
     public int PageSize { get; set; } = NetworkRosterDefaults.DefaultPageSize;

--- a/src/services/provider-service/Models/NetworkRosterQuery.cs
+++ b/src/services/provider-service/Models/NetworkRosterQuery.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Filters, paging, and sort applied to <c>GET /api/v1/networks/{id}/roster</c>.
+///
+/// <para>
+/// Bound from the query string by ASP.NET model binding. The route's
+/// <c>{id}</c> populates <see cref="NetworkId"/>; remaining fields come
+/// from <c>?lineOfBusiness=...&amp;specialty=...</c>. <see cref="TenantId"/>
+/// is set by the controller from <c>HttpContext.Items["TenantId"]</c>
+/// — never trusted from the wire.
+/// </para>
+/// </summary>
+public sealed class NetworkRosterQuery
+{
+    /// <summary>Tenant scope. Set by the controller, not by the caller.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Network chain key (<see cref="Organization.OrganizationId"/>) the
+    /// roster is being requested for. Set from the route, not the query
+    /// string.
+    /// </summary>
+    public string NetworkId { get; set; } = string.Empty;
+
+    /// <summary>Optional LOB filter. ANDed with all other filters.</summary>
+    public LineOfBusiness? LineOfBusiness { get; set; }
+
+    /// <summary>
+    /// NUCC taxonomy code or specialty substring. Matches case-insensitively
+    /// against <see cref="Provider.PrimarySpecialty"/> and
+    /// <see cref="Provider.TaxonomyCode"/>.
+    /// </summary>
+    [StringLength(50)]
+    public string? Specialty { get; set; }
+
+    /// <summary>Network tier exact match (e.g. <c>Tier1</c>).</summary>
+    [StringLength(20)]
+    public string? Tier { get; set; }
+
+    /// <summary>When set, restricts to participations matching the flag.</summary>
+    public bool? AcceptingNewPatients { get; set; }
+
+    /// <summary>
+    /// Snapshot date. When supplied, the roster includes only providers
+    /// whose latest Active version is in effect on this date AND whose
+    /// matching <see cref="NetworkParticipation"/> has
+    /// <c>EffectiveDate &lt;= AsOfDate</c> AND
+    /// <c>(TerminationDate is null OR TerminationDate &gt;= AsOfDate)</c>.
+    /// Defaults to <see cref="DateTime.UtcNow"/> when null.
+    /// </summary>
+    public DateTime? AsOfDate { get; set; }
+
+    /// <summary>1-based page index. Used only when <see cref="Cursor"/> is null.</summary>
+    [Range(1, int.MaxValue)]
+    public int Page { get; set; } = 1;
+
+    /// <summary>
+    /// Page size. Defaults to 100 (set in <c>NetworkRosterDefaults</c>);
+    /// hard cap of 1000 enforced by the controller via <c>Math.Clamp</c>.
+    /// </summary>
+    [Range(1, 1000)]
+    public int PageSize { get; set; } = NetworkRosterDefaults.DefaultPageSize;
+
+    /// <summary>
+    /// Sort selector. Accepts <c>name</c> (default) or <c>integrityScore</c>.
+    /// <c>distance</c> is reserved but not yet supported — the controller
+    /// returns 400 with a "not yet supported" message; see
+    /// <c>docs/architecture/network-roster-api.md</c> for the planned
+    /// geospatial-index treatment.
+    /// </summary>
+    [StringLength(32)]
+    public string? SortBy { get; set; }
+
+    /// <summary>Sort direction. <c>asc</c> or <c>desc</c>. Default depends on <see cref="SortBy"/>.</summary>
+    [StringLength(8)]
+    public string? SortDirection { get; set; }
+
+    /// <summary>
+    /// Opaque pagination cursor. When supplied, overrides
+    /// <see cref="Page"/>. The cursor is bound to the rest of the query
+    /// via a filter hash; mismatched filters → 400.
+    /// </summary>
+    [StringLength(2048)]
+    public string? Cursor { get; set; }
+}
+
+/// <summary>
+/// Defaults and limits for the network roster endpoint, kept in one place
+/// so controller, service, and tests share them.
+/// </summary>
+public static class NetworkRosterDefaults
+{
+    public const int DefaultPageSize = 100;
+    public const int MaxPageSize = 1000;
+    public const string SortByName = "name";
+    public const string SortByIntegrityScore = "integrityScore";
+    public const string SortByDistance = "distance";
+    public const string DirectionAsc = "asc";
+    public const string DirectionDesc = "desc";
+}
+
+/// <summary>
+/// Resolved sort selector after defaulting + validation. Kept separate
+/// from the wire-shape <see cref="NetworkRosterQuery"/> so the service
+/// layer never has to re-parse strings.
+/// </summary>
+public enum NetworkRosterSort
+{
+    NameAsc,
+    NameDesc,
+    IntegrityScoreDesc,
+}

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -349,6 +349,24 @@ public class NetworkParticipation
     public string? PlanId { get; set; }
 
     /// <summary>
+    /// Stable chain key of the <see cref="Organization"/> network this
+    /// participation is contracted under (capability 5.3 / 5.4). References
+    /// <see cref="Organization.OrganizationId"/> — never a per-version <c>Id</c>.
+    ///
+    /// <para>
+    /// Nullable for backward compatibility with participations written
+    /// before capability 5.4. Legacy participations without
+    /// <c>NetworkId</c> are <b>invisible</b> to <c>GET /api/v1/networks/{id}/roster</c>
+    /// by design; the migration path is per-tenant backfill as
+    /// <see cref="Organization"/> rows are authored. Plan-level lookups
+    /// (filter on <see cref="PlanId"/> / <see cref="LineOfBusiness"/>)
+    /// continue to work unchanged.
+    /// </para>
+    /// </summary>
+    [StringLength(64)]
+    public string? NetworkId { get; set; }
+
+    /// <summary>
     /// Line of Business
     /// </summary>
     [Required]

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -111,6 +111,12 @@ builder.Services.AddScoped<IOrganizationAdapter, QnxtOrganizationAdapter>();
 builder.Services.AddScoped<IOrganizationAdapter, FacetsOrganizationAdapter>();
 builder.Services.AddScoped<OrganizationAdapterFactory>();
 
+// Network roster (5.4 — paginated, filterable provider roster scoped to
+// a single Organization). Reads cached IntegrityScore directly from the
+// Provider row; never invokes ProviderVerificationOrchestrator on the
+// read path.
+builder.Services.AddScoped<INetworkRosterService, NetworkRosterService>();
+
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();
 

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -417,11 +417,11 @@ public class ProviderRepository : IProviderRepository
             // "Active" matches three shapes (mirrors Hydrate()):
             //   1. versionState == Active (current versioned shape)
             //   2. versionState absent (legacy)
-            //   3. versionId missing/empty AND status == 'Active' (legacy
+            //   3. versionId missing/null/empty AND status == 'Active' (legacy
             //      row where versionState defaulted to enum-zero on read)
             // Without (3) these legacy rows would be wrongly excluded.
             "(c.versionState = @active OR NOT IS_DEFINED(c.versionState) " +
-                "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = \"\") AND c.status = @statusActive))",
+                "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive))",
             "(NOT IS_DEFINED(c.terminationDate) OR c.terminationDate = null OR c.terminationDate >= @asOf)",
             existsClause,
         };
@@ -444,10 +444,13 @@ public class ProviderRepository : IProviderRepository
             NetworkRosterSort.NameDesc =>
                 "ORDER BY c.lastName DESC, c.organizationName DESC, c.id DESC",
             NetworkRosterSort.IntegrityScoreDesc =>
-                // Cosmos puts nulls before non-nulls on DESC; folding
-                // IS_DEFINED to a 0/1 sort key inverts that so unverified
-                // rows trail the head of the page (nulls-last semantics).
-                "ORDER BY (IS_DEFINED(c.integrityScore) ? 1 : 0) DESC, c.integrityScore DESC, c.id ASC",
+                // Cosmos can store integrityScore as null (field present
+                // but null) or absent entirely. IS_DEFINED returns 1 for
+                // both cases when null; IS_NUMBER returns true only for
+                // actual numeric values so providers with null or missing
+                // scores get hasScore=0 and sort last — nulls-last before
+                // the OFFSET/LIMIT clause.
+                "ORDER BY (IS_NUMBER(c.integrityScore) ? 1 : 0) DESC, c.integrityScore DESC, c.id ASC",
             _ =>
                 "ORDER BY c.lastName ASC, c.organizationName ASC, c.id ASC",
         };

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -379,6 +379,7 @@ public class ProviderRepository : IProviderRepository
             ("@tenantId", query.TenantId),
             ("@networkId", query.NetworkId),
             ("@active", ProviderVersionState.Active.ToString()),
+            ("@statusActive", ProviderStatus.Active.ToString()),
             ("@asOf", asOf),
         };
 
@@ -413,7 +414,14 @@ public class ProviderRepository : IProviderRepository
         var conditions = new List<string>
         {
             "c.tenantId = @tenantId",
-            "(NOT IS_DEFINED(c.versionState) OR c.versionState = @active)",
+            // "Active" matches three shapes (mirrors Hydrate()):
+            //   1. versionState == Active (current versioned shape)
+            //   2. versionState absent (legacy)
+            //   3. versionId missing/empty AND status == 'Active' (legacy
+            //      row where versionState defaulted to enum-zero on read)
+            // Without (3) these legacy rows would be wrongly excluded.
+            "(c.versionState = @active OR NOT IS_DEFINED(c.versionState) " +
+                "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = \"\") AND c.status = @statusActive))",
             "(NOT IS_DEFINED(c.terminationDate) OR c.terminationDate = null OR c.terminationDate >= @asOf)",
             existsClause,
         };

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -28,6 +28,27 @@ public interface IProviderRepository
     Task<Provider> UpdateAsync(Provider provider);
     Task DeleteAsync(string id);
 
+    /// <summary>
+    /// Backing query for <c>GET /api/v1/networks/{id}/roster</c>. Matches
+    /// the latest non-Draft head row for each provider in the tenant that
+    /// has a <see cref="NetworkParticipation"/> with
+    /// <c>NetworkId == query.NetworkId</c> AND every other supplied filter
+    /// AND (when <c>AsOfDate</c> is set) a participation period covering
+    /// that date. Sort + paging are applied at the repository layer so
+    /// the service never has to re-page.
+    ///
+    /// <para>
+    /// <paramref name="skip"/> is the offset already decoded from the
+    /// caller's cursor. The repository returns at most <c>pageSize</c>
+    /// rows.
+    /// </para>
+    /// </summary>
+    Task<IReadOnlyList<Provider>> ListNetworkRosterAsync(
+        NetworkRosterQuery query,
+        NetworkRosterSort sort,
+        int skip,
+        CancellationToken ct = default);
+
     // ---- Version-chain operations ------------------------------------
 
     /// <summary>
@@ -333,6 +354,125 @@ public class ProviderRepository : IProviderRepository
     {
         var tenantId = GetTenantId();
         await _container.DeleteItemAsync<Provider>(id, new PartitionKey(tenantId));
+    }
+
+    public async Task<IReadOnlyList<Provider>> ListNetworkRosterAsync(
+        NetworkRosterQuery query,
+        NetworkRosterSort sort,
+        int skip,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(query.TenantId))
+            throw new ArgumentException("NetworkRosterQuery.TenantId is required.", nameof(query));
+        if (string.IsNullOrEmpty(query.NetworkId))
+            throw new ArgumentException("NetworkRosterQuery.NetworkId is required.", nameof(query));
+
+        // Defensive clamp; the controller already enforces this. Skipping
+        // negative offsets prevents accidental SQL injection via the
+        // OFFSET/LIMIT literals below (we accept only int values).
+        var effectivePageSize = Math.Clamp(query.PageSize, 1, NetworkRosterDefaults.MaxPageSize);
+        var safeSkip = Math.Max(skip, 0);
+        var asOf = (query.AsOfDate ?? DateTime.UtcNow).ToUniversalTime();
+
+        var parameters = new List<(string Name, object Value)>
+        {
+            ("@tenantId", query.TenantId),
+            ("@networkId", query.NetworkId),
+            ("@active", ProviderVersionState.Active.ToString()),
+            ("@asOf", asOf),
+        };
+
+        // Participation-level filters live inside an EXISTS subquery so a
+        // single row matches when at least one participation satisfies
+        // every supplied filter. Provider-level filters stay on the outer.
+        var participationConditions = new List<string>
+        {
+            "n.networkId = @networkId",
+            "(NOT IS_DEFINED(n.effectiveDate) OR n.effectiveDate <= @asOf)",
+            "(NOT IS_DEFINED(n.terminationDate) OR n.terminationDate = null OR n.terminationDate >= @asOf)",
+        };
+        if (query.LineOfBusiness.HasValue)
+        {
+            participationConditions.Add("n.lineOfBusiness = @lineOfBusiness");
+            parameters.Add(("@lineOfBusiness", query.LineOfBusiness.Value.ToString()));
+        }
+        if (!string.IsNullOrEmpty(query.Tier))
+        {
+            participationConditions.Add("n.networkTier = @tier");
+            parameters.Add(("@tier", query.Tier));
+        }
+        if (query.AcceptingNewPatients.HasValue)
+        {
+            participationConditions.Add("n.acceptingNewPatients = @participationAcceptingNew");
+            parameters.Add(("@participationAcceptingNew", query.AcceptingNewPatients.Value));
+        }
+
+        var existsClause =
+            $"EXISTS(SELECT VALUE n FROM n IN c.networkParticipations WHERE {string.Join(" AND ", participationConditions)})";
+
+        var conditions = new List<string>
+        {
+            "c.tenantId = @tenantId",
+            "(NOT IS_DEFINED(c.versionState) OR c.versionState = @active)",
+            "(NOT IS_DEFINED(c.terminationDate) OR c.terminationDate = null OR c.terminationDate >= @asOf)",
+            existsClause,
+        };
+
+        if (!string.IsNullOrEmpty(query.Specialty))
+        {
+            conditions.Add(
+                "(CONTAINS(LOWER(c.primarySpecialty), LOWER(@specialty)) OR CONTAINS(LOWER(c.taxonomyCode), LOWER(@specialty)))");
+            parameters.Add(("@specialty", query.Specialty));
+        }
+
+        if (query.AcceptingNewPatients.HasValue)
+        {
+            conditions.Add("c.acceptingNewPatients = @providerAcceptingNew");
+            parameters.Add(("@providerAcceptingNew", query.AcceptingNewPatients.Value));
+        }
+
+        var orderBy = sort switch
+        {
+            NetworkRosterSort.NameDesc =>
+                "ORDER BY c.lastName DESC, c.organizationName DESC, c.id DESC",
+            NetworkRosterSort.IntegrityScoreDesc =>
+                // Cosmos puts nulls before non-nulls on DESC; folding
+                // IS_DEFINED to a 0/1 sort key inverts that so unverified
+                // rows trail the head of the page (nulls-last semantics).
+                "ORDER BY (IS_DEFINED(c.integrityScore) ? 1 : 0) DESC, c.integrityScore DESC, c.id ASC",
+            _ =>
+                "ORDER BY c.lastName ASC, c.organizationName ASC, c.id ASC",
+        };
+
+        var sql =
+            "SELECT * FROM c WHERE " + string.Join(" AND ", conditions) + " " +
+            orderBy + " " +
+            $"OFFSET {safeSkip} LIMIT {effectivePageSize}";
+
+        var queryDef = new QueryDefinition(sql);
+        foreach (var (name, value) in parameters)
+        {
+            queryDef = queryDef.WithParameter(name, value);
+        }
+
+        var iterator = _container.GetItemQueryIterator<Provider>(
+            queryDef,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(query.TenantId),
+                MaxItemCount = effectivePageSize,
+            });
+
+        var results = new List<Provider>(effectivePageSize);
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page.Select(Hydrate));
+            if (results.Count >= effectivePageSize) break;
+        }
+
+        return results;
     }
 
     public async Task<Provider?> GetLatestActiveAsync(string providerId, DateTime asOf)

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -37,6 +37,12 @@ public class ProviderRepositoryMongo : IProviderRepository
             new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ZipCode)),
             // Multikey index for network participations
             new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.PlanId")),
+            // Network roster (capability 5.4) — multikey on the new
+            // NetworkParticipation.NetworkId, scoped under TenantId for
+            // partition-aware lookups. Tier secondary key keeps the
+            // common (network + tier) filter index-only.
+            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.NetworkId")),
+            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.NetworkId").Ascending("NetworkParticipations.NetworkTier")),
             // Version-chain indexes
             new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ProviderId).Ascending(p => p.VersionNumber)),
             new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ProviderId).Ascending(p => p.VersionId)),
@@ -266,6 +272,97 @@ public class ProviderRepositoryMongo : IProviderRepository
             Builders<Provider>.Filter.Eq(p => p.TenantId, tenantId)
         );
         await _collection.DeleteOneAsync(filter);
+    }
+
+    public async Task<IReadOnlyList<Provider>> ListNetworkRosterAsync(
+        NetworkRosterQuery query,
+        NetworkRosterSort sort,
+        int skip,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(query.TenantId))
+            throw new ArgumentException("NetworkRosterQuery.TenantId is required.", nameof(query));
+        if (string.IsNullOrEmpty(query.NetworkId))
+            throw new ArgumentException("NetworkRosterQuery.NetworkId is required.", nameof(query));
+
+        var pageSize = Math.Clamp(query.PageSize, 1, NetworkRosterDefaults.MaxPageSize);
+        var safeSkip = Math.Max(skip, 0);
+        var asOf = (query.AsOfDate ?? DateTime.UtcNow).ToUniversalTime();
+
+        var b = Builders<Provider>.Filter;
+        var nb = Builders<NetworkParticipation>.Filter;
+
+        // Build the per-participation filter (ElemMatch). NetworkId is the
+        // primary key — without it the row is invisible to this endpoint
+        // by design (see network-roster-api.md migration note).
+        var participationFilter = nb.And(
+            nb.Eq(n => n.NetworkId, query.NetworkId),
+            nb.Or(nb.Lte(n => n.EffectiveDate, asOf), nb.Exists(n => n.EffectiveDate, false)),
+            nb.Or(nb.Eq(n => n.TerminationDate, null), nb.Gte(n => n.TerminationDate, asOf)));
+
+        if (query.LineOfBusiness.HasValue)
+            participationFilter = nb.And(participationFilter, nb.Eq(n => n.LineOfBusiness, query.LineOfBusiness.Value));
+        if (!string.IsNullOrEmpty(query.Tier))
+            participationFilter = nb.And(participationFilter, nb.Eq(n => n.NetworkTier, query.Tier));
+        if (query.AcceptingNewPatients.HasValue)
+            participationFilter = nb.And(participationFilter, nb.Eq(n => n.AcceptingNewPatients, query.AcceptingNewPatients.Value));
+
+        // Provider chain must be Active (or legacy/unset) and not
+        // terminated before AsOfDate. Hydration will normalize legacy
+        // rows on read; the filter accepts the absent-VersionState shape.
+        var stateFilter = b.Or(
+            b.Eq(p => p.VersionState, ProviderVersionState.Active),
+            b.Exists(p => p.VersionState, false));
+
+        var providerFilter = b.And(
+            b.Eq(p => p.TenantId, query.TenantId),
+            stateFilter,
+            b.Or(b.Eq(p => p.TerminationDate, null), b.Gte(p => p.TerminationDate, asOf)),
+            b.ElemMatch(p => p.NetworkParticipations, participationFilter));
+
+        if (!string.IsNullOrEmpty(query.Specialty))
+        {
+            var rgx = new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(query.Specialty), "i");
+            providerFilter = b.And(providerFilter,
+                b.Or(b.Regex(p => p.PrimarySpecialty, rgx), b.Regex(p => p.TaxonomyCode, rgx)));
+        }
+
+        if (query.AcceptingNewPatients.HasValue)
+        {
+            providerFilter = b.And(providerFilter,
+                b.Eq(p => p.AcceptingNewPatients, query.AcceptingNewPatients.Value));
+        }
+
+        var sortDef = sort switch
+        {
+            NetworkRosterSort.NameDesc =>
+                Builders<Provider>.Sort
+                    .Descending(p => p.LastName)
+                    .Descending(p => p.OrganizationName)
+                    .Descending(p => p.Id),
+            NetworkRosterSort.IntegrityScoreDesc =>
+                // Mongo orders BSON null before any number on Descending —
+                // exactly what we don't want for a "best score first" view.
+                // The repository emits a deterministic descending order;
+                // the service layer reorders nulls to the tail (see
+                // NetworkRosterService.ApplyNullsLastForIntegrityScore).
+                Builders<Provider>.Sort
+                    .Descending(p => p.IntegrityScore)
+                    .Ascending(p => p.Id),
+            _ =>
+                Builders<Provider>.Sort
+                    .Ascending(p => p.LastName)
+                    .Ascending(p => p.OrganizationName)
+                    .Ascending(p => p.Id),
+        };
+
+        var docs = await _collection.Find(providerFilter)
+            .Sort(sortDef)
+            .Skip(safeSkip)
+            .Limit(pageSize)
+            .ToListAsync(ct);
+
+        return docs.Select(Hydrate).ToList();
     }
 
     private static FilterDefinition<Provider> ChainKeyFilter(string providerId)

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -308,11 +308,21 @@ public class ProviderRepositoryMongo : IProviderRepository
             participationFilter = nb.And(participationFilter, nb.Eq(n => n.AcceptingNewPatients, query.AcceptingNewPatients.Value));
 
         // Provider chain must be Active (or legacy/unset) and not
-        // terminated before AsOfDate. Hydration will normalize legacy
-        // rows on read; the filter accepts the absent-VersionState shape.
+        // terminated before AsOfDate. Three shapes count as "active":
+        //   1. VersionState == Active (current versioned shape).
+        //   2. VersionState absent (legacy row pre-versioning).
+        //   3. VersionId empty/missing AND Status == Active (legacy row
+        //      where VersionState defaulted to the C# enum zero value
+        //      Draft on read — Hydrate() derives Active from Status).
+        // Without (3) those legacy rows would be excluded, which doesn't
+        // match Hydrate()'s read-side normalization elsewhere in the
+        // repo.
         var stateFilter = b.Or(
             b.Eq(p => p.VersionState, ProviderVersionState.Active),
-            b.Exists(p => p.VersionState, false));
+            b.Exists(p => p.VersionState, false),
+            b.And(
+                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Eq(p => p.Status, ProviderStatus.Active)));
 
         var providerFilter = b.And(
             b.Eq(p => p.TenantId, query.TenantId),
@@ -333,6 +343,45 @@ public class ProviderRepositoryMongo : IProviderRepository
                 b.Eq(p => p.AcceptingNewPatients, query.AcceptingNewPatients.Value));
         }
 
+        // IntegrityScoreDesc needs nulls-last across the whole result
+        // set, not just within a page. Find().Sort() places BSON null
+        // first on Descending, which would put unverified providers at
+        // the head of page 1 and push high-score rows into later pages.
+        // Solution: aggregate with a computed has-score key and sort by
+        // (hasScore desc, IntegrityScore desc, _id asc) BEFORE skip/limit.
+        // The other sorts have well-defined Mongo semantics on non-null
+        // string fields (LastName / OrganizationName), so they keep the
+        // simpler Find path.
+        if (sort == NetworkRosterSort.IntegrityScoreDesc)
+        {
+            var addFields = new MongoDB.Bson.BsonDocument("$addFields",
+                new MongoDB.Bson.BsonDocument("hasScore",
+                    new MongoDB.Bson.BsonDocument("$cond", new MongoDB.Bson.BsonArray
+                    {
+                        new MongoDB.Bson.BsonDocument("$gt", new MongoDB.Bson.BsonArray
+                        {
+                            "$IntegrityScore", MongoDB.Bson.BsonNull.Value
+                        }),
+                        1, 0
+                    })));
+            var sortStage = new MongoDB.Bson.BsonDocument("$sort", new MongoDB.Bson.BsonDocument
+            {
+                { "hasScore", -1 },
+                { "IntegrityScore", -1 },
+                { "_id", 1 },
+            });
+
+            var fluent = _collection.Aggregate()
+                .Match(providerFilter)
+                .AppendStage<Provider>(addFields)
+                .AppendStage<Provider>(sortStage)
+                .Skip(safeSkip)
+                .Limit(pageSize);
+
+            var aggDocs = await fluent.ToListAsync(ct);
+            return aggDocs.Select(Hydrate).ToList();
+        }
+
         var sortDef = sort switch
         {
             NetworkRosterSort.NameDesc =>
@@ -340,15 +389,6 @@ public class ProviderRepositoryMongo : IProviderRepository
                     .Descending(p => p.LastName)
                     .Descending(p => p.OrganizationName)
                     .Descending(p => p.Id),
-            NetworkRosterSort.IntegrityScoreDesc =>
-                // Mongo orders BSON null before any number on Descending —
-                // exactly what we don't want for a "best score first" view.
-                // The repository emits a deterministic descending order;
-                // the service layer reorders nulls to the tail (see
-                // NetworkRosterService.ApplyNullsLastForIntegrityScore).
-                Builders<Provider>.Sort
-                    .Descending(p => p.IntegrityScore)
-                    .Ascending(p => p.Id),
             _ =>
                 Builders<Provider>.Sort
                     .Ascending(p => p.LastName)

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -321,7 +321,10 @@ public class ProviderRepositoryMongo : IProviderRepository
             b.Eq(p => p.VersionState, ProviderVersionState.Active),
             b.Exists(p => p.VersionState, false),
             b.And(
-                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Or(
+                    b.Exists(p => p.VersionId, false),
+                    b.Eq(p => p.VersionId, null),
+                    b.Eq(p => p.VersionId, string.Empty)),
                 b.Eq(p => p.Status, ProviderStatus.Active)));
 
         var providerFilter = b.And(

--- a/src/services/provider-service/Services/NetworkRosterService.cs
+++ b/src/services/provider-service/Services/NetworkRosterService.cs
@@ -70,13 +70,18 @@ public class NetworkRosterService : INetworkRosterService
 
         var sort = ResolveSort(query);
 
-        // Cursor wins over Page when both are supplied. Filter-hash binding
-        // means tampering with filters between pages is rejected — no
-        // half-page splices.
+        // Cursor wins over Page when both are supplied. Filter-hash
+        // binding includes the cursor's claimed AsOfDate so a tampered
+        // cursor JSON (which is plain base64, not authenticated) can't
+        // smuggle a different snapshot date past the check.
         var skip = 0;
         if (!string.IsNullOrEmpty(query.Cursor))
         {
             var decoded = NetworkRosterCursor.Decode(query.Cursor);
+            // Apply the cursor's AsOfDate before computing the expected
+            // hash so a tamper of `decoded.AsOfDate` produces a hash
+            // mismatch (the original was hashed with the genuine value).
+            query.AsOfDate = decoded.AsOfDate;
             var expectedHash = ComputeFilterHash(query, sort);
             if (!CryptographicOperations.FixedTimeEquals(
                     Encoding.UTF8.GetBytes(decoded.FilterHash),
@@ -87,8 +92,6 @@ public class NetworkRosterService : INetworkRosterService
                     "Cursor filter hash does not match the supplied query. Restart pagination from page 1.");
             }
             skip = decoded.Offset;
-            // Lock AsOfDate to the cursor so re-paging doesn't drift.
-            query.AsOfDate = decoded.AsOfDate;
         }
         else if (query.Page > 1)
         {
@@ -270,14 +273,26 @@ public class NetworkRosterService : INetworkRosterService
             || n.MaxAcceptedAgeYears.HasValue;
 
     /// <summary>
-    /// Stable hash of every field that affects result ordering / membership.
-    /// Used to bind a cursor to its query so an attacker (or a buggy
-    /// client) can't smuggle a different filter set into a mid-page
-    /// continuation. We hash the canonicalized JSON representation so
-    /// field order doesn't matter.
+    /// Stable hash of every field that affects result ordering /
+    /// membership — including <c>AsOfDate</c> (normalized to UTC ticks),
+    /// since the snapshot date is part of the query's identity for
+    /// re-paging. Used to bind a cursor to its query so a tampered
+    /// cursor body produces a hash mismatch on the next page.
+    ///
+    /// <para>
+    /// Not authentication — the inputs are public — but it catches
+    /// accidental and tamper-style mismatches alike.
+    /// </para>
     /// </summary>
     internal static string ComputeFilterHash(NetworkRosterQuery query, NetworkRosterSort sort)
     {
+        // Round to seconds to keep page 1 / page 2 stable when the
+        // AsOfDate defaults to "now" — sub-second drift between calls
+        // shouldn't invalidate paging.
+        var asOfTicks = query.AsOfDate.HasValue
+            ? new DateTime(query.AsOfDate.Value.Ticks - (query.AsOfDate.Value.Ticks % TimeSpan.TicksPerSecond), DateTimeKind.Utc).Ticks
+            : 0L;
+
         var canonical = new
         {
             t = query.TenantId,
@@ -288,11 +303,10 @@ public class NetworkRosterService : INetworkRosterService
             ap = query.AcceptingNewPatients,
             ps = query.PageSize,
             so = sort.ToString(),
+            ao = asOfTicks,
         };
         var json = JsonSerializer.Serialize(canonical);
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
-        // First 16 bytes (128 bits) is plenty — we're not authenticating,
-        // just preventing accidental reuse with mismatched filters.
         return Convert.ToHexString(bytes, 0, 16);
     }
 }

--- a/src/services/provider-service/Services/NetworkRosterService.cs
+++ b/src/services/provider-service/Services/NetworkRosterService.cs
@@ -1,0 +1,350 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Owns the read path for <c>GET /api/v1/networks/{id}/roster</c>:
+/// resolves filter + sort, drives the repository, decodes/encodes the
+/// pagination cursor, and maps results into <see cref="NetworkRosterEntry"/>.
+///
+/// <para>
+/// Reads from the cached <see cref="Provider.IntegrityScore"/> column —
+/// never calls into <c>ProviderVerificationOrchestrator</c>. See
+/// <c>docs/architecture/network-roster-api.md</c> for the read-path
+/// contract and the known gap around verification write-back.
+/// </para>
+/// </summary>
+public interface INetworkRosterService
+{
+    Task<NetworkRosterResponse> GetRosterAsync(NetworkRosterQuery query, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Thrown by <see cref="NetworkRosterService"/> for client-correctable
+/// problems. The controller maps each <see cref="ErrorCode"/> to an
+/// appropriate HTTP status — currently 400 for everything.
+/// </summary>
+public sealed class NetworkRosterValidationException : Exception
+{
+    public string ErrorCode { get; }
+
+    public NetworkRosterValidationException(string errorCode, string message) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+}
+
+public class NetworkRosterService : INetworkRosterService
+{
+    private readonly IProviderRepository _repository;
+    private readonly ILogger<NetworkRosterService> _logger;
+
+    public NetworkRosterService(
+        IProviderRepository repository,
+        ILogger<NetworkRosterService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<NetworkRosterResponse> GetRosterAsync(NetworkRosterQuery query, CancellationToken ct = default)
+    {
+        if (query is null) throw new ArgumentNullException(nameof(query));
+        if (string.IsNullOrEmpty(query.TenantId))
+            throw new ArgumentException("Query must have TenantId set by the controller.", nameof(query));
+        if (string.IsNullOrEmpty(query.NetworkId))
+            throw new NetworkRosterValidationException("missing_network_id", "NetworkId is required.");
+
+        // Defaults are stable: AsOfDate defaults to UTC now, and we serialize
+        // it into the cursor so re-paging stays consistent across pages even
+        // if the clock advances mid-traversal.
+        if (query.AsOfDate == null) query.AsOfDate = DateTime.UtcNow;
+        query.PageSize = Math.Clamp(
+            query.PageSize <= 0 ? NetworkRosterDefaults.DefaultPageSize : query.PageSize,
+            1,
+            NetworkRosterDefaults.MaxPageSize);
+
+        var sort = ResolveSort(query);
+
+        // Cursor wins over Page when both are supplied. Filter-hash binding
+        // means tampering with filters between pages is rejected — no
+        // half-page splices.
+        var skip = 0;
+        if (!string.IsNullOrEmpty(query.Cursor))
+        {
+            var decoded = NetworkRosterCursor.Decode(query.Cursor);
+            var expectedHash = ComputeFilterHash(query, sort);
+            if (!CryptographicOperations.FixedTimeEquals(
+                    Encoding.UTF8.GetBytes(decoded.FilterHash),
+                    Encoding.UTF8.GetBytes(expectedHash)))
+            {
+                throw new NetworkRosterValidationException(
+                    "cursor_filter_mismatch",
+                    "Cursor filter hash does not match the supplied query. Restart pagination from page 1.");
+            }
+            skip = decoded.Offset;
+            // Lock AsOfDate to the cursor so re-paging doesn't drift.
+            query.AsOfDate = decoded.AsOfDate;
+        }
+        else if (query.Page > 1)
+        {
+            skip = (query.Page - 1) * query.PageSize;
+        }
+
+        var rows = await _repository.ListNetworkRosterAsync(query, sort, skip, ct);
+
+        if (sort == NetworkRosterSort.IntegrityScoreDesc)
+        {
+            rows = ApplyNullsLastForIntegrityScore(rows);
+        }
+
+        var items = rows.Select(p => MapToEntry(p, query)).ToList();
+
+        // We requested PageSize rows. A short page means the underlying
+        // result set is exhausted and there's no next cursor. We don't
+        // peek ahead — saves one trip and keeps the cursor stateless.
+        string? nextCursor = null;
+        if (items.Count == query.PageSize)
+        {
+            nextCursor = NetworkRosterCursor.Encode(new NetworkRosterCursor
+            {
+                Offset = skip + query.PageSize,
+                AsOfDate = query.AsOfDate!.Value,
+                FilterHash = ComputeFilterHash(query, sort),
+            });
+        }
+
+        return new NetworkRosterResponse
+        {
+            Items = items,
+            NextCursor = nextCursor,
+            PageSize = query.PageSize,
+        };
+    }
+
+    internal static NetworkRosterSort ResolveSort(NetworkRosterQuery query)
+    {
+        var sortBy = (query.SortBy ?? NetworkRosterDefaults.SortByName).Trim();
+        var direction = (query.SortDirection ?? string.Empty).Trim();
+
+        if (sortBy.Equals(NetworkRosterDefaults.SortByDistance, StringComparison.OrdinalIgnoreCase))
+        {
+            // §4b — deferred. The roster API rejects distance sort with a
+            // 400 + "not yet supported" until the geospatial-index follow-up
+            // ships. See network-roster-api.md "Deferred — distance sort".
+            throw new NetworkRosterValidationException(
+                "distance_sort_unsupported",
+                "sortBy=distance is not yet supported. Tracked in network-roster-api.md follow-up.");
+        }
+
+        if (sortBy.Equals(NetworkRosterDefaults.SortByIntegrityScore, StringComparison.OrdinalIgnoreCase))
+        {
+            // integrityScore only sorts descending. ascending makes no
+            // operational sense (we don't surface "worst providers first")
+            // so we fold any explicit asc into desc and document it.
+            return NetworkRosterSort.IntegrityScoreDesc;
+        }
+
+        if (sortBy.Equals(NetworkRosterDefaults.SortByName, StringComparison.OrdinalIgnoreCase))
+        {
+            return direction.Equals(NetworkRosterDefaults.DirectionDesc, StringComparison.OrdinalIgnoreCase)
+                ? NetworkRosterSort.NameDesc
+                : NetworkRosterSort.NameAsc;
+        }
+
+        throw new NetworkRosterValidationException(
+            "unsupported_sort",
+            $"sortBy '{query.SortBy}' is not supported. Allowed: name | integrityScore.");
+    }
+
+    /// <summary>
+    /// Reorders so providers without an integrity score trail those with
+    /// one. The repository layers can't express this uniformly across
+    /// Cosmos and Mongo (Cosmos: IS_DEFINED prefix; Mongo: nulls-first on
+    /// descending), so we normalize after the fact on the page-sized
+    /// slice.
+    /// </summary>
+    internal static IReadOnlyList<Provider> ApplyNullsLastForIntegrityScore(IReadOnlyList<Provider> rows)
+    {
+        return rows
+            .OrderByDescending(p => p.IntegrityScore.HasValue)
+            .ThenByDescending(p => p.IntegrityScore ?? int.MinValue)
+            .ThenBy(p => p.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Picks the participation row that drove the match. The repository
+    /// ElemMatch ensures at least one participation under
+    /// <see cref="NetworkRosterQuery.NetworkId"/> satisfied every filter;
+    /// we re-walk the same predicate here so the response surfaces that
+    /// row rather than an arbitrary first-with-NetworkId.
+    /// </summary>
+    private NetworkRosterEntry MapToEntry(Provider provider, NetworkRosterQuery query)
+    {
+        var asOf = (query.AsOfDate ?? DateTime.UtcNow).ToUniversalTime();
+
+        bool ParticipationDroveTheMatch(NetworkParticipation n)
+        {
+            if (n.NetworkId != query.NetworkId) return false;
+            if (n.EffectiveDate > asOf) return false;
+            if (n.TerminationDate.HasValue && n.TerminationDate.Value < asOf) return false;
+            if (query.LineOfBusiness.HasValue && n.LineOfBusiness != query.LineOfBusiness.Value) return false;
+            if (!string.IsNullOrEmpty(query.Tier) && !string.Equals(n.NetworkTier, query.Tier, StringComparison.Ordinal)) return false;
+            if (query.AcceptingNewPatients.HasValue && n.AcceptingNewPatients != query.AcceptingNewPatients.Value) return false;
+            return true;
+        }
+
+        var participation = provider.NetworkParticipations.FirstOrDefault(ParticipationDroveTheMatch)
+            ?? provider.NetworkParticipations.FirstOrDefault(n => n.NetworkId == query.NetworkId)
+            ?? new NetworkParticipation();
+
+        var displayName = provider.ProviderType == ProviderType.Individual
+            ? string.Join(' ',
+                new[] { provider.FirstName, provider.MiddleName, provider.LastName, provider.Credentials }
+                    .Where(s => !string.IsNullOrWhiteSpace(s)))
+            : (provider.OrganizationName ?? string.Empty);
+
+        var panel = HasAnyPanelGating(participation)
+            ? new RosterPanelGating
+            {
+                PanelLimit = participation.PanelLimit,
+                PanelAccepted = participation.PanelAccepted,
+                AcceptedLobs = participation.AcceptedLobs.Count > 0 ? participation.AcceptedLobs : null,
+                MinAcceptedAgeYears = participation.MinAcceptedAgeYears,
+                MaxAcceptedAgeYears = participation.MaxAcceptedAgeYears,
+            }
+            : null;
+
+        var integrity = provider.IntegrityScore.HasValue
+                        || !string.IsNullOrEmpty(provider.IntegrityRating)
+                        || provider.LastVerifiedAt.HasValue
+            ? new RosterIntegrityScore
+            {
+                Score = provider.IntegrityScore,
+                Rating = provider.IntegrityRating,
+                LastVerifiedAt = provider.LastVerifiedAt,
+            }
+            : null;
+
+        return new NetworkRosterEntry
+        {
+            ProviderId = provider.ProviderId,
+            VersionId = provider.VersionId,
+            Provider = new RosterProviderSummary
+            {
+                Npi = provider.NPI,
+                ProviderType = provider.ProviderType,
+                DisplayName = displayName,
+                PrimarySpecialty = provider.PrimarySpecialty,
+                TaxonomyCode = provider.TaxonomyCode,
+                Address = provider.Address,
+                City = provider.City,
+                State = provider.State,
+                ZipCode = provider.ZipCode,
+                AcceptingNewPatients = provider.AcceptingNewPatients,
+            },
+            Participation = new RosterParticipationSummary
+            {
+                PlanId = participation.PlanId,
+                LineOfBusiness = participation.LineOfBusiness,
+                NetworkTier = participation.NetworkTier,
+                AcceptingNewPatients = participation.AcceptingNewPatients,
+                EffectiveDate = participation.EffectiveDate,
+                TerminationDate = participation.TerminationDate,
+                PanelGating = panel,
+            },
+            IntegrityScore = integrity,
+        };
+    }
+
+    private static bool HasAnyPanelGating(NetworkParticipation n)
+        => n.PanelLimit.HasValue
+            || n.PanelAccepted.HasValue
+            || n.AcceptedLobs.Count > 0
+            || n.MinAcceptedAgeYears.HasValue
+            || n.MaxAcceptedAgeYears.HasValue;
+
+    /// <summary>
+    /// Stable hash of every field that affects result ordering / membership.
+    /// Used to bind a cursor to its query so an attacker (or a buggy
+    /// client) can't smuggle a different filter set into a mid-page
+    /// continuation. We hash the canonicalized JSON representation so
+    /// field order doesn't matter.
+    /// </summary>
+    internal static string ComputeFilterHash(NetworkRosterQuery query, NetworkRosterSort sort)
+    {
+        var canonical = new
+        {
+            t = query.TenantId,
+            n = query.NetworkId,
+            lob = query.LineOfBusiness?.ToString(),
+            sp = query.Specialty,
+            ti = query.Tier,
+            ap = query.AcceptingNewPatients,
+            ps = query.PageSize,
+            so = sort.ToString(),
+        };
+        var json = JsonSerializer.Serialize(canonical);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        // First 16 bytes (128 bits) is plenty — we're not authenticating,
+        // just preventing accidental reuse with mismatched filters.
+        return Convert.ToHexString(bytes, 0, 16);
+    }
+}
+
+/// <summary>
+/// Opaque cursor payload. Encoded as URL-safe base64 of the JSON shape;
+/// callers should treat the string as opaque.
+/// </summary>
+internal sealed class NetworkRosterCursor
+{
+    public int Offset { get; set; }
+    public DateTime AsOfDate { get; set; }
+    public string FilterHash { get; set; } = string.Empty;
+
+    public static string Encode(NetworkRosterCursor cursor)
+    {
+        var json = JsonSerializer.Serialize(cursor);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return ToBase64Url(bytes);
+    }
+
+    public static NetworkRosterCursor Decode(string token)
+    {
+        try
+        {
+            var bytes = FromBase64Url(token);
+            var json = Encoding.UTF8.GetString(bytes);
+            var decoded = JsonSerializer.Deserialize<NetworkRosterCursor>(json)
+                ?? throw new NetworkRosterValidationException("cursor_invalid", "Cursor is empty.");
+            if (decoded.Offset < 0)
+                throw new NetworkRosterValidationException("cursor_invalid", "Cursor offset must be >= 0.");
+            return decoded;
+        }
+        catch (Exception ex) when (ex is not NetworkRosterValidationException)
+        {
+            throw new NetworkRosterValidationException("cursor_invalid", "Cursor is not a valid pagination token.");
+        }
+    }
+
+    // .NET 8 has no built-in url-safe base64; the standard transform is
+    // base64 → swap '+/' for '-_' and strip '='.
+    private static string ToBase64Url(byte[] bytes)
+        => Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static byte[] FromBase64Url(string token)
+    {
+        var s = token.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+        }
+        return Convert.FromBase64String(s);
+    }
+}

--- a/src/services/provider-service/provider-service.csproj
+++ b/src/services/provider-service/provider-service.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CloudHealthOffice.ProviderService.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -151,6 +151,72 @@ public sealed class InMemoryProviderRepository : IProviderRepository
         return Task.CompletedTask;
     }
 
+    public Task<IReadOnlyList<Provider>> ListNetworkRosterAsync(
+        NetworkRosterQuery query,
+        NetworkRosterSort sort,
+        int skip,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(query.TenantId))
+            throw new ArgumentException("NetworkRosterQuery.TenantId is required.", nameof(query));
+        if (string.IsNullOrEmpty(query.NetworkId))
+            throw new ArgumentException("NetworkRosterQuery.NetworkId is required.", nameof(query));
+
+        var pageSize = Math.Clamp(query.PageSize, 1, NetworkRosterDefaults.MaxPageSize);
+        var safeSkip = Math.Max(skip, 0);
+        var asOf = (query.AsOfDate ?? DateTime.UtcNow).ToUniversalTime();
+
+        bool ParticipationMatches(NetworkParticipation n)
+        {
+            if (n.NetworkId != query.NetworkId) return false;
+            if (n.EffectiveDate > asOf) return false;
+            if (n.TerminationDate.HasValue && n.TerminationDate.Value < asOf) return false;
+            if (query.LineOfBusiness.HasValue && n.LineOfBusiness != query.LineOfBusiness.Value) return false;
+            if (!string.IsNullOrEmpty(query.Tier) && !string.Equals(n.NetworkTier, query.Tier, StringComparison.Ordinal)) return false;
+            if (query.AcceptingNewPatients.HasValue && n.AcceptingNewPatients != query.AcceptingNewPatients.Value) return false;
+            return true;
+        }
+
+        bool ProviderMatches(Provider p)
+        {
+            if (p.TenantId != query.TenantId) return false;
+            if (p.VersionState != ProviderVersionState.Active) return false;
+            if (p.TerminationDate.HasValue && p.TerminationDate.Value < asOf) return false;
+            if (!p.NetworkParticipations.Any(ParticipationMatches)) return false;
+            if (!string.IsNullOrEmpty(query.Specialty))
+            {
+                var s = query.Specialty;
+                if (!(p.PrimarySpecialty?.Contains(s, StringComparison.OrdinalIgnoreCase) ?? false)
+                    && !(p.TaxonomyCode?.Contains(s, StringComparison.OrdinalIgnoreCase) ?? false))
+                    return false;
+            }
+            if (query.AcceptingNewPatients.HasValue && p.AcceptingNewPatients != query.AcceptingNewPatients.Value) return false;
+            return true;
+        }
+
+        var hydrated = HydratedView().Where(ProviderMatches);
+
+        IEnumerable<Provider> ordered = sort switch
+        {
+            NetworkRosterSort.NameDesc => hydrated
+                .OrderByDescending(p => p.LastName ?? string.Empty, StringComparer.Ordinal)
+                .ThenByDescending(p => p.OrganizationName ?? string.Empty, StringComparer.Ordinal)
+                .ThenByDescending(p => p.Id, StringComparer.Ordinal),
+            NetworkRosterSort.IntegrityScoreDesc => hydrated
+                // Service layer normalizes nulls-last; the fake returns the
+                // raw score-desc order to mirror real-repo semantics.
+                .OrderByDescending(p => p.IntegrityScore ?? int.MinValue)
+                .ThenBy(p => p.Id, StringComparer.Ordinal),
+            _ => hydrated
+                .OrderBy(p => p.LastName ?? string.Empty, StringComparer.Ordinal)
+                .ThenBy(p => p.OrganizationName ?? string.Empty, StringComparer.Ordinal)
+                .ThenBy(p => p.Id, StringComparer.Ordinal),
+        };
+
+        var slice = ordered.Skip(safeSkip).Take(pageSize).ToList();
+        return Task.FromResult<IReadOnlyList<Provider>>(slice);
+    }
+
     public Task<Provider?> GetLatestActiveAsync(string providerId, DateTime asOf)
     {
         var match = HydratedView()

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterCursorTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterCursorTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Unit tests for the cursor encode/decode and the filter-hash binding.
+/// Targets the static helpers on <see cref="NetworkRosterService"/> so we
+/// don't have to plumb a repository.
+/// </summary>
+public class NetworkRosterCursorTests
+{
+    [Fact]
+    public void FilterHash_is_stable_across_equivalent_queries()
+    {
+        var q1 = new NetworkRosterQuery
+        {
+            TenantId = "t1",
+            NetworkId = "n1",
+            LineOfBusiness = LineOfBusiness.Medicare,
+            Specialty = "207R00000X",
+            Tier = "Tier1",
+            AcceptingNewPatients = true,
+            PageSize = 100,
+        };
+        var q2 = new NetworkRosterQuery
+        {
+            TenantId = "t1",
+            NetworkId = "n1",
+            LineOfBusiness = LineOfBusiness.Medicare,
+            Specialty = "207R00000X",
+            Tier = "Tier1",
+            AcceptingNewPatients = true,
+            PageSize = 100,
+        };
+
+        NetworkRosterService.ComputeFilterHash(q1, NetworkRosterSort.NameAsc)
+            .Should().Be(NetworkRosterService.ComputeFilterHash(q2, NetworkRosterSort.NameAsc));
+    }
+
+    [Fact]
+    public void FilterHash_diverges_when_any_filter_changes()
+    {
+        var baseline = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100 };
+        var hashBaseline = NetworkRosterService.ComputeFilterHash(baseline, NetworkRosterSort.NameAsc);
+
+        var lobChanged = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, LineOfBusiness = LineOfBusiness.Medicare };
+        NetworkRosterService.ComputeFilterHash(lobChanged, NetworkRosterSort.NameAsc).Should().NotBe(hashBaseline);
+
+        var sortChanged = NetworkRosterService.ComputeFilterHash(baseline, NetworkRosterSort.IntegrityScoreDesc);
+        sortChanged.Should().NotBe(hashBaseline);
+
+        var tierChanged = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, Tier = "Tier2" };
+        NetworkRosterService.ComputeFilterHash(tierChanged, NetworkRosterSort.NameAsc).Should().NotBe(hashBaseline);
+
+        var pageSizeChanged = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 50 };
+        NetworkRosterService.ComputeFilterHash(pageSizeChanged, NetworkRosterSort.NameAsc).Should().NotBe(hashBaseline);
+    }
+
+    [Fact]
+    public void ResolveSort_defaults_to_NameAsc()
+    {
+        NetworkRosterService.ResolveSort(new NetworkRosterQuery())
+            .Should().Be(NetworkRosterSort.NameAsc);
+    }
+
+    [Fact]
+    public void ResolveSort_name_desc_is_recognised()
+    {
+        var sort = NetworkRosterService.ResolveSort(new NetworkRosterQuery { SortBy = "name", SortDirection = "desc" });
+        sort.Should().Be(NetworkRosterSort.NameDesc);
+    }
+
+    [Fact]
+    public void ResolveSort_integrityScore_always_descends_regardless_of_direction()
+    {
+        // ascending integrity score makes no operational sense; the
+        // service folds any direction to descending and documents it.
+        NetworkRosterService.ResolveSort(new NetworkRosterQuery { SortBy = "integrityScore", SortDirection = "asc" })
+            .Should().Be(NetworkRosterSort.IntegrityScoreDesc);
+        NetworkRosterService.ResolveSort(new NetworkRosterQuery { SortBy = "integrityScore", SortDirection = "desc" })
+            .Should().Be(NetworkRosterSort.IntegrityScoreDesc);
+    }
+
+    [Fact]
+    public void ResolveSort_distance_is_explicitly_unsupported()
+    {
+        var act = () => NetworkRosterService.ResolveSort(new NetworkRosterQuery { SortBy = "distance" });
+        act.Should().Throw<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "distance_sort_unsupported");
+    }
+
+    [Fact]
+    public void ApplyNullsLastForIntegrityScore_pushes_unverified_to_tail()
+    {
+        var rows = new List<Provider>
+        {
+            new() { Id = "a", IntegrityScore = null },
+            new() { Id = "b", IntegrityScore = 75 },
+            new() { Id = "c", IntegrityScore = null },
+            new() { Id = "d", IntegrityScore = 92 },
+        };
+
+        var ordered = NetworkRosterService.ApplyNullsLastForIntegrityScore(rows);
+
+        ordered.Select(p => p.Id).Should().Equal("d", "b", "a", "c");
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterCursorTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterCursorTests.cs
@@ -59,6 +59,36 @@ public class NetworkRosterCursorTests
     }
 
     [Fact]
+    public void FilterHash_diverges_when_AsOfDate_changes()
+    {
+        var d1 = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var d2 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var q1 = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, AsOfDate = d1 };
+        var q2 = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, AsOfDate = d2 };
+
+        NetworkRosterService.ComputeFilterHash(q1, NetworkRosterSort.NameAsc)
+            .Should().NotBe(NetworkRosterService.ComputeFilterHash(q2, NetworkRosterSort.NameAsc));
+    }
+
+    [Fact]
+    public void FilterHash_AsOfDate_subsecond_drift_is_ignored()
+    {
+        // Page 1 binds AsOfDate to "now" (defaulted). Page 2's cursor decode
+        // applies the encoded AsOfDate. Sub-second drift between the two
+        // calls must not invalidate the hash — we round to seconds before
+        // hashing.
+        var d1 = new DateTime(2025, 1, 1, 12, 0, 0, 100, DateTimeKind.Utc);
+        var d2 = new DateTime(2025, 1, 1, 12, 0, 0, 900, DateTimeKind.Utc);
+
+        var q1 = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, AsOfDate = d1 };
+        var q2 = new NetworkRosterQuery { TenantId = "t1", NetworkId = "n1", PageSize = 100, AsOfDate = d2 };
+
+        NetworkRosterService.ComputeFilterHash(q1, NetworkRosterSort.NameAsc)
+            .Should().Be(NetworkRosterService.ComputeFilterHash(q2, NetworkRosterSort.NameAsc));
+    }
+
+    [Fact]
     public void ResolveSort_defaults_to_NameAsc()
     {
         NetworkRosterService.ResolveSort(new NetworkRosterQuery())

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
@@ -1,0 +1,497 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Behaviour tests for <see cref="NetworkRosterService"/>. Drives the
+/// in-memory repository so tests cover the full filter/sort/cursor path
+/// without the storage backends. Cosmos- and Mongo-specific filter
+/// shapes are covered indirectly by the repository contract.
+/// </summary>
+public class NetworkRosterServiceTests
+{
+    private const string TenantA = "tenant-a";
+    private const string TenantB = "tenant-b";
+    private const string Network1 = "net-aetna-ppo-fl-2025";
+    private const string Network2 = "net-bcbs-hmo-fl-2025";
+
+    [Fact]
+    public async Task Roster_returns_only_providers_in_the_requested_network()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1);
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network2);
+        await SeedProviderAsync(repo, "p3", "Carter", networkId: Network1);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        resp.Items.Should().HaveCount(2);
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p1", "p3" });
+    }
+
+    [Fact]
+    public async Task Roster_excludes_legacy_participations_without_NetworkId()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        // p1 has a legacy participation (NetworkId = null) — invisible by design.
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: null);
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        resp.Items.Should().HaveCount(1);
+        resp.Items[0].ProviderId.Should().Be("p2");
+    }
+
+    [Fact]
+    public async Task Roster_isolates_tenants()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1, tenantId: TenantA);
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1, tenantId: TenantB);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1, tenant: TenantA));
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p1" });
+    }
+
+    [Fact]
+    public async Task Roster_combines_LOB_specialty_and_acceptingNewPatients_filters()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            lob: LineOfBusiness.Medicare, specialty: "208000000X", accepting: true);
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1,
+            lob: LineOfBusiness.Commercial, specialty: "208000000X", accepting: true);
+        await SeedProviderAsync(repo, "p3", "Carter", networkId: Network1,
+            lob: LineOfBusiness.Medicare, specialty: "207R00000X", accepting: true);
+        await SeedProviderAsync(repo, "p4", "Davis", networkId: Network1,
+            lob: LineOfBusiness.Medicare, specialty: "208000000X", accepting: false);
+
+        var query = NewQuery(Network1);
+        query.LineOfBusiness = LineOfBusiness.Medicare;
+        query.Specialty = "208000000X";
+        query.AcceptingNewPatients = true;
+
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p1" });
+    }
+
+    [Fact]
+    public async Task Roster_asOfDate_excludes_participations_terminated_before_asOf()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            effectiveDate: asOf.AddYears(-2),
+            participationTerminationDate: asOf.AddDays(-1));
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1,
+            effectiveDate: asOf.AddYears(-2),
+            participationTerminationDate: null);
+
+        var query = NewQuery(Network1);
+        query.AsOfDate = asOf;
+
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p2" });
+    }
+
+    [Fact]
+    public async Task Roster_asOfDate_excludes_participations_effective_after_asOf()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            effectiveDate: asOf.AddDays(1));
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1,
+            effectiveDate: asOf.AddDays(-1));
+
+        var query = NewQuery(Network1);
+        query.AsOfDate = asOf;
+
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p2" });
+    }
+
+    [Fact]
+    public async Task Roster_paginates_disjoint_pages_via_cursor()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        for (var i = 0; i < 250; i++)
+        {
+            var idx = i.ToString("D3");
+            await SeedProviderAsync(repo, $"p-{idx}", $"Last-{idx}", networkId: Network1);
+        }
+
+        var query = NewQuery(Network1);
+        query.PageSize = 100;
+
+        var page1 = await svc.GetRosterAsync(query);
+        page1.Items.Should().HaveCount(100);
+        page1.NextCursor.Should().NotBeNull();
+
+        var query2 = NewQuery(Network1);
+        query2.PageSize = 100;
+        query2.Cursor = page1.NextCursor;
+        var page2 = await svc.GetRosterAsync(query2);
+        page2.Items.Should().HaveCount(100);
+        page2.NextCursor.Should().NotBeNull();
+
+        var query3 = NewQuery(Network1);
+        query3.PageSize = 100;
+        query3.Cursor = page2.NextCursor;
+        var page3 = await svc.GetRosterAsync(query3);
+        page3.Items.Should().HaveCount(50);
+        page3.NextCursor.Should().BeNull();
+
+        var ids = page1.Items.Concat(page2.Items).Concat(page3.Items)
+            .Select(e => e.ProviderId).ToList();
+        ids.Distinct().Should().HaveCount(250);
+    }
+
+    [Fact]
+    public async Task Roster_cursor_with_mismatched_filters_is_rejected()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1, lob: LineOfBusiness.Medicare);
+
+        var page1 = await svc.GetRosterAsync(NewQuery(Network1));
+        // Force a NextCursor by using a tiny page size.
+        for (var i = 0; i < 5; i++)
+            await SeedProviderAsync(repo, $"p-extra-{i}", $"Last-{i}", networkId: Network1);
+
+        var p1Query = NewQuery(Network1);
+        p1Query.PageSize = 2;
+        var first = await svc.GetRosterAsync(p1Query);
+        first.NextCursor.Should().NotBeNull();
+
+        var tampered = NewQuery(Network1);
+        tampered.PageSize = 2;
+        tampered.Cursor = first.NextCursor;
+        tampered.LineOfBusiness = LineOfBusiness.Commercial; // didn't match page 1
+
+        var act = async () => await svc.GetRosterAsync(tampered);
+        await act.Should().ThrowAsync<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "cursor_filter_mismatch");
+    }
+
+    [Fact]
+    public async Task Roster_invalid_cursor_token_returns_validation_error()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var query = NewQuery(Network1);
+        query.Cursor = "not-a-real-token";
+
+        var act = async () => await svc.GetRosterAsync(query);
+        await act.Should().ThrowAsync<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "cursor_invalid");
+    }
+
+    [Fact]
+    public async Task Roster_sort_by_name_asc_default()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Carter", networkId: Network1);
+        await SeedProviderAsync(repo, "p2", "Adams", networkId: Network1);
+        await SeedProviderAsync(repo, "p3", "Baker", networkId: Network1);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        resp.Items.Select(e => e.Provider.DisplayName.Split(' ').Last())
+            .Should().Equal("Adams", "Baker", "Carter");
+    }
+
+    [Fact]
+    public async Task Roster_sort_by_name_desc()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Carter", networkId: Network1);
+        await SeedProviderAsync(repo, "p2", "Adams", networkId: Network1);
+        await SeedProviderAsync(repo, "p3", "Baker", networkId: Network1);
+
+        var query = NewQuery(Network1);
+        query.SortBy = "name";
+        query.SortDirection = "desc";
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Select(e => e.Provider.DisplayName.Split(' ').Last())
+            .Should().Equal("Carter", "Baker", "Adams");
+    }
+
+    [Fact]
+    public async Task Roster_sort_by_integrityScore_desc_with_nulls_last()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1, integrityScore: 75);
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1, integrityScore: null);
+        await SeedProviderAsync(repo, "p3", "Carter", networkId: Network1, integrityScore: 92);
+        await SeedProviderAsync(repo, "p4", "Davis", networkId: Network1, integrityScore: null);
+
+        var query = NewQuery(Network1);
+        query.SortBy = "integrityScore";
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Select(e => e.ProviderId).Take(2).Should().Equal("p3", "p1");
+        resp.Items.Skip(2).Select(e => e.IntegrityScore).Should().AllSatisfy(i =>
+            (i?.Score ?? null).Should().BeNull());
+    }
+
+    [Fact]
+    public async Task Roster_sort_distance_returns_validation_error()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var query = NewQuery(Network1);
+        query.SortBy = "distance";
+
+        var act = async () => await svc.GetRosterAsync(query);
+        await act.Should().ThrowAsync<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "distance_sort_unsupported");
+    }
+
+    [Fact]
+    public async Task Roster_unknown_sortBy_returns_validation_error()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var query = NewQuery(Network1);
+        query.SortBy = "bogus";
+
+        var act = async () => await svc.GetRosterAsync(query);
+        await act.Should().ThrowAsync<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "unsupported_sort");
+    }
+
+    [Fact]
+    public async Task Roster_pageSize_clamps_to_max_1000()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1);
+
+        var query = NewQuery(Network1);
+        query.PageSize = 5000; // exceeds cap
+
+        var resp = await svc.GetRosterAsync(query);
+        resp.PageSize.Should().Be(NetworkRosterDefaults.MaxPageSize);
+    }
+
+    [Fact]
+    public async Task Roster_default_pageSize_is_100()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var query = NewQuery(Network1);
+        query.PageSize = 0; // unset → default
+
+        var resp = await svc.GetRosterAsync(query);
+        resp.PageSize.Should().Be(NetworkRosterDefaults.DefaultPageSize);
+    }
+
+    [Fact]
+    public async Task Roster_emits_panel_gating_when_populated()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            panelLimit: 1500, panelAccepted: false, minAge: 18, maxAge: 64);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        var entry = resp.Items.Single();
+        entry.Participation.PanelGating.Should().NotBeNull();
+        entry.Participation.PanelGating!.PanelLimit.Should().Be(1500);
+        entry.Participation.PanelGating.PanelAccepted.Should().BeFalse();
+        entry.Participation.PanelGating.MinAcceptedAgeYears.Should().Be(18);
+        entry.Participation.PanelGating.MaxAcceptedAgeYears.Should().Be(64);
+    }
+
+    [Fact]
+    public async Task Roster_omits_panel_gating_when_all_fields_null()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        resp.Items.Single().Participation.PanelGating.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Roster_emits_integrity_envelope_when_field_set()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            integrityScore: 88, integrityRating: "Clear",
+            lastVerifiedAt: new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        var i = resp.Items.Single().IntegrityScore;
+        i.Should().NotBeNull();
+        i!.Score.Should().Be(88);
+        i.Rating.Should().Be("Clear");
+        i.LastVerifiedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Roster_terminated_provider_chain_excluded()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var asOf = DateTime.UtcNow;
+        await SeedProviderAsync(repo, "p1", "Adams", networkId: Network1,
+            providerTerminationDate: asOf.AddDays(-1));
+        await SeedProviderAsync(repo, "p2", "Baker", networkId: Network1);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+        resp.Items.Select(e => e.ProviderId).Should().BeEquivalentTo(new[] { "p2" });
+    }
+
+    [Fact]
+    public async Task Roster_picks_participation_matching_query()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        // Provider has two participations on the same network — different LOBs.
+        // Query asks for Medicare; the response must surface the Medicare row.
+        var p = NewActiveProvider("p1", "Adams", TenantA);
+        p.NetworkParticipations.Add(NewParticipation(Network1, LineOfBusiness.Commercial, "Tier2"));
+        p.NetworkParticipations.Add(NewParticipation(Network1, LineOfBusiness.Medicare, "Tier1"));
+        await repo.CreateAsync(p);
+
+        var query = NewQuery(Network1);
+        query.LineOfBusiness = LineOfBusiness.Medicare;
+
+        var resp = await svc.GetRosterAsync(query);
+
+        resp.Items.Should().HaveCount(1);
+        resp.Items[0].Participation.LineOfBusiness.Should().Be(LineOfBusiness.Medicare);
+        resp.Items[0].Participation.NetworkTier.Should().Be("Tier1");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private static INetworkRosterService NewService(InMemoryProviderRepository repo)
+        => new NetworkRosterService(repo, NullLogger<NetworkRosterService>.Instance);
+
+    private static NetworkRosterQuery NewQuery(string networkId, string tenant = TenantA)
+        => new()
+        {
+            TenantId = tenant,
+            NetworkId = networkId,
+        };
+
+    private static async Task SeedProviderAsync(
+        InMemoryProviderRepository repo,
+        string providerId,
+        string lastName,
+        string? networkId,
+        string tenantId = TenantA,
+        LineOfBusiness lob = LineOfBusiness.Commercial,
+        string tier = "Tier1",
+        bool accepting = true,
+        string? specialty = null,
+        DateTime? effectiveDate = null,
+        DateTime? participationTerminationDate = null,
+        DateTime? providerTerminationDate = null,
+        int? integrityScore = null,
+        string? integrityRating = null,
+        DateTimeOffset? lastVerifiedAt = null,
+        int? panelLimit = null,
+        bool? panelAccepted = null,
+        int? minAge = null,
+        int? maxAge = null)
+    {
+        var p = NewActiveProvider(providerId, lastName, tenantId);
+        p.PrimarySpecialty = specialty ?? "207R00000X";
+        p.TaxonomyCode = specialty ?? "207R00000X";
+        p.AcceptingNewPatients = accepting;
+        p.IntegrityScore = integrityScore;
+        p.IntegrityRating = integrityRating;
+        p.LastVerifiedAt = lastVerifiedAt;
+        p.TerminationDate = providerTerminationDate;
+
+        var participation = NewParticipation(networkId, lob, tier);
+        participation.AcceptingNewPatients = accepting;
+        participation.EffectiveDate = effectiveDate ?? DateTime.UtcNow.AddYears(-1);
+        participation.TerminationDate = participationTerminationDate;
+        participation.PanelLimit = panelLimit;
+        participation.PanelAccepted = panelAccepted;
+        participation.MinAcceptedAgeYears = minAge;
+        participation.MaxAcceptedAgeYears = maxAge;
+        p.NetworkParticipations.Add(participation);
+
+        await repo.CreateAsync(p);
+    }
+
+    private static Provider NewActiveProvider(string providerId, string lastName, string tenantId)
+        => new()
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            VersionId = providerId + "-v1",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            TenantId = tenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = lastName,
+            PrimarySpecialty = "207R00000X",
+            TaxonomyCode = "207R00000X",
+            Status = ProviderStatus.Active,
+            AcceptingNewPatients = true,
+        };
+
+    private static NetworkParticipation NewParticipation(string? networkId, LineOfBusiness lob, string tier)
+        => new()
+        {
+            NetworkId = networkId,
+            LineOfBusiness = lob,
+            NetworkTier = tier,
+            EffectiveDate = DateTime.UtcNow.AddYears(-1),
+            AcceptingNewPatients = true,
+        };
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
@@ -374,6 +374,83 @@ public class NetworkRosterServiceTests
     }
 
     [Fact]
+    public async Task Roster_includes_legacy_rows_with_empty_VersionId_and_Status_Active()
+    {
+        // Legacy shape: VersionId / VersionState absent on disk, Status=Active.
+        // The fake's HydratedView normalizes these to VersionState=Active —
+        // exercising the same read-path semantics that the Mongo/Cosmos
+        // queries now accept after the legacy-state-filter fix.
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var legacy = new Provider
+        {
+            Id = "legacy-1",
+            // Note: ProviderId / VersionId / VersionState all defaulted (empty).
+            TenantId = TenantA,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Adams",
+            PrimarySpecialty = "207R00000X",
+            TaxonomyCode = "207R00000X",
+            Status = ProviderStatus.Active,
+            AcceptingNewPatients = true,
+        };
+        legacy.NetworkParticipations.Add(new NetworkParticipation
+        {
+            NetworkId = Network1,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            NetworkTier = "Tier1",
+            EffectiveDate = DateTime.UtcNow.AddYears(-1),
+            AcceptingNewPatients = true,
+        });
+        await repo.CreateAsync(legacy);
+
+        var resp = await svc.GetRosterAsync(NewQuery(Network1));
+
+        resp.Items.Should().HaveCount(1);
+        resp.Items[0].ProviderId.Should().Be("legacy-1");
+    }
+
+    [Fact]
+    public async Task Roster_cursor_AsOfDate_tamper_rejected()
+    {
+        // Tampering with the cursor's AsOfDate must produce a hash
+        // mismatch even when other fields are preserved — fix #5.
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        for (var i = 0; i < 6; i++)
+            await SeedProviderAsync(repo, $"p-{i}", $"Last-{i}", networkId: Network1);
+
+        var query = NewQuery(Network1);
+        query.PageSize = 2;
+        query.AsOfDate = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var page1 = await svc.GetRosterAsync(query);
+        page1.NextCursor.Should().NotBeNull();
+
+        // Forge a new cursor with a different AsOfDate — naive client mistake.
+        var decoded = System.Text.Json.JsonSerializer.Deserialize<System.Collections.Generic.Dictionary<string, object>>(
+            System.Text.Encoding.UTF8.GetString(
+                Convert.FromBase64String(PadBase64(page1.NextCursor!.Replace('-', '+').Replace('_', '/')))))!;
+        decoded["AsOfDate"] = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var tamperedJson = System.Text.Json.JsonSerializer.Serialize(decoded);
+        var tamperedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(tamperedJson))
+            .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        var query2 = NewQuery(Network1);
+        query2.PageSize = 2;
+        query2.AsOfDate = query.AsOfDate;
+        query2.Cursor = tamperedToken;
+
+        var act = async () => await svc.GetRosterAsync(query2);
+        await act.Should().ThrowAsync<NetworkRosterValidationException>()
+            .Where(e => e.ErrorCode == "cursor_filter_mismatch");
+    }
+
+    private static string PadBase64(string s) => (s.Length % 4) switch { 2 => s + "==", 3 => s + "=", _ => s };
+
+    [Fact]
     public async Task Roster_terminated_provider_chain_excluded()
     {
         var repo = new InMemoryProviderRepository { TenantId = TenantA };


### PR DESCRIPTION
## Summary

Capability **5.4** — paginated, filterable provider roster scoped to a single Organization (`5.3` network entity).

- `GET /api/v1/networks/{id}/roster`
- Filters: `lineOfBusiness`, `specialty` (NUCC), `tier`, `acceptingNewPatients`, `asOfDate`
- Cursor pagination with filter-hash binding; default 100, hard cap 1000
- Sort: `name` (asc/desc), `integrityScore` (desc, nulls-last)
- Reads cached `Provider.IntegrityScore` directly — never invokes `ProviderVerificationOrchestrator` on the read path

## Design notes (decisions ratified during planning)

- **`NetworkParticipation.NetworkId`** (nullable) was added so a participation can reference its `Organization.OrganizationId`. Legacy participations without `NetworkId` are **invisible to this endpoint by design** — migration is per-tenant backfill as Organizations are authored.
- **`distance` sort is deferred** — returns `400 distance_sort_unsupported`. Geospatial-index follow-up planned (Cosmos geospatial / Mongo `2dsphere`); see `docs/architecture/network-roster-api.md` "Deferred — distance sort".
- **Known gap surfaced during execution:** `provider-verification-service` does not currently persist back to `Provider.IntegrityScore`. The roster reads the column anyway; nulls-last sort handles the gap gracefully. Documented in the arch doc; tracked separately.

## Files

- `src/services/provider-service/Services/NetworkRosterService.cs` — owns sort/filter/cursor + mapping
- `src/services/provider-service/Models/NetworkRosterQuery.cs`, `NetworkRosterEntry.cs` — DTOs
- `src/services/provider-service/Controllers/NetworksController.cs` — new `GetRoster` endpoint
- `src/services/provider-service/Repositories/ProviderRepository*.cs` — Cosmos + Mongo backing query, plus new compound indexes on Mongo
- `src/services/provider-service/Models/Provider.cs` — `NetworkParticipation.NetworkId` field
- `tests/.../Services/NetworkRosterServiceTests.cs` + `NetworkRosterCursorTests.cs`
- `docs/architecture/network-roster-api.md`

## Test plan

- [ ] CI: `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — local sandbox lacks `dotnet`; tests authored against `InMemoryProviderRepository`
- [ ] Existing provider/organization tests still pass
- [ ] Manual smoke: seed two networks + a provider with `NetworkId` linking to one, call `GET /api/v1/networks/{id}/roster`, verify only matching participations appear
- [ ] Filter combo: `?lineOfBusiness=Medicare&specialty=207R00000X&acceptingNewPatients=true`
- [ ] AsOfDate: roster snapshot at a date before/after a participation's `TerminationDate`
- [ ] Cursor paging: 250-row dataset across 3 pages of 100/100/50
- [ ] Cursor tamper: reuse cursor with mutated filter → 400 `cursor_filter_mismatch`
- [ ] Tenant isolation: providers in tenant B do not appear in tenant A's roster
- [ ] `sortBy=distance` → 400 `distance_sort_unsupported`

https://claude.ai/code/session_01UGwdqmeTx21Vaw137pUbTz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGwdqmeTx21Vaw137pUbTz)_