### PR TITLE
5.5 — NetworkTier as Reference to Organization (benefit-plan)

### DIFF
--- a/docs/architecture/integrity-score-consumption.md
+++ b/docs/architecture/integrity-score-consumption.md
@@ -224,3 +224,7 @@ block alongside the rest of the Sentinel palette.
   (`ProviderIntegrityScoreExt` extension consumer).
 - `fhir-practitionerrole-projection.md` — capability 5.8.
 - `fhir-organization-projection.md` — capability 5.9.
+- `network-tier-organization-reference.md` — benefit-plan capability
+  5.5. Adds `IOrganizationLookupClient`, the second consumer of the
+  `HttpClient("ProviderService")` registration introduced here for
+  `HttpProviderIntegrityGate`.

--- a/docs/architecture/network-tier-organization-reference.md
+++ b/docs/architecture/network-tier-organization-reference.md
@@ -1,0 +1,297 @@
+# NetworkTier as Reference to Organization (Capability 5.5)
+
+> Replaces the legacy embedded NPI snapshot on `BenefitPlan.NetworkTier`
+> with a reference to the canonical `Organization` entity in
+> provider-service (capability 5.3). This is the realization of the
+> "Provider 5.3 unblock" called out in
+> [`network-as-organization.md`](./network-as-organization.md).
+
+## Why
+
+Until 5.5, each `BenefitPlan.NetworkTier` carried an embedded
+`ProviderNpis: List<string>` snapshot of the providers in that tier.
+That shape had three problems:
+
+1. **It didn't scale.** A plan with 50,000 in-network providers
+   carried a 50,000-NPI list inside the plan document. Cosmos document
+   size limits (2MB), Mongo working-set efficiency, and JSON
+   serialization all suffered.
+2. **It didn't reference the canonical network.** Provider 5.3 made
+   `Organization` (network) a first-class versioned entity in
+   provider-service. The `NetworkParticipation.NetworkId` field on
+   `Provider` points to it. But `BenefitPlan.NetworkTier` had no link
+   to the same `Organization` — the two services had parallel,
+   disconnected concepts of "network."
+3. **Update propagation was wrong.** When a network's roster changed
+   (provider joins/leaves), every `BenefitPlan` referencing that
+   network needed its `ProviderNpis` list updated. There was no
+   automated propagation; lists drifted from reality.
+
+A repo-wide audit during the 5.5 plan phase turned up a fourth signal:
+`tier.ProviderNpis` was never consulted by any production code path.
+Adjudication's network-tier dimension is an enum
+(`{InNetwork, OutOfNetwork, OutOfArea}`) classified upstream by claims
+scrubbing; the `MemberBenefitView` projection picks the lowest-tier
+name without touching the NPI list. The embedded list was dormant
+data.
+
+5.5 introduces the reference model and treats the legacy field as
+exactly that — legacy data preserved during a defined migration
+window, then removed.
+
+## What changed
+
+### Model
+
+`NetworkTier` (`src/services/benefit-plan-service/Models/BenefitPlan.cs`):
+
+- Adds `NetworkId: string?` — chain-key reference to
+  `Organization.OrganizationId` in provider-service.
+- Marks `ProviderNpis: List<string>` `[Obsolete]` and freezes it as a
+  legacy data carrier. Removed in a follow-up PR after telemetry
+  confirms zero remaining legacy-shape rows.
+- Adds matching XML doc that describes the reference semantics, the
+  null-NetworkId soft-validation contract, and the migration window.
+
+The wire-format DTO `AdapterNetworkTier`
+(`Models/BenefitPlanAdapterResponse.cs`) carries the same field
+addition; the `From` / `ToNetworkTier` mappings round-trip both fields
+during the migration window.
+
+### Cross-service contract
+
+```text
+benefit-plan-service                              provider-service
+        │                                                 │
+        │  GET /api/v1/networks/{id}                      │
+        │  via HttpClient("ProviderService")              │
+        ├────────────────────────────────────────────────►│
+        │                                                 │
+        │  Organization (head Active version)             │
+        │◄────────────────────────────────────────────────┤
+```
+
+`IOrganizationLookupClient`
+(`Services/IOrganizationLookupClient.cs`) is the read seam. It reuses
+the `HttpClient("ProviderService")` registration introduced by
+capability 5.10 (`HttpProviderIntegrityGate`); no new typed client is
+required. The single method —
+`GetOrganizationAsync(networkId, ct)` — returns a small projection
+(`organizationId`, `name`, `effectiveDate`, `terminationDate`) and is
+deliberately resilient: 404, 5xx, and transport failures all surface
+as `null` rather than throwing. Callers apply policy.
+
+### What is **not** in scope
+
+The capability ships only the read-side method that the backfill
+needs — `GetOrganizationAsync`. A per-claim membership check
+(`IsProviderInNetworkAsync`) and its in-process cache are deferred to
+the capability that actually consumes them (likely claims-service
+Phase 1). That decision was reached during the 5.5 plan phase: with
+no current adjudication or member-view consumer of NPI-membership
+checks, building cache + telemetry + a provider-service contract
+addition for zero present-day callers violates the codebase's stated
+YAGNI posture. See "Plan-First record" below.
+
+## Soft validation
+
+Every benefit-plan write surface inspects the supplied tiers and
+records a structured warning + a Prometheus counter for each tier
+that lacks a `NetworkId`. Mirrors Provider 5.5's panel-gating
+soft-validation pattern.
+
+Counter:
+
+```
+cho.benefit_plan.network_tier_missing_networkid_writes.total{cho.caller, cho.tenant_id}
+```
+
+`cho.caller` values: `CreatePlan | UpdatePlan | CreateDraft |
+AmendPublished | PublishAndSupersede`.
+
+Structured warning:
+
+```
+NetworkTierNetworkIdMissing on plan write.
+  caller=<CreatePlan|UpdatePlan|CreateDraft|AmendPublished|PublishAndSupersede>
+  tenantId=<tenant>
+  planId=<chain key>
+  versionId=<per-version id>
+  tierIndex=<int>
+  tierName=<operator label>
+  tierLevel=<int>
+```
+
+Operators dashboard the counter and watch it trend to zero. The
+follow-up PR flips soft validation to hard validation (400 with
+explanation, counter no longer needs to fire) once telemetry shows
+zero soft-warning producers across all tenants for a sustained window
+— typically 7+ days.
+
+## Backfill — admin HTTP endpoint
+
+```
+POST /api/v1/admin/benefit-plans/backfill-network-tiers?tenantId={X}
+
+{
+  "mappings": [
+    { "planId": "plan-001", "tierName": "In-Network",     "networkId": "org-aetna-ppo-fl-2025" },
+    { "planId": "plan-001", "tierName": "Out-of-Network", "networkId": "org-non-network" },
+    { "planId": "plan-002", "tierName": "Preferred",      "networkId": "org-cigna-pref-2025" }
+  ]
+}
+```
+
+### Authorization
+
+Two layers, both required:
+
+1. **Deployment-layer ACL** (NetworkPolicy / gateway). Load-bearing.
+2. **Feature flag** `NetworkTierBackfill:AdminBackfillEnabled = true`.
+   Defence-in-depth tripwire. When false the controller returns 503
+   (not 404) so operators see "endpoint exists, intentionally gated"
+   rather than "route was never registered."
+
+### Mapping strategy — operator-driven (Decision 5b)
+
+The request body carries an explicit
+`(planId, tierName) → networkId` dictionary. The service does not
+auto-resolve from any embedded NPI snapshot. Two reasons:
+
+1. Tenant data quality varies — auto-resolution against
+   provider-service requires that the Provider/Organization data is
+   already correct in that tenant's CHO instance. For pilot tenants
+   newly onboarded, this isn't guaranteed.
+2. Since `ProviderNpis` was never consulted in adjudication, a tenant
+   may carry seeded-but-stale values that don't reflect the canonical
+   roster. Auto-resolution against stale snapshots would compound the
+   problem.
+
+Operators submit the mapping intentionally; the service validates
+each `networkId` resolves in provider-service (records `unresolved` if
+not) before writing.
+
+### Idempotency
+
+The backfill is rerun-safe. A tier with a non-null `NetworkId` is
+counted under `skipped` and not re-patched. A rerun therefore
+produces a deterministic outcome: previously-mapped tiers stay
+mapped, newly-supplied mappings become applied, unresolved or
+unmappable tiers stay null and surface in the result issues list.
+
+### Outcomes
+
+```
+{
+  "backfillRunId": "<guid>",
+  "mappingsSubmitted": 3,
+  "patched":    2,
+  "skipped":    0,
+  "notFound":   0,
+  "unresolved": 1,
+  "failed":     0,
+  "issues": [
+    {
+      "planId": "plan-002",
+      "tierName": "Preferred",
+      "networkId": "org-cigna-pref-2025",
+      "outcome": "unresolved",
+      "detail": "Organization not resolvable in provider-service."
+    }
+  ]
+}
+```
+
+Counter:
+
+```
+cho.benefit_plan.network_tier.backfill.outcomes.total{cho.outcome, cho.tenant_id}
+```
+
+`cho.outcome` values: `patched | skipped | not_found | unresolved | failed`.
+
+## Version-immutability bypass
+
+The backfill writes to existing Published `BenefitPlan` rows. The
+default `UpdateAsync` path rejects writes against Published versions
+(create an amendment). 5.5 adds a sibling repository method that
+writes only the `NetworkTiers` collection on the head Active row via
+field-scoped patch (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`;
+Mongo `UpdateOneAsync` with `$set`) — no PlanVersion row created, no
+`PlanVersionEvent` emitted.
+
+Identity-bearing field writes still go through `UpdateAsync` and
+respect version-state enforcement. The exemption is documented in
+[`plan-versioning.md`](./plan-versioning.md) "Projection metadata —
+exempt from versioning"; the framework lifts directly from
+[`provider-versioning.md`](./provider-versioning.md).
+
+## Plan-First record
+
+The Plan-First gate that preceded this capability surfaced two
+material premise corrections that shaped the final scope:
+
+1. **Adjudication does not consult `tier.ProviderNpis`.**
+   `AdjudicationController.cs:884`'s `NetworkTier` property is the
+   `CloudHealthOffice.BenefitEngine.Domain.NetworkTier { InNetwork,
+   OutOfNetwork, OutOfArea }` enum, not the embedded class. There is
+   no `ProviderNpis.Contains(npi)` site anywhere in `src/`.
+2. **`MemberBenefitView` projection does not consult
+   `tier.ProviderNpis` either.** `BenefitViewService.cs:66-68` selects
+   the in-network tier name by tier-level ranking; no NPI lookup
+   flows through the projection.
+
+With both adjudication and member-view paths uninvolved, the
+capability scope reduced to the model change + backfill +
+write-time validation client. The cache, the per-claim membership
+check, and any provider-service contract addition required to support
+them were all deferred to the consumer that genuinely needs them.
+
+## What this capability unblocks
+
+- **5.8 — FHIR `InsurancePlan` projection.** `InsurancePlan.network`
+  references `Organization` resources. After 5.5 each
+  `NetworkTier.NetworkId` becomes an `InsurancePlan.network`
+  reference resolving via fhir-service to provider-service's
+  `Organization` endpoint.
+- **Future claims-service / FFS membership-check capability.**
+  Whichever service first needs "is NPI X in network Y?" can build
+  its own typed client (cache TTL + telemetry tuned to its access
+  pattern) and add the corresponding endpoint on provider-service
+  rather than inheriting an over-fitted contract from 5.5.
+
+## Recovery posture
+
+- **Backfill operator-supplied mapping wrong.** Re-run with corrected
+  mapping; previously-patched tiers are skipped; the corrected
+  mapping is applied against the offending tier's existing
+  `NetworkId` (which was wrong) — the rerun is idempotent on
+  already-mapped tiers, so a wrong mapping requires either a manual
+  amendment of the plan or a follow-up "force overwrite" mode (not
+  shipped in 5.5; defer to first reported incident).
+- **`UpdateNetworkTiersAsync` interpreted as version-identity
+  change.** Fast revert; the sibling-method bypass is fully
+  orthogonal to the identity-write path. Tests pin the orthogonality.
+- **Existing legacy `tier.ProviderNpis` data.** Preserved during
+  migration; never consulted; field removal deferred to a follow-up
+  PR once telemetry confirms zero remaining legacy-shape rows.
+- **Worst-case rollback: revert this PR.** Adjudication has nothing
+  to fall back to (it was never consuming NPI lists), so revert
+  affects only the model surface and the backfill endpoint. Any
+  `NetworkId` values written by the backfill stay present (extra
+  field; no harm).
+
+## See also
+
+- [`network-as-organization.md`](./network-as-organization.md) —
+  Provider 5.3 first-class network entity.
+- [`plan-versioning.md`](./plan-versioning.md) — projection-metadata
+  exemption framework.
+- [`provider-versioning.md`](./provider-versioning.md) — same
+  exemption framework on the provider side; 5.5 replicates the
+  pattern.
+- [`integrity-score-consumption.md`](./integrity-score-consumption.md)
+  — companion read-side client (`HttpProviderIntegrityGate`); shares
+  the same `HttpClient("ProviderService")` registration.
+- [`network-participation-backfill.md`](./network-participation-backfill.md)
+  — Provider 5.5 backfill pattern this capability mirrors.

--- a/docs/architecture/network-tier-organization-reference.md
+++ b/docs/architecture/network-tier-organization-reference.md
@@ -217,8 +217,9 @@ default `UpdateAsync` path rejects writes against Published versions
 (create an amendment). 5.5 adds a sibling repository method that
 writes only the `NetworkTiers` collection on the head Active row via
 field-scoped patch (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`;
-Mongo `UpdateOneAsync` with `$set`) — no PlanVersion row created, no
-`PlanVersionEvent` emitted.
+Mongo `FindOneAndUpdateAsync` with sort-by-`VersionNumber` and `$set`
+for the head-row patch in one round trip) — no PlanVersion row
+created, no `PlanVersionEvent` emitted.
 
 Identity-bearing field writes still go through `UpdateAsync` and
 respect version-state enforcement. The exemption is documented in
