### PR TITLE
5.4.5 — verification result write-back to Provider entity

### DIFF
--- a/docs/architecture/network-roster-api.md
+++ b/docs/architecture/network-roster-api.md
@@ -186,28 +186,33 @@ The roster path **never** invokes
 from the cached column on the Provider row. This satisfies the "no
 real-time multi-source call on the roster query path" constraint.
 
-## Known gap — verification write-back
+## Verification write-back — resolved by capability 5.4.5
 
-`Provider.IntegrityScore`, `IntegrityRating`, and `LastVerifiedAt` exist
-as columns on the Provider entity (see `Models/Provider.cs`). They are
-**not** currently written by `provider-verification-service` —
-verification runs end-to-end and exposes the score via a live HTTP
-endpoint, but no path persists the score back onto the Provider row.
+`Provider.IntegrityScore`, `IntegrityRating`, `LastVerifiedAt`, and
+`NextVerificationDue` are now populated by capability 5.4.5
+(`docs/architecture/verification-writeback.md`).
 
-Practical impact for this endpoint: until verification write-back lands,
-`integrityScore` is `null` for ~all roster rows. The nulls-last sort
-handles it gracefully; the field surface is forward-compatible.
+`IntegrityProjectionWorker` (a `BackgroundService` in provider-service)
+sweeps due providers per tenant on a schedule, calls
+`provider-verification-service` over HTTP via
+`POST /api/v1/providers/verify/batch`, and patches the four projection
+fields onto the head Active row via
+`IProviderRepository.UpdateIntegrityProjectionAsync`.
 
-Tracked as a separate capability — see the verification roadmap. A
-candidate implementation:
+For roster operators:
 
-1. Add a hosted projection in `provider-service` that subscribes to
-   verification events and patches `Provider.IntegrityScore` /
-   `IntegrityRating` / `LastVerifiedAt` on the head Active version.
-2. Or extend `provider-verification-service` to call back into
-   `provider-service` after each verification.
-
-Either approach is out of scope for 5.4.
+- After 5.4.5 ships and the per-tenant backfill runs (admin endpoint
+  `POST /api/v1/admin/providers/backfill-integrity-projection?tenantId=X`),
+  the `integrityScore` envelope on each roster row reflects the
+  cached projection from the most recent verification. No change to
+  roster code or schema.
+- The nulls-last sort (`NetworkRosterService.ApplyNullsLastForIntegrityScore`)
+  continues to work correctly during the backfill window — partially
+  populated tenants will have some null and some populated rows, and
+  nulls-last sort handles both cleanly.
+- Live HTTP fetch via `HttpProviderIntegrityGate` in
+  `benefit-plan-service` remains available for adjudication —
+  fresh-or-cached migration is capability 5.10's decision.
 
 ## Deferred — distance sort
 

--- a/docs/architecture/provider-versioning.md
+++ b/docs/architecture/provider-versioning.md
@@ -219,26 +219,76 @@ provider has an Active version — callers must amend through the new
 flow. The legacy `DELETE` path now performs a `Terminate` transition
 on the head Active version, preserving history.
 
+## Projection metadata — exempt from versioning
+
+A version-chain row is otherwise immutable once published Active —
+`UpdateAsync` rejects any write that targets a non-Draft row with
+`ProviderVersionStateException`. **Projection metadata is the one
+documented exception**: a small set of fields that are computed by
+external services on their own cadence and written back as a cached
+read-side projection. Updating them does **not** create a new
+`VersionNumber` and does **not** transition the chain through
+Draft → Active.
+
+Today the only projection-metadata fields are the integrity-score
+projection populated by capability 5.4.5
+(`docs/architecture/verification-writeback.md`):
+
+| Field | Source | Cadence |
+|---|---|---|
+| `IntegrityScore` | `provider-verification-service` | Shortest-active-window (24h) |
+| `IntegrityRating` | `provider-verification-service` | Shortest-active-window (24h) |
+| `LastVerifiedAt` | `provider-verification-service` | Shortest-active-window (24h) |
+| `NextVerificationDue` | computed locally | Shortest-active-window (24h) |
+
+The write path is `IProviderRepository.UpdateIntegrityProjectionAsync(
+tenantId, providerId, score, rating, verifiedAt, nextDue, ct)`:
+
+- **Cosmos** — `PatchItemAsync` with four `PatchOperation.Set` ops on
+  `/integrityScore`, `/integrityRating`, `/lastVerifiedAt`,
+  `/nextVerificationDue` (plus `/lastUpdatedDate`).
+- **Mongo** — `FindOneAndUpdateAsync` with `$set` on the same field
+  paths, sorted by `VersionNumber DESC` so amendments hit the latest
+  head.
+
+Both bypass the `UpdateAsync` state guard; neither writes the
+`VersionState`/`VersionNumber`/`PredecessorVersionId` fields.
+Identity-field writes against the same Active row continue to throw
+(verified by `IntegrityProjectionWritePathTests.UpdateAsync_against_active_still_throws_after_projection_patch`).
+
+**Why the carve-out**: integrity scores refresh on their own
+operational cadence (every 24h on the shortest-active-window
+schedule). Emitting a new chain version per refresh would produce
+unbounded version-chain growth and break the audit semantic that
+"each version represents an identity change." Projection metadata is
+write-side noise, not history.
+
+**Adding new projection fields**: any future capability that wants to
+join the carve-out should add a sibling repository method
+(`UpdateXxxProjectionAsync`) — not extend `UpdateIntegrityProjectionAsync`,
+not relax the `UpdateAsync` guard, not re-purpose
+`ReplaceVersionRowAsync`. Each carve-out documents its source service
+and refresh cadence in this section.
+
 ## Caveats / follow-ups
 
-- **Bus fan-out.** Decorator over `IProviderVersionEventPublisher` not
-  yet wired.
+- **Bus fan-out.** Decorator over `IProviderVersionEventPublisher`
+  not yet wired (verified — `IProviderVersionEventPublisher.cs:13-18`
+  documents the deferred decorator seam).
 - **Cross-tenant draft isolation.** Drafts are partitioned by
   `TenantId` like every other row; no extra access control beyond the
-  tenant middleware is implemented in this PR.
+  tenant middleware is implemented (verified — both repository
+  implementations partition every read on `TenantId`).
 - **Network-participation deltas.** The v2 / Active row carries the
   full `NetworkParticipations` array; downstream consumers that diff
   participations across versions can subtract by `(planId,
   effectiveDate)` keys. A dedicated participation-delta event is
   reserved for a follow-up if the downstream cost of replaying full
   arrays becomes problematic.
-- **`ProviderVerificationOrchestrator` integration.** Verification
-  results write `IntegrityScore` / `IntegrityRating` /
-  `LastVerifiedAt` / `NextVerificationDue` directly on the Active
-  version. Because Active rows are read-only at the controller
-  boundary, the orchestrator must call repository methods rather than
-  the public PUT endpoint. The repository's `ReplaceVersionRowAsync`
-  is the existing escape hatch for state-only mutations and remains
-  available for orchestrator-style writes; a follow-up will introduce
-  a dedicated `UpdateVerificationFieldsAsync` carve-out so the rest of
-  the row stays immutable.
+- **`ProviderVerificationOrchestrator` integration.** Resolved by
+  capability 5.4.5 — verification results are now written back to the
+  Provider entity via `UpdateIntegrityProjectionAsync` (see
+  "Projection metadata — exempt from versioning" above and
+  `verification-writeback.md`). The orchestrator itself stays focused
+  on producing a verification record from live data sources;
+  provider-service owns the projection write path.

--- a/docs/architecture/provider-versioning.md
+++ b/docs/architecture/provider-versioning.md
@@ -133,6 +133,84 @@ consumers — `coverage-service` `PcpAssignmentService` (which checks
 not need to migrate to `VersionState`; they can if they want stronger
 state assertions.
 
+## Legacy hydration query pattern
+
+Any query that filters provider rows on `VersionState` MUST mirror the
+mapping `Hydrate()` applies on read. Otherwise the query disagrees with
+what the rest of the codebase considers "Active" and silently includes
+or excludes legacy rows.
+
+### The rule
+
+A row counts as **Active** at query time when ANY of the following hold:
+
+1. `VersionState == Active` (current versioned shape).
+2. `VersionState` is missing **AND** `Status == Active` (rows that
+   pre-date capability 5.1 — `VersionState` was never persisted).
+3. `VersionId` is missing/null/empty **AND** `Status == Active` (rows
+   that defaulted `VersionState` to enum-zero `Draft` on read; the
+   `Hydrate()` fallback derives `Active` from `Status` when
+   `VersionId` is unset).
+
+Branches 2 and 3 cover two distinct shapes of legacy data depending on
+how the row was originally written; both are reachable in production.
+The `Status == Active` guard on branches 2 and 3 is non-negotiable —
+it's what excludes legacy Terminated / Suspended rows that lack
+`VersionState`.
+
+Concretely:
+
+```csharp
+// Mongo
+var b = Builders<Provider>.Filter;
+var activeFilter = b.Or(
+    b.Eq(p => p.VersionState, ProviderVersionState.Active),
+    b.And(
+        b.Exists(p => p.VersionState, false),
+        b.Eq(p => p.Status, ProviderStatus.Active)),
+    b.And(
+        b.Or(
+            b.Exists(p => p.VersionId, false),
+            b.Eq(p => p.VersionId, null),
+            b.Eq(p => p.VersionId, string.Empty)),
+        b.Eq(p => p.Status, ProviderStatus.Active)));
+```
+
+```sql
+-- Cosmos
+WHERE c.versionState = @active
+   OR (NOT IS_DEFINED(c.versionState) AND c.status = @statusActive)
+   OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = "")
+       AND c.status = @statusActive)
+```
+
+### What goes wrong without the `Status` guard
+
+Treating "missing `VersionState`" alone as Active pulls in legacy
+**Terminated** and **Suspended** rows whose `VersionState` was never
+written. Symptoms:
+
+- Roster listings include providers who left the network months ago.
+- Projection writers (capability 5.4.5) patch and emit refresh events
+  for non-active providers.
+- Read-only consumers see "Active" providers that the rest of the
+  system considers terminated.
+
+The matching read site (`GetLatestActiveAsync` in both repository
+implementations) already applies the rule. Capability 5.4.5 added four
+new query sites — `UpdateIntegrityProjectionAsync` and
+`ListProvidersForIntegrityRefreshAsync`, each in Cosmos and Mongo —
+all four of which must apply the same rule.
+
+### When adding a new capability
+
+If you write a new query that touches `Provider` rows, audit it
+against this rule. The fast check: does the filter mention
+`VersionState`? If yes, both branches of the legacy fallback must
+appear together. Don't write `OR NOT IS_DEFINED(c.versionState)` (or
+`b.Exists(p => p.VersionState, false)`) without an immediate
+`AND status = active` guard.
+
 ## Atomicity
 
 `ActivateAndSupersedeAsync` flips the draft to Active and the

--- a/docs/architecture/verification-writeback.md
+++ b/docs/architecture/verification-writeback.md
@@ -1,0 +1,310 @@
+# Verification Result Write-Back (Capability 5.4.5)
+
+Status: 5.4.5 — projection write-back  
+Service: `src/services/provider-service`  
+Depends on: `provider-verification-service` (HTTP)
+
+## Why
+
+Capability 5.1 (Provider Identity & Versioning) declared cached
+integrity-score columns on the `Provider` entity:
+
+```csharp
+public int? IntegrityScore { get; set; }
+public string? IntegrityRating { get; set; }
+public DateTimeOffset? LastVerifiedAt { get; set; }
+public DateTimeOffset? NextVerificationDue { get; set; }
+```
+
+…but no write path populated them. `ProviderVerificationOrchestrator`
+in `src/engines/CloudHealthOffice.ProviderVerificationEngine` produced a
+verification record on a transient object that was never persisted back
+to the entity. Capability 5.4 (Network Roster API) shipped a roster
+that reads `Provider.IntegrityScore` directly — and got `null` for
+every row in production.
+
+5.4.5 closes the gap. The roster's `IntegrityScore` column lights up;
+adjudication, FHIR projections, and the provider profile card can read
+the cached value without making per-request HTTP calls into
+verification-service.
+
+## Architecture — hosted projection in provider-service
+
+Of four reasonable architectures (hosted projection, outbound webhook,
+event bus, change-feed listener), 5.4.5 ships **hosted projection**.
+Three reasons:
+
+1. **Consistency with platform pattern.** `PlanYearScheduler` and
+   `PlanYearTransitionEventIndexInitializer` already establish the
+   hosted-service convention. A new `IntegrityProjectionWorker` fits
+   the slot natively — provider-service already registers a hosted
+   service (`ProviderVersionEventIndexInitializer`).
+2. **No new infrastructure.** Provider-service has no Kafka package
+   today; PR 7.2's `IProviderVersionEventPublisher` is in-process
+   Mongo only. Event-bus adoption (Option C) would require wiring
+   Kafka into provider-service in this PR — out of scope.
+3. **Idempotency is straightforward.** Each refresh runs against a
+   single Provider row keyed by `(TenantId, ProviderId)`. Restartable.
+   Failure modes are observable and retriable.
+
+Trade-off: pull-based, not push-based. For the verification cadence
+(NPPES daily, LEIE daily, PECOS weekly, FSMB monthly), pull-based is
+fine.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ provider-service                                                 │
+│                                                                  │
+│   IntegrityProjectionWorker (BackgroundService)                  │
+│        │ every SweepInterval (default 1h)                        │
+│        ▼                                                         │
+│   ListProviderTenantIdsAsync()  ── distinct tenants              │
+│        │                                                         │
+│        ▼  per tenant                                             │
+│   ProviderIntegrityProjectionService.RefreshTenantAsync(tenant)  │
+│        │                                                         │
+│        ├─► ListProvidersForIntegrityRefreshAsync                 │
+│        │     filter: NextVerificationDue <= now OR IS NULL       │
+│        │     paginate: 100/page                                  │
+│        │                                                         │
+│        ├─► HttpProviderVerificationClient.VerifyBatchAsync(npis) │
+│        │     POST /api/v1/providers/verify/batch  (HTTP)         │
+│        │     returns ProviderVerificationRecord per NPI          │
+│        │                                                         │
+│        ├─► UpdateIntegrityProjectionAsync(score, rating, ...)    │
+│        │     Cosmos: PatchItemAsync (4 Set ops on head row)      │
+│        │     Mongo:  FindOneAndUpdateAsync ($set on 4 fields)    │
+│        │     bypasses UpdateAsync's version-state guard          │
+│        │                                                         │
+│        └─► PublishRefreshedAsync(...)                            │
+│              ProviderVerificationEvents append-only stream       │
+│              EventId = "refreshed:{providerId}:{verifiedAtIso}"  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Projection metadata — exempt from versioning
+
+`IntegrityScore`, `IntegrityRating`, `LastVerifiedAt`, and
+`NextVerificationDue` are **projection metadata**, not provider-identity
+fields. They are computed by `provider-verification-service` and
+written back without ratifying a new version.
+
+Concretely:
+
+- `Provider.UpdateAsync` continues to throw `ProviderVersionStateException`
+  on non-Draft rows (PR 5.1 invariant preserved).
+- `IProviderRepository.UpdateIntegrityProjectionAsync` is a separate
+  write path that bypasses the state guard — it `$set`s only the four
+  projection fields on the head Active row. No new `VersionNumber` is
+  created.
+- See `provider-versioning.md` "Projection metadata — exempt from
+  versioning" for the policy statement.
+
+This avoids unbounded version-chain growth (verification refreshes run
+every 24h on the shortest-window cadence — emitting a new version per
+refresh would rapidly drown identity-change versions in noise) and
+preserves the audit semantic that "each version represents an
+identity change."
+
+## Verification-service contract
+
+Hosted worker calls **`POST /api/v1/providers/verify/batch`** on
+`provider-verification-service` (Minimal API at
+`src/services/provider-verification-service/Program.cs`). HTTP — not
+project reference — so:
+
+- Service boundary preserved (mirrors `HttpProviderIntegrityGate` in
+  `benefit-plan-service`).
+- The verification engine's six data-source HTTP clients (NPPES,
+  LEIE, PECOS, Open Payments, Medicare, FSMB) are not duplicated in
+  provider-service.
+
+The endpoint caps batch size at 100 NPIs;
+`IntegrityProjectionOptions.PageSize` defaults to 100 so each page is
+exactly one HTTP call. `HttpProviderVerificationClient` returns an
+empty result on transport failure or non-2xx; the projection service
+treats that as "no record" — cached scores stay put, the row's
+`NextVerificationDue` is left alone, the next sweep retries.
+
+## Schedule cadence — composite-on-shortest-window
+
+Per-source refresh windows (configurable in
+`IntegrityProjectionOptions.Windows`):
+
+| Source | Default window | Regulatory cadence |
+|--------|---------------|--------------------|
+| NPPES | 24 hours | Daily registry update |
+| LEIE / SAM | 24 hours | Daily exclusion list |
+| PECOS | 7 days | Weekly enrollment delta |
+| Open Payments | 90 days | Quarterly payment cycle |
+| Medicare Utilization | 90 days | Quarterly utilization cycle |
+| FSMB | 30 days | Monthly licensing review |
+
+The composite refresh runs at the **shortest active window** —
+currently 24 hours (NPPES). After every successful refresh, the
+worker computes
+`NextVerificationDue = LastVerifiedAt + ShortestActiveWindow()` and
+writes that back so the next sweep skips this row until it's due
+again.
+
+### Composite cadence trade-off
+
+"Shortest active window" means the full composite re-runs every 24h,
+including the 90-day Open Payments / Medicare sources. Operationally
+that's redundant — those source adapters might re-fetch identical
+data each refresh. The trade-off:
+
+- **What we ship (5.4.5):** one materialised
+  `Provider.NextVerificationDue` per row. Simple, low storage cost,
+  one Cosmos/Mongo column. Re-runs the full composite at the
+  shortest cadence.
+- **What we deferred (5.10):** per-source materialised refresh
+  state (six per-source `LastRefreshedAt` columns on `Provider`).
+  Each source refreshes on its own cadence; composite is recomputed
+  whenever any source updates. Honors all six cadences but adds six
+  fields and six timestamp comparisons per sweep.
+
+Capability 5.10 (Verification Integrity Score Surface) is the right
+place to revisit if the redundant fetches become operationally
+visible. Until then, the simpler model wins.
+
+## Iteration strategy
+
+Per-tenant pagination via `ListProvidersForIntegrityRefreshAsync`,
+mirroring the pattern established by `ListNetworkRosterAsync`:
+
+- **Cosmos:** `OFFSET / LIMIT` query, partition-scoped on `TenantId`,
+  filter on `(versionState = Active OR legacy) AND (nextVerificationDue
+  <= dueBefore OR null)`.
+- **Mongo:** `Find().Sort(ProviderId).Skip(safeSkip).Limit(pageSize)`,
+  same filter logic. Stable sort on `ProviderId, Id` so paginated
+  sweeps produce deterministic ordering.
+
+Per-tenant cap (`MaxProvidersPerTenantPerSweep`, default 1000)
+protects round-robin fairness when one tenant has a fully-due backlog
+post-deploy. Admin backfill bypasses the cap via
+`request.MaxProviders`.
+
+The worker enumerates distinct tenants via
+`ListProviderTenantIdsAsync`. Cross-partition scan; called once per
+sweep so RU cost is bounded by the sweep cadence (default 1h).
+
+## On-demand refresh endpoint
+
+```
+POST /api/v1/providers/{id}/verification/refresh?force=true
+```
+
+Returns the patched `IntegrityProjectionRefreshResult` synchronously.
+Used by credentialing workflows and credential-event-driven
+re-verification.
+
+Route is `/{id}/verification/refresh` (not `/{id}/verify`) to avoid
+ambiguity with verification-service's
+`GET /api/v1/providers/{npi}/verify`. The two services would otherwise
+share the `/api/v1/providers/...` path-prefix at the gateway layer.
+
+## Backfill — admin HTTP endpoint
+
+```
+POST /api/v1/admin/providers/backfill-integrity-projection?tenantId=X&maxProviders=N
+```
+
+Admin-callable. Iterates every Provider in the named tenant and forces
+a verification refresh — used per-tenant after this PR ships to
+populate `IntegrityScore` on legacy null rows. Idempotent: rerunning
+completes the gap from a previous partial run.
+
+**Auth posture.** This endpoint is not gated at the application layer
+in this PR — provider-service does not yet have an admin-role
+middleware. Operators must restrict access at the deployment layer
+(NetworkPolicy, gateway ACL) until a platform-wide admin-auth pattern
+lands. A capitation-service-style CLI was considered (precedent:
+`SplitCapitationContracts.cs`); HTTP fits provider-service's
+existing surface better and avoids an exec environment per tenant.
+
+## Event stream — `ProviderVerificationEvents`
+
+Each successful refresh emits a `ProviderVerificationRefreshed` event
+to a new Mongo collection `ProviderVerificationEvents`, mirroring the
+PR 5.1 `ProviderVersionEvents` pattern:
+
+- **Idempotent EventId**:
+  `refreshed:{providerId}:{verifiedAtUtcIso}`.
+  Re-emitting at the same `verifiedAt` returns the existing event.
+- **Monotonic Version per `(TenantId, ProviderId)`**.
+- **Partition key**: `{TenantId}:{ProviderId}`.
+- **Indexes** (provisioned by
+  `ProviderVerificationEventIndexInitializer`):
+  - `(TenantId, ProviderId, EventId)` UNIQUE — idempotency.
+  - `(TenantId, ProviderId, Version)` UNIQUE — monotonic ordering.
+
+No cross-service consumer ships in 5.4.5. Capability 5.10 is the
+planned subscriber. Cosmos-only deployments register
+`NoopProviderVerificationEventPublisher` which logs a warning per
+emit so ops can spot the missing wiring.
+
+## `HttpProviderIntegrityGate` posture — unchanged
+
+`benefit-plan-service` continues to consume the score live via
+`HttpProviderIntegrityGate.CheckAsync(npi)` per adjudication request.
+The cached projection is a *forward* path that consumers can adopt as
+they're ready; the live HTTP path remains the source of truth for
+adjudication.
+
+Capability 5.10 (Integrity Score Surface) is the right place to
+decide consumer-by-consumer migration to the cached path. 5.4.5 ships
+the persistence; 5.10 ships the consumption strategy.
+
+## Configuration
+
+```jsonc
+{
+  "IntegrityProjection": {
+    "Enabled": true,
+    "SweepInterval": "01:00:00",
+    "PageSize": 100,
+    "MaxProvidersPerTenantPerSweep": 1000,
+    "Windows": {
+      "Nppes":               "1.00:00:00",
+      "LeieSam":             "1.00:00:00",
+      "Pecos":               "7.00:00:00",
+      "OpenPayments":        "90.00:00:00",
+      "MedicareUtilization": "90.00:00:00",
+      "Fsmb":                "30.00:00:00"
+    }
+  },
+  "ProviderVerification": {
+    "BaseUrl": "http://provider-verification-service",
+    "TimeoutSeconds": 30
+  }
+}
+```
+
+`Enabled=false` keeps the worker idle (admin backfill + on-demand
+refresh remain available).
+
+## Recovery posture
+
+| Failure mode | Behavior |
+|---|---|
+| Hosted worker crashes | Restartable; idempotent refresh; re-runs after pod restart. |
+| Verification source down | `HttpProviderVerificationClient` returns empty; refresh skipped; cached score preserved; row's `NextVerificationDue` untouched so next sweep retries. |
+| Repository write fails | Caught, logged, counts as `Failed` in tenant sweep result; next sweep retries the row. |
+| Backfill partial | Idempotent; rerun completes the gap. |
+| Event publication fails after patch landed | Logged; patch already applied; re-emitting on next sweep is idempotent (deterministic `EventId` on `(providerId, verifiedAt)`). |
+| Projection-metadata write interpreted as version-identity change | Would be a regression — `IntegrityProjectionWritePathTests.UpdateIntegrityProjection_does_not_create_a_new_version` guards against it. |
+
+The work is purely additive. Worst-case rollback: revert the PR;
+roster's `IntegrityScore` column returns to null;
+`HttpProviderIntegrityGate` continues to work for adjudication
+critical path; nothing else regresses.
+
+## Out of scope (deferred to capability 5.10)
+
+- Per-source materialised refresh-state on `Provider`.
+- Migration of `HttpProviderIntegrityGate` to read from
+  `Provider.IntegrityScore` instead of live HTTP.
+- `ProviderVerificationRefreshed` event consumers / fan-out.
+- Application-layer admin-auth middleware on the backfill endpoint.
+- Per-source schedule overrides per tenant.

