### PR TITLE
5.7 — FHIR Practitioner projection + fhir-service proxy

### DIFF
--- a/docs/architecture/fhir-conformance.md
+++ b/docs/architecture/fhir-conformance.md
@@ -1,0 +1,86 @@
+# FHIR conformance posture
+
+This is the running ledger of which Implementation Guides CHO claims
+conformance to, what we test against, and where the gaps are.
+
+## In scope (Phase 1)
+
+| IG / profile                                     | Resources covered today                | Posture                                                 |
+|--------------------------------------------------|----------------------------------------|---------------------------------------------------------|
+| US Core 6.1.0                                    | Patient, Practitioner                  | Required elements asserted by unit tests                |
+| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner (subset)                  | Fields CHO has data for; extensions deferred to 5.17    |
+| FHIR R4 Bundle (`searchset`)                     | Practitioner search                    | Hand-built JsonObject, asserted by unit tests           |
+| FHIR R4 OperationOutcome                         | All error responses                    | Typed `OperationOutcome` model + hand-built JsonObject  |
+
+`meta.profile` values emitted on each resource:
+
+- Patient (member-service) — `http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient`
+- Practitioner (provider-service, capability 5.7) —
+  `http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner`
+  and
+  `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner`
+
+## Phase 2 / deferred
+
+| IG / capability                                  | Status                                                 |
+|--------------------------------------------------|--------------------------------------------------------|
+| Plan-Net 1.1.0 PractitionerRole                  | Capability 5.9                                         |
+| Plan-Net 1.1.0 Organization                      | Capability 5.8                                         |
+| Plan-Net 1.1.0 Bundle composite                  | Capability 5.18                                        |
+| Plan-Net extended extensions                     | Capability 5.17                                        |
+| CMS-0057-F unauthenticated Provider Directory    | Capability 5.19                                        |
+| Inferno test suite (Provider Directory)          | Separate Phase 2 capability                            |
+| US Core 6.1.0 Practitioner.gender                | Capability 5.17 (Provider entity gains the field)      |
+
+## Conformance testing today
+
+Each projector ships a comprehensive unit-test fixture that asserts
+required US Core elements are present, cardinality is honored, and
+the projection is byte-deterministic across runs. The relevant test
+classes:
+
+- [FhirPatientProjectorTests](../../src/services/member-service/MemberService.Tests/Services/FhirPatientProjectorTests.cs)
+  — member-service Patient projection.
+- [FhirPractitionerProjectorTests](../../tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerProjectorTests.cs)
+  — provider-service Practitioner projection.
+
+Conformance regressions surface as failing unit tests. There is no
+network-driven conformance suite in CI yet (see *Inferno* below).
+
+## Inferno
+
+CMS publishes Inferno test suites for ONC certification. CHO does
+not run any Inferno suite in CI today. The Plan-Net Provider Directory
+suite would validate capability 5.7 + 5.8 + 5.9 + 5.18 once those
+capabilities ship as a Bundle composite.
+
+A separate Phase 2 capability wires the Inferno Provider Directory
+suite to CI. Until then, conformance is structural-only via unit
+tests, and any failure surfaced by an external Inferno run is a
+follow-up bug rather than a CI regression.
+
+## CHO-authored extensions
+
+CHO uses the canonical base `http://fhir.cloudhealthoffice.com/`. All
+CHO-authored profiles, code systems, value sets, and extensions live
+under this base.
+
+Defined today (see
+[ChoFhirCanonicalUrls](../../src/services/fhir-service/Services/ChoFhirCanonicalUrls.cs)):
+
+- Appeals profiles + extensions + code systems + value sets +
+  operations (capabilities 3.x).
+- `provider-integrity-score` extension (capability 5.7) — emitted on
+  Practitioner; carries cached IntegrityScore + IntegrityRating +
+  LastVerifiedAt from the projection added in capability 5.4.5.
+
+A legacy URL
+`https://cloudhealthoffice.com/fhir/StructureDefinition/provider-verification`
+is used by the NPPES-path enrichment in fhir-service today. The
+NPPES path retires after capabilities 5.8 and 5.9 ship. Do not
+introduce new uses of this URL.
+
+## Cross references
+
+- [fhir-practitioner-projection.md](fhir-practitioner-projection.md) — capability 5.7 details.
+- [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `Practitioner.active`.

--- a/docs/architecture/fhir-practitioner-projection.md
+++ b/docs/architecture/fhir-practitioner-projection.md
@@ -1,0 +1,182 @@
+# FHIR Practitioner projection (capability 5.7)
+
+## What this is
+
+Provider-service projects each `Provider` row with
+`ProviderType.Individual` to a hand-built FHIR R4 Practitioner JsonObject
+and exposes the projection at `/fhir/Practitioner/{npi}` and
+`/fhir/Practitioner` (search). Fhir-service keeps the external
+`/fhir/r4/Practitioner/*` URL surface and proxies those calls to
+provider-service via a typed `ProviderService` `HttpClient`.
+
+The projection conforms to:
+
+- US Core 6.1.0 Practitioner profile.
+- Da Vinci PDex Plan-Net 1.1.0 Practitioner profile (for the fields
+  CHO has data for; see *Deferrals*).
+
+## Why the data flow inverted
+
+Before 5.7, `fhir-service ProviderDirectoryController` called NPPES
+directly and enriched with `provider-verification-service`. CHO's own
+`provider-service` (versioned `Provider`, IntegrityScore from 5.4.5,
+credentialing from 5.6, panel-gating from 5.5) was not consulted at
+all. That made the directory the union of every NPI in NPPES rather
+than the providers a payer has a relationship with.
+
+5.7 inverts the flow for Practitioner only:
+
+```
+external client
+   │
+   ▼
+fhir-service /fhir/r4/Practitioner/{npi}        ← URL stability
+   │
+   ▼  HTTP, "ProviderService" typed HttpClient
+provider-service /fhir/Practitioner/{npi}        ← projection authority
+   │
+   ▼
+FhirPractitionerProjector  →  IProviderRepository.GetByNPIAsync
+                              IProviderRepository.SearchAsync
+```
+
+Organization, PractitionerRole, and Location stay on the NPPES path
+in this PR. Capability 5.8 redirects Organization, capability 5.9
+redirects PractitionerRole, then a cleanup PR retires the NPPES code
+entirely and deletes the HYBRID STATE comment block.
+
+## Service boundaries
+
+| Concern                          | Owner                            |
+|----------------------------------|----------------------------------|
+| `Practitioner` JSON shape        | `provider-service` (`FhirPractitionerProjector`) |
+| `/fhir/r4/*` URL surface         | `fhir-service` (`ProviderDirectoryController`)   |
+| Tenant context, JWT, SMART scope | `fhir-service` (perimeter)       |
+| Integrity-score projection       | `provider-verification-service` writes; `provider-service` caches and projects |
+
+The proxy adds **no business logic** on the Practitioner path. It
+forwards the request, passes the body and status code through (with
+5xx mapped to a FHIR 502 OperationOutcome to avoid leaking upstream
+detail), and is otherwise dumb.
+
+## Mapping
+
+| FHIR element                       | Source                                                                |
+|------------------------------------|-----------------------------------------------------------------------|
+| `id`                               | `Provider.NPI`                                                         |
+| `meta.profile`                     | US Core 6.1.0 + Plan-Net 1.1.0 Practitioner                            |
+| `meta.lastUpdated`                 | `Provider.LastUpdatedDate` (ISO 8601, UTC)                             |
+| `identifier[]`                     | NPI with system `http://hl7.org/fhir/sid/us-npi`                       |
+| `active`                           | `VersionState == Active && Status == Active`                           |
+| `name[].family`                    | `Provider.LastName`                                                    |
+| `name[].given[]`                   | `Provider.FirstName`, `Provider.MiddleName` (in that order, when set)  |
+| `name[].suffix[]`                  | `Provider.Credentials` parsed comma-separated, trimmed, empties dropped |
+| `gender`                           | **NOT EMITTED** — see Deferrals                                        |
+| `address[]`                        | `Provider.Address` / `City` / `State` / `ZipCode`                      |
+| `telecom[]`                        | `Phone`, `Fax`, `Email` in that order                                  |
+| `qualification[].code` (primary)   | NUCC coding `{system, TaxonomyCode, PrimarySpecialty}`                 |
+| `qualification[].code` (secondary) | text-only CodeableConcept (no `coding`) — see Deferrals                 |
+| `qualification[].code` (board)     | v2-0360 `BC` "Board Certified" + period + issuer                       |
+| `communication[]`                  | `LanguagesSpoken` mapped to BCP-47 codings                             |
+| `extension`                        | `provider-integrity-score` (only when `IntegrityScore` non-null)       |
+
+## Deferrals (NOT in scope for 5.7)
+
+These are explicit out-of-scope choices, ratified during the plan
+phase. None of them are bugs.
+
+### Practitioner.gender — capability 5.17
+
+`Provider` has no `Gender` field today. US Core 6.1.0
+Practitioner.gender is `Must Support 0..1`, so omission is
+conformant. Adding the field to the versioned Provider entity is its
+own scope; it lands alongside other Plan-Net demographics (race,
+ethnicity, etc.) in capability 5.17.
+
+### Secondary specialty NUCC codes — future capability
+
+`Provider.PrimarySpecialty` (string) sits alongside
+`Provider.TaxonomyCode` (the NUCC code itself, e.g. `207R00000X`).
+`SecondarySpecialties` is `List<string>` with no parallel
+taxonomy-code list, and the NUCC crosswalk lives in
+`provider-verification-engine`, not provider-service.
+
+The projection emits primary specialty with full NUCC coding and
+emits secondaries as text-only `CodeableConcept` entries (no
+`coding`). FHIR `CodeableConcept` permits text without coding;
+conformant. A future capability adds secondary-taxonomy storage and
+resolution.
+
+### Plan-Net extended extensions — capability 5.17
+
+Cultural-competency, accessibility, gender-affirming care, and
+populations-served extensions on Plan-Net Practitioner are not
+emitted. Those fields don't exist on `Provider` today; adding them
+is capability 5.17.
+
+### Public CMS-0057-F endpoint — capability 5.19
+
+5.7 is internal-facing. Public unauthenticated access (CMS-0057-F
+Provider Directory API requirements) is capability 5.19, which adds
+a separate route, payer-id-scoped reads, and CMS-required search
+parameters.
+
+### Plan-Net Bundle composite — capability 5.18
+
+Plan-Net's `[Practitioner, PractitionerRole, Organization]` Bundle
+composite is capability 5.18. The proxy pattern established in 5.7
+is the first piece of that composite — fhir-service will assemble
+the Bundle by calling each domain service's FHIR endpoint once 5.8
+and 5.9 ship.
+
+### Inferno wiring — separate capability
+
+CHO has no Inferno test runner in CI today. Conformance is asserted
+via unit tests (`FhirPractitionerProjectorTests`). A separate Phase 2
+capability wires the Inferno Provider Directory test suite.
+
+## Tenant scoping
+
+The endpoint honors the existing `TenantMiddleware` mechanism on
+both services: JWT `tenant_id` claim → `X-Tenant-ID` header
+fallback → 401 if missing. Authenticated callers see their tenant's
+providers only. Public CMS-0057-F access lives on a separate
+endpoint added by capability 5.19.
+
+The proxy chains `TenantHeaderPropagationHandler` and
+`CorrelationIdPropagationHandler` (mirrors the
+`HttpFhirAppealAdapter` registration) so tenant + correlation ids
+flow end-to-end.
+
+## Integrity-score extension URI
+
+`http://fhir.cloudhealthoffice.com/StructureDefinition/provider-integrity-score`,
+defined by `ChoFhirCanonicalUrls.ProviderIntegrityScoreExt` in
+fhir-service and mirrored as `ChoProviderFhirUrls.ProviderIntegrityScoreExt`
+in provider-service (until a shared FHIR-infrastructure project
+lands). The mirror is intentional and documented in both files —
+provider-service does not reference fhir-service.
+
+The legacy
+`https://cloudhealthoffice.com/fhir/StructureDefinition/provider-verification`
+URL on the NPPES enrichment path is left untouched. It dies with the
+NPPES code in the post-5.8/5.9 cleanup PR.
+
+## Code references
+
+- [src/services/provider-service/Services/IFhirPractitionerProjector.cs](../../src/services/provider-service/Services/IFhirPractitionerProjector.cs)
+- [src/services/provider-service/Services/FhirPractitionerProjector.cs](../../src/services/provider-service/Services/FhirPractitionerProjector.cs)
+- [src/services/provider-service/Services/FhirExtensionBuilder.cs](../../src/services/provider-service/Services/FhirExtensionBuilder.cs)
+- [src/services/provider-service/Services/ChoProviderFhirUrls.cs](../../src/services/provider-service/Services/ChoProviderFhirUrls.cs)
+- [src/services/provider-service/Controllers/FhirPractitionerController.cs](../../src/services/provider-service/Controllers/FhirPractitionerController.cs)
+- [src/services/provider-service/Models/ProviderIntegrityProjection.cs](../../src/services/provider-service/Models/ProviderIntegrityProjection.cs)
+- [src/services/fhir-service/Controllers/ProviderDirectoryController.cs](../../src/services/fhir-service/Controllers/ProviderDirectoryController.cs)
+- [src/services/fhir-service/Services/ChoFhirCanonicalUrls.cs](../../src/services/fhir-service/Services/ChoFhirCanonicalUrls.cs)
+
+## Cross references
+
+- [provider-versioning.md](provider-versioning.md) — version chain semantics that drive `Practitioner.active`.
+- [network-roster-api.md](network-roster-api.md) — same `IProviderRepository`, same tenant model.
+- [provider-adapter-pattern.md](provider-adapter-pattern.md) — the FHIR projection sits alongside the adapter pattern; both consume `Provider`.
+- [credentialing-workflow.md](credentialing-workflow.md) — credentialing-status is intentionally NOT surfaced on Practitioner (provider-operations metadata, not directory-consumer-facing). PractitionerRole in 5.9 may surface it.
+- [fhir-conformance.md](fhir-conformance.md) — overall conformance posture and the Inferno deferral.

--- a/src/services/fhir-service/Controllers/FhirControllerBase.cs
+++ b/src/services/fhir-service/Controllers/FhirControllerBase.cs
@@ -60,6 +60,20 @@ public abstract class FhirControllerBase : ControllerBase
             OperationOutcome.IssueType.Processing,
             diagnostics));
 
