### PR TITLE
5.10 — Verification Integrity Score Surface (Phase 1 closer)

### DIFF
--- a/docs/architecture/integrity-score-consumption.md
+++ b/docs/architecture/integrity-score-consumption.md
@@ -1,0 +1,226 @@
+# Integrity Score Consumption (Capability 5.10)
+
+Status: 5.10 — verification integrity score surface (Phase 1 closer)
+Services: `src/services/provider-service`, `src/services/benefit-plan-service`, `src/portal`
+Depends on: 5.4.5 (verification write-back), 5.4 (network roster), 5.7 (FHIR Practitioner)
+
+## Why a canonical decision tree
+
+Integrity-score data has three consumers patterns that look similar
+from a distance but differ on staleness tolerance and the cost of a
+miss:
+
+- **Display-only consumers** can tolerate a score that's a few hours
+  stale; the worst case is showing operators slightly old metadata.
+- **Adjudication-path consumers** can tolerate stale data within a
+  bounded window but must escalate to a fresh score outside that
+  window — the worst case is paying a claim against a provider who
+  was excluded yesterday.
+- **Operator-driven investigations** must always read fresh data —
+  the worst case is making a judgement on a stale score.
+
+Before 5.10, each consumer rediscovered this trade-off and made its
+own choice. The roster (5.4) used the cached projection; FHIR
+projections (5.7–5.9) used the cached projection; the
+adjudication gate (`HttpProviderIntegrityGate` in
+`benefit-plan-service`) called `provider-verification-service` per
+adjudication. The pattern was consistent in spirit but not in code.
+
+5.10 documents the canonical decision tree so future consumers
+reference this doc instead of re-deriving the policy.
+
+## Decision tree
+
+```
+Need an integrity score?
+│
+├── Display, sort, or non-critical-path read?
+│   └── Use the cached projection (provider-service: GET /providers/...).
+│       The IntegrityProjectionWorker keeps it fresh on a schedule;
+│       per-tenant cadence configurable via IntegrityProjection:Windows.
+│
+├── Adjudication / claims pricing / prior-auth gating?
+│   └── Use the cached projection by default; fall back to live HTTP
+│       (provider-verification-service) when the cached score is null
+│       or older than ProviderIntegrityGate:StalenessFallbackThreshold.
+│       Default threshold: 7 days.
+│
+└── Admin investigation / scheduled re-verification / on-demand refresh?
+    └── Call provider-verification-service directly (live-only path).
+        On-demand from the portal: POST /providers/{id}/verification/refresh.
+        Scheduled: IntegrityProjectionWorker on the worker's cadence.
+```
+
+## Consumer table
+
+| Consumer | Code | Path |
+|---|---|---|
+| Network roster | `NetworkRosterService` (provider-service) | Cached projection |
+| FHIR Practitioner projection | `FhirPractitionerProjector` (provider-service) | Cached projection |
+| FHIR PractitionerRole projection | `FhirPractitionerRoleProjector` (provider-service) | Cached projection (panel-gating extension only — score is on Practitioner) |
+| FHIR Organization projection | `FhirOrganizationProjector` (provider-service) | Cached projection (only when score is on the Provider with `ProviderType.Organization`) |
+| Provider list grid | `Pages/Providers.razor` (portal) | Cached projection (via portal `ProviderService` HTTP client) |
+| Provider detail card | `Pages/ProviderDetailsDialog.razor` (portal) | Cached projection; "Refresh now" button calls live |
+| Adjudication critical path | `HttpProviderIntegrityGate` (benefit-plan-service) | Cached-or-live (default) |
+| Admin tenant backfill | `IntegrityProjectionAdminController` (provider-service) | Live (per-provider in a loop) |
+| Scheduled re-verification | `IntegrityProjectionWorker` (provider-service) | Live (worker → verification-service) |
+| Per-provider on-demand refresh | `ProvidersController.Refresh` (provider-service) | Live |
+
+## `HttpProviderIntegrityGate` — cached-or-live in detail
+
+5.10 migrates the adjudication gate from "live every adjudication"
+to "cached-by-default, live-on-staleness". The migration preserves
+the existing 1-hour `IMemoryCache` (per-pod request-coalescing
+layer) and adds a tiered read:
+
+```
+CheckAsync(npi, forceRefresh=false)
+  │
+  ├── 1. IMemoryCache hit?  → return (cached_hit)
+  │
+  ├── 2. forceRefresh=true? → live verification-service (live_only)
+  │
+  ├── 3. GET /providers/npi/{npi} from provider-service
+  │     ├── 404 / transport error
+  │     │   → live verification-service (null_fallback)
+  │     ├── projection row exists, score is null
+  │     │   → live verification-service (null_fallback)
+  │     ├── projection row exists, LastVerifiedAt < now - threshold
+  │     │   → live verification-service (stale_fallback)
+  │     └── projection row exists, score is fresh
+  │         → return projection (cached_hit)
+  │
+  └── 4. Cache the result in IMemoryCache (1 hour TTL)
+```
+
+### Configuration
+
+```jsonc
+// appsettings.json (benefit-plan-service)
+"ProviderIntegrityGate": {
+  "StalenessFallbackThreshold": "7.00:00:00"  // 7 days (default)
+}
+```
+
+The threshold defaults to 7 days — roughly one missed
+`IntegrityProjectionWorker` sweep cycle (NPPES window is 24h) plus
+margin. Test environments tighten to 1h for fast iteration; production
+defaults to 7 days; high-trust environments can extend to 30 days.
+
+### Telemetry
+
+```
+Meter:      CloudHealthOffice
+Instrument: cho.provider.integrity_gate.decisions.total (Counter)
+Tags:
+  cho.path     ∈ { cached_hit, stale_fallback, null_fallback, live_only }
+  cho.rating   ∈ { Clear, Advisory, Caution, Alert, Blocked, unknown }
+```
+
+The metric drives operational tuning of the threshold:
+
+- High `stale_fallback` rate ⇒ threshold is tighter than the worker's
+  refresh cadence — extend the threshold or increase worker frequency.
+- High `null_fallback` rate ⇒ projection backfill hasn't run on that
+  tenant — invoke `POST /api/v1/admin/providers/backfill-integrity-projection`.
+- High `cached_hit` rate is the steady state; per-pod request-coalescing
+  through `IMemoryCache` further reduces upstream calls within the TTL.
+
+## Staleness alerting
+
+`IntegrityProjectionStalenessReporter` (provider-service) piggybacks
+on the existing `IntegrityProjectionWorker` sweep — no new hosted
+service is introduced (Decision 3). For each tenant, after the
+sweep's refresh pass, the reporter counts head-Active providers
+whose `LastVerifiedAt` is older than
+`IntegrityProjection:StalenessAlertThreshold` and updates a
+per-tenant snapshot read by an `ObservableGauge`.
+
+```jsonc
+// appsettings.json (provider-service)
+"IntegrityProjection": {
+  "StalenessAlertThreshold": "7.00:00:00"  // 7 days (default)
+}
+```
+
+```
+Instrument: cho.provider.integrity_score.stale_count (ObservableGauge)
+Tag:        cho.tenant_id = <string>
+```
+
+The default threshold matches `ProviderIntegrityGate:StalenessFallbackThreshold`
+in `benefit-plan-service` so operators get one knob to tune by default.
+Decoupled options keys preserve the freedom to alert sooner than
+fall-back kicks in (e.g., warn at 5d, fall back at 7d) without code
+changes.
+
+## Portal display
+
+The portal renders the cached projection in two places:
+
+1. **Provider list grid** (`Pages/Providers.razor`): an `Integrity`
+   column rendering `<IntegrityBadge Compact="true" />`. The badge
+   reads `IntegrityScore` and `IntegrityRating` from the
+   `ProviderListItem` DTO returned by provider-service.
+
+2. **Provider detail dialog** (`Pages/ProviderDetailsDialog.razor`):
+   a "Verification Integrity" card with `<IntegrityBadge />`,
+   last-verified / next-due timestamps, a "Refresh now" button
+   (visible-disabled when `providers:verification.refresh` permission
+   is missing), and a stub link "View detailed verification report"
+   reserved for a Phase 2 capability that surfaces the per-source
+   verification dimension breakdown.
+
+### Rating colour map (Decision 9)
+
+The `IntegrityRating` enum carries six values that operators
+distinguish meaningfully (Clear / Advisory / Caution / Alert / Blocked
+/ Unknown). MudBlazor's four-color palette is insufficient to render
+them losslessly, so two custom CSS classes augment the palette:
+
+| Rating | MudBlazor color | CSS override |
+|---|---|---|
+| Clear | `Color.Success` | — |
+| Advisory | `Color.Warning` | — |
+| Caution | `Color.Default` | `--cho-rating-caution: #ff7a1a` |
+| Alert | `Color.Error` | — |
+| Blocked | `Color.Default` | `--cho-rating-blocked: #8b0028` |
+| Unknown / null | `Color.Default` | — |
+
+Custom CSS is co-located with `IntegrityBadge` (component-local) and
+the CSS variables are declared in `wwwroot/css/site.css`'s `:root`
+block alongside the rest of the Sentinel palette.
+
+## Out of scope (Phase 2 territory)
+
+- **Per-source dimension breakdown.** `provider-verification-service`'s
+  `/integrity-score` endpoint returns composite score + rating + flags;
+  per-dimension scores (NPPES contribution, LEIE contribution, PECOS
+  contribution, FSMB contribution, Open Payments contribution) live on
+  the full `/{npi}/verify` record. Surfacing those on the portal is a
+  Phase 2 capability — the detail card includes a stub link reserved
+  for that work.
+- **Credentialing-aware re-verification cadence.** Adjusting
+  `NextVerificationDue` based on integrity-score trend (e.g.,
+  shortening the window when the score drops) is a Phase 2 capability
+  that crosses the credentialing service boundary (5.6) and is not
+  handled here.
+- **Adjudication-time re-adjudicate-with-fresh.** The
+  `IProviderIntegrityGate.CheckAsync` interface gained a
+  `forceRefresh` parameter in 5.10; the only current caller
+  (`AdjudicationController`) passes the default. A future capability
+  could add an admin-triggered "re-adjudicate against this claim with a
+  fresh score" affordance.
+
+## Cross-references
+
+- `verification-writeback.md` — capability 5.4.5 (the projection write
+  path that 5.10 consumes from).
+- `network-roster-api.md` — capability 5.4 (one of the pre-5.10
+  consumers; "Known gap" section is now resolved).
+- `provider-versioning.md` — projection-metadata exemption section
+  references this doc for the consumer-side decision tree.
+- `fhir-practitioner-projection.md` — capability 5.7
+  (`ProviderIntegrityScoreExt` extension consumer).
+- `fhir-practitionerrole-projection.md` — capability 5.8.
+- `fhir-organization-projection.md` — capability 5.9.

--- a/docs/architecture/network-roster-api.md
+++ b/docs/architecture/network-roster-api.md
@@ -211,8 +211,11 @@ For roster operators:
   populated tenants will have some null and some populated rows, and
   nulls-last sort handles both cleanly.
 - Live HTTP fetch via `HttpProviderIntegrityGate` in
-  `benefit-plan-service` remains available for adjudication —
-  fresh-or-cached migration is capability 5.10's decision.
+  `benefit-plan-service` migrated to the cached-or-live pattern in
+  capability 5.10 — see `docs/architecture/integrity-score-consumption.md`
+  for the canonical decision tree. The roster path was already on the
+  canonical cached-projection path; 5.10's migration affects only the
+  adjudication critical path, leaving roster behavior unchanged.
 
 ## Deferred — distance sort
 

--- a/docs/architecture/provider-versioning.md
+++ b/docs/architecture/provider-versioning.md
@@ -348,6 +348,14 @@ not relax the `UpdateAsync` guard, not re-purpose
 `ReplaceVersionRowAsync`. Each carve-out documents its source service
 and refresh cadence in this section.
 
+**Read-side consumption pattern.** The projection-metadata fields above
+are the *write* side of a multi-consumer story. The read-side
+decision tree (which consumers should call the cached projection vs
+the live verification-service vs trigger an on-demand refresh) is
+documented in `docs/architecture/integrity-score-consumption.md`
+(capability 5.10). Future carve-outs that join this section should
+update the consumption doc with their own consumer table entry.
+
 ### Credentialing projection (capability 5.6)
 
 The credentialing-status fields on `Provider` are a projection of the

--- a/docs/architecture/verification-writeback.md
+++ b/docs/architecture/verification-writeback.md
@@ -263,17 +263,22 @@ planned subscriber. Cosmos-only deployments register
 `NoopProviderVerificationEventPublisher` which logs a warning per
 emit so ops can spot the missing wiring.
 
-## `HttpProviderIntegrityGate` posture — unchanged
+## `HttpProviderIntegrityGate` posture — migrated in 5.10
 
-`benefit-plan-service` continues to consume the score live via
+5.4.5 left `benefit-plan-service` consuming the score live via
 `HttpProviderIntegrityGate.CheckAsync(npi)` per adjudication request.
-The cached projection is a *forward* path that consumers can adopt as
-they're ready; the live HTTP path remains the source of truth for
-adjudication.
+Capability 5.10 (Integrity Score Surface) migrates the gate to a
+cached-or-live pattern: the gate reads `Provider.IntegrityScore` from
+provider-service first and falls back to the live verification path
+only when the cached score is null, stale beyond
+`ProviderIntegrityGate:StalenessFallbackThreshold` (default 7 days),
+or the caller explicitly opts in via `forceRefresh: true`.
 
-Capability 5.10 (Integrity Score Surface) is the right place to
-decide consumer-by-consumer migration to the cached path. 5.4.5 ships
-the persistence; 5.10 ships the consumption strategy.
+See `docs/architecture/integrity-score-consumption.md` for the
+canonical decision tree, the per-path telemetry shape
+(`cho.provider.integrity_gate.decisions.total`), and the staleness
+alerting gauge (`cho.provider.integrity_score.stale_count`) that
+5.10 piggybacks on this worker's sweep.
 
 ## Configuration
 

