### PR TITLE
5.6 — Credentialing workflow foundation (event-sourced chain + projection write-back)

### DIFF
--- a/docs/architecture/credentialing-workflow.md
+++ b/docs/architecture/credentialing-workflow.md
@@ -1,0 +1,239 @@
+# Credentialing workflow (capability 5.6)
+
+Provider credentialing is an event-sourced workflow. The
+`CredentialingEvents` stream is the system-of-record; the three flat
+fields on `Provider` (`CredentialingStatus`, `CredentialingDate`,
+`RecredentialingDueDate`) are a denormalized read-side projection
+written by `IProviderRepository.UpdateCredentialingProjectionAsync` —
+the same bypass pattern used by the integrity projection (5.4.5) and
+the panel-gating defaults backfill (5.5).
+
+This document explains the chain shape, the projection mapping, the
+endpoint surface, the failure semantics, and the boundary of Phase 1
+versus Phase 2.
+
+## Why event-sourcing
+
+Credentialing decisions are an audit-grade workflow:
+
+- Regulators (NCQA, URAC, state DOI) require an immutable trail of
+  who decided what and when. Decision authority, committee membership,
+  and minute references are part of the audit; rewriting them after the
+  fact is a compliance violation.
+- Re-credentialing happens every 2-3 years and the new decision must
+  link to its predecessor approval — chain linkage is a first-class
+  requirement, not an afterthought.
+- Submission, primary-source verification, committee review, and
+  decision are operationally distinct events. Collapsing them into a
+  single status field loses information that operators rely on
+  (e.g. "we submitted three weeks ago and PSV completed yesterday;
+  committee meets Friday").
+
+The platform already runs three event publishers
+(`ProviderVersionEventPublisher`,
+`NetworkParticipationEventPublisher`,
+`ProviderVerificationEventPublisher`); credentialing was the only
+major workflow without one. The fourth publisher
+(`CredentialingEventPublisher`) keeps the operational shape uniform.
+
+## Event chain
+
+Six event types, all in `Models/CredentialingEvent.cs`:
+
+| Event | Purpose | Status effect |
+|---|---|---|
+| `ApplicationSubmitted` | Opens a new chain. EventId is the application identifier referenced by every downstream event. | → Pending |
+| `PrimarySourceVerificationCompleted` | Records PSV against the open application. | (no change) |
+| `CommitteeReviewScheduled` | Marks committee review on the calendar. | (no change) |
+| `DecisionRecorded` | Closes the chain with Approved or Denied. Carries decision authority capture (committee members, minute reference). | → Approved / Denied |
+| `RecredentialingTriggered` | Opens a re-credentialing chain linked to the predecessor approval. The new application follows in the same chain. | → Pending |
+| `ApplicationWithdrawn` | Terminates the open chain. Projection reverts to the predecessor decision (or Unknown). | → predecessor |
+
+Chain linkage:
+
+- `ApplicationEventId` — set on every event after the opening
+  `ApplicationSubmitted`. Ties PSV / committee / decision / withdrawal
+  back to the application that opened the chain.
+- `PredecessorEventId` — set on `RecredentialingTriggered` to point at
+  the prior terminal `DecisionRecorded`. Lets the projector restore the
+  prior approval if the re-cred application is withdrawn.
+
+Idempotency keys are deterministic per event type — see the
+`Build*EventId` factories on `CredentialingEvent`. Re-publishing the
+same logical event collapses to the existing row via the publisher's
+idempotency probe.
+
+## Projection
+
+`CredentialingProjector` is a pure function over the chain. It is the
+single authority on the events → `CredentialingStatus` mapping; both
+the read-side (`GET /credentialing/status`) and the write-side
+projection patch use it to compute the value to store on `Provider`.
+
+| Sequence | Projected status |
+|---|---|
+| `[]` | `Unknown` |
+| `[ApplicationSubmitted]` | `Pending` |
+| `[ApplicationSubmitted, PSV]` | `Pending` |
+| `[ApplicationSubmitted, …, DecisionRecorded(Approved)]` (RecredDue future) | `Approved` |
+| `[ApplicationSubmitted, …, DecisionRecorded(Approved)]` (RecredDue past) | `Expired` |
+| `[ApplicationSubmitted, …, DecisionRecorded(Denied)]` | `Denied` |
+| `[…, Approved, RecredentialingTriggered]` | `Pending` |
+| `[…, Approved, RecredentialingTriggered, ApplicationSubmitted, …, DecisionRecorded(Approved)]` | `Approved` (new dates) |
+| `[ApplicationSubmitted, ApplicationWithdrawn]` | `Unknown` |
+| `[…, Approved, RecredentialingTriggered, ApplicationSubmitted, ApplicationWithdrawn]` | `Approved` (predecessor restored) |
+
+`Suspended` is not derivable from the chain in Phase 1 — see
+"Out-of-scope" below.
+
+`Expired` is computed at projection time from `RecredentialingDueDate`.
+The flat field on `Provider` is patched to the projector's at-write-time
+verdict on each transition; readers who consult `GET /credentialing/status`
+get a fresh evaluation each time. Between transitions, a stored value of
+`Approved` will read as `Approved` even after the recredentialing-due
+date elapses; the next transition (or a future hosted sweeper) reconciles.
+
+### Synthesized applications
+
+The legacy `PUT /providers/{id}/credentialing` shim (see "Endpoints"
+below) synthesizes an `ApplicationSubmitted` event when no chain is
+open, paired immediately with a `DecisionRecorded`. The synthesized
+event is flagged `synthesizedForDelegatedAuthority=true` so audit
+reviewers can distinguish it from a real submission.
+
+The projector explicitly filters out synthesized applications when
+computing "current open application" — defense in depth. Synthesized
+applications are paired with a matching `DecisionRecorded` by
+construction; if a future bug ever produces an orphaned one, the
+projector won't get stuck reporting `Pending`.
+
+## Endpoints
+
+All routes are tenant-scoped via `HttpContext.Items["TenantId"]`,
+populated by `TenantMiddleware`.
+
+| Method | Route | Body | Response | Notes |
+|---|---|---|---|---|
+| `POST` | `/api/v1/providers/{id}/credentialing/applications` | `SubmitApplicationRequest` | `CredentialingEvent` (201) | Opens a chain; rejects when one is already open. |
+| `POST` | `/api/v1/providers/{id}/credentialing/applications/{eventId}/withdraw` | `WithdrawApplicationRequest` | `CredentialingEvent` (200) | Terminates the open chain; reverts projection. |
+| `POST` | `/api/v1/providers/{id}/credentialing/verifications` | `RecordPrimarySourceVerificationRequest` | `CredentialingEvent` (201) | Status-neutral. |
+| `POST` | `/api/v1/providers/{id}/credentialing/committee-reviews` | `ScheduleCommitteeReviewRequest` | `CredentialingEvent` (201) | Status-neutral. |
+| `POST` | `/api/v1/providers/{id}/credentialing/decisions` | `RecordDecisionRequest` | `CredentialingEvent` (201) | Closes the chain; patches the projection. |
+| `POST` | `/api/v1/providers/{id}/credentialing/recredential` | `TriggerRecredentialingRequest` | `CredentialingEvent` (201) | Opens a re-cred chain; requires prior approval. |
+| `GET` | `/api/v1/providers/{id}/credentialing/status` | — | `CredentialingProjectionResult` (200) | Projection over the chain at request time. |
+| `GET` | `/api/v1/providers/{id}/credentialing/history` | — | `CredentialingHistoryPage` (200) | Newest-first paged chain; opaque cursor. |
+| `PUT` | `/api/v1/providers/{id}/credentialing` | `CredentialingUpdateRequest` (legacy) | `Provider` (200) | Rewired through `RecordDecisionAsync` with `DelegatedAuthority`. Same DTO, same response shape; internal mechanism upgraded. |
+
+Error mapping:
+
+- `CredentialingValidationException` → 400 with
+  `{ error: "credentialing_validation_failed", message }`.
+- Publisher exhaustion (5 retries failed) → 503 with
+  `{ error: "credentialing_publish_failed", message }`.
+- Provider not found (legacy `PUT`) → 404.
+
+## Decision authority capture
+
+`DecisionRecordedPayload` carries four authority fields:
+
+- `DecisionAuthorityType` — `CredentialingCommittee` |
+  `MedicalDirector` | `DelegatedAuthority` | `AutoApproved`.
+- `DecisionAuthorityId` — committee or actor identifier.
+- `CommitteeMembers` — list of participating actor IDs (nullable;
+  required for `CredentialingCommittee` path).
+- `DecisionMinuteReference` — pointer to minutes document
+  (`DocumentReference`); required for `CredentialingCommittee` path.
+
+The `DelegatedAuthority` short-circuit (used by the legacy `PUT`)
+skips the "open application required" guard and synthesizes the
+missing application event so the legacy endpoint always succeeds on
+Active providers. The synthesized application is flagged so audit
+reviewers can distinguish it.
+
+## Supporting documents
+
+Phase 1 carries `DocumentReference` URIs as opaque metadata on event
+payloads — there is no document upload service in this PR. The shape
+maps cleanly to FHIR `DocumentReference` for a future projection:
+
+- `Uri` → `DocumentReference.content.attachment.url`
+- `DocumentType` → `DocumentReference.type.coding`
+- `Sha256` → `DocumentReference.content.attachment.hash`
+
+`DocumentType` is intentionally a free-form string (not a closed enum)
+so future credentialing artifact categories don't require a code
+change. The credentialing service does NOT validate URI reachability,
+fetch the document, or recompute Sha256 — URI is opaque audit
+metadata. Validation is a Phase 2 document-service responsibility.
+
+## Failure semantics
+
+Canonical write order in `CredentialingService`:
+
+1. Read the chain ascending by `Version`.
+2. Project the pre-state.
+3. Validate the request.
+4. Build the event with deterministic `EventId`.
+5. Publish via `ICredentialingEventPublisher` (the system-of-record).
+6. For status-changing events: re-project including the new event,
+   then patch the flat-field projection on `Provider` via
+   `UpdateCredentialingProjectionAsync`.
+
+Failure modes:
+
+- **Publisher write fails after retries**: the service throws
+  `InvalidOperationException`; the controller surfaces 503. The chain
+  is unchanged. Caller retries.
+- **Projection patch returns false (no Active head)**: logged as a
+  warning; the event is still appended. The next status-changing
+  transition will reconcile, since each patch sends the projector's
+  authoritative full-state verdict (not a delta).
+- **Projection patch throws**: logged as an error; the event remains
+  the system-of-record. Same recovery as above.
+
+The chain has no destructive update path. Withdrawal is an event, not
+a row removal.
+
+## Cross-service consumers
+
+Phase 1: none. `coverage-service`
+(`PcpAssignmentService.cs`) and `benefit-plan-service`
+(`AdjudicationController.cs`) read the flat `CredentialingStatus` on
+`Provider` for gating; both continue to work unchanged.
+
+Phase 2 (out of scope): an event subscriber for credentialing-driven
+gating re-evaluations.
+
+## Out-of-scope (Phase 2 backlog)
+
+The following live in this section to make the boundary explicit:
+
+- **Document file storage.** Phase 1 carries URIs only; a Phase 2
+  document service handles upload, retention, and validation.
+- **Suspended status as event-driven.** No `SuspensionRecorded` event
+  type ships in Phase 1 — the enum value remains for read-side
+  compatibility. Phase 2 lands the event type alongside appeals and
+  peer review.
+- **Appeals workflow.** Reversing a Denied decision via formal appeal
+  is a credentialing concern but Phase 2.
+- **Peer review.** Quality-driven review tied to credentialing is
+  Phase 2.
+- **Delegated credentialing for sponsor-managed rosters.** Distinct
+  from `DecisionAuthorityType=DelegatedAuthority` (which is the legacy
+  shim path). Sponsor-managed credentialing where the sponsor holds
+  delegated authority for its own roster is Phase 2.
+- **Auto-invocation of `ProviderVerificationOrchestrator` from PSV.**
+  Phase 1 records PSV manually; Phase 2 wires the orchestrator into
+  the workflow.
+- **Hosted projection reconciler.** Today the flat-field projection
+  reconciles on the next status-changing transition. A scheduled
+  sweeper that reconciles between transitions is Phase 2.
+
+## Auth posture
+
+The new endpoints do not introduce additional authentication beyond
+what the service already enforces (tenant resolution via
+`TenantMiddleware`). Deployment-layer ACLs (NetworkPolicy + gateway
+allowlist) gate access to credentialing routes; no controller-level
+feature flag is appropriate because credentialing is a tenant-scoped
+operational endpoint, not an admin tool.

--- a/docs/architecture/provider-versioning.md
+++ b/docs/architecture/provider-versioning.md
@@ -348,6 +348,48 @@ not relax the `UpdateAsync` guard, not re-purpose
 `ReplaceVersionRowAsync`. Each carve-out documents its source service
 and refresh cadence in this section.
 
+### Credentialing projection (capability 5.6)
+
+The credentialing-status fields on `Provider` are a projection of the
+append-only credentialing event chain
+(`docs/architecture/credentialing-workflow.md`). The chain is the
+system-of-record; these flat fields are a denormalized read-side cache
+written on each chain transition.
+
+| Field | Source | Cadence |
+|---|---|---|
+| `CredentialingStatus` | `CredentialingService` (event-sourced workflow) | On state transition (Submit / Decision / Recredential / Withdraw) |
+| `CredentialingDate` | `CredentialingService` | On `DecisionRecorded(Approved)` |
+| `RecredentialingDueDate` | `CredentialingService` | On `DecisionRecorded(Approved)` |
+
+The write path is `IProviderRepository.UpdateCredentialingProjectionAsync(
+tenantId, providerId, status, credentialingDate,
+recredentialingDueDate, ct)`:
+
+- **Cosmos** — `PatchItemAsync` with three `PatchOperation.Set` ops on
+  `/credentialingStatus`, `/credentialingDate`,
+  `/recredentialingDueDate` (plus `/lastUpdatedDate`).
+- **Mongo** — `FindOneAndUpdateAsync` with `$set` on the same field
+  paths, sorted by `VersionNumber DESC` so amendments hit the latest
+  head.
+
+Identical mechanism to the integrity projection. Identity-field writes
+against the same Active row continue to throw (verified by
+`UpdateCredentialingProjectionAsyncTests.UpdateAsync_against_active_still_throws_after_credentialing_patch`).
+
+**Why the carve-out**: credentialing decisions are workflow events with
+their own audit chain. The flat status field is what coverage-service
+and benefit-plan-service consume for fast gating reads; surfacing the
+event projection on Active rows without forcing a full version
+transition keeps both reader patterns intact.
+
+**Pre-5.6 bug closed by this carve-out**: the previous
+`PUT /providers/{id}/credentialing` endpoint called `UpdateAsync` on
+Active providers and returned 409 in every case. The endpoint is now
+rewired through `CredentialingService.RecordDecisionAsync` with
+`DecisionAuthorityType=DelegatedAuthority`; the projection patch fires
+through the new bypass method and the 409 disappears.
+
 ### Operational backfill — one-time exemption
 
 Capability 5.5 introduces a **second** carve-out under this same

--- a/src/services/provider-service/Controllers/CredentialingController.cs
+++ b/src/services/provider-service/Controllers/CredentialingController.cs
@@ -51,6 +51,10 @@ public sealed class CredentialingController : ControllerBase
                 TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Created(string.Empty, evt);
         }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
+        }
         catch (CredentialingValidationException ex)
         {
             return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
@@ -86,6 +90,10 @@ public sealed class CredentialingController : ControllerBase
                 TenantId, id, eventId, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Ok(evt);
         }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
+        }
         catch (CredentialingValidationException ex)
         {
             return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
@@ -119,6 +127,10 @@ public sealed class CredentialingController : ControllerBase
             var evt = await _credentialing.RecordPrimarySourceVerificationAsync(
                 TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Created(string.Empty, evt);
+        }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
         }
         catch (CredentialingValidationException ex)
         {
@@ -154,6 +166,10 @@ public sealed class CredentialingController : ControllerBase
                 TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Created(string.Empty, evt);
         }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
+        }
         catch (CredentialingValidationException ex)
         {
             return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
@@ -188,6 +204,10 @@ public sealed class CredentialingController : ControllerBase
                 TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Created(string.Empty, evt);
         }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