@@ -262,13 +263,15 @@ them were all deferred to the consumer that genuinely needs them.
 
 ## Recovery posture
 
-- **Backfill operator-supplied mapping wrong.** Re-run with corrected
-  mapping; previously-patched tiers are skipped; the corrected
-  mapping is applied against the offending tier's existing
-  `NetworkId` (which was wrong) — the rerun is idempotent on
-  already-mapped tiers, so a wrong mapping requires either a manual
-  amendment of the plan or a follow-up "force overwrite" mode (not
-  shipped in 5.5; defer to first reported incident).
+- **Backfill operator-supplied mapping wrong.** Re-run with the
+  corrected mapping only to continue patching tiers that have not yet
+  been written; previously-patched tiers are skipped (the rerun is
+  idempotent on already-mapped tiers). A tier whose existing
+  `NetworkId` was set from the wrong mapping is **not** corrected by
+  rerun under the 5.5 backfill semantics — recovery requires either a
+  manual amendment of the affected plan or a follow-up "force
+  overwrite" mode (not shipped in 5.5; defer to first reported
+  incident).
 - **`UpdateNetworkTiersAsync` interpreted as version-identity
   change.** Fast revert; the sibling-method bypass is fully
   orthogonal to the identity-write path. Tests pin the orthogonality.

--- a/docs/architecture/plan-versioning.md
+++ b/docs/architecture/plan-versioning.md
@@ -159,6 +159,89 @@ member-view consolidation tracked under `TODO(deprecate-plans-route)`;
 versions endpoints will be mirrored there when that consolidation
 lands.
 