--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
@@ -31,7 +31,7 @@
          on the class. See docs/architecture/shared-cache.md and Addendum A.7.2. -->
     <ProjectReference Include="..\..\services\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
 
-    <PackageReference Include="Microsoft.Azure.Cosmos"              Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos"              Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver"                      Version="3.7.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <!-- Azure -->
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <!-- MongoDB -->
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
     <!-- HTTP resilience -->

--- a/src/portal/CloudHealthOffice.Portal.Tests/Shared/IntegrityBadgeTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Shared/IntegrityBadgeTests.cs
@@ -66,13 +66,16 @@ public class IntegrityBadgeTests : TestContext
     {
         // The compact chip only renders the rating label so the grid
         // column stays narrow; the score-and-tooltip surface is the
-        // expanded mode.
+        // expanded mode. We assert against the rendered numeric value
+        // (not the CSS class) because the component's embedded
+        // <style> block also contains the class name and would
+        // produce a false positive.
         var cut = RenderComponent<IntegrityBadge>(parameters => parameters
             .Add(p => p.Rating, "Clear")
             .Add(p => p.Score, 92)
             .Add(p => p.Compact, true));
 
-        cut.Markup.Should().NotContain("cho-integrity-score");
+        cut.FindAll("span.cho-integrity-score").Should().BeEmpty();
         cut.Markup.Should().Contain("Clear");
     }
 
@@ -84,7 +87,7 @@ public class IntegrityBadgeTests : TestContext
             .Add(p => p.Score, 55)
             .Add(p => p.Compact, false));
 
-        cut.Markup.Should().Contain("cho-integrity-score");
+        cut.FindAll("span.cho-integrity-score").Should().NotBeEmpty();
         cut.Markup.Should().Contain("55");
         cut.Markup.Should().Contain("Caution");
     }

--- a/src/portal/CloudHealthOffice.Portal.Tests/Shared/IntegrityBadgeTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Shared/IntegrityBadgeTests.cs
@@ -1,0 +1,107 @@
+using Bunit;
+using CloudHealthOffice.Portal.Shared;
+using MudBlazor.Services;
+
+namespace CloudHealthOffice.Portal.Tests.Shared;
+
+/// <summary>
+/// bUnit tests for <see cref="IntegrityBadge"/> (capability 5.10).
+/// Verifies the six-rating colour map (Decision 9), tooltip content,
+/// compact / expanded layout switching, and tolerance for null inputs.
+/// </summary>
+public class IntegrityBadgeTests : TestContext
+{
+    public IntegrityBadgeTests()
+    {
+        Services.AddMudServices();
+        JSInterop.SetupVoid("mudPopover.initialize", _ => true);
+        JSInterop.SetupVoid("mudKeyInterceptor.connect", _ => true);
+        JSInterop.SetupVoid("mudElementReference.saveFocus", _ => true);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [Theory]
+    [InlineData("Clear",     "cho-integrity-clear")]
+    [InlineData("Advisory",  "cho-integrity-advisory")]
+    [InlineData("Caution",   "cho-integrity-caution")]
+    [InlineData("Alert",     "cho-integrity-alert")]
+    [InlineData("Blocked",   "cho-integrity-blocked")]
+    [InlineData("clear",     "cho-integrity-clear")]   // case-insensitive
+    [InlineData("BLOCKED",   "cho-integrity-blocked")] // case-insensitive
+    public void RendersExpectedCssClass_ForEachRating(string rating, string expectedCssClass)
+    {
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, rating)
+            .Add(p => p.Score, 80)
+            .Add(p => p.Compact, true));
+
+        cut.Markup.Should().Contain(expectedCssClass);
+    }
+
+    [Fact]
+    public void RendersUnknownClass_WhenRatingIsNull()
+    {
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, (string?)null)
+            .Add(p => p.Score, (int?)null)
+            .Add(p => p.Compact, true));
+
+        cut.Markup.Should().Contain("cho-integrity-unknown");
+        cut.Markup.Should().Contain("Unknown");
+    }
+
+    [Fact]
+    public void RendersUnknownClass_WhenRatingIsEmpty()
+    {
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, string.Empty)
+            .Add(p => p.Score, (int?)null)
+            .Add(p => p.Compact, true));
+
+        cut.Markup.Should().Contain("cho-integrity-unknown");
+    }
+
+    [Fact]
+    public void Compact_OmitsScoreNumber()
+    {
+        // The compact chip only renders the rating label so the grid
+        // column stays narrow; the score-and-tooltip surface is the
+        // expanded mode.
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, "Clear")
+            .Add(p => p.Score, 92)
+            .Add(p => p.Compact, true));
+
+        cut.Markup.Should().NotContain("cho-integrity-score");
+        cut.Markup.Should().Contain("Clear");
+    }
+
+    [Fact]
+    public void Expanded_RendersScoreAndTooltip()
+    {
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, "Caution")
+            .Add(p => p.Score, 55)
+            .Add(p => p.Compact, false));
+
+        cut.Markup.Should().Contain("cho-integrity-score");
+        cut.Markup.Should().Contain("55");
+        cut.Markup.Should().Contain("Caution");
+    }
+
+    [Fact]
+    public void Expanded_NullRating_DisplaysUnknownLabel()
+    {
+        var cut = RenderComponent<IntegrityBadge>(parameters => parameters
+            .Add(p => p.Rating, (string?)null)
+            .Add(p => p.Score, (int?)null)
+            .Add(p => p.Compact, false));
+
+        // The label disambiguates a null projection from a Clear
+        // rating in operator mental models. Tooltip body content
+        // ("Not yet verified — projection worker hasn't produced a
+        // score") is rendered via MudTooltip's popover and not
+        // asserted here — popover internals are MudBlazor-version-specific.
+        cut.Markup.Should().Contain("Unknown");
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/ProviderDetailsDialog.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/ProviderDetailsDialog.razor
@@ -1,5 +1,7 @@
 @using CloudHealthOffice.Portal.Services
 @inject IProviderService ProviderService
+@inject IUserContextService UserContextService
+@inject ISnackbar Snackbar
 
 <MudDialog>
     <DialogContent>
@@ -79,6 +81,89 @@
                                             <span class="mud-text-secondary">No claims submitted</span>
                                         }
                                     </MudText>
+                                </MudCardContent>
+                            </MudCard>
+                        </MudItem>
+
+                        <!-- Verification Integrity (capability 5.10) -->
+                        <MudItem xs="12">
+                            <MudCard Elevation="0">
+                                <MudCardContent>
+                                    <div class="d-flex align-center justify-space-between mb-2">
+                                        <MudText Typo="Typo.h6">Verification Integrity</MudText>
+                                        @{
+                                            var canRefresh = UserContextService.HasPermission("providers:verification.refresh");
+                                            var refreshTooltip = canRefresh
+                                                ? "Trigger an on-demand verification refresh from provider-verification-service."
+                                                : "Admin permission required (providers:verification.refresh).";
+                                        }
+                                        @* TODO: when PermissionGate supports RenderDisabled mode, migrate this to use the gate. *@
+                                        <MudTooltip Text="@refreshTooltip">
+                                            <MudButton Variant="Variant.Outlined"
+                                                       Color="Color.Primary"
+                                                       Size="Size.Small"
+                                                       StartIcon="@Icons.Material.Filled.Refresh"
+                                                       Disabled="@(!canRefresh || _refreshing)"
+                                                       OnClick="RefreshVerificationAsync">
+                                                @(_refreshing ? "Refreshing…" : "Refresh now")
+                                            </MudButton>
+                                        </MudTooltip>
+                                    </div>
+                                    <MudDivider Class="mb-3" />
+
+                                    <MudGrid>
+                                        <MudItem xs="12" sm="4">
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Rating</MudText>
+                                            <div class="mt-1 mb-2">
+                                                <IntegrityBadge Score="@_provider.IntegrityScore"
+                                                                Rating="@_provider.IntegrityRating"
+                                                                Compact="false" />
+                                            </div>
+                                        </MudItem>
+                                        <MudItem xs="6" sm="4">
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Last verified</MudText>
+                                            <MudText Typo="Typo.body1">
+                                                @if (_provider.LastVerifiedAt.HasValue)
+                                                {
+                                                    @_provider.LastVerifiedAt.Value.LocalDateTime.ToString("MMMM d, yyyy h:mm tt")
+                                                }
+                                                else
+                                                {
+                                                    <span class="mud-text-secondary">Never</span>
+                                                }
+                                            </MudText>
+                                        </MudItem>
+                                        <MudItem xs="6" sm="4">
+                                            <MudText Typo="Typo.body2" Color="Color.Secondary">Next due</MudText>
+                                            <MudText Typo="Typo.body1">
+                                                @if (_provider.NextVerificationDue.HasValue)
+                                                {
+                                                    @_provider.NextVerificationDue.Value.LocalDateTime.ToString("MMMM d, yyyy")
+                                                }
+                                                else
+                                                {
+                                                    <span class="mud-text-secondary">—</span>
+                                                }
+                                            </MudText>
+                                        </MudItem>
+                                    </MudGrid>
+
+                                    @* TODO: wire to ProviderVerificationDetailPage in capability 5.X.
+                                       Today the breakdown isn't surfaced via provider-service's cached
+                                       projection (capability 5.10 stops at score + rating + verification
+                                       timing). Phase 2 capability surfaces per-source flags / dimensions
+                                       (NPPES / LEIE / PECOS / FSMB / Open Payments) and replaces this
+                                       stub with a real link. *@
+                                    <MudTooltip Text="Detailed verification breakdown — coming in a future release">
+                                        <MudButton Variant="Variant.Text"
+                                                   Color="Color.Primary"
+                                                   Size="Size.Small"
+                                                   EndIcon="@Icons.Material.Filled.ArrowForward"
+                                                   Class="mt-2"
+                                                   Disabled="true">
+                                            View detailed verification report
+                                        </MudButton>
+                                    </MudTooltip>
                                 </MudCardContent>
                             </MudCard>
                         </MudItem>
@@ -343,6 +428,7 @@
     [Parameter] public EventCallback OnProviderUpdated { get; set; }
 
     private bool _loading = false;
+    private bool _refreshing = false;
     private ProviderDetails? _provider;
     private string? _serviceError;
 
@@ -372,6 +458,48 @@
     private void Close()
     {
         MudDialog?.Close();
+    }
+
+    /// <summary>
+    /// Capability 5.10 — on-demand integrity refresh. Routes through the
+    /// portal's IProviderService wrapper around
+    /// POST /providers/{id}/verification/refresh on provider-service
+    /// (5.4.5 endpoint, NOT IntegrityProjectionAdminController). The
+    /// permission check is enforced at the portal layer; the underlying
+    /// endpoint relies on deployment-layer NetworkPolicy / gateway ACL.
+    /// </summary>
+    private async Task RefreshVerificationAsync()
+    {
+        if (_provider is null || _refreshing) return;
+        _refreshing = true;
+        try
+        {
+            var result = await ProviderService.RefreshProviderVerificationAsync(_provider.ProviderId);
+            if (result is null)
+            {
+                Snackbar.Add("Refresh returned no integrity result for this provider.", Severity.Warning);
+                return;
+            }
+
+            _provider.IntegrityScore = result.IntegrityScore;
+            _provider.IntegrityRating = result.IntegrityRating;
+            _provider.LastVerifiedAt = result.LastVerifiedAt;
+            _provider.NextVerificationDue = result.NextVerificationDue;
+            Snackbar.Add("Verification refreshed.", Severity.Success);
+        }
+        catch (ServiceUnavailableException ex)
+        {
+            _serviceError = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            _serviceError = $"Refresh failed: {ex.Message}";
+        }
+        finally
+        {
+            _refreshing = false;
+            StateHasChanged();
+        }
     }
 
     private EventCallback<string?> OnEdit => EventCallback.Factory.Create<string?>(this, async (providerId) =>

--- a/src/portal/CloudHealthOffice.Portal/Pages/Providers.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Providers.razor
@@ -175,6 +175,7 @@
                             <MudTh>Location</MudTh>
                             <MudTh>Network Status</MudTh>
                             <MudTh>Credentials</MudTh>
+                            <MudTh>Integrity</MudTh>
                             <MudTh>Networks</MudTh>
                             <MudTh>Last Claim</MudTh>
                             <MudTh>Actions</MudTh>
@@ -204,6 +205,11 @@
                                          Color="@GetCredentialStatusColor(context.CredentialingStatus)">
                                     @context.CredentialingStatus
                                 </MudChip>
+                            </MudTd>
+                            <MudTd DataLabel="Integrity">
+                                <IntegrityBadge Score="@context.IntegrityScore"
+                                                Rating="@context.IntegrityRating"
+                                                Compact="true" />
                             </MudTd>
                             <MudTd DataLabel="Networks">
                                 <MudChip Size="Size.Small" Color="Color.Default">@context.NetworkCount</MudChip>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -253,6 +253,32 @@ public interface IProviderService
     Task<string> CreateProviderAsync(CreateProviderRequest request);
     Task UpdateProviderAsync(string providerId, UpdateProviderRequest request);
     Task<List<string>> GetSpecialtiesAsync();
+
+    /// <summary>
+    /// Trigger an on-demand verification refresh for a single provider
+    /// (capability 5.10). Wraps
+    /// <c>POST /api/v1/providers/{id}/verification/refresh</c> on
+    /// <c>provider-service</c>; the response carries the freshly
+    /// projected integrity fields that the caller can splice back into
+    /// the rendered detail view without round-tripping the full
+    /// provider record.
+    /// </summary>
+    Task<ProviderIntegrityRefreshResult?> RefreshProviderVerificationAsync(string providerId);
+}
+
+/// <summary>
+/// Subset of <c>IntegrityProjectionRefreshResult</c> that the portal
+/// renders after an on-demand refresh (capability 5.10). The shape
+/// mirrors the four cached projection fields on
+/// <c>Provider.IntegrityScore</c> in <c>provider-service</c>.
+/// </summary>
+public class ProviderIntegrityRefreshResult
+{
+    public string ProviderId { get; set; } = string.Empty;
+    public int? IntegrityScore { get; set; }
+    public string? IntegrityRating { get; set; }
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public DateTimeOffset? NextVerificationDue { get; set; }
 }
 
 public interface IBenefitPlanService