--- a/docs/architecture/verification-writeback.md
+++ b/docs/architecture/verification-writeback.md
@@ -210,18 +210,37 @@ share the `/api/v1/providers/...` path-prefix at the gateway layer.
 POST /api/v1/admin/providers/backfill-integrity-projection?tenantId=X&maxProviders=N
 ```
 
-Admin-callable. Iterates every Provider in the named tenant and forces
-a verification refresh — used per-tenant after this PR ships to
-populate `IntegrityScore` on legacy null rows. Idempotent: rerunning
-completes the gap from a previous partial run.
+Admin-callable. Forces an integrity-projection refresh for every Active
+provider in the named tenant, regardless of `NextVerificationDue`.
+Idempotent (last-write-wins on the four projection-metadata fields):
+use to populate legacy null projections, recover from extended
+verification-service outages, or operator-driven data-quality refresh.
 
-**Auth posture.** This endpoint is not gated at the application layer
-in this PR — provider-service does not yet have an admin-role
-middleware. Operators must restrict access at the deployment layer
-(NetworkPolicy, gateway ACL) until a platform-wide admin-auth pattern
-lands. A capitation-service-style CLI was considered (precedent:
-`SplitCapitationContracts.cs`); HTTP fits provider-service's
-existing surface better and avoids an exec environment per tenant.
+### Auth posture — defence in depth
+
+Two gates protect this route:
+
+1. **`IntegrityProjection:AdminBackfillEnabled` flag, default `false`.**
+   The controller returns `503 Service Unavailable` (NOT 404 — operators
+   need to know the endpoint exists but is gated) until configuration
+   explicitly opts in. This is a tripwire: provider-service does not
+   yet configure authentication (`Program.cs` calls `UseAuthorization()`
+   with no `AddAuthentication()`), so without this guard a
+   misconfigured gateway / NetworkPolicy could expose a route that
+   triggers large cross-service work.
+2. **Deployment-layer ACL.** Even with the flag enabled, the load-bearing
+   authorization is in the deployment layer:
+   - Kubernetes `NetworkPolicy` restricting the `/api/v1/admin/...`
+     prefix to operator pods only;
+   - Gateway / ingress ACL with mTLS or signed admin JWT;
+   - Or both.
+
+The flag is a safety net, not authentication. Enabling it without a
+deployment-layer restriction exposes the endpoint.
+
+A capitation-service-style CLI was considered (precedent:
+`SplitCapitationContracts.cs`); HTTP fits provider-service's existing
+surface better and avoids an exec environment per tenant.
 
 ## Event stream — `ProviderVerificationEvents`
 
@@ -262,6 +281,7 @@ the persistence; 5.10 ships the consumption strategy.
 {
   "IntegrityProjection": {
     "Enabled": true,
+    "AdminBackfillEnabled": false,  // opt in per environment; pair with NetworkPolicy
     "SweepInterval": "01:00:00",
     "PageSize": 100,
     "MaxProvidersPerTenantPerSweep": 1000,

--- a/src/services/provider-service/Controllers/IntegrityProjectionAdminController.cs
+++ b/src/services/provider-service/Controllers/IntegrityProjectionAdminController.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc;
+using ProviderService.Services;
+
+namespace ProviderService.Controllers;
+
+/// <summary>
+/// Admin-callable surface for the integrity-projection write-back path
+/// (capability 5.4.5). Backfill iterates every Provider in a named
+/// tenant and forces a verification refresh — used after this PR ships
+/// to populate <c>IntegrityScore</c> on legacy rows.
+///
+/// <para>
+/// **Auth posture.** This endpoint is not gated at the application
+/// layer in this PR — provider-service does not yet have an admin-role
+/// middleware. Operators must restrict access at the deployment layer
+/// (NetworkPolicy, gateway ACL) until a platform-wide admin-auth
+/// pattern lands. Documented in
+/// <c>docs/architecture/verification-writeback.md</c> "Backfill activation".
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/v1/admin/providers")]
+[Produces("application/json")]
+public sealed class IntegrityProjectionAdminController : ControllerBase
+{
+    private readonly IProviderIntegrityProjectionService _projection;
+    private readonly ILogger<IntegrityProjectionAdminController> _logger;
+
+    public IntegrityProjectionAdminController(
+        IProviderIntegrityProjectionService projection,
+        ILogger<IntegrityProjectionAdminController> logger)
+    {
+        _projection = projection;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Force-refresh integrity projections for every provider in
+    /// <paramref name="tenantId"/>. Idempotent — only patches rows
+    /// where the projection is null or older than the configured
+    /// refresh window. Re-running completes any gap from a previous
+    /// partial run.
+    /// </summary>
+    [HttpPost("backfill-integrity-projection")]
+    [ProducesResponseType(typeof(IntegrityProjectionTenantSweepResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IntegrityProjectionTenantSweepResult>> BackfillIntegrityProjection(
+        [FromQuery] string tenantId,
+        [FromQuery] int? maxProviders,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return BadRequest(new { error = "tenantId query parameter is required" });
+        }
+
+        _logger.LogInformation(
+            "integrity projection backfill triggered for tenant={Tenant} maxProviders={Max}",
+            Sanitize(tenantId), maxProviders);
+
+        var result = await _projection.RefreshTenantAsync(
+            tenantId,
+            new IntegrityProjectionTenantSweepRequest
+            {
+                DueBefore = DateTimeOffset.UtcNow.AddYears(100), // force "every row is due"
+                IncludeNeverVerified = true,
+                MaxProviders = maxProviders,
+                ActorId = "admin:backfill-integrity-projection",
+            },
+            ct);
+
+        _logger.LogInformation(
+            "integrity projection backfill complete: tenant={Tenant} inspected={Inspected} patched={Patched} skipped={Skipped} failed={Failed}",
+            Sanitize(tenantId), result.Inspected, result.Patched,
+            result.Skipped, result.Failed);
+
+        return Ok(result);
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/provider-service/Controllers/IntegrityProjectionAdminController.cs
+++ b/src/services/provider-service/Controllers/IntegrityProjectionAdminController.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
 using ProviderService.Services;
 
 namespace ProviderService.Controllers;
@@ -10,12 +12,32 @@ namespace ProviderService.Controllers;
 /// to populate <c>IntegrityScore</c> on legacy rows.
 ///
 /// <para>
-/// **Auth posture.** This endpoint is not gated at the application
-/// layer in this PR — provider-service does not yet have an admin-role
-/// middleware. Operators must restrict access at the deployment layer
-/// (NetworkPolicy, gateway ACL) until a platform-wide admin-auth
-/// pattern lands. Documented in
-/// <c>docs/architecture/verification-writeback.md</c> "Backfill activation".
+/// **Auth posture (defence in depth).** Two gates protect this route:
+/// </para>
+///
+/// <list type="number">
+///   <item>
+///     <see cref="IntegrityProjectionOptions.AdminBackfillEnabled"/>
+///     defaults to <c>false</c>. The controller returns
+///     <see cref="StatusCodes.Status503ServiceUnavailable"/> until an
+///     operator explicitly opts in via configuration. Provider-service
+///     does not yet configure authentication
+///     (<c>Program.cs</c> calls <c>UseAuthorization()</c> with no
+///     <c>AddAuthentication()</c>) — without this guard a misconfigured
+///     gateway / NetworkPolicy could expose a route that triggers
+///     large cross-service work.
+///   </item>
+///   <item>
+///     Even with the flag enabled, the deployment layer
+///     (NetworkPolicy, gateway ACL, mTLS) is the load-bearing
+///     authorization. The flag is a tripwire, not authn.
+///   </item>
+/// </list>
+///
+/// <para>
+/// See <c>docs/architecture/verification-writeback.md</c>
+/// "Backfill — admin HTTP endpoint" for the deployment-layer
+/// requirement.
 /// </para>
 /// </summary>
 [ApiController]
@@ -24,31 +46,55 @@ namespace ProviderService.Controllers;
 public sealed class IntegrityProjectionAdminController : ControllerBase
 {
     private readonly IProviderIntegrityProjectionService _projection;
+    private readonly IOptionsMonitor<IntegrityProjectionOptions> _options;
     private readonly ILogger<IntegrityProjectionAdminController> _logger;
 
     public IntegrityProjectionAdminController(
         IProviderIntegrityProjectionService projection,
+        IOptionsMonitor<IntegrityProjectionOptions> options,
         ILogger<IntegrityProjectionAdminController> logger)
     {
         _projection = projection;
+        _options = options;
         _logger = logger;
     }
 
     /// <summary>
-    /// Force-refresh integrity projections for every provider in
-    /// <paramref name="tenantId"/>. Idempotent — only patches rows
-    /// where the projection is null or older than the configured
-    /// refresh window. Re-running completes any gap from a previous
-    /// partial run.
+    /// Forces an integrity-projection refresh for every Active
+    /// provider in the specified tenant. All rows are treated as due,
+    /// regardless of <see cref="Provider.NextVerificationDue"/>.
+    /// Idempotent because last-write-wins on projection-metadata
+    /// fields. Use to populate legacy null projections, recover from
+    /// extended verification-service outages, or operator-driven
+    /// data-quality refresh.
     /// </summary>
     [HttpPost("backfill-integrity-projection")]
     [ProducesResponseType(typeof(IntegrityProjectionTenantSweepResult), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<IntegrityProjectionTenantSweepResult>> BackfillIntegrityProjection(
         [FromQuery] string tenantId,
         [FromQuery] int? maxProviders,
         CancellationToken ct)
     {
+        if (!_options.CurrentValue.AdminBackfillEnabled)
+        {
+            // 503 (not 404) so operators know the endpoint exists and
+            // is intentionally gated — a 404 would falsely suggest the
+            // route was never registered.
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new
+                {
+                    error = "admin_backfill_disabled",
+                    message =
+                        "Integrity-projection backfill is gated. Set " +
+                        "IntegrityProjection:AdminBackfillEnabled=true to enable, " +
+                        "and ensure the deployment layer (NetworkPolicy / gateway ACL) " +
+                        "restricts access to this route.",
+                });
+        }
+
         if (string.IsNullOrWhiteSpace(tenantId))
         {
             return BadRequest(new { error = "tenantId query parameter is required" });

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -22,17 +22,20 @@ public class ProvidersController : ControllerBase
     private readonly IProviderRepository _providerRepository;
     private readonly IProviderVersioningService _versioning;
     private readonly ProviderAdapterFactory _adapterFactory;
+    private readonly IProviderIntegrityProjectionService _integrityProjection;
     private readonly ILogger<ProvidersController> _logger;
 
     public ProvidersController(
         IProviderRepository providerRepository,
         IProviderVersioningService versioning,
         ProviderAdapterFactory adapterFactory,
+        IProviderIntegrityProjectionService integrityProjection,
         ILogger<ProvidersController> logger)
     {
         _providerRepository = providerRepository;
         _versioning = versioning;
         _adapterFactory = adapterFactory;
+        _integrityProjection = integrityProjection;
         _logger = logger;
     }
 
@@ -430,6 +433,46 @@ public class ProvidersController : ControllerBase
         {
             return Conflict(new { message = ex.Message, providerId = ex.ProviderId, versionId = ex.VersionId, versionState = ex.CurrentState.ToString() });
         }
+    }
+
+    /// <summary>
+    /// On-demand integrity-projection refresh (capability 5.4.5). Forces
+    /// a verification round-trip outside the hosted-worker schedule and
+    /// patches the head Active version's
+    /// <see cref="Provider.IntegrityScore"/> /
+    /// <see cref="Provider.IntegrityRating"/> /
+    /// <see cref="Provider.LastVerifiedAt"/> /
+    /// <see cref="Provider.NextVerificationDue"/> fields. Used by
+    /// credentialing workflows and credential-event-driven re-verification.
+    ///
+    /// <para>
+    /// Route is <c>/{id}/verification/refresh</c> (not <c>/verify</c>) to
+    /// avoid namespace collision with verification-service's
+    /// <c>GET /api/v1/providers/{npi}/verify</c>.
+    /// </para>
+    /// </summary>
+    [HttpPost("{id}/verification/refresh")]
+    [ProducesResponseType(typeof(IntegrityProjectionRefreshResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IntegrityProjectionRefreshResult>> RefreshVerification(
+        string id,
+        [FromQuery] bool force = true,
+        CancellationToken ct = default)
+    {
+        _logger.LogInformation(
+            "on-demand verification refresh for provider {Id} force={Force}",
+            SanitizeForLog(id), force);
+
+        var result = await _integrityProjection.RefreshProviderAsync(
+            TenantId, id, forceRefresh: force,
+            actorId: ResolveActorId(),
+            correlationId: HttpContext.TraceIdentifier,
+            ct);
+        if (result == null)
+        {
+            return NotFound(new { message = $"Provider {id} not found or has no Active version" });
+        }
+        return Ok(result);
     }
 
     /// <summary>

--- a/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
+++ b/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace ProviderService.HostedServices;
+
+/// <summary>
+/// Background sweeper that refreshes <c>Provider.IntegrityScore</c> on a
+/// schedule (capability 5.4.5).
+///
+/// <para>
+/// Pattern mirrors <c>PlanYearScheduler</c> in <c>benefit-plan-service</c>:
+/// a <see cref="BackgroundService"/> that loops on a configurable
+/// interval, scopes a fresh repository per tenant via
+/// <see cref="IServiceScopeFactory"/>, and emits structured-log
+/// telemetry per tenant per sweep.
+/// </para>
+///
+/// <para>
+/// The worker is gated by per-provider <see cref="Provider.NextVerificationDue"/>
+/// — the sweep filter only returns providers actually due, so a shorter
+/// sweep interval translates into faster responsiveness, not more work.
+/// </para>
+/// </summary>
+public sealed class IntegrityProjectionWorker : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptionsMonitor<IntegrityProjectionOptions> _options;
+    private readonly ILogger<IntegrityProjectionWorker> _logger;
+
+    public IntegrityProjectionWorker(
+        IServiceScopeFactory scopeFactory,
+        IOptionsMonitor<IntegrityProjectionOptions> options,
+        ILogger<IntegrityProjectionWorker> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "IntegrityProjectionWorker started (Enabled={Enabled}, SweepInterval={Sweep}, PageSize={Page}, MaxPerSweep={Max})",
+            _options.CurrentValue.Enabled,
+            _options.CurrentValue.SweepInterval,
+            _options.CurrentValue.PageSize,
+            _options.CurrentValue.MaxProvidersPerTenantPerSweep);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!_options.CurrentValue.Enabled)
+                {
+                    await DelayAsync(_options.CurrentValue.SweepInterval, stoppingToken);
+                    continue;
+                }
+
+                await SweepAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "IntegrityProjectionWorker sweep failed; retrying after {Interval}",
+                    _options.CurrentValue.SweepInterval);
+            }
+
+            await DelayAsync(_options.CurrentValue.SweepInterval, stoppingToken);
+        }
+    }
+
+    private async Task SweepAsync(CancellationToken ct)
+    {
+        var sweepStart = DateTimeOffset.UtcNow;
+
+        // One scope per tenant so the scoped repository / projection
+        // service get fresh dependencies. This matches the pattern used
+        // by PlanYearScheduler in benefit-plan-service.
+        IReadOnlyList<string> tenantIds;
+        using (var bootScope = _scopeFactory.CreateScope())
+        {
+            var providers = bootScope.ServiceProvider.GetRequiredService<IProviderRepository>();
+            tenantIds = await providers.ListProviderTenantIdsAsync(ct);
+        }
+
+        var totalPatched = 0;
+        var totalFailed = 0;
+        var totalSkipped = 0;
+
+        foreach (var tenantId in tenantIds)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            using var scope = _scopeFactory.CreateScope();
+            var projection = scope.ServiceProvider
+                .GetRequiredService<IProviderIntegrityProjectionService>();
+
+            var result = await projection.RefreshTenantAsync(
+                tenantId,
+                new IntegrityProjectionTenantSweepRequest
+                {
+                    DueBefore = sweepStart,
+                    IncludeNeverVerified = true,
+                    ActorId = "system:integrity-projection-worker",
+                },
+                ct);
+
+            totalPatched += result.Patched;
+            totalFailed += result.Failed;
+            totalSkipped += result.Skipped;
+
+            _logger.LogInformation(
+                "IntegrityProjectionWorker tenant sweep: tenant={Tenant} inspected={Inspected} patched={Patched} skipped={Skipped} failed={Failed} window={Window}",
+                Sanitize(tenantId), result.Inspected, result.Patched,
+                result.Skipped, result.Failed, result.RefreshWindow);
+        }
+
+        _logger.LogInformation(
+            "IntegrityProjectionWorker sweep complete: tenants={Tenants} patched={Patched} skipped={Skipped} failed={Failed} duration={DurationMs}ms",
+            tenantIds.Count, totalPatched, totalSkipped, totalFailed,
+            (int)(DateTimeOffset.UtcNow - sweepStart).TotalMilliseconds);
+    }
+
+    private static async Task DelayAsync(TimeSpan delay, CancellationToken ct)
+    {
+        if (delay <= TimeSpan.Zero) delay = TimeSpan.FromMinutes(1);
+        try { await Task.Delay(delay, ct); }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/provider-service/HostedServices/ProviderVerificationEventIndexInitializer.cs
+++ b/src/services/provider-service/HostedServices/ProviderVerificationEventIndexInitializer.cs
@@ -1,0 +1,64 @@
+using ProviderService.Models;
+using MongoDB.Driver;
+
+namespace ProviderService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the <c>ProviderVerificationEvents</c>
+/// stream (capability 5.4.5). Mirrors
+/// <see cref="ProviderVersionEventIndexInitializer"/>: indexes are what
+/// make <c>MongoProviderVerificationEventPublisher</c>'s monotonic-version
+/// retry loop correct.
+///
+/// Idempotent — Mongo silently no-ops indexes that already exist with
+/// the same spec.
+/// </summary>
+public sealed class ProviderVerificationEventIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly string _collectionName;
+    private readonly ILogger<ProviderVerificationEventIndexInitializer> _logger;
+
+    public ProviderVerificationEventIndexInitializer(
+        IMongoDatabase db,
+        IConfiguration configuration,
+        ILogger<ProviderVerificationEventIndexInitializer> logger)
+    {
+        _db = db;
+        _collectionName = configuration["CosmosDb:ProviderVerificationEventsContainer"]
+            ?? "ProviderVerificationEvents";
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<ProviderVerificationEvent>(_collectionName);
+
+        var idemKeys = Builders<ProviderVerificationEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.ProviderId)
+            .Ascending(x => x.EventId);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<ProviderVerificationEvent>(
+                idemKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_provider_event" }),
+            cancellationToken: cancellationToken);
+
+        var orderKeys = Builders<ProviderVerificationEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.ProviderId)
+            .Ascending(x => x.Version);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<ProviderVerificationEvent>(
+                orderKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_provider_version" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation(
+            "ProviderVerificationEvent indexes ensured on collection '{Collection}'.",
+            _collectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/provider-service/Models/IntegrityProjectionOptions.cs
+++ b/src/services/provider-service/Models/IntegrityProjectionOptions.cs
@@ -1,0 +1,100 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Configuration for the integrity-projection write-back path (capability 5.4.5).
+///
+/// <para>
+/// The hosted worker (<c>IntegrityProjectionWorker</c>) sweeps providers that
+/// are due for re-verification, calls <c>provider-verification-service</c>
+/// over HTTP, and persists the resulting score back onto the head Active
+/// version via <c>IProviderRepository.UpdateIntegrityProjectionAsync</c>.
+/// </para>
+///
+/// <para>
+/// The composite refresh runs at the *shortest* due window across active
+/// sources (NPPES, 24h). Per-source materialized refresh state is a
+/// follow-up under capability 5.10 — see
+/// <c>docs/architecture/verification-writeback.md</c> "Composite cadence
+/// trade-off".
+/// </para>
+/// </summary>
+public sealed class IntegrityProjectionOptions
+{
+    public const string SectionName = "IntegrityProjection";
+
+    /// <summary>
+    /// Master switch. When false, the hosted worker stays idle (admin
+    /// backfill + on-demand refresh remain available).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// How often the worker wakes up and looks for due providers. The
+    /// loop is gated by per-provider <c>NextVerificationDue</c>, so a
+    /// shorter sweep interval doesn't translate into more work — only
+    /// faster responsiveness when a provider falls due between sweeps.
+    /// Default 1 hour.
+    /// </summary>
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Page size for both the per-tenant provider iterator and the
+    /// per-batch verification call. The verification service caps batch
+    /// size at 100 NPIs (see <c>provider-verification-service/Program.cs</c>);
+    /// keep these aligned to avoid extra HTTP round-trips per page.
+    /// </summary>
+    public int PageSize { get; set; } = 100;
+
+    /// <summary>
+    /// Hard cap on providers refreshed per tenant per sweep. Prevents a
+    /// fully-due tenant (post-deploy / backfill backlog) from
+    /// monopolising worker time at the expense of other tenants.
+    /// </summary>
+    public int MaxProvidersPerTenantPerSweep { get; set; } = 1000;
+
+    /// <summary>
+    /// Refresh-window per source. Composite refresh runs at the
+    /// shortest active window — the worker treats <c>NextVerificationDue</c>
+    /// as the materialised composite due-date and recomputes it after
+    /// each successful refresh as <c>LastVerifiedAt + ShortestActiveWindow()</c>.
+    /// </summary>
+    public RefreshWindowsOptions Windows { get; set; } = new();
+
+    /// <summary>
+    /// Returns the shortest configured refresh window across the active
+    /// sources. NPPES at 24h dominates today; if NPPES is disabled,
+    /// LEIE/SAM at 24h takes over.
+    /// </summary>
+    public TimeSpan ShortestActiveWindow()
+    {
+        var candidates = new[]
+        {
+            Windows.Nppes,
+            Windows.LeieSam,
+            Windows.Pecos,
+            Windows.OpenPayments,
+            Windows.MedicareUtilization,
+            Windows.Fsmb,
+        };
+        var min = TimeSpan.MaxValue;
+        foreach (var c in candidates)
+        {
+            if (c > TimeSpan.Zero && c < min) min = c;
+        }
+        return min == TimeSpan.MaxValue ? TimeSpan.FromHours(24) : min;
+    }
+}
+
+/// <summary>
+/// Per-source refresh windows. Aligns with regulatory cadences; documented
+/// trade-off in <c>verification-writeback.md</c>.
+/// </summary>
+public sealed class RefreshWindowsOptions
+{
+    public TimeSpan Nppes { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan LeieSam { get; set; } = TimeSpan.FromHours(24);
+    public TimeSpan Pecos { get; set; } = TimeSpan.FromDays(7);
+    public TimeSpan OpenPayments { get; set; } = TimeSpan.FromDays(90);
+    public TimeSpan MedicareUtilization { get; set; } = TimeSpan.FromDays(90);
+    public TimeSpan Fsmb { get; set; } = TimeSpan.FromDays(30);
+}

--- a/src/services/provider-service/Models/IntegrityProjectionOptions.cs
+++ b/src/services/provider-service/Models/IntegrityProjectionOptions.cs
@@ -29,6 +29,20 @@ public sealed class IntegrityProjectionOptions
     public bool Enabled { get; set; } = true;
 
     /// <summary>
+    /// Defence-in-depth gate for the admin backfill endpoint
+    /// (<c>POST /api/v1/admin/providers/backfill-integrity-projection</c>).
+    /// Default <c>false</c>: a misconfigured gateway / NetworkPolicy
+    /// can't expose the endpoint just because the route is registered.
+    /// Operators must explicitly opt in by setting
+    /// <c>IntegrityProjection:AdminBackfillEnabled=true</c> in
+    /// configuration AND restrict access at the deployment layer
+    /// (NetworkPolicy, gateway ACL). When disabled, the controller
+    /// returns 503 Service Unavailable so operators know the endpoint
+    /// exists but is gated.
+    /// </summary>
+    public bool AdminBackfillEnabled { get; set; } = false;
+
+    /// <summary>
     /// How often the worker wakes up and looks for due providers. The
     /// loop is gated by per-provider <c>NextVerificationDue</c>, so a
     /// shorter sweep interval doesn't translate into more work — only

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -258,14 +258,50 @@ public class Provider
     [StringLength(200)]
     public string? LastUpdatedBy { get; set; }
 
+    // ── Cached integrity projection (capability 5.4.5) ──────────────
+    //
+    // Projection metadata maintained by ProviderIntegrityProjectionService.
+    // The hosted IntegrityProjectionWorker calls provider-verification-service
+    // on a schedule and writes the four fields below back onto the head
+    // Active version via IProviderRepository.UpdateIntegrityProjectionAsync —
+    // a dedicated patch path that bypasses the version-state guard on
+    // UpdateAsync. Active rows otherwise remain read-only at the
+    // application layer (PR 7.2 / 5.1 — provider versioning).
+    //
+    // These fields are *projection metadata*, NOT version-identity fields:
+    // updating them does NOT create a new VersionNumber. See
+    // docs/architecture/provider-versioning.md "Projection metadata —
+    // exempt from versioning".
+    //
+    // Read consumers: roster (capability 5.4) sorts on IntegrityScore;
+    // adjudication, FHIR projections, and the provider-profile portal
+    // card surface it. Live HTTP fetch via HttpProviderIntegrityGate
+    // remains available for fresh-or-cached decisions per consumer.
+
     /// <summary>
-    /// Cached integrity score from the ProviderVerificationService.
-    /// Updated on verification and cached for claims-time lookup.
+    /// Composite integrity score (0–100) from the most recent
+    /// verification. Null until the projection worker runs the first
+    /// time for this provider.
     /// </summary>
     public int? IntegrityScore { get; set; }
+
+    /// <summary>
+    /// Rating bucket — Clear / Advisory / Caution / Alert / Blocked /
+    /// Unknown. Mirrors <c>IntegrityRating</c> in the verification engine.
+    /// </summary>
     [StringLength(50)]
     public string? IntegrityRating { get; set; }
+
+    /// <summary>
+    /// When the score was produced by provider-verification-service.
+    /// </summary>
     public DateTimeOffset? LastVerifiedAt { get; set; }
+
+    /// <summary>
+    /// When the projection worker should re-verify this provider next.
+    /// Computed from <c>LastVerifiedAt + ShortestActiveWindow</c>; null
+    /// for never-verified rows (sweep filter picks them up too).
+    /// </summary>
     public DateTimeOffset? NextVerificationDue { get; set; }
 
     // ---------------------------------------------------------------------

--- a/src/services/provider-service/Models/ProviderVerificationEvent.cs
+++ b/src/services/provider-service/Models/ProviderVerificationEvent.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Append-only event emitted by <c>ProviderIntegrityProjectionService</c>
+/// after a successful integrity-projection write-back (capability 5.4.5).
+///
+/// <para>
+/// Mirrors <see cref="ProviderVersionEvent"/>: client-supplied
+/// <see cref="EventId"/> for idempotency, monotonic per-aggregate
+/// <see cref="Version"/>, partition key <c>{TenantId}:{ProviderId}</c>.
+/// One event type today (<see cref="ProviderVerificationEventType.ProviderVerificationRefreshed"/>);
+/// the type field exists so future capabilities can extend without
+/// schema migration.
+/// </para>
+///
+/// <para>
+/// No cross-service consumer ships in this PR. Capability 5.10 (Verification
+/// Integrity Score Surface) is the planned subscriber.
+/// </para>
+/// </summary>
+[BsonIgnoreExtraElements]
+public class ProviderVerificationEvent
+{
+    [Required]
+    public string Id { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(256)]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client-supplied idempotency key. Format
+    /// <c>refreshed:{providerId}:{verifiedAtUtcIso}</c>. Unique within
+    /// <c>(TenantId, ProviderId)</c>.
+    /// </summary>
+    [Required]
+    [StringLength(256)]
+    public string EventId { get; set; } = string.Empty;
+
+    [Required]
+    public ProviderVerificationEventType EventType { get; set; }
+
+    /// <summary>1-based monotonic sequence per <c>(TenantId, ProviderId)</c>.</summary>
+    [Required]
+    public int Version { get; set; }
+
+    public int SchemaVersion { get; set; } = 1;
+
+    [Required]
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    public int? IntegrityScore { get; set; }
+
+    [StringLength(50)]
+    public string? IntegrityRating { get; set; }
+
+    public DateTimeOffset? VerifiedAt { get; set; }
+
+    public DateTimeOffset? NextVerificationDue { get; set; }
+
+    [StringLength(200)]
+    public string? ActorId { get; set; }
+
+    [StringLength(128)]
+    public string? CorrelationId { get; set; }
+
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string providerId) => $"{tenantId}:{providerId}";
+
+    public static string BuildRefreshedEventId(string providerId, DateTimeOffset verifiedAt)
+        => $"refreshed:{providerId}:{verifiedAt.UtcDateTime:O}";
+}
+
+/// <summary>
+/// Mirrors PR #705 enum-handling pattern: <c>Unknown=0</c>, explicit
+/// integer values, string serialization.
+/// </summary>
+public enum ProviderVerificationEventType
+{
+    Unknown = 0,
+    ProviderVerificationRefreshed = 1,
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.OpenApi.Models;
 using ProviderService.Adapters;
 using ProviderService.HostedServices;
 using ProviderService.Middleware;
+using ProviderService.Models;
 using ProviderService.Repositories;
 using ProviderService.Services;
 using CloudHealthOffice.Infrastructure.Configuration;
@@ -51,7 +52,9 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddScoped<IOrganizationRepository, OrganizationRepositoryMongo>();
     builder.Services.AddScoped<IProviderTransitionRepository, MongoProviderTransitionRepository>();
     builder.Services.AddScoped<IProviderVersionEventPublisher, MongoProviderVersionEventPublisher>();
+    builder.Services.AddScoped<IProviderVerificationEventPublisher, MongoProviderVerificationEventPublisher>();
     builder.Services.AddHostedService<ProviderVersionEventIndexInitializer>();
+    builder.Services.AddHostedService<ProviderVerificationEventIndexInitializer>();
     Console.WriteLine("Using MongoDB database provider");
 }
 else
@@ -79,6 +82,7 @@ else
     // Noop publisher logs a warning so ops can spot the missing wiring
     // without breaking the lifecycle path.
     builder.Services.AddScoped<IProviderVersionEventPublisher, NoopProviderVersionEventPublisher>();
+    builder.Services.AddScoped<IProviderVerificationEventPublisher, NoopProviderVerificationEventPublisher>();
 }
 
 // Provider versioning service (5.1 — provider identity & versioning)
@@ -116,6 +120,26 @@ builder.Services.AddScoped<OrganizationAdapterFactory>();
 // Provider row; never invokes ProviderVerificationOrchestrator on the
 // read path.
 builder.Services.AddScoped<INetworkRosterService, NetworkRosterService>();
+
+// Verification write-back (5.4.5 — projection from provider-verification-service
+// onto Provider.IntegrityScore + IntegrityRating + LastVerifiedAt + NextVerificationDue).
+// HTTP — not project reference — preserves the service boundary and avoids
+// duplicating the engine's six data-source clients into provider-service.
+// IntegrityProjectionWorker iterates per-tenant on a schedule (default 1h);
+// IntegrityProjectionAdminController surfaces a one-shot backfill endpoint.
+builder.Services.Configure<IntegrityProjectionOptions>(
+    builder.Configuration.GetSection(IntegrityProjectionOptions.SectionName));
+builder.Services.AddHttpClient<IProviderVerificationClient, HttpProviderVerificationClient>(client =>
+{
+    var baseUrl = builder.Configuration["ProviderVerification:BaseUrl"]
+        ?? "http://provider-verification-service";
+    client.BaseAddress = new Uri(baseUrl.EndsWith("/") ? baseUrl : baseUrl + "/");
+    client.Timeout = TimeSpan.FromSeconds(
+        builder.Configuration.GetValue("ProviderVerification:TimeoutSeconds", 30));
+})
+.SetHandlerLifetime(TimeSpan.FromMinutes(5));
+builder.Services.AddScoped<IProviderIntegrityProjectionService, ProviderIntegrityProjectionService>();
+builder.Services.AddHostedService<IntegrityProjectionWorker>();
 
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -97,6 +97,79 @@ public interface IProviderRepository
     /// in <see cref="UpdateAsync"/>.
     /// </summary>
     Task<Provider> ReplaceVersionRowAsync(Provider version);
+
+    // ---- Integrity projection write-back (capability 5.4.5) ----------
+
+    /// <summary>
+    /// Patch the four cached integrity-projection fields
+    /// (<see cref="Provider.IntegrityScore"/>,
+    /// <see cref="Provider.IntegrityRating"/>,
+    /// <see cref="Provider.LastVerifiedAt"/>,
+    /// <see cref="Provider.NextVerificationDue"/>) on the head Active
+    /// version of <paramref name="providerId"/>. No new version row is
+    /// created; identity-version semantics from PR 7.2 are preserved.
+    ///
+    /// <para>
+    /// These fields are *projection metadata*, not provider-identity
+    /// fields — see <c>docs/architecture/provider-versioning.md</c>
+    /// "Projection metadata — exempt from versioning". The bypass is
+    /// implemented as a separate write path: the Cosmos impl uses
+    /// <c>PatchItemAsync</c> with field-scoped <c>Set</c> ops and the
+    /// Mongo impl uses <c>UpdateOneAsync</c> with <c>$set</c> on the
+    /// four field paths only. Neither path goes through
+    /// <see cref="UpdateAsync"/>'s version-state guard.
+    /// </para>
+    ///
+    /// <para>
+    /// Returns <c>true</c> when the head Active version was patched;
+    /// <c>false</c> when no Active head exists (Suspended / Superseded /
+    /// Terminated / never-activated). Idempotent: rerunning with the same
+    /// inputs is a no-op overwrite. Does not throw on missing chains.
+    /// </para>
+    /// </summary>
+    Task<bool> UpdateIntegrityProjectionAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset? lastVerifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Page of head-Active providers in <paramref name="tenantId"/>
+    /// whose <see cref="Provider.NextVerificationDue"/> has elapsed
+    /// (<c>&lt;= dueBefore</c>) or is null when
+    /// <paramref name="includeNeverVerified"/> is true. Stable sort
+    /// (<c>ProviderId</c> asc) so <paramref name="skip"/> pagination is
+    /// deterministic across sweeps.
+    ///
+    /// <para>
+    /// Used by <c>IntegrityProjectionWorker</c>. Tenant id is taken
+    /// explicitly because the worker runs without an HTTP context — the
+    /// usual <see cref="IHttpContextAccessor"/> tenant resolution doesn't
+    /// apply.
+    /// </para>
+    /// </summary>
+    Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(
+        string tenantId,
+        DateTimeOffset dueBefore,
+        bool includeNeverVerified,
+        int skip,
+        int pageSize,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Distinct <see cref="Provider.TenantId"/>s across the Providers
+    /// collection. The worker uses this to iterate per-tenant on each
+    /// sweep without depending on a separate tenant catalogue.
+    ///
+    /// <para>
+    /// Cross-partition scan; the worker calls this once per sweep
+    /// interval (default 1h) so RU/IO cost is bounded.
+    /// </para>
+    /// </summary>
+    Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default);
 }
 
 /// <summary>
@@ -645,6 +718,138 @@ public class ProviderRepository : IProviderRepository
             version.Id,
             new PartitionKey(version.TenantId));
         return response.Resource;
+    }
+
+    public async Task<bool> UpdateIntegrityProjectionAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset? lastVerifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        CancellationToken ct = default)
+    {
+        // Resolve the head Active row by chain key. Cosmos PatchItemAsync
+        // is keyed on the per-row document Id, so we have to look up the
+        // row id first. The lookup query is partition-scoped.
+        var query = new QueryDefinition(
+                "SELECT TOP 1 c.id FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.providerId = @providerId OR (NOT IS_DEFINED(c.providerId) AND c.id = @providerId)) AND " +
+                "(c.versionState = @active OR NOT IS_DEFINED(c.versionState)) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@providerId", providerId)
+            .WithParameter("@active", ProviderVersionState.Active.ToString());
+
+        string? rowId = null;
+        var iterator = _container.GetItemQueryIterator<HeadIdResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            rowId = page.FirstOrDefault()?.Id;
+        }
+
+        if (string.IsNullOrEmpty(rowId)) return false;
+
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/integrityScore", integrityScore),
+            PatchOperation.Set("/integrityRating", integrityRating),
+            PatchOperation.Set("/lastVerifiedAt", lastVerifiedAt),
+            PatchOperation.Set("/nextVerificationDue", nextVerificationDue),
+            PatchOperation.Set("/lastUpdatedDate", DateTime.UtcNow),
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<Provider>(
+                rowId,
+                new PartitionKey(tenantId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Row was deleted between the lookup and the patch.
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(
+        string tenantId,
+        DateTimeOffset dueBefore,
+        bool includeNeverVerified,
+        int skip,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+        var safeSkip = Math.Max(skip, 0);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
+
+        // Active head only — projection only writes to Active rows.
+        // Three "Active" shapes mirror Hydrate(): explicit Active,
+        // missing versionState, or legacy (no versionId + status=Active).
+        var sql = "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
+                  "(c.versionState = @active OR NOT IS_DEFINED(c.versionState) OR " +
+                  "((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) AND ";
+        sql += includeNeverVerified
+            ? "(NOT IS_DEFINED(c.nextVerificationDue) OR c.nextVerificationDue = null OR c.nextVerificationDue <= @dueBefore) "
+            : "(IS_DEFINED(c.nextVerificationDue) AND c.nextVerificationDue != null AND c.nextVerificationDue <= @dueBefore) ";
+        sql += $"ORDER BY c.providerId ASC OFFSET {safeSkip} LIMIT {safePageSize}";
+
+        var query = new QueryDefinition(sql)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@active", ProviderVersionState.Active.ToString())
+            .WithParameter("@statusActive", ProviderStatus.Active.ToString())
+            .WithParameter("@dueBefore", dueBefore);
+
+        var iterator = _container.GetItemQueryIterator<Provider>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(tenantId),
+                MaxItemCount = safePageSize,
+            });
+
+        var results = new List<Provider>(safePageSize);
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page.Select(Hydrate));
+            if (results.Count >= safePageSize) break;
+        }
+        return results;
+    }
+
+    public async Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default)
+    {
+        // Cross-partition; Cosmos DISTINCT VALUE is supported on simple
+        // scalars. The hosted worker calls this once per sweep so the
+        // RU cost is bounded by the sweep cadence.
+        var query = new QueryDefinition("SELECT DISTINCT VALUE c.tenantId FROM c");
+        var iterator = _container.GetItemQueryIterator<string>(query);
+        var tenants = new HashSet<string>(StringComparer.Ordinal);
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+            foreach (var t in page)
+            {
+                if (!string.IsNullOrEmpty(t)) tenants.Add(t);
+            }
+        }
+        return tenants.OrderBy(x => x, StringComparer.Ordinal).ToList();
+    }
+
+    private sealed class HeadIdResult
+    {
+        public string Id { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -732,14 +732,26 @@ public class ProviderRepository : IProviderRepository
         // Resolve the head Active row by chain key. Cosmos PatchItemAsync
         // is keyed on the per-row document Id, so we have to look up the
         // row id first. The lookup query is partition-scoped.
+        //
+        // Hydration rule (mirrors Hydrate()) — three "Active" shapes,
+        // each Status-gated to keep legacy Terminated/Suspended rows
+        // out:
+        //   1. versionState = Active.
+        //   2. versionState undefined AND status = Active.
+        //   3. versionId undefined/null/empty AND status = Active.
+        // See docs/architecture/provider-versioning.md "Legacy
+        // hydration query pattern".
         var query = new QueryDefinition(
                 "SELECT TOP 1 c.id FROM c WHERE c.tenantId = @tenantId AND " +
                 "(c.providerId = @providerId OR (NOT IS_DEFINED(c.providerId) AND c.id = @providerId)) AND " +
-                "(c.versionState = @active OR NOT IS_DEFINED(c.versionState)) " +
+                "(c.versionState = @active " +
+                "OR (NOT IS_DEFINED(c.versionState) AND c.status = @statusActive) " +
+                "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) " +
                 "ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@providerId", providerId)
-            .WithParameter("@active", ProviderVersionState.Active.ToString());
+            .WithParameter("@active", ProviderVersionState.Active.ToString())
+            .WithParameter("@statusActive", ProviderStatus.Active.ToString());
 
         string? rowId = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
@@ -792,15 +804,25 @@ public class ProviderRepository : IProviderRepository
         var safePageSize = Math.Clamp(pageSize, 1, 1000);
 
         // Active head only — projection only writes to Active rows.
-        // Three "Active" shapes mirror Hydrate(): explicit Active,
-        // missing versionState, or legacy (no versionId + status=Active).
+        // Hydration rule (mirrors Hydrate()) — three "Active" shapes,
+        // each Status-gated to keep legacy Terminated/Suspended rows
+        // out of refresh batches:
+        //   1. versionState = Active.
+        //   2. versionState undefined AND status = Active.
+        //   3. versionId undefined/null/empty AND status = Active.
+        // See docs/architecture/provider-versioning.md "Legacy
+        // hydration query pattern".
         var sql = "SELECT * FROM c WHERE c.tenantId = @tenantId AND " +
-                  "(c.versionState = @active OR NOT IS_DEFINED(c.versionState) OR " +
-                  "((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) AND ";
+                  "(c.versionState = @active " +
+                  "OR (NOT IS_DEFINED(c.versionState) AND c.status = @statusActive) " +
+                  "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) AND ";
         sql += includeNeverVerified
             ? "(NOT IS_DEFINED(c.nextVerificationDue) OR c.nextVerificationDue = null OR c.nextVerificationDue <= @dueBefore) "
             : "(IS_DEFINED(c.nextVerificationDue) AND c.nextVerificationDue != null AND c.nextVerificationDue <= @dueBefore) ";
-        sql += $"ORDER BY c.providerId ASC OFFSET {safeSkip} LIMIT {safePageSize}";
+        // Secondary sort on c.id keeps OFFSET/LIMIT pagination
+        // deterministic when multiple rows share the same providerId
+        // (legacy single-row chains where providerId may be empty).
+        sql += $"ORDER BY c.providerId ASC, c.id ASC OFFSET {safeSkip} LIMIT {safePageSize}";
 
         var query = new QueryDefinition(sql)
             .WithParameter("@tenantId", tenantId)

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -613,6 +613,106 @@ public class ProviderRepositoryMongo : IProviderRepository
         return version;
     }
 
+    public async Task<bool> UpdateIntegrityProjectionAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset? lastVerifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        CancellationToken ct = default)
+    {
+        // $set on the four projection fields only — bypasses the
+        // version-state guard on UpdateAsync. Targets the head Active
+        // version of the chain (matching ChainKeyFilter + Active state).
+        // Hydration's "missing versionState ⇒ Active" rule means legacy
+        // rows participate too.
+        var b = Builders<Provider>.Filter;
+        var stateFilter = b.Or(
+            b.Eq(p => p.VersionState, ProviderVersionState.Active),
+            b.Exists(p => p.VersionState, false),
+            b.And(
+                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Eq(p => p.Status, ProviderStatus.Active)));
+
+        var filter = b.And(
+            b.Eq(p => p.TenantId, tenantId),
+            ChainKeyFilter(providerId),
+            stateFilter);
+
+        var update = Builders<Provider>.Update
+            .Set(p => p.IntegrityScore, integrityScore)
+            .Set(p => p.IntegrityRating, integrityRating)
+            .Set(p => p.LastVerifiedAt, lastVerifiedAt)
+            .Set(p => p.NextVerificationDue, nextVerificationDue)
+            .Set(p => p.LastUpdatedDate, DateTime.UtcNow);
+
+        // Sort by VersionNumber desc so amendments hit the latest head when
+        // there are historical Superseded rows. Mongo's UpdateOneAsync with
+        // a Sort option requires FindOneAndUpdate semantics; use that.
+        var options = new FindOneAndUpdateOptions<Provider>
+        {
+            Sort = Builders<Provider>.Sort.Descending(p => p.VersionNumber),
+            ReturnDocument = ReturnDocument.After,
+        };
+        var updated = await _collection.FindOneAndUpdateAsync(filter, update, options, ct);
+        return updated != null;
+    }
+
+    public async Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(
+        string tenantId,
+        DateTimeOffset dueBefore,
+        bool includeNeverVerified,
+        int skip,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+        var safeSkip = Math.Max(skip, 0);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
+
+        var b = Builders<Provider>.Filter;
+        var stateFilter = b.Or(
+            b.Eq(p => p.VersionState, ProviderVersionState.Active),
+            b.Exists(p => p.VersionState, false),
+            b.And(
+                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Eq(p => p.Status, ProviderStatus.Active)));
+
+        var dueFilter = includeNeverVerified
+            ? b.Or(
+                b.Exists(p => p.NextVerificationDue, false),
+                b.Eq(p => p.NextVerificationDue, null),
+                b.Lte(p => p.NextVerificationDue, dueBefore))
+            : b.And(
+                b.Exists(p => p.NextVerificationDue, true),
+                b.Ne(p => p.NextVerificationDue, null),
+                b.Lte(p => p.NextVerificationDue, dueBefore));
+
+        var filter = b.And(
+            b.Eq(p => p.TenantId, tenantId),
+            stateFilter,
+            dueFilter);
+
+        var docs = await _collection.Find(filter)
+            .Sort(Builders<Provider>.Sort.Ascending(p => p.ProviderId).Ascending(p => p.Id))
+            .Skip(safeSkip)
+            .Limit(safePageSize)
+            .ToListAsync(ct);
+        return docs.Select(Hydrate).ToList();
+    }
+
+    public async Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default)
+    {
+        var distinct = await _collection.DistinctAsync<string>(
+            "TenantId", FilterDefinition<Provider>.Empty, cancellationToken: ct);
+        var list = await distinct.ToListAsync(ct);
+        return list.Where(x => !string.IsNullOrEmpty(x))
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+    }
+
     private static Provider Hydrate(Provider provider)
     {
         if (string.IsNullOrEmpty(provider.ProviderId))

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -625,14 +625,33 @@ public class ProviderRepositoryMongo : IProviderRepository
         // $set on the four projection fields only — bypasses the
         // version-state guard on UpdateAsync. Targets the head Active
         // version of the chain (matching ChainKeyFilter + Active state).
-        // Hydration's "missing versionState ⇒ Active" rule means legacy
-        // rows participate too.
+        //
+        // Legacy-row hydration rule (mirrors Hydrate()): a row counts as
+        // Active when ANY of the following hold:
+        //   1. VersionState == Active (current versioned shape).
+        //   2. VersionState missing AND Status == Active (rows that
+        //      pre-date capability 5.1 — never had VersionState
+        //      persisted).
+        //   3. VersionId missing/empty AND Status == Active (rows that
+        //      defaulted VersionState to enum-zero Draft on read; the
+        //      Hydrate() fallback derives Active from Status when
+        //      VersionId is unset).
+        // The Status guard on branches 2 and 3 is non-negotiable — without
+        // it, legacy Terminated/Suspended rows would be patched, violating
+        // the method contract ("returns false when no Active head exists").
+        // See docs/architecture/provider-versioning.md "Legacy hydration
+        // query pattern".
         var b = Builders<Provider>.Filter;
         var stateFilter = b.Or(
             b.Eq(p => p.VersionState, ProviderVersionState.Active),
-            b.Exists(p => p.VersionState, false),
             b.And(
-                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Exists(p => p.VersionState, false),
+                b.Eq(p => p.Status, ProviderStatus.Active)),
+            b.And(
+                b.Or(
+                    b.Exists(p => p.VersionId, false),
+                    b.Eq(p => p.VersionId, null),
+                    b.Eq(p => p.VersionId, string.Empty)),
                 b.Eq(p => p.Status, ProviderStatus.Active)));
 
         var filter = b.And(
@@ -672,12 +691,25 @@ public class ProviderRepositoryMongo : IProviderRepository
         var safeSkip = Math.Max(skip, 0);
         var safePageSize = Math.Clamp(pageSize, 1, 1000);
 
+        // Hydration rule (mirrors Hydrate()) — three "Active" shapes,
+        // each Status-gated to keep legacy Terminated/Suspended rows
+        // out of refresh batches:
+        //   1. VersionState == Active.
+        //   2. VersionState missing AND Status == Active.
+        //   3. VersionId missing/empty AND Status == Active.
+        // See docs/architecture/provider-versioning.md "Legacy
+        // hydration query pattern".
         var b = Builders<Provider>.Filter;
         var stateFilter = b.Or(
             b.Eq(p => p.VersionState, ProviderVersionState.Active),
-            b.Exists(p => p.VersionState, false),
             b.And(
-                b.Or(b.Exists(p => p.VersionId, false), b.Eq(p => p.VersionId, string.Empty)),
+                b.Exists(p => p.VersionState, false),
+                b.Eq(p => p.Status, ProviderStatus.Active)),
+            b.And(
+                b.Or(
+                    b.Exists(p => p.VersionId, false),
+                    b.Eq(p => p.VersionId, null),
+                    b.Eq(p => p.VersionId, string.Empty)),
                 b.Eq(p => p.Status, ProviderStatus.Active)));
 
         var dueFilter = includeNeverVerified

--- a/src/services/provider-service/Services/ProviderIntegrityProjectionService.cs
+++ b/src/services/provider-service/Services/ProviderIntegrityProjectionService.cs
@@ -111,7 +111,7 @@ public sealed class ProviderIntegrityProjectionService : IProviderIntegrityProje
         {
             _logger.LogInformation(
                 "verification refresh produced no result for {ProviderId}; preserving cached projection",
-                providerId);
+                Sanitize(providerId));
             return new IntegrityProjectionRefreshResult
             {
                 ProviderId = head.ProviderId,
@@ -152,11 +152,20 @@ public sealed class ProviderIntegrityProjectionService : IProviderIntegrityProje
                 tenantId, dueBefore, includeNeverVerified, skip, pageSize, ct);
             if (page.Count == 0) break;
 
-            var npiToProvider = page.ToDictionary(p => p.NPI, p => p);
-            var npis = npiToProvider.Keys.ToList();
+            // De-dupe NPIs before the batch call: the (TenantId, NPI)
+            // index isn't unique, so a tenant can legitimately have
+            // multiple Provider rows sharing an NPI (chain history,
+            // genuine duplicates, data-quality drift). ToDictionary on
+            // a duplicated key would crash the whole sweep.
+            var npis = page.Select(p => p.NPI).Distinct().ToList();
 
             var verificationResults = await _verification.VerifyBatchAsync(npis, ct);
-            var resultByNpi = verificationResults.ToDictionary(r => r.Npi, r => r);
+            // GroupBy + First defends against the verification service
+            // returning duplicate records per NPI (server contract is
+            // one-per-NPI, but we shouldn't crash on contract drift).
+            var resultByNpi = verificationResults
+                .GroupBy(r => r.Npi)
+                .ToDictionary(g => g.Key, g => g.First());
 
             foreach (var p in page)
             {

--- a/src/services/provider-service/Services/ProviderIntegrityProjectionService.cs
+++ b/src/services/provider-service/Services/ProviderIntegrityProjectionService.cs
@@ -1,0 +1,326 @@
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Drives the verification → write-back projection pipeline (capability 5.4.5).
+///
+/// <list type="number">
+///   <item>Resolve due providers in a tenant via
+///     <see cref="IProviderRepository.ListProvidersForIntegrityRefreshAsync"/>.</item>
+///   <item>Batch their NPIs into <c>POST /verify/batch</c> calls (100/batch).</item>
+///   <item>Patch <c>IntegrityScore</c>/<c>IntegrityRating</c>/
+///     <c>LastVerifiedAt</c>/<c>NextVerificationDue</c> onto each head Active
+///     row via
+///     <see cref="IProviderRepository.UpdateIntegrityProjectionAsync"/>.</item>
+///   <item>Emit a deterministic <c>ProviderVerificationRefreshed</c> event per
+///     row via <see cref="IProviderVerificationEventPublisher"/>.</item>
+/// </list>
+///
+/// <para>
+/// Failure isolation: a verification-source outage returns an empty result
+/// for the batch — already-cached scores stay put, the row's
+/// <c>NextVerificationDue</c> is left alone so the next sweep retries.
+/// A patch failure on one row does not abort the batch.
+/// </para>
+/// </summary>
+public interface IProviderIntegrityProjectionService
+{
+    /// <summary>
+    /// Refresh a single provider on demand. Returns the patched score
+    /// and metadata, or null when the provider has no Active head.
+    /// Used by <c>POST /api/v1/providers/{id}/verification/refresh</c>.
+    /// </summary>
+    Task<IntegrityProjectionRefreshResult?> RefreshProviderAsync(
+        string tenantId,
+        string providerId,
+        bool forceRefresh,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Refresh all due providers in a tenant. Returns the per-tenant
+    /// telemetry: providers inspected vs. patched vs. skipped vs. failed.
+    /// Used by both the hosted worker and the admin backfill endpoint.
+    /// </summary>
+    Task<IntegrityProjectionTenantSweepResult> RefreshTenantAsync(
+        string tenantId,
+        IntegrityProjectionTenantSweepRequest request,
+        CancellationToken ct = default);
+}
+
+public sealed class ProviderIntegrityProjectionService : IProviderIntegrityProjectionService
+{
+    private readonly IProviderRepository _providers;
+    private readonly IProviderVerificationClient _verification;
+    private readonly IProviderVerificationEventPublisher _events;
+    private readonly IOptions<IntegrityProjectionOptions> _options;
+    private readonly ILogger<ProviderIntegrityProjectionService> _logger;
+
+    public ProviderIntegrityProjectionService(
+        IProviderRepository providers,
+        IProviderVerificationClient verification,
+        IProviderVerificationEventPublisher events,
+        IOptions<IntegrityProjectionOptions> options,
+        ILogger<ProviderIntegrityProjectionService> logger)
+    {
+        _providers = providers;
+        _verification = verification;
+        _events = events;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<IntegrityProjectionRefreshResult?> RefreshProviderAsync(
+        string tenantId,
+        string providerId,
+        bool forceRefresh,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        // The on-demand path bypasses the due-date filter when
+        // forceRefresh is true; otherwise it still consults
+        // NextVerificationDue so callers can re-trigger without paying
+        // for an unnecessary live verification.
+        var head = await _providers.GetLatestActiveAsync(providerId, DateTime.UtcNow);
+        if (head == null) return null;
+        if (head.TenantId != tenantId) return null;
+
+        if (!forceRefresh
+            && head.NextVerificationDue.HasValue
+            && head.NextVerificationDue.Value > DateTimeOffset.UtcNow)
+        {
+            return new IntegrityProjectionRefreshResult
+            {
+                ProviderId = head.ProviderId,
+                Skipped = true,
+                IntegrityScore = head.IntegrityScore,
+                IntegrityRating = head.IntegrityRating,
+                LastVerifiedAt = head.LastVerifiedAt,
+                NextVerificationDue = head.NextVerificationDue,
+            };
+        }
+
+        var results = await _verification.VerifyBatchAsync(new[] { head.NPI }, ct);
+        var match = results.FirstOrDefault(r => r.Npi == head.NPI);
+        if (match == null)
+        {
+            _logger.LogInformation(
+                "verification refresh produced no result for {ProviderId}; preserving cached projection",
+                providerId);
+            return new IntegrityProjectionRefreshResult
+            {
+                ProviderId = head.ProviderId,
+                Skipped = false,
+                Failed = true,
+                IntegrityScore = head.IntegrityScore,
+                IntegrityRating = head.IntegrityRating,
+                LastVerifiedAt = head.LastVerifiedAt,
+                NextVerificationDue = head.NextVerificationDue,
+            };
+        }
+
+        return await ApplyAsync(tenantId, head.ProviderId, match, actorId, correlationId, ct);
+    }
+
+    public async Task<IntegrityProjectionTenantSweepResult> RefreshTenantAsync(
+        string tenantId,
+        IntegrityProjectionTenantSweepRequest request,
+        CancellationToken ct = default)
+    {
+        var opts = _options.Value;
+        var result = new IntegrityProjectionTenantSweepResult { TenantId = tenantId };
+
+        // Per-sweep cap protects round-robin fairness across tenants when
+        // the worker is the caller; the admin backfill passes its own
+        // request.MaxProviders to bypass this for one-shot work.
+        var maxProviders = request.MaxProviders ?? opts.MaxProvidersPerTenantPerSweep;
+        var pageSize = Math.Clamp(request.PageSize ?? opts.PageSize, 1, 100);
+        var includeNeverVerified = request.IncludeNeverVerified;
+        var dueBefore = request.DueBefore ?? DateTimeOffset.UtcNow;
+        var refreshWindow = opts.ShortestActiveWindow();
+
+        var skip = 0;
+        while (result.Patched + result.Failed + result.Skipped < maxProviders)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await _providers.ListProvidersForIntegrityRefreshAsync(
+                tenantId, dueBefore, includeNeverVerified, skip, pageSize, ct);
+            if (page.Count == 0) break;
+
+            var npiToProvider = page.ToDictionary(p => p.NPI, p => p);
+            var npis = npiToProvider.Keys.ToList();
+
+            var verificationResults = await _verification.VerifyBatchAsync(npis, ct);
+            var resultByNpi = verificationResults.ToDictionary(r => r.Npi, r => r);
+
+            foreach (var p in page)
+            {
+                if (result.Patched + result.Failed + result.Skipped >= maxProviders) break;
+
+                if (!resultByNpi.TryGetValue(p.NPI, out var match))
+                {
+                    // Verification source returned no record for this
+                    // NPI — preserve cached projection and let the next
+                    // sweep retry.
+                    result.Failed++;
+                    continue;
+                }
+
+                try
+                {
+                    var apply = await ApplyAsync(
+                        tenantId, p.ProviderId, match,
+                        actorId: request.ActorId,
+                        correlationId: request.CorrelationId,
+                        ct);
+                    if (apply == null) result.Skipped++;
+                    else if (apply.Failed) result.Failed++;
+                    else result.Patched++;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "integrity projection write-back failed for {Tenant}/{Provider}",
+                        Sanitize(tenantId), Sanitize(p.ProviderId));
+                    result.Failed++;
+                }
+            }
+
+            // Avoid an infinite loop if the dueBefore filter still
+            // matches the same page after writes (in practice the patch
+            // moves NextVerificationDue past dueBefore, so the filter
+            // re-skips them — but we belt-and-suspenders skip forward).
+            skip += page.Count;
+            if (page.Count < pageSize) break;
+        }
+
+        result.RefreshWindow = refreshWindow;
+        return result;
+    }
+
+    private async Task<IntegrityProjectionRefreshResult> ApplyAsync(
+        string tenantId,
+        string providerId,
+        VerificationResult match,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct)
+    {
+        var verifiedAt = match.LastVerifiedAt;
+        var nextDue = match.NextScheduledVerification
+            ?? verifiedAt + _options.Value.ShortestActiveWindow();
+        var score = match.IntegrityScore?.CompositeScore;
+        var rating = match.IntegrityScore?.Rating;
+
+        var patched = await _providers.UpdateIntegrityProjectionAsync(
+            tenantId, providerId, score, rating, verifiedAt, nextDue, ct);
+        if (!patched)
+        {
+            return new IntegrityProjectionRefreshResult
+            {
+                ProviderId = providerId,
+                Skipped = true,
+                IntegrityScore = score,
+                IntegrityRating = rating,
+                LastVerifiedAt = verifiedAt,
+                NextVerificationDue = nextDue,
+            };
+        }
+
+        try
+        {
+            await _events.PublishRefreshedAsync(
+                tenantId, providerId, score, rating, verifiedAt, nextDue,
+                actorId, correlationId, ct);
+        }
+        catch (Exception ex)
+        {
+            // Event publication is best-effort; the patch already landed.
+            // Re-emitting on the next sweep is idempotent (deterministic
+            // EventId on (providerId, verifiedAt)).
+            _logger.LogWarning(ex,
+                "verification event publication failed for {Tenant}/{Provider}; patch already applied",
+                Sanitize(tenantId), Sanitize(providerId));
+        }
+
+        return new IntegrityProjectionRefreshResult
+        {
+            ProviderId = providerId,
+            IntegrityScore = score,
+            IntegrityRating = rating,
+            LastVerifiedAt = verifiedAt,
+            NextVerificationDue = nextDue,
+        };
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}
+
+/// <summary>
+/// Per-provider refresh outcome surfaced by the on-demand endpoint.
+/// </summary>
+public sealed class IntegrityProjectionRefreshResult
+{
+    public string ProviderId { get; set; } = string.Empty;
+    public int? IntegrityScore { get; set; }
+    public string? IntegrityRating { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public DateTimeOffset? NextVerificationDue { get; set; }
+    public bool Skipped { get; set; }
+    public bool Failed { get; set; }
+}
+
+/// <summary>
+/// Per-tenant sweep request used by both the hosted worker and the admin
+/// backfill endpoint. The same machinery serves both paths; the request
+/// shape distinguishes them via <see cref="IncludeNeverVerified"/> and
+/// <see cref="MaxProviders"/>.
+/// </summary>
+public sealed class IntegrityProjectionTenantSweepRequest
+{
+    /// <summary>Cutoff for "due now". Defaults to <see cref="DateTimeOffset.UtcNow"/>.</summary>
+    public DateTimeOffset? DueBefore { get; set; }
+
+    /// <summary>
+    /// True when null <c>NextVerificationDue</c> rows should be swept
+    /// (legacy / never-verified). Worker = true; admin backfill = true.
+    /// </summary>
+    public bool IncludeNeverVerified { get; set; } = true;
+
+    /// <summary>
+    /// Optional override for the per-sweep cap. Worker passes null
+    /// (uses <see cref="IntegrityProjectionOptions.MaxProvidersPerTenantPerSweep"/>);
+    /// admin backfill can pass a higher value.
+    /// </summary>
+    public int? MaxProviders { get; set; }
+
+    public int? PageSize { get; set; }
+
+    public string? ActorId { get; set; }
+    public string? CorrelationId { get; set; }
+}
+
+/// <summary>
+/// Telemetry surfaced by per-tenant sweeps. Worker logs aggregate; admin
+/// backfill returns this in the HTTP response body so operators can
+/// confirm the run.
+/// </summary>
+public sealed class IntegrityProjectionTenantSweepResult
+{
+    public string TenantId { get; set; } = string.Empty;
+    public int Patched { get; set; }
+    public int Skipped { get; set; }
+    public int Failed { get; set; }
+    public TimeSpan RefreshWindow { get; set; }
+    public int Inspected => Patched + Skipped + Failed;
+}

--- a/src/services/provider-service/Services/ProviderVerificationClient.cs
+++ b/src/services/provider-service/Services/ProviderVerificationClient.cs
@@ -80,8 +80,19 @@ public sealed class HttpProviderVerificationClient : IProviderVerificationClient
             var envelope = await response.Content.ReadFromJsonAsync<BatchResponse>(_json, ct);
             return envelope?.Results ?? (IReadOnlyList<VerificationResult>)Array.Empty<VerificationResult>();
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller-driven cancellation (worker shutdown, request abort) must
+            // propagate. Without this guard we'd swallow it as an "outage" and
+            // delay teardown by one full sweep cycle.
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
+            // HTTP timeout / transport failure / non-cancellation TaskCanceled
+            // (e.g. HttpClient.Timeout fired). Treat as an outage so the
+            // projection writer preserves cached scores instead of crashing
+            // the sweep.
             _logger.LogWarning(ex,
                 "verification batch failed for {Count} NPIs; preserving cached scores",
                 npis.Count);

--- a/src/services/provider-service/Services/ProviderVerificationClient.cs
+++ b/src/services/provider-service/Services/ProviderVerificationClient.cs
@@ -1,0 +1,157 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// HTTP wrapper over <c>provider-verification-service</c>. Used by the
+/// integrity-projection write-back path (capability 5.4.5).
+///
+/// <para>
+/// HTTP — not project reference — so the service boundary stays intact
+/// (mirrors <c>HttpProviderIntegrityGate</c> in <c>benefit-plan-service</c>).
+/// Project-referencing the verification engine into provider-service would
+/// double up the six data-source HTTP clients (NPPES, LEIE, PECOS, Open
+/// Payments, Medicare, FSMB).
+/// </para>
+/// </summary>
+public interface IProviderVerificationClient
+{
+    /// <summary>
+    /// Calls <c>POST /api/v1/providers/verify/batch</c>. The verification
+    /// service caps batch size at 100 NPIs; pass at most that many. Empty
+    /// or null inputs surface an empty result (no HTTP call).
+    /// </summary>
+    Task<IReadOnlyList<VerificationResult>> VerifyBatchAsync(
+        IReadOnlyList<string> npis,
+        CancellationToken ct = default);
+}
+
+public sealed class HttpProviderVerificationClient : IProviderVerificationClient
+{
+    public const string HttpClientName = "provider-verification";
+
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    private readonly HttpClient _http;
+    private readonly ILogger<HttpProviderVerificationClient> _logger;
+
+    public HttpProviderVerificationClient(
+        HttpClient http,
+        ILogger<HttpProviderVerificationClient> logger)
+    {
+        _http = http;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<VerificationResult>> VerifyBatchAsync(
+        IReadOnlyList<string> npis,
+        CancellationToken ct = default)
+    {
+        if (npis is null || npis.Count == 0)
+        {
+            return Array.Empty<VerificationResult>();
+        }
+        if (npis.Count > 100)
+        {
+            throw new ArgumentException(
+                "VerifyBatchAsync accepts at most 100 NPIs per call (provider-verification-service limit).",
+                nameof(npis));
+        }
+
+        try
+        {
+            var payload = new BatchRequest { Npis = npis.ToList() };
+            using var response = await _http.PostAsJsonAsync(
+                "api/v1/providers/verify/batch", payload, _json, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "verification batch returned {StatusCode} for {Count} NPIs",
+                    response.StatusCode, npis.Count);
+                return Array.Empty<VerificationResult>();
+            }
+
+            var envelope = await response.Content.ReadFromJsonAsync<BatchResponse>(_json, ct);
+            return envelope?.Results ?? (IReadOnlyList<VerificationResult>)Array.Empty<VerificationResult>();
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "verification batch failed for {Count} NPIs; preserving cached scores",
+                npis.Count);
+            return Array.Empty<VerificationResult>();
+        }
+    }
+
+    private sealed class BatchRequest
+    {
+        [JsonPropertyName("npis")]
+        public List<string> Npis { get; set; } = new();
+    }
+
+    private sealed class BatchResponse
+    {
+        [JsonPropertyName("count")]
+        public int Count { get; set; }
+
+        [JsonPropertyName("results")]
+        public List<VerificationResult> Results { get; set; } = new();
+    }
+}
+
+/// <summary>
+/// Slim projection of <c>ProviderVerificationRecord</c> — the only fields
+/// the projection writer needs. Mirrors the verification-service response
+/// shape but lives in provider-service so we don't take a project
+/// reference on the engine library.
+/// </summary>
+public sealed class VerificationResult
+{
+    [JsonPropertyName("npi")]
+    public string Npi { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public VerificationOutcome Status { get; set; } = VerificationOutcome.Pending;
+
+    [JsonPropertyName("integrityScore")]
+    public CompositeIntegrityScore IntegrityScore { get; set; } = new();
+
+    [JsonPropertyName("lastVerifiedAt")]
+    public DateTimeOffset LastVerifiedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    [JsonPropertyName("nextScheduledVerification")]
+    public DateTimeOffset? NextScheduledVerification { get; set; }
+}
+
+/// <summary>Mirror of <c>ProviderIntegrityScore</c> (score + rating only).</summary>
+public sealed class CompositeIntegrityScore
+{
+    [JsonPropertyName("compositeScore")]
+    public int CompositeScore { get; set; }
+
+    [JsonPropertyName("rating")]
+    public string Rating { get; set; } = "Unknown";
+}
+
+/// <summary>
+/// Mirror of <c>VerificationStatus</c>. The HTTP client deserializes by
+/// name (PR #705 string-enum-strict, allowIntegerValues=false). Unknown=0
+/// per project convention.
+/// </summary>
+public enum VerificationOutcome
+{
+    Unknown = 0,
+    Pending = 1,
+    Verified = 2,
+    VerifiedWithWarnings = 3,
+    Failed = 4,
+    Excluded = 5,
+    Expired = 6,
+    ManualReviewRequired = 7,
+}

--- a/src/services/provider-service/Services/ProviderVerificationEventPublisher.cs
+++ b/src/services/provider-service/Services/ProviderVerificationEventPublisher.cs
@@ -92,7 +92,13 @@ public sealed class MongoProviderVerificationEventPublisher : IProviderVerificat
         ProviderVerificationEvent evt, CancellationToken ct)
     {
         evt.PartitionKey = ProviderVerificationEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
-        evt.Id = evt.EventId;
+        // Mongo maps Id ⇒ _id which must be unique across the entire
+        // collection. EventId is only unique within (TenantId,ProviderId)
+        // — two tenants verifying the same NPI at the same instant
+        // would collide on _id alone. Scope _id to PartitionKey:EventId.
+        // The (TenantId, ProviderId, EventId) UNIQUE index from the
+        // initializer remains in place as the primary idempotency guard.
+        evt.Id = $"{evt.PartitionKey}:{evt.EventId}";
         if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
 
         var existing = await GetByEventIdAsync(evt.TenantId, evt.ProviderId, evt.EventId, ct);

--- a/src/services/provider-service/Services/ProviderVerificationEventPublisher.cs
+++ b/src/services/provider-service/Services/ProviderVerificationEventPublisher.cs
@@ -1,0 +1,196 @@
+using System.Text.Json.Nodes;
+using MongoDB.Driver;
+using ProviderService.Models;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Publishes <see cref="ProviderVerificationEvent"/>s to the append-only
+/// <c>ProviderVerificationEvents</c> stream. Mirrors
+/// <see cref="IProviderVersionEventPublisher"/>: client-supplied
+/// <see cref="ProviderVerificationEvent.EventId"/> for idempotency,
+/// monotonic <see cref="ProviderVerificationEvent.Version"/> per
+/// <c>(TenantId, ProviderId)</c>.
+///
+/// <para>
+/// Capability 5.4.5 ships the producer; no cross-service consumer is
+/// wired. The decorator path used for
+/// <see cref="IProviderVersionEventPublisher"/> applies here too if a
+/// future capability needs bus fan-out.
+/// </para>
+/// </summary>
+public interface IProviderVerificationEventPublisher
+{
+    Task<ProviderVerificationEvent> PublishRefreshedAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset verifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+}
+
+public sealed class MongoProviderVerificationEventPublisher : IProviderVerificationEventPublisher
+{
+    private const int MaxRetries = 5;
+    private static readonly int[] BackoffMs = { 2, 5, 25, 100, 250 };
+
+    private readonly IMongoCollection<ProviderVerificationEvent> _collection;
+    private readonly ILogger<MongoProviderVerificationEventPublisher> _logger;
+
+    public MongoProviderVerificationEventPublisher(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<MongoProviderVerificationEventPublisher> logger)
+    {
+        var collectionName = configuration["CosmosDb:ProviderVerificationEventsContainer"]
+            ?? "ProviderVerificationEvents";
+        _collection = database.GetCollection<ProviderVerificationEvent>(collectionName);
+        _logger = logger;
+    }
+
+    public Task<ProviderVerificationEvent> PublishRefreshedAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset verifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        var payload = new JsonObject
+        {
+            ["integrityScore"] = integrityScore,
+            ["integrityRating"] = integrityRating,
+            ["verifiedAt"] = verifiedAt,
+            ["nextVerificationDue"] = nextVerificationDue,
+        };
+
+        var evt = new ProviderVerificationEvent
+        {
+            EventId = ProviderVerificationEvent.BuildRefreshedEventId(providerId, verifiedAt),
+            EventType = ProviderVerificationEventType.ProviderVerificationRefreshed,
+            TenantId = tenantId,
+            ProviderId = providerId,
+            IntegrityScore = integrityScore,
+            IntegrityRating = integrityRating,
+            VerifiedAt = verifiedAt,
+            NextVerificationDue = nextVerificationDue,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = payload,
+        };
+        return AppendAsync(evt, ct);
+    }
+
+    private async Task<ProviderVerificationEvent> AppendAsync(
+        ProviderVerificationEvent evt, CancellationToken ct)
+    {
+        evt.PartitionKey = ProviderVerificationEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
+        evt.Id = evt.EventId;
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+
+        var existing = await GetByEventIdAsync(evt.TenantId, evt.ProviderId, evt.EventId, ct);
+        if (existing != null)
+        {
+            _logger.LogDebug(
+                "ProviderVerificationEvent {EventId} already present for {Tenant}:{Provider} (idempotent no-op)",
+                Sanitize(evt.EventId), Sanitize(evt.TenantId), Sanitize(evt.ProviderId));
+            return existing;
+        }
+
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
+        {
+            evt.Version = await GetNextVersionAsync(evt.TenantId, evt.ProviderId, ct);
+            try
+            {
+                await _collection.InsertOneAsync(evt, cancellationToken: ct);
+                return evt;
+            }
+            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                var refetch = await GetByEventIdAsync(evt.TenantId, evt.ProviderId, evt.EventId, ct);
+                if (refetch != null) return refetch;
+
+                _logger.LogWarning(
+                    "ProviderVerificationEvent version {Version} conflict for {Tenant}:{Provider}; retry {Attempt}/{Max}",
+                    evt.Version, Sanitize(evt.TenantId), Sanitize(evt.ProviderId), attempt + 1, MaxRetries);
+
+                if (attempt + 1 < MaxRetries)
+                    await Task.Delay(BackoffMs[attempt], ct);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to append ProviderVerificationEvent for {evt.TenantId}:{evt.ProviderId} after {MaxRetries} attempts");
+    }
+
+    private async Task<ProviderVerificationEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct)
+    {
+        var b = Builders<ProviderVerificationEvent>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderId, providerId),
+            b.Eq(x => x.EventId, eventId));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    private async Task<int> GetNextVersionAsync(string tenantId, string providerId, CancellationToken ct)
+    {
+        var b = Builders<ProviderVerificationEvent>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.ProviderId, providerId));
+        var latest = await _collection.Find(filter).SortByDescending(x => x.Version).FirstOrDefaultAsync(ct);
+        return (latest?.Version ?? 0) + 1;
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}
+
+/// <summary>
+/// No-op fallback used when no Mongo publisher is available (e.g.
+/// Cosmos-only deployments without the verification-events stream
+/// provisioned). Logs a warning so ops can spot the missing wiring.
+/// </summary>
+public sealed class NoopProviderVerificationEventPublisher : IProviderVerificationEventPublisher
+{
+    private readonly ILogger<NoopProviderVerificationEventPublisher> _logger;
+
+    public NoopProviderVerificationEventPublisher(ILogger<NoopProviderVerificationEventPublisher> logger)
+        => _logger = logger;
+
+    public Task<ProviderVerificationEvent> PublishRefreshedAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset verifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "ProviderVerificationEventPublisher is not configured; dropping refresh event for {ProviderId}",
+            providerId);
+        return Task.FromResult(new ProviderVerificationEvent
+        {
+            EventId = ProviderVerificationEvent.BuildRefreshedEventId(providerId, verifiedAt),
+            EventType = ProviderVerificationEventType.ProviderVerificationRefreshed,
+            TenantId = tenantId,
+            ProviderId = providerId,
+            IntegrityScore = integrityScore,
+            IntegrityRating = integrityRating,
+            VerifiedAt = verifiedAt,
+            NextVerificationDue = nextVerificationDue,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+        });
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/IntegrityProjectionAdminControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/IntegrityProjectionAdminControllerTests.cs
@@ -1,0 +1,81 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Unit-level coverage for <see cref="IntegrityProjectionAdminController"/>'s
+/// gate behavior — the AdminBackfillEnabled flag must default to false
+/// and surface 503 (not 404) so operators know the route exists but
+/// is intentionally gated.
+/// </summary>
+public class IntegrityProjectionAdminControllerTests
+{
+    private static IntegrityProjectionAdminController BuildController(
+        bool adminBackfillEnabled,
+        IProviderIntegrityProjectionService projection)
+    {
+        var opts = new IntegrityProjectionOptions { AdminBackfillEnabled = adminBackfillEnabled };
+        var monitor = new TestOptionsMonitor(opts);
+        return new IntegrityProjectionAdminController(
+            projection, monitor, NullLogger<IntegrityProjectionAdminController>.Instance);
+    }
+
+    private sealed class TestOptionsMonitor : IOptionsMonitor<IntegrityProjectionOptions>
+    {
+        private readonly IntegrityProjectionOptions _value;
+        public TestOptionsMonitor(IntegrityProjectionOptions value) => _value = value;
+        public IntegrityProjectionOptions CurrentValue => _value;
+        public IntegrityProjectionOptions Get(string? name) => _value;
+        public IDisposable? OnChange(Action<IntegrityProjectionOptions, string?> listener) => null;
+    }
+
+    private static ProviderIntegrityProjectionService BuildProjectionService()
+    {
+        var repo = new InMemoryProviderRepository();
+        var client = new FakeProviderVerificationClient();
+        var events = new FakeProviderVerificationEventPublisher();
+        return new ProviderIntegrityProjectionService(
+            repo, client, events,
+            Options.Create(new IntegrityProjectionOptions { AdminBackfillEnabled = true }),
+            NullLogger<ProviderIntegrityProjectionService>.Instance);
+    }
+
+    [Fact]
+    public async Task Backfill_returns_503_when_flag_disabled()
+    {
+        var controller = BuildController(adminBackfillEnabled: false, BuildProjectionService());
+        var result = await controller.BackfillIntegrityProjection("tenant-a", null, CancellationToken.None);
+
+        var status = result.Result as ObjectResult;
+        status.Should().NotBeNull();
+        status!.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public async Task Backfill_returns_400_on_missing_tenantId_when_flag_enabled()
+    {
+        var controller = BuildController(adminBackfillEnabled: true, BuildProjectionService());
+        var result = await controller.BackfillIntegrityProjection("", null, CancellationToken.None);
+
+        var bad = result.Result as BadRequestObjectResult;
+        bad.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Backfill_runs_when_flag_enabled_and_tenant_provided()
+    {
+        var controller = BuildController(adminBackfillEnabled: true, BuildProjectionService());
+        var result = await controller.BackfillIntegrityProjection(
+            "tenant-a", maxProviders: 10, CancellationToken.None);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        ok!.Value.Should().BeOfType<IntegrityProjectionTenantSweepResult>();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeProviderVerificationClient.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeProviderVerificationClient.cs
@@ -1,0 +1,53 @@
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IProviderVerificationClient"/>. Tests register
+/// canned <see cref="VerificationResult"/>s by NPI; calls to
+/// <see cref="VerifyBatchAsync"/> return the matching subset and record
+/// every batch invocation for later assertion.
+/// </summary>
+public sealed class FakeProviderVerificationClient : IProviderVerificationClient
+{
+    public Dictionary<string, VerificationResult> Canned { get; } = new();
+    public List<IReadOnlyList<string>> Calls { get; } = new();
+
+    /// <summary>
+    /// When true, <see cref="VerifyBatchAsync"/> returns no records (a
+    /// verification-source outage). Cached scores stay put.
+    /// </summary>
+    public bool SimulateOutage { get; set; }
+
+    public Task<IReadOnlyList<VerificationResult>> VerifyBatchAsync(
+        IReadOnlyList<string> npis, CancellationToken ct = default)
+    {
+        Calls.Add(npis.ToList());
+        if (SimulateOutage)
+        {
+            return Task.FromResult<IReadOnlyList<VerificationResult>>(
+                Array.Empty<VerificationResult>());
+        }
+
+        var results = npis
+            .Where(n => Canned.ContainsKey(n))
+            .Select(n => Canned[n])
+            .ToList();
+        return Task.FromResult<IReadOnlyList<VerificationResult>>(results);
+    }
+
+    public void Seed(string npi, int score, string rating)
+    {
+        Canned[npi] = new VerificationResult
+        {
+            Npi = npi,
+            Status = VerificationOutcome.Verified,
+            IntegrityScore = new CompositeIntegrityScore
+            {
+                CompositeScore = score,
+                Rating = rating,
+            },
+            LastVerifiedAt = DateTimeOffset.UtcNow,
+        };
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeProviderVerificationEventPublisher.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeProviderVerificationEventPublisher.cs
@@ -1,0 +1,50 @@
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IProviderVerificationEventPublisher"/>. Records
+/// every published event and enforces the same idempotency contract as
+/// the real Mongo publisher (deterministic <c>EventId</c> on
+/// <c>(providerId, verifiedAt)</c>).
+/// </summary>
+public sealed class FakeProviderVerificationEventPublisher : IProviderVerificationEventPublisher
+{
+    public List<ProviderVerificationEvent> Events { get; } = new();
+
+    public Task<ProviderVerificationEvent> PublishRefreshedAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset verifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        var eventId = ProviderVerificationEvent.BuildRefreshedEventId(providerId, verifiedAt);
+        var existing = Events.FirstOrDefault(e =>
+            e.TenantId == tenantId && e.ProviderId == providerId && e.EventId == eventId);
+        if (existing != null) return Task.FromResult(existing);
+
+        var evt = new ProviderVerificationEvent
+        {
+            EventId = eventId,
+            EventType = ProviderVerificationEventType.ProviderVerificationRefreshed,
+            TenantId = tenantId,
+            ProviderId = providerId,
+            IntegrityScore = integrityScore,
+            IntegrityRating = integrityRating,
+            VerifiedAt = verifiedAt,
+            NextVerificationDue = nextVerificationDue,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Version = Events.Count(e => e.TenantId == tenantId && e.ProviderId == providerId) + 1,
+            OccurredAt = DateTime.UtcNow,
+        };
+        Events.Add(evt);
+        return Task.FromResult(evt);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -320,6 +320,77 @@ public sealed class InMemoryProviderRepository : IProviderRepository
         _docs.Add(Clone(version));
         return Task.FromResult(Clone(version));
     }
+
+    public Task<bool> UpdateIntegrityProjectionAsync(
+        string tenantId,
+        string providerId,
+        int? integrityScore,
+        string? integrityRating,
+        DateTimeOffset? lastVerifiedAt,
+        DateTimeOffset? nextVerificationDue,
+        CancellationToken ct = default)
+    {
+        // Find the head Active row for the chain. Hydration normalises
+        // legacy rows (missing VersionState) to Active so they're patched
+        // too — matching the real-repo behaviour.
+        var head = _docs
+            .Select(d => Hydrate(Clone(d)))
+            .Where(d => d.TenantId == tenantId
+                && (d.ProviderId == providerId || d.Id == providerId)
+                && d.VersionState == ProviderVersionState.Active)
+            .OrderByDescending(d => d.VersionNumber)
+            .FirstOrDefault();
+        if (head == null) return Task.FromResult(false);
+
+        // Patch the underlying stored row (not the hydrated clone).
+        var stored = _docs.First(d => d.Id == head.Id && d.TenantId == head.TenantId);
+        stored.IntegrityScore = integrityScore;
+        stored.IntegrityRating = integrityRating;
+        stored.LastVerifiedAt = lastVerifiedAt;
+        stored.NextVerificationDue = nextVerificationDue;
+        stored.LastUpdatedDate = DateTime.UtcNow;
+        return Task.FromResult(true);
+    }
+
+    public Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(
+        string tenantId,
+        DateTimeOffset dueBefore,
+        bool includeNeverVerified,
+        int skip,
+        int pageSize,
+        CancellationToken ct = default)
+    {
+        var safeSkip = Math.Max(skip, 0);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
+
+        bool DueMatches(Provider p)
+        {
+            if (p.NextVerificationDue == null) return includeNeverVerified;
+            return p.NextVerificationDue <= dueBefore;
+        }
+
+        var slice = HydratedView()
+            .Where(d => d.TenantId == tenantId
+                && d.VersionState == ProviderVersionState.Active
+                && DueMatches(d))
+            .OrderBy(d => d.ProviderId, StringComparer.Ordinal)
+            .ThenBy(d => d.Id, StringComparer.Ordinal)
+            .Skip(safeSkip)
+            .Take(safePageSize)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Provider>>(slice);
+    }
+
+    public Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default)
+    {
+        var distinct = _docs
+            .Select(d => d.TenantId)
+            .Where(t => !string.IsNullOrEmpty(t))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(t => t, StringComparer.Ordinal)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<string>>(distinct);
+    }
 }
 
 public sealed class InMemoryProviderTransitionRepository : IProviderTransitionRepository

--- a/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/IntegrityProjectionWorkerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/IntegrityProjectionWorkerTests.cs
@@ -1,4 +1,5 @@
 using CloudHealthOffice.ProviderService.Tests.Fakes;
+using CloudHealthOffice.ProviderService.Tests.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -95,8 +96,10 @@ public class IntegrityProjectionWorkerTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await worker.StartAsync(cts.Token);
-        // Give the first sweep time to drain.
-        await Task.Delay(500);
+        await PollUntil.UntilAsync(
+            () => repo.Docs.FirstOrDefault(d => d.Id == "p-a")?.IntegrityScore == 80
+                  && repo.Docs.FirstOrDefault(d => d.Id == "p-b")?.IntegrityScore == 60,
+            description: "both tenants patched");
         await worker.StopAsync(CancellationToken.None);
 
         repo.Docs.First(d => d.Id == "p-a").IntegrityScore.Should().Be(80);
@@ -106,14 +109,24 @@ public class IntegrityProjectionWorkerTests
     [Fact]
     public async Task Worker_skips_when_disabled()
     {
-        var disabled = new IntegrityProjectionOptions { Enabled = false };
+        var disabled = new IntegrityProjectionOptions
+        {
+            Enabled = false,
+            // Short interval so the disabled-branch loop spins fast
+            // enough that we can observe its idle behaviour briefly.
+            SweepInterval = TimeSpan.FromMilliseconds(100),
+        };
         var (worker, repo, client, _, _) = BuildWorker(disabled);
         Seed(repo, "tenant-a", "p-a", "1111111111");
         client.Seed("1111111111", 80, "Clear");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         await worker.StartAsync(cts.Token);
-        await Task.Delay(500);
+        // Wait one sweep window then assert no work happened. There's
+        // no positive condition to poll for ("nothing happened" is
+        // intrinsically time-bounded), but the window is bounded by
+        // the configured SweepInterval — not an arbitrary 500ms.
+        await Task.Delay(disabled.SweepInterval + disabled.SweepInterval);
         await worker.StopAsync(CancellationToken.None);
 
         client.Calls.Should().BeEmpty();
@@ -129,7 +142,9 @@ public class IntegrityProjectionWorkerTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await worker.StartAsync(cts.Token);
-        await Task.Delay(500);
+        await PollUntil.UntilAsync(
+            () => events.Events.Any(e => e.ProviderId == "p-a"),
+            description: "refresh event emitted");
         await worker.StopAsync(CancellationToken.None);
 
         events.Events.Should().ContainSingle(e =>

--- a/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/IntegrityProjectionWorkerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/IntegrityProjectionWorkerTests.cs
@@ -1,0 +1,139 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.HostedServices;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.HostedServices;
+
+/// <summary>
+/// Coverage for <see cref="IntegrityProjectionWorker"/>'s sweep loop:
+/// per-tenant iteration via <see cref="IServiceScopeFactory"/>, due-row
+/// filtering, and graceful shutdown.
+///
+/// We avoid spinning a real <see cref="BackgroundService"/> host and
+/// instead exercise <c>StartAsync</c> + a short <c>StopAsync</c>; the
+/// sweep runs once and the disabled flag (or empty tenant set) keeps
+/// the loop idle so the test completes deterministically.
+/// </summary>
+public class IntegrityProjectionWorkerTests
+{
+    private static (IntegrityProjectionWorker worker,
+                    InMemoryProviderRepository repo,
+                    FakeProviderVerificationClient client,
+                    FakeProviderVerificationEventPublisher events,
+                    IServiceProvider sp)
+        BuildWorker(IntegrityProjectionOptions? options = null)
+    {
+        var repo = new InMemoryProviderRepository();
+        var client = new FakeProviderVerificationClient();
+        var events = new FakeProviderVerificationEventPublisher();
+        var opts = options ?? new IntegrityProjectionOptions
+        {
+            // Sweep interval doesn't matter for these tests — we cancel
+            // after the first sweep completes.
+            SweepInterval = TimeSpan.FromSeconds(60),
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IProviderRepository>(repo);
+        services.AddSingleton<IProviderVerificationClient>(client);
+        services.AddSingleton<IProviderVerificationEventPublisher>(events);
+        services.AddSingleton(Options.Create(opts));
+        services.AddSingleton<IProviderIntegrityProjectionService, ProviderIntegrityProjectionService>();
+        services.AddLogging();
+        var sp = services.BuildServiceProvider();
+
+        var worker = new IntegrityProjectionWorker(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            new TestOptionsMonitor(opts),
+            NullLogger<IntegrityProjectionWorker>.Instance);
+
+        return (worker, repo, client, events, sp);
+    }
+
+    private sealed class TestOptionsMonitor : IOptionsMonitor<IntegrityProjectionOptions>
+    {
+        private readonly IntegrityProjectionOptions _value;
+        public TestOptionsMonitor(IntegrityProjectionOptions value) => _value = value;
+        public IntegrityProjectionOptions CurrentValue => _value;
+        public IntegrityProjectionOptions Get(string? name) => _value;
+        public IDisposable? OnChange(Action<IntegrityProjectionOptions, string?> listener) => null;
+    }
+
+    private static void Seed(InMemoryProviderRepository repo, string tenant, string providerId, string npi)
+    {
+        var p = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = tenant,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Worker",
+            LastName = "Target",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = providerId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        };
+        repo.CreateAsync(p).GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public async Task Worker_iterates_each_tenant_and_patches_due_rows()
+    {
+        var (worker, repo, client, _, _) = BuildWorker();
+        Seed(repo, "tenant-a", "p-a", "1111111111");
+        Seed(repo, "tenant-b", "p-b", "2222222222");
+        client.Seed("1111111111", 80, "Clear");
+        client.Seed("2222222222", 60, "Advisory");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await worker.StartAsync(cts.Token);
+        // Give the first sweep time to drain.
+        await Task.Delay(500);
+        await worker.StopAsync(CancellationToken.None);
+
+        repo.Docs.First(d => d.Id == "p-a").IntegrityScore.Should().Be(80);
+        repo.Docs.First(d => d.Id == "p-b").IntegrityScore.Should().Be(60);
+    }
+
+    [Fact]
+    public async Task Worker_skips_when_disabled()
+    {
+        var disabled = new IntegrityProjectionOptions { Enabled = false };
+        var (worker, repo, client, _, _) = BuildWorker(disabled);
+        Seed(repo, "tenant-a", "p-a", "1111111111");
+        client.Seed("1111111111", 80, "Clear");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(500);
+        await worker.StopAsync(CancellationToken.None);
+
+        client.Calls.Should().BeEmpty();
+        repo.Docs.First(d => d.Id == "p-a").IntegrityScore.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Worker_emits_one_event_per_refresh()
+    {
+        var (worker, repo, client, events, _) = BuildWorker();
+        Seed(repo, "tenant-a", "p-a", "1111111111");
+        client.Seed("1111111111", 80, "Clear");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(500);
+        await worker.StopAsync(CancellationToken.None);
+
+        events.Events.Should().ContainSingle(e =>
+            e.ProviderId == "p-a"
+            && e.EventType == ProviderVerificationEventType.ProviderVerificationRefreshed);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Migrations/IntegrityProjectionBackfillTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Migrations/IntegrityProjectionBackfillTests.cs
@@ -1,0 +1,143 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Migrations;
+
+/// <summary>
+/// Coverage for the admin backfill path (capability 5.4.5). Backfill
+/// reuses <see cref="ProviderIntegrityProjectionService.RefreshTenantAsync"/>
+/// with a far-future <c>DueBefore</c> so every Provider in the named
+/// tenant is refreshed regardless of <c>NextVerificationDue</c>.
+///
+/// Verifies: idempotent reruns, tenant isolation, max-providers cap.
+/// </summary>
+public class IntegrityProjectionBackfillTests
+{
+    private readonly InMemoryProviderRepository _repo;
+    private readonly FakeProviderVerificationClient _client;
+    private readonly FakeProviderVerificationEventPublisher _events;
+    private readonly ProviderIntegrityProjectionService _svc;
+
+    public IntegrityProjectionBackfillTests()
+    {
+        _repo = new InMemoryProviderRepository();
+        _client = new FakeProviderVerificationClient();
+        _events = new FakeProviderVerificationEventPublisher();
+        var opts = Options.Create(new IntegrityProjectionOptions());
+        _svc = new ProviderIntegrityProjectionService(
+            _repo, _client, _events, opts,
+            NullLogger<ProviderIntegrityProjectionService>.Instance);
+    }
+
+    private void Seed(string tenant, string providerId, string npi, int? cachedScore = null)
+    {
+        var p = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = tenant,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Backfill",
+            LastName = "Target",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = providerId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            IntegrityScore = cachedScore,
+            // NextVerificationDue intentionally null — simulates legacy
+            // never-verified rows that backfill needs to populate.
+        };
+        _repo.CreateAsync(p).GetAwaiter().GetResult();
+    }
+
+    private static IntegrityProjectionTenantSweepRequest BackfillRequest() => new()
+    {
+        DueBefore = DateTimeOffset.UtcNow.AddYears(100), // every row is "due"
+        IncludeNeverVerified = true,
+        ActorId = "admin:backfill-integrity-projection",
+    };
+
+    [Fact]
+    public async Task Backfill_populates_legacy_null_scores()
+    {
+        Seed("tenant-a", "p1", "1234567890");
+        Seed("tenant-a", "p2", "1234567891");
+        _client.Seed("1234567890", 88, "Clear");
+        _client.Seed("1234567891", 60, "Advisory");
+
+        var result = await _svc.RefreshTenantAsync("tenant-a", BackfillRequest());
+
+        result.Patched.Should().Be(2);
+        result.Failed.Should().Be(0);
+
+        _repo.Docs.First(d => d.Id == "p1").IntegrityScore.Should().Be(88);
+        _repo.Docs.First(d => d.Id == "p2").IntegrityScore.Should().Be(60);
+    }
+
+    [Fact]
+    public async Task Backfill_is_idempotent_on_rerun()
+    {
+        Seed("tenant-a", "p1", "1234567890");
+        _client.Seed("1234567890", 88, "Clear");
+
+        var first = await _svc.RefreshTenantAsync("tenant-a", BackfillRequest());
+        var second = await _svc.RefreshTenantAsync("tenant-a", BackfillRequest());
+
+        first.Patched.Should().Be(1);
+        second.Patched.Should().Be(1); // same row patched again — same payload
+
+        _repo.Docs.First(d => d.Id == "p1").IntegrityScore.Should().Be(88);
+    }
+
+    [Fact]
+    public async Task Backfill_respects_tenant_isolation()
+    {
+        Seed("tenant-a", "p1", "1234567890");
+        Seed("tenant-b", "p1", "1234567891");
+        _client.Seed("1234567890", 88, "Clear");
+        _client.Seed("1234567891", 50, "Caution");
+
+        var result = await _svc.RefreshTenantAsync("tenant-a", BackfillRequest());
+        result.Patched.Should().Be(1);
+
+        // tenant-b row untouched.
+        _repo.Docs.First(d => d.TenantId == "tenant-b").IntegrityScore.Should().BeNull();
+        _repo.Docs.First(d => d.TenantId == "tenant-a").IntegrityScore.Should().Be(88);
+    }
+
+    [Fact]
+    public async Task Backfill_honours_max_providers_override()
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            var npi = $"700000000{i}";
+            Seed("tenant-a", $"cap-{i}", npi);
+            _client.Seed(npi, 80, "Clear");
+        }
+
+        var request = BackfillRequest();
+        request.MaxProviders = 4;
+        request.PageSize = 10;
+
+        var result = await _svc.RefreshTenantAsync("tenant-a", request);
+        result.Patched.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Backfill_preserves_cached_score_when_verification_returns_no_record()
+    {
+        Seed("tenant-a", "p1", "1234567890", cachedScore: 75);
+        // Don't seed verification client → no result for this NPI.
+
+        var result = await _svc.RefreshTenantAsync("tenant-a", BackfillRequest());
+
+        result.Failed.Should().Be(1);
+        result.Patched.Should().Be(0);
+        _repo.Docs.First(d => d.Id == "p1").IntegrityScore.Should().Be(75); // cached preserved
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Repositories/IntegrityProjectionWritePathTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Repositories/IntegrityProjectionWritePathTests.cs
@@ -137,6 +137,75 @@ public class IntegrityProjectionWritePathTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpdateIntegrityProjection_skips_legacy_terminated_row()
+    {
+        // Legacy row: VersionState never persisted, Status=Terminated.
+        // Pre-fix the missing-VersionState branch was treated as
+        // "Active" without consulting Status, so this would have been
+        // patched. Post-fix it must be excluded.
+        var collection = _database.GetCollection<Provider>("Providers");
+        await collection.InsertOneAsync(new Provider
+        {
+            Id = "legacy-term",
+            TenantId = Tenant,
+            NPI = "9999999990",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Legacy",
+            LastName = "Terminated",
+            PrimarySpecialty = "Cardiology",
+            TaxonomyCode = "207RC0000X",
+            Status = ProviderStatus.Terminated,
+            // VersionState / VersionId / VersionNumber intentionally unset
+        });
+
+        var patched = await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "legacy-term", 90, "Clear",
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+        patched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListProvidersForIntegrityRefresh_excludes_legacy_terminated_row()
+    {
+        // Twin of the above for the sweep query: a legacy
+        // Terminated/Suspended row must NOT show up in the
+        // refresh list.
+        var collection = _database.GetCollection<Provider>("Providers");
+        await collection.InsertOneAsync(new Provider
+        {
+            Id = "legacy-term-2",
+            TenantId = Tenant,
+            NPI = "9999999991",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Legacy",
+            LastName = "Suspended",
+            PrimarySpecialty = "Cardiology",
+            TaxonomyCode = "207RC0000X",
+            Status = ProviderStatus.Inactive,
+        });
+        // Sanity: an active legacy row should still be listed.
+        await collection.InsertOneAsync(new Provider
+        {
+            Id = "legacy-active",
+            TenantId = Tenant,
+            NPI = "9999999992",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Legacy",
+            LastName = "Active",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            Status = ProviderStatus.Active,
+        });
+
+        var rows = await _repo.ListProvidersForIntegrityRefreshAsync(
+            Tenant, DateTimeOffset.UtcNow, includeNeverVerified: true,
+            skip: 0, pageSize: 100);
+
+        rows.Select(p => p.Id).Should().NotContain("legacy-term-2");
+        rows.Select(p => p.Id).Should().Contain("legacy-active");
+    }
+
+    [Fact]
     public async Task ListProvidersForIntegrityRefresh_filters_by_due_date()
     {
         var due = await SeedActiveAsync("p-due", "5111111111");

--- a/tests/CloudHealthOffice.ProviderService.Tests/Repositories/IntegrityProjectionWritePathTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Repositories/IntegrityProjectionWritePathTests.cs
@@ -1,0 +1,186 @@
+using EphemeralMongo;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace CloudHealthOffice.ProviderService.Tests.Repositories;
+
+/// <summary>
+/// Mongo-backed coverage for the integrity-projection write path
+/// (capability 5.4.5): the projection-fields-only patch must succeed
+/// against an Active row WITHOUT triggering the version-state guard
+/// that <see cref="ProviderRepositoryMongo.UpdateAsync"/> enforces.
+/// Identity-field writes against the same Active row must STILL throw.
+/// </summary>
+public class IntegrityProjectionWritePathTests : IAsyncLifetime
+{
+    private const string Tenant = "tenant-a";
+
+    private IMongoRunner _runner = null!;
+    private IMongoDatabase _database = null!;
+    private ProviderRepositoryMongo _repo = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        _database = client.GetDatabase($"projection_writepath_{Guid.NewGuid():N}");
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = Tenant;
+        var accessor = new HttpContextAccessor { HttpContext = ctx };
+        _repo = new ProviderRepositoryMongo(_database, accessor, NullLogger<ProviderRepositoryMongo>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* see MpipRateServiceTests note */ }
+        return Task.CompletedTask;
+    }
+
+    private async Task<Provider> SeedActiveAsync(string providerId, string npi)
+    {
+        var draft = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = Tenant,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Patch",
+            LastName = "Target",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+        };
+        await _repo.CreateDraftAsync(draft);
+        var head = await _repo.GetVersionAsync(providerId, draft.VersionId);
+        head!.VersionState = ProviderVersionState.Active;
+        await _repo.ActivateAndSupersedeAsync(head, predecessor: null);
+        return head;
+    }
+
+    [Fact]
+    public async Task UpdateIntegrityProjection_patches_active_row_without_state_exception()
+    {
+        await SeedActiveAsync("ip1", "1234567890");
+        var verifiedAt = DateTimeOffset.UtcNow;
+        var nextDue = verifiedAt.AddDays(1);
+
+        var patched = await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "ip1", 92, "Clear", verifiedAt, nextDue);
+        patched.Should().BeTrue();
+
+        var head = await _repo.GetLatestActiveAsync("ip1", DateTime.UtcNow);
+        head.Should().NotBeNull();
+        head!.IntegrityScore.Should().Be(92);
+        head.IntegrityRating.Should().Be("Clear");
+        head.LastVerifiedAt.Should().BeCloseTo(verifiedAt, TimeSpan.FromSeconds(1));
+        head.NextVerificationDue.Should().BeCloseTo(nextDue, TimeSpan.FromSeconds(1));
+        head.VersionState.Should().Be(ProviderVersionState.Active); // state untouched
+    }
+
+    [Fact]
+    public async Task UpdateIntegrityProjection_does_not_create_a_new_version()
+    {
+        await SeedActiveAsync("ip2", "1234567891");
+
+        await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "ip2", 80, "Clear", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+        var (versions, _) = await _repo.ListVersionsAsync("ip2", 25, null);
+        versions.Should().HaveCount(1); // chain unchanged
+        versions[0].VersionNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_against_active_still_throws_after_projection_patch()
+    {
+        var head = await SeedActiveAsync("ip3", "1234567892");
+        await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "ip3", 85, "Clear", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+
+        // Identity-field write must still surface 409 — the projection
+        // patch did not weaken the state guard.
+        head.PrimarySpecialty = "Tampered";
+        head.IntegrityScore = 999; // even a projection field via UpdateAsync should fail
+        var act = () => _repo.UpdateAsync(head);
+        await act.Should().ThrowAsync<ProviderVersionStateException>()
+            .Where(ex => ex.CurrentState == ProviderVersionState.Active);
+    }
+
+    [Fact]
+    public async Task UpdateIntegrityProjection_returns_false_when_no_active_head()
+    {
+        // No provider seeded.
+        var patched = await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "missing", 50, "Caution",
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+        patched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateIntegrityProjection_skips_terminated_chain()
+    {
+        var head = await SeedActiveAsync("ip4", "1234567893");
+        // Terminate the head.
+        head.VersionState = ProviderVersionState.Terminated;
+        head.TerminationDate = DateTime.UtcNow;
+        await _repo.ReplaceVersionRowAsync(head);
+
+        var patched = await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "ip4", 90, "Clear",
+            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddDays(1));
+        patched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ListProvidersForIntegrityRefresh_filters_by_due_date()
+    {
+        var due = await SeedActiveAsync("p-due", "5111111111");
+        await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "p-due", 70, "Advisory",
+            DateTimeOffset.UtcNow.AddDays(-2),
+            DateTimeOffset.UtcNow.AddDays(-1)); // due in the past
+
+        var fresh = await SeedActiveAsync("p-fresh", "5222222222");
+        await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "p-fresh", 70, "Advisory",
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddDays(7)); // due in the future
+
+        await SeedActiveAsync("p-never", "5333333333"); // never verified — null
+
+        var dueRows = await _repo.ListProvidersForIntegrityRefreshAsync(
+            Tenant, DateTimeOffset.UtcNow, includeNeverVerified: true,
+            skip: 0, pageSize: 100);
+
+        dueRows.Select(p => p.ProviderId).Should().BeEquivalentTo(new[] { "p-due", "p-never" });
+    }
+
+    [Fact]
+    public async Task ListProviderTenantIds_returns_distinct_tenants()
+    {
+        await SeedActiveAsync("p-a", "6111111111");
+        // Insert a second tenant directly (bypass HttpContext).
+        var collection = _database.GetCollection<Provider>("Providers");
+        await collection.InsertOneAsync(new Provider
+        {
+            Id = "p-other",
+            ProviderId = "p-other",
+            TenantId = "tenant-b",
+            NPI = "6222222222",
+            ProviderType = ProviderType.Individual,
+            PrimarySpecialty = "Cardiology",
+            TaxonomyCode = "207RC0000X",
+            VersionId = "p-other",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        });
+
+        var tenants = await _repo.ListProviderTenantIdsAsync();
+        tenants.Should().BeEquivalentTo(new[] { Tenant, "tenant-b" });
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/HttpProviderVerificationClientTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/HttpProviderVerificationClientTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Coverage for <see cref="HttpProviderVerificationClient"/>'s failure
+/// posture: caller cancellation propagates (worker shutdown is
+/// timely), HTTP timeouts and transport failures degrade to "outage"
+/// (cached scores stay put), oversized batches throw early.
+/// </summary>
+public class HttpProviderVerificationClientTests
+{
+    private static HttpProviderVerificationClient BuildClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+    {
+        var http = new HttpClient(new DelegateHandler(handler))
+        {
+            BaseAddress = new Uri("http://provider-verification-service/"),
+        };
+        return new HttpProviderVerificationClient(
+            http, NullLogger<HttpProviderVerificationClient>.Instance);
+    }
+
+    [Fact]
+    public async Task VerifyBatchAsync_propagates_caller_cancellation()
+    {
+        // Handler honours the caller's CancellationToken: when the
+        // caller cancels, the awaited Task throws OperationCanceledException
+        // and the client must rethrow rather than swallow as outage.
+        var client = BuildClient(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        var act = () => client.VerifyBatchAsync(new[] { "1234567890" }, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task VerifyBatchAsync_returns_empty_on_transport_failure()
+    {
+        // Genuine HTTP transport failure (server unreachable / DNS
+        // failure / timeout from HttpClient.Timeout) MUST degrade
+        // gracefully — the projection writer preserves cached scores.
+        var client = BuildClient((_, _) =>
+            throw new HttpRequestException("server unreachable"));
+
+        var result = await client.VerifyBatchAsync(new[] { "1234567890" });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task VerifyBatchAsync_returns_empty_on_HttpClient_timeout()
+    {
+        // HttpClient.Timeout fires as TaskCanceledException with the
+        // CancellationToken NOT signalled. That's the "outage" path.
+        var client = BuildClient((_, _) =>
+            throw new TaskCanceledException("HttpClient timeout"));
+
+        var result = await client.VerifyBatchAsync(new[] { "1234567890" });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task VerifyBatchAsync_rejects_oversized_batches()
+    {
+        var client = BuildClient((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        var npis = Enumerable.Range(0, 101).Select(i => i.ToString("D10")).ToArray();
+        var act = () => client.VerifyBatchAsync(npis);
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task VerifyBatchAsync_short_circuits_on_empty_input()
+    {
+        var called = false;
+        var client = BuildClient((_, _) =>
+        {
+            called = true;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+        var result = await client.VerifyBatchAsync(Array.Empty<string>());
+        result.Should().BeEmpty();
+        called.Should().BeFalse();
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _h;
+        public DelegateHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> h) => _h = h;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => _h(request, cancellationToken);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderIntegrityProjectionServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderIntegrityProjectionServiceTests.cs
@@ -211,4 +211,29 @@ public class ProviderIntegrityProjectionServiceTests
             "wrong-tenant", "p-other", forceRefresh: true, null, null);
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task RefreshTenantAsync_tolerates_duplicate_NPIs_in_a_page()
+    {
+        // Two distinct provider rows sharing an NPI is a real shape:
+        // (TenantId, NPI) is not a unique index. Pre-fix this would
+        // crash in ToDictionary on the duplicate key and abort the
+        // sweep for the entire tenant.
+        Seed("p-a", "5550000000");
+        Seed("p-b", "5550000000");
+        _client.Seed("5550000000", 88, "Clear");
+
+        var result = await _svc.RefreshTenantAsync(Tenant,
+            new IntegrityProjectionTenantSweepRequest { IncludeNeverVerified = true });
+
+        // Both rows pick up the same score (last-write-wins on the
+        // chain key); the worker doesn't crash.
+        result.Patched.Should().Be(2);
+        _repo.Docs.First(d => d.Id == "p-a").IntegrityScore.Should().Be(88);
+        _repo.Docs.First(d => d.Id == "p-b").IntegrityScore.Should().Be(88);
+
+        // De-duped before the HTTP call: one NPI in the batch, not two.
+        _client.Calls.Should().ContainSingle();
+        _client.Calls[0].Should().BeEquivalentTo(new[] { "5550000000" });
+    }
 }

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderIntegrityProjectionServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderIntegrityProjectionServiceTests.cs
@@ -1,0 +1,214 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Service-layer coverage for the integrity-projection write-back
+/// pipeline (capability 5.4.5): RefreshProviderAsync (on-demand path),
+/// RefreshTenantAsync (worker / backfill path), idempotency, schedule-
+/// aware skip, and verification-source outage handling.
+/// </summary>
+public class ProviderIntegrityProjectionServiceTests
+{
+    private const string Tenant = "tenant-a";
+
+    private readonly InMemoryProviderRepository _repo;
+    private readonly FakeProviderVerificationClient _client;
+    private readonly FakeProviderVerificationEventPublisher _events;
+    private readonly ProviderIntegrityProjectionService _svc;
+
+    public ProviderIntegrityProjectionServiceTests()
+    {
+        _repo = new InMemoryProviderRepository { TenantId = Tenant };
+        _client = new FakeProviderVerificationClient();
+        _events = new FakeProviderVerificationEventPublisher();
+        var opts = Options.Create(new IntegrityProjectionOptions());
+        _svc = new ProviderIntegrityProjectionService(
+            _repo, _client, _events, opts,
+            NullLogger<ProviderIntegrityProjectionService>.Instance);
+    }
+
+    private Provider Seed(string providerId, string npi)
+    {
+        var p = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = Tenant,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Provider",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = providerId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        };
+        _repo.CreateAsync(p).GetAwaiter().GetResult();
+        return p;
+    }
+
+    [Fact]
+    public async Task RefreshProviderAsync_writes_score_and_emits_event()
+    {
+        Seed("p1", "1234567890");
+        _client.Seed("1234567890", score: 88, rating: "Clear");
+
+        var result = await _svc.RefreshProviderAsync(
+            Tenant, "p1", forceRefresh: true,
+            actorId: "user", correlationId: "corr-1");
+
+        result.Should().NotBeNull();
+        result!.IntegrityScore.Should().Be(88);
+        result.IntegrityRating.Should().Be("Clear");
+
+        var head = await _repo.GetLatestActiveAsync("p1", DateTime.UtcNow);
+        head!.IntegrityScore.Should().Be(88);
+        head.IntegrityRating.Should().Be("Clear");
+        head.LastVerifiedAt.Should().NotBeNull();
+        head.NextVerificationDue.Should().NotBeNull();
+
+        _events.Events.Should().ContainSingle(e =>
+            e.ProviderId == "p1"
+            && e.EventType == ProviderVerificationEventType.ProviderVerificationRefreshed
+            && e.IntegrityScore == 88);
+    }
+
+    [Fact]
+    public async Task RefreshProviderAsync_returns_null_when_no_active_head()
+    {
+        // No provider seeded.
+        var result = await _svc.RefreshProviderAsync(
+            Tenant, "missing", forceRefresh: true, actorId: null, correlationId: null);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RefreshProviderAsync_skips_when_not_due_and_not_forced()
+    {
+        var p = Seed("p2", "1234567891");
+        _client.Seed("1234567891", score: 70, rating: "Advisory");
+
+        // First call writes and sets NextVerificationDue ~24h out.
+        var first = await _svc.RefreshProviderAsync(
+            Tenant, "p2", forceRefresh: true, actorId: null, correlationId: null);
+        first!.IntegrityScore.Should().Be(70);
+
+        // Second call without force — should skip.
+        _client.Calls.Clear();
+        var second = await _svc.RefreshProviderAsync(
+            Tenant, "p2", forceRefresh: false, actorId: null, correlationId: null);
+
+        second!.Skipped.Should().BeTrue();
+        _client.Calls.Should().BeEmpty(); // no extra HTTP call
+    }
+
+    [Fact]
+    public async Task RefreshProviderAsync_idempotent_event_on_repeat_at_same_verifiedAt()
+    {
+        Seed("p3", "1234567892");
+        // Pin verifiedAt so two calls produce the same EventId.
+        var pinned = DateTimeOffset.UtcNow;
+        _client.Canned["1234567892"] = new VerificationResult
+        {
+            Npi = "1234567892",
+            Status = VerificationOutcome.Verified,
+            IntegrityScore = new CompositeIntegrityScore { CompositeScore = 90, Rating = "Clear" },
+            LastVerifiedAt = pinned,
+        };
+
+        await _svc.RefreshProviderAsync(Tenant, "p3", forceRefresh: true, null, null);
+        await _svc.RefreshProviderAsync(Tenant, "p3", forceRefresh: true, null, null);
+
+        // Idempotent EventId per (providerId, verifiedAt) — exactly one event.
+        _events.Events.Should().ContainSingle(e => e.ProviderId == "p3");
+    }
+
+    [Fact]
+    public async Task RefreshTenantAsync_iterates_only_due_providers()
+    {
+        // p-due: NextVerificationDue in the past
+        var due = Seed("p-due", "1111111111");
+        due.NextVerificationDue = DateTimeOffset.UtcNow.AddDays(-1);
+        _repo.Docs.First(d => d.Id == "p-due").NextVerificationDue = due.NextVerificationDue;
+
+        // p-fresh: NextVerificationDue in the future
+        var fresh = Seed("p-fresh", "2222222222");
+        fresh.NextVerificationDue = DateTimeOffset.UtcNow.AddDays(7);
+        _repo.Docs.First(d => d.Id == "p-fresh").NextVerificationDue = fresh.NextVerificationDue;
+
+        // p-never: never verified (NextVerificationDue null) — included
+        Seed("p-never", "3333333333");
+
+        _client.Seed("1111111111", 80, "Clear");
+        _client.Seed("3333333333", 50, "Caution");
+
+        var result = await _svc.RefreshTenantAsync(Tenant,
+            new IntegrityProjectionTenantSweepRequest { IncludeNeverVerified = true });
+
+        result.Patched.Should().Be(2);
+        result.Failed.Should().Be(0);
+
+        // p-fresh should still have its old verification window untouched.
+        var freshAfter = _repo.Docs.First(d => d.Id == "p-fresh");
+        freshAfter.IntegrityScore.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RefreshTenantAsync_outage_preserves_cached_score()
+    {
+        var p = Seed("p-cached", "4444444444");
+        // Pre-populate cached score.
+        await _repo.UpdateIntegrityProjectionAsync(
+            Tenant, "p-cached", 75, "Advisory",
+            DateTimeOffset.UtcNow.AddDays(-2), DateTimeOffset.UtcNow.AddDays(-1));
+
+        _client.SimulateOutage = true;
+
+        var result = await _svc.RefreshTenantAsync(Tenant,
+            new IntegrityProjectionTenantSweepRequest { IncludeNeverVerified = true });
+
+        result.Failed.Should().Be(1);
+        result.Patched.Should().Be(0);
+
+        var head = _repo.Docs.First(d => d.Id == "p-cached");
+        head.IntegrityScore.Should().Be(75); // cached score preserved
+        head.IntegrityRating.Should().Be("Advisory");
+    }
+
+    [Fact]
+    public async Task RefreshTenantAsync_respects_max_providers_cap()
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            var npi = $"500000000{i}";
+            Seed($"cap-{i}", npi);
+            _client.Seed(npi, 80, "Clear");
+        }
+
+        var result = await _svc.RefreshTenantAsync(Tenant,
+            new IntegrityProjectionTenantSweepRequest
+            {
+                IncludeNeverVerified = true,
+                MaxProviders = 3,
+                PageSize = 10,
+            });
+
+        result.Patched.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task RefreshProviderAsync_cross_tenant_returns_null()
+    {
+        Seed("p-other", "9999999990");
+
+        var result = await _svc.RefreshProviderAsync(
+            "wrong-tenant", "p-other", forceRefresh: true, null, null);
+        result.Should().BeNull();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderVerificationEventPublisherTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderVerificationEventPublisherTests.cs
@@ -1,0 +1,91 @@
+using EphemeralMongo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Mongo-backed verification-event publisher: idempotency on duplicate
+/// <see cref="ProviderVerificationEvent.EventId"/> and monotonic
+/// <see cref="ProviderVerificationEvent.Version"/> per
+/// <c>(TenantId, ProviderId)</c>. Mirrors the pattern in
+/// <c>ProviderVersionEventPublisherTests</c>.
+/// </summary>
+public class ProviderVerificationEventPublisherTests : IAsyncLifetime
+{
+    private const string Tenant = "tenant-a";
+    private const string ProviderId = "provider-001";
+
+    private IMongoRunner _runner = null!;
+    private IMongoDatabase _database = null!;
+    private MongoProviderVerificationEventPublisher _publisher = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        _database = client.GetDatabase("provider_verification_event_test");
+        var config = new ConfigurationBuilder().Build();
+        _publisher = new MongoProviderVerificationEventPublisher(
+            _database, config, NullLogger<MongoProviderVerificationEventPublisher>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* see MpipRateServiceTests note */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Publish_assigns_monotonic_version_per_provider()
+    {
+        var t1 = DateTimeOffset.UtcNow;
+        var t2 = t1.AddHours(1);
+        var t3 = t1.AddHours(2);
+
+        var v1 = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 80, "Clear", t1, t1.AddDays(1), "user", null);
+        var v2 = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 82, "Clear", t2, t2.AddDays(1), "user", null);
+        var v3 = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 84, "Clear", t3, t3.AddDays(1), "user", null);
+
+        v1.Version.Should().Be(1);
+        v2.Version.Should().Be(2);
+        v3.Version.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Publish_with_same_verifiedAt_is_idempotent()
+    {
+        var verifiedAt = DateTimeOffset.UtcNow;
+        var first = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 90, "Clear", verifiedAt, verifiedAt.AddDays(1), "user", null);
+        var second = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 90, "Clear", verifiedAt, verifiedAt.AddDays(1), "user", null);
+
+        first.EventId.Should().Be(second.EventId);
+        first.Version.Should().Be(second.Version);
+    }
+
+    [Fact]
+    public async Task Publish_writes_payload_fields_for_consumer()
+    {
+        var verifiedAt = DateTimeOffset.UtcNow;
+        var nextDue = verifiedAt.AddDays(1);
+        var evt = await _publisher.PublishRefreshedAsync(
+            Tenant, ProviderId, 77, "Advisory", verifiedAt, nextDue, "user", "corr-1");
+
+        evt.IntegrityScore.Should().Be(77);
+        evt.IntegrityRating.Should().Be("Advisory");
+        evt.VerifiedAt.Should().Be(verifiedAt);
+        evt.NextVerificationDue.Should().Be(nextDue);
+        evt.ActorId.Should().Be("user");
+        evt.CorrelationId.Should().Be("corr-1");
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderVerificationEventPublisherTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/ProviderVerificationEventPublisherTests.cs
@@ -88,4 +88,26 @@ public class ProviderVerificationEventPublisherTests : IAsyncLifetime
         evt.ActorId.Should().Be("user");
         evt.CorrelationId.Should().Be("corr-1");
     }
+
+    [Fact]
+    public async Task Publish_cross_tenant_same_eventId_does_not_collide()
+    {
+        // Pre-fix: evt.Id = evt.EventId, which is only documented as
+        // unique within (TenantId, ProviderId). Two tenants verifying
+        // the same NPI at the same instant share an EventId
+        // ("refreshed:provider-001:<verifiedAtIso>") and would collide
+        // on Mongo's _id. Post-fix: _id is scoped to {PartitionKey}:{EventId},
+        // and the (TenantId, ProviderId, EventId) UNIQUE index is the
+        // primary idempotency guard.
+        var verifiedAt = DateTimeOffset.UtcNow;
+
+        var a = await _publisher.PublishRefreshedAsync(
+            "tenant-a", ProviderId, 80, "Clear", verifiedAt, verifiedAt.AddDays(1), null, null);
+        var b = await _publisher.PublishRefreshedAsync(
+            "tenant-b", ProviderId, 80, "Clear", verifiedAt, verifiedAt.AddDays(1), null, null);
+
+        a.EventId.Should().Be(b.EventId); // same NPI + same instant
+        a.Id.Should().NotBe(b.Id);        // but different _id (PartitionKey-scoped)
+        a.TenantId.Should().NotBe(b.TenantId);
+    }
 }

--- a/tests/CloudHealthOffice.ProviderService.Tests/TestHelpers/PollUntil.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/TestHelpers/PollUntil.cs
@@ -1,0 +1,71 @@
+namespace CloudHealthOffice.ProviderService.Tests.TestHelpers;
+
+/// <summary>
+/// Deterministic polling helper for hosted-service / async-state tests.
+/// <para>
+/// Replaces fixed <c>Task.Delay(N)</c> sleeps that "give the work
+/// time to drain" — those are timing-dependent and become flaky under
+/// CI load. Polling against the actual condition with a bounded
+/// timeout is both faster on the happy path (returns as soon as the
+/// condition is true) and robust when the host is slow.
+/// </para>
+/// </summary>
+public static class PollUntil
+{
+    /// <summary>
+    /// Polls <paramref name="condition"/> until it returns true or
+    /// <paramref name="timeout"/> elapses. Throws <see cref="TimeoutException"/>
+    /// with <paramref name="description"/> if the condition never
+    /// holds.
+    /// </summary>
+    public static async Task UntilAsync(
+        Func<bool> condition,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null,
+        string? description = null,
+        CancellationToken ct = default)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(5);
+        var effectiveInterval = pollInterval ?? TimeSpan.FromMilliseconds(50);
+        var deadline = DateTime.UtcNow + effectiveTimeout;
+
+        while (!ct.IsCancellationRequested)
+        {
+            if (condition()) return;
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Condition '{description ?? "(unnamed)"}' did not hold within {effectiveTimeout}.");
+            }
+            try { await Task.Delay(effectiveInterval, ct); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    /// <summary>
+    /// Polls <paramref name="getValue"/> until it returns a non-null
+    /// (or, for value types, non-default) value or the timeout
+    /// elapses. Returns the resolved value.
+    /// </summary>
+    public static async Task<T> ForValueAsync<T>(
+        Func<T?> getValue,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null,
+        string? description = null,
+        CancellationToken ct = default)
+        where T : class
+    {
+        T? observed = null;
+        await UntilAsync(
+            () =>
+            {
+                observed = getValue();
+                return observed != null;
+            },
+            timeout,
+            pollInterval,
+            description,
+            ct);
+        return observed!;
+    }
+}


### PR DESCRIPTION
## Summary

- **Closes the gap discovered during PR 5.4** (Network Roster API): `Provider.IntegrityScore` was null for every roster row in production because `ProviderVerificationOrchestrator` only wrote to a transient record.
- **Hosted projection in provider-service** (Option A) sweeps due providers per tenant, calls `provider-verification-service` over HTTP via `/verify/batch`, and patches the four projection-metadata fields onto the head Active row via a new `UpdateIntegrityProjectionAsync` carve-out that bypasses the version-state guard.
- **Projection-metadata exemption** formally documented in `provider-versioning.md` — these fields update on their own cadence and do **not** create new chain versions.

Plan ratified 2026-04-27 (`memory/project_pr_5_4_5_verification_writeback_ratified_plan.md`); execution via "proceed override" same session, matching the pattern established for δ1/δ2/δ3/P2.

## What landed

**Models / repository:**
- `IProviderRepository.UpdateIntegrityProjectionAsync` — Cosmos `PatchItemAsync` / Mongo `FindOneAndUpdateAsync` patches just the four projection fields on the head Active row. No new `VersionNumber`. Identity-field writes against the same row continue to throw `ProviderVersionStateException`.
- `IProviderRepository.ListProvidersForIntegrityRefreshAsync` — per-tenant pagination filtered by `NextVerificationDue <= now OR IS NULL`. Stable sort on `(ProviderId, Id)`.
- `IProviderRepository.ListProviderTenantIdsAsync` — distinct `TenantId` enumeration (cross-partition; called once per sweep).
- `Provider.cs` XML doc rewritten to reflect actual write-back behavior.

**Services / hosted services:**
- `ProviderIntegrityProjectionService.RefreshProviderAsync` (on-demand) and `RefreshTenantAsync` (worker / backfill).
- `IntegrityProjectionWorker : BackgroundService` — sweeps each tenant via `IServiceScopeFactory`, default `SweepInterval = 1h`, default `PageSize = 100` (aligned with verification-service's batch cap), default `MaxProvidersPerTenantPerSweep = 1000` for round-robin fairness.
- `IntegrityProjectionOptions` with per-source refresh windows; composite refresh runs at the shortest active window (NPPES = 24h dominates today). Per-source materialised refresh state deferred to capability 5.10 — trade-off documented.

**Verification client:**
- `HttpProviderVerificationClient` calls `POST /api/v1/providers/verify/batch` (existing endpoint, no contract change). Service boundary preserved — no project reference on the verification engine; engine's six data-source HTTP clients (NPPES/LEIE/PECOS/Open Payments/Medicare/FSMB) stay in their service.

**Event stream:**
- New `ProviderVerificationEvents` Mongo collection mirroring PR 5.1's `ProviderVersionEvents` pattern. Deterministic `EventId = "refreshed:{providerId}:{verifiedAtIso}"`. Idempotent. Monotonic `Version` per `(TenantId, ProviderId)`. `NoopProviderVerificationEventPublisher` fallback for Cosmos-only deployments. No cross-service consumer in this PR (capability 5.10's job).

**Endpoints:**
- `POST /api/v1/providers/{id}/verification/refresh?force=true` — on-demand refresh. Route avoids namespace collision with verification-service's `GET /api/v1/providers/{npi}/verify`.
- `POST /api/v1/admin/providers/backfill-integrity-projection?tenantId=X&maxProviders=N` — admin-callable backfill. Idempotent. Auth posture documented (deployment-layer ACL until platform-wide admin-auth lands).

**Documentation:**
- `docs/architecture/verification-writeback.md` (new, ~250 lines) — architecture, contract, schedule, iteration, on-demand path, backfill, recovery posture, configuration, what-was-deferred-to-5.10.
- `docs/architecture/provider-versioning.md` — new "Projection metadata — exempt from versioning" section formalising the carve-out policy. Caveats section swept; the previous "ProviderVerificationOrchestrator integration" caveat (which described behavior that never existed) is rewritten to point at this PR.
- `docs/architecture/network-roster-api.md` — "Known gap" section marked resolved.

## Out of scope (preserved unchanged)

- `ProviderVerificationOrchestrator` (engine library) — signature unchanged; orchestrator stays focused on producing a verification record from live data sources.
- `provider-verification-service` `/verify`, `/integrity-score`, `/verify/batch` endpoint signatures.
- `HttpProviderIntegrityGate` in `benefit-plan-service` — live HTTP path remains source of truth for adjudication. Migration to cached projection is capability 5.10's call.
- PR 5.1 version-chain logic and tests (`ActivateAndSupersedeAsync`, `UpdateAsync` state guard, `ProviderRepositoryVersionChainTests`).
- PR 5.4 roster code and schema.
- PR 5.2 adapter pattern.

## Premise corrections from prompt (drift)

- Provider.cs TODO is at line **409** (not 316); concerns NetworkParticipation panel-gating, roadmap **5.7** context (not 5.5).
- Repository method is **`ActivateAndSupersedeAsync`** (not `PublishAndSupersedeAsync`).
- provider-verification-service uses **Minimal API in Program.cs** (not MVC controllers); endpoints exist at lines 142/197/223.

## Test plan

- [x] `dotnet build src/services/provider-service/provider-service.csproj` — clean
- [x] `dotnet build src/services/provider-verification-service/CloudHealthOffice.ProviderVerificationService.csproj` — clean (no contract change)
- [x] `dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj` — clean (`HttpProviderIntegrityGate` untouched)
- [x] `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — **136/136 passing** (110 baseline + 26 new)
  - `ProviderIntegrityProjectionServiceTests` (8 tests) — refresh, idempotency, schedule-aware skip, outage handling, tenant isolation, max-providers cap.
  - `IntegrityProjectionWritePathTests` (7 tests, EphemeralMongo) — projection-metadata bypass works, identity-field writes still throw, no new version created, terminated chains skipped, due-date filter, distinct-tenants enumeration.
  - `IntegrityProjectionWorkerTests` (3 tests) — per-tenant iteration, disabled-flag idle, single event per refresh.
  - `IntegrityProjectionBackfillTests` (5 tests) — populates legacy nulls, idempotent reruns, tenant isolation, max-providers override, cached-score preserved on outage.
  - `ProviderVerificationEventPublisherTests` (3 tests, EphemeralMongo) — monotonic Version per `(Tenant, Provider)`, idempotent EventId, payload fields written for consumer.

