### PR TITLE
5.8 — FHIR PractitionerRole projection + fhir-service proxy

### DIFF
--- a/docs/architecture/fhir-conformance.md
+++ b/docs/architecture/fhir-conformance.md
@@ -5,12 +5,12 @@ conformance to, what we test against, and where the gaps are.
 
 ## In scope (Phase 1)
 
-| IG / profile                                     | Resources covered today                | Posture                                                 |
-|--------------------------------------------------|----------------------------------------|---------------------------------------------------------|
-| US Core 6.1.0                                    | Patient, Practitioner                  | Required elements asserted by unit tests                |
-| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner (subset)                  | Fields CHO has data for; extensions deferred to 5.17    |
-| FHIR R4 Bundle (`searchset`)                     | Practitioner search                    | Hand-built JsonObject, asserted by unit tests           |
-| FHIR R4 OperationOutcome                         | All error responses                    | Typed `OperationOutcome` model + hand-built JsonObject  |
+| IG / profile                                     | Resources covered today                       | Posture                                                 |
+|--------------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
+| US Core 6.1.0                                    | Patient, Practitioner, PractitionerRole       | Required elements asserted by unit tests                |
+| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner, PractitionerRole (subset)       | Fields CHO has data for; extensions deferred to 5.17    |
+| FHIR R4 Bundle (`searchset`)                     | Practitioner, PractitionerRole search          | Hand-built JsonObject, asserted by unit tests           |
+| FHIR R4 OperationOutcome                         | All error responses                           | Typed `OperationOutcome` model + hand-built JsonObject  |
 
 `meta.profile` values emitted on each resource:
 
@@ -19,13 +19,16 @@ conformance to, what we test against, and where the gaps are.
   `http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner`
   and
   `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner`
+- PractitionerRole (provider-service, capability 5.8) —
+  `http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole`
+  and
+  `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole`
 
 ## Phase 2 / deferred
 
 | IG / capability                                  | Status                                                 |
 |--------------------------------------------------|--------------------------------------------------------|
-| Plan-Net 1.1.0 PractitionerRole                  | Capability 5.9                                         |
-| Plan-Net 1.1.0 Organization                      | Capability 5.8                                         |
+| Plan-Net 1.1.0 Organization                      | Capability 5.9                                         |
 | Plan-Net 1.1.0 Bundle composite                  | Capability 5.18                                        |
 | Plan-Net extended extensions                     | Capability 5.17                                        |
 | CMS-0057-F unauthenticated Provider Directory    | Capability 5.19                                        |
@@ -43,6 +46,8 @@ classes:
   — member-service Patient projection.
 - [FhirPractitionerProjectorTests](../../tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerProjectorTests.cs)
   — provider-service Practitioner projection.
+- [FhirPractitionerRoleProjectorTests](../../tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerRoleProjectorTests.cs)
+  — provider-service PractitionerRole projection.
 
 Conformance regressions surface as failing unit tests. There is no
 network-driven conformance suite in CI yet (see *Inferno* below).
@@ -52,7 +57,9 @@ network-driven conformance suite in CI yet (see *Inferno* below).
 CMS publishes Inferno test suites for ONC certification. CHO does
 not run any Inferno suite in CI today. The Plan-Net Provider Directory
 suite would validate capability 5.7 + 5.8 + 5.9 + 5.18 once those
-capabilities ship as a Bundle composite.
+capabilities ship as a Bundle composite. After 5.8, two of the four
+projection paths (Practitioner + PractitionerRole) carry CHO-canonical
+data; Inferno wiring is unblocked once 5.9 ships Organization.
 
 A separate Phase 2 capability wires the Inferno Provider Directory
 suite to CI. Until then, conformance is structural-only via unit