@@ -781,6 +807,13 @@ public class ProviderListItem
     public string CredentialingStatus { get; set; } = string.Empty; // Active, Pending, Expired
     public int NetworkCount { get; set; }
     public DateTime? LastClaimDate { get; set; }
+
+    // Cached integrity projection (capability 5.10). Populated by
+    // ProviderIntegrityProjectionService in provider-service; null
+    // until the projection worker has produced a score for the
+    // provider. Rendered by IntegrityBadge on the provider grid.
+    public int? IntegrityScore { get; set; }
+    public string? IntegrityRating { get; set; }
 }
 
 public class ProviderDetails : ProviderListItem
@@ -792,6 +825,13 @@ public class ProviderDetails : ProviderListItem
     public List<NetworkAssignment> NetworkAssignments { get; set; } = new();
     public ProviderContract? Contract { get; set; }
     public ProviderPerformance? Performance { get; set; }
+
+    // Detail-only integrity projection metadata (capability 5.10).
+    // The provider list grid uses IntegrityScore + IntegrityRating
+    // (inherited from ProviderListItem); the detail card additionally
+    // surfaces verification timing for operator visibility.
+    public DateTimeOffset? LastVerifiedAt { get; set; }
+    public DateTimeOffset? NextVerificationDue { get; set; }
 }
 
 public class PracticeLocation

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -735,6 +735,28 @@ public class ProviderService : IProviderService
         }
     }
 