## Manual smoke (post-merge per tenant)

- [ ] Deploy provider-service with `IntegrityProjection.Enabled=true`.
- [ ] Run admin backfill: `POST /api/v1/admin/providers/backfill-integrity-projection?tenantId=<TENANT>`.
- [ ] Verify roster (`GET /api/v1/networks/{id}/roster?sortBy=integrityScore`) shows non-null `integrityScore` values.
- [ ] Confirm `HttpProviderIntegrityGate` adjudication path in benefit-plan-service remains unchanged (live HTTP, not cached read).
- [ ] Confirm `ProviderRepositoryVersionChainTests` regression suite still green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Copilot review fixes (2026-04-27, commit 77a42fba)

Applied all 11 Copilot review comments + 1 CodeQL alert (12 total). Single follow-up commit; **148/148 tests passing** (136 baseline + 12 new).

### Critical
- **Comment 1 — admin endpoint auth (defence in depth).** Added `IntegrityProjection:AdminBackfillEnabled` to `IntegrityProjectionOptions`, defaults `false`. Controller returns **503 Service Unavailable** (not 404 — operators need to know the route exists but is gated) when the flag is off. Documented the deployment-layer ACL requirement in `verification-writeback.md`'s "Auth posture — defence in depth" section.
- **Comment 2 — duplicate NPI crash.** `RefreshTenantAsync` now `Distinct()`s NPIs before the batch HTTP call and uses `GroupBy().First()` on the result dictionary. Test: `RefreshTenantAsync_tolerates_duplicate_NPIs_in_a_page`.
- **Comment 8 — Mongo `_id` cross-tenant collision.** `evt.Id` is now scoped to `{PartitionKey}:{EventId}`. The `(TenantId, ProviderId, EventId)` UNIQUE index remains in place — both protections together. Test: `Publish_cross_tenant_same_eventId_does_not_collide` (two tenants verifying the same NPI at the same instant produce distinct `_id`s).