+    /// <summary>
+    /// 502 Bad Gateway with a FHIR <c>OperationOutcome</c>. Used when an
+    /// upstream FHIR service this controller proxies to (e.g.
+    /// provider-service for capability 5.7 Practitioner endpoints) fails
+    /// or returns a non-FHIR error. Diagnostics is the operator-facing
+    /// reason — DO NOT pass through arbitrary upstream response bodies
+    /// here as they may leak internal detail.
+    /// </summary>
+    protected IActionResult FhirBadGateway(string diagnostics)
+        => StatusCode(502, BuildOutcome(
+            OperationOutcome.IssueSeverity.Error,
+            OperationOutcome.IssueType.Transient,
+            diagnostics));
+
     private static OperationOutcome BuildOutcome(
         OperationOutcome.IssueSeverity severity,
         OperationOutcome.IssueType code,

--- a/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
+++ b/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
@@ -73,6 +73,11 @@ public class ProviderDirectoryController : FhirControllerBase
 
     private async Task<IActionResult> ProxyPractitionerAsync(string path, CancellationToken ct)
     {
+        // `path` is derived from the user-supplied URL / query string and
+        // flows into structured-log fields below. Sanitize once up front
+        // so all log sites share the same scrubbed value (CodeQL: log
+        // entries created from user input).
+        var loggablePath = SanitizeForLog(path);
         try
         {
             using var upstream = await _providerServiceClient.GetAsync(path, ct);
@@ -88,7 +93,7 @@ public class ProviderDirectoryController : FhirControllerBase
             {
                 _logger.LogWarning(
                     "provider-service Practitioner upstream returned {Status} for {Path}",
-                    (int)upstream.StatusCode, path);
+                    (int)upstream.StatusCode, loggablePath);
                 return FhirBadGateway("Practitioner upstream is unavailable.");
             }
 
@@ -101,12 +106,23 @@ public class ProviderDirectoryController : FhirControllerBase
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogWarning(ex, "provider-service Practitioner proxy hop failed for {Path}", path);
+            _logger.LogWarning(ex, "provider-service Practitioner proxy hop failed for {Path}", loggablePath);
             return FhirBadGateway("Practitioner upstream is unreachable.");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // The caller cancelled (client disconnect, server abort). Don't
+            // pretend the upstream timed out — propagate cancellation so
+            // the request pipeline returns its standard 499/aborted shape
+            // and we don't pollute logs / metrics with phantom 502s.
+            throw;
         }
         catch (TaskCanceledException ex)
         {
-            _logger.LogWarning(ex, "provider-service Practitioner proxy hop timed out for {Path}", path);
+            // HttpClient surfaces its own configured timeout as
+            // TaskCanceledException; ct was NOT cancelled (handled above).
+            // That genuinely is an upstream-too-slow → 502.
+            _logger.LogWarning(ex, "provider-service Practitioner proxy hop timed out for {Path}", loggablePath);
             return FhirBadGateway("Practitioner upstream timed out.");
         }
     }

--- a/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
+++ b/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
@@ -8,16 +8,24 @@ namespace FhirService.Controllers;
 
 /// <summary>
 /// Provider Directory API controller — exposes FHIR R4 provider directory resources
-/// (Practitioner, PractitionerRole, Organization, Location) backed by NPPES data
-/// fetched from provider-service via HTTP.
+/// (Practitioner, PractitionerRole, Organization, Location).
 ///
-/// Port of the TypeScript provider-directory-api.ts.
+/// HYBRID STATE (Phase 1 capability 5.7):
+///  - Practitioner:      proxied to provider-service /fhir/Practitioner (CHO-canonical projection).
+///  - Organization:      still served from NPPES (capability 5.8 will redirect).
+///  - PractitionerRole:  still served from NPPES (capability 5.9 will redirect).
+///  - Location:          still served from NPPES.
+/// The HYBRID STATE comment block is removed once 5.8 + 5.9 ship and the
+/// NPPES helpers below are fully retired.
+///
+/// Port of the TypeScript provider-directory-api.ts (NPPES path).
 /// </summary>
 [Route("fhir/r4")]
 public class ProviderDirectoryController : FhirControllerBase
 {
     private readonly HttpClient _httpClient;
     private readonly HttpClient _verificationClient;
+    private readonly HttpClient _providerServiceClient;
     private readonly ILogger<ProviderDirectoryController> _logger;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -31,76 +39,76 @@ public class ProviderDirectoryController : FhirControllerBase
     {
         _httpClient = httpClientFactory.CreateClient("NppesApi");
         _verificationClient = httpClientFactory.CreateClient("ProviderVerificationService");
+        _providerServiceClient = httpClientFactory.CreateClient("ProviderService");
         _logger = logger;
     }
 
-    // ── Practitioner ─────────────────────────────────────────────────────────
+    // ── Practitioner (proxied to provider-service, capability 5.7) ───────────
 
-    /// <summary>GET /fhir/r4/Practitioner/{id} — read Practitioner by NPI</summary>
+    /// <summary>
+    /// GET /fhir/r4/Practitioner/{id} — read Practitioner by NPI.
+    /// Proxies to provider-service /fhir/Practitioner/{id}; fhir-service is
+    /// the FHIR façade and provider-service owns the projection
+    /// (capability 5.7).
+    /// </summary>
     [HttpGet("Practitioner/{id}")]
     [Produces("application/fhir+json")]
-    public async Task<IActionResult> ReadPractitioner(string id, CancellationToken ct)
-    {
-        var nppes = await LookupNppesAsync(id, ct);
-        if (nppes is null || nppes.EnumerationType != "NPI-1")
-            return FhirNotFound("Practitioner", id);
+    public Task<IActionResult> ReadPractitioner(string id, CancellationToken ct)
+        => ProxyPractitionerAsync($"fhir/Practitioner/{Uri.EscapeDataString(id)}", ct);
 
-        var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(nppes);
-
-        var verification = await GetVerificationSummaryAsync(id, ct);
-        if (verification != null)
-            ProviderDirectoryMapper.EnrichWithVerification(practitioner, verification);
-
-        return Ok(practitioner);
-    }
-
-    /// <summary>GET /fhir/r4/Practitioner?npi=&amp;given=&amp;family=&amp;... — search Practitioners</summary>
+    /// <summary>
+    /// GET /fhir/r4/Practitioner?npi=&amp;given=&amp;family=&amp;... — search Practitioners.
+    /// Forwards the FHIR search query string to provider-service
+    /// /fhir/Practitioner unchanged (capability 5.7).
+    /// </summary>
     [HttpGet("Practitioner")]
     [Produces("application/fhir+json")]
-    public async Task<IActionResult> SearchPractitioners(
-        [FromQuery] string? npi,
-        [FromQuery] string? given,
-        [FromQuery] string? family,
-        [FromQuery] string? city,
-        [FromQuery] string? state,
-        [FromQuery(Name = "postal-code")] string? postalCode,
-        [FromQuery] string? specialty,
-        [FromQuery] int _count = 50,
-        [FromQuery] int _page = 1,
-        CancellationToken ct = default)
+    public Task<IActionResult> SearchPractitioners(CancellationToken ct = default)
     {
-        _count = ClampPageSize(_count, 200);
+        var qs = HttpContext.Request.QueryString.HasValue
+            ? HttpContext.Request.QueryString.Value
+            : string.Empty;
+        return ProxyPractitionerAsync($"fhir/Practitioner{qs}", ct);
+    }
 
-        if (!string.IsNullOrEmpty(npi))
+    private async Task<IActionResult> ProxyPractitionerAsync(string path, CancellationToken ct)
+    {
+        try
         {
-            var nppes = await LookupNppesAsync(npi, ct);
-            if (nppes is null || nppes.EnumerationType != "NPI-1")
-                return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", []));
+            using var upstream = await _providerServiceClient.GetAsync(path, ct);
+            var body = await upstream.Content.ReadAsStringAsync(ct);
+            var contentType = upstream.Content.Headers.ContentType?.ToString() ?? "application/fhir+json";
 
-            var practitioner = ProviderDirectoryMapper.MapNppesToPractitioner(nppes);
-            return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", [practitioner]));
+            // Pass status + body through verbatim. provider-service emits
+            // FHIR OperationOutcome on 4xx, so the proxy needs to forward
+            // those without rewrapping. 5xx responses are mapped to a
+            // FHIR 502 OperationOutcome — exposing upstream 5xx bodies
+            // could leak internal detail.
+            if ((int)upstream.StatusCode >= 500)
+            {
+                _logger.LogWarning(
+                    "provider-service Practitioner upstream returned {Status} for {Path}",
+                    (int)upstream.StatusCode, path);
+                return FhirBadGateway("Practitioner upstream is unavailable.");
+            }
+
+            return new ContentResult
+            {
+                Content = body,
+                ContentType = contentType,
+                StatusCode = (int)upstream.StatusCode
+            };
         }
-
-        var results = await SearchNppesAsync(new Dictionary<string, string?>
+        catch (HttpRequestException ex)
         {
-            ["first_name"] = given,
-            ["last_name"] = family,
-            ["city"] = city,
-            ["state"] = state,
-            ["postal_code"] = postalCode,
-            ["taxonomy_description"] = specialty,
-            ["enumeration_type"] = "NPI-1",
-            ["limit"] = _count.ToString(),
-            ["skip"] = ((_page - 1) * _count).ToString()
-        }, ct);
-
-        var practitioners = results
-            .Where(r => r.EnumerationType == "NPI-1")
-            .Select(ProviderDirectoryMapper.MapNppesToPractitioner)
-            .Cast<FhirResource>()
-            .ToList();
-
-        return Ok(ProviderDirectoryMapper.CreateSearchBundle("Practitioner", practitioners));
+            _logger.LogWarning(ex, "provider-service Practitioner proxy hop failed for {Path}", path);
+            return FhirBadGateway("Practitioner upstream is unreachable.");
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogWarning(ex, "provider-service Practitioner proxy hop timed out for {Path}", path);
+            return FhirBadGateway("Practitioner upstream timed out.");
+        }
     }
 
     // ── Organization ─────────────────────────────────────────────────────────

--- a/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
+++ b/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
@@ -54,6 +54,9 @@ public static partial class ProviderDirectoryMapper
     /// <summary>
     /// Maps an NPI-1 (individual) NPPES result to a FHIR Practitioner resource.
     /// </summary>
+    [Obsolete("Replaced by provider-service /fhir/Practitioner projection (capability 5.7). " +
+              "This method remains only because ProviderDirectoryMapperTests still exercises it. " +
+              "Will be removed once 5.8/5.9 retire the NPPES path entirely.")]
     public static FhirPractitioner MapNppesToPractitioner(NppesResult nppes)
     {
         if (nppes.EnumerationType != "NPI-1")
@@ -499,6 +502,10 @@ public static partial class ProviderDirectoryMapper
     /// Provider Verification Service. Adds an extension with integrity score,
     /// rating, and exclusion status. Sets active=false for excluded providers.
     /// </summary>
+    [Obsolete("Practitioner verification enrichment now lives on the provider-service projection " +
+              "as the cho-provider-integrity-score extension (capability 5.4.5 / 5.7). " +
+              "This method remains only because ProviderDirectoryVerificationTests still exercises it. " +
+              "Will be removed once 5.8/5.9 retire the NPPES path entirely.")]
     public static void EnrichWithVerification(
         FhirPractitioner practitioner, ProviderVerificationSummary verification)
     {

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -200,6 +200,24 @@ builder.Services.AddHttpClient("NppesApi", client =>
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 });
 
+// ── provider-service FHIR proxy (capability 5.7) ────────────────────────────
+// ProviderDirectoryController.ReadPractitioner / SearchPractitioners
+// proxies to provider-service's /fhir/Practitioner endpoint. Tenant
+// header propagation flows the caller's TenantId through so
+// provider-service's TenantMiddleware sees the same context (Decision
+// 5a — tenant-scoped directory). Capabilities 5.8 and 5.9 wire
+// Organization and PractitionerRole through this same client.
+builder.Services.AddHttpClient("ProviderService", client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:ProviderServiceUrl"]
+            ?? "http://provider-service.cloudhealthoffice/");
+    client.DefaultRequestHeaders.Add("Accept", "application/fhir+json");
+    client.Timeout = TimeSpan.FromSeconds(30);
+})
+.AddHttpMessageHandler<TenantHeaderPropagationHandler>()
+.AddHttpMessageHandler<CorrelationIdPropagationHandler>();
+
 // ── Da Vinci CRD / DTR / Bulk ─────────────────────────────────────────────────
 builder.Services.Configure<CrdConfig>(builder.Configuration.GetSection("Cms0057:Crd"));
 builder.Services.AddSingleton<ICrdService, CrdService>();