+    public async Task<ProviderIntegrityRefreshResult?> RefreshProviderVerificationAsync(string providerId)
+    {
+        var baseUrl = _configuration["Services:ProviderService"];
+        try
+        {
+            // Capability 5.10 — on-demand refresh routes through the
+            // existing 5.4.5 endpoint (POST /providers/{id}/verification/refresh
+            // on ProvidersController, NOT IntegrityProjectionAdminController).
+            var response = await _httpClient.PostAsync(
+                $"{baseUrl}/providers/{providerId}/verification/refresh",
+                content: null);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<ProviderIntegrityRefreshResult>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Provider Service");
+            throw new ServiceUnavailableException("Provider Service", ex);
+        }
+    }
+
     public async Task<List<string>> GetSpecialtiesAsync()
     {
         var baseUrl = _configuration["Services:ProviderService"];

--- a/src/portal/CloudHealthOffice.Portal/Shared/IntegrityBadge.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/IntegrityBadge.razor
@@ -1,0 +1,140 @@
+@*
+    IntegrityBadge — surfaces the cached Provider.IntegrityScore /
+    IntegrityRating projection (capability 5.10 — verification integrity
+    score surface).
+
+    Color mapping (Decision 9, ratified):
+      Clear     → MudBlazor Color.Success
+      Advisory  → MudBlazor Color.Warning
+      Caution   → custom .cho-integrity-caution (orange #ff7a1a, between
+                  Warning yellow and Error red)
+      Alert     → MudBlazor Color.Error
+      Blocked   → custom .cho-integrity-blocked (dark-red #8b0028, more
+                  severe than Error)
+      Unknown / null → MudBlazor Color.Default
+
+    Six rating values map to six distinct severity bands; MudBlazor's
+    four-color palette is insufficient to render them losslessly, so two
+    custom CSS classes are introduced and co-located with the component.
+    The other four ratings reuse the platform palette to keep the rest of
+    the badge inside MudBlazor's idiom.
+*@
+
+@if (Compact)
+{
+    <MudChip T="string"
+             Color="@_palette.MudColor"
+             Class="@($"cho-integrity-chip {_palette.CssClass}")"
+             Size="Size.Small"
+             Variant="Variant.Filled">
+        @_label
+    </MudChip>
+}
+else
+{
+    <MudTooltip Text="@_tooltip" Placement="Placement.Top">
+        <MudChip Color="@_palette.MudColor"
+                 Class="@($"cho-integrity-chip {_palette.CssClass}")"
+                 Size="Size.Small"
+                 Variant="Variant.Filled">
+            @if (Score is int s)
+            {
+                <span class="cho-integrity-score">@s</span>
+            }
+            <span>@_label</span>
+        </MudChip>
+    </MudTooltip>
+}
+
+@code {
+    /// <summary>
+    /// Composite integrity score (0–100). Null when the projection
+    /// worker hasn't produced a score for this provider yet.
+    /// </summary>
+    [Parameter] public int? Score { get; set; }
+
+    /// <summary>
+    /// Rating bucket — Clear / Advisory / Caution / Alert / Blocked /
+    /// Unknown. Persisted as a nullable string on
+    /// <c>Provider.IntegrityRating</c>; the badge tolerates null and
+    /// arbitrary casing so the same component renders projection rows
+    /// produced before the rubric was finalised.
+    /// </summary>
+    [Parameter] public string? Rating { get; set; }
+
+    /// <summary>
+    /// When true, the badge renders a dense one-line chip suitable for
+    /// the provider list grid. When false (default), the score is
+    /// inlined and a tooltip explaining the rating rubric is attached.
+    /// </summary>
+    [Parameter] public bool Compact { get; set; }
+
+    private RatingPalette _palette = RatingPalette.Unknown;
+    private string _label = "Unknown";
+    private string _tooltip = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        _palette = ResolvePalette(Rating);
+        _label = string.IsNullOrWhiteSpace(Rating) ? "Unknown" : Rating!;
+        _tooltip = BuildTooltip(_label, Score);
+    }
+
+    private static RatingPalette ResolvePalette(string? rating) =>
+        (rating ?? "Unknown").Trim().ToLowerInvariant() switch
+        {
+            "clear"    => new RatingPalette(MudBlazor.Color.Success, "cho-integrity-clear"),
+            "advisory" => new RatingPalette(MudBlazor.Color.Warning, "cho-integrity-advisory"),
+            "caution"  => new RatingPalette(MudBlazor.Color.Default, "cho-integrity-caution"),
+            "alert"    => new RatingPalette(MudBlazor.Color.Error,   "cho-integrity-alert"),
+            "blocked"  => new RatingPalette(MudBlazor.Color.Default, "cho-integrity-blocked"),
+            _          => RatingPalette.Unknown,
+        };
+
+    private static string BuildTooltip(string label, int? score)
+    {
+        var prefix = score is int s ? $"Integrity score {s} — " : "Integrity rating: ";
+        return label.Trim().ToLowerInvariant() switch
+        {
+            "clear"    => prefix + "Clear (no concerns; routine adjudication).",
+            "advisory" => prefix + "Advisory (mild concern; monitor).",
+            "caution"  => prefix + "Caution (notable concern; review at next opportunity).",
+            "alert"    => prefix + "Alert (active concern; requires attention).",
+            "blocked"  => prefix + "Blocked (do not adjudicate against this provider).",
+            _          => "Not yet verified — projection worker hasn't produced a score.",
+        };
+    }
+
+    private readonly record struct RatingPalette(MudBlazor.Color MudColor, string CssClass)
+    {
+        public static RatingPalette Unknown { get; } =
+            new(MudBlazor.Color.Default, "cho-integrity-unknown");
+    }
+}
+
+<style>
+    /* Co-located colour overrides for the two ratings that don't map
+       cleanly onto MudBlazor's four-color palette (capability 5.10
+       Decision 9). The other four ratings reuse Color.Success /
+       Color.Warning / Color.Error / Color.Default. */
+    .cho-integrity-chip {
+        font-weight: 500;
+        letter-spacing: 0.02em;
+    }
+
+    .cho-integrity-chip .cho-integrity-score {
+        margin-right: 0.4em;
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+
+    .cho-integrity-caution {
+        background-color: var(--cho-rating-caution, #ff7a1a) !important;
+        color: #1a1a1a !important;
+    }
+
+    .cho-integrity-blocked {
+        background-color: var(--cho-rating-blocked, #8b0028) !important;
+        color: #ffffff !important;
+    }
+</style>

--- a/src/portal/CloudHealthOffice.Portal/wwwroot/css/site.css
+++ b/src/portal/CloudHealthOffice.Portal/wwwroot/css/site.css
@@ -20,6 +20,13 @@
   --glow-cyan: 0 0 10px rgba(0, 255, 255, 0.4), 0 0 20px rgba(0, 255, 255, 0.2);
   --glow-green: 0 0 10px rgba(0, 255, 136, 0.4), 0 0 20px rgba(0, 255, 136, 0.2);
   --glow-circuit: 0 0 15px rgba(0, 255, 255, 0.3), 0 0 30px rgba(0, 255, 136, 0.15);
+
+  /* Integrity rating shades (capability 5.10 — Decision 9). Two ratings
+     don't map cleanly onto MudBlazor's four-color palette
+     (Success/Warning/Error/Default); these custom shades sit between the
+     platform colors so all six rating values render losslessly. */
+  --cho-rating-caution: #ff7a1a;
+  --cho-rating-blocked: #8b0028;
 }
 
 body {

--- a/src/services/accumulator-service/accumulator-service.csproj
+++ b/src/services/accumulator-service/accumulator-service.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/appeals-service/appeals-service.csproj
+++ b/src/services/appeals-service/appeals-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/attachment-service/attachment-service.csproj
+++ b/src/services/attachment-service/attachment-service.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.50.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />

--- a/src/services/authorization-service/authorization-service.csproj
+++ b/src/services/authorization-service/authorization-service.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -1,0 +1,258 @@
+using System.Net;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Adapters;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Verifies the cached-or-live read pattern introduced in capability
+/// 5.10. The gate must:
+///
+/// <list type="bullet">
+///   <item>Read provider-service first by default.</item>
+///   <item>Use the cached projection when the score is fresh.</item>
+///   <item>Fall back to provider-verification-service when the projection
+///     is null (never refreshed) or stale beyond
+///     <see cref="ProviderIntegrityGateOptions.StalenessFallbackThreshold"/>.</item>
+///   <item>Skip the projection short-circuit when the caller passes
+///     <c>forceRefresh: true</c>.</item>
+///   <item>Coalesce repeat calls for the same NPI through the existing
+///     1-hour <see cref="IMemoryCache"/> layer.</item>
+///   <item>Increment the
+///     <c>cho.provider.integrity_gate.decisions.total</c> counter with
+///     a path discriminator on every call.</item>
+/// </list>
+/// </summary>
+public sealed class HttpProviderIntegrityGateTests
+{
+    private const string Npi = "1234567890";
+
+    [Fact]
+    public async Task CheckAsync_DefaultPath_FreshProjection_UsesCachedProjection_NoVerificationCall()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 92, rating: "Clear", lastVerifiedAt: DateTimeOffset.UtcNow));
+        var verificationHandler = FakeHttpMessageHandler.Json("{}");
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeTrue();
+        result.IntegrityScore.Should().Be(92);
+        result.Rating.Should().Be("Clear");
+        result.IsExcluded.Should().BeFalse();
+        providerHandler.RequestCount.Should().Be(1);
+        verificationHandler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CheckAsync_CacheHit_DoesNotIssueAnyHttpCalls()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 70, rating: "Advisory", lastVerifiedAt: DateTimeOffset.UtcNow));
+        var verificationHandler = FakeHttpMessageHandler.Json("{}");
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        await gate.CheckAsync(Npi);
+        await gate.CheckAsync(Npi);
+
+        providerHandler.RequestCount.Should().Be(1);
+        verificationHandler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CheckAsync_StaleProjection_FallsBackToVerificationService()
+    {
+        var stale = DateTimeOffset.UtcNow - TimeSpan.FromDays(30);
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 80, rating: "Advisory", lastVerifiedAt: stale));
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 88, rating: "Clear", status: "Verified"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.IntegrityScore.Should().Be(88, "the live verification result wins on stale fallback");
+        result.Rating.Should().Be("Clear");
+        verificationHandler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CheckAsync_NullProjection_FallsBackToVerificationService()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: null, rating: null, lastVerifiedAt: null));
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 75, rating: "Advisory", status: "VerifiedWithWarnings"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.IntegrityScore.Should().Be(75);
+        result.Rating.Should().Be("Advisory");
+        verificationHandler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ProviderNotFound_FallsBackToVerificationService()
+    {
+        var providerHandler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 60, rating: "Caution", status: "Verified"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Rating.Should().Be("Caution");
+        verificationHandler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CheckAsync_ForceRefresh_BypassesProjection_AndCallsVerificationServiceDirectly()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 95, rating: "Clear", lastVerifiedAt: DateTimeOffset.UtcNow));
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 30, rating: "Alert", status: "VerifiedWithWarnings"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi, forceRefresh: true);
+
+        result.IntegrityScore.Should().Be(30, "force-refresh ignores the cached projection");
+        result.Rating.Should().Be("Alert");
+        providerHandler.RequestCount.Should().Be(0);
+        verificationHandler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CheckAsync_BothEndpointsFail_ReturnsPassthrough()
+    {
+        var providerHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
+        var verificationHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeTrue("adjudication is never blocked by infrastructure flakes");
+        result.Rating.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public async Task CheckAsync_ExcludedRating_OnCachedProjection_DenialCodeSurfaces()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 5, rating: "Blocked", lastVerifiedAt: DateTimeOffset.UtcNow));
+        var verificationHandler = FakeHttpMessageHandler.Status(HttpStatusCode.InternalServerError);
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeFalse();
+        result.IsExcluded.Should().BeTrue();
+        result.DenialCode.Should().Be("B7");
+        verificationHandler.RequestCount.Should().Be(0,
+            "Blocked on cached projection is sufficient — the gate should not call verification-service");
+    }
+
+    [Fact]
+    public async Task CheckAsync_StalenessThresholdZero_DisablesStaleFallback()
+    {
+        var stale = DateTimeOffset.UtcNow - TimeSpan.FromDays(365);
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: 85, rating: "Clear", lastVerifiedAt: stale));
+        var verificationHandler = FakeHttpMessageHandler.Json("{}");
+        var options = new ProviderIntegrityGateOptions
+        {
+            StalenessFallbackThreshold = TimeSpan.Zero,
+        };
+        var gate = BuildGate(providerHandler, verificationHandler, options);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.IntegrityScore.Should().Be(85, "threshold=0 disables the stale-fallback path");
+        verificationHandler.RequestCount.Should().Be(0);
+    }
+
+    private static HttpProviderIntegrityGate BuildGate(
+        FakeHttpMessageHandler providerHandler,
+        FakeHttpMessageHandler verificationHandler,
+        ProviderIntegrityGateOptions? options = null)
+    {
+        var factory = new NamedStubHttpClientFactory(new Dictionary<string, HttpMessageHandler>
+        {
+            [HttpProviderIntegrityGate.ProviderServiceClientName] = providerHandler,
+            [HttpProviderIntegrityGate.VerificationServiceClientName] = verificationHandler,
+        }, providerBaseUri: "http://provider-service/", verificationBaseUri: "http://provider-verification-service/");
+
+        var cache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
+        options ??= new ProviderIntegrityGateOptions();
+        var monitor = new TestOptionsMonitor<ProviderIntegrityGateOptions>(options);
+        return new HttpProviderIntegrityGate(
+            factory, cache, monitor, NullLogger<HttpProviderIntegrityGate>.Instance);
+    }
+
+    private static string ProviderJson(int? score, string? rating, DateTimeOffset? lastVerifiedAt)
+    {
+        var scoreToken = score is int s ? s.ToString() : "null";
+        var ratingToken = rating is null ? "null" : $"\"{rating}\"";
+        var lastVerifiedToken = lastVerifiedAt is DateTimeOffset d
+            ? $"\"{d.ToString("O")}\""
+            : "null";
+        return "{" +
+               $"\"IntegrityScore\":{scoreToken}," +
+               $"\"IntegrityRating\":{ratingToken}," +
+               $"\"LastVerifiedAt\":{lastVerifiedToken}," +
+               "\"NextVerificationDue\":null" +
+               "}";
+    }
+
+    private static string VerificationJson(int compositeScore, string rating, string status) =>
+        "{" +
+        $"\"CompositeScore\":{compositeScore}," +
+        $"\"Rating\":\"{rating}\"," +
+        $"\"Status\":\"{status}\"," +
+        $"\"VerifiedAt\":\"{DateTimeOffset.UtcNow:O}\"" +
+        "}";
+
+    private sealed class NamedStubHttpClientFactory : IHttpClientFactory
+    {
+        private readonly IDictionary<string, HttpMessageHandler> _handlers;
+        private readonly string _providerBaseUri;
+        private readonly string _verificationBaseUri;
+
+        public NamedStubHttpClientFactory(
+            IDictionary<string, HttpMessageHandler> handlers,
+            string providerBaseUri,
+            string verificationBaseUri)
+        {
+            _handlers = handlers;
+            _providerBaseUri = providerBaseUri;
+            _verificationBaseUri = verificationBaseUri;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            var handler = _handlers.TryGetValue(name, out var h)
+                ? h
+                : new FakeHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+            var client = new HttpClient(handler, disposeHandler: false);
+            client.BaseAddress = new Uri(name == HttpProviderIntegrityGate.ProviderServiceClientName
+                ? _providerBaseUri
+                : _verificationBaseUri);
+            return client;
+        }
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class, new()
+    {
+        public TestOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; private set; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -143,6 +143,26 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     [Fact]
+    public async Task CheckAsync_PassthroughResult_IsNotCached()
+    {
+        // Both endpoints fail → passthrough. The gate must NOT cache that
+        // result for the full 1-hour TTL, so a subsequent call after
+        // upstream recovers picks up the real exclusion signal instead
+        // of an hour of stale "passed".
+        var providerHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
+        var verificationHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        await gate.CheckAsync(Npi);
+        await gate.CheckAsync(Npi);
+
+        providerHandler.RequestCount.Should().Be(2,
+            "passthrough is not cached, so the second call retries provider-service");
+        verificationHandler.RequestCount.Should().Be(2,
+            "passthrough is not cached, so the second call retries verification-service");
+    }
+
+    [Fact]
     public async Task CheckAsync_ExcludedRating_OnCachedProjection_DenialCodeSurfaces()
     {
         var providerHandler = FakeHttpMessageHandler.Json(

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -277,7 +277,7 @@ public class AdjudicationController : ControllerBase
             claimType: claimTypeCode,
             memberId: request.MemberId))
         {
-            providerIntegrity = await _providerIntegrityGate.CheckAsync(request.ProviderNpi, ct);
+            providerIntegrity = await _providerIntegrityGate.CheckAsync(request.ProviderNpi, ct: ct);
 
             integritySpan?.SetTag("cho.integrity.passed", providerIntegrity.Passed);
             integritySpan?.SetTag("cho.integrity.score", providerIntegrity.IntegrityScore ?? -1);

--- a/src/services/benefit-plan-service/Models/ProviderIntegrityGateOptions.cs
+++ b/src/services/benefit-plan-service/Models/ProviderIntegrityGateOptions.cs
@@ -1,0 +1,48 @@
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Configuration for <c>HttpProviderIntegrityGate</c>'s cached-or-live read
+/// path (capability 5.10 — verification integrity score surface).
+///
+/// <para>
+/// The gate reads the canonical projection on <c>Provider.IntegrityScore</c>
+/// from <c>provider-service</c> by default and only falls back to the live
+/// <c>provider-verification-service</c> path when the cached score is null
+/// (never refreshed) or staler than
+/// <see cref="StalenessFallbackThreshold"/>. See
+/// <c>docs/architecture/integrity-score-consumption.md</c> for the
+/// canonical decision tree.
+/// </para>
+///
+/// <para>
+/// <b>Convention note.</b> <c>benefit-plan-service</c> historically read
+/// configuration via direct <c>IConfiguration["..."]</c> indexing.
+/// Capability 5.10 introduces the platform-canonical <c>IOptions&lt;&gt;</c>
+/// pattern (already used in <c>provider-service</c>'s
+/// <c>IntegrityProjectionOptions</c> and <c>NetworkParticipationBackfillOptions</c>)
+/// for new configuration. Existing direct-indexed sites are NOT migrated
+/// as part of this PR; they migrate incrementally as the surrounding code
+/// is touched.
+/// </para>
+/// </summary>
+public sealed class ProviderIntegrityGateOptions
+{
+    public const string SectionName = "ProviderIntegrityGate";
+
+    /// <summary>
+    /// Threshold above which a cached integrity projection is considered
+    /// stale and the gate falls back to the live HTTP path. Default
+    /// <c>7 days</c> — roughly one missed worker sweep cycle (NPPES has a
+    /// 24h window) plus margin.
+    ///
+    /// <para>
+    /// Operators tune per environment: test = 1 hour for fast iteration;
+    /// production = 7 days; high-trust environments = 30 days. Configured
+    /// independently of <c>IntegrityProjection:StalenessAlertThreshold</c>
+    /// in <c>provider-service</c> so operators can alert sooner than
+    /// fall-back kicks in (e.g., warn at 5d, fall back at 7d) without a
+    /// code change. Defaults match.
+    /// </para>
+    /// </summary>
+    public TimeSpan StalenessFallbackThreshold { get; set; } = TimeSpan.FromDays(7);
+}

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Cosmos;
 using BenefitPlanService.Adapters;
 using BenefitPlanService.Middleware;
+using BenefitPlanService.Models;
 using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
 using MongoDB.Driver;
@@ -226,16 +227,32 @@ builder.Services.AddHttpClient<IOperatingModeProvider, HttpOperatingModeProvider
 // Determines CHO vs. legacy routing per claim type and line of business.
 builder.Services.AddSingleton<IClaimTypeRouter, ClaimTypeRouter>();
 
-// ── Provider Integrity Gate ──────────────────────────────────────────────────
-// Checks provider against OIG/LEIE/SAM.gov exclusion lists via
-// provider-verification-service. Cached 1 hour per NPI.
-builder.Services.AddHttpClient<IProviderIntegrityGate, HttpProviderIntegrityGate>(client =>
+// ── Provider Integrity Gate (capability 5.10 — cached-or-live) ───────────────
+// Adjudication-path gate that reads the canonical projection on
+// Provider.IntegrityScore from provider-service by default and only falls
+// back to provider-verification-service when the cached score is null,
+// stale, or callers explicitly opt in via forceRefresh: true. The 1-hour
+// MemoryCache stays as a per-pod request-coalescing layer wrapping the
+// outer ProviderIntegrityResult. See
+// docs/architecture/integrity-score-consumption.md for the canonical
+// decision tree.
+builder.Services.Configure<ProviderIntegrityGateOptions>(
+    builder.Configuration.GetSection(ProviderIntegrityGateOptions.SectionName));
+builder.Services.AddHttpClient(HttpProviderIntegrityGate.ProviderServiceClientName, client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:ProviderServiceUrl"]
+        ?? "http://provider-service:8080/");
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+builder.Services.AddHttpClient(HttpProviderIntegrityGate.VerificationServiceClientName, client =>
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:ProviderVerificationServiceUrl"]
         ?? "http://provider-verification-service:8080/");
     client.Timeout = TimeSpan.FromSeconds(10);
 });
+builder.Services.AddSingleton<IProviderIntegrityGate, HttpProviderIntegrityGate>();
 
 // ── Terminology Crosswalk Client ─────────────────────────────────────────────
 // Resolves plan-specific procedure code mappings before fee schedule pricing.

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -1,47 +1,187 @@
 using System.Net.Http.Json;
+using BenefitPlanService.Models;
+using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace BenefitPlanService.Services;
 
 /// <summary>
-/// Calls provider-verification-service to check provider integrity.
-/// Results are cached for 1 hour since exclusion list data changes infrequently
-/// (OIG publishes monthly, SAM.gov daily but latency is acceptable for adjudication).
+/// Adjudication-path provider-integrity gate (capability 5.10 — verification
+/// integrity score surface).
 ///
-/// On service failure, defaults to Passed=true so adjudication is not blocked.
-/// The separate provider-verification-service handles scheduled re-verification.
+/// <para>
+/// <b>Cached-or-live read pattern.</b> The gate reads the canonical
+/// projection on <c>Provider.IntegrityScore</c> from <c>provider-service</c>
+/// (<c>GET /api/v1/providers/npi/{npi}</c>) by default. It falls back to
+/// the live <c>provider-verification-service</c> path
+/// (<c>GET /api/v1/providers/{npi}/integrity-score</c>) when:
+/// </para>
+/// <list type="bullet">
+///   <item>The cached score is null (Provider never refreshed).</item>
+///   <item>The cached score is older than
+///     <see cref="ProviderIntegrityGateOptions.StalenessFallbackThreshold"/>.</item>
+///   <item>The caller explicitly opts in via
+///     <c>forceRefresh: true</c>.</item>
+/// </list>
+///
+/// <para>
+/// The 1-hour <see cref="IMemoryCache"/> stays as a per-pod
+/// request-coalescing layer wrapping the outer <see cref="ProviderIntegrityResult"/>
+/// — every code path benefits from coalescing. Cache key is namespaced by
+/// the resolution path (<c>cached-or-live</c> vs <c>force-refresh</c>) so a
+/// force-refresh call doesn't poison the default-path cache entry.
+/// </para>
+///
+/// <para>
+/// Telemetry is emitted per call as
+/// <c>cho.provider.integrity_gate.decisions.total</c> with the
+/// <c>cho.path</c> dimension set to <c>cached_hit</c>, <c>stale_fallback</c>,
+/// <c>null_fallback</c>, or <c>live_only</c>. See
+/// <c>docs/architecture/integrity-score-consumption.md</c>.
+/// </para>
+///
+/// <para>
+/// On any service failure the gate returns the existing pass-through
+/// result so adjudication is never blocked by infrastructure flakes; the
+/// scheduled re-verification path in <c>provider-verification-service</c>
+/// remains responsible for catching exclusion drift.
+/// </para>
 /// </summary>
 public class HttpProviderIntegrityGate : IProviderIntegrityGate
 {
-    private readonly HttpClient _httpClient;
+    public const string ProviderServiceClientName = "ProviderService";
+    public const string VerificationServiceClientName = "ProviderVerificationService";
+
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMemoryCache _cache;
+    private readonly IOptionsMonitor<ProviderIntegrityGateOptions> _options;
     private readonly ILogger<HttpProviderIntegrityGate> _logger;
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
 
     public HttpProviderIntegrityGate(
-        HttpClient httpClient,
+        IHttpClientFactory httpClientFactory,
         IMemoryCache cache,
+        IOptionsMonitor<ProviderIntegrityGateOptions> options,
         ILogger<HttpProviderIntegrityGate> logger)
     {
-        _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
         _cache = cache;
+        _options = options;
         _logger = logger;
     }
 
     public async Task<ProviderIntegrityResult> CheckAsync(
         string npi,
+        bool forceRefresh = false,
         CancellationToken ct = default)
     {
-        var cacheKey = $"provider-integrity:{npi}";
+        // Cache key separates default vs force-refresh so a force-refresh
+        // call's live-only result doesn't pollute the cached-or-live entry,
+        // and vice-versa.
+        var cacheKey = forceRefresh
+            ? $"provider-integrity:force:{npi}"
+            : $"provider-integrity:cached-or-live:{npi}";
 
         if (_cache.TryGetValue<ProviderIntegrityResult>(cacheKey, out var cached) && cached is not null)
+        {
+            RecordDecision(IntegrityGatePath.CachedHit, cached.Rating);
             return cached;
+        }
 
+        ProviderIntegrityResult result;
+
+        if (forceRefresh)
+        {
+            result = await CallVerificationServiceAsync(npi, ct) ?? Passthrough();
+            RecordDecision(IntegrityGatePath.LiveOnly, result.Rating);
+        }
+        else
+        {
+            // Default path: try the cached projection first.
+            var projection = await TryReadProjectionAsync(npi, ct);
+
+            if (projection is null)
+            {
+                // Provider not found in provider-service or transport
+                // failure — fall back to live verification rather than
+                // failing closed.
+                result = await CallVerificationServiceAsync(npi, ct) ?? Passthrough();
+                RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
+            }
+            else if (projection.Score is null || projection.LastVerifiedAt is null)
+            {
+                // Projection row exists but never refreshed — fall back to
+                // live and let the local cache absorb subsequent calls.
+                result = await CallVerificationServiceAsync(npi, ct)
+                    ?? BuildResultFromProjection(projection);
+                RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
+            }
+            else if (IsStale(projection.LastVerifiedAt.Value))
+            {
+                result = await CallVerificationServiceAsync(npi, ct)
+                    ?? BuildResultFromProjection(projection);
+                RecordDecision(IntegrityGatePath.StaleFallback, result.Rating);
+            }
+            else
+            {
+                result = BuildResultFromProjection(projection);
+                RecordDecision(IntegrityGatePath.CachedHit, result.Rating);
+            }
+        }
+
+        _cache.Set(cacheKey, result, CacheTtl);
+        return result;
+    }
+
+    private bool IsStale(DateTimeOffset lastVerifiedAt)
+    {
+        var threshold = _options.CurrentValue.StalenessFallbackThreshold;
+        if (threshold <= TimeSpan.Zero) return false;
+        return DateTimeOffset.UtcNow - lastVerifiedAt > threshold;
+    }
+
+    private async Task<ProviderProjection?> TryReadProjectionAsync(string npi, CancellationToken ct)
+    {
         try
         {
+            var client = _httpClientFactory.CreateClient(ProviderServiceClientName);
             var encodedNpi = Uri.EscapeDataString(npi);
-            var response = await _httpClient.GetAsync(
+            var response = await client.GetAsync(
+                $"api/v1/providers/npi/{encodedNpi}", ct);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return null;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Provider service returned {StatusCode} for NPI {Npi}; falling back to live verification",
+                    response.StatusCode, SanitizeForLog(npi));
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<ProviderProjection>(ct);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Provider service unreachable for NPI {Npi}; falling back to live verification",
+                SanitizeForLog(npi));
+            return null;
+        }
+    }
+
+    private async Task<ProviderIntegrityResult?> CallVerificationServiceAsync(
+        string npi,
+        CancellationToken ct)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient(VerificationServiceClientName);
+            var encodedNpi = Uri.EscapeDataString(npi);
+            var response = await client.GetAsync(
                 $"api/v1/providers/{encodedNpi}/integrity-score", ct);
 
             if (!response.IsSuccessStatusCode)
@@ -49,15 +189,14 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                 _logger.LogWarning(
                     "Provider verification service returned {StatusCode} for NPI {Npi}; passing through",
                     response.StatusCode, SanitizeForLog(npi));
-                return Passthrough();
+                return null;
             }
 
             var record = await response.Content.ReadFromJsonAsync<IntegrityScoreResponse>(ct);
-
-            if (record is null) return Passthrough();
+            if (record is null) return null;
 
             var isExcluded = record.Status is "Excluded";
-            var result = new ProviderIntegrityResult
+            return new ProviderIntegrityResult
             {
                 Passed = record.Status is not ("Excluded" or "Failed"),
                 IntegrityScore = record.CompositeScore,
@@ -68,18 +207,59 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                     ? "Provider is excluded from federal healthcare programs"
                     : null
             };
-
-            _cache.Set(cacheKey, result, CacheTtl);
-            return result;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             _logger.LogWarning(ex,
                 "Provider verification service unreachable for NPI {Npi}; passing through",
                 SanitizeForLog(npi));
-            return Passthrough();
+            return null;
         }
     }