### High severity
- **Comments 5, 9, 10 + hidden 11 — legacy-row inclusion in 4 sites.** All four query sites (Cosmos head-row lookup, Cosmos sweeper SQL, Mongo `UpdateIntegrityProjectionAsync`, Mongo `ListProvidersForIntegrityRefreshAsync`) now gate the legacy fallback branches on `Status == Active`, mirroring `Hydrate()`. Both legacy detection branches preserved (missing `VersionState` AND missing `VersionId`) — the second covers test fixtures where the C# layer always serializes `VersionState` as enum-zero `Draft`. Tests: `UpdateIntegrityProjection_skips_legacy_terminated_row`, `ListProvidersForIntegrityRefresh_excludes_legacy_terminated_row`.
  - **Bonus.** New "Legacy hydration query pattern" section in `provider-versioning.md` documents the three-branch rule explicitly so future capability work (5.10, 5.11, …) doesn't regress the pattern.
- **Comment 6 — Cosmos pagination nondeterminism.** `ListProvidersForIntegrityRefreshAsync` Cosmos query now sorts by `c.providerId ASC, c.id ASC` (was `c.providerId ASC` only). Honors the interface contract "stable sort on (ProviderId, Id)".
- **Comment 7 — TaskCanceledException swallowing.** `HttpProviderVerificationClient.VerifyBatchAsync` rethrows `OperationCanceledException` when `ct.IsCancellationRequested` is true (caller-driven cancellation must propagate so worker shutdown is timely). Genuine `HttpClient.Timeout` / transport failures still degrade to "outage" path. Tests: 5 new in `HttpProviderVerificationClientTests` covering caller-cancellation, transport-failure, timeout, oversized batch, empty input.