+        }
         catch (CredentialingValidationException ex)
         {
             return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
@@ -221,6 +241,10 @@ public sealed class CredentialingController : ControllerBase
             var evt = await _credentialing.TriggerRecredentialingAsync(
                 TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
             return Created(string.Empty, evt);
+        }
+        catch (CredentialingNotFoundException ex)
+        {
+            return NotFound(new { error = "provider_not_found", message = ex.Message });
         }
         catch (CredentialingValidationException ex)
         {

--- a/src/services/provider-service/Controllers/CredentialingController.cs
+++ b/src/services/provider-service/Controllers/CredentialingController.cs
@@ -1,0 +1,277 @@
+using Microsoft.AspNetCore.Mvc;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace ProviderService.Controllers;
+
+/// <summary>
+/// Credentialing workflow REST surface (capability 5.6). Operates on the
+/// append-only credentialing event chain rooted at
+/// <c>/api/v1/providers/{id}/credentialing/...</c>. Status is a projection
+/// of the chain — see <c>docs/architecture/credentialing-workflow.md</c>.
+/// </summary>
+[ApiController]
+[Route("api/v1/providers/{id}/credentialing")]
+[Produces("application/json")]
+public sealed class CredentialingController : ControllerBase
+{
+    private readonly ICredentialingService _credentialing;
+    private readonly ILogger<CredentialingController> _logger;
+
+    public CredentialingController(
+        ICredentialingService credentialing,
+        ILogger<CredentialingController> logger)
+    {
+        _credentialing = credentialing;
+        _logger = logger;
+    }
+
+    private string TenantId =>
+        HttpContext.Items["TenantId"]?.ToString()
+            ?? throw new InvalidOperationException("TenantId not found in request context");
+
+    /// <summary>Submit a new credentialing application (opens a chain).</summary>
+    [HttpPost("applications")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> SubmitApplication(
+        string id,
+        [FromBody] SubmitApplicationRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Submitting credentialing application for provider {Id}, source={Source}",
+            SanitizeForLog(id), SanitizeForLog(request?.ApplicationSource));
+
+        try
+        {
+            var evt = await _credentialing.SubmitApplicationAsync(
+                TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Created(string.Empty, evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Withdraw the open credentialing application.</summary>
+    [HttpPost("applications/{eventId}/withdraw")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> WithdrawApplication(
+        string id,
+        string eventId,
+        [FromBody] WithdrawApplicationRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Withdrawing credentialing application {EventId} for provider {Id}",
+            SanitizeForLog(eventId), SanitizeForLog(id));
+
+        try
+        {
+            var evt = await _credentialing.WithdrawApplicationAsync(
+                TenantId, id, eventId, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Ok(evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Record primary-source verification completion.</summary>
+    [HttpPost("verifications")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> RecordPrimarySourceVerification(
+        string id,
+        [FromBody] RecordPrimarySourceVerificationRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Recording primary-source verification for provider {Id}, vendor={Vendor}",
+            SanitizeForLog(id), SanitizeForLog(request?.VerificationVendor));
+
+        try
+        {
+            var evt = await _credentialing.RecordPrimarySourceVerificationAsync(
+                TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Created(string.Empty, evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Schedule a committee review for the open application.</summary>
+    [HttpPost("committee-reviews")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> ScheduleCommitteeReview(
+        string id,
+        [FromBody] ScheduleCommitteeReviewRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Scheduling committee review for provider {Id}, committee={Committee}",
+            SanitizeForLog(id), SanitizeForLog(request?.CommitteeId));
+
+        try
+        {
+            var evt = await _credentialing.ScheduleCommitteeReviewAsync(
+                TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Created(string.Empty, evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Record a credentialing committee decision.</summary>
+    [HttpPost("decisions")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> RecordDecision(
+        string id,
+        [FromBody] RecordDecisionRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Recording credentialing decision for provider {Id}, decision={Decision}, authority={Authority}",
+            SanitizeForLog(id), request?.Decision, request?.DecisionAuthorityType);
+
+        try
+        {
+            var evt = await _credentialing.RecordDecisionAsync(
+                TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Created(string.Empty, evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Trigger the re-credentialing cycle (opens a new chain linked to the predecessor approval).</summary>
+    [HttpPost("recredential")]
+    [ProducesResponseType(typeof(CredentialingEvent), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<CredentialingEvent>> TriggerRecredentialing(
+        string id,
+        [FromBody] TriggerRecredentialingRequest request,
+        CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "Triggering re-credentialing for provider {Id}, reason={Reason}",
+            SanitizeForLog(id), SanitizeForLog(request?.Reason));
+
+        try
+        {
+            var evt = await _credentialing.TriggerRecredentialingAsync(
+                TenantId, id, request, ResolveActorId(), HttpContext.TraceIdentifier, ct);
+            return Created(string.Empty, evt);
+        }
+        catch (CredentialingValidationException ex)
+        {
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+    }
+
+    /// <summary>Current projected credentialing status for the provider.</summary>
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(CredentialingProjectionResult), StatusCodes.Status200OK)]
+    public async Task<ActionResult<CredentialingProjectionResult>> GetStatus(
+        string id,
+        CancellationToken ct)
+    {
+        var result = await _credentialing.GetCurrentStatusAsync(TenantId, id, ct);
+        return Ok(result);
+    }
+
+    /// <summary>Newest-first paged history of credentialing events for the provider.</summary>
+    [HttpGet("history")]
+    [ProducesResponseType(typeof(CredentialingHistoryPage), StatusCodes.Status200OK)]
+    public async Task<ActionResult<CredentialingHistoryPage>> GetHistory(
+        string id,
+        [FromQuery] string? cursor = null,
+        [FromQuery] int limit = 50,
+        CancellationToken ct = default)
+    {
+        var page = await _credentialing.GetHistoryAsync(TenantId, id, cursor, limit, ct);
+        return Ok(page);
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) && !string.IsNullOrEmpty(header.ToString()))
+            return header.ToString();
+        return "system";
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -757,12 +757,20 @@ public class ProvidersController : ControllerBase
         }
 
         var actorId = ResolveActorId();
+        // Inbound JSON DateTime values typically deserialize with
+        // Kind=Unspecified. Explicitly treat them as UTC before lifting
+        // to DateTimeOffset so the implicit DateTime→DateTimeOffset
+        // conversion can't pick up a local-time offset.
+        var rawCredentialingDate = request.CredentialingDate ?? DateTime.UtcNow;
+        var credentialingDateUtc = DateTime.SpecifyKind(rawCredentialingDate, DateTimeKind.Utc);
         var decisionRequest = new RecordDecisionRequest
         {
             Decision = decision,
-            DecidedAt = request.CredentialingDate ?? DateTime.UtcNow,
-            CredentialingDate = request.CredentialingDate ?? DateTime.UtcNow,
-            RecredentialingDueDate = request.RecredentialingDueDate,
+            DecidedAt = new DateTimeOffset(credentialingDateUtc, TimeSpan.Zero),
+            CredentialingDate = credentialingDateUtc,
+            RecredentialingDueDate = request.RecredentialingDueDate.HasValue
+                ? DateTime.SpecifyKind(request.RecredentialingDueDate.Value, DateTimeKind.Utc)
+                : null,
             DecisionAuthorityType = DecisionAuthorityType.DelegatedAuthority,
             DecisionAuthorityId = actorId,
             CommitteeMembers = null,
@@ -774,6 +782,10 @@ public class ProvidersController : ControllerBase
         {
             await _credentialing.RecordDecisionAsync(
                 TenantId, id, decisionRequest, actorId, HttpContext.TraceIdentifier, ct);
+        }
+        catch (CredentialingNotFoundException)
+        {
+            return NotFound($"Provider {id} not found");
         }
         catch (CredentialingValidationException ex)
         {

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -24,6 +24,7 @@ public class ProvidersController : ControllerBase
     private readonly ProviderAdapterFactory _adapterFactory;
     private readonly IProviderIntegrityProjectionService _integrityProjection;
     private readonly IPanelGatingValidator _panelGatingValidator;
+    private readonly ICredentialingService _credentialing;
     private readonly ILogger<ProvidersController> _logger;
 
     public ProvidersController(
@@ -32,6 +33,7 @@ public class ProvidersController : ControllerBase
         ProviderAdapterFactory adapterFactory,
         IProviderIntegrityProjectionService integrityProjection,
         IPanelGatingValidator panelGatingValidator,
+        ICredentialingService credentialing,
         ILogger<ProvidersController> logger)
     {
         _providerRepository = providerRepository;
@@ -39,6 +41,7 @@ public class ProvidersController : ControllerBase
         _adapterFactory = adapterFactory;
         _integrityProjection = integrityProjection;
         _panelGatingValidator = panelGatingValidator;
+        _credentialing = credentialing;
         _logger = logger;
     }
 
@@ -698,15 +701,25 @@ public class ProvidersController : ControllerBase
     }
 
     /// <summary>
-    /// Update provider credentialing status
+    /// Update provider credentialing status. Legacy endpoint preserved for
+    /// existing callers. Internally rewired through the event-sourced
+    /// credentialing workflow (capability 5.6) — emits a
+    /// <see cref="CredentialingEventType.DecisionRecorded"/> event with
+    /// <see cref="DecisionAuthorityType.DelegatedAuthority"/> and patches
+    /// the flat-field projection on <see cref="Provider"/>. Works on
+    /// Active providers (the previous implementation called
+    /// <see cref="IProviderRepository.UpdateAsync"/> and 409'd on every
+    /// non-Draft row).
     /// </summary>
     [HttpPut("{id}/credentialing")]
     [ProducesResponseType(typeof(Provider), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<ActionResult<Provider>> UpdateCredentialing(
         string id,
-        [FromBody] CredentialingUpdateRequest request)
+        [FromBody] CredentialingUpdateRequest request,
+        CancellationToken ct)
     {
         _logger.LogInformation(
             "Updating credentialing for provider {Id}, status={Status}",
@@ -718,20 +731,69 @@ public class ProvidersController : ControllerBase
             return NotFound($"Provider {id} not found");
         }
 
-        provider.CredentialingStatus = request.Status;
-        provider.CredentialingDate = request.CredentialingDate ?? DateTime.UtcNow;
-        provider.RecredentialingDueDate = request.RecredentialingDueDate;
-        provider.LastUpdatedDate = DateTime.UtcNow;
+        // Translate legacy status-only payload to a delegated-authority
+        // decision. Approved and Denied map directly. Pending/Expired/
+        // Suspended legacy values have no event-chain analogue — return
+        // 400 with a hint that those transitions require the explicit
+        // /credentialing/* sub-routes (or, for Suspended, await the
+        // Phase 2 SuspensionRecorded event type).
+        CredentialingDecision decision;
+        switch (request.Status)
+        {
+            case CredentialingStatus.Approved:
+                decision = CredentialingDecision.Approved;
+                break;
+            case CredentialingStatus.Denied:
+                decision = CredentialingDecision.Denied;
+                break;
+            default:
+                return BadRequest(new
+                {
+                    error = "unsupported_legacy_status",
+                    message = $"Status {request.Status} cannot be set via PUT /credentialing. " +
+                              "Use POST /credentialing/applications, /credentialing/recredential, " +
+                              "or /credentialing/decisions for workflow-driven transitions.",
+                });
+        }
+
+        var actorId = ResolveActorId();
+        var decisionRequest = new RecordDecisionRequest
+        {
+            Decision = decision,
+            DecidedAt = request.CredentialingDate ?? DateTime.UtcNow,
+            CredentialingDate = request.CredentialingDate ?? DateTime.UtcNow,
+            RecredentialingDueDate = request.RecredentialingDueDate,
+            DecisionAuthorityType = DecisionAuthorityType.DelegatedAuthority,
+            DecisionAuthorityId = actorId,
+            CommitteeMembers = null,
+            DecisionMinuteReference = null,
+            DenialReason = null,
+        };
 
         try
         {
-            var updated = await _providerRepository.UpdateAsync(provider);
-            return Ok(updated);
+            await _credentialing.RecordDecisionAsync(
+                TenantId, id, decisionRequest, actorId, HttpContext.TraceIdentifier, ct);
         }
-        catch (ProviderVersionStateException ex)
+        catch (CredentialingValidationException ex)
         {
-            return Conflict(new { message = ex.Message, providerId = ex.ProviderId, versionId = ex.VersionId, versionState = ex.CurrentState.ToString() });
+            return BadRequest(new { error = "credentialing_validation_failed", message = ex.Message });
         }
+        catch (InvalidOperationException ex)
+        {
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+            {
+                error = "credentialing_publish_failed",
+                message = ex.Message,
+            });
+        }
+
+        // Re-read so the response reflects the patched projection. The
+        // projection patch is best-effort — if the row hasn't been
+        // updated (no Active head) the response still surfaces the row
+        // as-stored.
+        var updated = await _providerRepository.GetByIdAsync(id);
+        return updated == null ? NotFound($"Provider {id} not found") : Ok(updated);
     }
 
     /// <summary>

--- a/src/services/provider-service/HostedServices/CredentialingEventIndexInitializer.cs
+++ b/src/services/provider-service/HostedServices/CredentialingEventIndexInitializer.cs
@@ -1,0 +1,64 @@
+using ProviderService.Models;
+using MongoDB.Driver;
+
+namespace ProviderService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the <c>CredentialingEvents</c>
+/// stream (capability 5.6). Mirrors
+/// <see cref="ProviderVerificationEventIndexInitializer"/>: indexes are
+/// what make <c>MongoCredentialingEventPublisher</c>'s monotonic-version
+/// retry loop correct.
+///
+/// Idempotent — Mongo silently no-ops indexes that already exist with
+/// the same spec.
+/// </summary>
+public sealed class CredentialingEventIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly string _collectionName;
+    private readonly ILogger<CredentialingEventIndexInitializer> _logger;
+
+    public CredentialingEventIndexInitializer(
+        IMongoDatabase db,
+        IConfiguration configuration,
+        ILogger<CredentialingEventIndexInitializer> logger)
+    {
+        _db = db;
+        _collectionName = configuration["CosmosDb:CredentialingEventsContainer"]
+            ?? "CredentialingEvents";
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<CredentialingEvent>(_collectionName);
+
+        var idemKeys = Builders<CredentialingEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.ProviderId)
+            .Ascending(x => x.EventId);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<CredentialingEvent>(
+                idemKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_provider_event" }),
+            cancellationToken: cancellationToken);
+
+        var orderKeys = Builders<CredentialingEvent>.IndexKeys
+            .Ascending(x => x.TenantId)
+            .Ascending(x => x.ProviderId)
+            .Ascending(x => x.Version);
+        collection.Indexes.CreateOne(
+            new CreateIndexModel<CredentialingEvent>(
+                orderKeys,
+                new CreateIndexOptions { Unique = true, Name = "ux_tenant_provider_version" }),
+            cancellationToken: cancellationToken);
+
+        _logger.LogInformation(
+            "CredentialingEvent indexes ensured on collection '{Collection}'.",
+            _collectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/provider-service/Models/CredentialingEvent.cs
+++ b/src/services/provider-service/Models/CredentialingEvent.cs
@@ -1,0 +1,186 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Append-only event in the credentialing workflow chain (capability 5.6).
+/// Each provider has zero or more credentialing chains over its lifetime —
+/// initial credentialing, then a re-credentialing chain every 2-3 years.
+/// The chain is the system-of-record; the three flat fields on
+/// <see cref="Provider"/> (<see cref="Provider.CredentialingStatus"/>,
+/// <see cref="Provider.CredentialingDate"/>,
+/// <see cref="Provider.RecredentialingDueDate"/>) are a denormalized
+/// projection written via
+/// <see cref="Repositories.IProviderRepository.UpdateCredentialingProjectionAsync"/>.
+///
+/// <para>
+/// Mirrors <see cref="ProviderVerificationEvent"/>: client-supplied
+/// <see cref="EventId"/> for idempotency, monotonic per-aggregate
+/// <see cref="Version"/>, partition key <c>{TenantId}:{ProviderId}</c>,
+/// Mongo <c>_id</c> scoped to <c>PartitionKey:EventId</c> for
+/// cross-tenant collision protection.
+/// </para>
+/// </summary>
+[BsonIgnoreExtraElements]
+public class CredentialingEvent
+{
+    [Required]
+    public string Id { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(256)]
+    public string PartitionKey { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(100)]
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Client-supplied idempotency key. Format varies by event type — see
+    /// the <c>Build*EventId</c> factories.
+    /// </summary>
+    [Required]
+    [StringLength(256)]
+    public string EventId { get; set; } = string.Empty;
+
+    [Required]
+    public CredentialingEventType EventType { get; set; }
+
+    /// <summary>1-based monotonic sequence per <c>(TenantId, ProviderId)</c>.</summary>
+    [Required]
+    public int Version { get; set; }
+
+    public int SchemaVersion { get; set; } = 1;
+
+    [Required]
+    public DateTime OccurredAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// EventId of the <see cref="CredentialingEventType.ApplicationSubmitted"/>
+    /// that opened the current chain. Set on every event that belongs to
+    /// an open application (PSV, CommitteeReviewScheduled, DecisionRecorded,
+    /// ApplicationWithdrawn). Null on chain-management events
+    /// (RecredentialingTriggered) and on the opening
+    /// <see cref="CredentialingEventType.ApplicationSubmitted"/> itself
+    /// (where the EventId IS the application identifier).
+    /// </summary>
+    [StringLength(256)]
+    public string? ApplicationEventId { get; set; }
+
+    /// <summary>
+    /// EventId of the predecessor terminal
+    /// <see cref="CredentialingEventType.DecisionRecorded"/>. Set on
+    /// <see cref="CredentialingEventType.RecredentialingTriggered"/> to
+    /// link the new chain to the prior approval.
+    /// </summary>
+    [StringLength(256)]
+    public string? PredecessorEventId { get; set; }
+
+    [StringLength(200)]
+    public string? ActorId { get; set; }
+
+    [StringLength(128)]
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Typed payload, serialized as a JSON object on the wire. Mirrors
+    /// the verification-event bridge: <see cref="Payload"/> is in-memory,
+    /// <see cref="PayloadJson"/> is the Mongo-persisted column. Each event
+    /// type has its own payload record under <see cref="CredentialingPayloads"/>.
+    /// </summary>
+    [BsonIgnore]
+    public JsonObject? Payload { get; set; }
+
+    [JsonIgnore]
+    public string? PayloadJson
+    {
+        get => Payload?.ToJsonString();
+        set => Payload = string.IsNullOrEmpty(value)
+            ? null
+            : JsonNode.Parse(value) as JsonObject;
+    }
+
+    public static string BuildPartitionKey(string tenantId, string providerId)
+        => $"{tenantId}:{providerId}";
+
+    // EventId factories — deterministic per event-type so re-publishing the
+    // same logical event collapses to a no-op via the idempotency probe.
+    public static string BuildApplicationSubmittedEventId(string providerId, DateTimeOffset submittedAt)
+        => $"applicationSubmitted:{providerId}:{submittedAt.UtcDateTime:O}";
+
+    /// <summary>
+    /// EventId for the application synthesized by the legacy
+    /// <c>PUT /providers/{id}/credentialing</c> shim when no open chain
+    /// exists. Deterministic on the paired
+    /// <see cref="CredentialingEventType.DecisionRecorded"/> EventId so
+    /// retries of the legacy endpoint collapse to the same synthesized
+    /// row.
+    /// </summary>
+    public static string BuildSynthesizedApplicationSubmittedEventId(string providerId, string decisionEventId)
+        => $"synthesized-application:{providerId}:{decisionEventId}";
+
+    public static string BuildPrimarySourceVerificationEventId(string providerId, string applicationEventId, DateTimeOffset verifiedAt)
+        => $"psv:{providerId}:{applicationEventId}:{verifiedAt.UtcDateTime:O}";
+
+    public static string BuildCommitteeReviewScheduledEventId(string providerId, string applicationEventId, DateTimeOffset scheduledFor)
+        => $"committeeScheduled:{providerId}:{applicationEventId}:{scheduledFor.UtcDateTime:O}";
+
+    public static string BuildDecisionRecordedEventId(string providerId, string applicationEventId, DateTimeOffset decidedAt)
+        => $"decision:{providerId}:{applicationEventId}:{decidedAt.UtcDateTime:O}";
+
+    public static string BuildRecredentialingTriggeredEventId(string providerId, DateTimeOffset triggeredAt)
+        => $"recredential:{providerId}:{triggeredAt.UtcDateTime:O}";
+
+    public static string BuildApplicationWithdrawnEventId(string providerId, string applicationEventId, DateTimeOffset withdrawnAt)
+        => $"withdrawn:{providerId}:{applicationEventId}:{withdrawnAt.UtcDateTime:O}";
+}
+
+/// <summary>
+/// Event types in the credentialing workflow chain. Mirrors PR #705
+/// enum-handling pattern: <c>Unknown=0</c>, explicit integer values,
+/// string serialization on the wire.
+/// </summary>
+public enum CredentialingEventType
+{
+    Unknown = 0,
+    ApplicationSubmitted = 1,
+    PrimarySourceVerificationCompleted = 2,
+    CommitteeReviewScheduled = 3,
+    DecisionRecorded = 4,
+    RecredentialingTriggered = 5,
+    ApplicationWithdrawn = 6,
+}
+
+/// <summary>
+/// Outcome of a credentialing committee decision. Carried in
+/// <see cref="CredentialingPayloads.DecisionRecordedPayload.Decision"/>.
+/// </summary>
+public enum CredentialingDecision
+{
+    Unknown = 0,
+    Approved = 1,
+    Denied = 2,
+}
+
+/// <summary>
+/// Authority that recorded a credentialing decision. The
+/// <see cref="DelegatedAuthority"/> path is used by the legacy
+/// <c>PUT /providers/{id}/credentialing</c> shim — the service synthesizes
+/// the missing application event when no chain is open so the legacy
+/// endpoint stays always-succeeds-on-Active providers.
+/// </summary>
+public enum DecisionAuthorityType
+{
+    Unknown = 0,
+    CredentialingCommittee = 1,
+    MedicalDirector = 2,
+    DelegatedAuthority = 3,
+    AutoApproved = 4,
+}

--- a/src/services/provider-service/Models/CredentialingPayloads.cs
+++ b/src/services/provider-service/Models/CredentialingPayloads.cs
@@ -1,0 +1,104 @@
+namespace ProviderService.Models.CredentialingPayloads;
+
+/// <summary>
+/// FHIR-aligned reference to a supporting document. Phase 1 carries the
+/// triple as opaque metadata on event payloads — there is no document
+/// upload service in this PR. The shape maps cleanly to FHIR
+/// DocumentReference for a future projection:
+/// <list type="bullet">
+///   <item><see cref="Uri"/> → <c>DocumentReference.content.attachment.url</c></item>
+///   <item><see cref="DocumentType"/> → <c>DocumentReference.type.coding</c></item>
+///   <item><see cref="Sha256"/> → <c>DocumentReference.content.attachment.hash</c></item>
+/// </list>
+/// <see cref="DocumentType"/> is intentionally an open string (not a
+/// closed enum) so future credentialing artifact categories don't require
+/// a code change — categorization vocabulary is a runtime concern.
+///
+/// <para>
+/// The credentialing service does NOT validate <see cref="Uri"/>
+/// reachability, does NOT fetch the document, and does NOT recompute
+/// <see cref="Sha256"/>. URI is opaque audit metadata; validation is a
+/// Phase 2 document-service responsibility.
+/// </para>
+/// </summary>
+public sealed record DocumentReference(
+    string Uri,
+    string DocumentType,
+    string? Sha256);
+
+/// <summary>
+/// Payload carried on
+/// <see cref="CredentialingEventType.ApplicationSubmitted"/>. The event's
+/// <see cref="CredentialingEvent.EventId"/> is the application identifier
+/// referenced by every downstream event in the chain.
+/// </summary>
+public sealed record ApplicationSubmittedPayload(
+    DateTimeOffset SubmittedAt,
+    string ApplicationSource,
+    IReadOnlyList<DocumentReference>? SupportingDocuments,
+    bool SynthesizedForDelegatedAuthority = false);
+
+/// <summary>
+/// Payload carried on
+/// <see cref="CredentialingEventType.PrimarySourceVerificationCompleted"/>.
+/// </summary>
+public sealed record PrimarySourceVerificationPayload(
+    DateTimeOffset VerifiedAt,
+    string VerificationVendor,
+    IReadOnlyList<string> VerifiedItems,
+    IReadOnlyList<DocumentReference>? Evidence);
+
+/// <summary>
+/// Payload carried on
+/// <see cref="CredentialingEventType.CommitteeReviewScheduled"/>.
+/// </summary>
+public sealed record CommitteeReviewScheduledPayload(
+    DateTimeOffset ScheduledFor,
+    string CommitteeId,
+    string? AgendaReference);
+
+/// <summary>
+/// Payload carried on <see cref="CredentialingEventType.DecisionRecorded"/>.
+/// The four authority fields
+/// (<see cref="DecisionAuthorityType"/>,
+/// <see cref="DecisionAuthorityId"/>, <see cref="CommitteeMembers"/>,
+/// <see cref="DecisionMinuteReference"/>) are what makes the chain
+/// credentialing-grade audit-quality.
+/// <see cref="CommitteeMembers"/> and <see cref="DecisionMinuteReference"/>
+/// are nullable — only the
+/// <see cref="ProviderService.Models.DecisionAuthorityType.CredentialingCommittee"/>
+/// path requires both.
+/// </summary>
+public sealed record DecisionRecordedPayload(
+    CredentialingDecision Decision,
+    DateTimeOffset DecidedAt,
+    DateTime? CredentialingDate,
+    DateTime? RecredentialingDueDate,
+    DecisionAuthorityType DecisionAuthorityType,
+    string DecisionAuthorityId,
+    IReadOnlyList<string>? CommitteeMembers,
+    string? DecisionMinuteReference,
+    string? DenialReason);
+
+/// <summary>
+/// Payload carried on
+/// <see cref="CredentialingEventType.RecredentialingTriggered"/>. Opens a
+/// new chain that will be followed by
+/// <see cref="CredentialingEventType.ApplicationSubmitted"/>; the projector
+/// flips status to <see cref="CredentialingStatus.Pending"/> on the trigger
+/// alone so consumers see the re-cred state immediately.
+/// </summary>
+public sealed record RecredentialingTriggeredPayload(
+    DateTimeOffset TriggeredAt,
+    string Reason);
+
+/// <summary>
+/// Payload carried on
+/// <see cref="CredentialingEventType.ApplicationWithdrawn"/>. Terminates
+/// the open chain; the projector reverts to the predecessor decision
+/// (or to <see cref="CredentialingStatus.Unknown"/> when no predecessor
+/// exists).
+/// </summary>
+public sealed record ApplicationWithdrawnPayload(
+    DateTimeOffset WithdrawnAt,
+    string Reason);

--- a/src/services/provider-service/Models/CredentialingRequests.cs
+++ b/src/services/provider-service/Models/CredentialingRequests.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+using ProviderService.Models.CredentialingPayloads;
+
+namespace ProviderService.Models;
+
+/// <summary>
+/// Body for <c>POST /api/v1/providers/{id}/credentialing/applications</c>.
+/// Opens a new credentialing chain.
+/// </summary>
+public sealed class SubmitApplicationRequest
+{
+    /// <summary>When the application was submitted. Defaults to <c>UtcNow</c> when null.</summary>
+    public DateTimeOffset? SubmittedAt { get; set; }
+
+    /// <summary>Free-form source identifier (e.g. <c>"CAQH"</c>, <c>"Manual"</c>, <c>"DelegatedRoster"</c>).</summary>
+    [Required]
+    [StringLength(100)]
+    public string ApplicationSource { get; set; } = string.Empty;
+
+    /// <summary>Optional supporting documents (license, board cert, malpractice insurance).</summary>
+    public IReadOnlyList<DocumentReference>? SupportingDocuments { get; set; }
+}
+
+/// <summary>
+/// Body for <c>POST /api/v1/providers/{id}/credentialing/verifications</c>.
+/// Records primary-source verification completion against the open chain.
+/// </summary>
+public sealed class RecordPrimarySourceVerificationRequest
+{
+    public DateTimeOffset? VerifiedAt { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string VerificationVendor { get; set; } = string.Empty;
+
+    [Required]
+    public IReadOnlyList<string> VerifiedItems { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyList<DocumentReference>? Evidence { get; set; }
+}
+
+/// <summary>
+/// Body for <c>POST /api/v1/providers/{id}/credentialing/committee-reviews</c>.
+/// Schedules a committee review for the open chain.
+/// </summary>
+public sealed class ScheduleCommitteeReviewRequest
+{
+    [Required]
+    public DateTimeOffset ScheduledFor { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string CommitteeId { get; set; } = string.Empty;
+
+    [StringLength(500)]
+    public string? AgendaReference { get; set; }
+}
+
+/// <summary>
+/// Body for <c>POST /api/v1/providers/{id}/credentialing/decisions</c> and
+/// for the rewired legacy <c>PUT /providers/{id}/credentialing</c> endpoint
+/// (translated from <see cref="CredentialingUpdateRequest"/>).
+/// </summary>
+public sealed class RecordDecisionRequest
+{
+    [Required]
+    public CredentialingDecision Decision { get; set; }
+
+    public DateTimeOffset? DecidedAt { get; set; }
+
+    public DateTime? CredentialingDate { get; set; }
+
+    public DateTime? RecredentialingDueDate { get; set; }
+
+    [Required]
+    public DecisionAuthorityType DecisionAuthorityType { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string DecisionAuthorityId { get; set; } = string.Empty;
+
+    public IReadOnlyList<string>? CommitteeMembers { get; set; }
+
+    [StringLength(500)]
+    public string? DecisionMinuteReference { get; set; }
+
+    [StringLength(2000)]
+    public string? DenialReason { get; set; }
+}
+
+/// <summary>
+/// Body for <c>POST /api/v1/providers/{id}/credentialing/recredential</c>.
+/// Opens a new chain linked to the predecessor approval.
+/// </summary>
+public sealed class TriggerRecredentialingRequest
+{
+    public DateTimeOffset? TriggeredAt { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Reason { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Body for
+/// <c>POST /api/v1/providers/{id}/credentialing/applications/{eventId}/withdraw</c>.
+/// </summary>
+public sealed class WithdrawApplicationRequest
+{
+    public DateTimeOffset? WithdrawnAt { get; set; }
+
+    [Required]
+    [StringLength(500)]
+    public string Reason { get; set; } = string.Empty;
+}

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -163,18 +163,31 @@ public class Provider
     public List<NetworkParticipation> NetworkParticipations { get; set; } = new();
 
     /// <summary>
-    /// Credentialing status
+    /// Credentialing status. Projection of the credentialing event chain
+    /// (capability 5.6) — written via
+    /// <see cref="Repositories.IProviderRepository.UpdateCredentialingProjectionAsync"/>,
+    /// NOT via <see cref="Repositories.IProviderRepository.UpdateAsync"/>.
+    /// New providers default to <see cref="CredentialingStatus.Unknown"/>
+    /// until an <see cref="CredentialingEventType.ApplicationSubmitted"/>
+    /// event opens the first chain.
     /// </summary>
     [Required]
-    public CredentialingStatus CredentialingStatus { get; set; } = CredentialingStatus.Pending;
+    public CredentialingStatus CredentialingStatus { get; set; } = CredentialingStatus.Unknown;
 
     /// <summary>
-    /// Credentialing date (initial or most recent re-credentialing)
+    /// Most recent approval date. Projection of the credentialing event
+    /// chain — set when a
+    /// <see cref="CredentialingEventType.DecisionRecorded"/> event with
+    /// <see cref="CredentialingDecision.Approved"/> lands.
     /// </summary>
     public DateTime? CredentialingDate { get; set; }
 
     /// <summary>
-    /// Next re-credentialing due date (typically every 2-3 years)
+    /// Next re-credentialing due date (typically every 2-3 years).
+    /// Projection of the credentialing event chain — set on the most
+    /// recent approval. When elapsed the projector reports
+    /// <see cref="CredentialingStatus.Expired"/> at read time even if the
+    /// stored value is still <see cref="CredentialingStatus.Approved"/>.
     /// </summary>
     public DateTime? RecredentialingDueDate { get; set; }
 
@@ -604,32 +617,59 @@ public enum ProviderType
 }
 
 /// <summary>
-/// Credentialing status
+/// Credentialing status — read-side projection of the credentialing event
+/// chain (capability 5.6). The credentialing event chain is the
+/// system-of-record; this enum is the collapsed status flag consumed by
+/// downstream services (coverage-service PCP gating, benefit-plan-service
+/// adjudication checks).
+///
+/// <para>
+/// Per PR #705 enum convention: <see cref="Unknown"/> = 0 first, explicit
+/// integer values, string serialization with
+/// <c>JsonStringEnumConverter(allowIntegerValues: false)</c>. Adding
+/// <see cref="Unknown"/>=0 in front of <see cref="Pending"/>=1 is
+/// backward-compatible: existing stored integer values map by position
+/// (Mongo's default reflection serializer reads integer 1 → Pending),
+/// and existing string values ("Pending", "Approved", etc.) continue to
+/// deserialize unchanged.
+/// </para>
 /// </summary>
 public enum CredentialingStatus
 {
     /// <summary>
-    /// Application submitted, under review
+    /// No credentialing chain has ever been opened for this provider.
+    /// Default for newly-created providers. The projector returns this
+    /// value when the event chain is empty.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Application submitted or re-credentialing triggered, under review.
     /// </summary>
     Pending = 1,
 
     /// <summary>
-    /// Credentialing approved, can participate
+    /// Credentialing approved, can participate.
     /// </summary>
     Approved = 2,
 
     /// <summary>
-    /// Credentialing denied
+    /// Credentialing denied.
     /// </summary>
     Denied = 3,
 
     /// <summary>
-    /// Re-credentialing required (expired)
+    /// Most recent approval has lapsed; re-credentialing required.
+    /// Computed at projection time from
+    /// <see cref="Provider.RecredentialingDueDate"/>.
     /// </summary>
     Expired = 4,
 
     /// <summary>
-    /// Suspended (quality issues, fraud, etc.)
+    /// Suspended (quality issues, fraud, etc.). Phase 1 has no event-driven
+    /// write path for this state — it remains for read-side compatibility.
+    /// A future <c>SuspensionRecorded</c> event lands in Phase 2 alongside
+    /// appeals and peer review.
     /// </summary>
     Suspended = 5
 }

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -54,9 +54,12 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddScoped<IProviderVersionEventPublisher, MongoProviderVersionEventPublisher>();
     builder.Services.AddScoped<IProviderVerificationEventPublisher, MongoProviderVerificationEventPublisher>();
     builder.Services.AddScoped<INetworkParticipationEventPublisher, MongoNetworkParticipationEventPublisher>();
+    builder.Services.AddScoped<ICredentialingEventPublisher, MongoCredentialingEventPublisher>();
+    builder.Services.AddScoped<ICredentialingEventRepository, MongoCredentialingEventRepository>();
     builder.Services.AddHostedService<ProviderVersionEventIndexInitializer>();
     builder.Services.AddHostedService<ProviderVerificationEventIndexInitializer>();
     builder.Services.AddHostedService<NetworkParticipationEventIndexInitializer>();
+    builder.Services.AddHostedService<CredentialingEventIndexInitializer>();
     Console.WriteLine("Using MongoDB database provider");
 }
 else
@@ -86,6 +89,8 @@ else
     builder.Services.AddScoped<IProviderVersionEventPublisher, NoopProviderVersionEventPublisher>();
     builder.Services.AddScoped<IProviderVerificationEventPublisher, NoopProviderVerificationEventPublisher>();
     builder.Services.AddScoped<INetworkParticipationEventPublisher, NoopNetworkParticipationEventPublisher>();
+    builder.Services.AddScoped<ICredentialingEventPublisher, NoopCredentialingEventPublisher>();
+    builder.Services.AddScoped<ICredentialingEventRepository, CosmosCredentialingEventRepository>();
 }
 
 // Provider versioning service (5.1 — provider identity & versioning)
@@ -152,6 +157,13 @@ builder.Services.Configure<NetworkParticipationBackfillOptions>(
     builder.Configuration.GetSection(NetworkParticipationBackfillOptions.SectionName));
 builder.Services.AddScoped<IPanelGatingValidator, PanelGatingValidator>();
 builder.Services.AddScoped<INetworkParticipationBackfillService, NetworkParticipationBackfillService>();
+
+// Credentialing workflow (5.6 — event-sourced credentialing chain
+// projected onto Provider.CredentialingStatus / CredentialingDate /
+// RecredentialingDueDate via the bypass write path mirroring 5.4.5 and
+// 5.5). The projector is a pure function — singleton-safe.
+builder.Services.AddSingleton<CredentialingProjector>();
+builder.Services.AddScoped<ICredentialingService, CredentialingService>();
 
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();

--- a/src/services/provider-service/Repositories/CosmosCredentialingEventRepository.cs
+++ b/src/services/provider-service/Repositories/CosmosCredentialingEventRepository.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using Microsoft.Azure.Cosmos;
+using ProviderService.Models;
+
+namespace ProviderService.Repositories;
+
+/// <summary>
+/// Cosmos-backed reader for the credentialing event stream. Used in
+/// Cosmos-only deployments that don't yet provision the events stream
+/// (paired with <see cref="Services.NoopCredentialingEventPublisher"/>).
+/// All reads are partition-scoped by <c>TenantId</c>.
+/// </summary>
+public sealed class CosmosCredentialingEventRepository : ICredentialingEventRepository
+{
+    private readonly Container _container;
+
+    public CosmosCredentialingEventRepository(
+        CosmosClient client,
+        IConfiguration configuration)
+    {
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "CloudHealthOffice";
+        var containerName = configuration["CosmosDb:CredentialingEventsContainer"]
+            ?? "CredentialingEvents";
+        _container = client.GetContainer(databaseName, containerName);
+    }
+
+    public async Task<IReadOnlyList<CredentialingEvent>> ListAscendingAsync(
+        string tenantId, string providerId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.providerId = @providerId " +
+                "ORDER BY c.version ASC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@providerId", providerId);
+
+        return await ReadAllAsync(query, tenantId, ct);
+    }
+
+    public async Task<CredentialingEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(
+                "SELECT TOP 1 * FROM c WHERE c.tenantId = @tenantId AND c.providerId = @providerId AND c.eventId = @eventId")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@providerId", providerId)
+            .WithParameter("@eventId", eventId);
+
+        var rows = await ReadAllAsync(query, tenantId, ct);
+        return rows.Count == 0 ? null : rows[0];
+    }
+
+    public async Task<CredentialingHistoryPage> ListHistoryDescendingAsync(
+        string tenantId,
+        string providerId,
+        string? continuationToken,
+        int limit,
+        CancellationToken ct = default)
+    {
+        var safeLimit = Math.Clamp(limit, 1, 200);
+        var afterVersion = DecodeCursor(continuationToken);
+
+        var sql = "SELECT * FROM c WHERE c.tenantId = @tenantId AND c.providerId = @providerId";
+        if (afterVersion.HasValue)
+        {
+            sql += " AND c.version < @afterVersion";
+        }
+        sql += $" ORDER BY c.version DESC OFFSET 0 LIMIT {safeLimit + 1}";
+
+        var query = new QueryDefinition(sql)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@providerId", providerId);
+        if (afterVersion.HasValue)
+        {
+            query = query.WithParameter("@afterVersion", afterVersion.Value);
+        }
+
+        var page = await ReadAllAsync(query, tenantId, ct);
+        string? next = null;
+        if (page.Count > safeLimit)
+        {
+            page = page.Take(safeLimit).ToList();
+            next = EncodeCursor(page[^1].Version);
+        }
+        return new CredentialingHistoryPage(page, next);
+    }
+
+    private async Task<List<CredentialingEvent>> ReadAllAsync(QueryDefinition query, string tenantId, CancellationToken ct)
+    {
+        var iterator = _container.GetItemQueryIterator<CredentialingEvent>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        var results = new List<CredentialingEvent>();
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+            results.AddRange(page);
+        }
+        return results;
+    }
+
+    private static int? DecodeCursor(string? token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+        try
+        {
+            var bytes = Convert.FromBase64String(token);
+            var decoded = Encoding.UTF8.GetString(bytes);
+            return int.TryParse(decoded, out var v) ? v : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string EncodeCursor(int lastVersion)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(lastVersion.ToString()));
+}

--- a/src/services/provider-service/Repositories/ICredentialingEventRepository.cs
+++ b/src/services/provider-service/Repositories/ICredentialingEventRepository.cs
@@ -1,0 +1,49 @@
+using ProviderService.Models;
+
+namespace ProviderService.Repositories;
+
+/// <summary>
+/// Read-side seam for the append-only
+/// <see cref="CredentialingEvent"/> stream (capability 5.6).
+/// Append happens exclusively through
+/// <see cref="Services.ICredentialingEventPublisher"/>; this interface
+/// exposes no Update/Delete operations to enforce the append-only
+/// invariant at the type level.
+/// </summary>
+public interface ICredentialingEventRepository
+{
+    /// <summary>
+    /// Full chain for <paramref name="providerId"/> in ascending
+    /// <see cref="CredentialingEvent.Version"/> order. Used by the
+    /// service layer to feed <see cref="Services.CredentialingProjector"/>.
+    /// </summary>
+    Task<IReadOnlyList<CredentialingEvent>> ListAscendingAsync(
+        string tenantId, string providerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Single event by client-supplied
+    /// <see cref="CredentialingEvent.EventId"/>. Used by the publisher
+    /// for idempotency probing and by tests for direct chain inspection.
+    /// </summary>
+    Task<CredentialingEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Newest-first page of the chain for the
+    /// <c>GET /credentialing/history</c> endpoint. Cursor format is
+    /// opaque base64 of <c>{lastVersion}</c>; a missing or invalid cursor
+    /// starts from the head. The continuation token is null when the
+    /// returned page is the last one.
+    /// </summary>
+    Task<CredentialingHistoryPage> ListHistoryDescendingAsync(
+        string tenantId,
+        string providerId,
+        string? continuationToken,
+        int limit,
+        CancellationToken ct = default);
+}
+
+/// <summary>Page envelope returned by <see cref="ICredentialingEventRepository.ListHistoryDescendingAsync"/>.</summary>
+public sealed record CredentialingHistoryPage(
+    IReadOnlyList<CredentialingEvent> Items,
+    string? ContinuationToken);

--- a/src/services/provider-service/Repositories/MongoCredentialingEventRepository.cs
+++ b/src/services/provider-service/Repositories/MongoCredentialingEventRepository.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using MongoDB.Driver;
+using ProviderService.Models;
+
+namespace ProviderService.Repositories;
+
+/// <summary>
+/// Mongo-backed reader for the credentialing event stream. Append happens
+/// in <see cref="Services.MongoCredentialingEventPublisher"/>; this class
+/// is read-only by contract.
+/// </summary>
+public sealed class MongoCredentialingEventRepository : ICredentialingEventRepository
+{
+    private readonly IMongoCollection<CredentialingEvent> _collection;
+
+    public MongoCredentialingEventRepository(
+        IMongoDatabase database,
+        IConfiguration configuration)
+    {
+        var collectionName = configuration["CosmosDb:CredentialingEventsContainer"]
+            ?? "CredentialingEvents";
+        _collection = database.GetCollection<CredentialingEvent>(collectionName);
+    }
+
+    public async Task<IReadOnlyList<CredentialingEvent>> ListAscendingAsync(
+        string tenantId, string providerId, CancellationToken ct = default)
+    {
+        var b = Builders<CredentialingEvent>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderId, providerId));
+        return await _collection.Find(filter)
+            .SortBy(x => x.Version)
+            .ToListAsync(ct);
+    }
+
+    public async Task<CredentialingEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct = default)
+    {
+        var b = Builders<CredentialingEvent>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderId, providerId),
+            b.Eq(x => x.EventId, eventId));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<CredentialingHistoryPage> ListHistoryDescendingAsync(
+        string tenantId,
+        string providerId,
+        string? continuationToken,
+        int limit,
+        CancellationToken ct = default)
+    {
+        var safeLimit = Math.Clamp(limit, 1, 200);
+        var afterVersion = DecodeCursor(continuationToken);
+
+        var b = Builders<CredentialingEvent>.Filter;
+        var filters = new List<FilterDefinition<CredentialingEvent>>
+        {
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderId, providerId),
+        };
+        if (afterVersion.HasValue)
+        {
+            // Newest-first cursor: return items strictly older than the
+            // last version surfaced on the previous page.
+            filters.Add(b.Lt(x => x.Version, afterVersion.Value));
+        }
+
+        // Fetch one extra row to detect whether more pages exist without
+        // a separate count query.
+        var page = await _collection.Find(b.And(filters))
+            .SortByDescending(x => x.Version)
+            .Limit(safeLimit + 1)
+            .ToListAsync(ct);
+
+        string? next = null;
+        if (page.Count > safeLimit)
+        {
+            page.RemoveAt(page.Count - 1);
+            next = EncodeCursor(page[^1].Version);
+        }
+
+        return new CredentialingHistoryPage(page, next);
+    }
+
+    private static int? DecodeCursor(string? token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+        try
+        {
+            var bytes = Convert.FromBase64String(token);
+            var decoded = Encoding.UTF8.GetString(bytes);
+            return int.TryParse(decoded, out var v) ? v : null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string EncodeCursor(int lastVersion)
+        => Convert.ToBase64String(Encoding.UTF8.GetBytes(lastVersion.ToString()));
+}

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -941,9 +941,14 @@ public class ProviderRepository : IProviderRepository
 
         if (string.IsNullOrEmpty(rowId)) return false;
 
+        // Patch the enum value directly so the Cosmos SDK serializer
+        // chooses the same representation it uses for full-document
+        // writes. Calling .ToString() would force a string here even
+        // if the rest of the document stored the field differently —
+        // a future serializer-config change would silently diverge.
         var ops = new List<PatchOperation>
         {
-            PatchOperation.Set("/credentialingStatus", status.ToString()),
+            PatchOperation.Set("/credentialingStatus", status),
             PatchOperation.Set("/credentialingDate", credentialingDate),
             PatchOperation.Set("/recredentialingDueDate", recredentialingDueDate),
             PatchOperation.Set("/lastUpdatedDate", DateTime.UtcNow),

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -248,6 +248,43 @@ public interface IProviderRepository
         int skip,
         int pageSize,
         CancellationToken ct = default);
+
+    // ---- Credentialing projection write-back (capability 5.6) --------
+
+    /// <summary>
+    /// Patch the three credentialing-projection fields
+    /// (<see cref="Provider.CredentialingStatus"/>,
+    /// <see cref="Provider.CredentialingDate"/>,
+    /// <see cref="Provider.RecredentialingDueDate"/>) on the head Active
+    /// version of <paramref name="providerId"/>. Mirrors
+    /// <see cref="UpdateIntegrityProjectionAsync"/> — same hydration
+    /// rule, same exemption from the version-state guard.
+    ///
+    /// <para>
+    /// These fields are *projection metadata*, not provider-identity
+    /// fields — see <c>docs/architecture/provider-versioning.md</c>
+    /// "Projection metadata — exempt from versioning". The bypass is
+    /// implemented as a separate write path: the Cosmos impl uses
+    /// <c>PatchItemAsync</c> with field-scoped <c>Set</c> ops and the
+    /// Mongo impl uses <c>FindOneAndUpdateAsync</c> with <c>$set</c> on
+    /// the three field paths only. Neither path goes through
+    /// <see cref="UpdateAsync"/>'s version-state guard.
+    /// </para>
+    ///
+    /// <para>
+    /// Returns <c>true</c> when the head Active version was patched;
+    /// <c>false</c> when no Active head exists. Idempotent — rerunning
+    /// with the same inputs is a no-op overwrite. Does not throw on
+    /// missing chains.
+    /// </para>
+    /// </summary>
+    Task<bool> UpdateCredentialingProjectionAsync(
+        string tenantId,
+        string providerId,
+        CredentialingStatus status,
+        DateTime? credentialingDate,
+        DateTime? recredentialingDueDate,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -864,6 +901,65 @@ public class ProviderRepository : IProviderRepository
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             // Row was deleted between the lookup and the patch.
+            return false;
+        }
+    }
+
+    public async Task<bool> UpdateCredentialingProjectionAsync(
+        string tenantId,
+        string providerId,
+        CredentialingStatus status,
+        DateTime? credentialingDate,
+        DateTime? recredentialingDueDate,
+        CancellationToken ct = default)
+    {
+        // Mirror UpdateIntegrityProjectionAsync: lookup head Active row by
+        // chain key, patch only the three credentialing projection fields
+        // via PatchItemAsync. No version-state guard. Hydration rule
+        // (three "Active" shapes, each Status-gated) is identical.
+        var query = new QueryDefinition(
+                "SELECT TOP 1 c.id FROM c WHERE c.tenantId = @tenantId AND " +
+                "(c.providerId = @providerId OR (NOT IS_DEFINED(c.providerId) AND c.id = @providerId)) AND " +
+                "(c.versionState = @active " +
+                "OR (NOT IS_DEFINED(c.versionState) AND c.status = @statusActive) " +
+                "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@providerId", providerId)
+            .WithParameter("@active", ProviderVersionState.Active.ToString())
+            .WithParameter("@statusActive", ProviderStatus.Active.ToString());
+
+        string? rowId = null;
+        var iterator = _container.GetItemQueryIterator<HeadIdResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            rowId = page.FirstOrDefault()?.Id;
+        }
+
+        if (string.IsNullOrEmpty(rowId)) return false;
+
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/credentialingStatus", status.ToString()),
+            PatchOperation.Set("/credentialingDate", credentialingDate),
+            PatchOperation.Set("/recredentialingDueDate", recredentialingDueDate),
+            PatchOperation.Set("/lastUpdatedDate", DateTime.UtcNow),
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<Provider>(
+                rowId,
+                new PartitionKey(tenantId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
             return false;
         }
     }

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -678,6 +678,53 @@ public class ProviderRepositoryMongo : IProviderRepository
         return updated != null;
     }
 
+    public async Task<bool> UpdateCredentialingProjectionAsync(
+        string tenantId,
+        string providerId,
+        CredentialingStatus status,
+        DateTime? credentialingDate,
+        DateTime? recredentialingDueDate,
+        CancellationToken ct = default)
+    {
+        // Mirror UpdateIntegrityProjectionAsync: $set on the three
+        // credentialing projection fields only — bypasses the
+        // version-state guard on UpdateAsync. Targets the head Active
+        // version of the chain (matching ChainKeyFilter + Active state).
+        // Hydration rule (three "Active" shapes, each Status-gated) is
+        // identical.
+        var b = Builders<Provider>.Filter;
+        var stateFilter = b.Or(
+            b.Eq(p => p.VersionState, ProviderVersionState.Active),
+            b.And(
+                b.Exists(p => p.VersionState, false),
+                b.Eq(p => p.Status, ProviderStatus.Active)),
+            b.And(
+                b.Or(
+                    b.Exists(p => p.VersionId, false),
+                    b.Eq(p => p.VersionId, null),
+                    b.Eq(p => p.VersionId, string.Empty)),
+                b.Eq(p => p.Status, ProviderStatus.Active)));
+
+        var filter = b.And(
+            b.Eq(p => p.TenantId, tenantId),
+            ChainKeyFilter(providerId),
+            stateFilter);
+
+        var update = Builders<Provider>.Update
+            .Set(p => p.CredentialingStatus, status)
+            .Set(p => p.CredentialingDate, credentialingDate)
+            .Set(p => p.RecredentialingDueDate, recredentialingDueDate)
+            .Set(p => p.LastUpdatedDate, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<Provider>
+        {
+            Sort = Builders<Provider>.Sort.Descending(p => p.VersionNumber),
+            ReturnDocument = ReturnDocument.After,
+        };
+        var updated = await _collection.FindOneAndUpdateAsync(filter, update, options, ct);
+        return updated != null;
+    }
+
     public async Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(
         string tenantId,
         DateTimeOffset dueBefore,

--- a/src/services/provider-service/Services/CredentialingEventPublisher.cs
+++ b/src/services/provider-service/Services/CredentialingEventPublisher.cs
@@ -1,0 +1,143 @@
+using MongoDB.Driver;
+using ProviderService.Models;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Append-only writer for the
+/// <see cref="CredentialingEvent"/> stream (capability 5.6). Mirrors
+/// <see cref="IProviderVerificationEventPublisher"/> — single
+/// <c>PublishAsync</c> entry point because the
+/// <see cref="ICredentialingService"/> constructs the typed payload + sets
+/// <see cref="CredentialingEvent.EventId"/> +
+/// <see cref="CredentialingEvent.EventType"/>. The publisher's only job is
+/// the append-only mechanics: idempotency probe, monotonic version
+/// assignment with retry, and cross-tenant <c>_id</c> collision
+/// protection.
+/// </summary>
+public interface ICredentialingEventPublisher
+{
+    Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default);
+}
+
+public sealed class MongoCredentialingEventPublisher : ICredentialingEventPublisher
+{
+    private const int MaxRetries = 5;
+    private static readonly int[] BackoffMs = { 2, 5, 25, 100, 250 };
+
+    private readonly IMongoCollection<CredentialingEvent> _collection;
+    private readonly ILogger<MongoCredentialingEventPublisher> _logger;
+
+    public MongoCredentialingEventPublisher(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<MongoCredentialingEventPublisher> logger)
+    {
+        var collectionName = configuration["CosmosDb:CredentialingEventsContainer"]
+            ?? "CredentialingEvents";
+        _collection = database.GetCollection<CredentialingEvent>(collectionName);
+        _logger = logger;
+    }
+
+    public async Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default)
+    {
+        if (evt == null) throw new ArgumentNullException(nameof(evt));
+        if (string.IsNullOrEmpty(evt.TenantId)) throw new ArgumentException("TenantId is required.", nameof(evt));
+        if (string.IsNullOrEmpty(evt.ProviderId)) throw new ArgumentException("ProviderId is required.", nameof(evt));
+        if (string.IsNullOrEmpty(evt.EventId)) throw new ArgumentException("EventId is required.", nameof(evt));
+
+        evt.PartitionKey = CredentialingEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
+        // Mongo maps Id ⇒ _id which must be unique across the entire
+        // collection. EventId is only unique within (TenantId,ProviderId)
+        // — two tenants opening the same chain at the same instant would
+        // collide on _id alone. Scope _id to PartitionKey:EventId. The
+        // (TenantId, ProviderId, EventId) UNIQUE index from the
+        // initializer remains the primary idempotency guard.
+        evt.Id = $"{evt.PartitionKey}:{evt.EventId}";
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+
+        var existing = await GetByEventIdAsync(evt.TenantId, evt.ProviderId, evt.EventId, ct);
+        if (existing != null)
+        {
+            _logger.LogDebug(
+                "CredentialingEvent {EventId} already present for {Tenant}:{Provider} (idempotent no-op)",
+                Sanitize(evt.EventId), Sanitize(evt.TenantId), Sanitize(evt.ProviderId));
+            return existing;
+        }
+
+        for (var attempt = 0; attempt < MaxRetries; attempt++)
+        {
+            evt.Version = await GetNextVersionAsync(evt.TenantId, evt.ProviderId, ct);
+            try
+            {
+                await _collection.InsertOneAsync(evt, cancellationToken: ct);
+                return evt;
+            }
+            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+            {
+                var refetch = await GetByEventIdAsync(evt.TenantId, evt.ProviderId, evt.EventId, ct);
+                if (refetch != null) return refetch;
+
+                _logger.LogWarning(
+                    "CredentialingEvent version {Version} conflict for {Tenant}:{Provider}; retry {Attempt}/{Max}",
+                    evt.Version, Sanitize(evt.TenantId), Sanitize(evt.ProviderId), attempt + 1, MaxRetries);
+
+                if (attempt + 1 < MaxRetries)
+                    await Task.Delay(BackoffMs[attempt], ct);
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Failed to append CredentialingEvent for {evt.TenantId}:{evt.ProviderId} after {MaxRetries} attempts");
+    }
+
+    private async Task<CredentialingEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct)
+    {
+        var b = Builders<CredentialingEvent>.Filter;
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.ProviderId, providerId),
+            b.Eq(x => x.EventId, eventId));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    private async Task<int> GetNextVersionAsync(string tenantId, string providerId, CancellationToken ct)
+    {
+        var b = Builders<CredentialingEvent>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.ProviderId, providerId));
+        var latest = await _collection.Find(filter).SortByDescending(x => x.Version).FirstOrDefaultAsync(ct);
+        return (latest?.Version ?? 0) + 1;
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}
+
+/// <summary>
+/// No-op fallback used when no Mongo publisher is available (Cosmos-only
+/// deployments without the credentialing-events stream provisioned).
+/// Logs a warning so ops can spot the missing wiring without breaking
+/// the workflow path.
+/// </summary>
+public sealed class NoopCredentialingEventPublisher : ICredentialingEventPublisher
+{
+    private readonly ILogger<NoopCredentialingEventPublisher> _logger;
+
+    public NoopCredentialingEventPublisher(ILogger<NoopCredentialingEventPublisher> logger)
+        => _logger = logger;
+
+    public Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "CredentialingEventPublisher is not configured; dropping {EventType} event for {ProviderId}",
+            evt?.EventType, evt?.ProviderId);
+        evt ??= new CredentialingEvent();
+        if (string.IsNullOrEmpty(evt.PartitionKey) && !string.IsNullOrEmpty(evt.TenantId) && !string.IsNullOrEmpty(evt.ProviderId))
+        {
+            evt.PartitionKey = CredentialingEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
+        }
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+        return Task.FromResult(evt);
+    }
+}

--- a/src/services/provider-service/Services/CredentialingEventPublisher.cs
+++ b/src/services/provider-service/Services/CredentialingEventPublisher.cs
@@ -115,10 +115,16 @@ public sealed class MongoCredentialingEventPublisher : ICredentialingEventPublis
 }
 
 /// <summary>
-/// No-op fallback used when no Mongo publisher is available (Cosmos-only
-/// deployments without the credentialing-events stream provisioned).
-/// Logs a warning so ops can spot the missing wiring without breaking
-/// the workflow path.
+/// Fail-fast fallback used in Cosmos-only deployments without a
+/// provisioned credentialing-events stream. Unlike the integrity /
+/// version / participation Noop publishers (which are an audit
+/// supplement), the credentialing event chain IS the system-of-record
+/// for the workflow — if the chain can't be written, the projection
+/// patch must NOT proceed (otherwise Provider.CredentialingStatus
+/// would mutate without a matching audit record). Throwing
+/// <see cref="InvalidOperationException"/> here surfaces 503 from the
+/// controllers, matching the publisher-exhaustion contract in the
+/// Mongo path.
 /// </summary>
 public sealed class NoopCredentialingEventPublisher : ICredentialingEventPublisher
 {
@@ -130,18 +136,14 @@ public sealed class NoopCredentialingEventPublisher : ICredentialingEventPublish
     public Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default)
     {
         // Sanitize user-supplied identifier before logging — defense
-        // against log injection (CRLF). Mirrors the helper in
-        // MongoCredentialingEventPublisher.
-        _logger.LogWarning(
-            "CredentialingEventPublisher is not configured; dropping {EventType} event for {ProviderId}",
+        // against log injection (CRLF).
+        _logger.LogError(
+            "CredentialingEventPublisher is not configured; refusing to publish {EventType} event for {ProviderId} " +
+            "(the credentialing event chain is the system-of-record).",
             evt?.EventType, Sanitize(evt?.ProviderId));
-        evt ??= new CredentialingEvent();
-        if (string.IsNullOrEmpty(evt.PartitionKey) && !string.IsNullOrEmpty(evt.TenantId) && !string.IsNullOrEmpty(evt.ProviderId))
-        {
-            evt.PartitionKey = CredentialingEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
-        }
-        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
-        return Task.FromResult(evt);
+        throw new InvalidOperationException(
+            "CredentialingEventPublisher is not configured. Credentialing workflow endpoints require a " +
+            "provisioned events stream — check the Mongo connection or the CosmosDb:CredentialingEventsContainer setting.");
     }
 
     private static string Sanitize(string? value) =>

--- a/src/services/provider-service/Services/CredentialingEventPublisher.cs
+++ b/src/services/provider-service/Services/CredentialingEventPublisher.cs
@@ -129,9 +129,12 @@ public sealed class NoopCredentialingEventPublisher : ICredentialingEventPublish
 
     public Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default)
     {
+        // Sanitize user-supplied identifier before logging — defense
+        // against log injection (CRLF). Mirrors the helper in
+        // MongoCredentialingEventPublisher.
         _logger.LogWarning(
             "CredentialingEventPublisher is not configured; dropping {EventType} event for {ProviderId}",
-            evt?.EventType, evt?.ProviderId);
+            evt?.EventType, Sanitize(evt?.ProviderId));
         evt ??= new CredentialingEvent();
         if (string.IsNullOrEmpty(evt.PartitionKey) && !string.IsNullOrEmpty(evt.TenantId) && !string.IsNullOrEmpty(evt.ProviderId))
         {
@@ -140,4 +143,7 @@ public sealed class NoopCredentialingEventPublisher : ICredentialingEventPublish
         if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
         return Task.FromResult(evt);
     }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 }

--- a/src/services/provider-service/Services/CredentialingProjector.cs
+++ b/src/services/provider-service/Services/CredentialingProjector.cs
@@ -162,10 +162,23 @@ public sealed class CredentialingProjector
             // each event transition with the projector's at-write-time
             // verdict; readers who consult the projector directly get a
             // fresh evaluation each time.
-            if (lastDecisionPayload.RecredentialingDueDate.HasValue
-                && lastDecisionPayload.RecredentialingDueDate.Value.ToUniversalTime() < asOf.UtcDateTime)
+            //
+            // Normalize the stored due-date to UTC explicitly. Inbound
+            // JSON often deserializes DateTime with Kind=Unspecified;
+            // calling ToUniversalTime() on those would interpret them as
+            // local time and shift the boundary by the server's
+            // timezone offset. SpecifyKind treats Unspecified as
+            // already-UTC (matching how the service writes the value).
+            if (lastDecisionPayload.RecredentialingDueDate.HasValue)
             {
-                return CredentialingStatus.Expired;
+                var due = lastDecisionPayload.RecredentialingDueDate.Value;
+                var dueUtc = due.Kind switch
+                {
+                    DateTimeKind.Utc => due,
+                    DateTimeKind.Local => due.ToUniversalTime(),
+                    _ => DateTime.SpecifyKind(due, DateTimeKind.Utc),
+                };
+                if (dueUtc < asOf.UtcDateTime) return CredentialingStatus.Expired;
             }
             return CredentialingStatus.Approved;
         }

--- a/src/services/provider-service/Services/CredentialingProjector.cs
+++ b/src/services/provider-service/Services/CredentialingProjector.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+using ProviderService.Models;
+using ProviderService.Models.CredentialingPayloads;
+using CloudHealthOffice.Infrastructure.Json;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Pure function projecting an append-only
+/// <see cref="CredentialingEvent"/> chain into the collapsed status
+/// representation surfaced on <see cref="Provider"/> and returned by
+/// <c>GET /credentialing/status</c>. No I/O, no mutable state — safe to
+/// register as a singleton.
+///
+/// <para>
+/// The projector is the single authority on the
+/// <c>events → CredentialingStatus</c> mapping. Both the read-side
+/// (<see cref="ICredentialingService.GetCurrentStatusAsync"/>) and the
+/// write-side projection-patch use it to compute the exact value to
+/// store on <see cref="Provider"/>; there is no second source of truth.
+/// </para>
+/// </summary>
+public sealed class CredentialingProjector
+{
+    /// <summary>
+    /// Project the chain into a collapsed status snapshot. Events must be
+    /// supplied in ascending <see cref="CredentialingEvent.Version"/> order
+    /// (oldest first); the caller is responsible for sorting.
+    /// </summary>
+    public CredentialingProjectionResult Project(
+        IReadOnlyList<CredentialingEvent> eventsAscendingByVersion,
+        DateTimeOffset asOf)
+    {
+        if (eventsAscendingByVersion == null || eventsAscendingByVersion.Count == 0)
+        {
+            return CredentialingProjectionResult.Empty;
+        }
+
+        string? currentApplicationEventId = null;
+        DateTimeOffset? applicationSubmittedAt = null;
+
+        // Most-recent terminal decision and its dates. Survives
+        // RecredentialingTriggered (re-cred opens a new chain but the prior
+        // approval's dates remain the predecessor for restore-on-withdraw).
+        DecisionRecordedPayload? lastDecisionPayload = null;
+        DateTimeOffset? lastDecidedAt = null;
+
+        // True between RecredentialingTriggered and the next terminal
+        // decision (or withdraw of the re-cred application).
+        bool recredentialingPending = false;
+
+        foreach (var evt in eventsAscendingByVersion)
+        {
+            switch (evt.EventType)
+            {
+                case CredentialingEventType.ApplicationSubmitted:
+                    var submittedPayload = TryGetPayload<ApplicationSubmittedPayload>(evt);
+                    // Defense in depth: applications synthesized by the
+                    // legacy PUT /credentialing shim are paired with a
+                    // matching DecisionRecorded by construction. Treat
+                    // them as already-closed at projection time so a
+                    // future bug producing an orphaned synthesized
+                    // application can never present as a stuck open
+                    // chain.
+                    if (submittedPayload is { SynthesizedForDelegatedAuthority: true })
+                    {
+                        break;
+                    }
+                    currentApplicationEventId = evt.EventId;
+                    applicationSubmittedAt = submittedPayload?.SubmittedAt;
+                    break;
+
+                case CredentialingEventType.PrimarySourceVerificationCompleted:
+                case CredentialingEventType.CommitteeReviewScheduled:
+                    // Informational — no projection state change. The chain
+                    // stays open until DecisionRecorded or ApplicationWithdrawn.
+                    break;
+
+                case CredentialingEventType.DecisionRecorded:
+                    var decision = TryGetPayload<DecisionRecordedPayload>(evt);
+                    if (decision != null)
+                    {
+                        lastDecisionPayload = decision;
+                        lastDecidedAt = decision.DecidedAt;
+                    }
+                    currentApplicationEventId = null;
+                    applicationSubmittedAt = null;
+                    recredentialingPending = false;
+                    break;
+
+                case CredentialingEventType.RecredentialingTriggered:
+                    recredentialingPending = true;
+                    // The chain is "open for re-credentialing" but no new
+                    // ApplicationSubmitted has fired yet. Keep
+                    // currentApplicationEventId null until the next
+                    // ApplicationSubmitted lands.
+                    break;
+
+                case CredentialingEventType.ApplicationWithdrawn:
+                    currentApplicationEventId = null;
+                    applicationSubmittedAt = null;
+                    recredentialingPending = false;
+                    // Predecessor decision (if any) is restored by the
+                    // status-mapping below — no extra bookkeeping needed.
+                    break;
+
+                case CredentialingEventType.Unknown:
+                default:
+                    break;
+            }
+        }
+
+        var status = ComputeStatus(
+            currentApplicationEventId,
+            recredentialingPending,
+            lastDecisionPayload,
+            asOf);
+
+        var credentialingDate = status == CredentialingStatus.Approved || status == CredentialingStatus.Expired
+            ? lastDecisionPayload?.CredentialingDate
+            : null;
+        var recredentialingDueDate = status == CredentialingStatus.Approved || status == CredentialingStatus.Expired
+            ? lastDecisionPayload?.RecredentialingDueDate
+            : null;
+
+        return new CredentialingProjectionResult(
+            Status: status,
+            CredentialingDate: credentialingDate,
+            RecredentialingDueDate: recredentialingDueDate,
+            CurrentApplicationEventId: currentApplicationEventId,
+            ApplicationSubmittedAt: applicationSubmittedAt,
+            LastDecisionAuthorityId: lastDecisionPayload?.DecisionAuthorityId,
+            LastDecisionAuthorityType: lastDecisionPayload?.DecisionAuthorityType,
+            LastDecidedAt: lastDecidedAt,
+            EventCount: eventsAscendingByVersion.Count,
+            LatestVersion: eventsAscendingByVersion[^1].Version);
+    }
+
+    private static CredentialingStatus ComputeStatus(
+        string? currentApplicationEventId,
+        bool recredentialingPending,
+        DecisionRecordedPayload? lastDecisionPayload,
+        DateTimeOffset asOf)
+    {
+        // Open application (initial or re-cred) outranks everything else —
+        // we report Pending while the workflow is in flight.
+        if (currentApplicationEventId != null) return CredentialingStatus.Pending;
+
+        // Re-credentialing triggered but new application not yet submitted.
+        if (recredentialingPending) return CredentialingStatus.Pending;
+
+        // No open chain. Status reflects the last terminal decision.
+        if (lastDecisionPayload == null) return CredentialingStatus.Unknown;
+
+        if (lastDecisionPayload.Decision == CredentialingDecision.Denied)
+            return CredentialingStatus.Denied;
+
+        if (lastDecisionPayload.Decision == CredentialingDecision.Approved)
+        {
+            // Compute Expired at read time when the recredentialing-due
+            // date has elapsed. The flat field on Provider is patched on
+            // each event transition with the projector's at-write-time
+            // verdict; readers who consult the projector directly get a
+            // fresh evaluation each time.
+            if (lastDecisionPayload.RecredentialingDueDate.HasValue
+                && lastDecisionPayload.RecredentialingDueDate.Value.ToUniversalTime() < asOf.UtcDateTime)
+            {
+                return CredentialingStatus.Expired;
+            }
+            return CredentialingStatus.Approved;
+        }
+
+        return CredentialingStatus.Unknown;
+    }
+
+    private static T? TryGetPayload<T>(CredentialingEvent evt) where T : class
+    {
+        if (evt.Payload == null) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<T>(
+                evt.Payload.ToJsonString(),
+                CloudHealthOfficeJsonOptions.DefaultOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Read-side aggregate produced by <see cref="CredentialingProjector"/>.
+/// Returned by <c>GET /providers/{id}/credentialing/status</c> and
+/// consumed by <see cref="CredentialingService"/> when patching the
+/// flat-field projection on <see cref="Provider"/>.
+/// </summary>
+public sealed record CredentialingProjectionResult(
+    CredentialingStatus Status,
+    DateTime? CredentialingDate,
+    DateTime? RecredentialingDueDate,
+    string? CurrentApplicationEventId,
+    DateTimeOffset? ApplicationSubmittedAt,
+    string? LastDecisionAuthorityId,
+    DecisionAuthorityType? LastDecisionAuthorityType,
+    DateTimeOffset? LastDecidedAt,
+    int EventCount,
+    int LatestVersion)
+{
+    public static readonly CredentialingProjectionResult Empty = new(
+        Status: CredentialingStatus.Unknown,
+        CredentialingDate: null,
+        RecredentialingDueDate: null,
+        CurrentApplicationEventId: null,
+        ApplicationSubmittedAt: null,
+        LastDecisionAuthorityId: null,
+        LastDecisionAuthorityType: null,
+        LastDecidedAt: null,
+        EventCount: 0,
+        LatestVersion: 0);
+}

--- a/src/services/provider-service/Services/CredentialingService.cs
+++ b/src/services/provider-service/Services/CredentialingService.cs
@@ -76,6 +76,18 @@ public sealed class CredentialingValidationException : InvalidOperationException
     public CredentialingValidationException(string message) : base(message) { }
 }
 
+/// <summary>
+/// Thrown when a credentialing-workflow operation targets a provider
+/// that does not exist in the tenant. Mapped to HTTP 404 by the
+/// controller. Distinct from
+/// <see cref="CredentialingValidationException"/> so callers can tell
+/// "wrong state" apart from "wrong target."
+/// </summary>
+public sealed class CredentialingNotFoundException : InvalidOperationException
+{
+    public CredentialingNotFoundException(string message) : base(message) { }
+}
+
 public sealed class CredentialingService : ICredentialingService
 {
     private readonly ICredentialingEventRepository _eventRepository;
@@ -104,6 +116,7 @@ public sealed class CredentialingService : ICredentialingService
         string? actorId, string? correlationId, CancellationToken ct = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -143,6 +156,7 @@ public sealed class CredentialingService : ICredentialingService
         string? actorId, string? correlationId, CancellationToken ct = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -184,6 +198,7 @@ public sealed class CredentialingService : ICredentialingService
         string? actorId, string? correlationId, CancellationToken ct = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -228,6 +243,28 @@ public sealed class CredentialingService : ICredentialingService
             throw new CredentialingValidationException(
                 "Decision must be Approved or Denied.");
         }
+        if (string.IsNullOrEmpty(request.DecisionAuthorityId))
+        {
+            throw new CredentialingValidationException(
+                "DecisionAuthorityId is required.");
+        }
+        // Committee decisions are audit-grade — minutes and member roster
+        // must be captured at write time. The other authority types are
+        // single-actor paths where these fields don't apply.
+        if (request.DecisionAuthorityType == DecisionAuthorityType.CredentialingCommittee)
+        {
+            if (request.CommitteeMembers == null || request.CommitteeMembers.Count == 0)
+            {
+                throw new CredentialingValidationException(
+                    "CommitteeMembers is required for CredentialingCommittee decisions.");
+            }
+            if (string.IsNullOrEmpty(request.DecisionMinuteReference))
+            {
+                throw new CredentialingValidationException(
+                    "DecisionMinuteReference is required for CredentialingCommittee decisions.");
+            }
+        }
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -315,6 +352,7 @@ public sealed class CredentialingService : ICredentialingService
         string? actorId, string? correlationId, CancellationToken ct = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -369,6 +407,7 @@ public sealed class CredentialingService : ICredentialingService
         if (request == null) throw new ArgumentNullException(nameof(request));
         if (string.IsNullOrEmpty(applicationEventId))
             throw new ArgumentException("applicationEventId is required.", nameof(applicationEventId));
+        await EnsureProviderExistsAsync(providerId);
 
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
@@ -420,6 +459,23 @@ public sealed class CredentialingService : ICredentialingService
         string tenantId, string providerId,
         string? continuationToken, int limit, CancellationToken ct = default)
         => _eventRepository.ListHistoryDescendingAsync(tenantId, providerId, continuationToken, limit, ct);
+
+    private async Task EnsureProviderExistsAsync(string providerId)
+    {
+        // Status-changing operations must target a real provider —
+        // otherwise the chain accumulates events for an entity that
+        // can never present a flat-field projection (the patch will
+        // return false). Reads (GetCurrentStatusAsync, GetHistoryAsync)
+        // intentionally do NOT enforce this so admins can inspect a
+        // chain even after the underlying provider row has been
+        // deleted.
+        var provider = await _providerRepository.GetByIdAsync(providerId);
+        if (provider == null)
+        {
+            throw new CredentialingNotFoundException(
+                $"Provider {providerId} not found.");
+        }
+    }
 
     private async Task PatchProjectionAsync(
         string tenantId,

--- a/src/services/provider-service/Services/CredentialingService.cs
+++ b/src/services/provider-service/Services/CredentialingService.cs
@@ -1,0 +1,479 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CloudHealthOffice.Infrastructure.Json;
+using ProviderService.Models;
+using ProviderService.Models.CredentialingPayloads;
+using ProviderService.Repositories;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Workflow orchestration for the credentialing event chain (capability
+/// 5.6). Each method follows the canonical write order:
+/// <list type="number">
+///   <item>Read the chain ascending by Version.</item>
+///   <item>Project the pre-state.</item>
+///   <item>Validate the request against the pre-state.</item>
+///   <item>Build a typed event with deterministic EventId.</item>
+///   <item>Publish via <see cref="ICredentialingEventPublisher"/> (idempotent).</item>
+///   <item>For status-changing events: re-project including the new event,
+///         then patch the flat-field projection on <see cref="Provider"/>
+///         via <see cref="IProviderRepository.UpdateCredentialingProjectionAsync"/>.</item>
+/// </list>
+/// The publisher is the system-of-record; the projection patch is a
+/// best-effort denormalization for fast reads. If the patch fails after
+/// the event lands, the event remains and the next transition recovers.
+/// </summary>
+public interface ICredentialingService
+{
+    Task<CredentialingEvent> SubmitApplicationAsync(
+        string tenantId, string providerId,
+        SubmitApplicationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingEvent> RecordPrimarySourceVerificationAsync(
+        string tenantId, string providerId,
+        RecordPrimarySourceVerificationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingEvent> ScheduleCommitteeReviewAsync(
+        string tenantId, string providerId,
+        ScheduleCommitteeReviewRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingEvent> RecordDecisionAsync(
+        string tenantId, string providerId,
+        RecordDecisionRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingEvent> TriggerRecredentialingAsync(
+        string tenantId, string providerId,
+        TriggerRecredentialingRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingEvent> WithdrawApplicationAsync(
+        string tenantId, string providerId,
+        string applicationEventId,
+        WithdrawApplicationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default);
+
+    Task<CredentialingProjectionResult> GetCurrentStatusAsync(
+        string tenantId, string providerId, CancellationToken ct = default);
+
+    Task<CredentialingHistoryPage> GetHistoryAsync(
+        string tenantId, string providerId,
+        string? continuationToken, int limit, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Thrown when a credentialing-workflow operation is invalid for the
+/// current chain state (e.g. recording a decision without an open
+/// application, triggering re-credentialing without a prior approval).
+/// Mapped to HTTP 400 by the controller.
+/// </summary>
+public sealed class CredentialingValidationException : InvalidOperationException
+{
+    public CredentialingValidationException(string message) : base(message) { }
+}
+
+public sealed class CredentialingService : ICredentialingService
+{
+    private readonly ICredentialingEventRepository _eventRepository;
+    private readonly ICredentialingEventPublisher _eventPublisher;
+    private readonly IProviderRepository _providerRepository;
+    private readonly CredentialingProjector _projector;
+    private readonly ILogger<CredentialingService> _logger;
+
+    public CredentialingService(
+        ICredentialingEventRepository eventRepository,
+        ICredentialingEventPublisher eventPublisher,
+        IProviderRepository providerRepository,
+        CredentialingProjector projector,
+        ILogger<CredentialingService> logger)
+    {
+        _eventRepository = eventRepository;
+        _eventPublisher = eventPublisher;
+        _providerRepository = providerRepository;
+        _projector = projector;
+        _logger = logger;
+    }
+
+    public async Task<CredentialingEvent> SubmitApplicationAsync(
+        string tenantId, string providerId,
+        SubmitApplicationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+        if (preState.CurrentApplicationEventId != null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} already has an open credentialing application " +
+                $"(EventId={preState.CurrentApplicationEventId}). Withdraw it before submitting a new one.");
+        }
+
+        var submittedAt = (request.SubmittedAt ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var payload = new ApplicationSubmittedPayload(
+            SubmittedAt: submittedAt,
+            ApplicationSource: request.ApplicationSource,
+            SupportingDocuments: request.SupportingDocuments);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildApplicationSubmittedEventId(providerId, submittedAt),
+            EventType = CredentialingEventType.ApplicationSubmitted,
+            OccurredAt = submittedAt.UtcDateTime,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        var published = await _eventPublisher.PublishAsync(evt, ct);
+        await PatchProjectionAsync(tenantId, providerId, chain, published, ct);
+        return published;
+    }
+
+    public async Task<CredentialingEvent> RecordPrimarySourceVerificationAsync(
+        string tenantId, string providerId,
+        RecordPrimarySourceVerificationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+        if (preState.CurrentApplicationEventId == null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} has no open credentialing application; " +
+                "cannot record primary-source verification.");
+        }
+
+        var verifiedAt = (request.VerifiedAt ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var payload = new PrimarySourceVerificationPayload(
+            VerifiedAt: verifiedAt,
+            VerificationVendor: request.VerificationVendor,
+            VerifiedItems: request.VerifiedItems,
+            Evidence: request.Evidence);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildPrimarySourceVerificationEventId(
+                providerId, preState.CurrentApplicationEventId, verifiedAt),
+            EventType = CredentialingEventType.PrimarySourceVerificationCompleted,
+            OccurredAt = verifiedAt.UtcDateTime,
+            ApplicationEventId = preState.CurrentApplicationEventId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        // Status-neutral event — no projection patch.
+        return await _eventPublisher.PublishAsync(evt, ct);
+    }
+
+    public async Task<CredentialingEvent> ScheduleCommitteeReviewAsync(
+        string tenantId, string providerId,
+        ScheduleCommitteeReviewRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+        if (preState.CurrentApplicationEventId == null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} has no open credentialing application; " +
+                "cannot schedule a committee review.");
+        }
+
+        var scheduledFor = request.ScheduledFor.ToUniversalTime();
+        var payload = new CommitteeReviewScheduledPayload(
+            ScheduledFor: scheduledFor,
+            CommitteeId: request.CommitteeId,
+            AgendaReference: request.AgendaReference);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildCommitteeReviewScheduledEventId(
+                providerId, preState.CurrentApplicationEventId, scheduledFor),
+            EventType = CredentialingEventType.CommitteeReviewScheduled,
+            OccurredAt = DateTime.UtcNow,
+            ApplicationEventId = preState.CurrentApplicationEventId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        return await _eventPublisher.PublishAsync(evt, ct);
+    }
+
+    public async Task<CredentialingEvent> RecordDecisionAsync(
+        string tenantId, string providerId,
+        RecordDecisionRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (request.Decision != CredentialingDecision.Approved && request.Decision != CredentialingDecision.Denied)
+        {
+            throw new CredentialingValidationException(
+                "Decision must be Approved or Denied.");
+        }
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+
+        var decidedAt = (request.DecidedAt ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var applicationEventId = preState.CurrentApplicationEventId;
+
+        // The legacy PUT /credentialing path uses DelegatedAuthority to
+        // skip the "open application required" guard. When no chain is
+        // open, synthesize a paired ApplicationSubmitted event with a
+        // deterministic EventId so retries collapse, then proceed with
+        // the decision. The synthesized application is filtered out by
+        // the projector (defense in depth) — it never appears as an
+        // open chain even if a future bug orphans one.
+        if (applicationEventId == null)
+        {
+            if (request.DecisionAuthorityType != DecisionAuthorityType.DelegatedAuthority)
+            {
+                throw new CredentialingValidationException(
+                    $"Provider {providerId} has no open credentialing application; " +
+                    "submit an application before recording a decision.");
+            }
+
+            var decisionEventId = CredentialingEvent.BuildDecisionRecordedEventId(
+                providerId, applicationEventId: "synthesized", decidedAt);
+            var synthesizedEventId = CredentialingEvent.BuildSynthesizedApplicationSubmittedEventId(
+                providerId, decisionEventId);
+
+            var synthesizedPayload = new ApplicationSubmittedPayload(
+                SubmittedAt: decidedAt,
+                ApplicationSource: "DelegatedAuthority",
+                SupportingDocuments: null,
+                SynthesizedForDelegatedAuthority: true);
+
+            var synthesized = new CredentialingEvent
+            {
+                TenantId = tenantId,
+                ProviderId = providerId,
+                EventId = synthesizedEventId,
+                EventType = CredentialingEventType.ApplicationSubmitted,
+                OccurredAt = decidedAt.UtcDateTime,
+                ActorId = actorId,
+                CorrelationId = correlationId,
+                Payload = SerializePayload(synthesizedPayload),
+            };
+
+            await _eventPublisher.PublishAsync(synthesized, ct);
+            applicationEventId = synthesizedEventId;
+        }
+
+        var payload = new DecisionRecordedPayload(
+            Decision: request.Decision,
+            DecidedAt: decidedAt,
+            CredentialingDate: request.CredentialingDate
+                ?? (request.Decision == CredentialingDecision.Approved ? decidedAt.UtcDateTime : null),
+            RecredentialingDueDate: request.RecredentialingDueDate,
+            DecisionAuthorityType: request.DecisionAuthorityType,
+            DecisionAuthorityId: request.DecisionAuthorityId,
+            CommitteeMembers: request.CommitteeMembers,
+            DecisionMinuteReference: request.DecisionMinuteReference,
+            DenialReason: request.DenialReason);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildDecisionRecordedEventId(
+                providerId, applicationEventId, decidedAt),
+            EventType = CredentialingEventType.DecisionRecorded,
+            OccurredAt = decidedAt.UtcDateTime,
+            ApplicationEventId = applicationEventId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        var published = await _eventPublisher.PublishAsync(evt, ct);
+        await PatchProjectionAsync(tenantId, providerId, chain, published, ct);
+        return published;
+    }
+
+    public async Task<CredentialingEvent> TriggerRecredentialingAsync(
+        string tenantId, string providerId,
+        TriggerRecredentialingRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+
+        if (preState.CurrentApplicationEventId != null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} already has an open credentialing application " +
+                "or pending re-credentialing chain.");
+        }
+        if (preState.LastDecidedAt == null
+            || preState.LastDecisionAuthorityType == null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} has no prior decision; " +
+                "submit an initial application instead of triggering re-credentialing.");
+        }
+
+        var triggeredAt = (request.TriggeredAt ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var predecessorEventId = chain
+            .LastOrDefault(e => e.EventType == CredentialingEventType.DecisionRecorded)
+            ?.EventId;
+
+        var payload = new RecredentialingTriggeredPayload(
+            TriggeredAt: triggeredAt,
+            Reason: request.Reason);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildRecredentialingTriggeredEventId(providerId, triggeredAt),
+            EventType = CredentialingEventType.RecredentialingTriggered,
+            OccurredAt = triggeredAt.UtcDateTime,
+            PredecessorEventId = predecessorEventId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        var published = await _eventPublisher.PublishAsync(evt, ct);
+        await PatchProjectionAsync(tenantId, providerId, chain, published, ct);
+        return published;
+    }
+
+    public async Task<CredentialingEvent> WithdrawApplicationAsync(
+        string tenantId, string providerId,
+        string applicationEventId,
+        WithdrawApplicationRequest request,
+        string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        if (string.IsNullOrEmpty(applicationEventId))
+            throw new ArgumentException("applicationEventId is required.", nameof(applicationEventId));
+
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        var preState = _projector.Project(chain, DateTimeOffset.UtcNow);
+
+        if (preState.CurrentApplicationEventId == null)
+        {
+            throw new CredentialingValidationException(
+                $"Provider {providerId} has no open credentialing application to withdraw.");
+        }
+        if (!string.Equals(preState.CurrentApplicationEventId, applicationEventId, StringComparison.Ordinal))
+        {
+            throw new CredentialingValidationException(
+                $"applicationEventId {applicationEventId} does not match the open application " +
+                $"({preState.CurrentApplicationEventId}).");
+        }
+
+        var withdrawnAt = (request.WithdrawnAt ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var payload = new ApplicationWithdrawnPayload(
+            WithdrawnAt: withdrawnAt,
+            Reason: request.Reason);
+
+        var evt = new CredentialingEvent
+        {
+            TenantId = tenantId,
+            ProviderId = providerId,
+            EventId = CredentialingEvent.BuildApplicationWithdrawnEventId(
+                providerId, applicationEventId, withdrawnAt),
+            EventType = CredentialingEventType.ApplicationWithdrawn,
+            OccurredAt = withdrawnAt.UtcDateTime,
+            ApplicationEventId = applicationEventId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = SerializePayload(payload),
+        };
+
+        var published = await _eventPublisher.PublishAsync(evt, ct);
+        await PatchProjectionAsync(tenantId, providerId, chain, published, ct);
+        return published;
+    }
+
+    public async Task<CredentialingProjectionResult> GetCurrentStatusAsync(
+        string tenantId, string providerId, CancellationToken ct = default)
+    {
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        return _projector.Project(chain, DateTimeOffset.UtcNow);
+    }
+
+    public Task<CredentialingHistoryPage> GetHistoryAsync(
+        string tenantId, string providerId,
+        string? continuationToken, int limit, CancellationToken ct = default)
+        => _eventRepository.ListHistoryDescendingAsync(tenantId, providerId, continuationToken, limit, ct);
+
+    private async Task PatchProjectionAsync(
+        string tenantId,
+        string providerId,
+        IReadOnlyList<CredentialingEvent> existingChain,
+        CredentialingEvent published,
+        CancellationToken ct)
+    {
+        // Re-project including the just-published event and patch the
+        // flat-field projection on Provider. The projection is
+        // best-effort — if the patch fails (e.g. no Active head exists
+        // because the provider is still a Draft chain), log a warning
+        // and continue. The event is the system-of-record; the next
+        // transition will reconcile.
+        var withNew = existingChain
+            .Where(e => e.EventId != published.EventId)
+            .Append(published)
+            .OrderBy(e => e.Version)
+            .ToList();
+        var projection = _projector.Project(withNew, DateTimeOffset.UtcNow);
+
+        try
+        {
+            var patched = await _providerRepository.UpdateCredentialingProjectionAsync(
+                tenantId,
+                providerId,
+                projection.Status,
+                projection.CredentialingDate,
+                projection.RecredentialingDueDate,
+                ct);
+            if (!patched)
+            {
+                _logger.LogWarning(
+                    "CredentialingProjection patch returned false for {Tenant}:{Provider}; " +
+                    "no Active head row found. Event {EventId} ({EventType}) was still appended.",
+                    Sanitize(tenantId), Sanitize(providerId), Sanitize(published.EventId), published.EventType);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "CredentialingProjection patch failed for {Tenant}:{Provider}; " +
+                "event {EventId} ({EventType}) is appended but the flat projection is stale.",
+                Sanitize(tenantId), Sanitize(providerId), Sanitize(published.EventId), published.EventType);
+        }
+    }
+
+    private static JsonObject? SerializePayload<T>(T payload) where T : class
+    {
+        if (payload == null) return null;
+        var json = JsonSerializer.Serialize(payload, CloudHealthOfficeJsonOptions.DefaultOptions);
+        return JsonNode.Parse(json) as JsonObject;
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using ProviderService.Controllers;
 using ProviderService.Models;
+using ProviderService.Repositories;
 using ProviderService.Services;
 
 namespace CloudHealthOffice.ProviderService.Tests.Controllers;

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerTests.cs
@@ -1,0 +1,160 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Endpoint-shape coverage for <see cref="CredentialingController"/>: each
+/// route surfaces the right status code on happy path, validation
+/// failure, and publisher exhaustion.
+/// </summary>
+public class CredentialingControllerTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryCredentialingEventRepository _eventRepository = new();
+    private readonly FakeCredentialingEventPublisher _publisher;
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly CredentialingService _service;
+    private readonly CredentialingController _controller;
+
+    public CredentialingControllerTests()
+    {
+        _publisher = new FakeCredentialingEventPublisher(_eventRepository);
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        SeedActiveProvider();
+        _service = new CredentialingService(
+            _eventRepository, _publisher, _providerRepository,
+            new CredentialingProjector(),
+            NullLogger<CredentialingService>.Instance);
+        _controller = new CredentialingController(_service, NullLogger<CredentialingController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    [Fact]
+    public async Task SubmitApplication_returns_201_on_happy_path()
+    {
+        var result = await _controller.SubmitApplication(
+            ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" },
+            CancellationToken.None);
+        var created = result.Result as CreatedResult;
+        created.Should().NotBeNull();
+        created!.Value.Should().BeOfType<CredentialingEvent>();
+    }
+
+    [Fact]
+    public async Task SubmitApplication_returns_400_when_application_already_open()
+    {
+        await _controller.SubmitApplication(
+            ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" },
+            CancellationToken.None);
+
+        var second = await _controller.SubmitApplication(
+            ProviderId,
+            new SubmitApplicationRequest
+            {
+                ApplicationSource = "Manual",
+                SubmittedAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            },
+            CancellationToken.None);
+        second.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetStatus_returns_unknown_for_provider_with_no_chain()
+    {
+        var result = await _controller.GetStatus("never-credentialed", CancellationToken.None);
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var projection = ok!.Value as CredentialingProjectionResult;
+        projection.Should().NotBeNull();
+        projection!.Status.Should().Be(CredentialingStatus.Unknown);
+    }
+
+    [Fact]
+    public async Task GetHistory_returns_paged_descending_with_continuation()
+    {
+        await _controller.SubmitApplication(
+            ProviderId,
+            new SubmitApplicationRequest
+            {
+                ApplicationSource = "Manual",
+                SubmittedAt = DateTimeOffset.UtcNow.AddMinutes(-3),
+            },
+            CancellationToken.None);
+        await _controller.RecordPrimarySourceVerification(
+            ProviderId,
+            new RecordPrimarySourceVerificationRequest
+            {
+                VerificationVendor = "CAQH",
+                VerifiedItems = new[] { "License" },
+                VerifiedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+            },
+            CancellationToken.None);
+
+        var result = await _controller.GetHistory(ProviderId, cursor: null, limit: 1, CancellationToken.None);
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var page = ok!.Value as CredentialingHistoryPage;
+        page.Should().NotBeNull();
+        page!.Items.Should().HaveCount(1);
+        page.ContinuationToken.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RecordDecision_returns_201_with_DelegatedAuthority_synthesizing_application()
+    {
+        var result = await _controller.RecordDecision(
+            ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.DelegatedAuthority,
+                DecisionAuthorityId = "delegated-actor",
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            CancellationToken.None);
+        result.Result.Should().BeOfType<CreatedResult>();
+    }
+
+    [Fact]
+    public async Task TriggerRecredentialing_returns_400_without_prior_approval()
+    {
+        var result = await _controller.TriggerRecredentialing(
+            ProviderId,
+            new TriggerRecredentialingRequest { Reason = "DueDateElapsed" },
+            CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    private void SeedActiveProvider()
+    {
+        _providerRepository.CreateAsync(new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Provider",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = ProviderId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        }).GetAwaiter().GetResult();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerCredentialingTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerCredentialingTests.cs
@@ -1,0 +1,177 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Regression coverage for the legacy
+/// <c>PUT /api/v1/providers/{id}/credentialing</c> endpoint after the
+/// 5.6 rewire. Pre-rewire this endpoint called
+/// <see cref="IProviderRepository.UpdateAsync"/> on Active providers and
+/// always returned 409 (the bug capability 5.6 fixes). Post-rewire the
+/// endpoint funnels through the event-sourced credentialing workflow
+/// with <see cref="DecisionAuthorityType.DelegatedAuthority"/> and
+/// always succeeds on Active providers.
+/// </summary>
+public class ProvidersControllerCredentialingTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryCredentialingEventRepository _eventRepository = new();
+    private readonly FakeCredentialingEventPublisher _publisher;
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly CredentialingService _credentialing;
+    private readonly ProvidersController _controller;
+
+    public ProvidersControllerCredentialingTests()
+    {
+        _publisher = new FakeCredentialingEventPublisher(_eventRepository);
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        SeedActiveProvider();
+        _credentialing = new CredentialingService(
+            _eventRepository, _publisher, _providerRepository,
+            new CredentialingProjector(),
+            NullLogger<CredentialingService>.Instance);
+
+        _controller = new ProvidersController(
+            providerRepository: _providerRepository,
+            versioning: null!,
+            adapterFactory: null!,
+            integrityProjection: null!,
+            panelGatingValidator: null!,
+            credentialing: _credentialing,
+            logger: NullLogger<ProvidersController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    [Fact]
+    public async Task Legacy_PUT_credentialing_against_active_provider_returns_200_not_409()
+    {
+        // The headline regression: pre-5.6 this returned 409 because
+        // the underlying UpdateAsync rejects non-Draft rows. Post-5.6
+        // the endpoint emits a DecisionRecorded event with
+        // DelegatedAuthority and patches the projection.
+        var result = await _controller.UpdateCredentialing(
+            ProviderId,
+            new CredentialingUpdateRequest
+            {
+                Status = CredentialingStatus.Approved,
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            CancellationToken.None);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var provider = ok!.Value as Provider;
+        provider.Should().NotBeNull();
+        provider!.CredentialingStatus.Should().Be(CredentialingStatus.Approved);
+    }
+
+    [Fact]
+    public async Task Legacy_PUT_credentialing_writes_DecisionRecorded_event_with_DelegatedAuthority()
+    {
+        await _controller.UpdateCredentialing(
+            ProviderId,
+            new CredentialingUpdateRequest
+            {
+                Status = CredentialingStatus.Approved,
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            CancellationToken.None);
+
+        _eventRepository.Store
+            .Should().Contain(e =>
+                e.TenantId == TenantId
+                && e.ProviderId == ProviderId
+                && e.EventType == CredentialingEventType.DecisionRecorded);
+
+        // The synthesized application event must be present too.
+        _eventRepository.Store
+            .Should().Contain(e =>
+                e.TenantId == TenantId
+                && e.ProviderId == ProviderId
+                && e.EventType == CredentialingEventType.ApplicationSubmitted
+                && e.EventId.StartsWith("synthesized-application:"));
+    }
+
+    [Fact]
+    public async Task Legacy_PUT_credentialing_with_unsupported_status_returns_400()
+    {
+        // Pending / Expired / Suspended have no event-chain analogue.
+        // The endpoint must surface 400 with a hint, not silently
+        // succeed or 500.
+        var result = await _controller.UpdateCredentialing(
+            ProviderId,
+            new CredentialingUpdateRequest
+            {
+                Status = CredentialingStatus.Suspended,
+                CredentialingDate = DateTime.UtcNow,
+            },
+            CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Legacy_PUT_credentialing_returns_404_when_provider_missing()
+    {
+        var result = await _controller.UpdateCredentialing(
+            "missing-provider",
+            new CredentialingUpdateRequest
+            {
+                Status = CredentialingStatus.Approved,
+            },
+            CancellationToken.None);
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task Legacy_PUT_credentialing_is_idempotent_for_same_decision()
+    {
+        var when = DateTime.UtcNow;
+        var request = new CredentialingUpdateRequest
+        {
+            Status = CredentialingStatus.Approved,
+            CredentialingDate = when,
+            RecredentialingDueDate = when.AddYears(2),
+        };
+
+        await _controller.UpdateCredentialing(ProviderId, request, CancellationToken.None);
+        await _controller.UpdateCredentialing(ProviderId, request, CancellationToken.None);
+
+        // Two events: synthesized application + decision. Retrying the
+        // same instant must not double-write either.
+        _eventRepository.Store
+            .Count(e => e.TenantId == TenantId && e.ProviderId == ProviderId)
+            .Should().Be(2);
+    }
+
+    private void SeedActiveProvider()
+    {
+        _providerRepository.CreateAsync(new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Provider",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = ProviderId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        }).GetAwaiter().GetResult();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeCredentialingEventPublisher.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/FakeCredentialingEventPublisher.cs
@@ -1,0 +1,43 @@
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ICredentialingEventPublisher"/> that mirrors the
+/// production semantics needed by service-level tests: deterministic
+/// EventId-based idempotency, monotonic Version per (TenantId, ProviderId),
+/// PartitionKey + Mongo-style _id assignment. Wraps an
+/// <see cref="InMemoryCredentialingEventRepository"/> so a single store
+/// is shared with the service's read-side dependency.
+/// </summary>
+public sealed class FakeCredentialingEventPublisher : ICredentialingEventPublisher
+{
+    private readonly InMemoryCredentialingEventRepository _repository;
+
+    public FakeCredentialingEventPublisher(InMemoryCredentialingEventRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<CredentialingEvent> PublishAsync(CredentialingEvent evt, CancellationToken ct = default)
+    {
+        evt.PartitionKey = CredentialingEvent.BuildPartitionKey(evt.TenantId, evt.ProviderId);
+        evt.Id = $"{evt.PartitionKey}:{evt.EventId}";
+        if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
+
+        var existing = _repository.Store.FirstOrDefault(e =>
+            e.TenantId == evt.TenantId && e.ProviderId == evt.ProviderId && e.EventId == evt.EventId);
+        if (existing != null) return Task.FromResult(existing);
+
+        var nextVersion = _repository.Store
+            .Where(e => e.TenantId == evt.TenantId && e.ProviderId == evt.ProviderId)
+            .Select(e => e.Version)
+            .DefaultIfEmpty(0)
+            .Max() + 1;
+        evt.Version = nextVersion;
+        _repository.Store.Add(evt);
+        return Task.FromResult(evt);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryCredentialingEventRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryCredentialingEventRepository.cs
@@ -1,0 +1,74 @@
+using System.Text;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace CloudHealthOffice.ProviderService.Tests.Fakes;
+
+/// <summary>
+/// In-memory fake for <see cref="ICredentialingEventRepository"/> backing
+/// the <c>CredentialingService</c> unit tests. Append happens via
+/// <see cref="FakeCredentialingEventPublisher"/>; this fake exposes only
+/// reads — matching the production interface contract.
+/// </summary>
+public sealed class InMemoryCredentialingEventRepository : ICredentialingEventRepository
+{
+    public List<CredentialingEvent> Store { get; } = new();
+
+    public Task<IReadOnlyList<CredentialingEvent>> ListAscendingAsync(
+        string tenantId, string providerId, CancellationToken ct = default)
+    {
+        var rows = Store
+            .Where(e => e.TenantId == tenantId && e.ProviderId == providerId)
+            .OrderBy(e => e.Version)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<CredentialingEvent>>(rows);
+    }
+
+    public Task<CredentialingEvent?> GetByEventIdAsync(
+        string tenantId, string providerId, string eventId, CancellationToken ct = default)
+    {
+        var row = Store.FirstOrDefault(e =>
+            e.TenantId == tenantId && e.ProviderId == providerId && e.EventId == eventId);
+        return Task.FromResult<CredentialingEvent?>(row);
+    }
+
+    public Task<CredentialingHistoryPage> ListHistoryDescendingAsync(
+        string tenantId,
+        string providerId,
+        string? continuationToken,
+        int limit,
+        CancellationToken ct = default)
+    {
+        var safeLimit = Math.Clamp(limit, 1, 200);
+        var afterVersion = DecodeCursor(continuationToken);
+
+        var rows = Store
+            .Where(e => e.TenantId == tenantId && e.ProviderId == providerId)
+            .Where(e => !afterVersion.HasValue || e.Version < afterVersion.Value)
+            .OrderByDescending(e => e.Version)
+            .Take(safeLimit + 1)
+            .ToList();
+
+        string? next = null;
+        if (rows.Count > safeLimit)
+        {
+            rows.RemoveAt(rows.Count - 1);
+            next = EncodeCursor(rows[^1].Version);
+        }
+        return Task.FromResult(new CredentialingHistoryPage(rows, next));
+    }
+
+    private static int? DecodeCursor(string? token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+        try
+        {
+            var bytes = Convert.FromBase64String(token);
+            return int.TryParse(Encoding.UTF8.GetString(bytes), out var v) ? v : null;
+        }
+        catch (FormatException) { return null; }
+    }
+
+    private static string EncodeCursor(int v) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(v.ToString()));
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -463,6 +463,40 @@ public sealed class InMemoryProviderRepository : IProviderRepository
             .ToList();
         return Task.FromResult<IReadOnlyList<Provider>>(slice);
     }
+
+    /// <summary>
+    /// Calls captured by <see cref="UpdateCredentialingProjectionAsync"/>
+    /// — service-level tests inspect this list to assert the projection
+    /// patch was invoked with the expected arguments.
+    /// </summary>
+    public List<(string TenantId, string ProviderId, CredentialingStatus Status, DateTime? CredentialingDate, DateTime? RecredentialingDueDate)> CredentialingProjectionPatches { get; } = new();
+
+    public Task<bool> UpdateCredentialingProjectionAsync(
+        string tenantId,
+        string providerId,
+        CredentialingStatus status,
+        DateTime? credentialingDate,
+        DateTime? recredentialingDueDate,
+        CancellationToken ct = default)
+    {
+        CredentialingProjectionPatches.Add((tenantId, providerId, status, credentialingDate, recredentialingDueDate));
+
+        var head = _docs
+            .Select(d => Hydrate(Clone(d)))
+            .Where(d => d.TenantId == tenantId
+                && (d.ProviderId == providerId || d.Id == providerId)
+                && d.VersionState == ProviderVersionState.Active)
+            .OrderByDescending(d => d.VersionNumber)
+            .FirstOrDefault();
+        if (head == null) return Task.FromResult(false);
+
+        var stored = _docs.First(d => d.Id == head.Id && d.TenantId == head.TenantId);
+        stored.CredentialingStatus = status;
+        stored.CredentialingDate = credentialingDate;
+        stored.RecredentialingDueDate = recredentialingDueDate;
+        stored.LastUpdatedDate = DateTime.UtcNow;
+        return Task.FromResult(true);
+    }
 }
 
 public sealed class InMemoryProviderTransitionRepository : IProviderTransitionRepository

--- a/tests/CloudHealthOffice.ProviderService.Tests/Repositories/UpdateCredentialingProjectionAsyncTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Repositories/UpdateCredentialingProjectionAsyncTests.cs
@@ -1,0 +1,156 @@
+using EphemeralMongo;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace CloudHealthOffice.ProviderService.Tests.Repositories;
+
+/// <summary>
+/// Mongo-backed coverage for the credentialing-projection write path
+/// (capability 5.6): the projection-fields-only patch must succeed
+/// against an Active row WITHOUT triggering the version-state guard
+/// that <see cref="ProviderRepositoryMongo.UpdateAsync"/> enforces.
+/// Identity-field writes against the same Active row must STILL throw.
+/// </summary>
+public class UpdateCredentialingProjectionAsyncTests : IAsyncLifetime
+{
+    private const string Tenant = "tenant-a";
+
+    private IMongoRunner _runner = null!;
+    private IMongoDatabase _database = null!;
+    private ProviderRepositoryMongo _repo = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        _database = client.GetDatabase($"credentialing_projection_writepath_{Guid.NewGuid():N}");
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = Tenant;
+        var accessor = new HttpContextAccessor { HttpContext = ctx };
+        _repo = new ProviderRepositoryMongo(_database, accessor, NullLogger<ProviderRepositoryMongo>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* see MpipRateServiceTests note */ }
+        return Task.CompletedTask;
+    }
+
+    private async Task<Provider> SeedActiveAsync(string providerId, string npi)
+    {
+        var draft = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            TenantId = Tenant,
+            NPI = npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Patch",
+            LastName = "Target",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+        };
+        await _repo.CreateDraftAsync(draft);
+        var head = await _repo.GetVersionAsync(providerId, draft.VersionId);
+        head!.VersionState = ProviderVersionState.Active;
+        await _repo.ActivateAndSupersedeAsync(head, predecessor: null);
+        return head;
+    }
+
+    [Fact]
+    public async Task UpdateCredentialingProjection_patches_active_row_without_state_exception()
+    {
+        await SeedActiveAsync("cp1", "1234567890");
+        var credentialingDate = DateTime.UtcNow;
+        var nextDue = credentialingDate.AddYears(2);
+
+        var patched = await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "cp1", CredentialingStatus.Approved, credentialingDate, nextDue);
+        patched.Should().BeTrue();
+
+        var head = await _repo.GetLatestActiveAsync("cp1", DateTime.UtcNow);
+        head.Should().NotBeNull();
+        head!.CredentialingStatus.Should().Be(CredentialingStatus.Approved);
+        head.CredentialingDate.Should().BeCloseTo(credentialingDate, TimeSpan.FromSeconds(1));
+        head.RecredentialingDueDate.Should().BeCloseTo(nextDue, TimeSpan.FromSeconds(1));
+        head.VersionState.Should().Be(ProviderVersionState.Active);
+    }
+
+    [Fact]
+    public async Task UpdateCredentialingProjection_does_not_create_a_new_version()
+    {
+        await SeedActiveAsync("cp2", "1234567891");
+
+        await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "cp2", CredentialingStatus.Approved, DateTime.UtcNow, DateTime.UtcNow.AddYears(2));
+
+        var (versions, _) = await _repo.ListVersionsAsync("cp2", 25, null);
+        versions.Should().HaveCount(1);
+        versions[0].VersionNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_against_active_still_throws_after_credentialing_patch()
+    {
+        var head = await SeedActiveAsync("cp3", "1234567892");
+        await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "cp3", CredentialingStatus.Approved, DateTime.UtcNow, DateTime.UtcNow.AddYears(2));
+
+        head.PrimarySpecialty = "Tampered";
+        var act = () => _repo.UpdateAsync(head);
+        await act.Should().ThrowAsync<ProviderVersionStateException>()
+            .Where(ex => ex.CurrentState == ProviderVersionState.Active);
+    }
+
+    [Fact]
+    public async Task UpdateCredentialingProjection_returns_false_when_no_active_head()
+    {
+        var patched = await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "missing", CredentialingStatus.Approved,
+            DateTime.UtcNow, DateTime.UtcNow.AddYears(2));
+        patched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateCredentialingProjection_skips_terminated_chain()
+    {
+        var head = await SeedActiveAsync("cp4", "1234567893");
+        head.VersionState = ProviderVersionState.Terminated;
+        head.TerminationDate = DateTime.UtcNow;
+        await _repo.ReplaceVersionRowAsync(head);
+
+        var patched = await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "cp4", CredentialingStatus.Approved,
+            DateTime.UtcNow, DateTime.UtcNow.AddYears(2));
+        patched.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateCredentialingProjection_patches_legacy_row_with_missing_versionState()
+    {
+        // Legacy row: VersionState never persisted, Status=Active.
+        var collection = _database.GetCollection<Provider>("Providers");
+        await collection.InsertOneAsync(new Provider
+        {
+            Id = "legacy-active-cp",
+            TenantId = Tenant,
+            NPI = "9999999990",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Legacy",
+            LastName = "Active",
+            PrimarySpecialty = "Cardiology",
+            TaxonomyCode = "207RC0000X",
+            Status = ProviderStatus.Active,
+        });
+
+        var patched = await _repo.UpdateCredentialingProjectionAsync(
+            Tenant, "legacy-active-cp", CredentialingStatus.Approved,
+            DateTime.UtcNow, DateTime.UtcNow.AddYears(2));
+        patched.Should().BeTrue();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingEventPublisherTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingEventPublisherTests.cs
@@ -1,0 +1,109 @@
+using EphemeralMongo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Mongo-backed publisher coverage for capability 5.6: monotonic
+/// <see cref="CredentialingEvent.Version"/> per
+/// <c>(TenantId, ProviderId)</c>, idempotent re-publish on duplicate
+/// <see cref="CredentialingEvent.EventId"/>, and cross-tenant
+/// <c>_id</c> collision protection (PR 5.4.5 lesson).
+/// </summary>
+public class CredentialingEventPublisherTests : IAsyncLifetime
+{
+    private const string Tenant = "tenant-a";
+    private const string ProviderId = "provider-001";
+
+    private IMongoRunner _runner = null!;
+    private IMongoDatabase _database = null!;
+    private MongoCredentialingEventPublisher _publisher = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        _database = client.GetDatabase($"credentialing_event_test_{Guid.NewGuid():N}");
+        var config = new ConfigurationBuilder().Build();
+        _publisher = new MongoCredentialingEventPublisher(
+            _database, config, NullLogger<MongoCredentialingEventPublisher>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* EphemeralMongo / driver mismatch on disposal */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Publish_assigns_monotonic_version_per_provider()
+    {
+        var v1 = await _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, "evt-1"));
+        var v2 = await _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, "evt-2"));
+        var v3 = await _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, "evt-3"));
+
+        v1.Version.Should().Be(1);
+        v2.Version.Should().Be(2);
+        v3.Version.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Publish_with_duplicate_eventId_is_idempotent()
+    {
+        var evt = BuildSubmitted(Tenant, ProviderId, "evt-dup");
+        var first = await _publisher.PublishAsync(evt);
+        var second = await _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, "evt-dup"));
+
+        first.EventId.Should().Be(second.EventId);
+        first.Version.Should().Be(second.Version);
+    }
+
+    [Fact]
+    public async Task Publish_assigns_partition_scoped_id()
+    {
+        var evt = await _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, "evt-id"));
+        evt.PartitionKey.Should().Be($"{Tenant}:{ProviderId}");
+        evt.Id.Should().Be($"{Tenant}:{ProviderId}:evt-id");
+    }
+
+    [Fact]
+    public async Task Publish_cross_tenant_same_eventId_does_not_collide()
+    {
+        // Two tenants append events with the same EventId (e.g. two
+        // tenants running the legacy PUT /credentialing at the same
+        // instant for providers that happen to share a logical id).
+        // Without the _id = PartitionKey:EventId scope, Mongo would
+        // throw on the second insert.
+        var a = await _publisher.PublishAsync(BuildSubmitted("tenant-a", "p-1", "common"));
+        var b = await _publisher.PublishAsync(BuildSubmitted("tenant-b", "p-1", "common"));
+
+        a.PartitionKey.Should().Be("tenant-a:p-1");
+        b.PartitionKey.Should().Be("tenant-b:p-1");
+        a.Id.Should().NotBe(b.Id);
+    }
+
+    [Fact]
+    public async Task Publish_concurrent_inserts_serialize_via_retry_loop()
+    {
+        var tasks = Enumerable.Range(1, 5)
+            .Select(i => _publisher.PublishAsync(BuildSubmitted(Tenant, ProviderId, $"evt-c{i}")))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+        var versions = results.Select(r => r.Version).OrderBy(v => v).ToList();
+        versions.Should().Equal(new[] { 1, 2, 3, 4, 5 });
+    }
+
+    private static CredentialingEvent BuildSubmitted(string tenantId, string providerId, string eventId) => new()
+    {
+        TenantId = tenantId,
+        ProviderId = providerId,
+        EventId = eventId,
+        EventType = CredentialingEventType.ApplicationSubmitted,
+    };
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingProjectorTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingProjectorTests.cs
@@ -1,0 +1,300 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CloudHealthOffice.Infrastructure.Json;
+using ProviderService.Models;
+using ProviderService.Models.CredentialingPayloads;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Pure-function coverage for <see cref="CredentialingProjector"/> across
+/// the canonical event sequences. The projector is the single authority on
+/// the events → CredentialingStatus mapping; these tests anchor that
+/// mapping so future contributors can refactor with confidence.
+/// </summary>
+public class CredentialingProjectorTests
+{
+    private static readonly DateTimeOffset NowAsOf = DateTimeOffset.Parse("2026-04-27T12:00:00Z");
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly CredentialingProjector _projector = new();
+
+    [Fact]
+    public void Empty_chain_projects_unknown()
+    {
+        var result = _projector.Project(Array.Empty<CredentialingEvent>(), NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Unknown);
+        result.EventCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Single_ApplicationSubmitted_projects_pending()
+    {
+        var events = new[]
+        {
+            App(1, NowAsOf.AddDays(-30)),
+        };
+        var result = _projector.Project(events, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Pending);
+        result.CurrentApplicationEventId.Should().Be(events[0].EventId);
+    }
+
+    [Fact]
+    public void ApplicationSubmitted_then_PSV_stays_pending()
+    {
+        var app = App(1, NowAsOf.AddDays(-30));
+        var psv = Psv(2, app.EventId, NowAsOf.AddDays(-25));
+        var result = _projector.Project(new[] { app, psv }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Pending);
+        result.CurrentApplicationEventId.Should().Be(app.EventId);
+    }
+
+    [Fact]
+    public void ApplicationSubmitted_then_DecisionApproved_projects_approved_with_dates()
+    {
+        var app = App(1, NowAsOf.AddDays(-30));
+        var decided = Decision(2, app.EventId, NowAsOf.AddDays(-1),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddDays(-1).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(2).UtcDateTime,
+            authority: DecisionAuthorityType.CredentialingCommittee);
+
+        var result = _projector.Project(new[] { app, decided }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Approved);
+        result.CredentialingDate.Should().Be(NowAsOf.AddDays(-1).UtcDateTime);
+        result.RecredentialingDueDate.Should().Be(NowAsOf.AddYears(2).UtcDateTime);
+        result.CurrentApplicationEventId.Should().BeNull();
+        result.LastDecisionAuthorityType.Should().Be(DecisionAuthorityType.CredentialingCommittee);
+    }
+
+    [Fact]
+    public void ApplicationSubmitted_then_DecisionDenied_projects_denied()
+    {
+        var app = App(1, NowAsOf.AddDays(-30));
+        var decided = Decision(2, app.EventId, NowAsOf.AddDays(-1),
+            CredentialingDecision.Denied);
+        var result = _projector.Project(new[] { app, decided }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Denied);
+        result.CredentialingDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void Approved_with_past_RecredDue_projects_expired()
+    {
+        var app = App(1, NowAsOf.AddYears(-3));
+        var decided = Decision(2, app.EventId, NowAsOf.AddYears(-3),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddYears(-3).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddDays(-1).UtcDateTime);
+
+        var result = _projector.Project(new[] { app, decided }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Expired);
+        result.CredentialingDate.Should().Be(NowAsOf.AddYears(-3).UtcDateTime);
+    }
+
+    [Fact]
+    public void Approved_then_RecredentialingTriggered_projects_pending()
+    {
+        var app = App(1, NowAsOf.AddYears(-2));
+        var decided = Decision(2, app.EventId, NowAsOf.AddYears(-2),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddYears(-2).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(1).UtcDateTime);
+        var trigger = RecredentialTrigger(3, NowAsOf, decided.EventId);
+
+        var result = _projector.Project(new[] { app, decided, trigger }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Pending);
+        // No open application yet — trigger fired but submission hasn't.
+        result.CurrentApplicationEventId.Should().BeNull();
+    }
+
+    [Fact]
+    public void RecredentialTriggered_then_NewSubmission_then_NewApproval_projects_approved_with_new_dates()
+    {
+        var app1 = App(1, NowAsOf.AddYears(-3));
+        var dec1 = Decision(2, app1.EventId, NowAsOf.AddYears(-3),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddYears(-3).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(-1).UtcDateTime);
+        var trigger = RecredentialTrigger(3, NowAsOf.AddDays(-30), dec1.EventId);
+        var app2 = App(4, NowAsOf.AddDays(-25));
+        var dec2 = Decision(5, app2.EventId, NowAsOf.AddDays(-1),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddDays(-1).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(2).UtcDateTime);
+
+        var result = _projector.Project(new[] { app1, dec1, trigger, app2, dec2 }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Approved);
+        result.CredentialingDate.Should().Be(NowAsOf.AddDays(-1).UtcDateTime);
+        result.RecredentialingDueDate.Should().Be(NowAsOf.AddYears(2).UtcDateTime);
+    }
+
+    [Fact]
+    public void Submission_then_Withdrawal_with_no_predecessor_reverts_to_unknown()
+    {
+        var app = App(1, NowAsOf.AddDays(-10));
+        var withdraw = Withdraw(2, app.EventId, NowAsOf.AddDays(-1));
+        var result = _projector.Project(new[] { app, withdraw }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Unknown);
+        result.CurrentApplicationEventId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Approved_then_RecredTrigger_then_NewSubmission_then_Withdrawal_reverts_to_predecessor_approval()
+    {
+        var app1 = App(1, NowAsOf.AddYears(-2));
+        var dec1 = Decision(2, app1.EventId, NowAsOf.AddYears(-2),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddYears(-2).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(1).UtcDateTime);
+        var trigger = RecredentialTrigger(3, NowAsOf.AddDays(-10), dec1.EventId);
+        var app2 = App(4, NowAsOf.AddDays(-9));
+        var withdraw = Withdraw(5, app2.EventId, NowAsOf.AddDays(-1));
+
+        var result = _projector.Project(new[] { app1, dec1, trigger, app2, withdraw }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Approved);
+        result.CredentialingDate.Should().Be(NowAsOf.AddYears(-2).UtcDateTime);
+        result.RecredentialingDueDate.Should().Be(NowAsOf.AddYears(1).UtcDateTime);
+    }
+
+    [Fact]
+    public void Synthesized_application_alone_does_not_appear_as_open_chain()
+    {
+        // Defense in depth: an orphaned synthesized application (which
+        // should never happen — they're paired with a DecisionRecorded by
+        // construction) must NOT present as Pending.
+        var synthesized = App(1, NowAsOf.AddDays(-1), synthesized: true);
+        var result = _projector.Project(new[] { synthesized }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Unknown);
+        result.CurrentApplicationEventId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Synthesized_application_paired_with_decision_projects_approved()
+    {
+        var synthesized = App(1, NowAsOf.AddDays(-1), synthesized: true);
+        var decided = Decision(2, synthesized.EventId, NowAsOf.AddDays(-1),
+            CredentialingDecision.Approved,
+            credentialingDate: NowAsOf.AddDays(-1).UtcDateTime,
+            recredentialingDueDate: NowAsOf.AddYears(2).UtcDateTime,
+            authority: DecisionAuthorityType.DelegatedAuthority);
+        var result = _projector.Project(new[] { synthesized, decided }, NowAsOf);
+        result.Status.Should().Be(CredentialingStatus.Approved);
+        result.LastDecisionAuthorityType.Should().Be(DecisionAuthorityType.DelegatedAuthority);
+    }
+
+    // ----- helpers ------------------------------------------------------
+
+    private static CredentialingEvent App(int version, DateTimeOffset submittedAt, bool synthesized = false)
+    {
+        var payload = new ApplicationSubmittedPayload(
+            SubmittedAt: submittedAt,
+            ApplicationSource: synthesized ? "DelegatedAuthority" : "Manual",
+            SupportingDocuments: null,
+            SynthesizedForDelegatedAuthority: synthesized);
+        return new CredentialingEvent
+        {
+            TenantId = TenantId,
+            ProviderId = ProviderId,
+            EventId = synthesized
+                ? CredentialingEvent.BuildSynthesizedApplicationSubmittedEventId(ProviderId, $"decision-{version}")
+                : CredentialingEvent.BuildApplicationSubmittedEventId(ProviderId, submittedAt),
+            EventType = CredentialingEventType.ApplicationSubmitted,
+            Version = version,
+            OccurredAt = submittedAt.UtcDateTime,
+            Payload = Serialize(payload),
+        };
+    }
+
+    private static CredentialingEvent Psv(int version, string applicationEventId, DateTimeOffset verifiedAt)
+    {
+        var payload = new PrimarySourceVerificationPayload(
+            VerifiedAt: verifiedAt,
+            VerificationVendor: "CAQH",
+            VerifiedItems: new[] { "License", "DEA" },
+            Evidence: null);
+        return new CredentialingEvent
+        {
+            TenantId = TenantId,
+            ProviderId = ProviderId,
+            EventId = CredentialingEvent.BuildPrimarySourceVerificationEventId(ProviderId, applicationEventId, verifiedAt),
+            EventType = CredentialingEventType.PrimarySourceVerificationCompleted,
+            Version = version,
+            ApplicationEventId = applicationEventId,
+            OccurredAt = verifiedAt.UtcDateTime,
+            Payload = Serialize(payload),
+        };
+    }
+
+    private static CredentialingEvent Decision(
+        int version,
+        string applicationEventId,
+        DateTimeOffset decidedAt,
+        CredentialingDecision decision,
+        DateTime? credentialingDate = null,
+        DateTime? recredentialingDueDate = null,
+        DecisionAuthorityType authority = DecisionAuthorityType.CredentialingCommittee)
+    {
+        var payload = new DecisionRecordedPayload(
+            Decision: decision,
+            DecidedAt: decidedAt,
+            CredentialingDate: credentialingDate,
+            RecredentialingDueDate: recredentialingDueDate,
+            DecisionAuthorityType: authority,
+            DecisionAuthorityId: "actor-1",
+            CommitteeMembers: authority == DecisionAuthorityType.CredentialingCommittee ? new[] { "m1", "m2" } : null,
+            DecisionMinuteReference: authority == DecisionAuthorityType.CredentialingCommittee ? "minutes/abc" : null,
+            DenialReason: decision == CredentialingDecision.Denied ? "test" : null);
+        return new CredentialingEvent
+        {
+            TenantId = TenantId,
+            ProviderId = ProviderId,
+            EventId = CredentialingEvent.BuildDecisionRecordedEventId(ProviderId, applicationEventId, decidedAt),
+            EventType = CredentialingEventType.DecisionRecorded,
+            Version = version,
+            ApplicationEventId = applicationEventId,
+            OccurredAt = decidedAt.UtcDateTime,
+            Payload = Serialize(payload),
+        };
+    }
+
+    private static CredentialingEvent RecredentialTrigger(int version, DateTimeOffset triggeredAt, string predecessor)
+    {
+        var payload = new RecredentialingTriggeredPayload(triggeredAt, "DueDateElapsed");
+        return new CredentialingEvent
+        {
+            TenantId = TenantId,
+            ProviderId = ProviderId,
+            EventId = CredentialingEvent.BuildRecredentialingTriggeredEventId(ProviderId, triggeredAt),
+            EventType = CredentialingEventType.RecredentialingTriggered,
+            Version = version,
+            PredecessorEventId = predecessor,
+            OccurredAt = triggeredAt.UtcDateTime,
+            Payload = Serialize(payload),
+        };
+    }
+
+    private static CredentialingEvent Withdraw(int version, string applicationEventId, DateTimeOffset withdrawnAt)
+    {
+        var payload = new ApplicationWithdrawnPayload(withdrawnAt, "withdrew");
+        return new CredentialingEvent
+        {
+            TenantId = TenantId,
+            ProviderId = ProviderId,
+            EventId = CredentialingEvent.BuildApplicationWithdrawnEventId(ProviderId, applicationEventId, withdrawnAt),
+            EventType = CredentialingEventType.ApplicationWithdrawn,
+            Version = version,
+            ApplicationEventId = applicationEventId,
+            OccurredAt = withdrawnAt.UtcDateTime,
+            Payload = Serialize(payload),
+        };
+    }
+
+    private static JsonObject? Serialize<T>(T payload) where T : class
+    {
+        var json = JsonSerializer.Serialize(payload, CloudHealthOfficeJsonOptions.DefaultOptions);
+        return JsonNode.Parse(json) as JsonObject;
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceTests.cs
@@ -108,9 +108,66 @@ public class CredentialingServiceTests
                 Decision = CredentialingDecision.Approved,
                 DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
                 DecisionAuthorityId = "committee-x",
+                CommitteeMembers = new[] { "m1", "m2" },
+                DecisionMinuteReference = "minutes/abc",
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
             },
             "actor-1", null);
-        await act.Should().ThrowAsync<CredentialingValidationException>();
+        await act.Should().ThrowAsync<CredentialingValidationException>()
+            .Where(ex => ex.Message.Contains("no open credentialing application"));
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsync_committee_path_requires_CommitteeMembers()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+
+        var act = () => _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "committee-x",
+                DecisionMinuteReference = "minutes/abc",
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>()
+            .Where(ex => ex.Message.Contains("CommitteeMembers"));
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsync_committee_path_requires_DecisionMinuteReference()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+
+        var act = () => _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "committee-x",
+                CommitteeMembers = new[] { "m1" },
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>()
+            .Where(ex => ex.Message.Contains("DecisionMinuteReference"));
+    }
+
+    [Fact]
+    public async Task SubmitApplicationAsync_throws_NotFound_for_missing_provider()
+    {
+        var act = () => _service.SubmitApplicationAsync(
+            TenantId, "missing-provider",
+            new SubmitApplicationRequest { ApplicationSource = "Manual" },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingNotFoundException>();
     }
 
     [Fact]
@@ -258,6 +315,7 @@ public class CredentialingServiceTests
                 DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
                 DecisionAuthorityId = "c-1",
                 CommitteeMembers = new[] { "m1" },
+                DecisionMinuteReference = "minutes/abc",
                 CredentialingDate = DateTime.UtcNow,
                 RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
             },

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceTests.cs
@@ -1,0 +1,294 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Models;
+using ProviderService.Models.CredentialingPayloads;
+using ProviderService.Services;
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Orchestration coverage for <see cref="CredentialingService"/>: each
+/// workflow method validates the chain pre-state, publishes a typed
+/// event, and (for status-changing events) patches the flat-field
+/// projection on Provider.
+/// </summary>
+public class CredentialingServiceTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryCredentialingEventRepository _eventRepository = new();
+    private readonly FakeCredentialingEventPublisher _publisher;
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly CredentialingService _service;
+
+    public CredentialingServiceTests()
+    {
+        _publisher = new FakeCredentialingEventPublisher(_eventRepository);
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        SeedActiveProvider();
+        _service = new CredentialingService(
+            _eventRepository,
+            _publisher,
+            _providerRepository,
+            new CredentialingProjector(),
+            NullLogger<CredentialingService>.Instance);
+    }
+
+    [Fact]
+    public async Task SubmitApplicationAsync_appends_event_and_patches_projection_to_pending()
+    {
+        var submittedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var evt = await _service.SubmitApplicationAsync(
+            TenantId, ProviderId,
+            new SubmitApplicationRequest { SubmittedAt = submittedAt, ApplicationSource = "Manual" },
+            actorId: "actor-1", correlationId: null);
+
+        evt.EventType.Should().Be(CredentialingEventType.ApplicationSubmitted);
+        evt.Version.Should().Be(1);
+        _providerRepository.CredentialingProjectionPatches.Should().HaveCount(1);
+        _providerRepository.CredentialingProjectionPatches[0].Status.Should().Be(CredentialingStatus.Pending);
+    }
+
+    [Fact]
+    public async Task SubmitApplicationAsync_with_open_application_throws()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+
+        var act = () => _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest
+            {
+                ApplicationSource = "Manual",
+                SubmittedAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>();
+    }
+
+    [Fact]
+    public async Task RecordPrimarySourceVerificationAsync_requires_open_application()
+    {
+        var act = () => _service.RecordPrimarySourceVerificationAsync(
+            TenantId, ProviderId,
+            new RecordPrimarySourceVerificationRequest
+            {
+                VerificationVendor = "CAQH",
+                VerifiedItems = new[] { "License" },
+            },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>();
+    }
+
+    [Fact]
+    public async Task RecordPrimarySourceVerificationAsync_does_not_patch_projection()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+        var patchesBefore = _providerRepository.CredentialingProjectionPatches.Count;
+
+        await _service.RecordPrimarySourceVerificationAsync(TenantId, ProviderId,
+            new RecordPrimarySourceVerificationRequest
+            {
+                VerificationVendor = "CAQH",
+                VerifiedItems = new[] { "License", "DEA" },
+                VerifiedAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            },
+            "actor-1", null);
+
+        _providerRepository.CredentialingProjectionPatches.Should().HaveCount(patchesBefore);
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsync_requires_open_application_when_authority_is_committee()
+    {
+        var act = () => _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "committee-x",
+            },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>();
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsync_with_DelegatedAuthority_synthesizes_application_when_none_open()
+    {
+        var decidedAt = DateTimeOffset.UtcNow;
+        var decision = await _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecidedAt = decidedAt,
+                CredentialingDate = decidedAt.UtcDateTime,
+                RecredentialingDueDate = decidedAt.UtcDateTime.AddYears(2),
+                DecisionAuthorityType = DecisionAuthorityType.DelegatedAuthority,
+                DecisionAuthorityId = "delegated-actor",
+            },
+            actorId: "delegated-actor", correlationId: null);
+
+        decision.EventType.Should().Be(CredentialingEventType.DecisionRecorded);
+        // Two events appended — synthesized application + decision.
+        var chain = _eventRepository.Store
+            .Where(e => e.TenantId == TenantId && e.ProviderId == ProviderId)
+            .OrderBy(e => e.Version)
+            .ToList();
+        chain.Should().HaveCount(2);
+        chain[0].EventType.Should().Be(CredentialingEventType.ApplicationSubmitted);
+        chain[0].EventId.Should().StartWith("synthesized-application:");
+        chain[1].EventType.Should().Be(CredentialingEventType.DecisionRecorded);
+        chain[1].ApplicationEventId.Should().Be(chain[0].EventId);
+
+        _providerRepository.CredentialingProjectionPatches.Should()
+            .Contain(p => p.Status == CredentialingStatus.Approved);
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsync_with_DelegatedAuthority_is_idempotent()
+    {
+        var decidedAt = DateTimeOffset.UtcNow;
+        var request = new RecordDecisionRequest
+        {
+            Decision = CredentialingDecision.Approved,
+            DecidedAt = decidedAt,
+            CredentialingDate = decidedAt.UtcDateTime,
+            RecredentialingDueDate = decidedAt.UtcDateTime.AddYears(2),
+            DecisionAuthorityType = DecisionAuthorityType.DelegatedAuthority,
+            DecisionAuthorityId = "delegated-actor",
+        };
+
+        var first = await _service.RecordDecisionAsync(TenantId, ProviderId, request, "delegated-actor", null);
+        var second = await _service.RecordDecisionAsync(TenantId, ProviderId, request, "delegated-actor", null);
+
+        first.EventId.Should().Be(second.EventId);
+        first.Version.Should().Be(second.Version);
+        // Chain should still be two events — synthesized + decision —
+        // even after the retry.
+        _eventRepository.Store
+            .Count(e => e.TenantId == TenantId && e.ProviderId == ProviderId)
+            .Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TriggerRecredentialingAsync_requires_prior_approval()
+    {
+        var act = () => _service.TriggerRecredentialingAsync(TenantId, ProviderId,
+            new TriggerRecredentialingRequest { Reason = "DueDateElapsed" },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>();
+    }
+
+    [Fact]
+    public async Task TriggerRecredentialingAsync_carries_PredecessorEventId_of_last_decision()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+        var decision = await _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "committee-x",
+                CommitteeMembers = new[] { "m1", "m2" },
+                DecisionMinuteReference = "minutes/123",
+            },
+            "actor-1", null);
+
+        var trigger = await _service.TriggerRecredentialingAsync(TenantId, ProviderId,
+            new TriggerRecredentialingRequest
+            {
+                Reason = "DueDateElapsed",
+                TriggeredAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            },
+            "actor-1", null);
+
+        trigger.EventType.Should().Be(CredentialingEventType.RecredentialingTriggered);
+        trigger.PredecessorEventId.Should().Be(decision.EventId);
+        _providerRepository.CredentialingProjectionPatches.Last().Status
+            .Should().Be(CredentialingStatus.Pending);
+    }
+
+    [Fact]
+    public async Task WithdrawApplicationAsync_with_mismatched_eventId_throws_validation()
+    {
+        var app = await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual" }, "actor-1", null);
+
+        var act = () => _service.WithdrawApplicationAsync(TenantId, ProviderId,
+            applicationEventId: "wrong-id",
+            new WithdrawApplicationRequest { Reason = "test" },
+            "actor-1", null);
+        await act.Should().ThrowAsync<CredentialingValidationException>();
+    }
+
+    [Fact]
+    public async Task GetCurrentStatusAsync_returns_Unknown_for_provider_without_chain()
+    {
+        var result = await _service.GetCurrentStatusAsync(TenantId, "no-chain");
+        result.Status.Should().Be(CredentialingStatus.Unknown);
+        result.EventCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetHistoryAsync_returns_paged_descending_with_continuation()
+    {
+        await _service.SubmitApplicationAsync(TenantId, ProviderId,
+            new SubmitApplicationRequest
+            {
+                ApplicationSource = "Manual",
+                SubmittedAt = DateTimeOffset.UtcNow.AddMinutes(-3),
+            },
+            "actor-1", null);
+        await _service.RecordPrimarySourceVerificationAsync(TenantId, ProviderId,
+            new RecordPrimarySourceVerificationRequest
+            {
+                VerificationVendor = "CAQH",
+                VerifiedItems = new[] { "License" },
+                VerifiedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+            },
+            "actor-1", null);
+        await _service.RecordDecisionAsync(TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "c-1",
+                CommitteeMembers = new[] { "m1" },
+                CredentialingDate = DateTime.UtcNow,
+                RecredentialingDueDate = DateTime.UtcNow.AddYears(2),
+            },
+            "actor-1", null);
+
+        var page1 = await _service.GetHistoryAsync(TenantId, ProviderId, null, limit: 2);
+        page1.Items.Should().HaveCount(2);
+        page1.ContinuationToken.Should().NotBeNull();
+
+        var page2 = await _service.GetHistoryAsync(TenantId, ProviderId, page1.ContinuationToken, limit: 2);
+        page2.Items.Should().HaveCount(1);
+        page2.ContinuationToken.Should().BeNull();
+    }
+
+    private void SeedActiveProvider()
+    {
+        var provider = new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Provider",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = ProviderId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+        };
+        _providerRepository.CreateAsync(provider).GetAwaiter().GetResult();
+    }
+}


### PR DESCRIPTION
## Summary

Builds credentialing as an event-sourced workflow alongside the existing flat-field projection on `Provider`. Closes the pre-existing 409 bug on the legacy `PUT /providers/{id}/credentialing` endpoint.

- **Event chain.** Append-only `CredentialingEvents` stream — six event types (`ApplicationSubmitted`, `PrimarySourceVerificationCompleted`, `CommitteeReviewScheduled`, `DecisionRecorded`, `RecredentialingTriggered`, `ApplicationWithdrawn`). Mirrors the three existing publishers (`ProviderVersionEvents`, `NetworkParticipationEvents`, `ProviderVerificationEvents`); uses the post-5.4.5 `_id = "{PartitionKey}:{EventId}"` pattern for cross-tenant collision protection.
- **Projection.** `CredentialingProjector` is a pure function over the chain → `CredentialingProjectionResult`. Single authority on the events → status mapping; both `GET /credentialing/status` and the write-side projection patch use it.
- **Bypass write path.** `IProviderRepository.UpdateCredentialingProjectionAsync` mirrors `UpdateIntegrityProjectionAsync` (5.4.5) and `UpdatePanelGatingDefaultsAsync` (5.5). Patches `CredentialingStatus`, `CredentialingDate`, `RecredentialingDueDate` on the head Active row without going through `UpdateAsync`'s version-state guard.
- **Legacy endpoint rewired.** `PUT /providers/{id}/credentialing` now funnels through `RecordDecisionAsync` with `DecisionAuthorityType=DelegatedAuthority`. Synthesizes a paired `ApplicationSubmitted` event when no chain is open (flagged `synthesizedForDelegatedAuthority=true`; filtered by the projector for defense in depth) so the endpoint always succeeds on Active providers. Same DTO and response shape preserved.
- **Enum migration.** `CredentialingStatus` gains `Unknown = 0` per PR #705 conventions. Existing integer values (`Pending=1`, etc.) are numerically stable; new `Provider` defaults to `Unknown` until the first `ApplicationSubmitted`.
- **Architecture docs.** New `docs/architecture/credentialing-workflow.md`; new "Credentialing projection (capability 5.6)" subsection in `docs/architecture/provider-versioning.md`.

## Out of scope (Phase 2)

- `Suspended` status as event-driven write path (deferred — enum value remains for read-side compatibility; XML doc notes the deferral).
- Document file storage (Phase 1 carries `DocumentReference` URIs — `Uri` + `DocumentType` + `Sha256` — as opaque metadata; FHIR-aligned for future projection).
- Appeals, peer review, sponsor-managed delegated credentialing.
- Auto-invocation of `ProviderVerificationOrchestrator` from the PSV step.
- Hosted projection reconciler (today the projection reconciles on the next status-changing transition).

## Test plan

- [ ] CI green (`test-dotnet.yml`)
- [ ] `CredentialingProjectorTests` — twelve sequence cases covering empty / pending / approved / denied / expired / re-credentialing / withdrawal / synthesized application
- [ ] `CredentialingServiceTests` — orchestration: validation, idempotency, projection patch ordering, DelegatedAuthority short-circuit, re-credentialing chain linkage
- [ ] `CredentialingEventPublisherTests` (ephemeral Mongo) — monotonic version, idempotent re-publish, partition-scoped `_id`, cross-tenant collision protection, concurrent retry serialization
- [ ] `UpdateCredentialingProjectionAsyncTests` (ephemeral Mongo) — bypass succeeds on Active, identity-field write still throws, returns false on no Active head, skips terminated, patches legacy rows
- [ ] `CredentialingControllerTests` — endpoint shapes (201/200/400), tenant resolution, history pagination
- [ ] `ProvidersControllerCredentialingTests` — **legacy `PUT /credentialing` returns 200, not 409, on Active providers** (the regression closed by this PR), idempotent retries, 404 on missing provider, 400 on unsupported legacy status

## Recovery

Worst-case rollback: revert the PR. The pre-existing 409 bug returns (known; pre-existing). Credentialing event stream disappears. Provider identity fields and the three other capabilities (5.4.5 integrity projection, 5.5 panel-gating backfill, 5.4 roster API) are untouched.

https://claude.ai/code/session_01JYVMQ3Ln45D2LFa72t3Udc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYVMQ3Ln45D2LFa72t3Udc)_