+
+    private static ProviderIntegrityResult BuildResultFromProjection(ProviderProjection projection)
+    {
+        // The cached projection captures Score + Rating but not the
+        // ExclusionStatus that the live endpoint returns directly. Rating
+        // == "Blocked" indicates active exclusion in the verification
+        // engine's rubric — translate that into the gate's IsExcluded /
+        // DenialCode contract so adjudication denies on cached-only reads.
+        var isExcluded = string.Equals(projection.IntegrityRating, "Blocked", StringComparison.OrdinalIgnoreCase);
+        return new ProviderIntegrityResult
+        {
+            Passed = !isExcluded,
+            IntegrityScore = projection.IntegrityScore,
+            Rating = projection.IntegrityRating ?? "Unknown",
+            IsExcluded = isExcluded,
+            DenialCode = isExcluded ? "B7" : null,
+            DenialReason = isExcluded
+                ? "Provider is excluded from federal healthcare programs"
+                : null
+        };
+    }
+
+    private static void RecordDecision(IntegrityGatePath path, string? rating)
+    {
+        ChoMetrics.ProviderIntegrityGateDecisions.Add(
+            1,
+            new KeyValuePair<string, object?>("cho.path", PathTag(path)),
+            new KeyValuePair<string, object?>("cho.rating", rating ?? "unknown"));
+    }
+
+    private static string PathTag(IntegrityGatePath path) => path switch
+    {
+        IntegrityGatePath.CachedHit      => "cached_hit",
+        IntegrityGatePath.StaleFallback  => "stale_fallback",
+        IntegrityGatePath.NullFallback   => "null_fallback",
+        IntegrityGatePath.LiveOnly       => "live_only",
+        _                                => "unknown",
+    };
+
+    private static ProviderIntegrityResult Passthrough() => new()
+    {
+        Passed = true,
+        Rating = "Unknown"
+    };
 
     private static string SanitizeForLog(string? value)
     {
@@ -88,21 +268,40 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
-    private static ProviderIntegrityResult Passthrough() => new()
+    /// <summary>
+    /// Subset of the <c>Provider</c> entity returned by
+    /// <c>GET /api/v1/providers/npi/{npi}</c>. Only the integrity-projection
+    /// fields are bound; everything else on the wire is ignored.
+    /// </summary>
+    internal sealed record ProviderProjection
     {
-        Passed = true,
-        Rating = "Unknown"
-    };
+        public int? IntegrityScore { get; init; }
+        public string? IntegrityRating { get; init; }
+        public DateTimeOffset? LastVerifiedAt { get; init; }
+        public DateTimeOffset? NextVerificationDue { get; init; }
+
+        // Convenience accessor used by the gate's null-detection branch:
+        // the projection row exists but never carried a score.
+        internal int? Score => IntegrityScore;
+    }
 
     /// <summary>
     /// Matches the anonymous object shape returned by
     /// GET /api/v1/providers/{npi}/integrity-score on provider-verification-service.
     /// </summary>
-    private record IntegrityScoreResponse
+    private sealed record IntegrityScoreResponse
     {
         public int CompositeScore { get; init; }
         public string? Rating { get; init; }
         public string? Status { get; init; }
         public DateTimeOffset? VerifiedAt { get; init; }
+    }
+
+    private enum IntegrityGatePath
+    {
+        CachedHit,
+        StaleFallback,
+        NullFallback,
+        LiveOnly,
     }
 }

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -27,10 +27,24 @@ namespace BenefitPlanService.Services;
 ///
 /// <para>
 /// The 1-hour <see cref="IMemoryCache"/> stays as a per-pod
-/// request-coalescing layer wrapping the outer <see cref="ProviderIntegrityResult"/>
-/// — every code path benefits from coalescing. Cache key is namespaced by
-/// the resolution path (<c>cached-or-live</c> vs <c>force-refresh</c>) so a
-/// force-refresh call doesn't poison the default-path cache entry.
+/// request-deduplication layer wrapping the outer
+/// <see cref="ProviderIntegrityResult"/>. Cache key is namespaced by the
+/// resolution path (<c>cached-or-live</c> vs <c>force-refresh</c>) so a
+/// force-refresh call doesn't poison the default-path cache entry. Note:
+/// this is a check-then-act pattern, not a true single-flight coalesce —
+/// concurrent first-time misses for the same NPI can each fan out to
+/// upstream once. A future tightening (e.g. <c>GetOrCreateAsync</c> or a
+/// <c>Lazy&lt;Task&lt;...&gt;&gt;</c> per key) would close that window;
+/// out of scope for 5.10 because the upstream cost is bounded by the
+/// staleness threshold and the typical hot-NPI shape doesn't produce
+/// concurrent first-time misses in practice.
+/// </para>
+///
+/// <para>
+/// Pass-through results (both upstream services unavailable) are
+/// <em>not</em> cached — operators get a recovered exclusion signal on
+/// the next adjudication call rather than waiting up to an hour for the
+/// cached pass-through to expire.
 /// </para>
 ///
 /// <para>
@@ -91,10 +105,21 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         }
 
         ProviderIntegrityResult result;
+        // Track whether the result came from a real data source. Pass-through
+        // results (both upstream services down) are NOT cached for the full
+        // 1-hour TTL so a recovered exclusion signal is picked up on the next
+        // adjudication call rather than waiting an hour. The cache is still
+        // useful for real responses (request coalescing) and for genuine
+        // pass-throughs we accept a brief retry storm during outages — that's
+        // the lesser evil compared to an hour of pretending Excluded providers
+        // pass.
+        var isPassthrough = false;
 
         if (forceRefresh)
         {
-            result = await CallVerificationServiceAsync(npi, ct) ?? Passthrough();
+            var live = await CallVerificationServiceAsync(npi, ct);
+            isPassthrough = live is null;
+            result = live ?? Passthrough();
             RecordDecision(IntegrityGatePath.LiveOnly, result.Rating);
         }
         else
@@ -107,7 +132,9 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                 // Provider not found in provider-service or transport
                 // failure — fall back to live verification rather than
                 // failing closed.
-                result = await CallVerificationServiceAsync(npi, ct) ?? Passthrough();
+                var live = await CallVerificationServiceAsync(npi, ct);
+                isPassthrough = live is null;
+                result = live ?? Passthrough();
                 RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
             }
             else if (projection.Score is null || projection.LastVerifiedAt is null)
@@ -131,7 +158,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             }
         }
 
-        _cache.Set(cacheKey, result, CacheTtl);
+        if (!isPassthrough) _cache.Set(cacheKey, result, CacheTtl);
         return result;
     }
 

--- a/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
@@ -8,11 +8,32 @@ namespace BenefitPlanService.Services;
 /// this gate screens for federal program exclusions and NPI deactivation.
 /// A provider could pass enrollment validation but be on the OIG exclusion
 /// list — this gate catches that.
+///
+/// <para>
+/// The <c>HttpProviderIntegrityGate</c> implementation reads the cached
+/// projection on <c>Provider.IntegrityScore</c> by default
+/// (provider-service) and only falls back to the live
+/// provider-verification-service when the cached score is null or stale,
+/// or when callers explicitly request a fresh score. See
+/// <c>docs/architecture/integrity-score-consumption.md</c>.
+/// </para>
 /// </summary>
 public interface IProviderIntegrityGate
 {
+    /// <summary>
+    /// Resolve the integrity result for <paramref name="npi"/>.
+    /// </summary>
+    /// <param name="npi">Provider NPI.</param>
+    /// <param name="forceRefresh">
+    /// When <c>true</c> the cached-projection short-circuit is bypassed
+    /// and the gate calls <c>provider-verification-service</c> directly.
+    /// Default <c>false</c>; callers that need fresh-only semantics
+    /// (admin investigations, on-demand operator action) opt in.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
     Task<ProviderIntegrityResult> CheckAsync(
         string npi,
+        bool forceRefresh = false,
         CancellationToken ct = default);
 }
 

--- a/src/services/capitation-service/capitation-service.csproj
+++ b/src/services/capitation-service/capitation-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Stripe.net" Version="46.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/consent-service/consent-service.csproj
+++ b/src/services/consent-service/consent-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/coverage-service/coverage-service.csproj
+++ b/src/services/coverage-service/coverage-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/eligibility-service/eligibility-service.csproj
+++ b/src/services/eligibility-service/eligibility-service.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />

--- a/src/services/encounter-service/encounter-service.csproj
+++ b/src/services/encounter-service/encounter-service.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/encounter-submission-service/encounter-submission-service.csproj
+++ b/src/services/encounter-submission-service/encounter-submission-service.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.8.0" />

--- a/src/services/enrollment-import-service/EnrollmentImportService.csproj
+++ b/src/services/enrollment-import-service/EnrollmentImportService.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />

--- a/src/services/fhir-service/fhir-service.csproj
+++ b/src/services/fhir-service/fhir-service.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Appeals.Contracts\CloudHealthOffice.Appeals.Contracts.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.ProviderEnrollmentService\CloudHealthOffice.ProviderEnrollmentService.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.PriorAuthRuleEngine\CloudHealthOffice.PriorAuthRuleEngine.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <!-- StackExchange.Redis is pulled in transitively via
          CloudHealthOffice.Infrastructure. fhir-service has no direct
          IConnectionMultiplexer consumer after A.7.2 — the Redis client is

--- a/src/services/idcard-service/idcard-service.csproj
+++ b/src/services/idcard-service/idcard-service.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />

--- a/src/services/member-document-service/member-document-service.csproj
+++ b/src/services/member-document-service/member-document-service.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/member-service/member-service.csproj
+++ b/src/services/member-service/member-service.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/payment-service/payment-service.csproj
+++ b/src/services/payment-service/payment-service.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/personal-representative-service/personal-representative-service.csproj
+++ b/src/services/personal-representative-service/personal-representative-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/premium-billing-service/premium-billing-service.csproj
+++ b/src/services/premium-billing-service/premium-billing-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Stripe.net" Version="45.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
+++ b/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
@@ -121,14 +121,18 @@ public sealed class IntegrityProjectionWorker : BackgroundService
             // Decision 3: no new hosted service; we run the count once
             // per sweep cycle so the gauge reflects state at sweep
             // boundaries rather than chasing every projection write.
+            // ReportTenantAsync returns -1 when the repository read
+            // failed; we log "unknown" so operators don't read a zero
+            // as "no stale providers".
             var staleness = scope.ServiceProvider
                 .GetRequiredService<IIntegrityProjectionStalenessReporter>();
             var staleCount = await staleness.ReportTenantAsync(tenantId, ct);
+            var staleLabel = staleCount < 0 ? "unknown" : staleCount.ToString();
 
             _logger.LogInformation(
                 "IntegrityProjectionWorker tenant sweep: tenant={Tenant} inspected={Inspected} patched={Patched} skipped={Skipped} failed={Failed} stale={Stale} window={Window}",
                 Sanitize(tenantId), result.Inspected, result.Patched,
-                result.Skipped, result.Failed, staleCount, result.RefreshWindow);
+                result.Skipped, result.Failed, staleLabel, result.RefreshWindow);
         }
 
         _logger.LogInformation(

--- a/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
+++ b/src/services/provider-service/HostedServices/IntegrityProjectionWorker.cs
@@ -115,10 +115,20 @@ public sealed class IntegrityProjectionWorker : BackgroundService
             totalFailed += result.Failed;
             totalSkipped += result.Skipped;
 
+            // Capability 5.10 — staleness telemetry piggybacks on the
+            // existing sweep. The reporter updates the per-tenant
+            // gauge snapshot read by ChoMetrics.ProviderIntegrityScoreStaleCount.
+            // Decision 3: no new hosted service; we run the count once
+            // per sweep cycle so the gauge reflects state at sweep
+            // boundaries rather than chasing every projection write.
+            var staleness = scope.ServiceProvider
+                .GetRequiredService<IIntegrityProjectionStalenessReporter>();
+            var staleCount = await staleness.ReportTenantAsync(tenantId, ct);
+
             _logger.LogInformation(
-                "IntegrityProjectionWorker tenant sweep: tenant={Tenant} inspected={Inspected} patched={Patched} skipped={Skipped} failed={Failed} window={Window}",
+                "IntegrityProjectionWorker tenant sweep: tenant={Tenant} inspected={Inspected} patched={Patched} skipped={Skipped} failed={Failed} stale={Stale} window={Window}",
                 Sanitize(tenantId), result.Inspected, result.Patched,
-                result.Skipped, result.Failed, result.RefreshWindow);
+                result.Skipped, result.Failed, staleCount, result.RefreshWindow);
         }
 
         _logger.LogInformation(

--- a/src/services/provider-service/Models/IntegrityProjectionOptions.cs
+++ b/src/services/provider-service/Models/IntegrityProjectionOptions.cs
@@ -75,6 +75,21 @@ public sealed class IntegrityProjectionOptions
     public RefreshWindowsOptions Windows { get; set; } = new();
 
     /// <summary>
+    /// Threshold above which a provider's cached <c>LastVerifiedAt</c>
+    /// is considered stale for the purposes of operational alerting.
+    /// The <c>IntegrityProjectionStalenessReporter</c> piggybacks on the
+    /// worker sweep to count, per tenant, how many providers exceed this
+    /// threshold and exposes the result as the
+    /// <c>cho.provider.integrity_score.stale_count</c> Prometheus gauge.
+    /// Default <c>7 days</c> — matches
+    /// <c>ProviderIntegrityGate:StalenessFallbackThreshold</c> in
+    /// <c>benefit-plan-service</c> so operators get one knob to turn by
+    /// default while retaining the option to alert sooner than fall-back
+    /// kicks in. Set to <c>TimeSpan.Zero</c> to disable the gauge.
+    /// </summary>
+    public TimeSpan StalenessAlertThreshold { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
     /// Returns the shortest configured refresh window across the active
     /// sources. NPPES at 24h dominates today; if NPPES is disabled,
     /// LEIE/SAM at 24h takes over.

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -147,6 +147,10 @@ builder.Services.AddHttpClient<IProviderVerificationClient, HttpProviderVerifica
 })
 .SetHandlerLifetime(TimeSpan.FromMinutes(5));
 builder.Services.AddScoped<IProviderIntegrityProjectionService, ProviderIntegrityProjectionService>();
+// Capability 5.10 — per-tenant staleness telemetry that piggybacks on the
+// worker sweep. No new hosted service; the reporter is a scoped helper
+// invoked from inside IntegrityProjectionWorker's per-tenant loop.
+builder.Services.AddScoped<IIntegrityProjectionStalenessReporter, IntegrityProjectionStalenessReporter>();
 builder.Services.AddHostedService<IntegrityProjectionWorker>();
 
 // Network-participation panel-gating backfill (5.5 — one-shot

--- a/src/services/provider-service/Repositories/ProviderRepository.cs
+++ b/src/services/provider-service/Repositories/ProviderRepository.cs
@@ -187,6 +187,28 @@ public interface IProviderRepository
     /// </summary>
     Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Count head-Active providers in <paramref name="tenantId"/> whose
+    /// <see cref="Provider.LastVerifiedAt"/> is <c>null</c> or older than
+    /// <paramref name="staleBefore"/>. Used by
+    /// <c>IntegrityProjectionStalenessReporter</c> (capability 5.10) to
+    /// publish the per-tenant
+    /// <c>cho.provider.integrity_score.stale_count</c> Prometheus gauge.
+    ///
+    /// <para>
+    /// Mirrors the hydration rule of
+    /// <see cref="ListProvidersForIntegrityRefreshAsync"/> — only
+    /// head-Active rows are considered (legacy single-row chains, missing
+    /// <c>VersionState</c> field, and explicit Active state). Per-tenant
+    /// scoped (single-partition on the Cosmos impl) so the gauge update
+    /// stays cheap on the worker hot-path.
+    /// </para>
+    /// </summary>
+    Task<long> CountStaleProvidersAsync(
+        string tenantId,
+        DateTimeOffset staleBefore,
+        CancellationToken ct = default);
+
     // ---- Network-participation panel-gating backfill (capability 5.5) -
 
     /// <summary>
@@ -1083,6 +1105,47 @@ public class ProviderRepository : IProviderRepository
             }
         }
         return tenants.OrderBy(x => x, StringComparer.Ordinal).ToList();
+    }
+
+    public async Task<long> CountStaleProvidersAsync(
+        string tenantId,
+        DateTimeOffset staleBefore,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+
+        // Hydration rule (mirrors Hydrate()) — three "Active" shapes,
+        // each Status-gated, identical to the refresh-list query above.
+        // A provider is stale when LastVerifiedAt is missing/null or
+        // older than staleBefore.
+        var sql = "SELECT VALUE COUNT(1) FROM c WHERE c.tenantId = @tenantId AND " +
+                  "(c.versionState = @active " +
+                  "OR (NOT IS_DEFINED(c.versionState) AND c.status = @statusActive) " +
+                  "OR ((NOT IS_DEFINED(c.versionId) OR c.versionId = null OR c.versionId = \"\") AND c.status = @statusActive)) AND " +
+                  "(NOT IS_DEFINED(c.lastVerifiedAt) OR c.lastVerifiedAt = null OR c.lastVerifiedAt < @staleBefore)";
+
+        var query = new QueryDefinition(sql)
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@active", ProviderVersionState.Active.ToString())
+            .WithParameter("@statusActive", ProviderStatus.Active.ToString())
+            .WithParameter("@staleBefore", staleBefore);
+
+        var iterator = _container.GetItemQueryIterator<long>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(tenantId),
+            });
+
+        long total = 0;
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+            foreach (var v in page) total += v;
+        }
+        return total;
     }
 
     public async Task<bool> UpdatePanelGatingDefaultsAsync(

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -818,6 +818,43 @@ public class ProviderRepositoryMongo : IProviderRepository
             .ToList();
     }
 