### Medium
- **Comment 3 — backfill docstring mismatch.** Rewrote the docstring to describe actual force-refresh behavior: "Forces an integrity-projection refresh for every Active provider in the specified tenant. All rows are treated as due. Idempotent because last-write-wins on projection metadata fields. Use to populate legacy null projections, recover from extended verification-service outages, or operator-driven data-quality refresh."

### Low
- **Comment 4 — `Task.Delay` test flakiness.** New `tests/.../TestHelpers/PollUntil.cs` helper. Worker tests now poll the actual condition (e.g. "patch landed" / "event emitted") with bounded timeout instead of sleeping a fixed 500ms. The `Worker_skips_when_disabled` test sleeps `2× SweepInterval` (currently 200ms) since "nothing happened" can't be polled — but the window is bounded by configuration, not arbitrary.

### CodeQL
- **`ProviderIntegrityProjectionService.cs:114` log injection.** Added `Sanitize(providerId)` on the `LogInformation` call site that previously passed the raw value.

### New tests (12 added across 3 new files + 4 existing)
- `tests/.../Controllers/IntegrityProjectionAdminControllerTests.cs` (3) — flag-disabled→503, missing tenantId→400, enabled+valid→200.
- `tests/.../Services/HttpProviderVerificationClientTests.cs` (5) — caller-cancel propagates, transport-fail returns empty, timeout returns empty, oversized rejected, empty short-circuits.
- `tests/.../TestHelpers/PollUntil.cs` — polling helper.
- `IntegrityProjectionWritePathTests` (+2) — terminated-legacy-row excluded from patch + list.
- `ProviderIntegrityProjectionServiceTests` (+1) — duplicate-NPI tolerance.
- `ProviderVerificationEventPublisherTests` (+1) — cross-tenant `_id` distinctness.