--- a/src/services/fhir-service/Services/ChoFhirCanonicalUrls.cs
+++ b/src/services/fhir-service/Services/ChoFhirCanonicalUrls.cs
@@ -51,6 +51,18 @@ public static class ChoFhirCanonicalUrls
     // ── CHO appeal operations ───────────────────────────────────────────────
     public const string AppealSubmitOperation = OperationDefinitionBase + "cho-appeal-submit";
 
+    // ── CHO provider extensions (capability 5.7) ────────────────────────────
+    /// <summary>
+    /// CHO-prefixed extension carrying the cached Provider Integrity
+    /// projection (capability 5.4.5 — IntegrityScore + IntegrityRating +
+    /// LastVerifiedAt). Emitted on Practitioner resources by
+    /// provider-service's <c>FhirPractitionerProjector</c>; mirrored in
+    /// <c>provider-service/Services/ChoProviderFhirUrls.cs</c> until a
+    /// shared FHIR-infrastructure project lands.
+    /// </summary>
+    public const string ProviderIntegrityScoreExt =
+        StructureDefinitionBase + "provider-integrity-score";
+
     /// <summary>All CHO appeal resource profile URLs (not extensions).</summary>
     public static readonly IReadOnlyList<string> AllAppealResourceProfiles =
     [

--- a/src/services/provider-service/Controllers/FhirPractitionerController.cs
+++ b/src/services/provider-service/Controllers/FhirPractitionerController.cs
@@ -112,10 +112,19 @@ public class FhirPractitionerController : ControllerBase
 
         // Resolve identifier=NPI:value or identifier=value to the npi
         // shortcut. FHIR token parameters use system|value or value alone.
+        // An `identifier` whose system is something OTHER than NPI is a
+        // caller error for this directory — we only index by NPI today —
+        // so reject with 400 rather than silently falling back to a
+        // broad search (FHIR token semantics say: don't ignore filters).
         var resolvedNpi = npi;
         if (string.IsNullOrEmpty(resolvedNpi) && !string.IsNullOrEmpty(identifier))
         {
             resolvedNpi = ParseNpiIdentifier(identifier);
+            if (string.IsNullOrEmpty(resolvedNpi))
+            {
+                return FhirOperationOutcome(400, "invalid",
+                    $"identifier '{SanitizeForLog(identifier)}' is not a recognized NPI token; supply system http://hl7.org/fhir/sid/us-npi or no system.");
+            }
         }
 
         if (!string.IsNullOrEmpty(resolvedNpi))
@@ -191,20 +200,23 @@ public class FhirPractitionerController : ControllerBase
         };
     }
 
-    private JsonObject WrapEntry(JsonObject resource)
+    private static JsonObject WrapEntry(JsonObject resource)
     {
-        var npi = resource["id"]?.GetValue<string>() ?? string.Empty;
-        var entry = new JsonObject
+        // Bundle.entry.fullUrl is OPTIONAL in FHIR R4 (see
+        // http://hl7.org/fhir/R4/bundle-definitions.html#Bundle.entry.fullUrl).
+        // We deliberately omit it: this controller is reached either
+        // directly OR via fhir-service's Practitioner proxy, in which case
+        // HttpContext.Request.Host is the *internal* provider-service
+        // hostname and would leak into the response. fhir-service's proxy
+        // does not yet rewrite forwarded headers and we don't want
+        // Bundle entries to look different depending on which path was
+        // taken. Consumers can construct Practitioner/{id} references
+        // themselves using the resource's `id` field.
+        return new JsonObject
         {
             ["resource"] = resource,
             ["search"] = new JsonObject { ["mode"] = "match" }
         };
-        if (!string.IsNullOrEmpty(npi))
-        {
-            var req = HttpContext.Request;
-            entry["fullUrl"] = $"{req.Scheme}://{req.Host}/fhir/Practitioner/{npi}";
-        }
-        return entry;
     }
 
     private IActionResult FhirOperationOutcome(int status, string code, string diagnostics)

--- a/src/services/provider-service/Controllers/FhirPractitionerController.cs
+++ b/src/services/provider-service/Controllers/FhirPractitionerController.cs
@@ -1,0 +1,273 @@
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace ProviderService.Controllers;
+
+/// <summary>
+/// FHIR R4 Practitioner read + search endpoint (capability 5.7).
+/// provider-service is the canonical authority on the projection;
+/// fhir-service proxies <c>/fhir/r4/Practitioner/*</c> requests here so
+/// CHO retains a single FHIR façade for external consumers while each
+/// domain service owns its own projection (mirrors member-service's
+/// <c>MembersController.GetFhirPatient</c>).
+///
+/// <para>
+/// Tenant scoping per Decision 5a: requests honor the existing
+/// <see cref="Middleware.TenantMiddleware"/> mechanism. Authenticated /
+/// header-scoped callers see their tenant's providers only. Public
+/// CMS-0057-F access is a separate capability (5.19).
+/// </para>
+/// </summary>
+[ApiController]
+[Route("fhir")]
+public class FhirPractitionerController : ControllerBase
+{
+    private const string FhirContentType = "application/fhir+json";
+    private const string NpiSystemToken = "http://hl7.org/fhir/sid/us-npi";
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+
+    private static readonly Regex NpiPattern = new(@"^\d{10}$", RegexOptions.Compiled);
+
+    private readonly IProviderRepository _repository;
+    private readonly IFhirPractitionerProjector _projector;
+    private readonly ILogger<FhirPractitionerController> _logger;
+
+    public FhirPractitionerController(
+        IProviderRepository repository,
+        IFhirPractitionerProjector projector,
+        ILogger<FhirPractitionerController> logger)
+    {
+        _repository = repository;
+        _projector = projector;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// FHIR Practitioner read by NPI. The path segment is the FHIR
+    /// resource <c>id</c>, which capability 5.7 maps to NPI per
+    /// Decision 3.
+    /// </summary>
+    [HttpGet("Practitioner/{npi}")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> ReadPractitioner(string npi, CancellationToken ct)
+    {
+        if (!NpiPattern.IsMatch(npi))
+        {
+            return FhirOperationOutcome(400, "invalid", $"NPI '{SanitizeForLog(npi)}' is not a 10-digit identifier.");
+        }
+
+        var provider = await _repository.GetByNPIAsync(npi);
+        if (provider == null || provider.ProviderType != ProviderType.Individual)
+        {
+            return FhirOperationOutcome(404, "not-found", $"Practitioner/{npi} not found.");
+        }
+
+        var integrity = ProviderIntegrityProjection.FromProvider(provider);
+        var resource = _projector.Project(provider, integrity);
+        if (resource == null)
+        {
+            // Defensive: projector returns null for ProviderType.Organization,
+            // which is filtered above. Treat as 404 so the surface stays
+            // consistent if a future Provider value sneaks past the type check.
+            return FhirOperationOutcome(404, "not-found", $"Practitioner/{npi} not found.");
+        }
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = resource.ToJsonString(),
+            StatusCode = 200
+        };
+    }
+
+    /// <summary>
+    /// FHIR Practitioner search. Honors FHIR R4 search parameter names
+    /// (<c>given</c>, <c>family</c>, <c>city</c>, <c>state</c>,
+    /// <c>postal-code</c>, <c>specialty</c>, <c>identifier</c>) plus the
+    /// shorthand <c>npi</c> alias the existing fhir-service controller
+    /// uses. Returns a FHIR <c>Bundle</c> of type <c>searchset</c>.
+    /// </summary>
+    [HttpGet("Practitioner")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> SearchPractitioners(
+        [FromQuery] string? npi,
+        [FromQuery] string? identifier,
+        [FromQuery] string? given,
+        [FromQuery] string? family,
+        [FromQuery] string? city,
+        [FromQuery] string? state,
+        [FromQuery(Name = "postal-code")] string? postalCode,
+        [FromQuery] string? specialty,
+        [FromQuery] int _count = DefaultPageSize,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        var pageSize = Math.Clamp(_count, 1, MaxPageSize);
+        var page = Math.Max(1, _page);
+
+        // Resolve identifier=NPI:value or identifier=value to the npi
+        // shortcut. FHIR token parameters use system|value or value alone.
+        var resolvedNpi = npi;
+        if (string.IsNullOrEmpty(resolvedNpi) && !string.IsNullOrEmpty(identifier))
+        {
+            resolvedNpi = ParseNpiIdentifier(identifier);
+        }
+
+        if (!string.IsNullOrEmpty(resolvedNpi))
+        {
+            if (!NpiPattern.IsMatch(resolvedNpi))
+            {
+                return FhirOperationOutcome(400, "invalid",
+                    $"identifier '{SanitizeForLog(identifier ?? npi ?? string.Empty)}' is not a valid NPI.");
+            }
+
+            var single = await _repository.GetByNPIAsync(resolvedNpi);
+            var bundleEntries = new JsonArray();
+            if (single != null && single.ProviderType == ProviderType.Individual)
+            {
+                var integrity = ProviderIntegrityProjection.FromProvider(single);
+                var projected = _projector.Project(single, integrity);
+                if (projected != null) bundleEntries.Add(WrapEntry(projected));
+            }
+            return BundleResult(bundleEntries);
+        }
+
+        IEnumerable<Provider> results;
+        try
+        {
+            results = await _repository.SearchAsync(
+                name: null,
+                specialty: specialty,
+                zipCode: postalCode,
+                state: state,
+                planId: null,
+                lineOfBusiness: null,
+                providerType: ProviderType.Individual,
+                acceptingNewPatients: null,
+                page: page,
+                pageSize: pageSize,
+                firstName: given,
+                lastName: family,
+                city: city);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Practitioner search failed");
+            return FhirOperationOutcome(500, "exception", "Practitioner search failed.");
+        }
+
+        var entries = new JsonArray();
+        foreach (var provider in results)
+        {
+            if (provider.ProviderType != ProviderType.Individual) continue;
+            var integrity = ProviderIntegrityProjection.FromProvider(provider);
+            var projected = _projector.Project(provider, integrity);
+            if (projected != null) entries.Add(WrapEntry(projected));
+        }
+        return BundleResult(entries);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private IActionResult BundleResult(JsonArray entries)
+    {
+        var bundle = new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "searchset",
+            ["total"] = entries.Count,
+            ["entry"] = entries
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = bundle.ToJsonString(),
+            StatusCode = 200
+        };
+    }
+
+    private JsonObject WrapEntry(JsonObject resource)
+    {
+        var npi = resource["id"]?.GetValue<string>() ?? string.Empty;
+        var entry = new JsonObject
+        {
+            ["resource"] = resource,
+            ["search"] = new JsonObject { ["mode"] = "match" }
+        };
+        if (!string.IsNullOrEmpty(npi))
+        {
+            var req = HttpContext.Request;
+            entry["fullUrl"] = $"{req.Scheme}://{req.Host}/fhir/Practitioner/{npi}";
+        }
+        return entry;
+    }
+
+    private IActionResult FhirOperationOutcome(int status, string code, string diagnostics)
+    {
+        var outcome = new JsonObject
+        {
+            ["resourceType"] = "OperationOutcome",
+            ["issue"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["severity"] = "error",
+                    ["code"] = code,
+                    ["diagnostics"] = diagnostics
+                }
+            }
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = outcome.ToJsonString(),
+            StatusCode = status
+        };
+    }
+
+    private static string? ParseNpiIdentifier(string identifier)
+    {
+        // FHIR token parameter forms:
+        //   identifier=12345                 → bare value
+        //   identifier=NPI|12345             → system|value (treat NPI as alias)
+        //   identifier=http://hl7.org/...|12345 → fully-qualified system|value
+        //   identifier=NPI:12345             → legacy shorthand the existing fhir-service uses
+        if (string.IsNullOrEmpty(identifier)) return null;
+
+        var pipe = identifier.IndexOf('|');
+        if (pipe >= 0)
+        {
+            var system = identifier[..pipe];
+            var value = identifier[(pipe + 1)..];
+            if (string.IsNullOrEmpty(system)
+                || string.Equals(system, NpiSystemToken, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(system, "NPI", StringComparison.OrdinalIgnoreCase))
+            {
+                return value;
+            }
+            return null;
+        }
+
+        var colon = identifier.IndexOf(':');
+        if (colon > 0)
+        {
+            var system = identifier[..colon];
+            var value = identifier[(colon + 1)..];
+            if (string.Equals(system, "NPI", StringComparison.OrdinalIgnoreCase))
+            {
+                return value;
+            }
+        }
+
+        return identifier;
+    }
+
+    private static string SanitizeForLog(string value)
+        => value.Replace("\r", string.Empty, StringComparison.Ordinal)
+                .Replace("\n", string.Empty, StringComparison.Ordinal);
+}

--- a/src/services/provider-service/Models/Provider.cs
+++ b/src/services/provider-service/Models/Provider.cs
@@ -6,6 +6,13 @@ namespace ProviderService.Models;
 /// <summary>
 /// Represents a healthcare provider (physician, hospital, facility).
 /// Used for network validation, claims adjudication, and provider directory.
+///
+/// <para>
+/// Individual-type rows (<see cref="ProviderType.Individual"/>) are
+/// projected to a FHIR R4 Practitioner resource by
+/// <see cref="Services.IFhirPractitionerProjector"/> (capability 5.7).
+/// Organization-type rows project as FHIR Organization in capability 5.9.
+/// </para>
 /// </summary>
 public class Provider
 {

--- a/src/services/provider-service/Models/ProviderIntegrityProjection.cs
+++ b/src/services/provider-service/Models/ProviderIntegrityProjection.cs
@@ -1,0 +1,34 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Read-side snapshot of a provider's integrity-projection state, fed to
+/// <see cref="Services.IFhirPractitionerProjector"/>. Decouples the
+/// projector from the storage shape — today the four fields live directly
+/// on <see cref="Provider"/> (capability 5.4.5), but the projector
+/// interface accepts this record so a future move to a separate document
+/// is a controller-side change only.
+/// </summary>
+/// <param name="Score">Composite integrity score (0–100). Null when the projection has not yet been populated.</param>
+/// <param name="Rating">Rating bucket (Clear / Advisory / Caution / Alert / Blocked / Unknown). Null when no score has been computed.</param>
+/// <param name="LastVerifiedAt">When provider-verification-service produced the score. Null when never verified.</param>
+public sealed record ProviderIntegrityProjection(
+    int? Score,
+    string? Rating,
+    DateTimeOffset? LastVerifiedAt)
+{
+    /// <summary>
+    /// Build a projection snapshot from the four fields embedded on
+    /// <see cref="Provider"/>. Returns null when no score is available so
+    /// the projector can omit the integrity extension entirely (no
+    /// placeholder, no zero score).
+    /// </summary>
+    public static ProviderIntegrityProjection? FromProvider(Provider provider)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        if (provider.IntegrityScore is null) return null;
+        return new ProviderIntegrityProjection(
+            provider.IntegrityScore,
+            provider.IntegrityRating,
+            provider.LastVerifiedAt);
+    }
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -165,6 +165,13 @@ builder.Services.AddScoped<INetworkParticipationBackfillService, NetworkParticip
 builder.Services.AddSingleton<CredentialingProjector>();
 builder.Services.AddScoped<ICredentialingService, CredentialingService>();
 
+// FHIR R4 Practitioner projection (5.7 — provider-service is the
+// canonical source for the Practitioner FHIR resource; fhir-service
+// proxies /fhir/r4/Practitioner/* to FhirPractitionerController). The
+// projector is stateless (singleton-safe) and mirrors member-service's
+// IFhirPatientProjector.
+builder.Services.AddSingleton<IFhirPractitionerProjector, FhirPractitionerProjector>();
+
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();
 

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -13,6 +13,19 @@ public interface IProviderRepository
 {
     Task<Provider?> GetByIdAsync(string id);
     Task<Provider?> GetByNPIAsync(string npi);
+    /// <summary>
+    /// General provider search across the tenant's head non-Draft rows.
+    /// Filters are AND-combined; null / empty values are skipped.
+    ///
+    /// <para>
+    /// <paramref name="firstName"/>, <paramref name="lastName"/>, and
+    /// <paramref name="city"/> were added in capability 5.7 to support
+    /// FHIR Practitioner search semantics (<c>given</c> / <c>family</c> /
+    /// <c>city</c>). They are optional; legacy callers (the adapter
+    /// roster path) leave them null and continue to use the combined
+    /// <paramref name="name"/> filter.
+    /// </para>
+    /// </summary>
     Task<IEnumerable<Provider>> SearchAsync(
         string? name,
         string? specialty,
@@ -23,7 +36,10 @@ public interface IProviderRepository
         ProviderType? providerType,
         bool? acceptingNewPatients,
         int page,
-        int pageSize);
+        int pageSize,
+        string? firstName = null,
+        string? lastName = null,
+        string? city = null);
     Task<Provider> CreateAsync(Provider provider);
     Task<Provider> UpdateAsync(Provider provider);
     Task DeleteAsync(string id);
@@ -409,7 +425,10 @@ public class ProviderRepository : IProviderRepository
         ProviderType? providerType,
         bool? acceptingNewPatients,
         int page,
-        int pageSize)
+        int pageSize,
+        string? firstName = null,
+        string? lastName = null,
+        string? city = null)
     {
         var tenantId = GetTenantId();
 
@@ -422,6 +441,18 @@ public class ProviderRepository : IProviderRepository
         {
             conditions.Add("(CONTAINS(LOWER(c.firstName), LOWER(@name)) OR CONTAINS(LOWER(c.lastName), LOWER(@name)) OR CONTAINS(LOWER(c.organizationName), LOWER(@name)))");
             queryDef.WithParameter("@name", name);
+        }
+
+        if (!string.IsNullOrEmpty(firstName))
+        {
+            conditions.Add("CONTAINS(LOWER(c.firstName), LOWER(@firstName))");
+            queryDef.WithParameter("@firstName", firstName);
+        }
+
+        if (!string.IsNullOrEmpty(lastName))
+        {
+            conditions.Add("CONTAINS(LOWER(c.lastName), LOWER(@lastName))");
+            queryDef.WithParameter("@lastName", lastName);
         }
 
         if (!string.IsNullOrEmpty(specialty))
@@ -440,6 +471,12 @@ public class ProviderRepository : IProviderRepository
         {
             conditions.Add("c.state = @state");
             queryDef.WithParameter("@state", state);
+        }
+
+        if (!string.IsNullOrEmpty(city))
+        {
+            conditions.Add("CONTAINS(LOWER(c.city), LOWER(@city))");
+            queryDef.WithParameter("@city", city);
         }
 
         if (providerType.HasValue)

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -143,8 +143,12 @@ public class ProviderRepositoryMongo : IProviderRepository
 
         if (!string.IsNullOrEmpty(name))
         {
-            // Case-insensitive regex for Name (First, Last, or Org)
-            var regex = new BsonRegularExpression(name, "i");
+            // Case-insensitive regex for Name (First, Last, or Org). Escape
+            // user input so regex metacharacters / pathological patterns
+            // can't be injected into the BSON query — matches the
+            // firstName / lastName / city handling below and the roster
+            // path in ListNetworkRosterAsync.
+            var regex = new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(name), "i");
             var nameFilter = builder.Or(
                 builder.Regex(p => p.FirstName, regex),
                 builder.Regex(p => p.LastName, regex),
@@ -167,7 +171,8 @@ public class ProviderRepositoryMongo : IProviderRepository
 
         if (!string.IsNullOrEmpty(specialty))
         {
-            filter = builder.And(filter, builder.Regex(p => p.PrimarySpecialty, new BsonRegularExpression(specialty, "i")));
+            filter = builder.And(filter, builder.Regex(p => p.PrimarySpecialty,
+                new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(specialty), "i")));
         }
 
         if (!string.IsNullOrEmpty(zipCode))

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -127,7 +127,10 @@ public class ProviderRepositoryMongo : IProviderRepository
         ProviderType? providerType,
         bool? acceptingNewPatients,
         int page,
-        int pageSize)
+        int pageSize,
+        string? firstName = null,
+        string? lastName = null,
+        string? city = null)
     {
         var tenantId = GetTenantId();
         var builder = Builders<Provider>.Filter;
@@ -150,6 +153,18 @@ public class ProviderRepositoryMongo : IProviderRepository
             filter = builder.And(filter, nameFilter);
         }
 