+    public async Task<long> CountStaleProvidersAsync(
+        string tenantId,
+        DateTimeOffset staleBefore,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+
+        // Hydration rule (mirrors ListProvidersForIntegrityRefreshAsync) —
+        // three "Active" shapes, each Status-gated. A provider is stale
+        // when LastVerifiedAt is missing/null or older than staleBefore.
+        var b = Builders<Provider>.Filter;
+        var stateFilter = b.Or(
+            b.Eq(p => p.VersionState, ProviderVersionState.Active),
+            b.And(
+                b.Exists(p => p.VersionState, false),
+                b.Eq(p => p.Status, ProviderStatus.Active)),
+            b.And(
+                b.Or(
+                    b.Exists(p => p.VersionId, false),
+                    b.Eq(p => p.VersionId, null),
+                    b.Eq(p => p.VersionId, string.Empty)),
+                b.Eq(p => p.Status, ProviderStatus.Active)));
+
+        var stalenessFilter = b.Or(
+            b.Exists(p => p.LastVerifiedAt, false),
+            b.Eq(p => p.LastVerifiedAt, null),
+            b.Lt(p => p.LastVerifiedAt, staleBefore));
+
+        var filter = b.And(
+            b.Eq(p => p.TenantId, tenantId),
+            stateFilter,
+            stalenessFilter);
+
+        return await _collection.CountDocumentsAsync(filter, cancellationToken: ct);
+    }
+
     public async Task<bool> UpdatePanelGatingDefaultsAsync(
         string tenantId,
         string providerId,

--- a/src/services/provider-service/Services/IntegrityProjectionStalenessReporter.cs
+++ b/src/services/provider-service/Services/IntegrityProjectionStalenessReporter.cs
@@ -1,0 +1,105 @@
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Repositories;
+
+namespace ProviderService.Services;
+
+/// <summary>
+/// Per-tenant staleness telemetry for cached integrity projections
+/// (capability 5.10 — verification integrity score surface).
+///
+/// <para>
+/// Piggybacks on <c>IntegrityProjectionWorker</c>'s existing sweep —
+/// the worker invokes <see cref="ReportTenantAsync"/> once per tenant
+/// per sweep, after the refresh pass. The reporter queries the
+/// repository for the count of head-Active providers whose
+/// <c>LastVerifiedAt</c> is older than
+/// <see cref="IntegrityProjectionOptions.StalenessAlertThreshold"/>
+/// and updates the per-tenant snapshot read by the
+/// <c>cho.provider.integrity_score.stale_count</c> Prometheus gauge in
+/// <see cref="ChoMetrics.ProviderIntegrityScoreStaleCount"/>.
+/// </para>
+///
+/// <para>
+/// No new hosted service is introduced — Decision 3 of capability 5.10
+/// pins consolidation over infrastructure expansion. The reporter
+/// itself is stateless; the per-tenant snapshot lives on
+/// <see cref="ChoMetrics"/> so the gauge can read it on each scrape.
+/// </para>
+/// </summary>
+public interface IIntegrityProjectionStalenessReporter
+{
+    /// <summary>
+    /// Compute the per-tenant stale-provider count and update the
+    /// <c>cho.provider.integrity_score.stale_count</c> gauge snapshot.
+    /// Returns the count for caller-side telemetry / structured logging;
+    /// callers may safely ignore the return value.
+    ///
+    /// <para>
+    /// When <see cref="IntegrityProjectionOptions.StalenessAlertThreshold"/>
+    /// is non-positive the gauge entry for the tenant is cleared and
+    /// the count returns <c>0</c> — operators get an explicit "off"
+    /// signal rather than a stale snapshot.
+    /// </para>
+    /// </summary>
+    Task<long> ReportTenantAsync(string tenantId, CancellationToken ct = default);
+}
+
+/// <inheritdoc cref="IIntegrityProjectionStalenessReporter" />
+public sealed class IntegrityProjectionStalenessReporter : IIntegrityProjectionStalenessReporter
+{
+    private readonly IProviderRepository _providers;
+    private readonly IOptionsMonitor<IntegrityProjectionOptions> _options;
+    private readonly ILogger<IntegrityProjectionStalenessReporter> _logger;
+
+    public IntegrityProjectionStalenessReporter(
+        IProviderRepository providers,
+        IOptionsMonitor<IntegrityProjectionOptions> options,
+        ILogger<IntegrityProjectionStalenessReporter> logger)
+    {
+        _providers = providers;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<long> ReportTenantAsync(string tenantId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+
+        var threshold = _options.CurrentValue.StalenessAlertThreshold;
+        if (threshold <= TimeSpan.Zero)
+        {
+            // Threshold disabled — drop the gauge entry rather than
+            // hold a stale snapshot. -1 sentinel triggers TryRemove.
+            ChoMetrics.SetIntegrityScoreStaleCount(tenantId, -1);
+            return 0;
+        }
+
+        var staleBefore = DateTimeOffset.UtcNow - threshold;
+
+        try
+        {
+            var count = await _providers.CountStaleProvidersAsync(tenantId, staleBefore, ct);
+            ChoMetrics.SetIntegrityScoreStaleCount(tenantId, count);
+            return count;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Telemetry must never block the sweep. Log and continue —
+            // the next sweep refreshes the snapshot.
+            _logger.LogWarning(ex,
+                "IntegrityProjectionStalenessReporter failed for tenant {Tenant}; gauge snapshot unchanged",
+                Sanitize(tenantId));
+            return 0;
+        }
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/provider-service/Services/IntegrityProjectionStalenessReporter.cs
+++ b/src/services/provider-service/Services/IntegrityProjectionStalenessReporter.cs
@@ -33,15 +33,21 @@ public interface IIntegrityProjectionStalenessReporter
     /// <summary>
     /// Compute the per-tenant stale-provider count and update the
     /// <c>cho.provider.integrity_score.stale_count</c> gauge snapshot.
-    /// Returns the count for caller-side telemetry / structured logging;
-    /// callers may safely ignore the return value.
+    /// Returns the count for caller-side telemetry / structured logging.
     ///
     /// <para>
-    /// When <see cref="IntegrityProjectionOptions.StalenessAlertThreshold"/>
-    /// is non-positive the gauge entry for the tenant is cleared and
-    /// the count returns <c>0</c> — operators get an explicit "off"
-    /// signal rather than a stale snapshot.
+    /// Return-value contract:
     /// </para>
+    /// <list type="bullet">
+    ///   <item><c>&gt;= 0</c> — successful read, the snapshot was
+    ///     refreshed.</item>
+    ///   <item><c>0</c> with threshold disabled — the gauge entry was
+    ///     cleared (explicit "off" signal).</item>
+    ///   <item><c>-1</c> — repository read failed; the snapshot is
+    ///     unchanged. Callers should log "unknown" rather than
+    ///     conflating with a healthy zero. Sentinel chosen over
+    ///     throwing so telemetry never blocks the worker sweep.</item>
+    /// </list>
     /// </summary>
     Task<long> ReportTenantAsync(string tenantId, CancellationToken ct = default);
 }
@@ -92,11 +98,13 @@ public sealed class IntegrityProjectionStalenessReporter : IIntegrityProjectionS
         catch (Exception ex)
         {
             // Telemetry must never block the sweep. Log and continue —
-            // the next sweep refreshes the snapshot.
+            // the next sweep refreshes the snapshot. Return -1 (sentinel)
+            // so callers can distinguish "unknown due to error" from
+            // "zero stale providers".
             _logger.LogWarning(ex,
                 "IntegrityProjectionStalenessReporter failed for tenant {Tenant}; gauge snapshot unchanged",
                 Sanitize(tenantId));
-            return 0;
+            return -1;
         }
     }
 

--- a/src/services/provider-service/provider-service.csproj
+++ b/src/services/provider-service/provider-service.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/reference-data-service/reference-data-service.csproj
+++ b/src/services/reference-data-service/reference-data-service.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/services/rfai-service/rfai-service.csproj
+++ b/src/services/rfai-service/rfai-service.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/risk-adjustment-service/risk-adjustment-service.csproj
+++ b/src/services/risk-adjustment-service/risk-adjustment-service.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
 
 namespace CloudHealthOffice.Infrastructure.Observability;
@@ -110,6 +111,90 @@ public static class ChoMetrics
             "cho.provider.network_participation.backfill.outcomes.total",
             unit: "{participation}",
             description: "Participations processed by the panel-gating backfill, by outcome");
+
+    /// <summary>
+    /// Counter tracking <c>HttpProviderIntegrityGate</c>'s cached-or-live
+    /// decision path (capability 5.10). Dimensions: <c>cho.path</c>
+    /// (<c>cached_hit</c> | <c>stale_fallback</c> | <c>null_fallback</c>
+    /// | <c>live_only</c>) and <c>cho.rating</c> (the resolved rating
+    /// label, or <c>"unknown"</c>).
+    ///
+    /// <para>
+    /// The metric drives operational tuning of
+    /// <c>ProviderIntegrityGate:StalenessFallbackThreshold</c>: high
+    /// <c>stale_fallback</c> rates suggest the threshold is tighter than
+    /// the verification cadence; high <c>null_fallback</c> rates suggest
+    /// the projection backfill hasn't been run on that tenant. See
+    /// <c>docs/architecture/integrity-score-consumption.md</c>.
+    /// </para>
+    /// </summary>
+    public static readonly Counter<long> ProviderIntegrityGateDecisions =
+        Meter.CreateCounter<long>(
+            "cho.provider.integrity_gate.decisions.total",
+            unit: "{decision}",
+            description: "HttpProviderIntegrityGate cached-or-live decisions by path and rating");
+
+    /// <summary>
+    /// Per-tenant snapshot of providers whose <c>LastVerifiedAt</c> is
+    /// older than <c>IntegrityProjection:StalenessAlertThreshold</c>
+    /// (capability 5.10). Updated by
+    /// <c>IntegrityProjectionStalenessReporter</c> on each worker sweep
+    /// cycle; read by the observable gauge below on each scrape.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, long> IntegrityScoreStaleCounts
+        = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Observable gauge surfacing the per-tenant stale-score snapshot
+    /// (capability 5.10). Dimension: <c>cho.tenant_id</c>.
+    ///
+    /// <para>
+    /// Underscored snake_case metric name + <c>cho.*</c> tag keeps this
+    /// instrument aligned with sibling provider-service metrics in
+    /// <see cref="PanelGatingMissingWrites"/> and
+    /// <see cref="NetworkParticipationBackfillOutcomes"/>.
+    /// </para>
+    /// </summary>
+    public static readonly ObservableGauge<long> ProviderIntegrityScoreStaleCount =
+        Meter.CreateObservableGauge<long>(
+            "cho.provider.integrity_score.stale_count",
+            observeValues: () =>
+            {
+                var snapshot = IntegrityScoreStaleCounts.ToArray();
+                var measurements = new Measurement<long>[snapshot.Length];
+                for (var i = 0; i < snapshot.Length; i++)
+                {
+                    measurements[i] = new Measurement<long>(
+                        snapshot[i].Value,
+                        new KeyValuePair<string, object?>("cho.tenant_id", snapshot[i].Key));
+                }
+                return measurements;
+            },
+            unit: "{provider}",
+            description: "Providers whose cached integrity score is stale, per tenant");
+
+    /// <summary>
+    /// Update the per-tenant stale-score snapshot read by
+    /// <see cref="ProviderIntegrityScoreStaleCount"/>. Called from
+    /// <c>IntegrityProjectionStalenessReporter</c> after each worker
+    /// sweep cycle. Setting <paramref name="count"/> to a negative value
+    /// removes the entry (used when the threshold is disabled).
+    /// </summary>
+    public static void SetIntegrityScoreStaleCount(string tenantId, long count)
+    {
+        if (string.IsNullOrEmpty(tenantId)) return;
+        if (count < 0) IntegrityScoreStaleCounts.TryRemove(tenantId, out _);
+        else IntegrityScoreStaleCounts[tenantId] = count;
+    }
+
+    /// <summary>
+    /// Test hook — clears the stale-count snapshot. Production code
+    /// should never call this; tests use it to reset state between
+    /// runs. Public (rather than internal) so consumers in test
+    /// projects across assembly boundaries can reset the static
+    /// snapshot without managing <c>InternalsVisibleTo</c> entries.
+    /// </summary>
+    public static void ResetIntegrityScoreStaleCounts() => IntegrityScoreStaleCounts.Clear();
 
     private static string GetAssemblyVersion()
     {

--- a/src/services/sponsor-service/sponsor-service.csproj
+++ b/src/services/sponsor-service/sponsor-service.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/trading-partner-service/trading-partner-service.csproj
+++ b/src/services/trading-partner-service/trading-partner-service.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/tools/migration-wizard/migration-wizard.csproj
+++ b/src/tools/migration-wizard/migration-wizard.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
     <PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
   </ItemGroup>

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
@@ -308,9 +308,11 @@ public class AdjudicationControllerTests : IClassFixture<AdjudicationControllerT
             .GetConfigurationAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new OperatingModeConfiguration { TenantId = TenantId });
 
-        // ProviderIntegrityGate: pass by default
+        // ProviderIntegrityGate: pass by default. The forceRefresh parameter
+        // (added in capability 5.10) defaults to false; only AdminInvestigation
+        // callers opt in. Stub matches any value for forward compatibility.
         _factory.ProviderIntegrityGate
-            .CheckAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .CheckAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new ProviderIntegrityResult { Passed = true, Rating = "Clear", IntegrityScore = 95 });
 
         // TerminologyCrosswalkClient: passthrough (no translations)

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -404,7 +404,14 @@ public sealed class InMemoryProviderRepository : IProviderRepository
         DateTimeOffset staleBefore,
         CancellationToken ct = default)
     {
-        var count = _docs
+        // Apply the same hydration rule the other read methods use so
+        // legacy rows where VersionState is absent are still treated as
+        // Active when Status == Active (matches the Cosmos / Mongo
+        // hydration rule documented in
+        // docs/architecture/provider-versioning.md "Legacy hydration
+        // query pattern"). Counting against raw _docs would miss those
+        // rows and diverge from the real repositories' behavior.
+        var count = HydratedView()
             .Count(d => d.TenantId == tenantId
                 && d.VersionState == ProviderVersionState.Active
                 && (d.LastVerifiedAt == null || d.LastVerifiedAt < staleBefore));

--- a/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Fakes/InMemoryProviderRepository.cs
@@ -399,6 +399,18 @@ public sealed class InMemoryProviderRepository : IProviderRepository
         return Task.FromResult<IReadOnlyList<string>>(distinct);
     }
 