@@ -73,14 +80,22 @@ Defined today (see
 - `provider-integrity-score` extension (capability 5.7) — emitted on
   Practitioner; carries cached IntegrityScore + IntegrityRating +
   LastVerifiedAt from the projection added in capability 5.4.5.
+- `practitionerrole-panel-gating` extension (capability 5.8) — emitted
+  on PractitionerRole; grouped extension carrying `panel-limit`,
+  `panel-accepted`, `accepted-lobs`, `min-accepted-age-years`,
+  `max-accepted-age-years` sub-extensions sourced from the
+  panel-gating fields on `NetworkParticipation` (capability 5.5).
+- `CodeSystem/line-of-business` (capability 5.8) — internal CodeSystem
+  for the LOB codings emitted inside `accepted-lobs` sub-extensions.
 
 A legacy URL
 `https://cloudhealthoffice.com/fhir/StructureDefinition/provider-verification`
 is used by the NPPES-path enrichment in fhir-service today. The
-NPPES path retires after capabilities 5.8 and 5.9 ship. Do not
-introduce new uses of this URL.
+NPPES path retires after capability 5.9 ships. Do not introduce new
+uses of this URL.
 
 ## Cross references
 
 - [fhir-practitioner-projection.md](fhir-practitioner-projection.md) — capability 5.7 details.
-- [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `Practitioner.active`.
+- [fhir-practitionerrole-projection.md](fhir-practitionerrole-projection.md) — capability 5.8 details.
+- [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `Practitioner.active` and `PractitionerRole.active`.

--- a/docs/architecture/fhir-practitioner-projection.md
+++ b/docs/architecture/fhir-practitioner-projection.md
@@ -41,8 +41,8 @@ FhirPractitionerProjector  →  IProviderRepository.GetByNPIAsync
 ```
 
 Organization, PractitionerRole, and Location stay on the NPPES path
-in this PR. Capability 5.8 redirects Organization, capability 5.9
-redirects PractitionerRole, then a cleanup PR retires the NPPES code
+in this PR. Capability 5.8 redirects PractitionerRole, capability 5.9
+redirects Organization, then a cleanup PR retires the NPPES code
 entirely and deletes the HYBRID STATE comment block.
 
 ## Service boundaries

--- a/docs/architecture/fhir-practitionerrole-projection.md
+++ b/docs/architecture/fhir-practitionerrole-projection.md
@@ -1,0 +1,296 @@
+# FHIR PractitionerRole projection (capability 5.8)
+
+## What this is
+
+Provider-service projects each `NetworkParticipation` on an Active
+individual `Provider` to a hand-built FHIR R4 PractitionerRole
+JsonObject and exposes the projection at `/fhir/PractitionerRole/{id}`
+and `/fhir/PractitionerRole` (search). Fhir-service keeps the external
+`/fhir/r4/PractitionerRole/*` URL surface and proxies those calls to
+provider-service via the same typed `ProviderService` `HttpClient`
+established by capability 5.7.
+
+The projection conforms to:
+
+- US Core 6.1.0 PractitionerRole profile.
+- Da Vinci PDex Plan-Net 1.1.0 PractitionerRole profile (for the
+  fields CHO has data for; see *Deferrals*).
+
+## Why this PR
+
+Before 5.8, fhir-service `ProviderDirectoryController` synthesized
+PractitionerRole from NPPES taxonomy data. That carried two problems:
+
+1. The synthesized PractitionerRole had no notion of network — every
+   PractitionerRole had id `{NPI}-role`, one per provider, no
+   participation context. Plan-Net IG requires
+   `PractitionerRole.organization`, which 5.4's network-as-Organization
+   work made it possible to populate canonically.
+2. Panel-gating, network-tier, line-of-business, and effective dating
+   live on `NetworkParticipation` (capability 5.5). The synthesized
+   shape couldn't surface them.
+
+5.8 inverts the flow for PractitionerRole exactly as 5.7 did for
+Practitioner:
+
+```
+external client
+   │
+   ▼
+fhir-service /fhir/r4/PractitionerRole/{id}      ← URL stability
+   │
+   ▼  HTTP, "ProviderService" typed HttpClient
+provider-service /fhir/PractitionerRole/{id}     ← projection authority
+   │
+   ▼
+FhirPractitionerRoleProjector
+   │
+   ├─ IProviderRepository.GetByNPIAsync / SearchAsync /
+   │   ListNetworkRosterAsync
+   └─ IOrganizationRepository.GetByIdAsync (for organization.display)
+```
+
+After 5.8 ships, two of the four provider-directory resources
+(Practitioner, PractitionerRole) carry CHO-canonical data. Organization
+follows in 5.9. Location remains NPPES-backed until a Phase 2
+location-modeling capability lands.
+
+## Service boundaries
+
+| Concern                          | Owner                                                  |
+|----------------------------------|--------------------------------------------------------|
+| `PractitionerRole` JSON shape    | `provider-service` (`FhirPractitionerRoleProjector`)   |
+| `/fhir/r4/*` URL surface         | `fhir-service` (`ProviderDirectoryController`)         |
+| Tenant context, JWT, SMART scope | `fhir-service` (perimeter)                             |
+| Panel-gating projection          | `provider-service` (`FhirPractitionerRoleProjector`)   |
+
+The proxy adds **no business logic** on the PractitionerRole path. It
+forwards the request, passes the body and status code through (with
+5xx mapped to a FHIR 502 OperationOutcome to avoid leaking upstream
+detail), and is otherwise dumb. The same `ProxyProviderServiceAsync`
+helper now serves Practitioner and PractitionerRole — Organization
+plugs into the same shape in 5.9.
+
+## Mapping
+
+| FHIR element                       | Source                                                                                |
+|------------------------------------|---------------------------------------------------------------------------------------|
+| `id`                               | composite-tuple `{npi}-{lobInt}-{yyyymmdd}-{networkId}` — see *ID encoding*           |
+| `meta.profile`                     | US Core 6.1.0 + Plan-Net 1.1.0 PractitionerRole                                        |
+| `meta.lastUpdated`                 | `Provider.LastUpdatedDate` (ISO 8601, UTC)                                             |
+| `active`                           | derived — see *Active flag*                                                            |
+| `practitioner.reference`           | `Practitioner/{Provider.NPI}`                                                          |
+| `practitioner.display`             | `FirstName MiddleName LastName Credentials` (whitespace-trimmed)                       |
+| `organization.reference`           | `Organization/{NetworkParticipation.NetworkId}`                                        |
+| `organization.display`             | `Organization.Name` when the network resolves; omitted otherwise                       |
+| `code[]`                           | `NetworkParticipation.NetworkTier` text-only CodeableConcept                           |
+| `specialty[]` (primary)            | NUCC coding `{system, Provider.TaxonomyCode, PrimarySpecialty}`                        |
+| `specialty[]` (secondary)          | text-only CodeableConcept (no `coding`) — see *Deferrals*                              |
+| `period.start` / `period.end`      | `EffectiveDate` / `TerminationDate` (UTC, `yyyy-MM-dd`)                                |
+| `telecom[]`                        | `Provider.Phone`, `Provider.Fax`, `Provider.Email` in that order                       |
+| `extension[panel-gating]`          | grouped extension — see *Panel-gating extension*                                        |
+
+### ID encoding
+
+The FHIR R4 `id` data type grammar is `[A-Za-z0-9\-\.]{1,64}`. The
+PractitionerRole composite-tuple is encoded as a dash-delimited compact
+form:
+
+```
+{npi}-{lobInt}-{yyyymmdd}-{networkId}
+```
+
+- `{npi}` = 10-digit National Provider Identifier
+- `{lobInt}` = `LineOfBusiness` enum integer value (1–6)
+- `{yyyymmdd}` = `EffectiveDate` UTC, compact ISO with no separators (8 digits)
+- `{networkId}` = `Organization.OrganizationId` chain key
+
+**Decoder.** Regex `^(?<npi>\d{10})-(?<lob>\d+)-(?<date>\d{8})-(?<network>.+)$`.
+The first three captures have fixed shape so the trailing capture
+absorbs the rest of the id, including any internal hyphens in the
+network id (Guid-shaped chain keys are the common case).
+
+**64-char cap.** Worst case the composite is `10 + 1 + 8 + 3 + len(networkId)`
+≈ 22 + `len(networkId)`. For Guid-shaped network ids (36 chars) the
+total is 58 characters — fits. For network ids longer than 42 chars,
+the projector returns null (the row is invisible to FHIR rather than
+emitting a non-conformant id) and reads against such ids return 404.
+This guards against a silent FHIR-grammar violation that would only
+surface at the consumer.
+
+**No Base64URL.** Base64URL output uses `_` which is not in the FHIR
+`id` grammar. The dash-delimited form is grammar-conformant and
+trivially reversible.
+
+### Active flag
+
+```
+active = participation.EffectiveDate <= UtcNow
+      && (participation.TerminationDate is null
+          || participation.TerminationDate >= UtcNow)
+      && provider.VersionState == Active
+      && provider.Status == Active
+```
+
+Both the participation period and the provider's version / status must
+be active. A terminated participation on an active provider emits
+`active=false` and `period.end`. A suspended provider's
+PractitionerRoles are not projected at all (the projector returns null
+for non-Active providers, so the row is omitted from search results
+and 404 on read).
+
+### Panel-gating extension
+
+A single grouped extension at the canonical URL
+`http://fhir.cloudhealthoffice.com/StructureDefinition/practitionerrole-panel-gating`,
+with sub-extensions:
+
+| sub-extension URL          | Source                                  | Type           |
+|----------------------------|-----------------------------------------|----------------|
+| `panel-limit`              | `NetworkParticipation.PanelLimit`       | `valueInteger` |
+| `panel-accepted`           | `NetworkParticipation.PanelAccepted`    | `valueBoolean` |
+| `accepted-lobs`            | `NetworkParticipation.AcceptedLobs`     | repeated `valueCoding` |
+| `min-accepted-age-years`   | `NetworkParticipation.MinAcceptedAgeYears` | `valueInteger` |
+| `max-accepted-age-years`   | `NetworkParticipation.MaxAcceptedAgeYears` | `valueInteger` |
+
+**Emission rules.**
+
+- Each sub-extension emits only when its source field is non-null.
+- `accepted-lobs` emits one `valueCoding` per LOB in the list (using
+  CHO's internal `CodeSystem/line-of-business`).
+- The grouped parent extension is omitted entirely when all five
+  sub-extensions would be empty — legacy / unconstrained participations
+  that pre-date capability 5.5 carry no extension on the wire.
+
+## Search semantics
+
+| Query                                               | Behavior                                                                 |
+|-----------------------------------------------------|--------------------------------------------------------------------------|
+| `?practitioner=Practitioner/{npi}`                  | All visible participations on the latest Active provider                 |
+| `?practitioner=Practitioner/{npi}&organization=...` | Conjunction — only participations matching the organization filter      |
+| `?organization=Organization/{networkId}`            | All providers in the network, one role per matching participation       |
+| `?specialty=...`                                    | Provider-level filter on `PrimarySpecialty` / `TaxonomyCode`            |
+| (none of the above)                                 | Empty Bundle (mirrors the existing fhir-service behavior)               |
+
+**Premise correction (capability 5.8 plan-phase).** The
+`NetworkParticipation` model has no `Specialty` field today; specialty
+is sourced from the linked `Provider` (primary as NUCC-coded
+CodeableConcept, secondaries as text-only). The `?specialty=...` filter
+matches against the same fields the 5.4 roster uses — `PrimarySpecialty`
+substring or `TaxonomyCode` substring, case-insensitive.
+
+**Pagination.** Page-based via `_count` (1–200, default 50) and
+`_page` — mirrors the 5.7 Practitioner controller. Cursor-based
+pagination is not surfaced here; the operational roster (capability
+5.4) keeps the cursor shape because it has different stability
+semantics.
+
+**Search-by-organization implementation.** The controller calls
+`IProviderRepository.ListNetworkRosterAsync` directly (Decision 8 of
+the 5.8 plan-phase). The roster service layer
+(`INetworkRosterService.GetRosterAsync`) is intentionally bypassed
+because its cursor-binding hash logic does not apply to a FHIR search
+and its `NetworkRosterEntry` shape is operational, not FHIR. Both the
+roster API and the FHIR PractitionerRole search now go through the
+same repository query — see
+[network-roster-api.md](network-roster-api.md).
+
+## Tenant scoping
+
+Honored via the existing `TenantMiddleware` mechanism (Decision 8 of
+the 5.8 plan-phase). Authenticated / header-scoped callers see their
+tenant's PractitionerRoles only. Public CMS-0057-F unauthenticated
+access is a separate capability (5.19) — both the Practitioner and
+PractitionerRole endpoints will be wired through that capability's
+public surface together.
+
+## Verification metadata stays on Practitioner
+
+PractitionerRole references the Practitioner via
+`PractitionerRole.practitioner`. Integrity score and verification
+extensions live on the Practitioner projection (capability 5.7). They
+are NOT duplicated on PractitionerRole. A consumer that wants the
+verification metadata follows the practitioner reference — exactly the
+posture the previous NPPES-backed PractitionerRole carried, preserved
+verbatim.
+
+## Deferrals
+
+### Plan-Net extended extensions — capability 5.17
+
+`PractitionerRole.healthcareService`, `PractitionerRole.location`,
+`PractitionerRole.availableTime`, plus the Plan-Net IG profile slices
+(`acceptingPatients`, `qualification`, `endpoint`) are not in scope.
+CHO does not have data for these fields today; capability 5.17 either
+adds the data or formally documents the gap.
+
+### NUCC resolution for secondary specialties
+
+Provider-service stores secondary specialties as free text. The
+projector emits text-only CodeableConcept entries — Plan-Net IG
+accepts text-only under "extensible" binding strength. A future
+capability adds a NUCC resolver and upgrades the secondary entries to
+fully-coded.
+
+### Per-participation Specialty field
+
+`NetworkParticipation` does not carry a per-participation specialty
+today; specialty derives from the linked Provider. If payer contracts
+ever require that a single provider participate in different networks
+with different declared specialties, a model change adds the field.
+Out of scope for 5.8.
+
+### Inferno wiring — separate capability
+
+CHO has no Inferno test runner in CI today. Conformance is asserted
+via xUnit structural tests (US Core PractitionerRole Must Support
+elements + Plan-Net IG required slices). The Inferno wiring is a
+separate Phase 2 capability and unblocked once 5.9 ships Organization.
+
+## Tests
+
+- [`FhirPractitionerRoleProjectorTests`](../../tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerRoleProjectorTests.cs)
+  — projection correctness, US Core profile structure, edge cases
+  (legacy NetworkId-null returns null, Organization-type provider
+  returns null, terminated participation emits `period.end` and
+  `active=false`, panel-gating extensions emit only when populated),
+  composite-id round-trip, determinism check.
+- [`FhirPractitionerRoleControllerTests`](../../tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerRoleControllerTests.cs)
+  — endpoint behavior, search-parameter semantics
+  (practitioner / organization / specialty conjunction), composite-id
+  encode/decode round-trip, FHIR OperationOutcome shapes on errors,
+  tenant scoping.
+- [`ProviderDirectoryControllerPractitionerRoleProxyTests`](../../tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerPractitionerRoleProxyTests.cs)
+  — fhir-service proxy verifies status / body / content-type
+  pass-through, 5xx → 502, NPPES + verification clients NOT touched on
+  the PractitionerRole path.
+
+## Recovery posture
+
+This PR adds a new projection and rewires one existing endpoint.
+Failure modes:
+
+- **Composite-ID decoding edge cases** — handled defensively in the
+  controller; malformed id returns 404 with FHIR OperationOutcome.
+- **fhir-service proxy hop fails** — caller sees 502; fhir-service
+  logs the failure with a `PractitionerRole`-labelled structured
+  field; provider-service unaffected; revert restores NPPES path if
+  needed.
+- **Panel-gating extension format wrong** — caught by unit tests and
+  conformance assertions; fast fix.
+- **Legacy NetworkId-null participation handling** — explicit
+  invisible semantic; documented in the projector XML doc and the
+  search behavior table above.
+
+Worst-case rollback: revert this PR. fhir-service PractitionerRole
+endpoints return to the NPPES path. provider-service projector code
+remains but is unwired.
+
+## Cross references
+
+- [fhir-practitioner-projection.md](fhir-practitioner-projection.md) — capability 5.7 details (the proxy pattern this PR extends).
+- [network-roster-api.md](network-roster-api.md) — operational roster API; capability 5.8 reuses the underlying repository query.
+- [network-as-organization.md](network-as-organization.md) — Organization entity (capability 5.3) referenced by `PractitionerRole.organization`.
+- [network-participation-backfill.md](network-participation-backfill.md) — panel-gating defaults (capability 5.5) surfaced by the panel-gating extension.
+- [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `PractitionerRole.active`.
+- [fhir-conformance.md](fhir-conformance.md) — running conformance ledger.

--- a/docs/architecture/network-roster-api.md
+++ b/docs/architecture/network-roster-api.md
@@ -274,4 +274,12 @@ Mongo.
   `BenefitPlan.NetworkTier` reference (capability 5.5) by joining the
   tier's `NetworkId` against this endpoint.
 - FHIR projections (5.7+) can render `PractitionerRole` collections
-  scoped to a network using the same query path.
+  scoped to a network using the same query path. Capability 5.8 wires
+  this connection: `GET /fhir/PractitionerRole?organization=Organization/{networkId}`
+  reuses `IProviderRepository.ListNetworkRosterAsync` (the same query
+  this endpoint drives) and projects each matching participation to a
+  FHIR PractitionerRole. The two surfaces are equivalent in source data
+  and complementary in shape: roster is the operational summary
+  (`NetworkRosterEntry`) for admin tooling; PractitionerRole is the
+  FHIR-canonical projection for external consumers. See
+  [fhir-practitionerrole-projection.md](fhir-practitionerrole-projection.md).

--- a/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
+++ b/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
@@ -10,12 +10,12 @@ namespace FhirService.Controllers;
 /// Provider Directory API controller — exposes FHIR R4 provider directory resources
 /// (Practitioner, PractitionerRole, Organization, Location).
 ///
-/// HYBRID STATE (Phase 1 capability 5.7):
-///  - Practitioner:      proxied to provider-service /fhir/Practitioner (CHO-canonical projection).
-///  - Organization:      still served from NPPES (capability 5.8 will redirect).
-///  - PractitionerRole:  still served from NPPES (capability 5.9 will redirect).
+/// HYBRID STATE (Phase 1):
+///  - Practitioner:      proxied to provider-service /fhir/Practitioner (capability 5.7).
+///  - PractitionerRole:  proxied to provider-service /fhir/PractitionerRole (capability 5.8).
+///  - Organization:      still served from NPPES (capability 5.9 will redirect).
 ///  - Location:          still served from NPPES.
-/// The HYBRID STATE comment block is removed once 5.8 + 5.9 ship and the
+/// The HYBRID STATE comment block is removed once 5.9 ships and the
 /// NPPES helpers below are fully retired.
 ///
 /// Port of the TypeScript provider-directory-api.ts (NPPES path).
@@ -54,7 +54,7 @@ public class ProviderDirectoryController : FhirControllerBase
     [HttpGet("Practitioner/{id}")]
     [Produces("application/fhir+json")]
     public Task<IActionResult> ReadPractitioner(string id, CancellationToken ct)
-        => ProxyPractitionerAsync($"fhir/Practitioner/{Uri.EscapeDataString(id)}", ct);
+        => ProxyProviderServiceAsync("Practitioner", $"fhir/Practitioner/{Uri.EscapeDataString(id)}", ct);
 
     /// <summary>
     /// GET /fhir/r4/Practitioner?npi=&amp;given=&amp;family=&amp;... — search Practitioners.
@@ -68,10 +68,21 @@ public class ProviderDirectoryController : FhirControllerBase
         var qs = HttpContext.Request.QueryString.HasValue
             ? HttpContext.Request.QueryString.Value
             : string.Empty;
-        return ProxyPractitionerAsync($"fhir/Practitioner{qs}", ct);
+        return ProxyProviderServiceAsync("Practitioner", $"fhir/Practitioner{qs}", ct);
     }
 
-    private async Task<IActionResult> ProxyPractitionerAsync(string path, CancellationToken ct)
+    /// <summary>
+    /// Generic proxy hop to provider-service for the FHIR resources
+    /// where provider-service is the canonical authority (capability 5.7
+    /// — Practitioner; capability 5.8 — PractitionerRole). Status pass
+    /// through, 5xx → 502 OperationOutcome, transport faults → 502.
+    /// Resource label flows into structured-log fields so operators can
+    /// distinguish Practitioner vs PractitionerRole proxy failures.
+    /// </summary>
+    private async Task<IActionResult> ProxyProviderServiceAsync(
+        string resourceLabel,
+        string path,
+        CancellationToken ct)
     {
         // `path` is derived from the user-supplied URL / query string and
         // flows into structured-log fields below. Sanitize once up front
@@ -92,9 +103,9 @@ public class ProviderDirectoryController : FhirControllerBase
             if ((int)upstream.StatusCode >= 500)
             {
                 _logger.LogWarning(
-                    "provider-service Practitioner upstream returned {Status} for {Path}",
-                    (int)upstream.StatusCode, loggablePath);
-                return FhirBadGateway("Practitioner upstream is unavailable.");
+                    "provider-service {Resource} upstream returned {Status} for {Path}",
+                    resourceLabel, (int)upstream.StatusCode, loggablePath);
+                return FhirBadGateway($"{resourceLabel} upstream is unavailable.");
             }
 
             return new ContentResult
@@ -106,8 +117,10 @@ public class ProviderDirectoryController : FhirControllerBase
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogWarning(ex, "provider-service Practitioner proxy hop failed for {Path}", loggablePath);
-            return FhirBadGateway("Practitioner upstream is unreachable.");
+            _logger.LogWarning(ex,
+                "provider-service {Resource} proxy hop failed for {Path}",
+                resourceLabel, loggablePath);
+            return FhirBadGateway($"{resourceLabel} upstream is unreachable.");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -122,8 +135,10 @@ public class ProviderDirectoryController : FhirControllerBase
             // HttpClient surfaces its own configured timeout as
             // TaskCanceledException; ct was NOT cancelled (handled above).
             // That genuinely is an upstream-too-slow → 502.
-            _logger.LogWarning(ex, "provider-service Practitioner proxy hop timed out for {Path}", loggablePath);
-            return FhirBadGateway("Practitioner upstream timed out.");
+            _logger.LogWarning(ex,
+                "provider-service {Resource} proxy hop timed out for {Path}",
+                resourceLabel, loggablePath);
+            return FhirBadGateway($"{resourceLabel} upstream timed out.");
         }
     }
 
@@ -187,64 +202,36 @@ public class ProviderDirectoryController : FhirControllerBase
         return Ok(ProviderDirectoryMapper.CreateSearchBundle("Organization", organizations));
     }
 
-    // ── PractitionerRole ─────────────────────────────────────────────────────
+    // ── PractitionerRole (proxied to provider-service, capability 5.8) ───────
 
-    /// <summary>GET /fhir/r4/PractitionerRole/{id} — read PractitionerRole by practitioner NPI</summary>
+    /// <summary>
+    /// GET /fhir/r4/PractitionerRole/{id} — read PractitionerRole by composite id.
+    /// Proxies to provider-service /fhir/PractitionerRole/{id}; provider-service
+    /// owns the projection (capability 5.8). The id format is the
+    /// composite-tuple shape <c>{npi}-{lobInt}-{yyyymmdd}-{networkId}</c>
+    /// per the projection's <c>EncodeId</c>.
+    /// </summary>
     [HttpGet("PractitionerRole/{id}")]
     [Produces("application/fhir+json")]
-    public async Task<IActionResult> ReadPractitionerRole(string id, CancellationToken ct)
-    {
-        // ID format: {NPI}-role
-        var npi = id.EndsWith("-role", StringComparison.Ordinal) ? id[..^5] : id;
-        var nppes = await LookupNppesAsync(npi, ct);
-        if (nppes is null || nppes.EnumerationType != "NPI-1")
-            return FhirNotFound("PractitionerRole", id);
+    public Task<IActionResult> ReadPractitionerRole(string id, CancellationToken ct)
+        => ProxyProviderServiceAsync(
+            "PractitionerRole",
+            $"fhir/PractitionerRole/{Uri.EscapeDataString(id)}",
+            ct);
 
-        var role = ProviderDirectoryMapper.MapNppesToPractitionerRole(nppes);
-        // Note: PractitionerRole does not get verification enrichment directly —
-        // the linked Practitioner resource carries the verification metadata.
-        return Ok(role);
-    }
-
-    /// <summary>GET /fhir/r4/PractitionerRole?practitioner=&amp;specialty=&amp;... — search PractitionerRoles</summary>
+    /// <summary>
+    /// GET /fhir/r4/PractitionerRole?practitioner=&amp;organization=&amp;specialty=&amp;... — search PractitionerRoles.
+    /// Forwards the FHIR search query string to provider-service
+    /// /fhir/PractitionerRole unchanged (capability 5.8).
+    /// </summary>
     [HttpGet("PractitionerRole")]
     [Produces("application/fhir+json")]
-    public async Task<IActionResult> SearchPractitionerRoles(
-        [FromQuery] string? practitioner,
-        [FromQuery] string? organization,
-        [FromQuery] string? specialty,
-        [FromQuery] int _count = 50,
-        CancellationToken ct = default)
+    public Task<IActionResult> SearchPractitionerRoles(CancellationToken ct = default)
     {
-        _count = ClampPageSize(_count, 200);
-        var roles = new List<FhirResource>();
-
-        if (!string.IsNullOrEmpty(practitioner))
-        {
-            var npi = practitioner.Replace("Practitioner/", "", StringComparison.Ordinal);
-            var nppes = await LookupNppesAsync(npi, ct);
-            if (nppes is not null && nppes.EnumerationType == "NPI-1")
-            {
-                var orgRef = !string.IsNullOrEmpty(organization)
-                    ? new FhirReference { Reference = organization }
-                    : null;
-                roles.Add(ProviderDirectoryMapper.MapNppesToPractitionerRole(nppes, orgRef));
-            }
-        }
-        else if (!string.IsNullOrEmpty(specialty))
-        {
-            var results = await SearchNppesAsync(new Dictionary<string, string?>
-            {
-                ["taxonomy_description"] = specialty,
-                ["enumeration_type"] = "NPI-1",
-                ["limit"] = _count.ToString()
-            }, ct);
-
-            foreach (var r in results.Where(r => r.EnumerationType == "NPI-1"))
-                roles.Add(ProviderDirectoryMapper.MapNppesToPractitionerRole(r));
-        }
-
-        return Ok(ProviderDirectoryMapper.CreateSearchBundle("PractitionerRole", roles));
+        var qs = HttpContext.Request.QueryString.HasValue
+            ? HttpContext.Request.QueryString.Value
+            : string.Empty;
+        return ProxyProviderServiceAsync("PractitionerRole", $"fhir/PractitionerRole{qs}", ct);
     }
 
     // ── Location ─────────────────────────────────────────────────────────────

--- a/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
+++ b/src/services/fhir-service/Mappers/ProviderDirectoryMapper.cs
@@ -130,7 +130,19 @@ public static partial class ProviderDirectoryMapper
 
     /// <summary>
     /// Maps an NPI-1 NPPES result to a FHIR PractitionerRole resource.
+    ///
+    /// <para>
+    /// <b>Deprecated (capability 5.8).</b> The PractitionerRole projection
+    /// is now served from provider-service's CHO-canonical
+    /// <c>FhirPractitionerRoleProjector</c>; <c>ProviderDirectoryController</c>
+    /// proxies <c>/fhir/r4/PractitionerRole/*</c> there. This helper is
+    /// retained until capability 5.9 retires the NPPES helpers wholesale,
+    /// then deleted alongside <c>MapNppesToOrganization</c> and
+    /// <c>MapNppesToLocation</c>.
+    /// </para>
     /// </summary>
+    [Obsolete("Replaced by provider-service FhirPractitionerRoleProjector (capability 5.8). " +
+              "Removed alongside the rest of the NPPES path in capability 5.9.")]
     public static FhirPractitionerRole MapNppesToPractitionerRole(
         NppesResult practitionerNppes,
         FhirReference? organizationRef = null)

--- a/src/services/provider-service/Controllers/FhirPractitionerRoleController.cs
+++ b/src/services/provider-service/Controllers/FhirPractitionerRoleController.cs
@@ -168,7 +168,8 @@ public class FhirPractitionerRoleController : ControllerBase
                     specialty,
                     page,
                     pageSize,
-                    entries);
+                    entries,
+                    ct);
             }
             else if (!string.IsNullOrEmpty(organizationId))
             {
@@ -177,7 +178,8 @@ public class FhirPractitionerRoleController : ControllerBase
                     specialty,
                     page,
                     pageSize,
-                    entries);
+                    entries,
+                    ct);
             }
             else if (!string.IsNullOrEmpty(specialty))
             {
@@ -185,7 +187,8 @@ public class FhirPractitionerRoleController : ControllerBase
                     specialty,
                     page,
                     pageSize,
-                    entries);
+                    entries,
+                    ct);
             }
             // No filters supplied → empty Bundle. FHIR doesn't require
             // Bundle.entry to be populated and an unbounded directory
@@ -210,8 +213,14 @@ public class FhirPractitionerRoleController : ControllerBase
         string? specialtyFilter,
         int page,
         int pageSize,
-        JsonArray entries)
+        JsonArray entries,
+        CancellationToken ct)
     {
+        // GetByNPIAsync / GetByIdAsync don't take a CancellationToken
+        // today (cross-service cleanup tracked separately). Honor the
+        // caller's cancellation cooperatively at the helper boundary so
+        // an aborted request short-circuits before the next repo hop.
+        ct.ThrowIfCancellationRequested();
         var provider = await _providerRepository.GetByNPIAsync(npi);
         if (provider == null
             || provider.ProviderType != ProviderType.Individual
@@ -246,7 +255,8 @@ public class FhirPractitionerRoleController : ControllerBase
         string? specialtyFilter,
         int page,
         int pageSize,
-        JsonArray entries)
+        JsonArray entries,
+        CancellationToken ct)
     {
         // Reuse the 5.4 roster repository query (Decision 8 — direct
         // repo call, skip INetworkRosterService). NetworkRosterQuery's
@@ -263,10 +273,10 @@ public class FhirPractitionerRoleController : ControllerBase
         };
         if (string.IsNullOrEmpty(query.TenantId))
         {
-            // The InMemory fake reads TenantId from query.TenantId, the
-            // real repository falls back to the same path. Empty tenant
-            // would silently match all rows in the fake; surface as an
-            // empty result.
+            // The InMemory fake reads TenantId from query.TenantId and
+            // would otherwise match all rows when it is empty. The real
+            // Cosmos / Mongo repositories require TenantId and would
+            // throw, so surface this as an empty result instead.
             return;
         }
 
@@ -274,7 +284,8 @@ public class FhirPractitionerRoleController : ControllerBase
         var rows = await _providerRepository.ListNetworkRosterAsync(
             query,
             NetworkRosterSort.NameAsc,
-            skip);
+            skip,
+            ct);
 
         var network = await _organizationRepository.GetByIdAsync(networkId);
 
@@ -302,12 +313,16 @@ public class FhirPractitionerRoleController : ControllerBase
         string specialty,
         int page,
         int pageSize,
-        JsonArray entries)
+        JsonArray entries,
+        CancellationToken ct)
     {
         // Specialty-only search routes through IProviderRepository.SearchAsync
         // (the existing 5.7 search shape). Per provider, we emit one
         // PractitionerRole per network participation with a populated
-        // NetworkId.
+        // NetworkId. SearchAsync / GetByIdAsync don't take a
+        // CancellationToken today; honor cancellation cooperatively at
+        // the helper boundary.
+        ct.ThrowIfCancellationRequested();
         var providers = await _providerRepository.SearchAsync(
             name: null,
             specialty: specialty,

--- a/src/services/provider-service/Controllers/FhirPractitionerRoleController.cs
+++ b/src/services/provider-service/Controllers/FhirPractitionerRoleController.cs
@@ -1,0 +1,431 @@
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using ProviderService.Models;
+using ProviderService.Repositories;
+using ProviderService.Services;
+
+namespace ProviderService.Controllers;
+
+/// <summary>
+/// FHIR R4 PractitionerRole read + search endpoint (capability 5.8).
+/// provider-service is the canonical authority on the projection;
+/// fhir-service proxies <c>/fhir/r4/PractitionerRole/*</c> requests here
+/// so CHO retains a single FHIR façade for external consumers while each
+/// domain service owns its own projection (mirrors
+/// <see cref="FhirPractitionerController"/> from capability 5.7).
+///
+/// <para>
+/// Tenant scoping is honored via the existing
+/// <see cref="Middleware.TenantMiddleware"/> mechanism (Decision 8 of the
+/// 5.8 plan-phase). Public CMS-0057-F unauthenticated access is a
+/// separate capability (5.19).
+/// </para>
+///
+/// <para>
+/// Pagination is page-based to match
+/// <see cref="FhirPractitionerController"/>; the cursor-based shape used
+/// by the operational roster API is intentionally not surfaced here —
+/// FHIR clients expect <c>_count</c> + a paged Bundle.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("fhir")]
+public class FhirPractitionerRoleController : ControllerBase
+{
+    private const string FhirContentType = "application/fhir+json";
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+
+    private static readonly Regex NpiPattern = new(@"^\d{10}$", RegexOptions.Compiled);
+    private static readonly Regex NetworkIdPattern = new(@"^[A-Za-z0-9\-]{1,64}$", RegexOptions.Compiled);
+
+    private readonly IProviderRepository _providerRepository;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IFhirPractitionerRoleProjector _projector;
+    private readonly ILogger<FhirPractitionerRoleController> _logger;
+
+    public FhirPractitionerRoleController(
+        IProviderRepository providerRepository,
+        IOrganizationRepository organizationRepository,
+        IFhirPractitionerRoleProjector projector,
+        ILogger<FhirPractitionerRoleController> logger)
+    {
+        _providerRepository = providerRepository;
+        _organizationRepository = organizationRepository;
+        _projector = projector;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// FHIR PractitionerRole read by composite-tuple id. The id format is
+    /// <c>{npi}-{lobInt}-{yyyymmdd}-{networkId}</c> (capability 5.8
+    /// Decision 6) — decoded back to the tuple, then the matching
+    /// <see cref="NetworkParticipation"/> is located on the head Active
+    /// version of the linked provider.
+    /// </summary>
+    [HttpGet("PractitionerRole/{id}")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> ReadPractitionerRole(string id, CancellationToken ct)
+    {
+        var decoded = _projector.DecodeId(id);
+        if (decoded is null)
+        {
+            return FhirOperationOutcome(404, "not-found", $"PractitionerRole/{SanitizeForLog(id)} not found.");
+        }
+
+        var provider = await _providerRepository.GetByNPIAsync(decoded.Npi);
+        if (provider == null
+            || provider.ProviderType != ProviderType.Individual
+            || provider.VersionState != ProviderVersionState.Active
+            || provider.Status != ProviderStatus.Active)
+        {
+            return FhirOperationOutcome(404, "not-found", $"PractitionerRole/{SanitizeForLog(id)} not found.");
+        }
+
+        var participation = provider.NetworkParticipations.FirstOrDefault(p =>
+            p.NetworkId == decoded.NetworkId
+            && p.LineOfBusiness == decoded.LineOfBusiness
+            // SpecifyKind, not ToUniversalTime — Cosmos / Mongo
+            // round-trip dates as Kind=Unspecified and ToUniversalTime
+            // would shift them by the host TZ offset.
+            && DateTime.SpecifyKind(p.EffectiveDate, DateTimeKind.Utc).Date == decoded.EffectiveDate.Date);
+        if (participation is null)
+        {
+            return FhirOperationOutcome(404, "not-found", $"PractitionerRole/{SanitizeForLog(id)} not found.");
+        }
+
+        var network = await _organizationRepository.GetByIdAsync(decoded.NetworkId);
+        var resource = _projector.Project(participation, provider, network);
+        if (resource == null)
+        {
+            return FhirOperationOutcome(404, "not-found", $"PractitionerRole/{SanitizeForLog(id)} not found.");
+        }
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = resource.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    /// <summary>
+    /// FHIR PractitionerRole search. Honors the FHIR R4 search parameter
+    /// names <c>practitioner</c>, <c>organization</c>, <c>specialty</c>,
+    /// and <c>_count</c> from the existing fhir-service surface; adds
+    /// <c>_page</c> for page-based pagination. Returns a FHIR
+    /// <c>Bundle</c> of type <c>searchset</c>.
+    /// </summary>
+    [HttpGet("PractitionerRole")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> SearchPractitionerRoles(
+        [FromQuery] string? practitioner,
+        [FromQuery] string? organization,
+        [FromQuery] string? specialty,
+        [FromQuery] int _count = DefaultPageSize,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        var pageSize = Math.Clamp(_count, 1, MaxPageSize);
+        var page = Math.Max(1, _page);
+
+        var practitionerNpi = ParseReference(practitioner, "Practitioner/");
+        var organizationId = ParseReference(organization, "Organization/");
+
+        // Reject malformed reference inputs early — silent fallback would
+        // produce an unbounded search the caller didn't request.
+        if (!string.IsNullOrEmpty(practitioner) && string.IsNullOrEmpty(practitionerNpi))
+        {
+            return FhirOperationOutcome(400, "invalid",
+                $"practitioner '{SanitizeForLog(practitioner)}' is not a recognized Practitioner reference.");
+        }
+        if (!string.IsNullOrEmpty(practitionerNpi) && !NpiPattern.IsMatch(practitionerNpi))
+        {
+            return FhirOperationOutcome(400, "invalid",
+                $"practitioner '{SanitizeForLog(practitioner!)}' does not contain a 10-digit NPI.");
+        }
+        if (!string.IsNullOrEmpty(organization) && string.IsNullOrEmpty(organizationId))
+        {
+            return FhirOperationOutcome(400, "invalid",
+                $"organization '{SanitizeForLog(organization)}' is not a recognized Organization reference.");
+        }
+        if (!string.IsNullOrEmpty(organizationId) && !NetworkIdPattern.IsMatch(organizationId))
+        {
+            return FhirOperationOutcome(400, "invalid",
+                $"organization '{SanitizeForLog(organization!)}' references an unsupported network id shape.");
+        }
+
+        var entries = new JsonArray();
+
+        try
+        {
+            if (!string.IsNullOrEmpty(practitionerNpi))
+            {
+                await BuildEntriesByPractitionerAsync(
+                    practitionerNpi,
+                    organizationId,
+                    specialty,
+                    page,
+                    pageSize,
+                    entries);
+            }
+            else if (!string.IsNullOrEmpty(organizationId))
+            {
+                await BuildEntriesByOrganizationAsync(
+                    organizationId,
+                    specialty,
+                    page,
+                    pageSize,
+                    entries);
+            }
+            else if (!string.IsNullOrEmpty(specialty))
+            {
+                await BuildEntriesBySpecialtyAsync(
+                    specialty,
+                    page,
+                    pageSize,
+                    entries);
+            }
+            // No filters supplied → empty Bundle. FHIR doesn't require
+            // Bundle.entry to be populated and an unbounded directory
+            // dump is not what callers expect; mirror the existing
+            // fhir-service behavior of "must specify at least one of
+            // practitioner / organization / specialty".
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "PractitionerRole search failed");
+            return FhirOperationOutcome(500, "exception", "PractitionerRole search failed.");
+        }
+
+        return BundleResult(entries);
+    }
+
+    // ── search helpers ────────────────────────────────────────────────
+
+    private async Task BuildEntriesByPractitionerAsync(
+        string npi,
+        string? organizationFilter,
+        string? specialtyFilter,
+        int page,
+        int pageSize,
+        JsonArray entries)
+    {
+        var provider = await _providerRepository.GetByNPIAsync(npi);
+        if (provider == null
+            || provider.ProviderType != ProviderType.Individual
+            || provider.VersionState != ProviderVersionState.Active
+            || provider.Status != ProviderStatus.Active)
+        {
+            return;
+        }
+
+        if (!MatchesSpecialty(provider, specialtyFilter)) return;
+
+        var participations = provider.NetworkParticipations
+            .Where(p => !string.IsNullOrEmpty(p.NetworkId))
+            .Where(p => string.IsNullOrEmpty(organizationFilter) || p.NetworkId == organizationFilter)
+            .OrderBy(p => p.NetworkId, StringComparer.Ordinal)
+            .ThenBy(p => p.EffectiveDate)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        var networkCache = new Dictionary<string, Organization?>(StringComparer.Ordinal);
+        foreach (var participation in participations)
+        {
+            var network = await ResolveNetworkAsync(participation.NetworkId!, networkCache);
+            var projected = _projector.Project(participation, provider, network);
+            if (projected != null) entries.Add(WrapEntry(projected));
+        }
+    }
+
+    private async Task BuildEntriesByOrganizationAsync(
+        string networkId,
+        string? specialtyFilter,
+        int page,
+        int pageSize,
+        JsonArray entries)
+    {
+        // Reuse the 5.4 roster repository query (Decision 8 — direct
+        // repo call, skip INetworkRosterService). NetworkRosterQuery's
+        // server-only fields (TenantId, NetworkId) are populated here;
+        // the controller's TenantMiddleware sets the per-request tenant
+        // context, which is read inside the repository.
+        var query = new NetworkRosterQuery
+        {
+            TenantId = HttpContext.Items["TenantId"] as string ?? string.Empty,
+            NetworkId = networkId,
+            Specialty = specialtyFilter,
+            PageSize = pageSize,
+            Page = page,
+        };
+        if (string.IsNullOrEmpty(query.TenantId))
+        {
+            // The InMemory fake reads TenantId from query.TenantId, the
+            // real repository falls back to the same path. Empty tenant
+            // would silently match all rows in the fake; surface as an
+            // empty result.
+            return;
+        }
+
+        var skip = (page - 1) * pageSize;
+        var rows = await _providerRepository.ListNetworkRosterAsync(
+            query,
+            NetworkRosterSort.NameAsc,
+            skip);
+
+        var network = await _organizationRepository.GetByIdAsync(networkId);
+
+        foreach (var provider in rows)
+        {
+            if (provider.ProviderType != ProviderType.Individual) continue;
+            if (provider.VersionState != ProviderVersionState.Active) continue;
+            if (provider.Status != ProviderStatus.Active) continue;
+
+            // The repository EXISTS-clause guarantees ≥1 participation
+            // with the requested NetworkId; emit one PractitionerRole
+            // per matching participation so a provider with multiple
+            // (e.g. different LOBs in the same network) appears once
+            // per role.
+            foreach (var participation in provider.NetworkParticipations)
+            {
+                if (participation.NetworkId != networkId) continue;
+                var projected = _projector.Project(participation, provider, network);
+                if (projected != null) entries.Add(WrapEntry(projected));
+            }
+        }
+    }
+
+    private async Task BuildEntriesBySpecialtyAsync(
+        string specialty,
+        int page,
+        int pageSize,
+        JsonArray entries)
+    {
+        // Specialty-only search routes through IProviderRepository.SearchAsync
+        // (the existing 5.7 search shape). Per provider, we emit one
+        // PractitionerRole per network participation with a populated
+        // NetworkId.
+        var providers = await _providerRepository.SearchAsync(
+            name: null,
+            specialty: specialty,
+            zipCode: null,
+            state: null,
+            planId: null,
+            lineOfBusiness: null,
+            providerType: ProviderType.Individual,
+            acceptingNewPatients: null,
+            page: page,
+            pageSize: pageSize);
+
+        var networkCache = new Dictionary<string, Organization?>(StringComparer.Ordinal);
+        foreach (var provider in providers)
+        {
+            if (provider.ProviderType != ProviderType.Individual) continue;
+            if (provider.VersionState != ProviderVersionState.Active) continue;
+            if (provider.Status != ProviderStatus.Active) continue;
+
+            foreach (var participation in provider.NetworkParticipations)
+            {
+                if (string.IsNullOrEmpty(participation.NetworkId)) continue;
+                var network = await ResolveNetworkAsync(participation.NetworkId, networkCache);
+                var projected = _projector.Project(participation, provider, network);
+                if (projected != null) entries.Add(WrapEntry(projected));
+            }
+        }
+    }
+
+    private async Task<Organization?> ResolveNetworkAsync(
+        string networkId,
+        Dictionary<string, Organization?> cache)
+    {
+        if (cache.TryGetValue(networkId, out var cached)) return cached;
+        var network = await _organizationRepository.GetByIdAsync(networkId);
+        cache[networkId] = network;
+        return network;
+    }
+
+    private static bool MatchesSpecialty(Provider provider, string? specialty)
+    {
+        if (string.IsNullOrEmpty(specialty)) return true;
+        return (provider.PrimarySpecialty?.Contains(specialty, StringComparison.OrdinalIgnoreCase) ?? false)
+            || (provider.TaxonomyCode?.Contains(specialty, StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static string? ParseReference(string? raw, string typePrefix)
+    {
+        if (string.IsNullOrEmpty(raw)) return null;
+        // Accept both "Practitioner/{id}" and bare "{id}" forms. FHIR
+        // search reference parameters specify the typed form, but bare
+        // values are common in the wild and the existing fhir-service
+        // controller accepted them.
+        if (raw.StartsWith(typePrefix, StringComparison.Ordinal))
+        {
+            var value = raw[typePrefix.Length..];
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+        if (raw.Contains('/', StringComparison.Ordinal))
+        {
+            // A typed reference to a different resource type — reject.
+            return null;
+        }
+        return raw;
+    }
+
+    // ── response helpers ──────────────────────────────────────────────
+
+    private IActionResult BundleResult(JsonArray entries)
+    {
+        var bundle = new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "searchset",
+            ["total"] = entries.Count,
+            ["entry"] = entries,
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = bundle.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    private static JsonObject WrapEntry(JsonObject resource) => new()
+    {
+        // fullUrl is intentionally omitted for the same reason it is on
+        // the Practitioner Bundle (5.7): under the proxy hop, Request.Host
+        // is the internal provider-service hostname.
+        ["resource"] = resource,
+        ["search"] = new JsonObject { ["mode"] = "match" },
+    };
+
+    private IActionResult FhirOperationOutcome(int status, string code, string diagnostics)
+    {
+        var outcome = new JsonObject
+        {
+            ["resourceType"] = "OperationOutcome",
+            ["issue"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["severity"] = "error",
+                    ["code"] = code,
+                    ["diagnostics"] = diagnostics,
+                },
+            },
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = outcome.ToJsonString(),
+            StatusCode = status,
+        };
+    }
+
+    private static string SanitizeForLog(string value)
+        => value.Replace("\r", string.Empty, StringComparison.Ordinal)
+                .Replace("\n", string.Empty, StringComparison.Ordinal);
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -172,6 +172,14 @@ builder.Services.AddScoped<ICredentialingService, CredentialingService>();
 // IFhirPatientProjector.
 builder.Services.AddSingleton<IFhirPractitionerProjector, FhirPractitionerProjector>();
 
+// FHIR R4 PractitionerRole projection (5.8 — provider-service is the
+// canonical source for the PractitionerRole FHIR resource; fhir-service
+// proxies /fhir/r4/PractitionerRole/* to FhirPractitionerRoleController).
+// One PractitionerRole projects per Provider.NetworkParticipation with a
+// non-null NetworkId. The projector is stateless (singleton-safe) and
+// mirrors the 5.7 IFhirPractitionerProjector pattern.
+builder.Services.AddSingleton<IFhirPractitionerRoleProjector, FhirPractitionerRoleProjector>();
+
 // HTTP context accessor (for tenant middleware)
 builder.Services.AddHttpContextAccessor();
 

--- a/src/services/provider-service/Services/ChoProviderFhirUrls.cs
+++ b/src/services/provider-service/Services/ChoProviderFhirUrls.cs
@@ -41,4 +41,29 @@ internal static class ChoProviderFhirUrls
 
     public const string PlanNetPractitionerProfile =
         "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Practitioner";
+
+    public const string UsCorePractitionerRoleProfile =
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole";
+
+    public const string PlanNetPractitionerRoleProfile =
+        "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole";
+
+    /// <summary>
+    /// CHO grouped extension carrying panel-gating fields on a
+    /// PractitionerRole resource (capability 5.8 Decision 9 — single
+    /// top-level extension with sub-extensions, mirroring 5.7's
+    /// <see cref="ProviderIntegrityScoreExt"/> shape). The five
+    /// sub-extensions emit only when their source field is non-null;
+    /// the parent extension is omitted entirely when all five are null.
+    /// </summary>
+    public const string PractitionerRolePanelGatingExt =
+        StructureDefinitionBase + "practitionerrole-panel-gating";
+
+    /// <summary>
+    /// Coding system used for the LOBs surfaced inside the
+    /// <c>accepted-lobs</c> sub-extension. CHO does not yet bind LOB to
+    /// an external canonical value set; we publish under a CHO base so
+    /// consumers see a stable system + code pair.
+    /// </summary>
+    public const string LineOfBusinessSystem = Base + "CodeSystem/line-of-business";
 }

--- a/src/services/provider-service/Services/FhirPractitionerRoleProjector.cs
+++ b/src/services/provider-service/Services/FhirPractitionerRoleProjector.cs
@@ -60,9 +60,11 @@ public sealed class FhirPractitionerRoleProjector : IFhirPractitionerRoleProject
         {
             // Composite would exceed FHIR R4 id 64-char grammar (a
             // long-form NetworkId stretches the encoding past the cap).
-            // Emitting an invalid id would silently break consumers; skip
-            // the row instead. The controller's read path returns 422
-            // separately when called with such an id.
+            // Emitting an invalid id would silently break consumers, so
+            // the row is treated as non-projectable: search omits the
+            // row, and the read path falls through to the same null-
+            // handling shape as the other cases above (404
+            // OperationOutcome).
             return null;
         }
 

--- a/src/services/provider-service/Services/FhirPractitionerRoleProjector.cs
+++ b/src/services/provider-service/Services/FhirPractitionerRoleProjector.cs
@@ -1,0 +1,320 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using ProviderService.Models;
+using static ProviderService.Services.FhirExtensionBuilder;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Hand-built FHIR R4 PractitionerRole projector (capability 5.8). Pattern
+/// mirrors <see cref="FhirPractitionerProjector"/> (5.7): stateless,
+/// deterministic, no Hl7.Fhir.R4 dependency. Source data is the
+/// <see cref="NetworkParticipation"/> on an Active individual
+/// <see cref="Provider"/>, optionally enriched with the resolved
+/// <see cref="Organization"/> head version for the participation's
+/// <c>NetworkId</c>.
+/// </summary>
+public sealed class FhirPractitionerRoleProjector : IFhirPractitionerRoleProjector
+{
+    /// <summary>
+    /// FHIR R4 <c>id</c> grammar is <c>[A-Za-z0-9\-\.]{1,64}</c>. The
+    /// composite-id encoding uses dash separators only, so we just need
+    /// to enforce the length cap.
+    /// </summary>
+    private const int FhirIdMaxLength = 64;
+
+    /// <summary>
+    /// Composite shape: <c>{npi:10}-{lobInt:1+}-{yyyymmdd:8}-{networkId}</c>.
+    /// The trailing capture is the network id (which itself may contain
+    /// hyphens — guid-shaped chain keys are the common case), so the
+    /// regex is anchored at the start to lock the first three components
+    /// to fixed-shape captures.
+    /// </summary>
+    private static readonly Regex IdPattern = new(
+        @"^(?<npi>\d{10})-(?<lob>\d+)-(?<date>\d{8})-(?<network>.+)$",
+        RegexOptions.Compiled);
+
+    public JsonObject? Project(NetworkParticipation participation, Provider provider, Organization? network)
+    {
+        ArgumentNullException.ThrowIfNull(participation);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        // Decision 5.8/2 (premise gate): legacy participations without a
+        // NetworkId are invisible to FHIR — same posture as the 5.4
+        // roster API. Caller maps this to a 404 OperationOutcome on the
+        // read path or skips the row on search.
+        if (string.IsNullOrEmpty(participation.NetworkId)) return null;
+
+        // Organization-type providers project as FHIR Organization
+        // (capability 5.9), not PractitionerRole. Caller maps to 404.
+        if (provider.ProviderType != ProviderType.Individual) return null;
+
+        // Only project from the head Active version. Suspended /
+        // Terminated / Superseded versions are not directory-eligible.
+        if (provider.VersionState != ProviderVersionState.Active) return null;
+        if (provider.Status != ProviderStatus.Active) return null;
+
+        var encodedId = EncodeId(participation, provider);
+        if (encodedId is null)
+        {
+            // Composite would exceed FHIR R4 id 64-char grammar (a
+            // long-form NetworkId stretches the encoding past the cap).
+            // Emitting an invalid id would silently break consumers; skip
+            // the row instead. The controller's read path returns 422
+            // separately when called with such an id.
+            return null;
+        }
+
+        var role = new JsonObject
+        {
+            ["resourceType"] = "PractitionerRole",
+            ["id"] = encodedId,
+            ["active"] = ComputeActive(participation, provider, DateTime.UtcNow),
+        };
+
+        // ── practitioner reference ──────────────────────────────────
+        role["practitioner"] = new JsonObject
+        {
+            ["reference"] = $"Practitioner/{provider.NPI}",
+            ["display"] = BuildPractitionerDisplay(provider),
+        };
+
+        // ── organization reference ──────────────────────────────────
+        // Always emit when NetworkId is set; FHIR does not require the
+        // reference target to be resolvable. Display name is filled in
+        // when the caller supplied a resolved Organization head.
+        var orgRef = new JsonObject
+        {
+            ["reference"] = $"Organization/{participation.NetworkId}",
+        };
+        if (network != null && !string.IsNullOrEmpty(network.Name))
+        {
+            orgRef["display"] = network.Name;
+        }
+        role["organization"] = orgRef;
+
+        // ── code (network tier) ─────────────────────────────────────
+        // CHO does not bind NetworkTier to a canonical CodeSystem; emit
+        // a text-only CodeableConcept. Plan-Net IG accepts text-only
+        // under the "extensible" binding strength.
+        if (!string.IsNullOrEmpty(participation.NetworkTier))
+        {
+            role["code"] = new JsonArray
+            {
+                CodeableConcept(coding: null, text: participation.NetworkTier)
+            };
+        }
+
+        // ── specialty (NUCC from Provider) ──────────────────────────
+        // No per-participation Specialty field exists on
+        // NetworkParticipation today (premise correction 1a). Specialty
+        // is derived from the linked Provider — primary specialty as
+        // NUCC-coded CodeableConcept when TaxonomyCode is set, plus
+        // text-only entries for SecondarySpecialties (mirrors 5.7
+        // qualification handling).
+        var specialties = BuildSpecialties(provider);
+        if (specialties.Count > 0) role["specialty"] = specialties;
+
+        // ── period ──────────────────────────────────────────────────
+        var period = new JsonObject
+        {
+            ["start"] = FormatFhirDate(participation.EffectiveDate),
+        };
+        if (participation.TerminationDate.HasValue)
+        {
+            period["end"] = FormatFhirDate(participation.TerminationDate.Value);
+        }
+        role["period"] = period;
+
+        // ── telecom (from Provider) ─────────────────────────────────
+        var telecom = new JsonArray();
+        if (!string.IsNullOrEmpty(provider.Phone))
+            telecom.Add(new JsonObject { ["system"] = "phone", ["value"] = provider.Phone, ["use"] = "work" });
+        if (!string.IsNullOrEmpty(provider.Fax))
+            telecom.Add(new JsonObject { ["system"] = "fax", ["value"] = provider.Fax, ["use"] = "work" });
+        if (!string.IsNullOrEmpty(provider.Email))
+            telecom.Add(new JsonObject { ["system"] = "email", ["value"] = provider.Email, ["use"] = "work" });
+        if (telecom.Count > 0) role["telecom"] = telecom;
+
+        // ── extension: panel-gating (Decision 9) ────────────────────
+        var panelGating = BuildPanelGatingExtension(participation);
+        if (panelGating != null)
+        {
+            role["extension"] = new JsonArray { panelGating };
+        }
+
+        // ── meta ─────────────────────────────────────────────────────
+        role["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = DateTime.SpecifyKind(provider.LastUpdatedDate, DateTimeKind.Utc).ToString("o"),
+            ["profile"] = new JsonArray(
+                ChoProviderFhirUrls.UsCorePractitionerRoleProfile,
+                ChoProviderFhirUrls.PlanNetPractitionerRoleProfile),
+        };
+
+        return role;
+    }
+
+    public string? EncodeId(NetworkParticipation participation, Provider provider)
+    {
+        ArgumentNullException.ThrowIfNull(participation);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        if (string.IsNullOrEmpty(provider.NPI)) return null;
+        if (string.IsNullOrEmpty(participation.NetworkId)) return null;
+
+        var lobInt = ((int)participation.LineOfBusiness).ToString(CultureInfo.InvariantCulture);
+        // SpecifyKind preserves the calendar value; ToUniversalTime
+        // would shift Kind=Unspecified rows by the local TZ offset.
+        // Persistence layers round-trip dates as Kind=Unspecified, so
+        // SpecifyKind is the safer normalisation.
+        var date = DateTime.SpecifyKind(participation.EffectiveDate, DateTimeKind.Utc)
+            .ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+        var composite = $"{provider.NPI}-{lobInt}-{date}-{participation.NetworkId}";
+        if (composite.Length > FhirIdMaxLength) return null;
+        return composite;
+    }
+
+    public PractitionerRoleId? DecodeId(string id)
+    {
+        if (string.IsNullOrEmpty(id)) return null;
+
+        var match = IdPattern.Match(id);
+        if (!match.Success) return null;
+
+        var npi = match.Groups["npi"].Value;
+        var lobRaw = match.Groups["lob"].Value;
+        var dateRaw = match.Groups["date"].Value;
+        var networkId = match.Groups["network"].Value;
+
+        if (!int.TryParse(lobRaw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var lobInt))
+            return null;
+        if (!Enum.IsDefined(typeof(LineOfBusiness), lobInt)) return null;
+
+        if (!DateTime.TryParseExact(
+                dateRaw, "yyyyMMdd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var effective))
+        {
+            return null;
+        }
+
+        return new PractitionerRoleId(npi, (LineOfBusiness)lobInt, effective, networkId);
+    }
+
+    /// <summary>
+    /// Active flag derivation per Decision 7 of the 5.8 plan. Both the
+    /// participation period and the provider's version / status must be
+    /// active at <paramref name="asOf"/>. Caller passes <c>UtcNow</c> in
+    /// production; tests inject a fixed instant for determinism.
+    /// </summary>
+    internal static bool ComputeActive(NetworkParticipation participation, Provider provider, DateTime asOf)
+    {
+        // SpecifyKind, not ToUniversalTime — see EncodeId for the
+        // rationale on persistence-roundtrip Kind=Unspecified rows.
+        var asOfUtc = DateTime.SpecifyKind(asOf, DateTimeKind.Utc);
+        if (provider.VersionState != ProviderVersionState.Active) return false;
+        if (provider.Status != ProviderStatus.Active) return false;
+        if (DateTime.SpecifyKind(participation.EffectiveDate, DateTimeKind.Utc) > asOfUtc) return false;
+        if (participation.TerminationDate.HasValue
+            && DateTime.SpecifyKind(participation.TerminationDate.Value, DateTimeKind.Utc) < asOfUtc) return false;
+        return true;
+    }
+
+    private static string BuildPractitionerDisplay(Provider provider)
+    {
+        var parts = new[] { provider.FirstName, provider.MiddleName, provider.LastName, provider.Credentials }
+            .Where(s => !string.IsNullOrWhiteSpace(s));
+        return string.Join(' ', parts).Trim();
+    }
+
+    private static JsonArray BuildSpecialties(Provider provider)
+    {
+        var specialties = new JsonArray();
+
+        if (!string.IsNullOrEmpty(provider.PrimarySpecialty)
+            || !string.IsNullOrEmpty(provider.TaxonomyCode))
+        {
+            JsonObject codeNode;
+            if (!string.IsNullOrEmpty(provider.TaxonomyCode))
+            {
+                var coding = Coding(
+                    ChoProviderFhirUrls.NuccTaxonomySystem,
+                    provider.TaxonomyCode,
+                    string.IsNullOrEmpty(provider.PrimarySpecialty) ? null : provider.PrimarySpecialty);
+                codeNode = CodeableConcept(coding,
+                    text: string.IsNullOrEmpty(provider.PrimarySpecialty)
+                        ? provider.TaxonomyCode
+                        : provider.PrimarySpecialty);
+            }
+            else
+            {
+                codeNode = CodeableConcept(coding: null, text: provider.PrimarySpecialty);
+            }
+            specialties.Add(codeNode);
+        }
+
+        foreach (var secondary in provider.SecondarySpecialties)
+        {
+            if (string.IsNullOrWhiteSpace(secondary)) continue;
+            specialties.Add(CodeableConcept(coding: null, text: secondary));
+        }
+
+        return specialties;
+    }
+
+    /// <summary>
+    /// Build the grouped panel-gating extension (capability 5.8 Decision
+    /// 9). Returns null when none of the five panel-gating fields are
+    /// populated, so the caller can skip emitting the parent extension
+    /// entirely on legacy / unconstrained participations.
+    /// </summary>
+    private static JsonObject? BuildPanelGatingExtension(NetworkParticipation participation)
+    {
+        var inner = new JsonArray();
+
+        if (participation.PanelLimit.HasValue)
+        {
+            inner.Add(ExtensionInteger("panel-limit", participation.PanelLimit.Value));
+        }
+        if (participation.PanelAccepted.HasValue)
+        {
+            inner.Add(new JsonObject
+            {
+                ["url"] = "panel-accepted",
+                ["valueBoolean"] = participation.PanelAccepted.Value,
+            });
+        }
+        if (participation.AcceptedLobs.Count > 0)
+        {
+            foreach (var lob in participation.AcceptedLobs)
+            {
+                inner.Add(ExtensionCoding(
+                    "accepted-lobs",
+                    Coding(ChoProviderFhirUrls.LineOfBusinessSystem, lob.ToString(), lob.ToString())));
+            }
+        }
+        if (participation.MinAcceptedAgeYears.HasValue)
+        {
+            inner.Add(ExtensionInteger("min-accepted-age-years", participation.MinAcceptedAgeYears.Value));
+        }
+        if (participation.MaxAcceptedAgeYears.HasValue)
+        {
+            inner.Add(ExtensionInteger("max-accepted-age-years", participation.MaxAcceptedAgeYears.Value));
+        }
+
+        if (inner.Count == 0) return null;
+
+        return new JsonObject
+        {
+            ["url"] = ChoProviderFhirUrls.PractitionerRolePanelGatingExt,
+            ["extension"] = inner,
+        };
+    }
+
+    private static string FormatFhirDate(DateTime value)
+        => DateTime.SpecifyKind(value, DateTimeKind.Utc).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}

--- a/src/services/provider-service/Services/IFhirPractitionerRoleProjector.cs
+++ b/src/services/provider-service/Services/IFhirPractitionerRoleProjector.cs
@@ -1,0 +1,92 @@
+using System.Text.Json.Nodes;
+using ProviderService.Models;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Projects a single <see cref="NetworkParticipation"/> on an Active
+/// <see cref="ProviderType.Individual"/> <see cref="Provider"/> into a FHIR
+/// R4 PractitionerRole resource (as a <see cref="JsonObject"/>). Mirrors
+/// the design of <see cref="IFhirPractitionerProjector"/> (capability 5.7):
+/// hand-built to avoid the Hl7.Fhir.R4 transitive dep graph and keep
+/// serialization deterministic for tests.
+///
+/// <para>
+/// Returns <c>null</c> in three cases — caller maps null to FHIR
+/// <c>OperationOutcome</c> 404:
+/// <list type="bullet">
+///   <item><c>provider.ProviderType != Individual</c>. Organization-type
+///   providers project as FHIR Organization (capability 5.9), not
+///   PractitionerRole.</item>
+///   <item><c>provider.VersionState != Active</c> or <c>provider.Status != Active</c>.
+///   PractitionerRole is only projected from the head Active version.</item>
+///   <item><c>participation.NetworkId is null</c>. Legacy participations
+///   without a network reference are invisible to the FHIR surface (same
+///   posture as the 5.4 roster API). Backfill is per-tenant operational
+///   work tracked in <c>docs/architecture/network-participation-backfill.md</c>.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// The projection emits <c>meta.profile</c> with both the US Core 6.1.0
+/// PractitionerRole profile and the Da Vinci Plan-Net 1.1.0
+/// PractitionerRole profile. Required US Core elements (practitioner,
+/// active) are honored. Plan-Net cardinality (organization, code,
+/// specialty, telecom, period) is honored where CHO has data today;
+/// extended Plan-Net extensions (cultural competency, accessibility,
+/// populations served) remain deferred to capability 5.17.
+/// </para>
+///
+/// <para>
+/// Verification metadata stays on the linked Practitioner per Decision 5
+/// of the 5.8 plan-phase. PractitionerRole carries panel-gating
+/// information via a CHO-canonical extension (Decision 9), but no
+/// integrity-score extension — consumers dereference
+/// <c>PractitionerRole.practitioner</c> for that.
+/// </para>
+/// </summary>
+public interface IFhirPractitionerRoleProjector
+{
+    /// <summary>
+    /// Project a single network participation. <paramref name="network"/>
+    /// is the resolved <see cref="Organization"/> head version when known
+    /// — supplied so the projection can emit the Organization display
+    /// name; null is acceptable and produces a reference-only
+    /// <c>organization</c> field.
+    /// </summary>
+    JsonObject? Project(NetworkParticipation participation, Provider provider, Organization? network);
+
+    /// <summary>
+    /// Encode the canonical composite-tuple PractitionerRole id from the
+    /// inputs that uniquely identify a participation
+    /// (<c>NPI</c>, <c>LineOfBusiness</c>, <c>EffectiveDate</c>,
+    /// <c>NetworkId</c>). Format: <c>{npi}-{lobInt}-{yyyymmdd}-{networkId}</c>.
+    /// Returns null when any required component is missing or when the
+    /// composite would exceed FHIR R4's 64-character <c>id</c> grammar
+    /// limit; caller emits 422 / skips the row in that case.
+    /// </summary>
+    string? EncodeId(NetworkParticipation participation, Provider provider);
+
+    /// <summary>
+    /// Decode a PractitionerRole id back to its composite tuple. Returns
+    /// null when the id does not match the canonical shape — caller maps
+    /// to a 404 OperationOutcome.
+    /// </summary>
+    PractitionerRoleId? DecodeId(string id);
+}
+
+/// <summary>
+/// Decoded composite-tuple PractitionerRole id (capability 5.8 Decision 6).
+/// </summary>
+/// <param name="Npi">10-digit National Provider Identifier of the linked
+/// individual provider.</param>
+/// <param name="LineOfBusiness">LOB enum value from the participation.</param>
+/// <param name="EffectiveDate">UTC <c>DateTime.Date</c> of the
+/// participation's <c>EffectiveDate</c>.</param>
+/// <param name="NetworkId">Chain key of the linked
+/// <see cref="Organization"/>.</param>
+public sealed record PractitionerRoleId(
+    string Npi,
+    LineOfBusiness LineOfBusiness,
+    DateTime EffectiveDate,
+    string NetworkId);

--- a/src/services/provider-service/Services/IFhirPractitionerRoleProjector.cs
+++ b/src/services/provider-service/Services/IFhirPractitionerRoleProjector.cs
@@ -12,8 +12,8 @@ namespace ProviderService.Services;
 /// serialization deterministic for tests.
 ///
 /// <para>
-/// Returns <c>null</c> in three cases — caller maps null to FHIR
-/// <c>OperationOutcome</c> 404:
+/// Returns <c>null</c> in any of these cases — caller maps null to FHIR
+/// <c>OperationOutcome</c> 404 (read path) or skips the row (search):
 /// <list type="bullet">
 ///   <item><c>provider.ProviderType != Individual</c>. Organization-type
 ///   providers project as FHIR Organization (capability 5.9), not
@@ -24,6 +24,12 @@ namespace ProviderService.Services;
 ///   without a network reference are invisible to the FHIR surface (same
 ///   posture as the 5.4 roster API). Backfill is per-tenant operational
 ///   work tracked in <c>docs/architecture/network-participation-backfill.md</c>.</item>
+///   <item>The composite-tuple id would exceed the FHIR R4 <c>id</c>
+///   grammar's 64-character limit (e.g. an unusually long
+///   <c>NetworkId</c> stretches the encoding past the cap). Emitting a
+///   non-conformant id would silently break consumers; the row is
+///   omitted instead.</item>
+///   <item>Any required id component (NPI, NetworkId) is missing.</item>
 /// </list>
 /// </para>
 ///
@@ -63,7 +69,10 @@ public interface IFhirPractitionerRoleProjector
     /// <c>NetworkId</c>). Format: <c>{npi}-{lobInt}-{yyyymmdd}-{networkId}</c>.
     /// Returns null when any required component is missing or when the
     /// composite would exceed FHIR R4's 64-character <c>id</c> grammar
-    /// limit; caller emits 422 / skips the row in that case.
+    /// limit. Search callers skip the row in that case; the read path
+    /// surfaces the resulting non-addressable resource as a 404
+    /// <c>OperationOutcome</c> (consistent with the existing
+    /// null-handling shape).
     /// </summary>
     string? EncodeId(NetworkParticipation participation, Provider provider);
 

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerPractitionerRoleProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerPractitionerRoleProxyTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using System.Text;
+using FhirService.Controllers;
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudHealthOffice.FhirService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.8 — proxy-shape coverage for the rewritten
+/// PractitionerRole endpoints in
+/// <see cref="ProviderDirectoryController"/>. Mirrors the 5.7
+/// Practitioner proxy tests: the controller no longer talks to NPPES on
+/// the PractitionerRole path; it issues a single GET to the typed
+/// <c>ProviderService</c> HttpClient and passes the response through.
+/// </summary>
+public class ProviderDirectoryControllerPractitionerRoleProxyTests
+{
+    private readonly Mock<IHttpClientFactory> _factory = new();
+    private readonly RecordingHandler _providerServiceHandler = new();
+    private readonly RecordingHandler _verificationHandler = new();
+    private readonly RecordingHandler _nppesHandler = new();
+    private readonly ProviderDirectoryController _controller;
+
+    public ProviderDirectoryControllerPractitionerRoleProxyTests()
+    {
+        _factory.Setup(f => f.CreateClient("ProviderService"))
+            .Returns(() => new HttpClient(_providerServiceHandler)
+            {
+                BaseAddress = new Uri("http://provider-service.test/")
+            });
+        _factory.Setup(f => f.CreateClient("ProviderVerificationService"))
+            .Returns(() => new HttpClient(_verificationHandler)
+            {
+                BaseAddress = new Uri("http://provider-verification-service.test/")
+            });
+        _factory.Setup(f => f.CreateClient("NppesApi"))
+            .Returns(() => new HttpClient(_nppesHandler)
+            {
+                BaseAddress = new Uri("http://nppes.test/")
+            });
+
+        _controller = new ProviderDirectoryController(
+            _factory.Object,
+            NullLogger<ProviderDirectoryController>.Instance);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_forwards_composite_id_to_provider_service()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"PractitionerRole\",\"id\":\"1234567890-1-20240101-net\"}"));
+
+        var compositeId = "1234567890-1-20240101-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        var result = await _controller.ReadPractitionerRole(compositeId, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"PractitionerRole\"");
+
+        var req = _providerServiceHandler.Calls.Single();
+        req.Method.Should().Be(HttpMethod.Get);
+        req.RequestUri!.AbsolutePath.Should().Be($"/fhir/PractitionerRole/{compositeId}");
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_passes_404_OperationOutcome_through()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.NotFound,
+            "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"not-found\"}]}"));
+
+        var result = await _controller.ReadPractitionerRole("not-found-id", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.Content.Should().Contain("OperationOutcome");
+        content.Content.Should().Contain("not-found");
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_translates_upstream_5xx_to_502_OperationOutcome()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.InternalServerError,
+            "internal upstream noise that must NOT leak"));
+
+        var result = await _controller.ReadPractitionerRole(
+            "1234567890-1-20240101-network-a", default);
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        var outcome = status.Value.Should().BeOfType<OperationOutcome>().Subject;
+        outcome.Issue.Single().Code.Should().Be(OperationOutcome.IssueType.Transient);
+        outcome.Issue.Single().Diagnostics.Should().NotContain("internal upstream noise");
+        // Diagnostics labels the resource so operators can distinguish
+        // PractitionerRole upstream failures from Practitioner ones.
+        outcome.Issue.Single().Diagnostics.Should().Contain("PractitionerRole");
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_handles_upstream_unreachable_as_502()
+    {
+        _providerServiceHandler.Respond(_ =>
+            throw new HttpRequestException("connection refused"));
+
+        var result = await _controller.ReadPractitionerRole(
+            "1234567890-1-20240101-network-a", default);
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        status.Value.Should().BeOfType<OperationOutcome>();
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_forwards_query_string_to_provider_service()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new QueryString(
+            "?practitioner=Practitioner/1234567890&organization=Organization/net-a&specialty=cardiology&_count=25");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchPractitionerRoles(default);
+
+        var req = _providerServiceHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/PractitionerRole");
+        req.RequestUri.Query.Should().Contain("practitioner=Practitioner/1234567890");
+        req.RequestUri.Query.Should().Contain("organization=Organization/net-a");
+        req.RequestUri.Query.Should().Contain("specialty=cardiology");
+        req.RequestUri.Query.Should().Contain("_count=25");
+    }
+
+    [Fact]
+    public async Task PractitionerRole_path_does_not_call_NPPES_or_verification()
+    {
+        _providerServiceHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new QueryString("?practitioner=Practitioner/1234567890");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+
+        await _controller.SearchPractitionerRoles(default);
+
+        _nppesHandler.Calls.Should().BeEmpty(
+            "the NPPES path is dead for PractitionerRole now");
+        _verificationHandler.Calls.Should().BeEmpty(
+            "verification metadata stays on the linked Practitioner — PractitionerRole proxy never enriches");
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/fhir+json")
+        };
+
+    /// <summary>
+    /// Test double for HttpMessageHandler that records each request and
+    /// dispatches via a caller-supplied delegate. Mirror of the helper
+    /// in <see cref="ProviderDirectoryControllerProxyTests"/>; keeping a
+    /// per-fixture copy avoids cross-file private-type coupling.
+    /// </summary>
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = new();
+        private Func<HttpRequestMessage, HttpResponseMessage> _responder =
+            _ => new HttpResponseMessage(HttpStatusCode.NotImplemented);
+
+        public void Respond(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs
@@ -319,6 +319,13 @@ public class ProviderDirectoryMapperTests
     }
 
     // ── NPPES → PractitionerRole Mapping ─────────────────────────────────────
+    //
+    // The NPPES PractitionerRole mapping is the legacy path replaced by
+    // capability 5.8 (provider-service FhirPractitionerRoleProjector).
+    // The helper is marked [Obsolete] so callers migrate, but these tests
+    // continue to gate the helper's behaviour until capability 5.9
+    // retires the NPPES path entirely. Suppress CS0618 for the section.
+#pragma warning disable CS0618 // PractitionerRole helper is intentionally Obsolete (capability 5.8)
 
     [Fact]
     public void MapNppesToPractitionerRole_CreatesResourceWithCorrectIdFormat()
@@ -380,6 +387,8 @@ public class ProviderDirectoryMapperTests
         role.Location.Should().HaveCount(1);
         role.Location![0].Reference.Should().Be("Location/1234567893-loc-0");
     }
+
+#pragma warning restore CS0618
 
     // ── NPPES → Location Mapping ─────────────────────────────────────────────
 

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerRoleControllerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerRoleControllerTests.cs
@@ -1,0 +1,319 @@
+using System.Text.Json.Nodes;
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.8 — endpoint-shape coverage for
+/// <see cref="FhirPractitionerRoleController"/>: read by composite id,
+/// search by practitioner / organization / specialty, malformed-id 404,
+/// malformed-reference 400, FHIR Bundle searchset shape, and tenant
+/// scoping. Mirrors the structure of <see cref="FhirPractitionerControllerTests"/>.
+/// </summary>
+public class FhirPractitionerRoleControllerTests
+{
+    private const string TenantId = "tenant-a";
+    private const string NetworkA = "network-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string NetworkB = "network-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    private readonly InMemoryProviderRepository _providerRepo = new() { TenantId = TenantId };
+    private readonly InMemoryOrganizationRepository _orgRepo = new() { TenantId = TenantId };
+    private readonly FhirPractitionerRoleProjector _projector = new();
+    private readonly FhirPractitionerRoleController _controller;
+
+    public FhirPractitionerRoleControllerTests()
+    {
+        _controller = new FhirPractitionerRoleController(
+            _providerRepo, _orgRepo, _projector,
+            NullLogger<FhirPractitionerRoleController>.Instance);
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        ctx.Request.Scheme = "https";
+        ctx.Request.Host = new HostString("provider.test.local");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    private static Provider IndividualProvider(
+        string npi,
+        string firstName,
+        string lastName,
+        string? specialty = null,
+        string? taxonomy = null,
+        IEnumerable<NetworkParticipation>? participations = null) => new()
+    {
+        TenantId = TenantId,
+        Id = $"v-{npi}",
+        ProviderId = $"p-{npi}",
+        VersionId = $"v-{npi}",
+        VersionNumber = 1,
+        VersionState = ProviderVersionState.Active,
+        Status = ProviderStatus.Active,
+        NPI = npi,
+        ProviderType = ProviderType.Individual,
+        FirstName = firstName,
+        LastName = lastName,
+        PrimarySpecialty = specialty ?? "Internal Medicine",
+        TaxonomyCode = taxonomy ?? "207R00000X",
+        NetworkParticipations = participations?.ToList() ?? new List<NetworkParticipation>(),
+    };
+
+    private static NetworkParticipation Participation(
+        string? networkId,
+        LineOfBusiness lob = LineOfBusiness.Commercial,
+        DateTime? effective = null) => new()
+        {
+            NetworkId = networkId,
+            LineOfBusiness = lob,
+            NetworkTier = "Tier1",
+            EffectiveDate = effective ?? new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            AcceptingNewPatients = true,
+        };
+
+    private static Organization Network(string id, string name = "Test Network") => new()
+    {
+        TenantId = TenantId,
+        Id = id,
+        OrganizationId = id,
+        Name = name,
+        NetworkType = NetworkType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        EffectiveDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Status = OrganizationStatus.Active,
+        VersionState = OrganizationVersionState.Active,
+        VersionNumber = 1,
+        VersionId = $"v-{id}",
+    };
+
+    private static JsonObject ParseFhirContent(IActionResult result)
+    {
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.ContentType.Should().Be("application/fhir+json");
+        return JsonNode.Parse(content.Content!)!.AsObject();
+    }
+
+    private void Seed()
+    {
+        // The in-memory repo's ActivateAndSupersedeAsync just adds the
+        // (already-Active) row to its store; we skip the draft step
+        // because the projection does not depend on draft history.
+        _orgRepo.ActivateAndSupersedeAsync(Network(NetworkA, "Network A"), predecessor: null).Wait();
+        _orgRepo.ActivateAndSupersedeAsync(Network(NetworkB, "Network B"), predecessor: null).Wait();
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_returns_200_for_valid_composite_id()
+    {
+        Seed();
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(NetworkA),
+        });
+        await _providerRepo.CreateAsync(provider);
+
+        var id = _projector.EncodeId(provider.NetworkParticipations[0], provider)!;
+        var result = await _controller.ReadPractitionerRole(id, default);
+
+        var json = ParseFhirContent(result);
+        json["resourceType"]!.GetValue<string>().Should().Be("PractitionerRole");
+        json["id"]!.GetValue<string>().Should().Be(id);
+        json["practitioner"]!["reference"]!.GetValue<string>().Should().Be("Practitioner/1234567890");
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_returns_404_OperationOutcome_for_unknown_id()
+    {
+        var result = await _controller.ReadPractitionerRole("9999999999-1-20240101-unknown", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.Content.Should().Contain("OperationOutcome");
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_returns_404_for_malformed_id()
+    {
+        var result = await _controller.ReadPractitionerRole("not-a-valid-id", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task ReadPractitionerRole_returns_404_for_legacy_NetworkId_null_participation()
+    {
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(networkId: null),
+        });
+        await _providerRepo.CreateAsync(provider);
+
+        // The composite id can't be encoded (NetworkId is null), so we
+        // synthesize a plausible id-shape and expect 404. This guards
+        // against an external caller probing for legacy participations.
+        var result = await _controller.ReadPractitionerRole(
+            "1234567890-1-20240101-some-network", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_by_practitioner_returns_one_role_per_participation()
+    {
+        Seed();
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(NetworkA, LineOfBusiness.Commercial),
+            Participation(NetworkB, LineOfBusiness.Medicare),
+            Participation(networkId: null),  // legacy — invisible
+        });
+        await _providerRepo.CreateAsync(provider);
+
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Practitioner/1234567890",
+            organization: null, specialty: null);
+
+        var bundle = ParseFhirContent(result);
+        bundle["resourceType"]!.GetValue<string>().Should().Be("Bundle");
+        bundle["type"]!.GetValue<string>().Should().Be("searchset");
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+        bundle["entry"]!.AsArray().Count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_by_practitioner_and_organization_intersects()
+    {
+        Seed();
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(NetworkA, LineOfBusiness.Commercial),
+            Participation(NetworkB, LineOfBusiness.Medicare),
+        });
+        await _providerRepo.CreateAsync(provider);
+
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Practitioner/1234567890",
+            organization: $"Organization/{NetworkA}",
+            specialty: null);
+
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        var role = bundle["entry"]!.AsArray()[0]!["resource"]!.AsObject();
+        role["organization"]!["reference"]!.GetValue<string>().Should().Be($"Organization/{NetworkA}");
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_by_organization_returns_all_providers_in_network()
+    {
+        Seed();
+        var p1 = IndividualProvider("1111111111", "Alice", "First", participations: new[]
+        {
+            Participation(NetworkA, LineOfBusiness.Commercial),
+        });
+        var p2 = IndividualProvider("2222222222", "Bob", "Second", participations: new[]
+        {
+            Participation(NetworkA, LineOfBusiness.Commercial),
+            Participation(NetworkB, LineOfBusiness.Medicare),  // different net — excluded
+        });
+        var p3 = IndividualProvider("3333333333", "Carol", "Third", participations: new[]
+        {
+            Participation(NetworkB, LineOfBusiness.Medicare),  // wrong net — excluded
+        });
+        await _providerRepo.CreateAsync(p1);
+        await _providerRepo.CreateAsync(p2);
+        await _providerRepo.CreateAsync(p3);
+
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: null,
+            organization: $"Organization/{NetworkA}",
+            specialty: null);
+
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+        var refs = bundle["entry"]!.AsArray()
+            .Select(e => e!["resource"]!["practitioner"]!["reference"]!.GetValue<string>())
+            .ToList();
+        refs.Should().BeEquivalentTo(new[] { "Practitioner/1111111111", "Practitioner/2222222222" });
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_returns_400_for_unrecognized_reference()
+    {
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Patient/1234",
+            organization: null, specialty: null);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+        content.Content.Should().Contain("OperationOutcome");
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_returns_400_for_invalid_npi()
+    {
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Practitioner/12345",
+            organization: null, specialty: null);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_with_no_filters_returns_empty_bundle()
+    {
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: null, organization: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+        bundle["entry"]!.AsArray().Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_unknown_practitioner_returns_empty_bundle()
+    {
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Practitioner/9999999999",
+            organization: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_excludes_inactive_providers()
+    {
+        Seed();
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(NetworkA),
+        });
+        provider.VersionState = ProviderVersionState.Suspended;
+        provider.Status = ProviderStatus.Inactive;
+        await _providerRepo.CreateAsync(provider);
+
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "Practitioner/1234567890",
+            organization: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchPractitionerRoles_accepts_bare_NPI_in_practitioner_param()
+    {
+        Seed();
+        var provider = IndividualProvider("1234567890", "Jane", "Doe", participations: new[]
+        {
+            Participation(NetworkA),
+        });
+        await _providerRepo.CreateAsync(provider);
+
+        var result = await _controller.SearchPractitionerRoles(
+            practitioner: "1234567890",  // bare NPI, no Practitioner/ prefix
+            organization: null, specialty: null);
+        var bundle = ParseFhirContent(result);
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerRoleProjectorTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerRoleProjectorTests.cs
@@ -1,0 +1,333 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Capability 5.8 — FHIR PractitionerRole projection unit tests. Mirrors
+/// the fixture style of <see cref="FhirPractitionerProjectorTests"/>:
+/// US Core 6.1.0 + Plan-Net IG 1.1.0 structural conformance, edge-case
+/// coverage (legacy NetworkId-null returns null, Organization-type
+/// providers return null, terminated participation emits period.end and
+/// active=false, panel-gating extension only when populated), composite-id
+/// round-trip, and a determinism check.
+/// </summary>
+public class FhirPractitionerRoleProjectorTests
+{
+    private readonly FhirPractitionerRoleProjector _projector = new();
+
+    private const string DefaultNetworkId = "11111111-1111-1111-1111-111111111111";
+
+    private static Provider BuildProvider(string npi = "1234567890") => new()
+    {
+        TenantId = "tenant-a",
+        Id = "v-1",
+        ProviderId = "p-1",
+        VersionId = "v-1",
+        VersionNumber = 1,
+        VersionState = ProviderVersionState.Active,
+        Status = ProviderStatus.Active,
+        NPI = npi,
+        ProviderType = ProviderType.Individual,
+        FirstName = "Jane",
+        MiddleName = "Q",
+        LastName = "Doe",
+        Credentials = "MD",
+        PrimarySpecialty = "Internal Medicine",
+        TaxonomyCode = "207R00000X",
+        SecondarySpecialties = new() { "Cardiology" },
+        Phone = "617-555-0100",
+        Fax = "617-555-0101",
+        Email = "jane.doe@example.com",
+        LastUpdatedDate = new DateTime(2026, 4, 27, 10, 0, 0, DateTimeKind.Utc),
+    };
+
+    private static NetworkParticipation BuildParticipation(
+        string? networkId = DefaultNetworkId,
+        LineOfBusiness lob = LineOfBusiness.Commercial,
+        string? networkTier = "Tier1",
+        DateTime? effective = null,
+        DateTime? termination = null) => new()
+        {
+            NetworkId = networkId,
+            PlanId = "PLAN-1",
+            LineOfBusiness = lob,
+            NetworkTier = networkTier ?? string.Empty,
+            EffectiveDate = effective ?? new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TerminationDate = termination,
+            AcceptingNewPatients = true,
+        };
+
+    private static Organization BuildOrganization(string? id = null) => new()
+    {
+        TenantId = "tenant-a",
+        Id = id ?? DefaultNetworkId,
+        OrganizationId = id ?? DefaultNetworkId,
+        Name = "Aetna PPO Florida 2024",
+        NetworkType = NetworkType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        EffectiveDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Status = OrganizationStatus.Active,
+        VersionState = OrganizationVersionState.Active,
+        VersionNumber = 1,
+        VersionId = "vorg-1",
+    };
+
+    [Fact]
+    public void Projects_minimum_required_elements()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization());
+
+        result.Should().NotBeNull();
+        result!["resourceType"]!.GetValue<string>().Should().Be("PractitionerRole");
+        result["id"]!.GetValue<string>().Should().StartWith("1234567890-1-20240101-");
+
+        var profiles = result["meta"]!["profile"]!.AsArray()
+            .Select(n => n!.GetValue<string>()).ToList();
+        profiles.Should().Contain("http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole");
+        profiles.Should().Contain("http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-PractitionerRole");
+    }
+
+    [Fact]
+    public void Active_when_period_open_and_provider_active()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        result["active"]!.GetValue<bool>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Active_false_when_terminated_in_past()
+    {
+        var participation = BuildParticipation(
+            effective: new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: new DateTime(2020, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+        var result = _projector.Project(participation, BuildProvider(), BuildOrganization())!;
+        result["active"]!.GetValue<bool>().Should().BeFalse();
+        result["period"]!["end"]!.GetValue<string>().Should().Be("2020-12-31");
+    }
+
+    [Fact]
+    public void Period_emits_start_only_when_no_termination()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var period = result["period"]!.AsObject();
+        period["start"]!.GetValue<string>().Should().Be("2024-01-01");
+        period.ContainsKey("end").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Practitioner_reference_uses_NPI()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var practitionerRef = result["practitioner"]!.AsObject();
+        practitionerRef["reference"]!.GetValue<string>().Should().Be("Practitioner/1234567890");
+        practitionerRef["display"]!.GetValue<string>().Should().Contain("Jane");
+        practitionerRef["display"]!.GetValue<string>().Should().Contain("Doe");
+    }
+
+    [Fact]
+    public void Organization_reference_uses_NetworkId_with_display_when_resolved()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var orgRef = result["organization"]!.AsObject();
+        orgRef["reference"]!.GetValue<string>().Should().Be($"Organization/{DefaultNetworkId}");
+        orgRef["display"]!.GetValue<string>().Should().Be("Aetna PPO Florida 2024");
+    }
+
+    [Fact]
+    public void Organization_reference_emits_without_display_when_network_unresolved()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), network: null)!;
+        var orgRef = result["organization"]!.AsObject();
+        orgRef["reference"]!.GetValue<string>().Should().Be($"Organization/{DefaultNetworkId}");
+        orgRef.ContainsKey("display").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Returns_null_when_participation_has_no_NetworkId()
+    {
+        var participation = BuildParticipation(networkId: null);
+        var result = _projector.Project(participation, BuildProvider(), network: null);
+        result.Should().BeNull("legacy participations without NetworkId are invisible to FHIR");
+    }
+
+    [Fact]
+    public void Returns_null_for_organization_type_provider()
+    {
+        var provider = BuildProvider();
+        provider.ProviderType = ProviderType.Organization;
+        var result = _projector.Project(BuildParticipation(), provider, BuildOrganization());
+        result.Should().BeNull("Organization-type providers project as FHIR Organization, not PractitionerRole");
+    }
+
+    [Fact]
+    public void Returns_null_for_non_active_provider_version()
+    {
+        var provider = BuildProvider();
+        provider.VersionState = ProviderVersionState.Suspended;
+        var result = _projector.Project(BuildParticipation(), provider, BuildOrganization());
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_null_for_non_active_provider_status()
+    {
+        var provider = BuildProvider();
+        provider.Status = ProviderStatus.Terminated;
+        var result = _projector.Project(BuildParticipation(), provider, BuildOrganization());
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Code_emits_NetworkTier_text_only()
+    {
+        var result = _projector.Project(BuildParticipation(networkTier: "Preferred"), BuildProvider(), BuildOrganization())!;
+        var codes = result["code"]!.AsArray();
+        codes.Count.Should().Be(1);
+        codes[0]!["text"]!.GetValue<string>().Should().Be("Preferred");
+    }
+
+    [Fact]
+    public void Code_omitted_when_NetworkTier_blank()
+    {
+        var result = _projector.Project(BuildParticipation(networkTier: string.Empty), BuildProvider(), BuildOrganization())!;
+        result.ContainsKey("code").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Specialty_carries_NUCC_coding_for_primary_and_text_for_secondary()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var specialty = result["specialty"]!.AsArray();
+        specialty.Count.Should().Be(2);
+
+        var primary = specialty[0]!.AsObject();
+        var primaryCoding = primary["coding"]!.AsArray()[0]!.AsObject();
+        primaryCoding["system"]!.GetValue<string>().Should().Be("http://nucc.org/provider-taxonomy");
+        primaryCoding["code"]!.GetValue<string>().Should().Be("207R00000X");
+        primaryCoding["display"]!.GetValue<string>().Should().Be("Internal Medicine");
+
+        var secondary = specialty[1]!.AsObject();
+        secondary.ContainsKey("coding").Should().BeFalse();
+        secondary["text"]!.GetValue<string>().Should().Be("Cardiology");
+    }
+
+    [Fact]
+    public void Telecom_passes_through_provider_fields_in_order()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var telecom = result["telecom"]!.AsArray();
+        telecom.Count.Should().Be(3);
+        telecom[0]!["system"]!.GetValue<string>().Should().Be("phone");
+        telecom[1]!["system"]!.GetValue<string>().Should().Be("fax");
+        telecom[2]!["system"]!.GetValue<string>().Should().Be("email");
+    }
+
+    [Fact]
+    public void Panel_gating_extension_omitted_when_all_fields_null()
+    {
+        var result = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        result.ContainsKey("extension").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Panel_gating_extension_emits_only_populated_subextensions()
+    {
+        var participation = BuildParticipation();
+        participation.PanelLimit = 250;
+        participation.PanelAccepted = true;
+        participation.AcceptedLobs = new() { LineOfBusiness.Commercial, LineOfBusiness.Medicare };
+        // MinAcceptedAgeYears + MaxAcceptedAgeYears intentionally null
+
+        var result = _projector.Project(participation, BuildProvider(), BuildOrganization())!;
+        var extension = result["extension"]!.AsArray()[0]!.AsObject();
+        extension["url"]!.GetValue<string>().Should().Be(
+            "http://fhir.cloudhealthoffice.com/StructureDefinition/practitionerrole-panel-gating");
+
+        var inner = extension["extension"]!.AsArray();
+        var urls = inner.Select(n => n!["url"]!.GetValue<string>()).ToList();
+        urls.Should().Contain("panel-limit");
+        urls.Should().Contain("panel-accepted");
+        urls.Count(u => u == "accepted-lobs").Should().Be(2);
+        urls.Should().NotContain("min-accepted-age-years");
+        urls.Should().NotContain("max-accepted-age-years");
+    }
+
+    [Fact]
+    public void Panel_gating_extension_emits_age_bounds_when_set()
+    {
+        var participation = BuildParticipation();
+        participation.MinAcceptedAgeYears = 18;
+        participation.MaxAcceptedAgeYears = 65;
+
+        var result = _projector.Project(participation, BuildProvider(), BuildOrganization())!;
+        var extension = result["extension"]!.AsArray()[0]!.AsObject();
+        var inner = extension["extension"]!.AsArray();
+
+        var min = inner.Single(n => n!["url"]!.GetValue<string>() == "min-accepted-age-years")!.AsObject();
+        min["valueInteger"]!.GetValue<int>().Should().Be(18);
+        var max = inner.Single(n => n!["url"]!.GetValue<string>() == "max-accepted-age-years")!.AsObject();
+        max["valueInteger"]!.GetValue<int>().Should().Be(65);
+    }
+
+    [Fact]
+    public void Encode_id_and_decode_id_round_trip()
+    {
+        var participation = BuildParticipation(
+            lob: LineOfBusiness.Medicare,
+            effective: new DateTime(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc));
+        var encoded = _projector.EncodeId(participation, BuildProvider());
+
+        encoded.Should().Be($"1234567890-2-20240615-{DefaultNetworkId}");
+
+        var decoded = _projector.DecodeId(encoded!);
+        decoded.Should().NotBeNull();
+        decoded!.Npi.Should().Be("1234567890");
+        decoded.LineOfBusiness.Should().Be(LineOfBusiness.Medicare);
+        decoded.EffectiveDate.Date.Should().Be(new DateTime(2024, 6, 15));
+        decoded.NetworkId.Should().Be(DefaultNetworkId);
+    }
+
+    [Fact]
+    public void Encode_id_returns_null_when_composite_exceeds_64_chars()
+    {
+        // 64-char NetworkId pushes the composite over the FHIR id grammar
+        // limit. Projector returns null so caller can skip the row.
+        var longNetworkId = new string('a', 64);
+        var participation = BuildParticipation(networkId: longNetworkId);
+        var encoded = _projector.EncodeId(participation, BuildProvider());
+        encoded.Should().BeNull();
+
+        var role = _projector.Project(participation, BuildProvider(), network: null);
+        role.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("not-a-real-id")]
+    [InlineData("1234567890-x-20240101-foo")]
+    [InlineData("1234567890-1-2024XXXX-foo")]
+    [InlineData("123-1-20240101-foo")]
+    [InlineData("1234567890-99-20240101-foo")]  // LOB enum out of range
+    public void Decode_id_rejects_malformed_inputs(string id)
+    {
+        _projector.DecodeId(id).Should().BeNull();
+    }
+
+    [Fact]
+    public void Decode_id_preserves_hyphens_in_network_id()
+    {
+        var decoded = _projector.DecodeId($"1234567890-1-20240101-{DefaultNetworkId}");
+        decoded.Should().NotBeNull();
+        decoded!.NetworkId.Should().Be(DefaultNetworkId);
+    }
+
+    [Fact]
+    public void Projection_is_deterministic_across_calls()
+    {
+        var first = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        var second = _projector.Project(BuildParticipation(), BuildProvider(), BuildOrganization())!;
+        first.ToJsonString().Should().Be(second.ToJsonString());
+    }
+}


### PR DESCRIPTION
## Summary

Inverts the PractitionerRole data flow from NPPES synthesis to the CHO-canonical `NetworkParticipation` chain. provider-service owns the hand-built FHIR R4 PractitionerRole projection (`IFhirPractitionerRoleProjector` / `FhirPractitionerRoleController`); fhir-service proxies `/fhir/r4/PractitionerRole/*` to the new endpoint through the existing typed `ProviderService` HttpClient established by capability 5.7.

After this PR, two of the four provider-directory resources (Practitioner, PractitionerRole) carry CHO-canonical data. Organization follows in 5.9.

- One PractitionerRole projects per `NetworkParticipation` with a non-null `NetworkId` on the head Active version of an individual Provider.
- Composite-tuple id format `{npi}-{lobInt}-{yyyymmdd}-{networkId}` stays inside FHIR R4's id grammar (64-char cap, `[A-Za-z0-9.-]`).
- Panel-gating fields from 5.5 surface as a single grouped CHO extension on PractitionerRole. Verification metadata stays on the linked Practitioner (5.7).
- US Core 6.1.0 PractitionerRole + Plan-Net IG 1.1.0 PractitionerRole profile references emitted in `meta.profile`.
- `?organization=...` reuses `IProviderRepository.ListNetworkRosterAsync` (the same query the 5.4 roster API drives), so the operational roster and FHIR PractitionerRole surfaces stay sourced from one repository method.
- NPPES `MapNppesToPractitionerRole` helper marked `[Obsolete]` — final removal after 5.9 retires the rest of the NPPES path. HYBRID STATE comment block in `ProviderDirectoryController` updated.

## Plan-First decisions ratified during the gate

1. **Specialty source (premise correction).** `NetworkParticipation` has no `Specialty` field; specialty derives from the linked `Provider` (NUCC primary + text-only secondaries). `?specialty=...` filters Provider, mirroring the 5.4 roster.
2. **Panel-gating extension URI prefix (premise correction).** Used the existing `http://fhir.cloudhealthoffice.com/StructureDefinition/...` base, not the `cloudhealthoffice.com/fhir/...` shape from the prompt — matches `ChoProviderFhirUrls`.
3. **Composite-id encoding (Decision 6).** Dash-delimited `{npi}-{lobInt}-{yyyymmdd}-{networkId}`; not Base64URL (underscore is outside the FHIR R4 `id` grammar). Projector returns null and read returns 404 when a long NetworkId stretches the composite past 64 chars.
4. **Search edge cases (Decision 7).** Page-based pagination (mirror 5.7 Practitioner). 0 participations → empty Bundle. Conjunction filter for `practitioner` + `organization`.
5. **Panel-gating extension shape (Decision 9).** Single grouped extension `practitionerrole-panel-gating` with sub-extensions; mirrors how 5.7 emits `provider-integrity-score`.
6. **Search-by-organization implementation.** Direct `IProviderRepository.ListNetworkRosterAsync` call from the new controller; bypass `INetworkRosterService` (its cursor-binding logic does not apply to a FHIR search).
7. **Active-flag derivation.** `EffectiveDate ≤ now ∧ (TerminationDate is null ∨ ≥ now) ∧ Provider.VersionState=Active ∧ Provider.Status=Active`. Date kinds normalised via `SpecifyKind` not `ToUniversalTime` (Cosmos / Mongo round-trip as `Kind=Unspecified`).

## Files

**provider-service additions**
- `Services/IFhirPractitionerRoleProjector.cs`
- `Services/FhirPractitionerRoleProjector.cs`
- `Controllers/FhirPractitionerRoleController.cs`
- `Services/ChoProviderFhirUrls.cs` — added US Core + Plan-Net PractitionerRole profile URLs, `practitionerrole-panel-gating` extension URL, internal `line-of-business` CodeSystem
- `Program.cs` — DI registration

**fhir-service modifications**
- `Controllers/ProviderDirectoryController.cs` — PractitionerRole endpoints rewired to proxy via the existing `ProviderService` HttpClient; `ProxyPractitionerAsync` generalised to `ProxyProviderServiceAsync(resourceLabel, ...)` so 5.9 plugs into the same shape; HYBRID STATE comment block updated.
- `Mappers/ProviderDirectoryMapper.cs` — `MapNppesToPractitionerRole` marked `[Obsolete]`.

**Tests**
- `tests/CloudHealthOffice.ProviderService.Tests/Services/FhirPractitionerRoleProjectorTests.cs`
- `tests/CloudHealthOffice.ProviderService.Tests/Controllers/FhirPractitionerRoleControllerTests.cs`
- `tests/CloudHealthOffice.FhirService.Tests/Controllers/ProviderDirectoryControllerPractitionerRoleProxyTests.cs`
- `tests/CloudHealthOffice.FhirService.Tests/ProviderDirectoryMapperTests.cs` — `#pragma warning disable CS0618` around the deprecated mapper tests

**Documentation**
- `docs/architecture/fhir-practitionerrole-projection.md` (new)
- `docs/architecture/fhir-conformance.md` — PractitionerRole posture, Inferno status carry-forward, CHO extension list
- `docs/architecture/network-roster-api.md` — cross-reference to the FHIR PractitionerRole projection
- `docs/architecture/fhir-practitioner-projection.md` — capability-5.8/5.9 ordering correction in the HYBRID-state paragraph

## Test plan

- [ ] `dotnet build` succeeds (provider-service + fhir-service, both test projects).
- [ ] `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — projector + controller tests pass.
- [ ] `dotnet test tests/CloudHealthOffice.FhirService.Tests` — proxy tests pass alongside the existing 5.7 suite.
- [ ] Existing `/fhir/r4/PractitionerRole/{id}` and `/fhir/r4/PractitionerRole?...` URL surface returns CHO-canonical responses; verify with a smoke call against a tenant that has at least one Active provider with a non-null `NetworkId` participation.
- [ ] Search by `?organization=Organization/{networkId}` returns the same provider set the 5.4 roster surfaces.
- [ ] Panel-gating extension only appears on participations whose 5.5 fields are populated.

## Recovery posture

- Composite-id decoding edge cases — handled defensively in the controller; malformed id returns 404 with FHIR `OperationOutcome`.
- fhir-service proxy hop fails — caller sees 502; logs label the resource as `PractitionerRole`; revert restores NPPES path if needed.
- Worst-case rollback: revert this PR. fhir-service `PractitionerRole` endpoints return to the NPPES path; provider-service projector code remains but is unwired.

https://claude.ai/code/session_01FFf1r6phZAgN5vM8MJ8Gda

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFf1r6phZAgN5vM8MJ8Gda)_