+        if (!string.IsNullOrEmpty(firstName))
+        {
+            var rgx = new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(firstName), "i");
+            filter = builder.And(filter, builder.Regex(p => p.FirstName, rgx));
+        }
+
+        if (!string.IsNullOrEmpty(lastName))
+        {
+            var rgx = new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(lastName), "i");
+            filter = builder.And(filter, builder.Regex(p => p.LastName, rgx));
+        }
+
         if (!string.IsNullOrEmpty(specialty))
         {
             filter = builder.And(filter, builder.Regex(p => p.PrimarySpecialty, new BsonRegularExpression(specialty, "i")));
@@ -163,6 +178,12 @@ public class ProviderRepositoryMongo : IProviderRepository
         if (!string.IsNullOrEmpty(state))
         {
             filter = builder.And(filter, builder.Eq(p => p.State, state));
+        }
+
+        if (!string.IsNullOrEmpty(city))
+        {
+            var rgx = new BsonRegularExpression(System.Text.RegularExpressions.Regex.Escape(city), "i");
+            filter = builder.And(filter, builder.Regex(p => p.City, rgx));
         }
 
         if (providerType.HasValue)

--- a/src/services/provider-service/Services/ChoProviderFhirUrls.cs
+++ b/src/services/provider-service/Services/ChoProviderFhirUrls.cs
@@ -1,0 +1,44 @@
+namespace ProviderService.Services;
+
+/// <summary>
+/// Canonical URLs for FHIR artifacts the provider-service projector
+/// emits. Mirrors the convention in fhir-service's
+/// <c>ChoFhirCanonicalUrls</c> (base <c>http://fhir.cloudhealthoffice.com/</c>);
+/// the integrity-score extension URL must be byte-identical between the
+/// two services so consumers see one canonical extension regardless of
+/// which service rendered the resource.
+///
+/// <para>
+/// TODO: consolidate with fhir-service ChoFhirCanonicalUrls when a
+/// shared FHIR-infrastructure project lands (capability 5.10 closer or
+/// a Phase 2 cleanup PR). Provider-service does not reference
+/// fhir-service today, so the constants are mirrored here.
+/// </para>
+/// </summary>
+internal static class ChoProviderFhirUrls
+{
+    public const string Base                    = "http://fhir.cloudhealthoffice.com/";
+    public const string StructureDefinitionBase = Base + "StructureDefinition/";
+
+    /// <summary>
+    /// CHO-prefixed extension carrying the cached Provider Integrity
+    /// projection (capability 5.4.5 — IntegrityScore + IntegrityRating +
+    /// LastVerifiedAt). Emitted on Practitioner resources only when
+    /// <see cref="Models.Provider.IntegrityScore"/> is non-null.
+    /// </summary>
+    public const string ProviderIntegrityScoreExt =
+        StructureDefinitionBase + "provider-integrity-score";
+
+    // ── Standard FHIR / IG profile URLs ─────────────────────────────────
+
+    public const string NpiSystem            = "http://hl7.org/fhir/sid/us-npi";
+    public const string NuccTaxonomySystem   = "http://nucc.org/provider-taxonomy";
+    public const string Bcp47LanguageSystem  = "urn:ietf:bcp:47";
+    public const string Hl70360CodeSystem    = "http://terminology.hl7.org/CodeSystem/v2-0360";
+
+    public const string UsCorePractitionerProfile =
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner";
+
+    public const string PlanNetPractitionerProfile =
+        "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner";
+}

--- a/src/services/provider-service/Services/FhirExtensionBuilder.cs
+++ b/src/services/provider-service/Services/FhirExtensionBuilder.cs
@@ -1,0 +1,95 @@
+// TODO: extract to a shared FHIR-infrastructure project. Mirrors
+// member-service's MemberService.Services.FhirExtensionBuilder verbatim
+// (same helpers, same US Core URL constants). Deliberate replication
+// rather than a project reference because cross-service projects in CHO
+// today don't share infrastructure and adding one is its own
+// architectural decision (Phase 2 cleanup PR).
+
+using System.Text.Json.Nodes;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Small helper for assembling FHIR extension nodes. Keeps US Core
+/// extension wiring DRY across resource projectors.
+/// </summary>
+internal static class FhirExtensionBuilder
+{
+    public const string UsCoreRace           = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race";
+    public const string UsCoreEthnicity      = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity";
+    public const string UsCoreBirthSex       = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex";
+    public const string UsCoreGenderIdentity = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-genderIdentity";
+
+    public static JsonObject Coding(string system, string code, string? display = null)
+    {
+        var coding = new JsonObject
+        {
+            ["system"] = system,
+            ["code"] = code
+        };
+        if (!string.IsNullOrEmpty(display)) coding["display"] = display;
+        return coding;
+    }
+
+    public static JsonObject ExtensionString(string url, string value) => new()
+    {
+        ["url"] = url,
+        ["valueString"] = value
+    };
+
+    public static JsonObject ExtensionInteger(string url, int value) => new()
+    {
+        ["url"] = url,
+        ["valueInteger"] = value
+    };
+
+    public static JsonObject ExtensionDateTime(string url, DateTimeOffset value) => new()
+    {
+        ["url"] = url,
+        ["valueDateTime"] = value.ToString("o")
+    };
+
+    public static JsonObject ExtensionCoding(string url, JsonObject coding) => new()
+    {
+        ["url"] = url,
+        ["valueCoding"] = coding
+    };
+
+    public static JsonObject ExtensionCodeableConcept(string url, JsonObject codeableConcept) => new()
+    {
+        ["url"] = url,
+        ["valueCodeableConcept"] = codeableConcept
+    };
+
+    /// <summary>
+    /// Build a CodeableConcept JsonObject. Either <paramref name="coding"/>
+    /// or <paramref name="text"/> (or both) must be non-empty; a fully
+    /// empty CodeableConcept is not valid FHIR.
+    /// </summary>
+    public static JsonObject CodeableConcept(JsonObject? coding = null, string? text = null)
+    {
+        var concept = new JsonObject();
+        if (coding != null)
+        {
+            concept["coding"] = new JsonArray(coding);
+        }
+        if (!string.IsNullOrEmpty(text))
+        {
+            concept["text"] = text;
+        }
+        return concept;
+    }
+
+    /// <summary>
+    /// Build a CodeableConcept JsonObject with multiple coding entries.
+    /// </summary>
+    public static JsonObject CodeableConcept(IEnumerable<JsonObject> codings, string? text = null)
+    {
+        var concept = new JsonObject();
+        var array = new JsonArray();
+        foreach (var c in codings) array.Add(c);
+        if (array.Count > 0) concept["coding"] = array;
+        if (!string.IsNullOrEmpty(text)) concept["text"] = text;
+        return concept;
+    }
+}

--- a/src/services/provider-service/Services/FhirPractitionerProjector.cs
+++ b/src/services/provider-service/Services/FhirPractitionerProjector.cs
@@ -18,7 +18,7 @@ public sealed class FhirPractitionerProjector : IFhirPractitionerProjector
         ArgumentNullException.ThrowIfNull(provider);
 
         // Organization-type providers project as FHIR Organization
-        // (capability 5.9), not Practitioner. Caller maps null to 404.
+        // (capability 5.8), not Practitioner. Caller maps null to 404.
         if (provider.ProviderType == ProviderType.Organization) return null;
 
         var practitioner = new JsonObject

--- a/src/services/provider-service/Services/FhirPractitionerProjector.cs
+++ b/src/services/provider-service/Services/FhirPractitionerProjector.cs
@@ -1,0 +1,283 @@
+using System.Text.Json.Nodes;
+using ProviderService.Models;
+using static ProviderService.Services.FhirExtensionBuilder;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Hand-built FHIR R4 Practitioner projector (capability 5.7). Pattern
+/// mirrors member-service's <c>FhirPatientProjector</c>: stateless,
+/// deterministic, no Hl7.Fhir.R4 dependency.
+/// </summary>
+public sealed class FhirPractitionerProjector : IFhirPractitionerProjector
+{
+    public JsonObject? Project(Provider provider) => Project(provider, null);
+
+    public JsonObject? Project(Provider provider, ProviderIntegrityProjection? integrity)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        // Organization-type providers project as FHIR Organization
+        // (capability 5.9), not Practitioner. Caller maps null to 404.
+        if (provider.ProviderType == ProviderType.Organization) return null;
+
+        var practitioner = new JsonObject
+        {
+            ["resourceType"] = "Practitioner",
+            ["id"] = provider.NPI,
+            // Active when the head version is Active *and* the legacy
+            // Status flag is Active. Hydration normalises Status from
+            // VersionState, so this is effectively single-state, but
+            // checking both shields against any future divergence.
+            ["active"] = provider.VersionState == ProviderVersionState.Active
+                         && provider.Status == ProviderStatus.Active
+        };
+
+        // ── Identifier (NPI) ─────────────────────────────────────────
+        practitioner["identifier"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["use"] = "official",
+                ["system"] = ChoProviderFhirUrls.NpiSystem,
+                ["value"] = provider.NPI
+            }
+        };
+
+        // ── Name ─────────────────────────────────────────────────────
+        var nameNode = new JsonObject { ["use"] = "official" };
+        if (!string.IsNullOrEmpty(provider.LastName))
+        {
+            nameNode["family"] = provider.LastName;
+        }
+
+        var givenNames = new JsonArray();
+        if (!string.IsNullOrEmpty(provider.FirstName)) givenNames.Add(provider.FirstName);
+        if (!string.IsNullOrEmpty(provider.MiddleName)) givenNames.Add(provider.MiddleName);
+        if (givenNames.Count > 0) nameNode["given"] = givenNames;
+
+        var suffixes = ParseCredentialsToSuffixes(provider.Credentials);
+        if (suffixes.Count > 0)
+        {
+            var suffixArray = new JsonArray();
+            foreach (var s in suffixes) suffixArray.Add(s);
+            nameNode["suffix"] = suffixArray;
+        }
+        practitioner["name"] = new JsonArray { nameNode };
+
+        // ── gender ───────────────────────────────────────────────────
+        // Intentionally omitted. Provider has no Gender field today;
+        // capability 5.17 adds Plan-Net demographics. US Core 6.1.0
+        // Practitioner.gender is Must Support 0..1 — omission is conformant.
+
+        // ── Telecom ──────────────────────────────────────────────────
+        var telecom = new JsonArray();
+        if (!string.IsNullOrEmpty(provider.Phone))
+            telecom.Add(new JsonObject { ["system"] = "phone", ["value"] = provider.Phone, ["use"] = "work" });
+        if (!string.IsNullOrEmpty(provider.Fax))
+            telecom.Add(new JsonObject { ["system"] = "fax", ["value"] = provider.Fax, ["use"] = "work" });
+        if (!string.IsNullOrEmpty(provider.Email))
+            telecom.Add(new JsonObject { ["system"] = "email", ["value"] = provider.Email, ["use"] = "work" });
+        if (telecom.Count > 0) practitioner["telecom"] = telecom;
+
+        // ── Address ──────────────────────────────────────────────────
+        if (HasAddress(provider))
+        {
+            var address = new JsonObject { ["use"] = "work" };
+            if (!string.IsNullOrEmpty(provider.Address))
+                address["line"] = new JsonArray { provider.Address };
+            if (!string.IsNullOrEmpty(provider.City)) address["city"] = provider.City;
+            if (!string.IsNullOrEmpty(provider.State)) address["state"] = provider.State;
+            if (!string.IsNullOrEmpty(provider.ZipCode)) address["postalCode"] = provider.ZipCode;
+            practitioner["address"] = new JsonArray { address };
+        }
+
+        // ── Communication (LanguagesSpoken → BCP-47) ────────────────
+        if (provider.LanguagesSpoken.Count > 0)
+        {
+            var communication = new JsonArray();
+            foreach (var lang in provider.LanguagesSpoken)
+            {
+                if (string.IsNullOrEmpty(lang)) continue;
+                var display = LanguageDisplayName(lang) ?? lang;
+                communication.Add(CodeableConcept(
+                    Coding(ChoProviderFhirUrls.Bcp47LanguageSystem, lang, display),
+                    text: display));
+            }
+            if (communication.Count > 0) practitioner["communication"] = communication;
+        }
+
+        // ── Qualification (specialties + board certifications) ──────
+        var qualifications = BuildQualifications(provider);
+        if (qualifications.Count > 0) practitioner["qualification"] = qualifications;
+
+        // ── Extension: integrity score (capability 5.4.5) ───────────
+        if (integrity != null && integrity.Score.HasValue)
+        {
+            var extInner = new JsonArray
+            {
+                ExtensionInteger("score", integrity.Score.Value)
+            };
+            if (!string.IsNullOrEmpty(integrity.Rating))
+            {
+                extInner.Add(ExtensionString("rating", integrity.Rating));
+            }
+            if (integrity.LastVerifiedAt.HasValue)
+            {
+                extInner.Add(ExtensionDateTime("lastVerifiedAt", integrity.LastVerifiedAt.Value));
+            }
+
+            practitioner["extension"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["url"] = ChoProviderFhirUrls.ProviderIntegrityScoreExt,
+                    ["extension"] = extInner
+                }
+            };
+        }
+
+        // ── Meta ────────────────────────────────────────────────────
+        practitioner["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = DateTime.SpecifyKind(provider.LastUpdatedDate, DateTimeKind.Utc).ToString("o"),
+            ["profile"] = new JsonArray(
+                ChoProviderFhirUrls.UsCorePractitionerProfile,
+                ChoProviderFhirUrls.PlanNetPractitionerProfile)
+        };
+
+        return practitioner;
+    }
+
+    /// <summary>
+    /// Parse the comma-separated <c>Credentials</c> string ("MD",
+    /// "MD, FACP", "DO,NP") into a trimmed list suitable for FHIR
+    /// HumanName.suffix. Empty / whitespace-only entries are dropped;
+    /// duplicates are preserved (caller-supplied order is honored).
+    /// </summary>
+    private static IReadOnlyList<string> ParseCredentialsToSuffixes(string? credentials)
+    {
+        if (string.IsNullOrWhiteSpace(credentials)) return Array.Empty<string>();
+        return credentials
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+    }
+
+    private static bool HasAddress(Provider p) =>
+        !string.IsNullOrEmpty(p.Address) || !string.IsNullOrEmpty(p.City) ||
+        !string.IsNullOrEmpty(p.State) || !string.IsNullOrEmpty(p.ZipCode);
+
+    /// <summary>
+    /// Build the <c>qualification</c> array. Three sources:
+    /// <list type="number">
+    /// <item>Primary specialty: full NUCC coding from
+    /// <see cref="Provider.TaxonomyCode"/> + display from
+    /// <see cref="Provider.PrimarySpecialty"/>.</item>
+    /// <item>Secondary specialties: text-only CodeableConcept entries.
+    /// Provider-service does not store NUCC codes for secondaries
+    /// today; emitting text-only is conformant FHIR. Capability 5.17 or
+    /// later adds taxonomy resolution.</item>
+    /// <item>Board certifications: each cert becomes a qualification
+    /// entry with the v2-0360 BC code, period, and issuer display.</item>
+    /// </list>
+    /// </summary>
+    private static JsonArray BuildQualifications(Provider provider)
+    {
+        var qualifications = new JsonArray();
+
+        if (!string.IsNullOrEmpty(provider.PrimarySpecialty)
+            || !string.IsNullOrEmpty(provider.TaxonomyCode))
+        {
+            JsonObject codeNode;
+            if (!string.IsNullOrEmpty(provider.TaxonomyCode))
+            {
+                var coding = Coding(
+                    ChoProviderFhirUrls.NuccTaxonomySystem,
+                    provider.TaxonomyCode,
+                    string.IsNullOrEmpty(provider.PrimarySpecialty) ? null : provider.PrimarySpecialty);
+                codeNode = CodeableConcept(coding,
+                    text: string.IsNullOrEmpty(provider.PrimarySpecialty) ? provider.TaxonomyCode : provider.PrimarySpecialty);
+            }
+            else
+            {
+                codeNode = CodeableConcept(coding: null, text: provider.PrimarySpecialty);
+            }
+            qualifications.Add(new JsonObject { ["code"] = codeNode });
+        }
+
+        foreach (var secondary in provider.SecondarySpecialties)
+        {
+            if (string.IsNullOrWhiteSpace(secondary)) continue;
+            qualifications.Add(new JsonObject
+            {
+                ["code"] = CodeableConcept(coding: null, text: secondary)
+            });
+        }
+
+        foreach (var cert in provider.BoardCertifications)
+        {
+            if (string.IsNullOrEmpty(cert.Specialty) && string.IsNullOrEmpty(cert.Board)) continue;
+
+            var certText = string.IsNullOrEmpty(cert.Board)
+                ? cert.Specialty
+                : (string.IsNullOrEmpty(cert.Specialty) ? cert.Board : $"{cert.Specialty} ({cert.Board})");
+
+            var qualification = new JsonObject
+            {
+                ["code"] = CodeableConcept(
+                    Coding(ChoProviderFhirUrls.Hl70360CodeSystem, "BC", "Board Certified"),
+                    text: certText)
+            };
+
+            if (cert.CertificationDate != default)
+            {
+                var period = new JsonObject
+                {
+                    ["start"] = DateTime.SpecifyKind(cert.CertificationDate, DateTimeKind.Utc).ToString("yyyy-MM-dd")
+                };
+                if (cert.ExpirationDate.HasValue)
+                {
+                    period["end"] = DateTime.SpecifyKind(cert.ExpirationDate.Value, DateTimeKind.Utc).ToString("yyyy-MM-dd");
+                }
+                qualification["period"] = period;
+            }
+
+            if (!string.IsNullOrEmpty(cert.Board))
+            {
+                qualification["issuer"] = new JsonObject { ["display"] = cert.Board };
+            }
+
+            qualifications.Add(qualification);
+        }
+
+        return qualifications;
+    }
+
+    /// <summary>
+    /// Display name for the most common ISO 639-1 language codes that
+    /// providers actually carry. Falls through to the code itself for
+    /// anything not in the table; FHIR consumers should resolve via
+    /// terminology service for full coverage. The handful of mappings
+    /// here mirrors the LanguagesSpoken comment on Provider.cs.
+    /// </summary>
+    private static string? LanguageDisplayName(string code) => code.ToLowerInvariant() switch
+    {
+        "en" => "English",
+        "es" => "Spanish",
+        "zh" => "Chinese",
+        "vi" => "Vietnamese",
+        "tl" => "Tagalog",
+        "ko" => "Korean",
+        "ru" => "Russian",
+        "ar" => "Arabic",
+        "fr" => "French",
+        "de" => "German",
+        "hi" => "Hindi",
+        "ja" => "Japanese",
+        "pt" => "Portuguese",
+        "it" => "Italian",
+        "pl" => "Polish",
+        _ => null
+    };
+}