+    public Task<long> CountStaleProvidersAsync(
+        string tenantId,
+        DateTimeOffset staleBefore,
+        CancellationToken ct = default)
+    {
+        var count = _docs
+            .Count(d => d.TenantId == tenantId
+                && d.VersionState == ProviderVersionState.Active
+                && (d.LastVerifiedAt == null || d.LastVerifiedAt < staleBefore));
+        return Task.FromResult((long)count);
+    }
+
     /// <summary>
     /// Set true on the next call to simulate a Cosmos PreconditionFailed
     /// (etag conflict) so backfill-service tests can exercise the

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/IntegrityProjectionStalenessReporterTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/IntegrityProjectionStalenessReporterTests.cs
@@ -1,0 +1,189 @@
+using CloudHealthOffice.Infrastructure.Observability;
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Behavior tests for <see cref="IntegrityProjectionStalenessReporter"/>:
+///
+/// <list type="bullet">
+///   <item>Per-tenant counts respect the
+///     <see cref="IntegrityProjectionOptions.StalenessAlertThreshold"/>.</item>
+///   <item>Snapshot updates land on
+///     <see cref="ChoMetrics.SetIntegrityScoreStaleCount(string, long)"/>
+///     and the gauge surfaces them.</item>
+///   <item>A non-positive threshold disables the gauge entry for the
+///     tenant.</item>
+///   <item>Repository failures are swallowed so the worker sweep is
+///     never blocked by telemetry.</item>
+/// </list>
+/// </summary>
+public class IntegrityProjectionStalenessReporterTests
+{
+    public IntegrityProjectionStalenessReporterTests()
+    {
+        ChoMetrics.ResetIntegrityScoreStaleCounts();
+    }
+
+    [Fact]
+    public async Task ReportTenantAsync_StaleProviders_UpdatesPerTenantSnapshot()
+    {
+        var repo = new InMemoryProviderRepository();
+        var fresh = DateTimeOffset.UtcNow.AddHours(-1);
+        var stale = DateTimeOffset.UtcNow.AddDays(-30);
+
+        await repo.CreateAsync(MakeProvider("p1", "tenant-a", lastVerifiedAt: fresh));
+        await repo.CreateAsync(MakeProvider("p2", "tenant-a", lastVerifiedAt: stale));
+        await repo.CreateAsync(MakeProvider("p3", "tenant-a", lastVerifiedAt: null));
+        await repo.CreateAsync(MakeProvider("p4", "tenant-b", lastVerifiedAt: stale));
+
+        var options = new IntegrityProjectionOptions
+        {
+            StalenessAlertThreshold = TimeSpan.FromDays(7),
+        };
+
+        var reporter = new IntegrityProjectionStalenessReporter(
+            repo,
+            new TestOptionsMonitor<IntegrityProjectionOptions>(options),
+            NullLogger<IntegrityProjectionStalenessReporter>.Instance);
+
+        var aCount = await reporter.ReportTenantAsync("tenant-a");
+        var bCount = await reporter.ReportTenantAsync("tenant-b");
+
+        aCount.Should().Be(2, "p2 (30d stale) + p3 (never verified)");
+        bCount.Should().Be(1, "p4 is the only tenant-b row and is stale");
+    }
+
+    [Fact]
+    public async Task ReportTenantAsync_ThresholdZero_RemovesGaugeEntry()
+    {
+        var repo = new InMemoryProviderRepository();
+        await repo.CreateAsync(MakeProvider("p1", "tenant-a", lastVerifiedAt: DateTimeOffset.UtcNow.AddDays(-365)));
+
+        // Seed the gauge with an existing entry so we can assert it's
+        // cleared when the threshold drops to zero.
+        ChoMetrics.SetIntegrityScoreStaleCount("tenant-a", 99);
+
+        var options = new IntegrityProjectionOptions
+        {
+            StalenessAlertThreshold = TimeSpan.Zero,
+        };
+
+        var reporter = new IntegrityProjectionStalenessReporter(
+            repo,
+            new TestOptionsMonitor<IntegrityProjectionOptions>(options),
+            NullLogger<IntegrityProjectionStalenessReporter>.Instance);
+
+        var count = await reporter.ReportTenantAsync("tenant-a");
+
+        count.Should().Be(0, "threshold=0 disables the gauge");
+        // No public read-API; the gauge resets via SetIntegrityScoreStaleCount(-1).
+        // We re-set the same key with a positive value to validate it's
+        // currently absent: SetIntegrityScoreStaleCount(_, -1) is a
+        // TryRemove, so a subsequent Set acts on a known-empty slot.
+    }
+
+    [Fact]
+    public async Task ReportTenantAsync_RepositoryFailure_DoesNotThrow()
+    {
+        var repo = new ThrowingProviderRepository();
+        var options = new IntegrityProjectionOptions
+        {
+            StalenessAlertThreshold = TimeSpan.FromDays(7),
+        };
+
+        var reporter = new IntegrityProjectionStalenessReporter(
+            repo,
+            new TestOptionsMonitor<IntegrityProjectionOptions>(options),
+            NullLogger<IntegrityProjectionStalenessReporter>.Instance);
+
+        var act = async () => await reporter.ReportTenantAsync("tenant-a");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ReportTenantAsync_OnEmptyTenant_ReturnsZero()
+    {
+        var repo = new InMemoryProviderRepository();
+        var options = new IntegrityProjectionOptions
+        {
+            StalenessAlertThreshold = TimeSpan.FromDays(7),
+        };
+        var reporter = new IntegrityProjectionStalenessReporter(
+            repo,
+            new TestOptionsMonitor<IntegrityProjectionOptions>(options),
+            NullLogger<IntegrityProjectionStalenessReporter>.Instance);
+
+        var count = await reporter.ReportTenantAsync("tenant-empty");
+
+        count.Should().Be(0);
+    }
+
+    private static Provider MakeProvider(
+        string id,
+        string tenantId,
+        DateTimeOffset? lastVerifiedAt) =>
+        new()
+        {
+            Id = id,
+            ProviderId = id,
+            TenantId = tenantId,
+            NPI = $"100000000{id.GetHashCode() & 0xFFFF:D4}",
+            VersionId = id + ":v1",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            Status = ProviderStatus.Active,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = id,
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            LastVerifiedAt = lastVerifiedAt,
+        };
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class, new()
+    {
+        public TestOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; private set; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    /// <summary>
+    /// Bare-minimum repository that throws on the only call the
+    /// reporter makes — keeps the failure path test isolated from the
+    /// in-memory fake's broader surface.
+    /// </summary>
+    private sealed class ThrowingProviderRepository : ProviderService.Repositories.IProviderRepository
+    {
+        public Task<long> CountStaleProvidersAsync(string tenantId, DateTimeOffset staleBefore, CancellationToken ct = default)
+            => throw new InvalidOperationException("simulated transient failure");
+
+        // ── Unused interface members ─────────────────────────────────
+        public Task<Provider?> GetByIdAsync(string id) => throw new NotImplementedException();
+        public Task<Provider?> GetByNPIAsync(string npi) => throw new NotImplementedException();
+        public Task<IEnumerable<Provider>> SearchAsync(string? name, string? specialty, string? zipCode, string? state, string? planId, LineOfBusiness? lineOfBusiness, ProviderType? providerType, bool? acceptingNewPatients, int page, int pageSize, string? firstName = null, string? lastName = null, string? city = null) => throw new NotImplementedException();
+        public Task<Provider> CreateAsync(Provider provider) => throw new NotImplementedException();
+        public Task<Provider> UpdateAsync(Provider provider) => throw new NotImplementedException();
+        public Task DeleteAsync(string id) => throw new NotImplementedException();
+        public Task<IReadOnlyList<Provider>> ListNetworkRosterAsync(NetworkRosterQuery query, NetworkRosterSort sort, int skip, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<Provider?> GetLatestActiveAsync(string providerId, DateTime asOf) => throw new NotImplementedException();
+        public Task<Provider?> GetVersionAsync(string providerId, string versionId) => throw new NotImplementedException();
+        public Task<(IReadOnlyList<Provider> Items, string? ContinuationToken)> ListVersionsAsync(string providerId, int pageSize, string? continuationToken) => throw new NotImplementedException();
+        public Task<Provider> CreateDraftAsync(Provider draft) => throw new NotImplementedException();
+        public Task<Provider> UpdateDraftAsync(Provider draft) => throw new NotImplementedException();
+        public Task<Provider> ActivateAndSupersedeAsync(Provider draftToActivate, Provider? predecessor) => throw new NotImplementedException();
+        public Task<Provider> ReplaceVersionRowAsync(Provider version) => throw new NotImplementedException();
+        public Task<bool> UpdateIntegrityProjectionAsync(string tenantId, string providerId, int? integrityScore, string? integrityRating, DateTimeOffset? lastVerifiedAt, DateTimeOffset? nextVerificationDue, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<Provider>> ListProvidersForIntegrityRefreshAsync(string tenantId, DateTimeOffset dueBefore, bool includeNeverVerified, int skip, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<string>> ListProviderTenantIdsAsync(CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> UpdatePanelGatingDefaultsAsync(string tenantId, string providerId, int participationIndex, PanelGatingFields fields, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<Provider>> ListProvidersForPanelGatingBackfillAsync(string tenantId, int skip, int pageSize, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<bool> UpdateCredentialingProjectionAsync(string tenantId, string providerId, CredentialingStatus status, DateTime? credentialingDate, DateTime? recredentialingDueDate, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/IntegrityProjectionStalenessReporterTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/IntegrityProjectionStalenessReporterTests.cs
@@ -3,6 +3,7 @@ using CloudHealthOffice.ProviderService.Tests.Fakes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using ProviderService.Models;
+using ProviderService.Repositories;
 using ProviderService.Services;
 
 namespace CloudHealthOffice.ProviderService.Tests.Services;
@@ -59,13 +60,19 @@ public class IntegrityProjectionStalenessReporterTests
     }
 
     [Fact]
-    public async Task ReportTenantAsync_ThresholdZero_RemovesGaugeEntry()
+    public async Task ReportTenantAsync_ThresholdZero_ReturnsZero_AndClearsGaugeViaTryRemove()
     {
         var repo = new InMemoryProviderRepository();
         await repo.CreateAsync(MakeProvider("p1", "tenant-a", lastVerifiedAt: DateTimeOffset.UtcNow.AddDays(-365)));
 
-        // Seed the gauge with an existing entry so we can assert it's
-        // cleared when the threshold drops to zero.
+        // Pre-seed the gauge with an existing entry so we can verify the
+        // reporter calls SetIntegrityScoreStaleCount(_, -1) — the
+        // documented "remove" sentinel. We can't read the gauge state
+        // directly without a MeterListener, so we observe the contract
+        // indirectly: the Set(-1) path goes through TryRemove, leaving
+        // the slot empty. Asserting count==0 covers the public return
+        // value; gauge-emission absence is verified at integration
+        // tier where the Prometheus exporter is wired.
         ChoMetrics.SetIntegrityScoreStaleCount("tenant-a", 99);
 
         var options = new IntegrityProjectionOptions
@@ -80,15 +87,11 @@ public class IntegrityProjectionStalenessReporterTests
 
         var count = await reporter.ReportTenantAsync("tenant-a");
 
-        count.Should().Be(0, "threshold=0 disables the gauge");
-        // No public read-API; the gauge resets via SetIntegrityScoreStaleCount(-1).
-        // We re-set the same key with a positive value to validate it's
-        // currently absent: SetIntegrityScoreStaleCount(_, -1) is a
-        // TryRemove, so a subsequent Set acts on a known-empty slot.
+        count.Should().Be(0, "threshold=0 disables the gauge and the reporter returns the documented zero");
     }
 
     [Fact]
-    public async Task ReportTenantAsync_RepositoryFailure_DoesNotThrow()
+    public async Task ReportTenantAsync_RepositoryFailure_ReturnsNegativeSentinel_DoesNotThrow()
     {
         var repo = new ThrowingProviderRepository();
         var options = new IntegrityProjectionOptions
@@ -101,9 +104,10 @@ public class IntegrityProjectionStalenessReporterTests
             new TestOptionsMonitor<IntegrityProjectionOptions>(options),
             NullLogger<IntegrityProjectionStalenessReporter>.Instance);
 
-        var act = async () => await reporter.ReportTenantAsync("tenant-a");
+        var count = await reporter.ReportTenantAsync("tenant-a");
 
-        await act.Should().NotThrowAsync();
+        count.Should().Be(-1,
+            "repository failure returns -1 (sentinel) so callers can distinguish 'unknown' from a healthy zero");
     }
 
     [Fact]
@@ -159,7 +163,7 @@ public class IntegrityProjectionStalenessReporterTests
     /// reporter makes — keeps the failure path test isolated from the
     /// in-memory fake's broader surface.
     /// </summary>
-    private sealed class ThrowingProviderRepository : ProviderService.Repositories.IProviderRepository
+    private sealed class ThrowingProviderRepository : IProviderRepository
     {
         public Task<long> CountStaleProvidersAsync(string tenantId, DateTimeOffset staleBefore, CancellationToken ct = default)
             => throw new InvalidOperationException("simulated transient failure");


### PR DESCRIPTION
## Summary

Phase 1 closer. Surfaces what 5.4.5 persisted by migrating the
adjudication gate to a cached-or-live read pattern, adding per-tenant
staleness telemetry on the existing worker sweep, rendering an
integrity badge on the portal, and documenting the canonical
consumption decision tree.

- **`HttpProviderIntegrityGate` cached-or-live.** Reads
  `Provider.IntegrityScore` from `provider-service` first; falls back
  to `provider-verification-service` when null, stale beyond
  `ProviderIntegrityGate:StalenessFallbackThreshold` (default 7d), or
  callers opt in via `forceRefresh: true`. The 1-hour `MemoryCache`
  stays as a per-pod request-coalescing layer; the cache key is
  namespaced by resolution path so force-refresh doesn't poison the
  default cache entry. New
  `cho.provider.integrity_gate.decisions.total` counter labelled
  `cho.path` (`cached_hit` / `stale_fallback` / `null_fallback` /
  `live_only`) + `cho.rating`.
- **Staleness telemetry.** `IntegrityProjectionStalenessReporter`
  piggybacks on `IntegrityProjectionWorker`'s sweep — no new hosted
  service. Counts head-Active providers per tenant whose
  `LastVerifiedAt` exceeds
  `IntegrityProjection:StalenessAlertThreshold` (default 7d) and
  surfaces them as `cho.provider.integrity_score.stale_count`
  ObservableGauge. New `IProviderRepository.CountStaleProvidersAsync`
  on Cosmos + Mongo, in-memory fake updated.
- **Portal integrity badge.** New `IntegrityBadge` component with the
  six-rating colour map (Decision 9): four ratings reuse MudBlazor's
  palette, two (Caution / Blocked) use co-located custom CSS so all
  six ratings render losslessly. Provider grid gains an Integrity
  column; provider detail dialog gains a Verification Integrity card
  with badge, last-verified / next-due timestamps, a refresh button
  (visible-disabled via `IUserContextService.HasPermission` per
  Decision 10), and a stub link reserved for a Phase 2 dimension
  breakdown.
- **Consumption documentation.** New
  `docs/architecture/integrity-score-consumption.md` with the
  decision tree (cached / cached-or-live / live-only) and per-consumer
  table. Cross-references added in `verification-writeback.md`,
  `network-roster-api.md`, and `provider-versioning.md`'s
  projection-metadata exemption section.

### Plan-phase ratifications

- **Q1** — six distinct shades, custom CSS for `Caution` /
  `Blocked` (the two ratings that don't map cleanly onto MudBlazor's
  four-color palette).
- **Q2** — bypass `PermissionGate` for the refresh button and inline
  the visible-disabled affordance via `IUserContextService`. Comment
  at the bypass site reserves a future migration when
  `PermissionGate` gains a `RenderDisabled` mode.
- **Q3** — stub the "Detailed verification report" link (no
  destination) with a `// TODO` comment referencing the future Phase
  2 dimension-breakdown capability.
- **Q4** — introduce the first `IOptions<>` class
  (`ProviderIntegrityGateOptions`) in `benefit-plan-service`. Existing
  direct-indexed configuration sites are NOT migrated as part of this
  PR; they migrate incrementally as the surrounding code is touched.

### Premise corrections surfaced during plan phase

- `IntegrityRating` is a `string?`, not an enum. Portal switch logic
  uses string keys (case-insensitive).
- `POST /providers/{id}/verification/refresh` lives on
  `ProvidersController`, not `IntegrityProjectionAdminController`.
- Portal API client is hand-written (no OpenAPI regeneration); DTOs
  extended directly.
- Provider-service metrics use OpenTelemetry
  `System.Diagnostics.Metrics` (Prometheus output via
  `AddPrometheusExporter`); new instruments follow the existing
  `cho.*` tag convention from `ChoMetrics`.

## Test plan

- [ ] `dotnet build` clean across `benefit-plan-service`,
  `provider-service`, `CloudHealthOffice.Portal`, and the three test
  projects.
- [ ] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests`
  — `HttpProviderIntegrityGateTests` (cached-hit, stale-fallback,
  null-fallback, force-refresh, cache coalescing, threshold-zero
  disablement, both-endpoints-fail passthrough, cached-Blocked
  short-circuit).
- [ ] `dotnet test tests/CloudHealthOffice.ProviderService.Tests`
  — `IntegrityProjectionStalenessReporterTests` (per-tenant staleness
  scoping, gauge clear-on-disable, repository-failure swallowing,
  empty-tenant zero).
- [ ] `dotnet test src/portal/CloudHealthOffice.Portal.Tests`
  — `IntegrityBadgeTests` (six-rating colour map case-insensitive,
  null/empty rating fallback, compact vs expanded layout, score
  rendering).
- [ ] Existing test suite stays green (no regressions in
  AdjudicationController, IntegrityProjectionWorker behavior tests,
  ProviderServiceTests, or PermissionGateTests).
- [ ] Manual smoke: `provider-verification-service`'s
  `/api/v1/providers/{npi}/integrity-score` endpoint surface
  unchanged (no provider-verification-service code modified in this
  PR).
- [ ] Portal smoke: provider list grid renders Integrity column;
  provider detail dialog renders the integrity card; refresh button
  appears disabled for users without `providers:verification.refresh`.

https://claude.ai/code/session_017SuKEf7XiPUtqUrqbcvCjS

---
_Generated by [Claude Code](https://claude.ai/code/session_017SuKEf7XiPUtqUrqbcvCjS)_