+## Projection metadata — exempt from versioning
+
+A small, deliberately-bounded set of fields on a `BenefitPlan` row is
+operationally distinct from version identity. These fields are
+patched in place on the head Published row through sibling repository
+methods that bypass the `UpdateAsync` "Published is read-only" guard.
+The exemption is the exact pattern Provider 5.4.5 / 5.5 established in
+[`provider-versioning.md`](./provider-versioning.md) under the section
+of the same name; the principle is unchanged here.
+
+### Why an exemption exists
+
+A version is identity. Cost-sharing math, benefit categories,
+network-tier definitions, plan-year boundaries, prior-auth gates — all
+of those are part of what makes one Published version distinct from
+its predecessor. Updating any of them must produce a new Draft, then a
+new Published version, with its own row in the chain.
+
+A handful of fields on the same document are *projections* of state
+managed by another service or another lifecycle. They are not part of
+the plan's identity; they are a cached read-side snapshot kept on the
+plan row for query convenience. Forcing every refresh through a full
+amendment would create a Published row per refresh — millions per
+year across a tenant population — purely to track operational metadata
+that has no benefit-design content.
+
+Both lanes coexist. Identity-bearing fields go through `UpdateAsync`
+(fails on Published); projection-metadata fields go through their
+dedicated sibling method.
+
+### Fields exempt today
+
+| Field | Owner | Sibling method | Capability |
+|-------|-------|----------------|------------|
+| `NetworkTiers[].NetworkId` | provider-service `Organization` (5.3) | `UpdateNetworkTiersAsync(tenantId, planId, tiers, ct)` | 5.5 — NetworkTier as Reference to Organization |
+
+`UpdateNetworkTiersAsync` resolves the head Published row by chain
+key, then patches the entire `NetworkTiers` collection with a single
+field-scoped op (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`;
+Mongo `UpdateOneAsync` with `$set`). No `PlanVersionEvent` is
+emitted — the operation is a projection-metadata refresh, not a chain
+transition.
+
+### Invariants the bypass must preserve
+
+1. **No version-state writes.** The bypass method must not change
+   `VersionState`, `VersionId`, `VersionNumber`, `PredecessorVersionId`,
+   `PublishedAt`, `SupersededAt`, or any other identity field. A
+   patch op that touches any of those is a bug.
+2. **`UpdateAsync` still enforces immutability.** A regular
+   `UpdateAsync` against a Published row continues to raise
+   `PlanVersionStateException`. The projection patch and the identity
+   write are fully orthogonal — covered by
+   [`UpdateNetworkTiersAsyncTests`](../../src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/UpdateNetworkTiersAsyncTests.cs).
+3. **Single field scope.** Each bypass method patches exactly one
+   logical concern. A future field that wants the exemption must add
+   a new sibling method, not extend an existing one to cover unrelated
+   fields.
+4. **Idempotent.** Re-running the same patch is safe by construction:
+   the bypass writes deterministic values, never relative deltas.
+
+### Adding a new projection-metadata field
+
+Future capabilities that want this exemption should:
+
+1. Document the field's owner (the service / lifecycle that produces
+   the value).
+2. Add a sibling repository method named
+   `Update<Field>ProjectionAsync` (or `Update<Field>Async` when the
+   semantics are richer than a projection refresh — see
+   `UpdateNetworkTiersAsync`).
+3. Implement Cosmos and Mongo variants symmetrically. The Mongo
+   variant uses `UpdateOneAsync` with `$set`; the Cosmos variant uses
+   `PatchItemAsync` with field-scoped `Set` ops.
+4. Add a row to the table above so the exemption stays auditable.
+5. Cover both lanes in tests: the bypass succeeds against Published,
+   and the corresponding `UpdateAsync` against the same row still
+   throws.
+
+A field that doesn't meet the "managed by another service or another
+lifecycle" bar isn't projection metadata — it's identity, and the
+amendment path is the right tool.
+
 ## Caveats / follow-ups
 
 - **Terminate-without-successor.** `SupersedeVersionAsync` currently
@@ -168,3 +251,9 @@ lands.
 - **Cross-tenant draft isolation.** Drafts are partitioned by
   `TenantId` like every other row; no extra access control beyond the
   tenant middleware is implemented in this PR.
+- **Hard validation of `NetworkTier.NetworkId`.** Capability 5.5
+  ships nullable `NetworkId` with soft-validation telemetry. The
+  follow-up flips to hard validation once
+  `cho.benefit_plan.network_tier_missing_networkid_writes.total` reads
+  zero across all tenants for a sustained window. See
+  [`network-tier-organization-reference.md`](./network-tier-organization-reference.md).

--- a/docs/architecture/plan-versioning.md
+++ b/docs/architecture/plan-versioning.md
@@ -198,7 +198,8 @@ dedicated sibling method.
 `UpdateNetworkTiersAsync` resolves the head Published row by chain
 key, then patches the entire `NetworkTiers` collection with a single
 field-scoped op (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`;
-Mongo `UpdateOneAsync` with `$set`). No `PlanVersionEvent` is
+Mongo `FindOneAndUpdateAsync` with sort-by-`VersionNumber` and `$set`,
+patching the head row in one round trip). No `PlanVersionEvent` is
 emitted — the operation is a projection-metadata refresh, not a chain
 transition.
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
@@ -23,7 +23,7 @@ public class BenefitPlansControllerVersionTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         var viewService = new BenefitViewService(service, NullLogger<BenefitViewService>.Instance);
 
         // Default adapter: real CHO adapter backed by the in-memory service so

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/NetworkTierBackfillAdminControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/NetworkTierBackfillAdminControllerTests.cs
@@ -1,0 +1,134 @@
+using BenefitPlanService.Controllers;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.5 — admin endpoint for the operator-driven NetworkId
+/// backfill. Verifies the feature-flag tripwire, the request-shape
+/// validation, and that approved requests reach the underlying service.
+/// </summary>
+public sealed class NetworkTierBackfillAdminControllerTests
+{
+    [Fact]
+    public async Task BackfillNetworkTiers_Returns_503_When_Feature_Flag_Is_Off()
+    {
+        var (controller, _) = Build(adminEnabled: false);
+
+        var response = await controller.BackfillNetworkTiers(
+            tenantId: "tenant-a",
+            request: new NetworkTierBackfillRequest(),
+            ct: default);
+
+        var status = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task BackfillNetworkTiers_Returns_400_When_TenantId_Missing()
+    {
+        var (controller, _) = Build(adminEnabled: true);
+
+        var response = await controller.BackfillNetworkTiers(
+            tenantId: "",
+            request: new NetworkTierBackfillRequest(),
+            ct: default);
+
+        response.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task BackfillNetworkTiers_Returns_400_When_Mappings_Exceed_Cap()
+    {
+        var (controller, _) = Build(adminEnabled: true, maxMappingsPerCall: 2);
+
+        var request = new NetworkTierBackfillRequest
+        {
+            Mappings = Enumerable.Range(0, 3)
+                .Select(i => new NetworkTierBackfillMapping
+                {
+                    PlanId = $"plan-{i}",
+                    TierName = "In-Network",
+                    NetworkId = $"net-{i}",
+                })
+                .ToList(),
+        };
+
+        var response = await controller.BackfillNetworkTiers("tenant-a", request, default);
+
+        response.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task BackfillNetworkTiers_Forwards_Approved_Request_To_Service_And_Returns_The_Result()
+    {
+        var (controller, service) = Build(adminEnabled: true);
+        service.NextResult = new NetworkTierBackfillResult { Patched = 7 };
+
+        var response = await controller.BackfillNetworkTiers(
+            tenantId: "tenant-a",
+            request: new NetworkTierBackfillRequest
+            {
+                Mappings = new()
+                {
+                    new() { PlanId = "plan-1", TierName = "In-Network", NetworkId = "net-1" },
+                },
+            },
+            ct: default);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<NetworkTierBackfillResult>().Which.Patched.Should().Be(7);
+        service.LastTenantId.Should().Be("tenant-a");
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.Mappings.Should().ContainSingle(m => m.PlanId == "plan-1");
+    }
+
+    private static (NetworkTierBackfillAdminController controller, RecordingBackfillService service) Build(
+        bool adminEnabled,
+        int maxMappingsPerCall = 5_000)
+    {
+        var service = new RecordingBackfillService();
+        var options = new NetworkTierBackfillOptions
+        {
+            AdminBackfillEnabled = adminEnabled,
+            MaxMappingsPerCall = maxMappingsPerCall,
+        };
+        var monitor = new SingleValueOptionsMonitor<NetworkTierBackfillOptions>(options);
+        var controller = new NetworkTierBackfillAdminController(
+            service, monitor, NullLogger<NetworkTierBackfillAdminController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+        return (controller, service);
+    }
+
+    private sealed class RecordingBackfillService : INetworkTierBackfillService
+    {
+        public NetworkTierBackfillResult NextResult { get; set; } = new();
+        public string? LastTenantId { get; private set; }
+        public NetworkTierBackfillRequest? LastRequest { get; private set; }
+
+        public Task<NetworkTierBackfillResult> RunTenantAsync(
+            string tenantId,
+            NetworkTierBackfillRequest request,
+            CancellationToken ct = default)
+        {
+            LastTenantId = tenantId;
+            LastRequest = request;
+            return Task.FromResult(NextResult);
+        }
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -160,7 +160,7 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
         var head = _docs
             .Where(d => d.TenantId == tenantId
                 && d.PlanId == planId
-                && (d.VersionState == PlanVersionState.Published || d.VersionState == default)
+                && d.VersionState == PlanVersionState.Published
                 && d.EffectiveDate <= asOf
                 && (d.TerminationDate == null || d.TerminationDate >= asOf))
             .OrderByDescending(d => d.VersionNumber)

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -150,6 +150,29 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
         return Task.FromResult(Clone(draft));
     }
 
+    public Task<bool> UpdateNetworkTiersAsync(
+        string tenantId,
+        string planId,
+        IReadOnlyList<NetworkTier> tiers,
+        CancellationToken ct = default)
+    {
+        var asOf = DateTime.UtcNow;
+        var head = _docs
+            .Where(d => d.TenantId == tenantId
+                && d.PlanId == planId
+                && (d.VersionState == PlanVersionState.Published || d.VersionState == default)
+                && d.EffectiveDate <= asOf
+                && (d.TerminationDate == null || d.TerminationDate >= asOf))
+            .OrderByDescending(d => d.VersionNumber)
+            .FirstOrDefault();
+
+        if (head is null) return Task.FromResult(false);
+
+        head.NetworkTiers = tiers.ToList();
+        head.ModifiedDate = DateTime.UtcNow;
+        return Task.FromResult(true);
+    }
+
     public Task<BenefitPlan> PublishAndSupersedeAsync(BenefitPlan draftToPublish, BenefitPlan? predecessor)
     {
         if (FailNextPublish)
@@ -252,6 +275,17 @@ public sealed class FakePlanYearTransitionPublisher : IPlanYearTransitionPublish
             CorrelationId = correlationId,
             OccurredAt = DateTime.UtcNow
         };
+}
+
+/// <summary>
+/// No-op <see cref="INetworkTierSoftValidator"/> for service-level
+/// tests that don't exercise the soft-validation telemetry path. Tests
+/// that do exercise it construct <see cref="NetworkTierSoftValidator"/>
+/// directly with their own logger / options.
+/// </summary>
+public sealed class NoOpNetworkTierSoftValidator : INetworkTierSoftValidator
+{
+    public void Inspect(BenefitPlan plan, NetworkTierWriteCaller caller) { }
 }
 
 public sealed class FakePlanYearScheduleSource : IPlanYearScheduleSource

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
@@ -27,7 +27,7 @@ public class TypedBenefitRoundTripTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         return (service, repo, transitions, events);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/UpdateNetworkTiersAsyncTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/UpdateNetworkTiersAsyncTests.cs
@@ -1,0 +1,125 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Tests.Fakes;
+
+namespace BenefitPlanService.Tests.Repositories;
+
+/// <summary>
+/// Capability 5.5 — projection-metadata bypass writes for
+/// <c>BenefitPlan.NetworkTiers</c>. The bypass is exempt from the
+/// <c>UpdateAsync</c> "Published is read-only" guard (mirrors
+/// <c>UpdateIntegrityProjectionAsync</c> on provider-service). These
+/// tests pin the contract on the in-memory fake and document the
+/// invariant that real repositories must preserve.
+/// </summary>
+public sealed class UpdateNetworkTiersAsyncTests
+{
+    private const string Tenant = "tenant-a";
+    private const string PlanId = "plan-001";
+
+    [Fact]
+    public async Task UpdateNetworkTiersAsync_Patches_Head_Published_Row_Without_Triggering_Version_Guard()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        await SeedPublishedAsync(repo);
+
+        var newTiers = new List<NetworkTier>
+        {
+            new() { TierName = "In-Network", TierLevel = 1, NetworkId = "net-1" },
+            new() { TierName = "Out-of-Network", TierLevel = 2, NetworkId = "net-2" },
+        };
+
+        var ok = await repo.UpdateNetworkTiersAsync(Tenant, PlanId, newTiers);
+
+        ok.Should().BeTrue();
+        var head = await repo.GetLatestPublishedAsync(PlanId, Tenant, DateTime.UtcNow);
+        head.Should().NotBeNull();
+        head!.NetworkTiers.Should().HaveCount(2);
+        head.NetworkTiers.Single(t => t.TierName == "In-Network").NetworkId.Should().Be("net-1");
+        head.NetworkTiers.Single(t => t.TierName == "Out-of-Network").NetworkId.Should().Be("net-2");
+    }
+
+    [Fact]
+    public async Task UpdateNetworkTiersAsync_Returns_False_When_No_Published_Head()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+
+        var ok = await repo.UpdateNetworkTiersAsync(Tenant, "ghost-plan", Array.Empty<NetworkTier>());
+
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateNetworkTiersAsync_Skips_Draft_Heads()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        await SeedDraftAsync(repo);
+
+        var ok = await repo.UpdateNetworkTiersAsync(Tenant, PlanId, new List<NetworkTier>
+        {
+            new() { TierName = "In-Network", NetworkId = "net-1" },
+        });
+
+        // No Published version exists → the bypass returns false rather
+        // than upgrading the Draft.
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Still_Throws_On_Published_Rows_After_Bypass_Patch()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var head = await SeedPublishedAsync(repo);
+
+        await repo.UpdateNetworkTiersAsync(Tenant, PlanId, new List<NetworkTier>
+        {
+            new() { TierName = "In-Network", NetworkId = "net-1" },
+        });
+
+        // Identity-write path is unaffected: a regular UpdateAsync against
+        // a Published row still raises PlanVersionStateException.
+        head.PlanName = "Renamed Mid-Flight";
+        await FluentActions
+            .Invoking(() => repo.UpdateAsync(head))
+            .Should().ThrowAsync<BenefitPlanService.Repositories.PlanVersionStateException>();
+    }
+
+    private static async Task<BenefitPlan> SeedPublishedAsync(InMemoryBenefitPlanRepository repo)
+    {
+        var plan = new BenefitPlan
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = Tenant,
+            PlanId = PlanId,
+            PlanName = "Sample",
+            Payer = "Acme Health",
+            EffectiveDate = DateTime.UtcNow.AddMonths(-3),
+            VersionId = Guid.NewGuid().ToString(),
+            VersionNumber = 1,
+            VersionState = PlanVersionState.Published,
+            NetworkTiers = new()
+            {
+                new NetworkTier { TierName = "In-Network", TierLevel = 1 },
+                new NetworkTier { TierName = "Out-of-Network", TierLevel = 2 },
+            },
+        };
+        await repo.CreateAsync(plan);
+        return plan;
+    }
+
+    private static async Task SeedDraftAsync(InMemoryBenefitPlanRepository repo)
+    {
+        var draft = new BenefitPlan
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = Tenant,
+            PlanId = PlanId,
+            PlanName = "Sample Draft",
+            Payer = "Acme Health",
+            EffectiveDate = DateTime.UtcNow.AddMonths(-3),
+            VersionId = Guid.NewGuid().ToString(),
+            VersionNumber = 1,
+            VersionState = PlanVersionState.Draft,
+        };
+        await repo.CreateDraftAsync(draft);
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
@@ -24,7 +24,7 @@ public class BenefitPlanServiceVersionTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         return (service, repo, transitions, events);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpOrganizationLookupClientTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpOrganizationLookupClientTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Adapters;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability 5.5 — verifies the HTTP-only contract between
+/// benefit-plan-service and provider-service for Organization
+/// resolution. Mirrors the failure-mode posture from
+/// <see cref="HttpProviderIntegrityGate"/>: 404 and transport failures
+/// surface as <c>null</c>; the caller decides policy.
+/// </summary>
+public sealed class HttpOrganizationLookupClientTests
+{
+    [Fact]
+    public async Task GetOrganizationAsync_Returns_The_Organization_When_Resolved()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            "{\"organizationId\":\"net-1\",\"name\":\"Aetna PPO Florida 2025\",\"effectiveDate\":\"2025-01-01T00:00:00Z\"}");
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync("net-1");
+
+        result.Should().NotBeNull();
+        result!.OrganizationId.Should().Be("net-1");
+        result.Name.Should().Be("Aetna PPO Florida 2025");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_Returns_Null_On_404()
+    {
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync("missing-network");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_Returns_Null_On_5xx_Without_Throwing()
+    {
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.InternalServerError);
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync("flaky-network");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_Returns_Null_On_Transport_Failure()
+    {
+        var handler = FakeHttpMessageHandler.Throw(new HttpRequestException("connection refused"));
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync("unreachable");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_Returns_Null_When_NetworkId_Is_Empty()
+    {
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.OK);
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync(string.Empty);
+
+        result.Should().BeNull();
+        // Short-circuit: no HTTP call issued for an empty id.
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_Url_Encodes_The_NetworkId()
+    {
+        string? observedPath = null;
+        var handler = new FakeHttpMessageHandler(req =>
+        {
+            observedPath = req.RequestUri?.AbsolutePath;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"organizationId\":\"net 1\",\"name\":\"With Space\",\"effectiveDate\":\"2025-01-01T00:00:00Z\"}",
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+        var client = BuildClient(handler);
+
+        var result = await client.GetOrganizationAsync("net 1");
+
+        result.Should().NotBeNull();
+        observedPath.Should().Be("/api/v1/networks/net%201");
+    }
+
+    private static HttpOrganizationLookupClient BuildClient(HttpMessageHandler handler)
+    {
+        var factory = new SingleClientFactory(handler);
+        return new HttpOrganizationLookupClient(factory, NullLogger<HttpOrganizationLookupClient>.Instance);
+    }
+
+    private sealed class SingleClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public SingleClientFactory(HttpMessageHandler handler) { _handler = handler; }
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("http://provider-service:8080/"),
+        };
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/NetworkTierBackfillServiceTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/NetworkTierBackfillServiceTests.cs
@@ -1,0 +1,220 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability 5.5 — operator-driven NetworkTier.NetworkId backfill.
+/// Verifies idempotency, soft-miss outcomes, organization
+/// resolution gating, and the head-row patch path through
+/// <see cref="InMemoryBenefitPlanRepository.UpdateNetworkTiersAsync"/>.
+/// </summary>
+public sealed class NetworkTierBackfillServiceTests
+{
+    private const string Tenant = "tenant-a";
+    private const string PlanId = "plan-001";
+
+    [Fact]
+    public async Task RunTenantAsync_Patches_A_Tier_When_NetworkId_Is_Null_And_Organization_Resolves()
+    {
+        var (service, repo, _) = Build(networkResolves: true);
+        await SeedPlanAsync(repo, withNetworkIds: false);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = PlanId, TierName = "In-Network", NetworkId = "net-1" },
+            },
+        });
+
+        result.Patched.Should().Be(1);
+        result.Skipped.Should().Be(0);
+        result.Failed.Should().Be(0);
+
+        var stored = repo.Docs.Single(d => d.PlanId == PlanId);
+        stored.NetworkTiers.Single(t => t.TierName == "In-Network").NetworkId.Should().Be("net-1");
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Is_Idempotent_For_Tiers_Already_Mapped()
+    {
+        var (service, repo, _) = Build(networkResolves: true);
+        await SeedPlanAsync(repo, withNetworkIds: true);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = PlanId, TierName = "In-Network", NetworkId = "net-2" },
+            },
+        });
+
+        result.Patched.Should().Be(0);
+        result.Skipped.Should().Be(1);
+        var stored = repo.Docs.Single(d => d.PlanId == PlanId);
+        stored.NetworkTiers.Single(t => t.TierName == "In-Network").NetworkId.Should().Be("preexisting-net-id");
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Records_Unresolved_When_Organization_Lookup_Returns_Null()
+    {
+        var (service, repo, _) = Build(networkResolves: false);
+        await SeedPlanAsync(repo, withNetworkIds: false);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = PlanId, TierName = "In-Network", NetworkId = "net-bogus" },
+            },
+        });
+
+        result.Patched.Should().Be(0);
+        result.Unresolved.Should().Be(1);
+        var stored = repo.Docs.Single(d => d.PlanId == PlanId);
+        stored.NetworkTiers.Single(t => t.TierName == "In-Network").NetworkId.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Reports_NotFound_When_The_Plan_Has_No_Published_Version()
+    {
+        var (service, _, _) = Build(networkResolves: true);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = "ghost-plan", TierName = "In-Network", NetworkId = "net-1" },
+            },
+        });
+
+        result.NotFound.Should().Be(1);
+        result.Patched.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Reports_Failed_When_Tier_Name_Not_On_Plan()
+    {
+        var (service, repo, _) = Build(networkResolves: true);
+        await SeedPlanAsync(repo, withNetworkIds: false);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = PlanId, TierName = "Phantom-Tier", NetworkId = "net-1" },
+            },
+        });
+
+        result.Failed.Should().Be(1);
+        result.Patched.Should().Be(0);
+        result.Issues.Should().ContainSingle(i =>
+            i.PlanId == PlanId && i.TierName == "Phantom-Tier" && i.Outcome == "failed");
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Empty_Mapping_Set_Is_A_Noop()
+    {
+        var (service, _, _) = Build(networkResolves: true);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest());
+
+        result.MappingsSubmitted.Should().Be(0);
+        result.Patched.Should().Be(0);
+        result.Skipped.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunTenantAsync_Multiple_Tiers_On_Same_Plan_Patch_In_One_Pass()
+    {
+        var (service, repo, _) = Build(networkResolves: true);
+        await SeedPlanAsync(repo, withNetworkIds: false);
+
+        var result = await service.RunTenantAsync(Tenant, new NetworkTierBackfillRequest
+        {
+            Mappings = new()
+            {
+                new() { PlanId = PlanId, TierName = "In-Network",     NetworkId = "net-1" },
+                new() { PlanId = PlanId, TierName = "Out-of-Network", NetworkId = "net-2" },
+            },
+        });
+
+        result.Patched.Should().Be(2);
+        var stored = repo.Docs.Single(d => d.PlanId == PlanId);
+        stored.NetworkTiers.Single(t => t.TierName == "In-Network").NetworkId.Should().Be("net-1");
+        stored.NetworkTiers.Single(t => t.TierName == "Out-of-Network").NetworkId.Should().Be("net-2");
+    }
+
+    private static (NetworkTierBackfillService service,
+                    InMemoryBenefitPlanRepository repo,
+                    StubOrganizationLookup lookup) Build(bool networkResolves)
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var lookup = new StubOrganizationLookup(networkResolves);
+        var options = Options.Create(new NetworkTierBackfillOptions { AdminBackfillEnabled = true });
+        var monitor = new SingleValueOptionsMonitor<NetworkTierBackfillOptions>(options.Value);
+        var service = new NetworkTierBackfillService(
+            repo, lookup, monitor, NullLogger<NetworkTierBackfillService>.Instance);
+        return (service, repo, lookup);
+    }
+
+    private static Task SeedPlanAsync(InMemoryBenefitPlanRepository repo, bool withNetworkIds)
+    {
+        var plan = new BenefitPlan
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = Tenant,
+            PlanId = PlanId,
+            PlanName = "Sample",
+            Payer = "Acme Health",
+            EffectiveDate = DateTime.UtcNow.AddMonths(-3),
+            VersionId = Guid.NewGuid().ToString(),
+            VersionNumber = 1,
+            VersionState = PlanVersionState.Published,
+            NetworkTiers = new()
+            {
+                new NetworkTier
+                {
+                    TierName = "In-Network",
+                    TierLevel = 1,
+                    NetworkId = withNetworkIds ? "preexisting-net-id" : null,
+                },
+                new NetworkTier
+                {
+                    TierName = "Out-of-Network",
+                    TierLevel = 2,
+                    NetworkId = null,
+                },
+            },
+        };
+        return repo.CreateAsync(plan);
+    }
+
+    private sealed class StubOrganizationLookup : IOrganizationLookupClient
+    {
+        private readonly bool _resolves;
+        public StubOrganizationLookup(bool resolves) { _resolves = resolves; }
+        public Task<OrganizationLookupResult?> GetOrganizationAsync(string networkId, CancellationToken ct = default)
+        {
+            if (!_resolves) return Task.FromResult<OrganizationLookupResult?>(null);
+            return Task.FromResult<OrganizationLookupResult?>(new OrganizationLookupResult
+            {
+                OrganizationId = networkId,
+                Name = "Resolved",
+                EffectiveDate = DateTime.UtcNow.AddYears(-1),
+            });
+        }
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/NetworkTierSoftValidatorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/NetworkTierSoftValidatorTests.cs
@@ -1,0 +1,107 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability 5.5 — soft-validation telemetry on
+/// <c>BenefitPlan.NetworkTiers</c> writes. Verifies the warning emits
+/// once per offending tier with the expected caller dimension and
+/// passes through cleanly when every tier carries a NetworkId.
+/// </summary>
+public sealed class NetworkTierSoftValidatorTests
+{
+    [Fact]
+    public void Inspect_Emits_One_Warning_Per_Tier_Without_NetworkId()
+    {
+        var logger = new RecordingLogger();
+        var validator = BuildValidator(logger);
+        var plan = new BenefitPlan
+        {
+            TenantId = "tenant-a",
+            PlanId = "plan-001",
+            VersionId = "v1",
+            NetworkTiers = new()
+            {
+                new NetworkTier { TierName = "In-Network",     TierLevel = 1, NetworkId = null },
+                new NetworkTier { TierName = "Out-of-Network", TierLevel = 2, NetworkId = "net-2" },
+                new NetworkTier { TierName = "OON-Tier-3",     TierLevel = 3, NetworkId = "" },
+            },
+        };
+
+        validator.Inspect(plan, NetworkTierWriteCaller.UpdatePlan);
+
+        // Two offending tiers (null + empty), one populated tier — two warnings.
+        logger.Records.Should().HaveCount(2);
+        logger.Records.Should().AllSatisfy(r => r.LogLevel.Should().Be(LogLevel.Warning));
+        logger.Records.All(r => r.Message.Contains("UpdatePlan")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Inspect_Is_A_NoOp_When_Plan_Has_No_Tiers()
+    {
+        var logger = new RecordingLogger();
+        var validator = BuildValidator(logger);
+        var plan = new BenefitPlan { TenantId = "tenant-a", PlanId = "plan-001" };
+
+        validator.Inspect(plan, NetworkTierWriteCaller.CreatePlan);
+
+        logger.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Inspect_Honors_The_Configured_LogLevel()
+    {
+        var logger = new RecordingLogger();
+        var options = new NetworkTierBackfillOptions { SoftValidationLogLevel = LogLevel.Information };
+        var validator = new NetworkTierSoftValidator(
+            new SingleValueOptionsMonitor<NetworkTierBackfillOptions>(options),
+            logger);
+        var plan = new BenefitPlan
+        {
+            TenantId = "tenant-a",
+            PlanId = "plan-001",
+            NetworkTiers = new() { new NetworkTier { TierName = "In-Network", NetworkId = null } },
+        };
+
+        validator.Inspect(plan, NetworkTierWriteCaller.PublishAndSupersede);
+
+        logger.Records.Single().LogLevel.Should().Be(LogLevel.Information);
+    }
+
+    private static NetworkTierSoftValidator BuildValidator(ILogger<NetworkTierSoftValidator> logger)
+    {
+        var options = new NetworkTierBackfillOptions();
+        return new NetworkTierSoftValidator(
+            new SingleValueOptionsMonitor<NetworkTierBackfillOptions>(options),
+            logger);
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class RecordingLogger : ILogger<NetworkTierSoftValidator>
+    {
+        public List<(LogLevel LogLevel, string Message)> Records { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Records.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/services/benefit-plan-service/Controllers/NetworkTierBackfillAdminController.cs
+++ b/src/services/benefit-plan-service/Controllers/NetworkTierBackfillAdminController.cs
@@ -1,0 +1,134 @@
+using BenefitPlanService.Middleware;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Controllers;
+
+/// <summary>
+/// Admin endpoint for the one-shot, operator-triggered backfill that
+/// populates <see cref="NetworkTier.NetworkId"/> on existing benefit
+/// plans (capability 5.5 — NetworkTier as Reference to Organization).
+///
+/// <para>
+/// Authorization is layered: the deployment layer (NetworkPolicy /
+/// gateway ACL) is the load-bearing control, and the
+/// <see cref="NetworkTierBackfillOptions.AdminBackfillEnabled"/> flag
+/// is a defence-in-depth tripwire. When the flag is false the
+/// controller returns 503 Service Unavailable; a misconfigured
+/// gateway can't expose the route just because it's registered.
+/// </para>
+///
+/// <para>
+/// Operations are per-tenant; a multi-tenant rollout is scripted
+/// externally as one call per tenant. Reruns are safe — the service
+/// only writes a <c>NetworkId</c> on tiers where it is currently
+/// null (skipped on reruns).
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/v1/admin/benefit-plans")]
+public sealed class NetworkTierBackfillAdminController : ControllerBase
+{
+    private readonly INetworkTierBackfillService _backfill;
+    private readonly IOptionsMonitor<NetworkTierBackfillOptions> _options;
+    private readonly ILogger<NetworkTierBackfillAdminController> _logger;
+
+    public NetworkTierBackfillAdminController(
+        INetworkTierBackfillService backfill,
+        IOptionsMonitor<NetworkTierBackfillOptions> options,
+        ILogger<NetworkTierBackfillAdminController> logger)
+    {
+        _backfill = backfill;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Apply operator-supplied <c>(planId, tierName) → networkId</c>
+    /// mappings to the supplied tenant. The endpoint is idempotent:
+    /// reruns skip tiers that already have a <c>NetworkId</c> and
+    /// only patch newly-mapped pairs.
+    /// </summary>
+    [HttpPost("backfill-network-tiers")]
+    [ProducesResponseType(typeof(NetworkTierBackfillResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<NetworkTierBackfillResult>> BackfillNetworkTiers(
+        [FromQuery] string tenantId,
+        [FromBody] NetworkTierBackfillRequest request,
+        CancellationToken ct)
+    {
+        if (!_options.CurrentValue.AdminBackfillEnabled)
+        {
+            // 503 (not 404) so operators know the endpoint exists and
+            // is intentionally gated — a 404 would falsely suggest the
+            // route was never registered.
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new
+                {
+                    error = "admin_backfill_disabled",
+                    message =
+                        "Network-tier NetworkId backfill is gated. Set " +
+                        "NetworkTierBackfill:AdminBackfillEnabled=true to enable, " +
+                        "and ensure the deployment layer (NetworkPolicy / gateway ACL) " +
+                        "restricts access to this route.",
+                });
+        }
+
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return BadRequest(new { error = "tenantId query parameter is required" });
+        }
+
+        var contextTenantId = HttpContext.GetTenantId();
+        if (!string.IsNullOrEmpty(contextTenantId)
+            && !string.Equals(contextTenantId, tenantId, StringComparison.Ordinal))
+        {
+            return BadRequest(new
+            {
+                error = "tenant_mismatch",
+                message = "tenantId query parameter does not match the X-Tenant-ID header.",
+            });
+        }
+
+        if (request is null)
+        {
+            return BadRequest(new { error = "request_body_required" });
+        }
+
+        var max = _options.CurrentValue.MaxMappingsPerCall;
+        if (max > 0 && request.Mappings.Count > max)
+        {
+            return BadRequest(new
+            {
+                error = "too_many_mappings",
+                message = $"Mappings count {request.Mappings.Count} exceeds MaxMappingsPerCall={max}.",
+            });
+        }
+
+        request.ActorId ??= ResolveActorId();
+        request.CorrelationId ??= HttpContext.TraceIdentifier;
+
+        _logger.LogInformation(
+            "network-tier backfill triggered tenant={Tenant} mappings={Mappings} actor={Actor}",
+            Sanitize(tenantId), request.Mappings.Count, Sanitize(request.ActorId));
+
+        var result = await _backfill.RunTenantAsync(tenantId, request, ct);
+        return Ok(result);
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) && !string.IsNullOrEmpty(header.ToString()))
+            return header.ToString();
+        return "admin:backfill-network-tiers";
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -290,7 +290,32 @@ public class Benefit
 }
 
 /// <summary>
-/// Network tier (in-network, out-of-network, etc.)
+/// Plan-level network tier (capability 5.5 — NetworkTier as Reference to
+/// Organization). A tier is the operator-facing label and ranking that
+/// claim adjudication uses to bucket cost-sharing (e.g. "In-Network" tier
+/// 1 vs "Out-of-Network" tier 2). After capability 5.5, the canonical
+/// roster lives on the provider-service <c>Organization</c> entity
+/// (capability 5.3) and is referenced here by
+/// <see cref="NetworkId"/> rather than embedded as a static NPI list.
+///
+/// <para>
+/// During the migration window the legacy <see cref="ProviderNpis"/>
+/// field is preserved on the wire so existing documents continue to
+/// hydrate without a backfill — but it is no longer consulted by any
+/// production code path (verified by repo-wide audit during 5.5 plan
+/// phase). The field is removed in a follow-up PR after telemetry
+/// confirms zero remaining legacy-shape rows.
+/// </para>
+///
+/// <para>
+/// <see cref="NetworkId"/> is nullable on purpose. A null value is a
+/// legacy-tier marker that drives the soft-validation counter
+/// <c>cho.benefit_plan.network_tier_missing_networkid_writes_total</c>;
+/// the follow-up hard-validation PR flips this to <c>[Required]</c>
+/// once the counter reads zero across all tenants for a sustained
+/// window. See
+/// <c>docs/architecture/network-tier-organization-reference.md</c>.
+/// </para>
 /// </summary>
 public class NetworkTier
 {
@@ -304,6 +329,25 @@ public class NetworkTier
     [JsonPropertyName("tierLevel")]
     public int TierLevel { get; set; } // 1 = best, 2 = second, etc.
 
+    /// <summary>
+    /// Reference to the canonical <c>Organization.OrganizationId</c>
+    /// (chain key) in provider-service. Resolves the tier's roster
+    /// authoritatively at lookup time rather than from an embedded
+    /// snapshot. Nullable during the 5.5 → hard-validation rollout;
+    /// null produces a soft-validation warning + counter increment.
+    /// </summary>
+    [JsonPropertyName("networkId")]
+    public string? NetworkId { get; set; }
+
+    /// <summary>
+    /// Legacy embedded roster snapshot. Preserved on the wire during
+    /// the 5.5 migration window so existing plan documents continue to
+    /// hydrate; not consulted by any production code path. Removed in
+    /// a follow-up PR once telemetry confirms zero remaining
+    /// legacy-shape rows. New code must use <see cref="NetworkId"/>
+    /// and resolve membership via <c>IOrganizationLookupClient</c>.
+    /// </summary>
+    [Obsolete("Use NetworkId + IOrganizationLookupClient. See docs/architecture/network-tier-organization-reference.md. Field is preserved during the 5.5 migration window only.")]
     [JsonPropertyName("providerNpis")]
     public List<string> ProviderNpis { get; set; } = new();
 }

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -310,7 +310,7 @@ public class Benefit
 /// <para>
 /// <see cref="NetworkId"/> is nullable on purpose. A null value is a
 /// legacy-tier marker that drives the soft-validation counter
-/// <c>cho.benefit_plan.network_tier_missing_networkid_writes_total</c>;
+/// <c>cho.benefit_plan.network_tier_missing_networkid_writes.total</c>;
 /// the follow-up hard-validation PR flips this to <c>[Required]</c>
 /// once the counter reads zero across all tenants for a sustained
 /// window. See

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -517,13 +517,28 @@ public class AdapterNetworkTier
     public string Id { get; set; } = string.Empty;
     public string TierName { get; set; } = string.Empty;
     public int TierLevel { get; set; }
+
+    /// <summary>
+    /// Reference to <c>Organization.OrganizationId</c> in provider-service
+    /// (capability 5.5). Nullable during migration; see
+    /// <see cref="NetworkTier.NetworkId"/>.
+    /// </summary>
+    public string? NetworkId { get; set; }
+
+    /// <summary>
+    /// Legacy embedded roster snapshot. Preserved on the wire during the
+    /// 5.5 migration window. Removed in a follow-up PR.
+    /// </summary>
+    [Obsolete("Use NetworkId. See docs/architecture/network-tier-organization-reference.md.")]
     public List<string> ProviderNpis { get; set; } = new();
 
+#pragma warning disable CS0618 // Round-trip through obsolete field is required during the 5.5 migration window
     public static AdapterNetworkTier From(NetworkTier n) => new()
     {
         Id = n.Id,
         TierName = n.TierName,
         TierLevel = n.TierLevel,
+        NetworkId = n.NetworkId,
         ProviderNpis = n.ProviderNpis.ToList(),
     };
 
@@ -532,8 +547,10 @@ public class AdapterNetworkTier
         Id = Id,
         TierName = TierName,
         TierLevel = TierLevel,
+        NetworkId = NetworkId,
         ProviderNpis = ProviderNpis.ToList(),
     };
+#pragma warning restore CS0618
 }
 
 public class AdapterCostSharing

--- a/src/services/benefit-plan-service/Models/NetworkTierBackfillOptions.cs
+++ b/src/services/benefit-plan-service/Models/NetworkTierBackfillOptions.cs
@@ -1,0 +1,55 @@
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Configuration for the one-time benefit-plan network-tier
+/// <c>NetworkId</c> backfill (capability 5.5 — NetworkTier as Reference
+/// to Organization).
+///
+/// <para>
+/// Mirrors the configuration shape established by
+/// <c>NetworkParticipationBackfillOptions</c> in provider-service 5.5: a
+/// default-false admin gate plus per-call sizing knobs. The operation is
+/// admin-triggered, per-tenant, and idempotent (only writes a
+/// <c>NetworkId</c> on tiers where it is currently null).
+/// </para>
+///
+/// <para>
+/// See <c>docs/architecture/network-tier-organization-reference.md</c>
+/// for operational guidance. The deployment-layer ACL is the
+/// load-bearing authorization — this flag is a tripwire.
+/// </para>
+/// </summary>
+public sealed class NetworkTierBackfillOptions
+{
+    public const string SectionName = "NetworkTierBackfill";
+
+    /// <summary>
+    /// Defence-in-depth gate for the admin backfill endpoint
+    /// (<c>POST /api/v1/admin/benefit-plans/backfill-network-tiers</c>).
+    /// Default <c>false</c>: a misconfigured gateway / NetworkPolicy can't
+    /// expose the endpoint just because the route is registered. Operators
+    /// must explicitly opt in by setting
+    /// <c>NetworkTierBackfill:AdminBackfillEnabled=true</c> in configuration
+    /// AND restrict access at the deployment layer (NetworkPolicy, gateway
+    /// ACL). When disabled, the controller returns 503 Service Unavailable.
+    /// </summary>
+    public bool AdminBackfillEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Maximum number of <c>(planId, tierName) → networkId</c> entries
+    /// accepted in a single request body. Defends against accidental
+    /// oversized payloads. Default 5,000 — large enough for any realistic
+    /// per-tenant cutover, small enough to keep the request bounded.
+    /// </summary>
+    public int MaxMappingsPerCall { get; set; } = 5_000;
+
+    /// <summary>
+    /// Log-level for the soft-validation warning emitted when a write
+    /// surface produces a <see cref="NetworkTier"/> with no
+    /// <see cref="NetworkTier.NetworkId"/>. Default <c>Warning</c>; ops
+    /// can downgrade to <c>Information</c> when volume is the priority,
+    /// or upgrade in an environment driving the hard-validation cutover.
+    /// </summary>
+    public Microsoft.Extensions.Logging.LogLevel SoftValidationLogLevel { get; set; }
+        = Microsoft.Extensions.Logging.LogLevel.Warning;
+}

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -254,6 +254,17 @@ builder.Services.AddHttpClient(HttpProviderIntegrityGate.VerificationServiceClie
 });
 builder.Services.AddSingleton<IProviderIntegrityGate, HttpProviderIntegrityGate>();
 
+// ── Network-Tier → Organization Reference (5.5) ──────────────────────────────
+// Read-side lookup against provider-service capability 5.3 Organization
+// entity. Reuses the ProviderService HttpClient registered above. Backfill
+// service + admin controller realise the operator-driven NetworkId
+// mapping. See docs/architecture/network-tier-organization-reference.md.
+builder.Services.AddSingleton<IOrganizationLookupClient, HttpOrganizationLookupClient>();
+builder.Services.Configure<NetworkTierBackfillOptions>(
+    builder.Configuration.GetSection(NetworkTierBackfillOptions.SectionName));
+builder.Services.AddSingleton<INetworkTierSoftValidator, NetworkTierSoftValidator>();
+builder.Services.AddScoped<INetworkTierBackfillService, NetworkTierBackfillService>();
+
 // ── Terminology Crosswalk Client ─────────────────────────────────────────────
 // Resolves plan-specific procedure code mappings before fee schedule pricing.
 builder.Services.AddHttpClient<ITerminologyCrosswalkClient, HttpTerminologyCrosswalkClient>(client =>

--- a/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
@@ -67,6 +67,37 @@ public interface IBenefitPlanRepository
     /// writes and log a compensating-action warning.
     /// </summary>
     Task<BenefitPlan> PublishAndSupersedeAsync(BenefitPlan draftToPublish, BenefitPlan? predecessor);
+
+    /// <summary>
+    /// Projection-metadata bypass write: replaces the
+    /// <see cref="BenefitPlan.NetworkTiers"/> collection on the head
+    /// Published version of <paramref name="planId"/> without going
+    /// through <see cref="UpdateAsync"/>. Used by the capability 5.5
+    /// network-tier <c>NetworkId</c> backfill (and only by the
+    /// backfill).
+    ///
+    /// <para>
+    /// The Cosmos impl uses <c>PatchItemAsync</c> with a single
+    /// field-scoped <c>Set</c> op, the Mongo impl uses
+    /// <c>UpdateOneAsync</c> with <c>$set</c>. No
+    /// <c>PlanVersionEvent</c> is emitted — the operation is a
+    /// projection-metadata refresh, not a chain transition. See
+    /// <c>docs/architecture/plan-versioning.md</c> "Projection
+    /// metadata — exempt from versioning".
+    /// </para>
+    ///
+    /// <para>
+    /// Returns <c>true</c> when the head row was patched, <c>false</c>
+    /// when no head Published row exists for the plan or the row was
+    /// removed between lookup and patch (treated as a soft miss; the
+    /// backfill counts it under <c>skipped</c>).
+    /// </para>
+    /// </summary>
+    Task<bool> UpdateNetworkTiersAsync(
+        string tenantId,
+        string planId,
+        IReadOnlyList<NetworkTier> tiers,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -388,6 +419,73 @@ public class BenefitPlanRepository : IBenefitPlanRepository
         }
 
         return draftToPublish;
+    }
+
+    public async Task<bool> UpdateNetworkTiersAsync(
+        string tenantId,
+        string planId,
+        IReadOnlyList<NetworkTier> tiers,
+        CancellationToken ct = default)
+    {
+        // Resolve the head Published row by chain key. PatchItemAsync is
+        // keyed on the per-row document Id, so we look up the row id
+        // first. The lookup uses the same legacy-aware predicate as
+        // GetLatestPublishedAsync — versionState = Published OR missing,
+        // restricted to the active effective window.
+        var asOf = DateTime.UtcNow;
+        var query = new QueryDefinition(
+                "SELECT TOP 1 c.id FROM c WHERE c.tenantId = @tenantId AND c.planId = @planId AND " +
+                "(NOT IS_DEFINED(c.versionState) OR c.versionState = @published) AND " +
+                "(NOT IS_DEFINED(c.effectiveDate) OR c.effectiveDate <= @asOf) AND " +
+                "(NOT IS_DEFINED(c.terminationDate) OR c.terminationDate = null OR c.terminationDate >= @asOf) " +
+                "ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@planId", planId)
+            .WithParameter("@published", PlanVersionState.Published.ToString())
+            .WithParameter("@asOf", asOf);
+
+        string? rowId = null;
+        var iterator = _container.GetItemQueryIterator<HeadIdResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            rowId = page.FirstOrDefault()?.Id;
+        }
+
+        if (string.IsNullOrEmpty(rowId)) return false;
+
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/networkTiers", tiers),
+            PatchOperation.Set("/modifiedDate", DateTime.UtcNow),
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<BenefitPlan>(
+                rowId,
+                new PartitionKey(tenantId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Row was deleted between lookup and patch.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Projection of the per-row document id used by the head-row
+    /// lookup in <see cref="UpdateNetworkTiersAsync"/>.
+    /// </summary>
+    private sealed record HeadIdResult
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        public string Id { get; init; } = string.Empty;
     }
 
     private static BenefitPlan Hydrate(BenefitPlan plan)

--- a/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
@@ -78,8 +78,10 @@ public interface IBenefitPlanRepository
     ///
     /// <para>
     /// The Cosmos impl uses <c>PatchItemAsync</c> with a single
-    /// field-scoped <c>Set</c> op, the Mongo impl uses
-    /// <c>UpdateOneAsync</c> with <c>$set</c>. No
+    /// field-scoped <c>Set</c> op; the Mongo impl uses
+    /// <c>FindOneAndUpdateAsync</c> with a sort on
+    /// <c>VersionNumber</c> and <c>$set</c> so the head row is
+    /// resolved and patched in a single round-trip. No
     /// <c>PlanVersionEvent</c> is emitted — the operation is a
     /// projection-metadata refresh, not a chain transition. See
     /// <c>docs/architecture/plan-versioning.md</c> "Projection
@@ -90,7 +92,7 @@ public interface IBenefitPlanRepository
     /// Returns <c>true</c> when the head row was patched, <c>false</c>
     /// when no head Published row exists for the plan or the row was
     /// removed between lookup and patch (treated as a soft miss; the
-    /// backfill counts it under <c>skipped</c>).
+    /// backfill records it under <c>not_found</c>).
     /// </para>
     /// </summary>
     Task<bool> UpdateNetworkTiersAsync(

--- a/src/services/benefit-plan-service/Repositories/BenefitPlanRepositoryMongo.cs
+++ b/src/services/benefit-plan-service/Repositories/BenefitPlanRepositoryMongo.cs
@@ -304,6 +304,48 @@ public class BenefitPlanRepositoryMongo : IBenefitPlanRepository
         return draftToPublish;
     }
 
+    public async Task<bool> UpdateNetworkTiersAsync(
+        string tenantId,
+        string planId,
+        IReadOnlyList<NetworkTier> tiers,
+        CancellationToken ct = default)
+    {
+        // $set on the NetworkTiers collection only — bypasses the
+        // version-state guard on UpdateAsync. Targets the head
+        // Published version of the chain. Legacy-row hydration rule
+        // mirrors GetLatestPublishedAsync (versionState = Published OR
+        // missing) plus effective-window guards.
+        //
+        // FindOneAndUpdate lets us sort by VersionNumber desc within
+        // the same round-trip as the patch — same idiom as
+        // ProviderRepositoryMongo.UpdateIntegrityProjectionAsync.
+        var asOf = DateTime.UtcNow;
+        var b = Builders<BenefitPlan>.Filter;
+        var stateFilter = b.Or(
+            b.Eq(x => x.VersionState, PlanVersionState.Published),
+            b.Exists(x => x.VersionState, false));
+        var filter = b.And(
+            b.Eq(x => x.TenantId, tenantId),
+            b.Eq(x => x.PlanId, planId),
+            stateFilter,
+            b.Lte(x => x.EffectiveDate, asOf),
+            b.Or(
+                b.Eq(x => x.TerminationDate, null),
+                b.Gte(x => x.TerminationDate, asOf)));
+
+        var update = Builders<BenefitPlan>.Update
+            .Set(x => x.NetworkTiers, tiers.ToList())
+            .Set(x => x.ModifiedDate, DateTime.UtcNow);
+
+        var options = new FindOneAndUpdateOptions<BenefitPlan>
+        {
+            Sort = Builders<BenefitPlan>.Sort.Descending(x => x.VersionNumber),
+            ReturnDocument = ReturnDocument.After,
+        };
+        var updated = await _collection.FindOneAndUpdateAsync(filter, update, options, ct);
+        return updated != null;
+    }
+
     private static BenefitPlan Hydrate(BenefitPlan plan)
     {
         if (string.IsNullOrEmpty(plan.VersionId))

--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -62,17 +62,20 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
     private readonly IBenefitPlanRepository _repository;
     private readonly IPlanVersionTransitionRepository _transitions;
     private readonly IPlanVersionEventPublisher _events;
+    private readonly INetworkTierSoftValidator _networkTierValidator;
     private readonly ILogger<BenefitPlanServiceImpl> _logger;
 
     public BenefitPlanServiceImpl(
         IBenefitPlanRepository repository,
         IPlanVersionTransitionRepository transitions,
         IPlanVersionEventPublisher events,
+        INetworkTierSoftValidator networkTierValidator,
         ILogger<BenefitPlanServiceImpl> logger)
     {
         _repository = repository;
         _transitions = transitions;
         _events = events;
+        _networkTierValidator = networkTierValidator;
         _logger = logger;
     }
 
@@ -117,6 +120,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         plan.VersionState = PlanVersionState.Published;
         plan.PublishedAt = DateTime.UtcNow;
 
+        _networkTierValidator.Inspect(plan, NetworkTierWriteCaller.CreatePlan);
         return await _repository.CreateAsync(plan);
     }
 
@@ -130,6 +134,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
 
         plan.TenantId = tenantId;
         plan.UpdatedAt = DateTime.UtcNow;
+        _networkTierValidator.Inspect(plan, NetworkTierWriteCaller.UpdatePlan);
         // Repository raises PlanVersionStateException for Published/Superseded;
         // controller maps to 409.
         return await _repository.UpdateAsync(plan);
@@ -333,6 +338,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         // Legacy IsActive semantics ⇒ Drafts are not active.
         draft.IsActive = false;
 
+        _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.CreateDraft);
         return await _repository.CreateDraftAsync(draft);
     }
 
@@ -389,6 +395,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
             predecessor.IsActive = false;
         }
 
+        _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.PublishAndSupersede);
         await _repository.PublishAndSupersedeAsync(draft, predecessor);
 
         await _transitions.AppendAsync(new PlanVersionTransition
@@ -433,6 +440,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         draft.CreatedAt = DateTime.UtcNow;
         draft.UpdatedAt = DateTime.UtcNow;
 
+        _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.AmendPublished);
         var stored = await _repository.CreateDraftAsync(draft);
 
         await _transitions.AppendAsync(new PlanVersionTransition
@@ -510,12 +518,15 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
     private static Benefit CloneBenefit(Benefit b)
         => JsonSerializer.Deserialize<Benefit>(JsonSerializer.Serialize(b, _benefitCloneOpts), _benefitCloneOpts)!;
 
+#pragma warning disable CS0618 // Cloning ProviderNpis preserves the legacy field during the 5.5 migration window
     private static NetworkTier CloneNetworkTier(NetworkTier n) => new()
     {
         TierName = n.TierName,
         TierLevel = n.TierLevel,
+        NetworkId = n.NetworkId,
         ProviderNpis = n.ProviderNpis.ToList()
     };
+#pragma warning restore CS0618
 
     private static CostSharing CloneCostSharing(CostSharing c) => new()
     {

--- a/src/services/benefit-plan-service/Services/INetworkTierBackfillService.cs
+++ b/src/services/benefit-plan-service/Services/INetworkTierBackfillService.cs
@@ -139,12 +139,28 @@ public sealed class NetworkTierBackfillService : INetworkTierBackfillService
             return result;
         }
 
-        // Group mappings by planId so each plan is loaded and patched
-        // exactly once even when the operator submits multiple tier
-        // mappings against the same plan.
-        var byPlan = request.Mappings
-            .Where(m => !string.IsNullOrWhiteSpace(m.PlanId))
-            .GroupBy(m => m.PlanId, StringComparer.Ordinal);
+        // Validate PlanId per mapping before grouping. Mappings with a
+        // blank/whitespace PlanId are recorded as `failed` (visible in
+        // both the per-tenant counter and the operator-facing result
+        // summary) instead of being silently dropped — submitted-vs-
+        // outcome totals stay in balance and the operator gets explicit
+        // feedback.
+        var validMappings = new List<NetworkTierBackfillMapping>();
+        foreach (var mapping in request.Mappings)
+        {
+            if (string.IsNullOrWhiteSpace(mapping.PlanId))
+            {
+                RecordOutcome(tenantId, "failed", mapping, result, detail: "planId is required.");
+                result.Failed++;
+                continue;
+            }
+            validMappings.Add(mapping);
+        }
+
+        // Group surviving mappings by planId so each plan is loaded and
+        // patched exactly once even when the operator submits multiple
+        // tier mappings against the same plan.
+        var byPlan = validMappings.GroupBy(m => m.PlanId, StringComparer.Ordinal);
 
         foreach (var group in byPlan)
         {
@@ -181,7 +197,13 @@ public sealed class NetworkTierBackfillService : INetworkTierBackfillService
         }
 
         var tiers = plan.NetworkTiers.Select(CloneTier).ToList();
-        var changed = false;
+        // Buffer the mappings that resolved cleanly (organization
+        // exists, tier exists, NetworkId is null today). Their `patched`
+        // counter and result-summary increments are deferred until
+        // UpdateNetworkTiersAsync returns true — a Prometheus counter
+        // can't be decremented, so we never want to emit `patched` for
+        // a mapping whose write later failed.
+        var pendingPatched = new List<NetworkTierBackfillMapping>();
 
         foreach (var mapping in mappings)
         {
@@ -218,48 +240,57 @@ public sealed class NetworkTierBackfillService : INetworkTierBackfillService
             }
 
             tier.NetworkId = mapping.NetworkId;
-            changed = true;
-            result.Patched++;
+            pendingPatched.Add(mapping);
+        }
+
+        if (pendingPatched.Count == 0) return;
+
+        bool writeOk;
+        try
+        {
+            writeOk = await _repository.UpdateNetworkTiersAsync(tenantId, planId, tiers, ct);
+        }
+        catch (Exception ex)
+        {
+            // Repository patch threw — every pendingPatched mapping is
+            // unwritten. Surface them as `failed` (counter + summary)
+            // and continue with the next plan.
+            _logger.LogError(ex,
+                "network-tier backfill failed tenant={Tenant} planId={PlanId} runId={RunId}",
+                SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
+            foreach (var m in pendingPatched)
+            {
+                RecordOutcome(tenantId, "failed", m, result, detail: ex.GetType().Name);
+                result.Failed++;
+            }
+            return;
+        }
+
+        if (!writeOk)
+        {
+            // Lost-write race — head row vanished between
+            // GetLatestPublishedAsync and UpdateNetworkTiersAsync. None
+            // of the pendingPatched mappings were written; record each
+            // as `not_found`.
+            _logger.LogWarning(
+                "network-tier backfill: head row vanished mid-operation tenant={Tenant} planId={PlanId} runId={RunId}",
+                SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
+            foreach (var m in pendingPatched)
+            {
+                RecordOutcome(tenantId, "not_found", m, result, detail: "Head version disappeared during patch.");
+                result.NotFound++;
+            }
+            return;
+        }
+
+        // Write succeeded → emit `patched` once per mapping.
+        foreach (var m in pendingPatched)
+        {
             ChoMetrics.NetworkTierBackfillOutcomes.Add(
                 1,
                 new KeyValuePair<string, object?>("cho.outcome", "patched"),
                 new KeyValuePair<string, object?>("cho.tenant_id", tenantId));
-        }
-
-        if (!changed) return;
-
-        try
-        {
-            var ok = await _repository.UpdateNetworkTiersAsync(tenantId, planId, tiers, ct);
-            if (!ok)
-            {
-                // Lost-write race — head row was deleted between
-                // GetLatestPublishedAsync and UpdateNetworkTiersAsync.
-                // Roll back the per-mapping counters we already recorded
-                // for this plan so the totals still balance.
-                _logger.LogWarning(
-                    "network-tier backfill: head row vanished mid-operation tenant={Tenant} planId={PlanId} runId={RunId}",
-                    SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
-                foreach (var m in mappings)
-                {
-                    if (result.Issues.Any(i => i.PlanId == planId && i.TierName == m.TierName)) continue;
-                    RecordOutcome(tenantId, "not_found", m, result, detail: "Head version disappeared during patch.");
-                    result.NotFound++;
-                    result.Patched--; // we incremented above; undo on miss
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "network-tier backfill failed tenant={Tenant} planId={PlanId} runId={RunId}",
-                SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
-            foreach (var m in mappings)
-            {
-                RecordOutcome(tenantId, "failed", m, result, detail: ex.GetType().Name);
-            }
-            result.Failed += mappings.Count;
-            result.Patched -= mappings.Count;
+            result.Patched++;
         }
     }
 

--- a/src/services/benefit-plan-service/Services/INetworkTierBackfillService.cs
+++ b/src/services/benefit-plan-service/Services/INetworkTierBackfillService.cs
@@ -1,0 +1,304 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Repositories;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// One-shot, operator-triggered, per-tenant backfill that populates
+/// <see cref="NetworkTier.NetworkId"/> on existing benefit plans
+/// (capability 5.5 — NetworkTier as Reference to Organization).
+///
+/// <para>
+/// Operator-driven mapping (Decision 5b): the request body carries an
+/// explicit <c>(planId, tierName) → networkId</c> dictionary. The
+/// service does not auto-resolve from any embedded NPI snapshot —
+/// since <see cref="NetworkTier.ProviderNpis"/> was never consulted by
+/// any production code path, treating it as an authoritative auto-map
+/// source would compound any seeded-but-stale data the operator may
+/// already have in the tenant. See
+/// <c>docs/architecture/network-tier-organization-reference.md</c>
+/// for the rationale and rollback posture.
+/// </para>
+///
+/// <para>
+/// Idempotency: the patch is only applied when the head version's tier
+/// has a null/empty <see cref="NetworkTier.NetworkId"/> — re-running
+/// the same request is a no-op on already-mapped tiers and produces
+/// counter increments under <c>cho.outcome=skipped</c>. Each successful
+/// patch validates the supplied <c>networkId</c> against
+/// provider-service via <see cref="IOrganizationLookupClient"/>
+/// before writing; an unresolved id is recorded under
+/// <c>cho.outcome=unresolved</c> and not written.
+/// </para>
+/// </summary>
+public interface INetworkTierBackfillService
+{
+    Task<NetworkTierBackfillResult> RunTenantAsync(
+        string tenantId,
+        NetworkTierBackfillRequest request,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Operator-supplied backfill request body. Each entry is one
+/// <c>(planId, tierName) → networkId</c> mapping. A plan + tier pair
+/// not present in <see cref="Mappings"/> is left untouched (the
+/// operator chose not to map it this run).
+/// </summary>
+public sealed class NetworkTierBackfillRequest
+{
+    /// <summary>
+    /// Operator-supplied mappings. Keyed by <c>(planId, tierName)</c>;
+    /// the value is the <c>Organization.OrganizationId</c> chain key in
+    /// provider-service.
+    /// </summary>
+    public List<NetworkTierBackfillMapping> Mappings { get; set; } = new();
+
+    /// <summary>
+    /// Optional actor id (audit log only). Resolved from the request
+    /// principal at the controller boundary; defaults to a synthetic
+    /// label when no principal is available.
+    /// </summary>
+    public string? ActorId { get; set; }
+
+    /// <summary>
+    /// Optional correlation id for cross-service audit traceability.
+    /// Carried into log lines but not persisted.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+}
+
+public sealed class NetworkTierBackfillMapping
+{
+    public string PlanId { get; set; } = string.Empty;
+    public string TierName { get; set; } = string.Empty;
+    public string NetworkId { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Per-call summary returned to the operator. Counters mirror the
+/// <c>cho.benefit_plan.network_tier.backfill.outcomes.total</c> meter.
+/// </summary>
+public sealed class NetworkTierBackfillResult
+{
+    public string BackfillRunId { get; set; } = Guid.NewGuid().ToString();
+    public int MappingsSubmitted { get; set; }
+    public int Patched { get; set; }
+    public int Skipped { get; set; }
+    public int NotFound { get; set; }
+    public int Unresolved { get; set; }
+    public int Failed { get; set; }
+    public List<NetworkTierBackfillIssue> Issues { get; set; } = new();
+}
+
+public sealed class NetworkTierBackfillIssue
+{
+    public string PlanId { get; set; } = string.Empty;
+    public string TierName { get; set; } = string.Empty;
+    public string NetworkId { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public string? Detail { get; set; }
+}
+
+public sealed class NetworkTierBackfillService : INetworkTierBackfillService
+{
+    private readonly IBenefitPlanRepository _repository;
+    private readonly IOrganizationLookupClient _organizationLookup;
+    private readonly IOptionsMonitor<NetworkTierBackfillOptions> _options;
+    private readonly ILogger<NetworkTierBackfillService> _logger;
+
+    public NetworkTierBackfillService(
+        IBenefitPlanRepository repository,
+        IOrganizationLookupClient organizationLookup,
+        IOptionsMonitor<NetworkTierBackfillOptions> options,
+        ILogger<NetworkTierBackfillService> logger)
+    {
+        _repository = repository;
+        _organizationLookup = organizationLookup;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<NetworkTierBackfillResult> RunTenantAsync(
+        string tenantId,
+        NetworkTierBackfillRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var result = new NetworkTierBackfillResult
+        {
+            MappingsSubmitted = request.Mappings.Count,
+        };
+
+        if (request.Mappings.Count == 0)
+        {
+            return result;
+        }
+
+        // Group mappings by planId so each plan is loaded and patched
+        // exactly once even when the operator submits multiple tier
+        // mappings against the same plan.
+        var byPlan = request.Mappings
+            .Where(m => !string.IsNullOrWhiteSpace(m.PlanId))
+            .GroupBy(m => m.PlanId, StringComparer.Ordinal);
+
+        foreach (var group in byPlan)
+        {
+            ct.ThrowIfCancellationRequested();
+            await ProcessPlanAsync(tenantId, group.Key, group.ToList(), result, request, ct);
+        }
+
+        _logger.LogInformation(
+            "network-tier backfill complete tenant={Tenant} runId={RunId} submitted={Submitted} patched={Patched} skipped={Skipped} notFound={NotFound} unresolved={Unresolved} failed={Failed}",
+            SanitizeForLog(tenantId), result.BackfillRunId,
+            result.MappingsSubmitted, result.Patched, result.Skipped,
+            result.NotFound, result.Unresolved, result.Failed);
+
+        return result;
+    }
+
+    private async Task ProcessPlanAsync(
+        string tenantId,
+        string planId,
+        List<NetworkTierBackfillMapping> mappings,
+        NetworkTierBackfillResult result,
+        NetworkTierBackfillRequest request,
+        CancellationToken ct)
+    {
+        var plan = await _repository.GetLatestPublishedAsync(planId, tenantId, DateTime.UtcNow);
+        if (plan is null)
+        {
+            foreach (var m in mappings)
+            {
+                RecordOutcome(tenantId, "not_found", m, result, detail: $"No Published version of plan {planId} found.");
+                result.NotFound++;
+            }
+            return;
+        }
+
+        var tiers = plan.NetworkTiers.Select(CloneTier).ToList();
+        var changed = false;
+
+        foreach (var mapping in mappings)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(mapping.TierName) || string.IsNullOrWhiteSpace(mapping.NetworkId))
+            {
+                RecordOutcome(tenantId, "failed", mapping, result, detail: "tierName and networkId are required.");
+                result.Failed++;
+                continue;
+            }
+
+            var tier = tiers.FirstOrDefault(t => string.Equals(t.TierName, mapping.TierName, StringComparison.Ordinal));
+            if (tier is null)
+            {
+                RecordOutcome(tenantId, "failed", mapping, result, detail: $"Tier '{mapping.TierName}' not found on plan.");
+                result.Failed++;
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(tier.NetworkId))
+            {
+                RecordOutcome(tenantId, "skipped", mapping, result, detail: "Tier already has NetworkId.");
+                result.Skipped++;
+                continue;
+            }
+
+            var organization = await _organizationLookup.GetOrganizationAsync(mapping.NetworkId, ct);
+            if (organization is null)
+            {
+                RecordOutcome(tenantId, "unresolved", mapping, result, detail: "Organization not resolvable in provider-service.");
+                result.Unresolved++;
+                continue;
+            }
+
+            tier.NetworkId = mapping.NetworkId;
+            changed = true;
+            result.Patched++;
+            ChoMetrics.NetworkTierBackfillOutcomes.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.outcome", "patched"),
+                new KeyValuePair<string, object?>("cho.tenant_id", tenantId));
+        }
+
+        if (!changed) return;
+
+        try
+        {
+            var ok = await _repository.UpdateNetworkTiersAsync(tenantId, planId, tiers, ct);
+            if (!ok)
+            {
+                // Lost-write race — head row was deleted between
+                // GetLatestPublishedAsync and UpdateNetworkTiersAsync.
+                // Roll back the per-mapping counters we already recorded
+                // for this plan so the totals still balance.
+                _logger.LogWarning(
+                    "network-tier backfill: head row vanished mid-operation tenant={Tenant} planId={PlanId} runId={RunId}",
+                    SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
+                foreach (var m in mappings)
+                {
+                    if (result.Issues.Any(i => i.PlanId == planId && i.TierName == m.TierName)) continue;
+                    RecordOutcome(tenantId, "not_found", m, result, detail: "Head version disappeared during patch.");
+                    result.NotFound++;
+                    result.Patched--; // we incremented above; undo on miss
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "network-tier backfill failed tenant={Tenant} planId={PlanId} runId={RunId}",
+                SanitizeForLog(tenantId), SanitizeForLog(planId), result.BackfillRunId);
+            foreach (var m in mappings)
+            {
+                RecordOutcome(tenantId, "failed", m, result, detail: ex.GetType().Name);
+            }
+            result.Failed += mappings.Count;
+            result.Patched -= mappings.Count;
+        }
+    }
+
+    private void RecordOutcome(
+        string tenantId,
+        string outcome,
+        NetworkTierBackfillMapping mapping,
+        NetworkTierBackfillResult result,
+        string? detail)
+    {
+        ChoMetrics.NetworkTierBackfillOutcomes.Add(
+            1,
+            new KeyValuePair<string, object?>("cho.outcome", outcome),
+            new KeyValuePair<string, object?>("cho.tenant_id", tenantId));
+
+        result.Issues.Add(new NetworkTierBackfillIssue
+        {
+            PlanId = mapping.PlanId,
+            TierName = mapping.TierName,
+            NetworkId = mapping.NetworkId,
+            Outcome = outcome,
+            Detail = detail,
+        });
+    }
+
+#pragma warning disable CS0618 // Cloning ProviderNpis preserves the legacy field during the migration window
+    private static NetworkTier CloneTier(NetworkTier t) => new()
+    {
+        Id = t.Id,
+        TierName = t.TierName,
+        TierLevel = t.TierLevel,
+        NetworkId = t.NetworkId,
+        ProviderNpis = t.ProviderNpis.ToList(),
+    };
+#pragma warning restore CS0618
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Services/INetworkTierSoftValidator.cs
+++ b/src/services/benefit-plan-service/Services/INetworkTierSoftValidator.cs
@@ -1,0 +1,99 @@
+using BenefitPlanService.Models;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Soft-validation gate (capability 5.5 — NetworkTier as Reference to
+/// Organization). Walks the <see cref="BenefitPlan.NetworkTiers"/>
+/// collection on every write surface and records a structured warning
+/// plus a Prometheus counter increment for each tier that lacks
+/// <see cref="NetworkTier.NetworkId"/>.
+///
+/// <para>
+/// Mirrors the soft-validation pattern from provider-service capability
+/// 5.5 (<c>IPanelGatingValidator</c>): writes still succeed; the
+/// counter drives the eventual hard-validation cutover. When
+/// <c>cho.benefit_plan.network_tier_missing_networkid_writes.total</c>
+/// reads zero across all tenants for a sustained window the follow-up
+/// PR flips this from soft to hard validation (400 rejection).
+/// </para>
+/// </summary>
+public interface INetworkTierSoftValidator
+{
+    /// <summary>
+    /// Inspect <paramref name="plan"/> and emit a warning + counter
+    /// increment for each <see cref="NetworkTier"/> that has a null or
+    /// empty <see cref="NetworkTier.NetworkId"/>. The
+    /// <paramref name="caller"/> label distinguishes write surfaces in
+    /// telemetry.
+    /// </summary>
+    void Inspect(BenefitPlan plan, NetworkTierWriteCaller caller);
+}
+
+/// <summary>
+/// Write-surface labels for the soft-validation counter dimension
+/// <c>cho.caller</c>. New write surfaces must add a label here so the
+/// counter never carries an unbounded set of values.
+/// </summary>
+public enum NetworkTierWriteCaller
+{
+    CreatePlan,
+    UpdatePlan,
+    CreateDraft,
+    AmendPublished,
+    PublishAndSupersede,
+}
+
+public sealed class NetworkTierSoftValidator : INetworkTierSoftValidator
+{
+    private readonly IOptionsMonitor<NetworkTierBackfillOptions> _options;
+    private readonly ILogger<NetworkTierSoftValidator> _logger;
+
+    public NetworkTierSoftValidator(
+        IOptionsMonitor<NetworkTierBackfillOptions> options,
+        ILogger<NetworkTierSoftValidator> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public void Inspect(BenefitPlan plan, NetworkTierWriteCaller caller)
+    {
+        if (plan?.NetworkTiers is null || plan.NetworkTiers.Count == 0) return;
+
+        var level = _options.CurrentValue.SoftValidationLogLevel;
+        for (var i = 0; i < plan.NetworkTiers.Count; i++)
+        {
+            var tier = plan.NetworkTiers[i];
+            if (!string.IsNullOrEmpty(tier?.NetworkId)) continue;
+
+            ChoMetrics.NetworkTierMissingNetworkIdWrites.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.caller", caller.ToString()),
+                new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId ?? string.Empty));
+
+            // Structured single-line warning per offending tier. Fields
+            // mirror the panel-gating soft-validation shape from
+            // provider-service 5.5 so dashboards can be templated across
+            // both signals.
+            _logger.Log(
+                level,
+                "NetworkTierNetworkIdMissing on plan write. caller={Caller} tenantId={TenantId} planId={PlanId} versionId={VersionId} tierIndex={TierIndex} tierName={TierName} tierLevel={TierLevel}",
+                caller,
+                SanitizeForLog(plan.TenantId),
+                SanitizeForLog(plan.PlanId),
+                SanitizeForLog(plan.VersionId),
+                i,
+                SanitizeForLog(tier?.TierName ?? string.Empty),
+                tier?.TierLevel ?? 0);
+        }
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Services/IOrganizationLookupClient.cs
+++ b/src/services/benefit-plan-service/Services/IOrganizationLookupClient.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Cross-service read client for <c>Organization</c> (the canonical
+/// payer-defined network from provider-service capability 5.3). Used by
+/// benefit-plan-service to resolve <c>NetworkTier.NetworkId</c>
+/// references at write time so operators get an early failure when a
+/// plan references a network that doesn't exist or has been terminated.
+///
+/// <para>
+/// HTTP-only contract via the named <c>HttpClient("ProviderService")</c>
+/// registered in <c>Program.cs</c>. No project reference; mirrors
+/// <see cref="HttpProviderIntegrityGate"/> from capability 5.10.
+/// </para>
+///
+/// <para>
+/// Capability 5.5 ships only <see cref="GetOrganizationAsync"/>. The
+/// per-claim membership check (<c>IsProviderInNetworkAsync</c>) and its
+/// in-process cache deferred to the capability that actually consumes
+/// it — see plan-first record in
+/// <c>docs/architecture/network-tier-organization-reference.md</c>.
+/// </para>
+/// </summary>
+public interface IOrganizationLookupClient
+{
+    /// <summary>
+    /// Returns the head version of the network identified by
+    /// <paramref name="networkId"/> (the chain key
+    /// <c>Organization.OrganizationId</c>), or <c>null</c> when the
+    /// network does not exist or provider-service is unreachable.
+    /// Failures are logged at warning and surfaced as null so callers
+    /// can apply their own policy (warn-and-continue at write time
+    /// today).
+    /// </summary>
+    Task<OrganizationLookupResult?> GetOrganizationAsync(
+        string networkId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Subset of the provider-service <c>Organization</c> wire shape that
+/// benefit-plan-service actually needs at the moment. Bound by the
+/// <c>HttpClient.GetFromJsonAsync</c> deserializer; unknown wire fields
+/// are ignored.
+/// </summary>
+public sealed record OrganizationLookupResult
+{
+    [JsonPropertyName("organizationId")]
+    public string OrganizationId { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("effectiveDate")]
+    public DateTime EffectiveDate { get; init; }
+
+    [JsonPropertyName("terminationDate")]
+    public DateTime? TerminationDate { get; init; }
+}
+
+/// <summary>
+/// HTTP-backed <see cref="IOrganizationLookupClient"/> against
+/// <c>provider-service</c> via the same named client used by
+/// <see cref="HttpProviderIntegrityGate"/>.
+/// </summary>
+public class HttpOrganizationLookupClient : IOrganizationLookupClient
+{
+    public const string ProviderServiceClientName = HttpProviderIntegrityGate.ProviderServiceClientName;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpOrganizationLookupClient> _logger;
+
+    public HttpOrganizationLookupClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpOrganizationLookupClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<OrganizationLookupResult?> GetOrganizationAsync(
+        string networkId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(networkId))
+        {
+            return null;
+        }
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(ProviderServiceClientName);
+            var encoded = Uri.EscapeDataString(networkId);
+            using var response = await client.GetAsync($"api/v1/networks/{encoded}", ct);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Provider service returned {StatusCode} for network {NetworkId}",
+                    response.StatusCode, SanitizeForLog(networkId));
+                return null;
+            }
+
+            return await response.Content.ReadFromJsonAsync<OrganizationLookupResult>(ct);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Provider service unreachable for network {NetworkId}; treating as unresolved",
+                SanitizeForLog(networkId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Services/IOrganizationLookupClient.cs
+++ b/src/services/benefit-plan-service/Services/IOrganizationLookupClient.cs
@@ -110,8 +110,21 @@ public class HttpOrganizationLookupClient : IOrganizationLookupClient
 
             return await response.Content.ReadFromJsonAsync<OrganizationLookupResult>(ct);
         }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller-driven cancellation must propagate. Swallowing this
+            // would surface as an `unresolved` outcome and obscure the
+            // actual cancellation signal from the orchestrator.
+            throw;
+        }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
+            // HttpRequestException → transport / DNS failure.
+            // TaskCanceledException without ct.IsCancellationRequested →
+            // HttpClient request timeout (the typed client's Timeout
+            // surfaces as TaskCanceledException). Treat both as
+            // "unresolved" so the caller's policy (warn + continue at
+            // write time today) applies.
             _logger.LogWarning(ex,
                 "Provider service unreachable for network {NetworkId}; treating as unresolved",
                 SanitizeForLog(networkId));

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -119,8 +119,8 @@ public static class ChoMetrics
     /// when this counter is zero across all tenants for a sustained
     /// window, the follow-up PR can flip soft warnings to 400
     /// rejections without breaking callers. Dimensions:
-    /// <c>cho.caller</c> (CreatePlan | UpdatePlan | UpdateDraft |
-    /// PublishAndSupersede), <c>cho.tenant_id</c>.
+    /// <c>cho.caller</c> (CreatePlan | UpdatePlan | CreateDraft |
+    /// AmendPublished | PublishAndSupersede), <c>cho.tenant_id</c>.
     /// </summary>
     public static readonly Counter<long> NetworkTierMissingNetworkIdWrites =
         Meter.CreateCounter<long>(
@@ -129,17 +129,19 @@ public static class ChoMetrics
             description: "Writes to BenefitPlan.NetworkTiers that elide NetworkTier.NetworkId (5.5 soft validation)");
 
     /// <summary>
-    /// Counter tracking benefit plans patched by the
+    /// Counter tracking network-tier mapping outcomes emitted by the
     /// <c>NetworkTierBackfillService</c> (benefit-plan capability 5.5
-    /// admin-triggered backfill). Dimensions: <c>cho.outcome</c>
-    /// (patched | skipped | not_found | unresolved | failed),
-    /// <c>cho.tenant_id</c>.
+    /// admin-triggered backfill). A single benefit plan can contribute
+    /// multiple increments when the operator submits multiple tier
+    /// mappings against the same plan in one request. Dimensions:
+    /// <c>cho.outcome</c> (patched | skipped | not_found | unresolved |
+    /// failed), <c>cho.tenant_id</c>.
     /// </summary>
     public static readonly Counter<long> NetworkTierBackfillOutcomes =
         Meter.CreateCounter<long>(
             "cho.benefit_plan.network_tier.backfill.outcomes.total",
-            unit: "{plan}",
-            description: "Benefit plans processed by the network-tier NetworkId backfill, by outcome");
+            unit: "{mapping}",
+            description: "Network-tier mapping outcomes processed by the NetworkId backfill, by outcome");
 
     /// <summary>
     /// Counter tracking <c>HttpProviderIntegrityGate</c>'s cached-or-live

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -113,6 +113,35 @@ public static class ChoMetrics
             description: "Participations processed by the panel-gating backfill, by outcome");
 
     /// <summary>
+    /// Counter tracking writes to <c>BenefitPlan.NetworkTiers</c> that
+    /// elide <c>NetworkTier.NetworkId</c> (benefit-plan capability 5.5
+    /// soft validation). Drives the eventual hard-validation cutover —
+    /// when this counter is zero across all tenants for a sustained
+    /// window, the follow-up PR can flip soft warnings to 400
+    /// rejections without breaking callers. Dimensions:
+    /// <c>cho.caller</c> (CreatePlan | UpdatePlan | UpdateDraft |
+    /// PublishAndSupersede), <c>cho.tenant_id</c>.
+    /// </summary>
+    public static readonly Counter<long> NetworkTierMissingNetworkIdWrites =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.network_tier_missing_networkid_writes.total",
+            unit: "{write}",
+            description: "Writes to BenefitPlan.NetworkTiers that elide NetworkTier.NetworkId (5.5 soft validation)");
+
+    /// <summary>
+    /// Counter tracking benefit plans patched by the
+    /// <c>NetworkTierBackfillService</c> (benefit-plan capability 5.5
+    /// admin-triggered backfill). Dimensions: <c>cho.outcome</c>
+    /// (patched | skipped | not_found | unresolved | failed),
+    /// <c>cho.tenant_id</c>.
+    /// </summary>
+    public static readonly Counter<long> NetworkTierBackfillOutcomes =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.network_tier.backfill.outcomes.total",
+            unit: "{plan}",
+            description: "Benefit plans processed by the network-tier NetworkId backfill, by outcome");
+
+    /// <summary>
     /// Counter tracking <c>HttpProviderIntegrityGate</c>'s cached-or-live
     /// decision path (capability 5.10). Dimensions: <c>cho.path</c>
     /// (<c>cached_hit</c> | <c>stale_fallback</c> | <c>null_fallback</c>


### PR DESCRIPTION
## Summary

Replaces the embedded NPI snapshot on `BenefitPlan.NetworkTier` with a nullable `NetworkId` reference to the canonical `Organization` entity in provider-service (capability 5.3). Realizes the "Provider 5.3 unblock" called out in `network-as-organization.md`.

## Plan-First record — Option B

The plan phase surfaced two material premise corrections that reshaped the scope:

1. **No adjudication migration.** `AdjudicationController.NetworkTier` (line 884) is the `CloudHealthOffice.BenefitEngine.Domain.NetworkTier { InNetwork, OutOfNetwork, OutOfArea }` enum, not the embedded class. There is no `tier.ProviderNpis.Contains(npi)` call site anywhere in `src/`.
2. **No MemberBenefitView migration.** `BenefitViewService.cs:66-68` selects the in-network tier name by tier-level ranking; never consults `ProviderNpis`.

`ProviderNpis` was a dormant data carrier. With no current consumer of NPI-membership lookups, building `IsProviderInNetworkAsync` + cache + telemetry + a provider-service contract addition for zero present-day callers was deferred per the codebase's YAGNI posture. They land when the consumer that genuinely needs them — likely claims-service Phase 1 — drafts its capability prompt against actual access patterns and performance budgets.

## What ships

- **Model** (`Models/BenefitPlan.cs`): `NetworkTier.NetworkId` added (nullable). `ProviderNpis` marked `[Obsolete]` and frozen during the migration window; final removal in a follow-up PR after telemetry confirms zero remaining legacy-shape rows.
- **Wire format** (`Models/BenefitPlanAdapterResponse.cs`): `AdapterNetworkTier.NetworkId` added; round-trips both fields during migration.
- **`IOrganizationLookupClient`** (`Services/IOrganizationLookupClient.cs`): HTTP-only contract via the existing `HttpClient("ProviderService")` registration introduced for `HttpProviderIntegrityGate` (capability 5.10). Ships `GetOrganizationAsync` only; resilient — 404, 5xx, transport failures all surface as `null`.
- **Repository bypass** (`Repositories/BenefitPlanRepository.cs`, `BenefitPlanRepositoryMongo.cs`): `UpdateNetworkTiersAsync(tenantId, planId, tiers, ct)` patches only `NetworkTiers` on the head Published row (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`; Mongo `FindOneAndUpdateAsync` with `$set`). Bypasses `UpdateAsync`'s "Published is read-only" guard. No `PlanVersionEvent` emitted. Identity-bearing field writes still go through `UpdateAsync` and respect version-state enforcement (covered by tests).
- **Soft validation** (`Services/INetworkTierSoftValidator.cs` + write-surface hooks): writes that elide `NetworkId` emit a structured warning + Prometheus counter `cho.benefit_plan.network_tier_missing_networkid_writes.total{cho.caller, cho.tenant_id}`. Mirrors Provider 5.5's panel-gating pattern; drives the eventual hard-validation cutover.
- **Backfill** (`Services/INetworkTierBackfillService.cs` + `Controllers/NetworkTierBackfillAdminController.cs`): admin endpoint `POST /api/v1/admin/benefit-plans/backfill-network-tiers?tenantId=X` behind `NetworkTierBackfill:AdminBackfillEnabled` (default `false`, returns 503 when off). **Operator-driven mapping (Decision 5b)** — request body carries explicit `(planId, tierName) → networkId` dictionary. Each `networkId` is validated against provider-service before patching. Idempotent on reruns (skipped tiers).
- **Telemetry counters** (`Observability/ChoMetrics.cs`):
  - `cho.benefit_plan.network_tier_missing_networkid_writes.total{cho.caller, cho.tenant_id}` — soft-validation.
  - `cho.benefit_plan.network_tier.backfill.outcomes.total{cho.outcome, cho.tenant_id}` — backfill outcomes (patched | skipped | not_found | unresolved | failed).
- **Documentation**:
  - `docs/architecture/network-tier-organization-reference.md` (new) — capability doc with cross-service contract, mapping-strategy rationale, soft-validation contract, recovery posture.
  - `docs/architecture/plan-versioning.md` — extended with "Projection metadata — exempt from versioning" section adapted from `provider-versioning.md:300-475`.
  - `docs/architecture/integrity-score-consumption.md` — cross-reference added (benefit-plan-service now consumes provider-service via two adapters: `HttpProviderIntegrityGate` and the new `IOrganizationLookupClient`).

## Tests

| File | Coverage |
| --- | --- |
| `HttpOrganizationLookupClientTests` | resolved, 404, 5xx, transport failure, empty input, URL encoding |
| `NetworkTierBackfillServiceTests` | patched, skipped, unresolved, not_found, failed, multi-tier, empty mappings |
| `NetworkTierSoftValidatorTests` | per-tier warning, no-op when no tiers, configurable `LogLevel` |
| `UpdateNetworkTiersAsyncTests` | head-row patch, draft skip, no-head miss, version-guard preserved on `UpdateAsync` after bypass |
| `NetworkTierBackfillAdminControllerTests` | feature-flag tripwire, request-shape validation, service forwarding |

Three existing test ctor sites updated for the new `INetworkTierSoftValidator` dependency on `BenefitPlanServiceImpl` (using a `NoOpNetworkTierSoftValidator` fake).

## Diff envelope

~2,100 lines added, ~4 lines modified across 24 files. Larger than the plan-phase estimate (~1,830) — mostly down to richer tests and the capability doc growing past the initial outline.

## Out of scope (deferred)

- `IsProviderInNetworkAsync` + in-process cache + cache-hit telemetry — defer to first real consumer.
- Provider-service `GET /api/v1/networks/{id}/members/{npi}` (or query-filter NPI) endpoint addition — defer with the consumer.
- Final removal of `NetworkTier.ProviderNpis` — defer to follow-up after legacy-row telemetry trends to zero.
- Hard validation (`[Required]`) of `NetworkId` — defer to follow-up after soft-validation counter trends to zero across all tenants.

## Test plan

- [ ] `dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj` succeeds.
- [ ] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests/BenefitPlanService.Tests.csproj` — all tests pass, including the existing version-chain suite (BenefitPlanServiceImpl ctor change requires the no-op validator wiring; updated in this PR).
- [ ] Manual smoke: with the feature flag off, `POST /api/v1/admin/benefit-plans/backfill-network-tiers?tenantId=test` returns 503 with the gating message.
- [ ] Manual smoke: with the feature flag on and a seeded plan whose tiers have null `NetworkId`, supplying a mapping for a resolvable network in provider-service patches the head row; rerun is idempotent.
- [ ] Counter `cho.benefit_plan.network_tier_missing_networkid_writes.total` increments on a write-path that supplies tiers without `NetworkId`.

https://claude.ai/code/session_01Egry7Ne8woGfETBPkSk6vs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Egry7Ne8woGfETBPkSk6vs)_