--- a/src/services/provider-service/Services/IFhirPractitionerProjector.cs
+++ b/src/services/provider-service/Services/IFhirPractitionerProjector.cs
@@ -12,7 +12,7 @@ namespace ProviderService.Services;
 ///
 /// <para>
 /// Returns <c>null</c> when called with <see cref="ProviderType.Organization"/>
-/// — those project as FHIR Organization (capability 5.9), not Practitioner.
+/// — those project as FHIR Organization (capability 5.8), not Practitioner.
 /// Caller maps null to FHIR <c>OperationOutcome</c> 404.
 /// </para>
 ///

--- a/src/services/provider-service/Services/IFhirPractitionerProjector.cs
+++ b/src/services/provider-service/Services/IFhirPractitionerProjector.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Nodes;
+using ProviderService.Models;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Projects a <see cref="Provider"/> with <see cref="ProviderType.Individual"/>
+/// into a FHIR R4 Practitioner resource (as a <see cref="JsonObject"/>).
+/// Mirrors <c>IFhirPatientProjector</c> in member-service: hand-built to
+/// avoid the Hl7.Fhir.R4 transitive dep graph and keep serialization
+/// deterministic for tests.
+///
+/// <para>
+/// Returns <c>null</c> when called with <see cref="ProviderType.Organization"/>
+/// — those project as FHIR Organization (capability 5.9), not Practitioner.
+/// Caller maps null to FHIR <c>OperationOutcome</c> 404.
+/// </para>
+///
+/// <para>
+/// The projection emits <c>meta.profile</c> with both the US Core 6.1.0
+/// Practitioner profile and the Da Vinci Plan-Net 1.1.0 Practitioner
+/// profile. Required US Core elements are honored (identifier, active,
+/// name, address, telecom, qualification). Plan-Net <c>qualification.code</c>
+/// is emitted with full NUCC coding for the primary specialty and as
+/// text-only CodeableConcept entries for secondary specialties (no
+/// parallel taxonomy-code list exists on Provider today). Extended
+/// Plan-Net extensions (cultural competency, accessibility, populations
+/// served) are deferred to capability 5.17.
+/// </para>
+///
+/// <para>
+/// Practitioner.gender is intentionally NOT emitted: there is no Gender
+/// field on <see cref="Provider"/> today. US Core 6.1.0 cardinality is
+/// Must Support 0..1, so omission is conformant. Capability 5.17 adds
+/// the field alongside other Plan-Net demographics.
+/// </para>
+/// </summary>
+public interface IFhirPractitionerProjector
+{
+    /// <summary>
+    /// Project a provider without integrity context. Equivalent to
+    /// <see cref="Project(Provider, ProviderIntegrityProjection?)"/> with
+    /// <c>integrity = null</c>.
+    /// </summary>
+    JsonObject? Project(Provider provider);
+
+    /// <summary>
+    /// Project a provider; when <paramref name="integrity"/> is provided,
+    /// emit a CHO-prefixed integrity-score extension so consumers can
+    /// surface the Provider Integrity verification result (capability
+    /// 5.4.5) without an extra lookup.
+    /// </summary>
+    JsonObject? Project(Provider provider, ProviderIntegrityProjection? integrity);
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerProxyTests.cs
@@ -1,0 +1,186 @@
+using System.Net;
+using System.Text;
+using FhirService.Controllers;
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+
+namespace CloudHealthOffice.FhirService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.7 — proxy-shape coverage for the rewritten Practitioner
+/// endpoints in <see cref="ProviderDirectoryController"/>. The
+/// controller no longer talks to NPPES or
+/// <c>ProviderVerificationService</c> on the Practitioner path; it issues
+/// a single GET to the typed <c>ProviderService</c> HttpClient and
+/// passes the response through. These tests assert:
+///
+/// <list type="bullet">
+///   <item>read forwards GET /fhir/Practitioner/{id} to provider-service;</item>
+///   <item>search forwards the original FHIR query string;</item>
+///   <item>4xx and 2xx responses pass through (status + body + content-type);</item>
+///   <item>5xx responses are translated to a FHIR 502 OperationOutcome
+///         (no upstream-body leak);</item>
+///   <item>upstream connection failure → 502 OperationOutcome;</item>
+///   <item>NPPES and verification HttpClients are NOT touched on the
+///         Practitioner path.</item>
+/// </list>
+/// </summary>
+public class ProviderDirectoryControllerProxyTests
+{
+    private readonly Mock<IHttpClientFactory> _factory = new();
+    private readonly RecordingHandler _providerServiceHandler = new();
+    private readonly RecordingHandler _verificationHandler = new();
+    private readonly RecordingHandler _nppesHandler = new();
+    private readonly ProviderDirectoryController _controller;
+
+    public ProviderDirectoryControllerProxyTests()
+    {
+        _factory.Setup(f => f.CreateClient("ProviderService"))
+            .Returns(() => new HttpClient(_providerServiceHandler)
+            {
+                BaseAddress = new Uri("http://provider-service.test/")
+            });
+        _factory.Setup(f => f.CreateClient("ProviderVerificationService"))
+            .Returns(() => new HttpClient(_verificationHandler)
+            {
+                BaseAddress = new Uri("http://provider-verification-service.test/")
+            });
+        _factory.Setup(f => f.CreateClient("NppesApi"))
+            .Returns(() => new HttpClient(_nppesHandler)
+            {
+                BaseAddress = new Uri("http://nppes.test/")
+            });
+
+        _controller = new ProviderDirectoryController(
+            _factory.Object,
+            NullLogger<ProviderDirectoryController>.Instance);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_forwards_to_provider_service_with_NPI_path()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Practitioner\",\"id\":\"1234567890\"}"));
+
+        var result = await _controller.ReadPractitioner("1234567890", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"Practitioner\"");
+
+        _providerServiceHandler.Calls.Should().ContainSingle();
+        var req = _providerServiceHandler.Calls[0];
+        req.Method.Should().Be(HttpMethod.Get);
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/Practitioner/1234567890");
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_passes_404_OperationOutcome_through()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.NotFound,
+            "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"not-found\"}]}"));
+
+        var result = await _controller.ReadPractitioner("9999999999", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.Content.Should().Contain("OperationOutcome");
+        content.Content.Should().Contain("not-found");
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_translates_upstream_5xx_to_502_OperationOutcome()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.InternalServerError,
+            "internal upstream noise that must NOT leak"));
+
+        var result = await _controller.ReadPractitioner("1234567890", default);
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        // FhirControllerBase.FhirBadGateway(...) returns the typed FHIR
+        // OperationOutcome model. Asserting on the type is more robust
+        // than serialising and grepping for "resourceType" — the FHIR
+        // formatter pipeline emits that, not raw JSON.
+        var outcome = status.Value.Should().BeOfType<OperationOutcome>().Subject;
+        outcome.Issue.Single().Code.Should().Be(OperationOutcome.IssueType.Transient);
+        outcome.Issue.Single().Diagnostics.Should().NotContain("internal upstream noise");
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_handles_upstream_unreachable_as_502()
+    {
+        _providerServiceHandler.Respond(_ =>
+            throw new HttpRequestException("connection refused"));
+
+        var result = await _controller.ReadPractitioner("1234567890", default);
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        status.Value.Should().BeOfType<OperationOutcome>();
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_forwards_query_string_to_provider_service()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new QueryString("?family=Smith&city=Boston&state=MA");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchPractitioners(default);
+
+        var req = _providerServiceHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/Practitioner");
+        req.RequestUri.Query.Should().Contain("family=Smith");
+        req.RequestUri.Query.Should().Contain("city=Boston");
+        req.RequestUri.Query.Should().Contain("state=MA");
+    }
+
+    [Fact]
+    public async Task Practitioner_path_does_not_call_NPPES_or_verification()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Practitioner\",\"id\":\"1234567890\"}"));
+
+        await _controller.ReadPractitioner("1234567890", default);
+
+        _nppesHandler.Calls.Should().BeEmpty(
+            "the NPPES path is dead for Practitioner now");
+        _verificationHandler.Calls.Should().BeEmpty(
+            "verification enrichment is folded into the provider-service projection");
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/fhir+json")
+        };
+
+    /// <summary>
+    /// Test double for HttpMessageHandler that records each request and
+    /// dispatches via a caller-supplied delegate.
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = new();
+        private Func<HttpRequestMessage, HttpResponseMessage> _responder =
+            _ => new HttpResponseMessage(HttpStatusCode.NotImplemented);
+
+        public void Respond(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerProxyTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Moq.Protected;
 
 namespace CloudHealthOffice.FhirService.Tests.Controllers;
 

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryVerificationTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryVerificationTests.cs
@@ -4,6 +4,12 @@ using FluentAssertions;
 
 namespace CloudHealthOffice.FhirService.Tests.Controllers;
 
+// CS0618: ProviderDirectoryMapper.MapNppesToPractitioner / EnrichWithVerification
+// were marked [Obsolete] in capability 5.7 — Practitioner proxies to
+// provider-service now. This class still exercises the NPPES enrichment
+// path until the mapper itself is removed in the post-5.8/5.9 cleanup PR.
+#pragma warning disable CS0618
+
 public class ProviderDirectoryVerificationTests
 {
     [Fact]

--- a/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
@@ -4,6 +4,13 @@ using FhirService.Models;
 
 namespace CloudHealthOffice.FhirService.Tests;
 
+// CS0618: ProviderDirectoryMapper.MapNppesToPractitioner / EnrichWithVerification
+// were marked [Obsolete] in capability 5.7. The Practitioner endpoints now
+// proxy to provider-service's projection; these mapper methods linger
+// only because this test class exercises them as part of the dying NPPES
+// path. The whole NPPES mapper retires once 5.8/5.9 ship.
+#pragma warning disable CS0618
+
 /// <summary>
 /// Unit tests for ProviderDirectoryMapper — port of the TypeScript
 /// provider-directory-api.test.ts test suite.

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerControllerTests.cs
@@ -1,0 +1,239 @@
+using System.Text.Json.Nodes;
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.7 — endpoint-shape coverage for the new
+/// <see cref="FhirPractitionerController"/>: read-by-NPI happy path,
+/// 404s on unknown / non-Individual NPIs, 400 on malformed NPI, search
+/// parameter wiring (given/family/city/state/postal-code/specialty),
+/// FHIR Bundle searchset shape, identifier alias resolution, and
+/// tenant scoping.
+/// </summary>
+public class FhirPractitionerControllerTests
+{
+    private const string TenantId = "tenant-a";
+
+    private readonly InMemoryProviderRepository _repository = new() { TenantId = TenantId };
+    private readonly FhirPractitionerProjector _projector = new();
+    private readonly FhirPractitionerController _controller;
+
+    public FhirPractitionerControllerTests()
+    {
+        _controller = new FhirPractitionerController(_repository, _projector,
+            NullLogger<FhirPractitionerController>.Instance);
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        ctx.Request.Scheme = "https";
+        ctx.Request.Host = new HostString("provider.test.local");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    private static Provider IndividualProvider(string npi, string firstName, string lastName, string? city = null, string? state = null, string? zip = null, string? specialty = null) => new()
+    {
+        TenantId = TenantId,
+        Id = $"v-{npi}",
+        ProviderId = $"p-{npi}",
+        VersionId = $"v-{npi}",
+        VersionNumber = 1,
+        VersionState = ProviderVersionState.Active,
+        Status = ProviderStatus.Active,
+        NPI = npi,
+        ProviderType = ProviderType.Individual,
+        FirstName = firstName,
+        LastName = lastName,
+        PrimarySpecialty = specialty ?? "Internal Medicine",
+        TaxonomyCode = "207R00000X",
+        City = city,
+        State = state,
+        ZipCode = zip,
+    };
+
+    private static Provider OrganizationProvider(string npi) => new()
+    {
+        TenantId = TenantId,
+        Id = $"v-{npi}",
+        ProviderId = $"p-{npi}",
+        VersionId = $"v-{npi}",
+        VersionNumber = 1,
+        VersionState = ProviderVersionState.Active,
+        Status = ProviderStatus.Active,
+        NPI = npi,
+        ProviderType = ProviderType.Organization,
+        OrganizationName = "Acme Hospital",
+        PrimarySpecialty = "Hospital",
+        TaxonomyCode = "282N00000X",
+    };
+
+    private static JsonObject ParseFhirContent(IActionResult result)
+    {
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.ContentType.Should().Be("application/fhir+json");
+        return JsonNode.Parse(content.Content!)!.AsObject();
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_returns_projection_for_known_NPI()
+    {
+        await _repository.CreateAsync(IndividualProvider("1234567890", "Jane", "Doe"));
+        var result = await _controller.ReadPractitioner("1234567890", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+        var body = ParseFhirContent(result);
+        body["resourceType"]!.GetValue<string>().Should().Be("Practitioner");
+        body["id"]!.GetValue<string>().Should().Be("1234567890");
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_returns_404_OperationOutcome_for_unknown_NPI()
+    {
+        var result = await _controller.ReadPractitioner("9999999999", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        var body = ParseFhirContent(result);
+        body["resourceType"]!.GetValue<string>().Should().Be("OperationOutcome");
+        body["issue"]!.AsArray().Single()!["code"]!.GetValue<string>().Should().Be("not-found");
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_returns_404_for_organization_provider()
+    {
+        await _repository.CreateAsync(OrganizationProvider("1111111111"));
+        var result = await _controller.ReadPractitioner("1111111111", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+    }
+
+    [Theory]
+    [InlineData("not-an-npi")]
+    [InlineData("12345")]
+    [InlineData("12345678901")]
+    [InlineData("123456789X")]
+    public async Task ReadPractitioner_returns_400_for_malformed_NPI(string npi)
+    {
+        var result = await _controller.ReadPractitioner(npi, default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+        var body = ParseFhirContent(result);
+        body["resourceType"]!.GetValue<string>().Should().Be("OperationOutcome");
+        body["issue"]!.AsArray().Single()!["code"]!.GetValue<string>().Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_NPI_param_degrades_to_single_entry_bundle()
+    {
+        await _repository.CreateAsync(IndividualProvider("1234567890", "Jane", "Doe"));
+        var result = await _controller.SearchPractitioners(
+            npi: "1234567890", identifier: null, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["resourceType"]!.GetValue<string>().Should().Be("Bundle");
+        bundle["type"]!.GetValue<string>().Should().Be("searchset");
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        var entry = bundle["entry"]!.AsArray().Single()!.AsObject();
+        entry["resource"]!["id"]!.GetValue<string>().Should().Be("1234567890");
+        entry["search"]!["mode"]!.GetValue<string>().Should().Be("match");
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_NPI_for_organization_returns_empty_bundle()
+    {
+        await _repository.CreateAsync(OrganizationProvider("1111111111"));
+        var result = await _controller.SearchPractitioners(
+            npi: "1111111111", identifier: null, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+        bundle["entry"]!.AsArray().Count.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("NPI:1234567890", "1234567890")]
+    [InlineData("http://hl7.org/fhir/sid/us-npi|1234567890", "1234567890")]
+    [InlineData("NPI|1234567890", "1234567890")]
+    [InlineData("|1234567890", "1234567890")]
+    [InlineData("1234567890", "1234567890")]
+    public async Task SearchPractitioners_identifier_alias_resolves_to_NPI(
+        string identifier, string expectedMatchingNpi)
+    {
+        await _repository.CreateAsync(IndividualProvider(expectedMatchingNpi, "Jane", "Doe"));
+        var result = await _controller.SearchPractitioners(
+            npi: null, identifier: identifier, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        bundle["entry"]!.AsArray().Single()!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be(expectedMatchingNpi);
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_filters_by_family_and_given()
+    {
+        await _repository.CreateAsync(IndividualProvider("1111111111", "Alice", "Smith"));
+        await _repository.CreateAsync(IndividualProvider("2222222222", "Bob", "Smith"));
+        await _repository.CreateAsync(IndividualProvider("3333333333", "Bob", "Jones"));
+
+        var result = await _controller.SearchPractitioners(
+            npi: null, identifier: null, given: "Bob", family: "Smith",
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        bundle["entry"]!.AsArray().Single()!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be("2222222222");
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_filters_by_city_state_postal()
+    {
+        await _repository.CreateAsync(IndividualProvider("1111111111", "Alice", "Boston", city: "Boston", state: "MA", zip: "02101"));
+        await _repository.CreateAsync(IndividualProvider("2222222222", "Alice", "Cambridge", city: "Cambridge", state: "MA", zip: "02139"));
+        await _repository.CreateAsync(IndividualProvider("3333333333", "Alice", "Albany", city: "Albany", state: "NY", zip: "12207"));
+
+        var result = await _controller.SearchPractitioners(
+            npi: null, identifier: null, given: null, family: null,
+            city: "Boston", state: "MA", postalCode: "02101", specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        bundle["entry"]!.AsArray().Single()!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be("1111111111");
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_excludes_organization_providers()
+    {
+        await _repository.CreateAsync(IndividualProvider("1111111111", "Alice", "Smith"));
+        await _repository.CreateAsync(OrganizationProvider("2222222222"));
+
+        var result = await _controller.SearchPractitioners(
+            npi: null, identifier: null, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["entry"]!.AsArray()
+            .Select(e => e!["resource"]!["id"]!.GetValue<string>())
+            .Should().BeEquivalentTo(new[] { "1111111111" });
+    }
+
+    [Fact]
+    public async Task ReadPractitioner_does_not_see_other_tenants_providers()
+    {
+        // Tenant-A owns the provider; controller is configured with
+        // tenant-A. The fake's TenantId is set to tenant-A so a
+        // tenant-B caller would not match. Simulate by writing into the
+        // repo as tenant-b directly.
+        var foreign = IndividualProvider("1234567890", "Jane", "Doe");
+        foreign.TenantId = "tenant-b";
+        await _repository.CreateAsync(foreign);
+
+        var result = await _controller.ReadPractitioner("1234567890", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerControllerTests.cs
@@ -174,6 +174,45 @@ public class FhirPractitionerControllerTests
             .Should().Be(expectedMatchingNpi);
     }
 
+    [Theory]
+    [InlineData("urn:other:system|1234567890")]
+    [InlineData("http://other-system.example.com|1234567890")]
+    public async Task SearchPractitioners_identifier_with_unrecognized_system_returns_400(
+        string identifier)
+    {
+        // Per FHIR token semantics, an identifier supplied with a system
+        // we don't index should NOT silently fall through to a broad
+        // search — that would ignore a caller-supplied filter.
+        await _repository.CreateAsync(IndividualProvider("1234567890", "Jane", "Doe"));
+        var result = await _controller.SearchPractitioners(
+            npi: null, identifier: identifier, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+        var body = ParseFhirContent(result);
+        body["resourceType"]!.GetValue<string>().Should().Be("OperationOutcome");
+        body["issue"]!.AsArray().Single()!["code"]!.GetValue<string>().Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task SearchPractitioners_bundle_entries_omit_fullUrl()
+    {
+        // Bundle.entry.fullUrl is optional in FHIR R4. provider-service
+        // omits it because the response is reachable directly OR via
+        // fhir-service's proxy; emitting fullUrl from HttpContext.Request
+        // would leak the internal provider-service host through the
+        // proxy path.
+        await _repository.CreateAsync(IndividualProvider("1234567890", "Jane", "Doe"));
+        var result = await _controller.SearchPractitioners(
+            npi: "1234567890", identifier: null, given: null, family: null,
+            city: null, state: null, postalCode: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        var entry = bundle["entry"]!.AsArray().Single()!.AsObject();
+        entry.ContainsKey("fullUrl").Should().BeFalse();
+        entry.ContainsKey("resource").Should().BeTrue();
+        entry["search"]!["mode"]!.GetValue<string>().Should().Be("match");
+    }
+
     [Fact]
     public async Task SearchPractitioners_filters_by_family_and_given()
     {

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -96,7 +96,8 @@ public sealed class InMemoryProviderRepository : IProviderRepository
     public Task<IEnumerable<Provider>> SearchAsync(
         string? name, string? specialty, string? zipCode, string? state,
         string? planId, LineOfBusiness? lineOfBusiness, ProviderType? providerType,
-        bool? acceptingNewPatients, int page, int pageSize)
+        bool? acceptingNewPatients, int page, int pageSize,
+        string? firstName = null, string? lastName = null, string? city = null)
     {
         IEnumerable<Provider> q = _docs.Where(d => d.TenantId == TenantId && d.Status == ProviderStatus.Active);
         if (!string.IsNullOrEmpty(name))
@@ -106,12 +107,18 @@ public sealed class InMemoryProviderRepository : IProviderRepository
                 (d.LastName ?? string.Empty).Contains(name, StringComparison.OrdinalIgnoreCase) ||
                 (d.OrganizationName ?? string.Empty).Contains(name, StringComparison.OrdinalIgnoreCase));
         }
+        if (!string.IsNullOrEmpty(firstName))
+            q = q.Where(d => (d.FirstName ?? string.Empty).Contains(firstName, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrEmpty(lastName))
+            q = q.Where(d => (d.LastName ?? string.Empty).Contains(lastName, StringComparison.OrdinalIgnoreCase));
         if (!string.IsNullOrEmpty(specialty))
             q = q.Where(d => d.PrimarySpecialty.Contains(specialty, StringComparison.OrdinalIgnoreCase));
         if (!string.IsNullOrEmpty(zipCode))
             q = q.Where(d => d.ZipCode == zipCode);
         if (!string.IsNullOrEmpty(state))
             q = q.Where(d => d.State == state);
+        if (!string.IsNullOrEmpty(city))
+            q = q.Where(d => (d.City ?? string.Empty).Contains(city, StringComparison.OrdinalIgnoreCase));
         if (providerType.HasValue)
             q = q.Where(d => d.ProviderType == providerType.Value);
         if (acceptingNewPatients.HasValue)

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerProjectorTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerProjectorTests.cs
@@ -1,0 +1,337 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Capability 5.7 — FHIR Practitioner projection unit tests. Mirrors
+/// member-service's <c>FhirPatientProjectorTests</c>: comprehensive
+/// fixture, structural conformance assertions for US Core 6.1.0 + Plan-Net
+/// IG 1.1.0 required elements, edge coverage (Organization → null,
+/// missing optionals, credential parsing, integrity extension presence /
+/// absence), and a determinism check.
+/// </summary>
+public class FhirPractitionerProjectorTests
+{
+    private readonly FhirPractitionerProjector _projector = new();
+
+    private static Provider BuildIndividualProvider() => new()
+    {
+        TenantId = "tenant-a",
+        Id = "v-1",
+        ProviderId = "p-1",
+        VersionId = "v-1",
+        VersionNumber = 1,
+        VersionState = ProviderVersionState.Active,
+        Status = ProviderStatus.Active,
+        NPI = "1234567890",
+        ProviderType = ProviderType.Individual,
+        FirstName = "Jane",
+        MiddleName = "Q",
+        LastName = "Doe",
+        Credentials = "MD, FACP",
+        PrimarySpecialty = "Internal Medicine",
+        TaxonomyCode = "207R00000X",
+        SecondarySpecialties = new() { "Cardiology", "Hypertension" },
+        Address = "100 Main St",
+        City = "Boston",
+        State = "MA",
+        ZipCode = "02101",
+        Phone = "617-555-0100",
+        Fax = "617-555-0101",
+        Email = "jane.doe@example.com",
+        LanguagesSpoken = new() { "en", "es" },
+        BoardCertifications = new()
+        {
+            new BoardCertification
+            {
+                Specialty = "Internal Medicine",
+                Board = "American Board of Internal Medicine",
+                CertificationDate = new DateTime(2018, 6, 1),
+                ExpirationDate = new DateTime(2028, 6, 1),
+            }
+        },
+        IntegrityScore = 87,
+        IntegrityRating = "Clear",
+        LastVerifiedAt = new DateTimeOffset(2026, 4, 22, 12, 0, 0, TimeSpan.Zero),
+        LastUpdatedDate = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public void Projects_minimum_required_elements()
+    {
+        var result = _projector.Project(BuildIndividualProvider());
+
+        result.Should().NotBeNull();
+        result!["resourceType"]!.GetValue<string>().Should().Be("Practitioner");
+        result["id"]!.GetValue<string>().Should().Be("1234567890");
+        result["active"]!.GetValue<bool>().Should().BeTrue();
+
+        var profiles = result["meta"]!["profile"]!.AsArray()
+            .Select(n => n!.GetValue<string>()).ToList();
+        profiles.Should().Contain("http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner");
+        profiles.Should().Contain("http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner");
+    }
+
+    [Fact]
+    public void Identifier_emits_NPI_with_us_npi_system()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var identifier = result["identifier"]!.AsArray().Single()!.AsObject();
+        identifier["system"]!.GetValue<string>().Should().Be("http://hl7.org/fhir/sid/us-npi");
+        identifier["value"]!.GetValue<string>().Should().Be("1234567890");
+        identifier["use"]!.GetValue<string>().Should().Be("official");
+    }
+
+    [Fact]
+    public void Name_parses_credentials_into_suffix_array()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var name = result["name"]!.AsArray().Single()!.AsObject();
+        name["family"]!.GetValue<string>().Should().Be("Doe");
+
+        var given = name["given"]!.AsArray().Select(n => n!.GetValue<string>()).ToList();
+        given.Should().BeEquivalentTo(new[] { "Jane", "Q" }, opt => opt.WithStrictOrdering());
+
+        var suffix = name["suffix"]!.AsArray().Select(n => n!.GetValue<string>()).ToList();
+        suffix.Should().BeEquivalentTo(new[] { "MD", "FACP" }, opt => opt.WithStrictOrdering());
+    }
+
+    [Theory]
+    [InlineData(null, new string[0])]
+    [InlineData("", new string[0])]
+    [InlineData("MD", new[] { "MD" })]
+    [InlineData("MD,FACP", new[] { "MD", "FACP" })]
+    [InlineData("MD , FACP , FAAFP", new[] { "MD", "FACP", "FAAFP" })]
+    [InlineData(",MD,,", new[] { "MD" })]
+    public void Credentials_parsing_strips_whitespace_and_drops_empty(string? credentials, string[] expected)
+    {
+        var provider = BuildIndividualProvider();
+        provider.Credentials = credentials;
+        var result = _projector.Project(provider)!;
+        var name = result["name"]!.AsArray().Single()!.AsObject();
+        if (expected.Length == 0)
+        {
+            name.ContainsKey("suffix").Should().BeFalse();
+        }
+        else
+        {
+            var suffix = name["suffix"]!.AsArray().Select(n => n!.GetValue<string>()).ToList();
+            suffix.Should().BeEquivalentTo(expected, opt => opt.WithStrictOrdering());
+        }
+    }
+
+    [Fact]
+    public void Name_omits_given_when_first_and_middle_are_empty()
+    {
+        var provider = BuildIndividualProvider();
+        provider.FirstName = null;
+        provider.MiddleName = null;
+        var result = _projector.Project(provider)!;
+        var name = result["name"]!.AsArray().Single()!.AsObject();
+        name.ContainsKey("given").Should().BeFalse();
+        name["family"]!.GetValue<string>().Should().Be("Doe");
+    }
+
+    [Fact]
+    public void Gender_is_never_emitted()
+    {
+        // Capability 5.7 Premise A: Provider has no Gender field today;
+        // US Core 6.1.0 Practitioner.gender 0..1 — omission is conformant.
+        // 5.17 adds the field; until then the projector MUST NOT emit it
+        // (consumers should treat absence as "unknown", not "unrepresented").
+        var result = _projector.Project(BuildIndividualProvider())!;
+        result.ContainsKey("gender").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Telecom_includes_phone_email_fax_in_canonical_order()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var telecom = result["telecom"]!.AsArray()
+            .Select(n => n!.AsObject())
+            .Select(o => (System: o["system"]!.GetValue<string>(), Value: o["value"]!.GetValue<string>()))
+            .ToList();
+        telecom.Should().HaveCount(3);
+        telecom[0].System.Should().Be("phone");
+        telecom[1].System.Should().Be("fax");
+        telecom[2].System.Should().Be("email");
+    }
+
+    [Fact]
+    public void Telecom_omits_missing_entries()
+    {
+        var provider = BuildIndividualProvider();
+        provider.Phone = null;
+        provider.Fax = null;
+        provider.Email = null;
+        var result = _projector.Project(provider)!;
+        result.ContainsKey("telecom").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Address_emits_when_any_component_present()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var address = result["address"]!.AsArray().Single()!.AsObject();
+        address["line"]!.AsArray().Single()!.GetValue<string>().Should().Be("100 Main St");
+        address["city"]!.GetValue<string>().Should().Be("Boston");
+        address["state"]!.GetValue<string>().Should().Be("MA");
+        address["postalCode"]!.GetValue<string>().Should().Be("02101");
+    }
+
+    [Fact]
+    public void Address_omitted_when_all_components_null()
+    {
+        var provider = BuildIndividualProvider();
+        provider.Address = null; provider.City = null; provider.State = null; provider.ZipCode = null;
+        var result = _projector.Project(provider)!;
+        result.ContainsKey("address").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Qualification_primary_specialty_carries_full_NUCC_coding()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var qualifications = result["qualification"]!.AsArray();
+        var primary = qualifications[0]!.AsObject()["code"]!.AsObject();
+
+        var coding = primary["coding"]!.AsArray().Single()!.AsObject();
+        coding["system"]!.GetValue<string>().Should().Be("http://nucc.org/provider-taxonomy");
+        coding["code"]!.GetValue<string>().Should().Be("207R00000X");
+        coding["display"]!.GetValue<string>().Should().Be("Internal Medicine");
+        primary["text"]!.GetValue<string>().Should().Be("Internal Medicine");
+    }
+
+    [Fact]
+    public void Qualification_secondary_specialties_emit_text_only()
+    {
+        // Capability 5.7 Premise B: Provider has no parallel taxonomy-code
+        // list for SecondarySpecialties. Text-only CodeableConcept is the
+        // ratified shape. A 'coding' array on these entries would be wrong.
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var qualifications = result["qualification"]!.AsArray();
+
+        var cardiology = qualifications[1]!.AsObject()["code"]!.AsObject();
+        cardiology.ContainsKey("coding").Should().BeFalse();
+        cardiology["text"]!.GetValue<string>().Should().Be("Cardiology");
+
+        var hypertension = qualifications[2]!.AsObject()["code"]!.AsObject();
+        hypertension.ContainsKey("coding").Should().BeFalse();
+        hypertension["text"]!.GetValue<string>().Should().Be("Hypertension");
+    }
+
+    [Fact]
+    public void Qualification_includes_board_certification_with_period()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var qualifications = result["qualification"]!.AsArray();
+        var cert = qualifications.Last()!.AsObject();
+
+        var coding = cert["code"]!["coding"]!.AsArray().Single()!.AsObject();
+        coding["system"]!.GetValue<string>().Should().Be("http://terminology.hl7.org/CodeSystem/v2-0360");
+        coding["code"]!.GetValue<string>().Should().Be("BC");
+        coding["display"]!.GetValue<string>().Should().Be("Board Certified");
+        cert["code"]!["text"]!.GetValue<string>()
+            .Should().Be("Internal Medicine (American Board of Internal Medicine)");
+        cert["period"]!["start"]!.GetValue<string>().Should().Be("2018-06-01");
+        cert["period"]!["end"]!.GetValue<string>().Should().Be("2028-06-01");
+        cert["issuer"]!["display"]!.GetValue<string>().Should().Be("American Board of Internal Medicine");
+    }
+
+    [Fact]
+    public void Communication_maps_languages_to_BCP47_with_display_names()
+    {
+        var result = _projector.Project(BuildIndividualProvider())!;
+        var communication = result["communication"]!.AsArray()
+            .Select(n => n!.AsObject())
+            .Select(o => (
+                Code: o["coding"]!.AsArray().Single()!["code"]!.GetValue<string>(),
+                Display: o["coding"]!.AsArray().Single()!["display"]!.GetValue<string>(),
+                Text: o["text"]!.GetValue<string>()))
+            .ToList();
+        communication.Should().Contain(("en", "English", "English"));
+        communication.Should().Contain(("es", "Spanish", "Spanish"));
+    }
+
+    [Fact]
+    public void Communication_omitted_when_no_languages()
+    {
+        var provider = BuildIndividualProvider();
+        provider.LanguagesSpoken = new();
+        var result = _projector.Project(provider)!;
+        result.ContainsKey("communication").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IntegrityScore_extension_emitted_when_score_present()
+    {
+        var integrity = ProviderIntegrityProjection.FromProvider(BuildIndividualProvider());
+        var result = _projector.Project(BuildIndividualProvider(), integrity)!;
+        var ext = result["extension"]!.AsArray().Single()!.AsObject();
+        ext["url"]!.GetValue<string>()
+            .Should().Be("http://fhir.cloudhealthoffice.com/StructureDefinition/provider-integrity-score");
+
+        var inner = ext["extension"]!.AsArray()
+            .Select(n => n!.AsObject())
+            .ToList();
+        inner.Single(e => e["url"]!.GetValue<string>() == "score")
+             ["valueInteger"]!.GetValue<int>().Should().Be(87);
+        inner.Single(e => e["url"]!.GetValue<string>() == "rating")
+             ["valueString"]!.GetValue<string>().Should().Be("Clear");
+        inner.Single(e => e["url"]!.GetValue<string>() == "lastVerifiedAt")
+             ["valueDateTime"]!.GetValue<string>().Should().StartWith("2026-04-22");
+    }
+
+    [Fact]
+    public void IntegrityScore_extension_omitted_when_score_null()
+    {
+        var provider = BuildIndividualProvider();
+        provider.IntegrityScore = null;
+        provider.IntegrityRating = null;
+        provider.LastVerifiedAt = null;
+
+        var integrity = ProviderIntegrityProjection.FromProvider(provider);
+        integrity.Should().BeNull();
+
+        var result = _projector.Project(provider, integrity)!;
+        result.ContainsKey("extension").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Returns_null_for_organization_provider()
+    {
+        var provider = BuildIndividualProvider();
+        provider.ProviderType = ProviderType.Organization;
+        provider.OrganizationName = "Acme Hospital";
+        _projector.Project(provider).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(ProviderVersionState.Active, ProviderStatus.Active, true)]
+    [InlineData(ProviderVersionState.Suspended, ProviderStatus.Inactive, false)]
+    [InlineData(ProviderVersionState.Terminated, ProviderStatus.Terminated, false)]
+    [InlineData(ProviderVersionState.Superseded, ProviderStatus.Inactive, false)]
+    [InlineData(ProviderVersionState.Draft, ProviderStatus.Pending, false)]
+    public void Active_flag_reflects_VersionState_and_Status(
+        ProviderVersionState versionState, ProviderStatus status, bool expectedActive)
+    {
+        var provider = BuildIndividualProvider();
+        provider.VersionState = versionState;
+        provider.Status = status;
+        var result = _projector.Project(provider);
+        result!["active"]!.GetValue<bool>().Should().Be(expectedActive);
+    }
+
+    [Fact]
+    public void Projection_is_deterministic_byte_for_byte()
+    {
+        var provider = BuildIndividualProvider();
+        var integrity = ProviderIntegrityProjection.FromProvider(provider);
+        var first = _projector.Project(provider, integrity)!.ToJsonString();
+        var second = _projector.Project(BuildIndividualProvider(), ProviderIntegrityProjection.FromProvider(BuildIndividualProvider()))!.ToJsonString();
+        second.Should().Be(first);
+    }
+}


### PR DESCRIPTION
## Summary

- **provider-service** projects each Individual `Provider` to a hand-built FHIR R4 Practitioner JsonObject (US Core 6.1.0 + Plan-Net IG 1.1.0 conformant for fields CHO has data for) at `/fhir/Practitioner`. Pattern mirrors member-service `IFhirPatientProjector` exactly.
- **fhir-service** keeps the external `/fhir/r4/Practitioner/*` URL surface and proxies to provider-service via a new typed `ProviderService` HttpClient (with TenantHeader + CorrelationId propagation). NPPES and verification calls removed from the Practitioner path only.
- **`IProviderRepository.SearchAsync`** gains optional `firstName`/`lastName`/`city` parameters to honor FHIR `given`/`family`/`city` search semantics; existing callers compile unchanged.

## Architecture decisions ratified

- **Decision 1 (CHO canonical, not NPPES)**: confirmed.
- **Decision 5 — tenant scoping = 5a**: existing `TenantMiddleware` mechanism end-to-end (JWT claim → header fallback → 401). Public CMS-0057-F is capability 5.19.
- **Decision 6 — Inferno not in CI**: Option B (unit-test conformance only). Inferno wiring is a separate Phase 2 capability.
- **Decision 7 — replicate `FhirExtensionBuilder`**: Option 7a (replicate locally with TODO marker; shared FHIR-infrastructure project is its own decision).
- **Decision 8 — verification-enrichment removal scope**: Practitioner path only (Organization / PractitionerRole still use NPPES + verification until 5.8 / 5.9 ship).

## Premise corrections (ratified mid-plan)

- **`Provider.Gender` does not exist** → omit `Practitioner.gender`. US Core 6.1.0 cardinality 0..1 — conformant. Capability 5.17 adds the field.
- **No NUCC codes for `SecondarySpecialties`** → primary specialty gets full NUCC coding from `TaxonomyCode`; secondaries emit as text-only `CodeableConcept` (no `coding`). Conformant FHIR; future capability adds resolution.

## Hybrid state

`ProviderDirectoryController` now carries a HYBRID STATE comment block:

- ✅ Practitioner — proxied to CHO provider-service projection.
- ⏳ Organization — still served from NPPES (capability 5.8 redirects).
- ⏳ PractitionerRole — still served from NPPES (capability 5.9 redirects).
- ⏳ Location — still served from NPPES.

After 5.8 + 5.9 ship, a cleanup PR retires the entire NPPES path and deletes the HYBRID STATE block.

## Test plan

- [x] `dotnet build` — provider-service, fhir-service, both test projects: clean (warnings unchanged from main).
- [x] 47 new provider-service tests (projector + controller) — all pass.
- [x] 6 new fhir-service proxy tests — all pass.
- [x] Full fhir-service suite — 337/337 green.
- [x] Pre-existing 35 provider-service test failures (`CredentialingProjectorTests` / `CredentialingControllerTests` / `CredentialingServiceTests` / `UpdateCredentialingProjectionAsyncTests` / `CredentialingEventPublisherTests`) confirmed pre-existing on `main` — root cause is `CloudHealthOffice.Infrastructure.Json.CloudHealthOfficeJsonOptions` static-constructor crash unrelated to capability 5.7.
- [ ] Manual smoke (deferred to first-on-main, since this is a new endpoint with no preview environment): `GET /fhir/r4/Practitioner/{tenant-NPI}` → 200; `GET /fhir/r4/Practitioner/{not-in-CHO-NPI}` → 404 OperationOutcome (CHO-canonical decision); `GET /fhir/r4/Practitioner?family=Smith&city=Boston` → searchset Bundle; `GET /fhir/r4/Practitioner/{org-NPI}` → 404 (Organization filtered); cross-tenant token → 404; provider-service downed → 502 OperationOutcome.
- [ ] First-on-main validation that the proxy hop works in staging.

## Documentation

- `docs/architecture/fhir-practitioner-projection.md` — projector pattern, canonical-source decision, proxy pattern, deferral list.
- `docs/architecture/fhir-conformance.md` — running ledger of IG conformance posture; what's tested, what's deferred (Inferno, Plan-Net extended extensions, CMS-0057-F).

## After this PR

Capability 5.8 (Organization), 5.9 (PractitionerRole), 5.10 (verification integrity score surface — Phase 1 closer). 5.8 and 5.9 mirror this PR's shape exactly: domain service projects, fhir-service proxies. The HYBRID STATE comment block updates as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)