### PR TITLE
BP 5.7 — Embedded vs Aggregate Family OOP Rules + ACA cap enforcement

### DIFF
--- a/docs/architecture/family-accumulator-models.md
+++ b/docs/architecture/family-accumulator-models.md
@@ -1,0 +1,213 @@
+# Family Accumulator Models — Embedded vs Aggregate (BP 5.7)
+
+This doc describes the plan-level family accumulator pooling model on
+`BenefitPlan`, the ACA 45 CFR §156.130 individual out-of-pocket cap that
+applies to Aggregate plans, and the gated rollout strategy for runtime
+enforcement.
+
+## What changed in 5.7
+
+Before BP 5.7:
+
+- `BenefitEngine.Domain.FamilyAccumulatorModel` enum existed (Embedded /
+  Aggregate) and `AccumulatorWorkingSet` honored both modes, but
+  `BenefitPlan` had no field exposing the choice. Every plan
+  effectively adjudicated as Embedded regardless of author intent.
+- Aggregate mode in the engine seeded only family-level accumulators —
+  no per-member sub-cap. A single member could in principle absorb the
+  entire family OOP pool, which violates ACA §156.130.
+
+After BP 5.7:
+
+- `BenefitPlan.FamilyAccumulatorModel` (top-level field, default
+  `Embedded`) carries the plan author's choice. Mirrored on
+  `MemberBenefitView`, `AdapterBenefitPlan`, `AdapterMemberBenefitView`,
+  and the portal's `MemberBenefitView` DTO.
+- `ChoBenefitPlanProvider.MapToConfig` projects the field onto the
+  engine's `BenefitPlanConfig.FamilyAccumulatorModel` plus the new
+  `AcaIndividualCap` (loaded via `IAcaLimitsProvider` from
+  `schemas/aca-oop-limits/limits.json`) and the `IsAcaCapEnforced` flag.
+- `AccumulatorWorkingSet` (Aggregate path) seeds an
+  `AccumulatorType.AcaIndividualCap` accumulator alongside the family
+  pool when `IsAcaCapEnforced` is true. `GetRemainingOopMax` returns
+  `min(family pool remaining, ACA individual cap remaining)`;
+  `ApplyOopMax` increments both buckets in lockstep.
+- `IPlanLimitValidator` is wired into all five
+  `BenefitPlanServiceImpl` write surfaces (`CreatePlanAsync`,
+  `UpdatePlanAsync`, `CreateDraftAsync`, `AmendPublishedPlanAsync`,
+  `PublishVersionAsync`). Plans with cost-sharing limits exceeding the
+  ACA caps are rejected with HTTP 400.
+
+## Embedded vs Aggregate semantics
+
+### Embedded
+
+Each member has an individual deductible and individual out-of-pocket
+maximum tracked independently. The plan also tracks family aggregates.
+
+- Individual deductible met → that member's portion is satisfied; other
+  members continue accumulating against their own individual limits.
+- Family deductible met → all members' deductible portions are
+  satisfied (the engine returns 0 remaining individual deductible when
+  family is met).
+- OOP works the same way: meeting family OOP zeroes out each member's
+  remaining individual responsibility.
+
+ACA §156.130 individual cap is enforced **at write time** by
+`IPlanLimitValidator` ensuring `IndividualOutOfPocketMax ≤
+acaIndividualCap`. Runtime enforcement is implicit: the existing
+`IndividualOutOfPocketMax` accumulator already constrains members.
+
+### Aggregate
+
+A single shared family pool. No individual sub-limit by default —
+members all draw from the same pot.
+
+But ACA §156.130 still applies: even on Aggregate plans, no individual
+member may absorb more than the ACA individual OOP cap for the plan
+year. Without this, a single member could exhaust the entire family
+pool, which is non-compliant.
+
+Aggregate mode therefore tracks two accumulators per network tier:
+1. **Family pool** (`FamilyOutOfPocketMax`) — primary ceiling shared
+   by all members.
+2. **ACA individual cap** (`AcaIndividualCap`) — per-member ceiling
+   equal to the §156.130 cap for the plan year. Caps how much of the
+   family pool any single member may absorb.
+
+Member responsibility on a claim line is the minimum of:
+- Family pool remaining
+- AcaIndividualCap remaining for this member
+
+The ACA cap accumulator is `AccumulatorScope.Individual`, so each
+member's working-set hydrates only their own row from the persistent
+store. This is the same hydration shape as the existing
+`IndividualOutOfPocketMax` accumulator in Embedded mode.
+
+## Gated rollout — `IsAcaCapEnforced` (G8)
+
+Rolling out runtime ACA cap enforcement across a population of
+in-flight Aggregate plans creates an operational concern: a member who
+has already accumulated $10,000 against an uncapped Aggregate pool
+shouldn't suddenly hit the cap mid-claim and get a confusing change in
+member responsibility.
+
+The rollout is therefore gated by `BenefitPlanConfig.IsAcaCapEnforced`,
+set by `ChoBenefitPlanProvider.MapToConfig`:
+
+- **New publishes** (plans with `PublishedAt` ≥ the post-5.7 cutoff,
+  currently `2026-04-28T00:00:00Z`) get `IsAcaCapEnforced=true`. Cap
+  is enforced from the first claim.
+- **Legacy plans** (`PublishedAt` before the cutoff) hydrate with
+  `IsAcaCapEnforced=false`. Engine behavior is unchanged from pre-5.7
+  — Aggregate plans run with family pool only, no per-member cap.
+- **Drafts** (`PublishedAt == null`) get `IsAcaCapEnforced=true`. The
+  draft is not yet adjudicating live claims, and any future publish
+  goes through the validator anyway.
+- **Embedded plans** always have `IsAcaCapEnforced=false`. The flag
+  only matters in Aggregate mode.
+
+Operators flip a legacy plan to enforced state by re-publishing the
+plan version (creating an amendment via `POST /amend` and publishing
+it). `PublishedAt` advances past the cutoff, the new
+`BenefitPlanConfig` carries `IsAcaCapEnforced=true`, and the new
+working-set seeds the cap accumulator on the next claim.
+
+This is **transition support, not permanent legacy support.** The
+team's intent is to deprecate the flag within 6–12 months of 5.7
+shipping. Until then, operators are expected to roll their Aggregate
+plans through one full publish-cycle so the entire population
+converges on enforced state.
+
+## Validation — `IPlanLimitValidator`
+
+Hard-validation gate; throws `PlanLimitValidationException` (mapped to
+HTTP 400 by the controllers). Distinct from the soft-validation
+`INetworkTierSoftValidator` — regulatory caps are not negotiable.
+
+The validator runs on **both** modes:
+- **Embedded**: `IndividualOutOfPocketMax ≤ acaIndividualCap` AND
+  `FamilyOutOfPocketMax ≤ acaFamilyCap`.
+- **Aggregate**: same two checks. The runtime-cap accumulator gives
+  defense-in-depth; the validator is the primary guard against
+  noncompliant plans landing in the store at all.
+
+Plan-year resolution (consumed by both the validator and
+`ChoBenefitPlanProvider`):
+
+```
+PlanYearResolver.Resolve(plan):
+    if plan.PlanYearDefinition.PlanYearStart != default:
+        return PlanYearStart.Year
+    return plan.EffectiveDate.Year
+```
+
+`PlanYearDefinition` (5.3) is authoritative when present because it
+carries the author's explicit plan-year intent. `EffectiveDate.Year`
+is a defensible fallback for plans authored before 5.3 or that opted
+out of the optional `PlanYearDefinition`.
+
+If the resolved plan year is not in `schemas/aca-oop-limits/limits.json`,
+the validator **fails closed** with a 400 response that lists the
+configured years. Better to force operators to refresh the seed file
+than silently accept a plan against missing caps.
+
+## Configuration — `schemas/aca-oop-limits/limits.json`
+
+File-backed seed file loaded once at service startup by
+`AcaLimitsProvider`. See
+[`schemas/aca-oop-limits/README.md`](../../schemas/aca-oop-limits/README.md)
+for the schema, source attribution, and update cadence.
+
+Operators bump the file when CMS publishes the annual NBPP final rule.
+The file ships with values for plan years 2024–2027 (2027 is a
+projection per the revised methodology — verify against the actual
+2027 NBPP final rule when published).
+
+**ACA cost-sharing max ≠ IRS HSA-qualified HDHP max.** They are
+different limits with different regulatory sources. This file holds
+the ACA value only; the IRS HDHP cap is enforced separately. See the
+schema README for details.
+
+## Telemetry
+
+- `cho.benefit_plan.plan_limit_validation_failures.total` — counter,
+  one increment per 400 rejection from `IPlanLimitValidator`.
+  Dimensions: `cho.caller`, `cho.tenant_id`, `cho.reason`
+  (`PlanYearNotConfigured` | `IndividualOopExceedsAcaCap` |
+  `FamilyOopExceedsAcaCap`).
+
+The validator is hard, not soft — every increment corresponds to a
+plan that operators tried to land but couldn't. Spikes here are a
+signal that either the seed file is out of date for a plan year
+operators are authoring against, or operator authoring tooling needs a
+nudge to surface the cap before submit.
+
+## Out of scope for 5.7
+
+- `BenefitRulePredicate` evaluation in the calc engine (deferred to
+  5.10).
+- `Unknown=0` migration on `FamilyAccumulatorModel` and
+  `AccumulatorType` enums (deferred to a follow-up "BenefitEngine enum
+  hygiene" PR — see PR #705 convention).
+- `accumulator-service` standalone schema work — its typed-column
+  storage doesn't touch the new `AcaIndividualCap` bucket.
+- Portal UX distinguishing Embedded vs Aggregate visually — DTO
+  mirrors only. The string field is on the wire so a future UX PR can
+  pick it up without another round-trip change.
+- `BenefitResolutionResult` shape changes — `AccumulatorSnapshot`
+  already surfaces the new bucket via enum-name-string keying.
+
+## Cross-references
+
+- [`docs/architecture/plan-versioning.md`](plan-versioning.md) —
+  `FamilyAccumulatorModel` is naturally version-identity-bearing.
+  Changing it on a Published plan requires a new version (the same as
+  any cost-sharing change).
+- [`docs/architecture/plan-year-definition.md`](plan-year-definition.md)
+  — `PlanYearDefinition` is the primary plan-year source consumed by
+  the validator's resolver.
+- [`schemas/aca-oop-limits/README.md`](../../schemas/aca-oop-limits/README.md)
+  — seed file authoring, CMS source attribution, methodology change.
+- [`schemas/service-category-mappings/README.md`](../../schemas/service-category-mappings/README.md)
+  — sister versioned-seed pattern from 5.6.

--- a/docs/architecture/plan-versioning.md
+++ b/docs/architecture/plan-versioning.md
@@ -195,6 +195,12 @@ dedicated sibling method.
 |-------|-------|----------------|------------|
 | `NetworkTiers[].NetworkId` | provider-service `Organization` (5.3) | `UpdateNetworkTiersAsync(tenantId, planId, tiers, ct)` | 5.5 — NetworkTier as Reference to Organization |
 
+**Identity-bearing additions (NOT exempt):** `BenefitPlan.FamilyAccumulatorModel`
+(BP 5.7) is identity-bearing by design. Changing the model on a
+Published plan affects in-flight adjudications materially and requires
+a new version, just like any cost-sharing change. No bypass method is
+provided.
+
 `UpdateNetworkTiersAsync` resolves the head Published row by chain
 key, then patches the entire `NetworkTiers` collection with a single
 field-scoped op (Cosmos `PatchItemAsync` `Set("/networkTiers", tiers)`;

--- a/schemas/aca-oop-limits/README.md
+++ b/schemas/aca-oop-limits/README.md
@@ -1,0 +1,117 @@
+# ACA Out-of-Pocket Limits
+
+This directory holds the file-backed seed values consumed by
+`IAcaLimitsProvider` in `benefit-plan-service`. The provider validates
+plan-author-supplied `IndividualOutOfPocketMax` and
+`FamilyOutOfPocketMax` against the values here at write time and
+projects the per-member ACA individual cap onto Aggregate-mode plans
+for runtime enforcement in the BenefitEngine.
+
+## Regulatory anchor
+
+ACA 45 CFR §156.130 sets annual maximum out-of-pocket cost-sharing
+amounts that apply to all non-grandfathered group and individual market
+plans. The ceiling is published by HHS / CMS each spring in the Notice
+of Benefit and Payment Parameters (NBPP) for the following plan year.
+
+The cap exists for **every** plan, including Aggregate-family plans
+that pool all members under a single family OOP. Without per-member
+runtime enforcement on Aggregate plans, a single member could absorb
+the entire family pool — which violates §156.130. See
+`docs/architecture/family-accumulator-models.md`.
+
+## Source attribution per plan year
+
+| Plan year | Individual | Family   | Source                                            |
+|-----------|-----------:|---------:|---------------------------------------------------|
+| 2024      | $9,450     | $18,900  | CMS-9911-F (NBPP 2024)                            |
+| 2025      | $9,200     | $18,400  | CMS-9895-F (NBPP 2025)                            |
+| 2026      | $10,600    | $21,200  | CMS-9888-F (NBPP 2026) — revised methodology      |
+| 2027      | $12,000    | $24,000  | Projected from revised methodology — verify!      |
+
+### 2026 methodology change
+
+The original NBPP 2026 finalization (released April 2024) set the caps
+at **$10,150 individual / $20,300 family**. A revised premium
+adjustment percentage methodology, finalized in 2025, recalculated the
+2026 ceiling upward to **$10,600 / $21,200**. The values in
+`limits.json` reflect the revised, currently-effective figures.
+
+If a stakeholder asks "where do these numbers come from?", point them
+at the 2026 final rule and the revised methodology rule both. Earlier
+documentation that cites 10,150 / 20,300 is referencing the superseded
+finalization.
+
+### 2027 caveat
+
+The 2027 row in `limits.json` is a **projection** off the revised
+methodology, NOT a published final rule. CMS typically publishes the
+final 2027 NBPP in mid-2026. When that rule lands:
+
+1. Update `limits.json` with the published values.
+2. Remove the `note` field on the 2027 row.
+3. Update the table above and the `lastReviewed` date.
+4. Bump `version` if the schema changed; otherwise leave it.
+
+Plans authored against plan year 2027 today will validate against the
+projected values. If the published values are lower than projected,
+some plans authored under the projection will need to be re-validated
+when their plan-year resolution falls in 2027.
+
+## Update cadence
+
+- Watch the CMS NBPP final-rule release (typically January–April of
+  each year, for the following plan year).
+- File a PR updating `limits.json` plus a one-line addition to the
+  table in this README.
+- Bump `lastReviewed`. Leave `version` unless the schema changes.
+
+## Important: ACA cost-sharing max ≠ HSA-qualified HDHP max
+
+The IRS publishes a separate set of out-of-pocket maximums for
+HSA-qualified High Deductible Health Plans (Internal Revenue Code
+§223). The HDHP-OOP-max is generally **lower** than the ACA-OOP-max
+and updates on a different cadence (Revenue Procedure each May for
+the following calendar year).
+
+This file is for the **ACA** ceiling only. Plans that are HSA-qualified
+HDHPs must satisfy BOTH ceilings; the lower of the two governs. HDHP
+caps are not enforced from this file — they are validated separately
+against IRS Publication 969 / Rev. Proc. parameters.
+
+If you are looking for the HDHP max, you want the IRS source, not this
+one.
+
+## File shape
+
+```jsonc
+{
+  "version": "1.0",                      // schema version, bump on shape change
+  "source": "...",                       // free-form provenance
+  "lastReviewed": "YYYY-MM-DD",          // when these values were last verified
+  "limits": [
+    {
+      "planYear": 2025,                  // calendar year of the plan year
+      "individualCap": 9200,             // §156.130 self-only OOP max
+      "familyCap": 18400,                // §156.130 other-than-self-only OOP max
+      "rule": "CMS-9895-F (NBPP 2025)",  // citation for the value
+      "note": "..."                      // optional caveats
+    }
+  ]
+}
+```
+
+The provider treats unknown fields tolerantly so future additions
+(e.g. catastrophic-plan caps, marketplace-specific subsidies) don't
+require lockstep code changes.
+
+## Loading behaviour
+
+- The provider loads `limits.json` once at service startup.
+- Plans with a plan year NOT present in `limits` cause the validator
+  to **fail-closed** — write rejected with a structured 400. Better
+  to force operators to publish a fresh `limits.json` than silently
+  accept a plan against stale or missing caps.
+- The lookup is keyed strictly on integer `planYear`; no fallback to
+  "nearest" or "latest" by design. Regulatory caps are point-in-time
+  values; using last year's number for next year is a compliance bug.

--- a/schemas/aca-oop-limits/limits.json
+++ b/schemas/aca-oop-limits/limits.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "source": "45 CFR §156.130 / CMS Notice of Benefit and Payment Parameters",
+  "lastReviewed": "2026-04-28",
+  "limits": [
+    {
+      "planYear": 2024,
+      "individualCap": 9450,
+      "familyCap": 18900,
+      "rule": "CMS-9911-F (NBPP 2024)"
+    },
+    {
+      "planYear": 2025,
+      "individualCap": 9200,
+      "familyCap": 18400,
+      "rule": "CMS-9895-F (NBPP 2025)"
+    },
+    {
+      "planYear": 2026,
+      "individualCap": 10600,
+      "familyCap": 21200,
+      "rule": "CMS-9888-F (NBPP 2026), revised methodology",
+      "note": "Original NBPP 2026 finalization at 10150/20300 was superseded by the revised premium adjustment methodology finalized in 2025."
+    },
+    {
+      "planYear": 2027,
+      "individualCap": 12000,
+      "familyCap": 24000,
+      "rule": "Per revised methodology projection",
+      "note": "Projected from the revised premium adjustment methodology; verify against the 2027 NBPP final rule when published."
+    }
+  ]
+}

--- a/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitDomain.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitDomain.cs
@@ -88,7 +88,19 @@ public enum AccumulatorType
     VisitCount,
     DollarLimit,
     DayCount,
-    LifetimeMax
+    LifetimeMax,
+
+    /// <summary>
+    /// Per-member ACA 45 CFR §156.130 individual out-of-pocket cap.
+    /// Only seeded by <see cref="AccumulatorWorkingSet"/> in Aggregate
+    /// mode when <c>BenefitPlanConfig.IsAcaCapEnforced</c> is true. The
+    /// adjudication engine clamps each member's contribution to
+    /// <c>min(family pool remaining, AcaIndividualCap remaining)</c> so a
+    /// single member cannot exhaust the family OOP pool past the ACA
+    /// individual ceiling. See
+    /// docs/architecture/family-accumulator-models.md.
+    /// </summary>
+    AcaIndividualCap
 }
 
 public enum AccumulatorScope

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/AccumulatorWorkingSet.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/AccumulatorWorkingSet.cs
@@ -9,8 +9,13 @@ namespace CloudHealthOffice.BenefitEngine.Services;
 /// Supports both Embedded and Aggregate family accumulator models:
 ///   Embedded:  individual + family accumulators tracked independently.
 ///              Individual met → that member done. Family met → all members done.
-///   Aggregate: family-only pool. No individual sub-limit. Any member
-///              contributes to the single family pool.
+///   Aggregate: family-only pool. Per ACA 45 CFR §156.130 each member also
+///              has an ACA individual cap that bounds how much of the family
+///              pool a single member can absorb. The cap is only seeded /
+///              enforced when <see cref="BenefitPlanConfig.IsAcaCapEnforced"/>
+///              is true and <see cref="BenefitPlanConfig.AcaIndividualCap"/>
+///              is set; legacy plans pre-5.7 hydrate with both false / null
+///              and behave exactly as before (single shared family pool).
 ///
 /// QNXT equivalent: The in-memory accumulator state that QNXT's
 /// adjudication engine maintains during claim processing, then writes
@@ -55,7 +60,7 @@ public class AccumulatorWorkingSet
         // Ensure standard accumulators exist based on family model
         if (plan.FamilyAccumulatorModel == FamilyAccumulatorModel.Aggregate)
         {
-            // Aggregate: only family-level accumulators exist
+            // Aggregate: family-level accumulators are the primary pool.
             EnsureAccumulator(AccumulatorType.FamilyDeductible, AccumulatorScope.Family,
                 NetworkTier.InNetwork, plan.FamilyDeductible ?? 0);
             EnsureAccumulator(AccumulatorType.FamilyDeductible, AccumulatorScope.Family,
@@ -64,6 +69,18 @@ public class AccumulatorWorkingSet
                 NetworkTier.InNetwork, plan.FamilyOopMax ?? 0);
             EnsureAccumulator(AccumulatorType.FamilyOutOfPocketMax, AccumulatorScope.Family,
                 NetworkTier.OutOfNetwork, plan.FamilyOopMaxOon ?? plan.FamilyOopMax ?? 0);
+
+            // ACA 45 CFR §156.130 individual cap. Gated by IsAcaCapEnforced
+            // so legacy Aggregate plans don't surprise-cap mid-year. The
+            // accumulator is scoped Individual so cap state is per-member;
+            // each member's working-set hydrates only their own row.
+            if (plan.IsAcaCapEnforced && plan.AcaIndividualCap is decimal cap && cap > 0)
+            {
+                EnsureAccumulator(AccumulatorType.AcaIndividualCap, AccumulatorScope.Individual,
+                    NetworkTier.InNetwork, cap);
+                EnsureAccumulator(AccumulatorType.AcaIndividualCap, AccumulatorScope.Individual,
+                    NetworkTier.OutOfNetwork, cap);
+            }
         }
         else
         {
@@ -170,12 +187,16 @@ public class AccumulatorWorkingSet
     {
         if (_plan.FamilyAccumulatorModel == FamilyAccumulatorModel.Aggregate)
         {
-            // Aggregate: only family pool
+            // Aggregate: family pool is primary; ACA per-member cap (when
+            // enforced) clamps how much of the pool one member may absorb.
             var familyKey = MakeKey(AccumulatorType.FamilyOutOfPocketMax,
                 AccumulatorScope.Family, networkTier);
             var family = _entries.GetValueOrDefault(familyKey);
             if (family is null) return decimal.MaxValue;
-            return Math.Max(0, family.LimitAmount - family.CurrentAccumulated);
+            var familyRemaining = Math.Max(0, family.LimitAmount - family.CurrentAccumulated);
+
+            var capRemaining = GetAcaIndividualCapRemaining(networkTier);
+            return capRemaining is decimal c ? Math.Min(familyRemaining, c) : familyRemaining;
         }
 
         // Embedded model
@@ -213,6 +234,16 @@ public class AccumulatorWorkingSet
             {
                 family.CurrentAccumulated += memberResponsibility;
                 RecordUpdate(family, memberResponsibility, "OOP-Family-Aggregate");
+            }
+
+            // ACA per-member cap accumulates in lockstep with family pool
+            // when enforced. Mirrors the Embedded dual-update pattern below.
+            var capKey = MakeKey(AccumulatorType.AcaIndividualCap,
+                AccumulatorScope.Individual, networkTier);
+            if (_entries.TryGetValue(capKey, out var cap))
+            {
+                cap.CurrentAccumulated += memberResponsibility;
+                RecordUpdate(cap, memberResponsibility, "OOP-AcaIndividualCap");
             }
             return;
         }
@@ -367,6 +398,24 @@ public class AccumulatorWorkingSet
             Amount = amount,
             Source = source
         });
+    }
+
+    /// <summary>
+    /// Per-member ACA 45 CFR §156.130 individual-cap remaining for the
+    /// given network tier. Returns null when the plan is not Aggregate
+    /// mode, when enforcement is disabled, or when no cap accumulator was
+    /// seeded — callers treat null as "no individual sub-limit applies".
+    /// </summary>
+    private decimal? GetAcaIndividualCapRemaining(NetworkTier networkTier)
+    {
+        if (_plan.FamilyAccumulatorModel != FamilyAccumulatorModel.Aggregate) return null;
+        if (!_plan.IsAcaCapEnforced) return null;
+
+        var key = MakeKey(AccumulatorType.AcaIndividualCap,
+            AccumulatorScope.Individual, networkTier);
+        if (!_entries.TryGetValue(key, out var entry)) return null;
+
+        return Math.Max(0, entry.LimitAmount - entry.CurrentAccumulated);
     }
 
     private static string MakeKey(AccumulatorType type, AccumulatorScope scope, NetworkTier tier)

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
@@ -79,6 +79,28 @@ public record BenefitPlanConfig
     // Deductible model
     public FamilyAccumulatorModel FamilyAccumulatorModel { get; init; } = FamilyAccumulatorModel.Embedded;
 
+    /// <summary>
+    /// ACA 45 CFR §156.130 per-member individual out-of-pocket cap for
+    /// the plan year. Resolved at <see cref="ChoBenefitPlanProvider"/>
+    /// mapping time from the file-backed <c>IAcaLimitsProvider</c>. Only
+    /// enforced in Aggregate mode (in Embedded mode the existing
+    /// <see cref="IndividualOopMax"/> already constrains members).
+    /// Null disables runtime enforcement; the
+    /// <c>IPlanLimitValidator</c> still runs at write time.
+    /// </summary>
+    public decimal? AcaIndividualCap { get; init; }
+
+    /// <summary>
+    /// Gated rollout flag for Aggregate-mode ACA cap enforcement (G8).
+    /// New plans published after capability 5.7 set this to true; legacy
+    /// plans hydrate with false so members on existing Aggregate plans
+    /// don't see surprise mid-year caps. Operators flip a legacy plan to
+    /// enforced state by re-publishing the version. Transition support,
+    /// not permanent legacy support — see
+    /// docs/architecture/family-accumulator-models.md.
+    /// </summary>
+    public bool IsAcaCapEnforced { get; init; }
+
     // ── HDHP / HSA ──
 
     /// <summary>

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
@@ -81,7 +81,7 @@ public record BenefitPlanConfig
 
     /// <summary>
     /// ACA 45 CFR §156.130 per-member individual out-of-pocket cap for
-    /// the plan year. Resolved at <see cref="ChoBenefitPlanProvider"/>
+    /// the plan year. Resolved at <see cref="IBenefitPlanProvider"/>
     /// mapping time from the file-backed <c>IAcaLimitsProvider</c>. Only
     /// enforced in Aggregate mode (in Embedded mode the existing
     /// <see cref="IndividualOopMax"/> already constrains members).

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -314,6 +314,7 @@ public class MemberBenefitView
     public DateTime EffectiveDate { get; set; }
     public DateTime? TerminationDate { get; set; }
     public string PlanVersion { get; set; } = string.Empty;
+    public string FamilyAccumulatorModel { get; set; } = "Embedded";
     public MemberBenefitCostSharing CostSharing { get; set; } = new();
     public List<CategorizedBenefit> Categories { get; set; } = new();
     public List<PlanDocumentLink> Documents { get; set; } = new();

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
@@ -23,7 +23,7 @@ public class BenefitPlansControllerVersionTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), new NoOpPlanLimitValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         var viewService = new BenefitViewService(service, NullLogger<BenefitViewService>.Instance);
 
         // Default adapter: real CHO adapter backed by the in-memory service so

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -288,6 +288,17 @@ public sealed class NoOpNetworkTierSoftValidator : INetworkTierSoftValidator
     public void Inspect(BenefitPlan plan, NetworkTierWriteCaller caller) { }
 }
 
+/// <summary>
+/// No-op <see cref="IPlanLimitValidator"/> for tests that don't exercise
+/// ACA-cap validation directly. Tests that do exercise it (see
+/// <c>PlanLimitValidatorTests</c>) construct
+/// <see cref="PlanLimitValidator"/> with stubbed limits and resolver.
+/// </summary>
+public sealed class NoOpPlanLimitValidator : IPlanLimitValidator
+{
+    public void Validate(BenefitPlan plan, PlanLimitWriteCaller caller) { }
+}
+
 public sealed class FakePlanYearScheduleSource : IPlanYearScheduleSource
 {
     public List<BenefitPlan> Plans { get; } = new();

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/TypedBenefitRoundTripTests.cs
@@ -27,7 +27,7 @@ public class TypedBenefitRoundTripTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), new NoOpPlanLimitValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         return (service, repo, transitions, events);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaLimitsProviderTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaLimitsProviderTests.cs
@@ -1,0 +1,114 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.7 — file-backed ACA OOP limits loader. Verifies the
+/// provider validates the file at startup so a malformed deploy fails
+/// fast rather than serve adjudications without enforcement.
+/// </summary>
+public sealed class AcaLimitsProviderTests
+{
+    private static IAcaLimitsProvider BuildProvider(string fileContent)
+    {
+        var dir = Directory.CreateTempSubdirectory("aca-limits-test").FullName;
+        var path = Path.Combine(dir, "limits.json");
+        File.WriteAllText(path, fileContent);
+
+        var options = Options.Create(new AcaOopLimitsOptions { LimitsFilePath = path });
+        return new AcaLimitsProvider(
+            options,
+            new StubHost(dir),
+            NullLogger<AcaLimitsProvider>.Instance);
+    }
+
+    [Fact]
+    public void GetForPlanYear_Returns_Configured_Row()
+    {
+        var json = """
+        {
+          "limits": [
+            { "planYear": 2025, "individualCap": 9200, "familyCap": 18400 },
+            { "planYear": 2026, "individualCap": 10600, "familyCap": 21200 }
+          ]
+        }
+        """;
+        var provider = BuildProvider(json);
+
+        var row = provider.GetForPlanYear(2025);
+
+        row.Should().NotBeNull();
+        row!.IndividualCap.Should().Be(9_200m);
+        row.FamilyCap.Should().Be(18_400m);
+    }
+
+    [Fact]
+    public void GetForPlanYear_Returns_Null_For_Unknown_Year()
+    {
+        var json = """{ "limits": [ { "planYear": 2025, "individualCap": 9200, "familyCap": 18400 } ] }""";
+        var provider = BuildProvider(json);
+
+        provider.GetForPlanYear(2099).Should().BeNull();
+    }
+
+    [Fact]
+    public void ConfiguredPlanYears_Lists_All_Loaded_Years()
+    {
+        var json = """
+        {
+          "limits": [
+            { "planYear": 2024, "individualCap": 9450, "familyCap": 18900 },
+            { "planYear": 2025, "individualCap": 9200, "familyCap": 18400 }
+          ]
+        }
+        """;
+        var provider = BuildProvider(json);
+
+        provider.ConfiguredPlanYears.Should().BeEquivalentTo(new[] { 2024, 2025 });
+    }
+
+    [Fact]
+    public void Construction_Throws_When_File_Missing()
+    {
+        var options = Options.Create(new AcaOopLimitsOptions
+        {
+            LimitsFilePath = Path.Combine(Path.GetTempPath(), "nonexistent-aca-file.json"),
+        });
+
+        var act = () => new AcaLimitsProvider(
+            options,
+            new StubHost(Path.GetTempPath()),
+            NullLogger<AcaLimitsProvider>.Instance);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ACA OOP limits file not found*");
+    }
+
+    [Fact]
+    public void Construction_Throws_When_File_Is_Malformed_Json()
+    {
+        var act = () => BuildProvider("not json");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*malformed*");
+    }
+
+    [Fact]
+    public void Construction_Throws_When_FamilyCap_Less_Than_IndividualCap()
+    {
+        var json = """{ "limits": [ { "planYear": 2025, "individualCap": 9200, "familyCap": 5000 } ] }""";
+        var act = () => BuildProvider(json);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*familyCap*less than*");
+    }
+
+    private sealed class StubHost : IHostEnvironment
+    {
+        public StubHost(string root) { ContentRootPath = root; }
+        public string EnvironmentName { get; set; } = "Test";
+        public string ApplicationName { get; set; } = "BenefitPlanService.Tests";
+        public string ContentRootPath { get; set; }
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaLimitsProviderTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaLimitsProviderTests.cs
@@ -11,11 +11,23 @@ namespace BenefitPlanService.Tests.Services;
 /// provider validates the file at startup so a malformed deploy fails
 /// fast rather than serve adjudications without enforcement.
 /// </summary>
-public sealed class AcaLimitsProviderTests
+public sealed class AcaLimitsProviderTests : IDisposable
 {
-    private static IAcaLimitsProvider BuildProvider(string fileContent)
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var dir in _tempDirs)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { /* best-effort */ }
+        }
+    }
+
+    private IAcaLimitsProvider BuildProvider(string fileContent)
     {
         var dir = Directory.CreateTempSubdirectory("aca-limits-test").FullName;
+        _tempDirs.Add(dir);
         var path = Path.Combine(dir, "limits.json");
         File.WriteAllText(path, fileContent);
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
@@ -24,7 +24,7 @@ public class BenefitPlanServiceVersionTests
         var repo = new InMemoryBenefitPlanRepository();
         var transitions = new InMemoryPlanVersionTransitionRepository();
         var events = new FakePlanVersionEventPublisher();
-        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
+        var service = new BenefitPlanServiceImpl(repo, transitions, events, new NoOpNetworkTierSoftValidator(), new NoOpPlanLimitValidator(), NullLogger<BenefitPlanServiceImpl>.Instance);
         return (service, repo, transitions, events);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitViewServiceFamilyModelTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitViewServiceFamilyModelTests.cs
@@ -1,0 +1,75 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.7 — verifies <see cref="BenefitViewService"/> projects
+/// <c>BenefitPlan.FamilyAccumulatorModel</c> onto the
+/// <c>MemberBenefitView</c> as a string. Portal DTO mirroring is covered
+/// by adapter round-trip tests; this fixture exercises the service-side
+/// projection only.
+/// </summary>
+public sealed class BenefitViewServiceFamilyModelTests
+{
+    private static (BenefitViewService view, BenefitPlanServiceImpl service,
+        InMemoryBenefitPlanRepository repo) Build()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var transitions = new InMemoryPlanVersionTransitionRepository();
+        var events = new FakePlanVersionEventPublisher();
+        var service = new BenefitPlanServiceImpl(
+            repo, transitions, events,
+            new NoOpNetworkTierSoftValidator(),
+            new NoOpPlanLimitValidator(),
+            NullLogger<BenefitPlanServiceImpl>.Instance);
+        var view = new BenefitViewService(service, NullLogger<BenefitViewService>.Instance);
+        return (view, service, repo);
+    }
+
+    private static BenefitPlan SamplePlan(FamilyAccumulatorModel model) => new()
+    {
+        Id = "plan-row-001",
+        TenantId = "tenant-a",
+        PlanId = "plan-001",
+        PlanName = "ACA Test",
+        Payer = "Acme",
+        EffectiveDate = new DateTime(2025, 1, 1),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        FamilyAccumulatorModel = model,
+        VersionId = "v1",
+        VersionNumber = 1,
+        VersionState = PlanVersionState.Published,
+        IsActive = true,
+        Benefits = new(),
+    };
+
+    [Fact]
+    public async Task GetMemberView_Surfaces_Embedded_Model_String()
+    {
+        var (view, _, repo) = Build();
+        var plan = SamplePlan(FamilyAccumulatorModel.Embedded);
+        await repo.CreateAsync(plan);
+
+        var result = await view.GetMemberViewAsync(plan.Id, plan.TenantId, DateTime.UtcNow);
+
+        result.Should().NotBeNull();
+        result!.FamilyAccumulatorModel.Should().Be("Embedded");
+    }
+
+    [Fact]
+    public async Task GetMemberView_Surfaces_Aggregate_Model_String()
+    {
+        var (view, _, repo) = Build();
+        var plan = SamplePlan(FamilyAccumulatorModel.Aggregate);
+        await repo.CreateAsync(plan);
+
+        var result = await view.GetMemberViewAsync(plan.Id, plan.TenantId, DateTime.UtcNow);
+
+        result.Should().NotBeNull();
+        result!.FamilyAccumulatorModel.Should().Be("Aggregate");
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
@@ -1,0 +1,157 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Repositories;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using CloudHealthOffice.BenefitEngine.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
+using ModelFamilyAccumulatorModel = BenefitPlanService.Models.FamilyAccumulatorModel;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.7 — verifies <see cref="ChoBenefitPlanProvider.MapToConfig"/>
+/// projects the new <c>FamilyAccumulatorModel</c> field plus the ACA
+/// individual cap and the gated <c>IsAcaCapEnforced</c> flag onto the
+/// engine config.
+/// </summary>
+public sealed class ChoBenefitPlanProviderModelMappingTests
+{
+    private static ChoBenefitPlanProvider Build(IAcaLimitsProvider? limits = null,
+        IBenefitPlanRepository? repo = null)
+    {
+        repo ??= new InMemoryBenefitPlanRepository();
+        limits ??= new StubLimits(new AcaLimits(2025, 9_200m, 18_400m));
+        return new ChoBenefitPlanProvider(
+            repo,
+            new StubTenantContext("tenant-a"),
+            limits,
+            new PlanYearResolver(),
+            NullLogger<ChoBenefitPlanProvider>.Instance);
+    }
+
+    private static BenefitPlan SamplePlan(
+        ModelFamilyAccumulatorModel model = ModelFamilyAccumulatorModel.Embedded,
+        DateTime? publishedAt = null) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = "tenant-a",
+        PlanId = "plan-001",
+        PlanName = "Test",
+        PlanType = PlanType.PPO,
+        EffectiveDate = new DateTime(2025, 1, 1),
+        VersionState = PlanVersionState.Published,
+        PublishedAt = publishedAt,
+        FamilyAccumulatorModel = model,
+        CostSharing = new CostSharing
+        {
+            IndividualOutOfPocketMax = 8_000m,
+            FamilyOutOfPocketMax = 16_000m,
+        },
+        Benefits = new(),
+    };
+
+    [Fact]
+    public void MapToConfig_Propagates_FamilyAccumulatorModel_Aggregate()
+    {
+        var provider = Build();
+        var plan = SamplePlan(model: ModelFamilyAccumulatorModel.Aggregate);
+
+        var config = provider.MapToConfig(plan);
+
+        config.FamilyAccumulatorModel.Should().Be(EngineFamilyAccumulatorModel.Aggregate);
+    }
+
+    [Fact]
+    public void MapToConfig_Defaults_To_Embedded_For_Legacy_Plans()
+    {
+        var provider = Build();
+        var plan = SamplePlan();
+
+        var config = provider.MapToConfig(plan);
+
+        config.FamilyAccumulatorModel.Should().Be(EngineFamilyAccumulatorModel.Embedded);
+    }
+
+    [Fact]
+    public void MapToConfig_Carries_AcaIndividualCap_From_LimitsProvider()
+    {
+        var provider = Build();
+        var plan = SamplePlan(model: ModelFamilyAccumulatorModel.Aggregate);
+
+        var config = provider.MapToConfig(plan);
+
+        config.AcaIndividualCap.Should().Be(9_200m);
+    }
+
+    [Fact]
+    public void MapToConfig_Returns_Null_AcaCap_When_PlanYear_Not_Configured()
+    {
+        var provider = Build(limits: new StubLimits(/* nothing for 2025 */));
+        var plan = SamplePlan(model: ModelFamilyAccumulatorModel.Aggregate);
+
+        var config = provider.MapToConfig(plan);
+
+        config.AcaIndividualCap.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToConfig_Sets_IsAcaCapEnforced_True_For_Post_Cutoff_Aggregate_Plans()
+    {
+        var provider = Build();
+        var plan = SamplePlan(
+            model: ModelFamilyAccumulatorModel.Aggregate,
+            publishedAt: new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var config = provider.MapToConfig(plan);
+
+        config.IsAcaCapEnforced.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MapToConfig_Sets_IsAcaCapEnforced_False_For_Legacy_Aggregate_Plans()
+    {
+        var provider = Build();
+        var plan = SamplePlan(
+            model: ModelFamilyAccumulatorModel.Aggregate,
+            publishedAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var config = provider.MapToConfig(plan);
+
+        config.IsAcaCapEnforced.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MapToConfig_Sets_IsAcaCapEnforced_False_For_Embedded_Plans()
+    {
+        // Embedded plans never need runtime enforcement (the existing
+        // IndividualOutOfPocketMax constraint is enforced by the engine
+        // separately). Field stays false regardless of publish date.
+        var provider = Build();
+        var plan = SamplePlan(
+            model: ModelFamilyAccumulatorModel.Embedded,
+            publishedAt: new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var config = provider.MapToConfig(plan);
+
+        config.IsAcaCapEnforced.Should().BeFalse();
+    }
+
+    private sealed class StubTenantContext : IBenefitEngineTenantContext
+    {
+        public StubTenantContext(string tenantId) { TenantId = tenantId; }
+        public string TenantId { get; }
+    }
+
+    private sealed class StubLimits : IAcaLimitsProvider
+    {
+        private readonly Dictionary<int, AcaLimits> _byYear;
+        public StubLimits(params AcaLimits[] rows)
+        {
+            _byYear = rows.ToDictionary(r => r.PlanYear);
+        }
+        public AcaLimits? GetForPlanYear(int planYear)
+            => _byYear.TryGetValue(planYear, out var row) ? row : null;
+        public IReadOnlyCollection<int> ConfiguredPlanYears => _byYear.Keys;
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanLimitValidatorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/PlanLimitValidatorTests.cs
@@ -1,0 +1,145 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.7 — write-time ACA §156.130 OOP cap validation.
+/// Both individual and family caps are checked on every write surface;
+/// missing plan-year config fails closed.
+/// </summary>
+public sealed class PlanLimitValidatorTests
+{
+    private static IPlanLimitValidator BuildValidator(IAcaLimitsProvider? limits = null)
+    {
+        limits ??= new StubLimits(new AcaLimits(2025, 9_200m, 18_400m));
+        return new PlanLimitValidator(
+            limits,
+            new PlanYearResolver(),
+            NullLogger<PlanLimitValidator>.Instance);
+    }
+
+    private static BenefitPlan PlanFor2025(decimal individualOop = 0m, decimal familyOop = 0m,
+        FamilyAccumulatorModel model = FamilyAccumulatorModel.Embedded) => new()
+    {
+        TenantId = "tenant-a",
+        PlanId = "plan-001",
+        VersionId = "v1",
+        EffectiveDate = new DateTime(2025, 1, 1),
+        FamilyAccumulatorModel = model,
+        CostSharing = new CostSharing
+        {
+            IndividualOutOfPocketMax = individualOop,
+            FamilyOutOfPocketMax = familyOop,
+        },
+    };
+
+    [Fact]
+    public void Validate_Passes_When_Caps_Within_Limits()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(individualOop: 9_000m, familyOop: 18_000m);
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Validate_Throws_When_IndividualOop_Exceeds_AcaCap()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(individualOop: 10_000m);
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+
+        act.Should().Throw<PlanLimitValidationException>()
+            .Which.Field.Should().Be("costSharing.individualOutOfPocketMax");
+    }
+
+    [Fact]
+    public void Validate_Throws_When_FamilyOop_Exceeds_AcaFamilyCap()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(familyOop: 19_000m, model: FamilyAccumulatorModel.Aggregate);
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+
+        act.Should().Throw<PlanLimitValidationException>()
+            .Which.Field.Should().Be("costSharing.familyOutOfPocketMax");
+    }
+
+    [Fact]
+    public void Validate_Throws_When_PlanYear_Is_Not_Configured()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(individualOop: 1_000m);
+        plan.EffectiveDate = new DateTime(2030, 1, 1); // unconfigured year
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+
+        act.Should().Throw<PlanLimitValidationException>()
+            .Which.Field.Should().Be("planYear");
+    }
+
+    [Fact]
+    public void Validate_Resolves_Year_From_PlanYearDefinition_First()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(individualOop: 9_300m); // > 2025 cap, < 2026 cap
+        plan.PlanYearDefinition = new PlanYearDefinition
+        {
+            PlanYearStart = new DateTime(2026, 1, 1),
+            PlanYearEnd = new DateTime(2026, 12, 31),
+        };
+
+        // Without year resolution, this would pass under 2026 caps
+        // (individual=10,600). But the configured stub only carries 2025;
+        // verify the validator looks up via PlanYearDefinition's year (2026)
+        // and rejects on missing year, not against 2025 caps.
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+        act.Should().Throw<PlanLimitValidationException>()
+            .Which.PlanYear.Should().Be(2026);
+    }
+
+    [Fact]
+    public void Validate_Falls_Back_To_EffectiveDate_When_PlanYearDefinition_Missing()
+    {
+        var validator = BuildValidator();
+        var plan = PlanFor2025(individualOop: 9_300m); // > 2025 cap of 9,200
+        plan.PlanYearDefinition = null;
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.PublishAndSupersede);
+
+        act.Should().Throw<PlanLimitValidationException>()
+            .Where(ex => ex.PlanYear == 2025 && ex.Cap == 9_200m);
+    }
+
+    [Fact]
+    public void Validate_Throws_With_Structured_Payload_Including_Configured_Years()
+    {
+        var validator = BuildValidator(new StubLimits(
+            new AcaLimits(2024, 9_450m, 18_900m),
+            new AcaLimits(2025, 9_200m, 18_400m)));
+        var plan = PlanFor2025();
+        plan.EffectiveDate = new DateTime(2030, 1, 1);
+
+        var act = () => validator.Validate(plan, PlanLimitWriteCaller.CreatePlan);
+
+        act.Should().Throw<PlanLimitValidationException>()
+            .WithMessage("*Configured years: [2024, 2025]*");
+    }
+
+    private sealed class StubLimits : IAcaLimitsProvider
+    {
+        private readonly Dictionary<int, AcaLimits> _byYear;
+        public StubLimits(params AcaLimits[] rows)
+        {
+            _byYear = rows.ToDictionary(r => r.PlanYear);
+        }
+        public AcaLimits? GetForPlanYear(int planYear)
+            => _byYear.TryGetValue(planYear, out var row) ? row : null;
+        public IReadOnlyCollection<int> ConfiguredPlanYears => _byYear.Keys;
+    }
+}

--- a/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
@@ -351,6 +351,7 @@ public class BenefitPlansController : ControllerBase
     /// </summary>
     [HttpPost("{planId}/versions/{versionId}/publish")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<BenefitPlan>> Publish(

--- a/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
@@ -100,8 +100,15 @@ public class BenefitPlansController : ControllerBase
             return BadRequest(new { field = ex.ParamName, message = ex.Message });
         }
 
-        var created = await _service.CreatePlanAsync(plan, TenantId);
-        return CreatedAtAction(nameof(GetPlan), new { id = created.Id }, created);
+        try
+        {
+            var created = await _service.CreatePlanAsync(plan, TenantId);
+            return CreatedAtAction(nameof(GetPlan), new { id = created.Id }, created);
+        }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
+        }
     }
 
     /// <summary>
@@ -138,6 +145,10 @@ public class BenefitPlansController : ControllerBase
                 return NotFound(new { message = $"Benefit plan '{id}' not found" });
             }
             return Ok(updated);
+        }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
         }
         catch (PlanVersionStateException ex)
         {
@@ -323,8 +334,15 @@ public class BenefitPlansController : ControllerBase
         try { PlanDocumentValidation.ValidateDocuments(plan.Documents); }
         catch (ArgumentException ex) { return BadRequest(new { field = ex.ParamName, message = ex.Message }); }
 
-        var draft = await _service.CreateDraftAsync(plan, TenantId, ResolveActorId());
-        return CreatedAtAction(nameof(GetVersion), new { planId = draft.PlanId, versionId = draft.VersionId }, draft);
+        try
+        {
+            var draft = await _service.CreateDraftAsync(plan, TenantId, ResolveActorId());
+            return CreatedAtAction(nameof(GetVersion), new { planId = draft.PlanId, versionId = draft.VersionId }, draft);
+        }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
+        }
     }
 
     /// <summary>
@@ -344,6 +362,10 @@ public class BenefitPlansController : ControllerBase
                 planId, versionId, TenantId, ResolveActorId(), body?.EffectiveDate);
             return Ok(published);
         }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
+        }
         catch (PlanVersionStateException ex) when (ex.IsNotFound)
         {
             return NotFound(new { message = ex.Message, planId = ex.PlanId, versionId = ex.VersionId });
@@ -360,6 +382,7 @@ public class BenefitPlansController : ControllerBase
     /// </summary>
     [HttpPost("{planId}/amend")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<BenefitPlan>> Amend(string planId)
     {
@@ -367,6 +390,10 @@ public class BenefitPlansController : ControllerBase
         {
             var draft = await _service.AmendPublishedPlanAsync(planId, TenantId, ResolveActorId());
             return CreatedAtAction(nameof(GetVersion), new { planId = draft.PlanId, versionId = draft.VersionId }, draft);
+        }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
         }
         catch (PlanVersionStateException ex) when (ex.IsNotFound)
         {
@@ -419,6 +446,18 @@ public class BenefitPlansController : ControllerBase
             return header.ToString();
         return "system";
     }
+
+    private static object PlanLimitValidationPayload(PlanLimitValidationException ex) => new
+    {
+        message = ex.Message,
+        code = "PLAN_LIMIT_ACA_VIOLATION",
+        planId = ex.PlanId,
+        versionId = ex.VersionId,
+        planYear = ex.PlanYear,
+        field = ex.Field,
+        supplied = ex.Supplied,
+        cap = ex.Cap
+    };
 
     private static string SanitizeForLog(string? value)
     {

--- a/src/services/benefit-plan-service/Models/AcaOopLimitsOptions.cs
+++ b/src/services/benefit-plan-service/Models/AcaOopLimitsOptions.cs
@@ -1,0 +1,33 @@
+namespace BenefitPlanService.Models;
+
+/// <summary>
+/// Configuration for <see cref="Services.IAcaLimitsProvider"/> (capability
+/// BP 5.7 — Embedded vs Aggregate Family OOP Rules + ACA cap enforcement).
+///
+/// <para>
+/// The ACA 45 CFR §156.130 individual / family out-of-pocket caps live
+/// in a versioned seed file (see <c>schemas/aca-oop-limits/limits.json</c>),
+/// loaded once at service startup by <see cref="Services.AcaLimitsProvider"/>.
+/// Operators bump the file when CMS publishes the annual NBPP final rule;
+/// the provider rejects unknown plan years at write time so a missing-year
+/// regression is impossible to ignore.
+/// </para>
+///
+/// <para>
+/// See <c>docs/architecture/family-accumulator-models.md</c> for the
+/// canonical resolution flow and <c>schemas/aca-oop-limits/README.md</c>
+/// for source attribution and update cadence.
+/// </para>
+/// </summary>
+public sealed class AcaOopLimitsOptions
+{
+    public const string SectionName = "AcaOopLimits";
+
+    /// <summary>
+    /// Filesystem path to the JSON limits file relative to the service
+    /// content root. Default <c>schemas/aca-oop-limits/limits.json</c>.
+    /// Override in tests to point at a fixture.
+    /// </summary>
+    public string LimitsFilePath { get; set; }
+        = "schemas/aca-oop-limits/limits.json";
+}

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -95,6 +95,28 @@ public class BenefitPlan
     [JsonPropertyName("isActive")]
     public bool IsActive { get; set; } = true;
 
+    /// <summary>
+    /// Plan-level family accumulator pooling model (5.7). Embedded =
+    /// per-member individual + family pools tracked independently;
+    /// Aggregate = single shared family pool with an ACA 45 CFR §156.130
+    /// per-member cap (enforced at runtime once the plan is republished
+    /// after capability 5.7).
+    ///
+    /// <para>
+    /// Defaults to <see cref="FamilyAccumulatorModel.Embedded"/>, which
+    /// matches the engine's pre-5.7 implicit default. Legacy plan
+    /// documents missing this field hydrate as Embedded — see
+    /// docs/architecture/family-accumulator-models.md.
+    /// </para>
+    ///
+    /// <para>
+    /// Version-identity-bearing. Changing the model on a Published plan
+    /// requires a new version (the same as any other cost-sharing change).
+    /// </para>
+    /// </summary>
+    [JsonPropertyName("familyAccumulatorModel")]
+    public FamilyAccumulatorModel FamilyAccumulatorModel { get; set; } = FamilyAccumulatorModel.Embedded;
+
     // ---------------------------------------------------------------------
     // Version identity (5.1 — Plan Identity & Versioning)
     //
@@ -540,4 +562,37 @@ public enum LineOfBusiness
     /// Veterans Affairs health coverage
     /// </summary>
     VA = 6
+}
+
+/// <summary>
+/// Plan-level family accumulator pooling model (capability 5.7). Mirrors
+/// <see cref="CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel"/>
+/// in the engine; the service-side mirror exists so the persisted plan
+/// document never takes a runtime dependency on the engine's domain
+/// namespace, matching the boundary stance taken for <see cref="PlanType"/>.
+///
+/// <para>
+/// <see cref="ChoBenefitPlanProvider"/> projects this value onto the
+/// engine's <c>BenefitPlanConfig.FamilyAccumulatorModel</c> at adjudication
+/// time; ACA-cap enforcement on Aggregate plans is gated by
+/// <c>BenefitPlanConfig.IsAcaCapEnforced</c> (set true on republish after
+/// capability 5.7, false on legacy hydration).
+/// </para>
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum FamilyAccumulatorModel
+{
+    /// <summary>
+    /// Each member has individual deductible / OOP; family aggregate also
+    /// tracked. Individual met → that member's portion satisfied. Family
+    /// met → all members' portions satisfied. Default for legacy plans.
+    /// </summary>
+    Embedded = 1,
+
+    /// <summary>
+    /// One shared family pool. Plus an ACA 45 CFR §156.130 per-member
+    /// cap (enforced at runtime once <c>IsAcaCapEnforced</c> is true on
+    /// the engine config). Common in HDHP / HSA plans.
+    /// </summary>
+    Aggregate = 2
 }

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -579,7 +579,6 @@ public enum LineOfBusiness
 /// capability 5.7, false on legacy hydration).
 /// </para>
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum FamilyAccumulatorModel
 {
     /// <summary>

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -57,6 +57,7 @@ public class AdapterBenefitPlan
     public PlanType PlanType { get; set; }
     public MetalLevel? MetalLevel { get; set; }
     public LineOfBusiness LineOfBusiness { get; set; } = LineOfBusiness.Commercial;
+    public FamilyAccumulatorModel FamilyAccumulatorModel { get; set; } = FamilyAccumulatorModel.Embedded;
 
     public List<AdapterBenefit> Benefits { get; set; } = new();
     public List<AdapterNetworkTier> NetworkTiers { get; set; } = new();
@@ -92,6 +93,7 @@ public class AdapterBenefitPlan
         PlanType = src.PlanType,
         MetalLevel = src.MetalLevel,
         LineOfBusiness = src.LineOfBusiness,
+        FamilyAccumulatorModel = src.FamilyAccumulatorModel,
         Benefits = src.Benefits.Select(AdapterBenefit.From).ToList(),
         NetworkTiers = src.NetworkTiers.Select(AdapterNetworkTier.From).ToList(),
         CostSharing = AdapterCostSharing.From(src.CostSharing),
@@ -124,6 +126,7 @@ public class AdapterBenefitPlan
         PlanType = PlanType,
         MetalLevel = MetalLevel,
         LineOfBusiness = LineOfBusiness,
+        FamilyAccumulatorModel = FamilyAccumulatorModel,
         Benefits = Benefits.Select(b => b.ToBenefit()).ToList(),
         NetworkTiers = NetworkTiers.Select(n => n.ToNetworkTier()).ToList(),
         CostSharing = CostSharing.ToCostSharing(),
@@ -655,6 +658,7 @@ public class AdapterMemberBenefitView
     public DateTime EffectiveDate { get; set; }
     public DateTime? TerminationDate { get; set; }
     public string PlanVersion { get; set; } = string.Empty;
+    public string FamilyAccumulatorModel { get; set; } = "Embedded";
     public AdapterCostSharing CostSharing { get; set; } = new();
     public List<AdapterCategorizedBenefit> Categories { get; set; } = new();
     public List<AdapterPlanDocumentLink> Documents { get; set; } = new();
@@ -671,6 +675,7 @@ public class AdapterMemberBenefitView
         EffectiveDate = v.EffectiveDate,
         TerminationDate = v.TerminationDate,
         PlanVersion = v.PlanVersion,
+        FamilyAccumulatorModel = v.FamilyAccumulatorModel,
         CostSharing = AdapterCostSharing.From(v.CostSharing),
         Categories = v.Categories.Select(AdapterCategorizedBenefit.From).ToList(),
         Documents = v.Documents.Select(AdapterPlanDocumentLink.From).ToList(),
@@ -688,6 +693,7 @@ public class AdapterMemberBenefitView
         EffectiveDate = EffectiveDate,
         TerminationDate = TerminationDate,
         PlanVersion = PlanVersion,
+        FamilyAccumulatorModel = FamilyAccumulatorModel,
         CostSharing = CostSharing.ToCostSharing(),
         Categories = Categories.Select(c => c.ToCategorizedBenefit()).ToList(),
         Documents = Documents.Select(d => d.ToPlanDocumentLink()).ToList(),

--- a/src/services/benefit-plan-service/Models/MemberBenefitView.cs
+++ b/src/services/benefit-plan-service/Models/MemberBenefitView.cs
@@ -45,6 +45,16 @@ public class MemberBenefitView
     [JsonPropertyName("planVersion")]
     public string PlanVersion { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Plan-level family accumulator pooling model (capability 5.7).
+    /// Surfaced as a string ("Embedded" / "Aggregate") so portal and
+    /// downstream consumers can render the model choice without taking
+    /// a code dependency on the enum. See
+    /// docs/architecture/family-accumulator-models.md.
+    /// </summary>
+    [JsonPropertyName("familyAccumulatorModel")]
+    public string FamilyAccumulatorModel { get; set; } = "Embedded";
+
     [JsonPropertyName("costSharing")]
     public CostSharing CostSharing { get; set; } = new();
 

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -161,6 +161,16 @@ builder.Services.AddBenefitEngine().UseRedisAccumulatorService();
 builder.Services.AddScoped<CloudHealthOffice.BenefitEngine.Services.IBenefitPlanProvider,
                            BenefitPlanService.Services.ChoBenefitPlanProvider>();
 
+// ── ACA OOP Limits + Plan-Limit Validator (capability BP 5.7) ────────────────
+// Loaded once at service startup; consumed by ChoBenefitPlanProvider when
+// projecting BenefitPlan onto BenefitPlanConfig and by IPlanLimitValidator
+// at every plan-write surface. See docs/architecture/family-accumulator-models.md.
+builder.Services.Configure<AcaOopLimitsOptions>(
+    builder.Configuration.GetSection(AcaOopLimitsOptions.SectionName));
+builder.Services.AddSingleton<IAcaLimitsProvider, AcaLimitsProvider>();
+builder.Services.AddSingleton<IPlanYearResolver, PlanYearResolver>();
+builder.Services.AddScoped<IPlanLimitValidator, PlanLimitValidator>();
+
 // ── Service-Category Mappings (capability BP 5.6) ────────────────────────────
 // Replaces the prior NullServiceCategoryMappingRepository with a real Cosmos
 // or Mongo backend (selected by the same MongoDb:ConnectionString switch

--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -63,6 +63,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
     private readonly IPlanVersionTransitionRepository _transitions;
     private readonly IPlanVersionEventPublisher _events;
     private readonly INetworkTierSoftValidator _networkTierValidator;
+    private readonly IPlanLimitValidator _planLimitValidator;
     private readonly ILogger<BenefitPlanServiceImpl> _logger;
 
     public BenefitPlanServiceImpl(
@@ -70,12 +71,14 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         IPlanVersionTransitionRepository transitions,
         IPlanVersionEventPublisher events,
         INetworkTierSoftValidator networkTierValidator,
+        IPlanLimitValidator planLimitValidator,
         ILogger<BenefitPlanServiceImpl> logger)
     {
         _repository = repository;
         _transitions = transitions;
         _events = events;
         _networkTierValidator = networkTierValidator;
+        _planLimitValidator = planLimitValidator;
         _logger = logger;
     }
 
@@ -121,6 +124,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         plan.PublishedAt = DateTime.UtcNow;
 
         _networkTierValidator.Inspect(plan, NetworkTierWriteCaller.CreatePlan);
+        _planLimitValidator.Validate(plan, PlanLimitWriteCaller.CreatePlan);
         return await _repository.CreateAsync(plan);
     }
 
@@ -135,6 +139,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         plan.TenantId = tenantId;
         plan.UpdatedAt = DateTime.UtcNow;
         _networkTierValidator.Inspect(plan, NetworkTierWriteCaller.UpdatePlan);
+        _planLimitValidator.Validate(plan, PlanLimitWriteCaller.UpdatePlan);
         // Repository raises PlanVersionStateException for Published/Superseded;
         // controller maps to 409.
         return await _repository.UpdateAsync(plan);
@@ -339,6 +344,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         draft.IsActive = false;
 
         _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.CreateDraft);
+        _planLimitValidator.Validate(draft, PlanLimitWriteCaller.CreateDraft);
         return await _repository.CreateDraftAsync(draft);
     }
 
@@ -396,6 +402,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         }
 
         _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.PublishAndSupersede);
+        _planLimitValidator.Validate(draft, PlanLimitWriteCaller.PublishAndSupersede);
         await _repository.PublishAndSupersedeAsync(draft, predecessor);
 
         await _transitions.AppendAsync(new PlanVersionTransition
@@ -441,6 +448,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         draft.UpdatedAt = DateTime.UtcNow;
 
         _networkTierValidator.Inspect(draft, NetworkTierWriteCaller.AmendPublished);
+        _planLimitValidator.Validate(draft, PlanLimitWriteCaller.AmendPublished);
         var stored = await _repository.CreateDraftAsync(draft);
 
         await _transitions.AppendAsync(new PlanVersionTransition
@@ -496,6 +504,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         PlanType = src.PlanType,
         MetalLevel = src.MetalLevel,
         LineOfBusiness = src.LineOfBusiness,
+        FamilyAccumulatorModel = src.FamilyAccumulatorModel,
         Benefits = src.Benefits.Select(CloneBenefit).ToList(),
         NetworkTiers = src.NetworkTiers.Select(CloneNetworkTier).ToList(),
         CostSharing = CloneCostSharing(src.CostSharing),

--- a/src/services/benefit-plan-service/Services/BenefitViewService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitViewService.cs
@@ -42,6 +42,7 @@ public class BenefitViewService : IBenefitViewService
             EffectiveDate = plan.EffectiveDate,
             TerminationDate = plan.TerminationDate,
             PlanVersion = BuildPlanVersion(plan),
+            FamilyAccumulatorModel = plan.FamilyAccumulatorModel.ToString(),
             CostSharing = plan.CostSharing,
             Categories = plan.Benefits.Select(b => ProjectBenefit(b, plan)).ToList(),
             Documents = plan.Documents.Select(ProjectDocument).ToList(),

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
@@ -4,6 +4,8 @@ using CloudHealthOffice.BenefitEngine.Domain;
 using CloudHealthOffice.BenefitEngine.Services;
 using EnginePlanType = CloudHealthOffice.BenefitEngine.Domain.PlanType;
 using ModelPlanType = BenefitPlanService.Models.PlanType;
+using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
+using ModelFamilyAccumulatorModel = BenefitPlanService.Models.FamilyAccumulatorModel;
 
 namespace BenefitPlanService.Services;
 
@@ -13,13 +15,37 @@ namespace BenefitPlanService.Services;
 /// </summary>
 public class ChoBenefitPlanProvider : IBenefitPlanProvider
 {
+    /// <summary>
+    /// Cutoff that distinguishes legacy plans (hydrate with
+    /// <c>IsAcaCapEnforced=false</c>) from post-5.7 publishes (which set
+    /// it true automatically). Plans with <see cref="BenefitPlan.PublishedAt"/>
+    /// at or after this UTC instant get runtime ACA cap enforcement on
+    /// Aggregate mode; legacy plans behave as they did pre-5.7 until an
+    /// operator amends + republishes them. Transition support per the
+    /// ratified plan (G8); see
+    /// <c>docs/architecture/family-accumulator-models.md</c>.
+    /// </summary>
+    public static readonly DateTime AcaCapEnforcementCutoffUtc =
+        new(2026, 4, 28, 0, 0, 0, DateTimeKind.Utc);
+
     private readonly IBenefitPlanRepository _repo;
     private readonly IBenefitEngineTenantContext _tenantContext;
+    private readonly IAcaLimitsProvider _acaLimits;
+    private readonly IPlanYearResolver _planYear;
+    private readonly ILogger<ChoBenefitPlanProvider> _logger;
 
-    public ChoBenefitPlanProvider(IBenefitPlanRepository repo, IBenefitEngineTenantContext tenantContext)
+    public ChoBenefitPlanProvider(
+        IBenefitPlanRepository repo,
+        IBenefitEngineTenantContext tenantContext,
+        IAcaLimitsProvider acaLimits,
+        IPlanYearResolver planYear,
+        ILogger<ChoBenefitPlanProvider> logger)
     {
         _repo = repo;
         _tenantContext = tenantContext;
+        _acaLimits = acaLimits;
+        _planYear = planYear;
+        _logger = logger;
     }
 
     public async Task<BenefitPlanConfig?> GetPlanAsync(Guid benefitPlanId, CancellationToken ct = default)
@@ -31,7 +57,7 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
         return MapToConfig(plan);
     }
 
-    private static BenefitPlanConfig MapToConfig(BenefitPlan plan)
+    internal BenefitPlanConfig MapToConfig(BenefitPlan plan)
     {
         var categories = plan.Benefits
             .Select(b => new BenefitCategoryConfig
@@ -47,12 +73,30 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
             })
             .ToList();
 
+        // Resolve ACA per-member cap for the plan year (capability 5.7).
+        // Lookup is best-effort here — when missing, the engine simply
+        // doesn't seed the cap accumulator. Hard rejection lives in
+        // IPlanLimitValidator at write time, which is the right gate for
+        // plan correctness; the read path stays soft so legacy plans
+        // hydrate even if the ops file falls behind.
+        var planYear = _planYear.Resolve(plan);
+        var acaCaps = _acaLimits.GetForPlanYear(planYear);
+        if (acaCaps is null)
+        {
+            _logger.LogWarning(
+                "ACA OOP limits not configured for plan year {PlanYear}; engine will receive null AcaIndividualCap for plan {PlanId} version {VersionId}",
+                planYear,
+                SanitizeForLog(plan.PlanId),
+                SanitizeForLog(plan.VersionId));
+        }
+
         return new BenefitPlanConfig
         {
             Id = Guid.Parse(plan.Id),
             TenantId = plan.TenantId,
             PlanName = plan.PlanName,
             PlanType = MapPlanType(plan.PlanType),
+            PlanYear = planYear.ToString(),
             LineOfBusiness = plan.LineOfBusiness.ToString(),
             IndividualDeductible = plan.CostSharing.IndividualDeductible > 0
                 ? plan.CostSharing.IndividualDeductible
@@ -76,9 +120,47 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
             IndividualOopMaxOon = plan.CostSharing.OutNetworkIndividualOutOfPocketMax
                 ?? (plan.CostSharing.OutOfNetworkOutOfPocketMax > 0 ? plan.CostSharing.OutOfNetworkOutOfPocketMax : null),
             FamilyOopMaxOon = plan.CostSharing.OutNetworkFamilyOutOfPocketMax,
+            FamilyAccumulatorModel = MapFamilyAccumulatorModel(plan.FamilyAccumulatorModel),
+            AcaIndividualCap = acaCaps?.IndividualCap,
+            IsAcaCapEnforced = ResolveIsAcaCapEnforced(plan),
             IsHdhp = plan.PlanType == ModelPlanType.HDHP,
             Categories = categories
         };
+    }
+
+    /// <summary>
+    /// G8 gated rollout. Plans published at or after the cutoff (or that
+    /// have not been published yet, i.e. drafts) get runtime ACA cap
+    /// enforcement; legacy plans published before the cutoff hydrate with
+    /// enforcement disabled so members on existing Aggregate plans don't
+    /// see surprise mid-year caps. Re-publishing a legacy plan flips it
+    /// to enforced state automatically because PublishedAt advances.
+    /// </summary>
+    private static bool ResolveIsAcaCapEnforced(BenefitPlan plan)
+    {
+        if (plan.FamilyAccumulatorModel != ModelFamilyAccumulatorModel.Aggregate)
+            return false;
+
+        if (!plan.PublishedAt.HasValue) return true;
+
+        var publishedAt = plan.PublishedAt.Value.Kind == DateTimeKind.Utc
+            ? plan.PublishedAt.Value
+            : plan.PublishedAt.Value.ToUniversalTime();
+
+        return publishedAt >= AcaCapEnforcementCutoffUtc;
+    }
+
+    private static EngineFamilyAccumulatorModel MapFamilyAccumulatorModel(ModelFamilyAccumulatorModel model)
+        => model switch
+        {
+            ModelFamilyAccumulatorModel.Aggregate => EngineFamilyAccumulatorModel.Aggregate,
+            _ => EngineFamilyAccumulatorModel.Embedded,
+        };
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
     private static IReadOnlyList<CostShareRuleConfig> BuildInNetworkCostSharing(Benefit b)

--- a/src/services/benefit-plan-service/Services/IAcaLimitsProvider.cs
+++ b/src/services/benefit-plan-service/Services/IAcaLimitsProvider.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using BenefitPlanService.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// ACA 45 CFR §156.130 out-of-pocket cap lookup, keyed by plan year
+/// (capability BP 5.7). Loaded once at service startup from the file
+/// configured via <see cref="AcaOopLimitsOptions.LimitsFilePath"/>;
+/// re-loads happen only on process restart by design — regulatory caps
+/// are point-in-time values and a hot-reload would obscure when a value
+/// changed.
+///
+/// <para>
+/// <b>Fail-closed.</b> When a plan year is not present in the loaded
+/// file, callers (the validator and the
+/// <c>ChoBenefitPlanProvider</c> mapper) treat the absence as a hard
+/// failure rather than fall back. Better to reject the plan with a
+/// structured error than silently compare against stale or missing
+/// regulatory limits.
+/// </para>
+/// </summary>
+public interface IAcaLimitsProvider
+{
+    /// <summary>
+    /// Look up the §156.130 caps for <paramref name="planYear"/>.
+    /// Returns <c>null</c> when the plan year is not configured;
+    /// callers are expected to reject the plan rather than substitute.
+    /// </summary>
+    AcaLimits? GetForPlanYear(int planYear);
+
+    /// <summary>
+    /// Plan years currently configured. Surfaced for diagnostic /
+    /// validation-error messages so operators see exactly which years
+    /// the file covers.
+    /// </summary>
+    IReadOnlyCollection<int> ConfiguredPlanYears { get; }
+}
+
+/// <summary>Per-plan-year ACA OOP caps in USD.</summary>
+public sealed record AcaLimits(int PlanYear, decimal IndividualCap, decimal FamilyCap);
+
+/// <summary>
+/// File-backed implementation. Loads <see cref="AcaOopLimitsOptions.LimitsFilePath"/>
+/// on construction; throws on a missing or malformed file so the service
+/// fails fast rather than serve adjudications without ACA enforcement.
+/// </summary>
+public sealed class AcaLimitsProvider : IAcaLimitsProvider
+{
+    private readonly Dictionary<int, AcaLimits> _byYear;
+
+    public AcaLimitsProvider(
+        IOptions<AcaOopLimitsOptions> options,
+        IHostEnvironment environment,
+        ILogger<AcaLimitsProvider> logger)
+    {
+        var path = ResolvePath(options.Value.LimitsFilePath, environment);
+        if (!File.Exists(path))
+        {
+            throw new InvalidOperationException(
+                $"ACA OOP limits file not found at '{path}'. Configure via " +
+                $"'{AcaOopLimitsOptions.SectionName}:{nameof(AcaOopLimitsOptions.LimitsFilePath)}' " +
+                "or place schemas/aca-oop-limits/limits.json in the service content root.");
+        }
+
+        var raw = File.ReadAllText(path);
+        LimitsFile? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<LimitsFile>(raw, JsonOpts);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"ACA OOP limits file at '{path}' is malformed: {ex.Message}", ex);
+        }
+
+        if (parsed is null || parsed.Limits is null || parsed.Limits.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"ACA OOP limits file at '{path}' is empty or missing the 'limits' array.");
+        }
+
+        _byYear = new Dictionary<int, AcaLimits>(parsed.Limits.Count);
+        foreach (var row in parsed.Limits)
+        {
+            if (row.PlanYear <= 0)
+                throw new InvalidOperationException(
+                    $"ACA OOP limits file at '{path}' has a row with invalid planYear '{row.PlanYear}'.");
+            if (row.IndividualCap <= 0 || row.FamilyCap <= 0)
+                throw new InvalidOperationException(
+                    $"ACA OOP limits file at '{path}' has non-positive caps for plan year {row.PlanYear}.");
+            if (row.FamilyCap < row.IndividualCap)
+                throw new InvalidOperationException(
+                    $"ACA OOP limits file at '{path}' has familyCap ({row.FamilyCap}) " +
+                    $"less than individualCap ({row.IndividualCap}) for plan year {row.PlanYear}.");
+
+            _byYear[row.PlanYear] = new AcaLimits(row.PlanYear, row.IndividualCap, row.FamilyCap);
+        }
+
+        logger.LogInformation(
+            "Loaded ACA OOP limits for plan years {Years} from {Path}",
+            string.Join(", ", _byYear.Keys.OrderBy(y => y)),
+            path);
+    }
+
+    public AcaLimits? GetForPlanYear(int planYear)
+        => _byYear.TryGetValue(planYear, out var row) ? row : null;
+
+    public IReadOnlyCollection<int> ConfiguredPlanYears => _byYear.Keys;
+
+    private static string ResolvePath(string configured, IHostEnvironment env)
+        => Path.IsPathRooted(configured)
+            ? configured
+            : Path.Combine(env.ContentRootPath, configured);
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private sealed class LimitsFile
+    {
+        public string? Version { get; set; }
+        public string? Source { get; set; }
+        public string? LastReviewed { get; set; }
+        public List<LimitsRow> Limits { get; set; } = new();
+    }
+
+    private sealed class LimitsRow
+    {
+        public int PlanYear { get; set; }
+        public decimal IndividualCap { get; set; }
+        public decimal FamilyCap { get; set; }
+        public string? Rule { get; set; }
+        public string? Note { get; set; }
+    }
+}

--- a/src/services/benefit-plan-service/Services/IAcaLimitsProvider.cs
+++ b/src/services/benefit-plan-service/Services/IAcaLimitsProvider.cs
@@ -14,20 +14,23 @@ namespace BenefitPlanService.Services;
 /// changed.
 ///
 /// <para>
-/// <b>Fail-closed.</b> When a plan year is not present in the loaded
-/// file, callers (the validator and the
-/// <c>ChoBenefitPlanProvider</c> mapper) treat the absence as a hard
-/// failure rather than fall back. Better to reject the plan with a
-/// structured error than silently compare against stale or missing
-/// regulatory limits.
+/// <b>Caller behavior by context.</b> When a plan year is not present in
+/// the loaded file, write-time validation treats the absence as a hard
+/// failure and rejects the plan with a structured error rather than
+/// compare against stale or missing regulatory limits. Read-time
+/// projection in <c>ChoBenefitPlanProvider</c> may, for legacy hydration,
+/// log the missing year and continue with a <c>null</c> cap instead of
+/// failing closed.
 /// </para>
 /// </summary>
 public interface IAcaLimitsProvider
 {
     /// <summary>
     /// Look up the §156.130 caps for <paramref name="planYear"/>.
-    /// Returns <c>null</c> when the plan year is not configured;
-    /// callers are expected to reject the plan rather than substitute.
+    /// Returns <c>null</c> when the plan year is not configured; callers
+    /// handle that according to context, with validation rejecting the
+    /// plan and some read-time projection paths remaining best-effort for
+    /// legacy hydration.
     /// </summary>
     AcaLimits? GetForPlanYear(int planYear);
 

--- a/src/services/benefit-plan-service/Services/IPlanLimitValidator.cs
+++ b/src/services/benefit-plan-service/Services/IPlanLimitValidator.cs
@@ -1,0 +1,188 @@
+using BenefitPlanService.Models;
+using CloudHealthOffice.Infrastructure.Observability;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Hard-validation gate for plan-level cost-sharing limits against ACA
+/// 45 CFR §156.130 caps (capability BP 5.7). Wired into all five
+/// <see cref="BenefitPlanServiceImpl"/> write surfaces so a noncompliant
+/// plan cannot land in the store regardless of which API path the
+/// operator used.
+///
+/// <para>
+/// Throws <see cref="PlanLimitValidationException"/> on violation;
+/// controllers map to <b>400 Bad Request</b>. Unlike
+/// <see cref="INetworkTierSoftValidator"/> (counter + log only), this
+/// validator is non-negotiable: regulatory caps are the floor, not a
+/// migration target.
+/// </para>
+///
+/// <para>
+/// <b>Both modes validated.</b> Embedded plans must satisfy
+/// <c>IndividualOutOfPocketMax ≤ acaIndividualCap</c>; Aggregate plans
+/// must satisfy <c>FamilyOutOfPocketMax ≤ acaFamilyCap</c>. Both checks
+/// run against the plan-year resolved by
+/// <see cref="IPlanYearResolver"/>.
+/// </para>
+/// </summary>
+public interface IPlanLimitValidator
+{
+    void Validate(BenefitPlan plan, PlanLimitWriteCaller caller);
+}
+
+/// <summary>
+/// Write-surface labels for the validator's telemetry counter dimension
+/// <c>cho.caller</c>. New write surfaces must add a label here so the
+/// counter never carries an unbounded set of values.
+/// </summary>
+public enum PlanLimitWriteCaller
+{
+    CreatePlan,
+    UpdatePlan,
+    CreateDraft,
+    AmendPublished,
+    PublishAndSupersede,
+}
+
+public sealed class PlanLimitValidator : IPlanLimitValidator
+{
+    private readonly IAcaLimitsProvider _limits;
+    private readonly IPlanYearResolver _planYear;
+    private readonly ILogger<PlanLimitValidator> _logger;
+
+    public PlanLimitValidator(
+        IAcaLimitsProvider limits,
+        IPlanYearResolver planYear,
+        ILogger<PlanLimitValidator> logger)
+    {
+        _limits = limits;
+        _planYear = planYear;
+        _logger = logger;
+    }
+
+    public void Validate(BenefitPlan plan, PlanLimitWriteCaller caller)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        var planYear = _planYear.Resolve(plan);
+        var caps = _limits.GetForPlanYear(planYear);
+        if (caps is null)
+        {
+            // Fail-closed: better to reject the plan with a clear pointer
+            // at the missing config than silently accept a plan against
+            // an absent cap (G3).
+            ChoMetrics.PlanLimitValidationFailures.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.caller", caller.ToString()),
+                new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId ?? string.Empty),
+                new KeyValuePair<string, object?>("cho.reason", "PlanYearNotConfigured"));
+
+            var configured = string.Join(", ", _limits.ConfiguredPlanYears.OrderBy(y => y));
+            throw new PlanLimitValidationException(
+                plan.PlanId,
+                plan.VersionId,
+                planYear,
+                field: "planYear",
+                message: $"ACA OOP limits not configured for plan year {planYear}. " +
+                         $"Configured years: [{configured}]. Update schemas/aca-oop-limits/limits.json " +
+                         $"or correct the plan's effective / plan-year-definition fields.",
+                supplied: planYear,
+                cap: 0);
+        }
+
+        var cs = plan.CostSharing ?? new CostSharing();
+
+        // Individual OOP cap — applies to BOTH modes. In Embedded mode this
+        // is the per-member cap directly. In Aggregate mode the equivalent
+        // per-member cap is the ACA cap itself, so the existing
+        // IndividualOutOfPocketMax field is treated advisory; if set, it
+        // still cannot exceed the ACA ceiling.
+        var individualOop = cs.IndividualOutOfPocketMax;
+        if (individualOop > 0 && individualOop > caps.IndividualCap)
+        {
+            ChoMetrics.PlanLimitValidationFailures.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.caller", caller.ToString()),
+                new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId ?? string.Empty),
+                new KeyValuePair<string, object?>("cho.reason", "IndividualOopExceedsAcaCap"));
+
+            throw new PlanLimitValidationException(
+                plan.PlanId,
+                plan.VersionId,
+                planYear,
+                field: "costSharing.individualOutOfPocketMax",
+                message: $"IndividualOutOfPocketMax ({individualOop:C0}) exceeds the ACA " +
+                         $"§156.130 individual cap ({caps.IndividualCap:C0}) for plan year {planYear}.",
+                supplied: individualOop,
+                cap: caps.IndividualCap);
+        }
+
+        // Family OOP cap — applies to BOTH modes (G6).
+        var familyOop = cs.FamilyOutOfPocketMax;
+        if (familyOop > 0 && familyOop > caps.FamilyCap)
+        {
+            ChoMetrics.PlanLimitValidationFailures.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.caller", caller.ToString()),
+                new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId ?? string.Empty),
+                new KeyValuePair<string, object?>("cho.reason", "FamilyOopExceedsAcaCap"));
+
+            throw new PlanLimitValidationException(
+                plan.PlanId,
+                plan.VersionId,
+                planYear,
+                field: "costSharing.familyOutOfPocketMax",
+                message: $"FamilyOutOfPocketMax ({familyOop:C0}) exceeds the ACA " +
+                         $"§156.130 family cap ({caps.FamilyCap:C0}) for plan year {planYear}.",
+                supplied: familyOop,
+                cap: caps.FamilyCap);
+        }
+
+        _logger.LogDebug(
+            "PlanLimitValidator passed for plan {PlanId} version {VersionId} caller={Caller} planYear={PlanYear}",
+            SanitizeForLog(plan.PlanId),
+            SanitizeForLog(plan.VersionId),
+            caller,
+            planYear);
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}
+
+/// <summary>
+/// Thrown when a plan's cost-sharing limits violate ACA §156.130 or the
+/// plan year is not configured. Mapped to HTTP 400 by the controllers.
+/// Distinct from <see cref="PlanVersionStateException"/> (which maps to
+/// 409) so error-handling paths stay clean.
+/// </summary>
+public sealed class PlanLimitValidationException : Exception
+{
+    public string PlanId { get; }
+    public string VersionId { get; }
+    public int PlanYear { get; }
+    public string Field { get; }
+    public decimal Supplied { get; }
+    public decimal Cap { get; }
+
+    public PlanLimitValidationException(
+        string planId,
+        string versionId,
+        int planYear,
+        string field,
+        string message,
+        decimal supplied,
+        decimal cap) : base(message)
+    {
+        PlanId = planId ?? string.Empty;
+        VersionId = versionId ?? string.Empty;
+        PlanYear = planYear;
+        Field = field;
+        Supplied = supplied;
+        Cap = cap;
+    }
+}

--- a/src/services/benefit-plan-service/Services/IPlanYearResolver.cs
+++ b/src/services/benefit-plan-service/Services/IPlanYearResolver.cs
@@ -1,0 +1,35 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Resolves the plan year used for ACA cap lookup (capability BP 5.7).
+///
+/// <para>
+/// Precedence: <see cref="PlanYearDefinition.PlanYearStart"/>.Year (when
+/// the plan author set up a 5.3 plan-year definition) → falls back to
+/// <see cref="BenefitPlan.EffectiveDate"/>.Year. Plan-year definition is
+/// authoritative because it carries the author's explicit choice; the
+/// effective-date fallback is the conventional inference for plans that
+/// predate 5.3 or skipped the optional definition.
+/// </para>
+/// </summary>
+public interface IPlanYearResolver
+{
+    int Resolve(BenefitPlan plan);
+}
+
+public sealed class PlanYearResolver : IPlanYearResolver
+{
+    public int Resolve(BenefitPlan plan)
+    {
+        if (plan is null) throw new ArgumentNullException(nameof(plan));
+
+        if (plan.PlanYearDefinition is { PlanYearStart: var start } && start != default)
+        {
+            return start.Year;
+        }
+
+        return plan.EffectiveDate.Year;
+    }
+}

--- a/src/services/benefit-plan-service/benefit-plan-service.csproj
+++ b/src/services/benefit-plan-service/benefit-plan-service.csproj
@@ -41,6 +41,20 @@
              Link="schemas\service-category-mappings\README.md"
              CopyToOutputDirectory="PreserveNewest"
              CopyToPublishDirectory="PreserveNewest" />
+    <!--
+      ACA OOP limits seed (capability BP 5.7). Copied to the build output
+      so AcaLimitsProvider finds the file at
+      <ContentRoot>/schemas/aca-oop-limits/limits.json regardless of
+      working-directory shape (local dev vs Dockerfile copy).
+    -->
+    <Content Include="..\..\..\schemas\aca-oop-limits\limits.json"
+             Link="schemas\aca-oop-limits\limits.json"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="..\..\..\schemas\aca-oop-limits\README.md"
+             Link="schemas\aca-oop-limits\README.md"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -129,6 +129,22 @@ public static class ChoMetrics
             description: "Writes to BenefitPlan.NetworkTiers that elide NetworkTier.NetworkId (5.5 soft validation)");
 
     /// <summary>
+    /// Counter tracking benefit-plan write rejections by
+    /// <c>IPlanLimitValidator</c> (capability 5.7 — ACA §156.130
+    /// individual / family OOP cap enforcement). Distinct from soft
+    /// validators: every increment corresponds to a 400 rejection.
+    /// Dimensions: <c>cho.caller</c> (one of the
+    /// <c>PlanLimitWriteCaller</c> values), <c>cho.tenant_id</c>,
+    /// <c>cho.reason</c> (PlanYearNotConfigured |
+    /// IndividualOopExceedsAcaCap | FamilyOopExceedsAcaCap).
+    /// </summary>
+    public static readonly Counter<long> PlanLimitValidationFailures =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.plan_limit_validation_failures.total",
+            unit: "{rejection}",
+            description: "Benefit-plan write rejections from IPlanLimitValidator (5.7 ACA OOP cap enforcement)");
+
+    /// <summary>
     /// Counter tracking network-tier mapping outcomes emitted by the
     /// <c>NetworkTierBackfillService</c> (benefit-plan capability 5.5
     /// admin-triggered backfill). A single benefit plan can contribute

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/AccumulatorWorkingSetAcaCapTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/AccumulatorWorkingSetAcaCapTests.cs
@@ -1,0 +1,174 @@
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Services;
+using Xunit;
+
+namespace CloudHealthOffice.BenefitEngine.Tests;
+
+/// <summary>
+/// Aggregate-mode ACA 45 CFR §156.130 individual-cap enforcement
+/// (capability BP 5.7). Exercises <see cref="AccumulatorWorkingSet"/>
+/// directly so the assertions don't depend on the broader engine wiring.
+///
+/// <para>
+/// Existing Aggregate tests in <see cref="BenefitCalculationEngineTests"/>
+/// stay unchanged: they use dollar amounts below the 2025 ACA cap of
+/// $9,200, so cap enforcement is a no-op for them. These tests pick
+/// scenarios where the cap actually bites.
+/// </para>
+/// </summary>
+public class AccumulatorWorkingSetAcaCapTests
+{
+    private const decimal AcaIndividualCap2025 = 9_200m;
+    private const decimal AcaFamilyCap2025 = 18_400m;
+
+    private static BenefitPlanConfig AggregatePlan(
+        decimal familyOop = AcaFamilyCap2025,
+        decimal? acaCap = AcaIndividualCap2025,
+        bool enforced = true) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = "tenant-aca",
+        PlanName = "Aggregate ACA",
+        PlanType = PlanType.HDHP,
+        FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+        FamilyOopMax = familyOop,
+        AcaIndividualCap = acaCap,
+        IsAcaCapEnforced = enforced,
+    };
+
+    [Fact]
+    public void Aggregate_AcaCapEnforced_RemainingOopMax_IsMinOfFamilyAndCap()
+    {
+        var plan = AggregatePlan();
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        // Empty pool: family $18,400 — cap $9,200 → min is the cap.
+        Assert.Equal(AcaIndividualCap2025, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+    }
+
+    [Fact]
+    public void Aggregate_AcaCapEnforced_MemberContributionLimitedByCap()
+    {
+        var plan = AggregatePlan();
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        // Member responsibility on a single $20,000 claim — engine bounds
+        // application by remaining-oop-max which is min(family, cap) =
+        // $9,200. Apply that and re-check.
+        ws.ApplyOopMax(AcaIndividualCap2025, NetworkTier.InNetwork);
+
+        // After the cap is hit, this member can absorb $0 more even
+        // though the family pool still has $9,200 of headroom.
+        Assert.Equal(0m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+    }
+
+    [Fact]
+    public void Aggregate_AcaCapEnforced_FamilyPoolAccumulatesAlongsideCap()
+    {
+        var plan = AggregatePlan();
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        ws.ApplyOopMax(5_000m, NetworkTier.InNetwork);
+
+        // Family pool: 18,400 - 5,000 = 13,400 remaining.
+        // ACA cap: 9,200 - 5,000 = 4,200 remaining.
+        // Member sees min = 4,200.
+        Assert.Equal(4_200m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+
+        // Snapshot exposes both buckets — the family pool entry shows
+        // 5,000 applied, the AcaIndividualCap entry shows 5,000 applied.
+        var snap = ws.GetSnapshot();
+        var family = snap.Single(e =>
+            e.Type == AccumulatorType.FamilyOutOfPocketMax &&
+            e.NetworkTier == NetworkTier.InNetwork);
+        var cap = snap.Single(e =>
+            e.Type == AccumulatorType.AcaIndividualCap &&
+            e.NetworkTier == NetworkTier.InNetwork);
+        Assert.Equal(5_000m, family.AmountApplied);
+        Assert.Equal(5_000m, cap.AmountApplied);
+    }
+
+    [Fact]
+    public void Aggregate_AcaCapEnforced_PendingUpdatesIncludeCapEntry()
+    {
+        var plan = AggregatePlan();
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        ws.ApplyOopMax(2_500m, NetworkTier.InNetwork);
+        var updates = ws.GetPendingUpdates();
+
+        // Two updates: family-aggregate + aca-individual-cap.
+        Assert.Contains(updates, u =>
+            u.Type == AccumulatorType.FamilyOutOfPocketMax &&
+            u.Source == "OOP-Family-Aggregate" &&
+            u.Amount == 2_500m);
+        Assert.Contains(updates, u =>
+            u.Type == AccumulatorType.AcaIndividualCap &&
+            u.Source == "OOP-AcaIndividualCap" &&
+            u.Amount == 2_500m);
+    }
+
+    [Fact]
+    public void Aggregate_AcaCapNotEnforced_RemainingOopMax_IsFamilyOnly()
+    {
+        // Legacy Aggregate plan (G8 gated rollout): IsAcaCapEnforced=false.
+        // Behavior must match pre-5.7 — full family pool is available to
+        // any single member; no per-member cap.
+        var plan = AggregatePlan(enforced: false);
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        Assert.Equal(AcaFamilyCap2025, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+
+        ws.ApplyOopMax(15_000m, NetworkTier.InNetwork);
+
+        // Family pool drops by 15,000; no ACA cap enforcement.
+        Assert.Equal(3_400m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+
+        // Snapshot does NOT include an AcaIndividualCap entry.
+        var snap = ws.GetSnapshot();
+        Assert.DoesNotContain(snap, e => e.Type == AccumulatorType.AcaIndividualCap);
+    }
+
+    [Fact]
+    public void Aggregate_AcaCapEnforced_NullCap_FallsBackToFamilyOnly()
+    {
+        // When IAcaLimitsProvider returns null (plan-year not configured)
+        // the mapper sets AcaIndividualCap to null. Even with
+        // IsAcaCapEnforced=true the working set then degrades gracefully
+        // to family-only behavior — runtime never crashes; the validator
+        // already rejected the plan at write time.
+        var plan = AggregatePlan(acaCap: null);
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        Assert.Equal(AcaFamilyCap2025, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+        var snap = ws.GetSnapshot();
+        Assert.DoesNotContain(snap, e => e.Type == AccumulatorType.AcaIndividualCap);
+    }
+
+    [Fact]
+    public void Embedded_Mode_IgnoresAcaCapField_NoCapAccumulator()
+    {
+        // Embedded plans rely on the existing IndividualOutOfPocketMax to
+        // bound members. Even if AcaIndividualCap is set on the config,
+        // no AcaIndividualCap accumulator is seeded — that bucket is
+        // Aggregate-mode-only.
+        var plan = new BenefitPlanConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = "tenant-emb",
+            PlanName = "Embedded",
+            PlanType = PlanType.PPO,
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded,
+            IndividualOopMax = 5_000m,
+            FamilyOopMax = 12_000m,
+            AcaIndividualCap = AcaIndividualCap2025,
+            IsAcaCapEnforced = true,
+        };
+        var ws = new AccumulatorWorkingSet(Array.Empty<AccumulatorSnapshot>(), plan);
+
+        var snap = ws.GetSnapshot();
+        Assert.DoesNotContain(snap, e => e.Type == AccumulatorType.AcaIndividualCap);
+        // Embedded uses the existing IndividualOutOfPocketMax, not the cap.
+        Assert.Equal(5_000m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+    }
+}


### PR DESCRIPTION
## Summary

- Surfaces the existing engine-side `FamilyAccumulatorModel` (Embedded / Aggregate) as a first-class field on `BenefitPlan`, propagated through `MapToConfig`, `MemberBenefitView`, the adapter envelope, and the portal DTO.
- Closes the ACA 45 CFR §156.130 gap: Aggregate-mode `AccumulatorWorkingSet` now seeds an `AcaIndividualCap` per-member accumulator alongside the family pool and clamps `GetRemainingOopMax` to `min(family pool, ACA cap)` when enforcement is on. Without this, a single member could absorb the entire family OOP pool.
- New `IPlanLimitValidator` wired into all 5 service write surfaces (`CreatePlanAsync`, `UpdatePlanAsync`, `CreateDraftAsync`, `AmendPublishedPlanAsync`, `PublishVersionAsync`) enforces both the individual and family caps at write time. Throws `PlanLimitValidationException` → 400. Fails-closed when the plan year is not in the seed file.

## What's new

**Engine** (`src/engines/CloudHealthOffice.BenefitEngine`):
- `AccumulatorType.AcaIndividualCap` enum value
- `BenefitPlanConfig.AcaIndividualCap` (decimal?) + `IsAcaCapEnforced` (bool) inputs
- `AccumulatorWorkingSet`: Aggregate-mode Aggregate path now seeds the cap accumulator (gated), clamps `GetRemainingOopMax`, and increments the cap in lockstep with family OOP in `ApplyOopMax`. Embedded path unchanged.

**benefit-plan-service**:
- `BenefitPlan.FamilyAccumulatorModel` (top-level, default `Embedded`); service-side enum mirror (avoids a new project-ref edge to the engine domain)
- `IAcaLimitsProvider` (file-backed, validates at startup, fails fast on malformed file), `IPlanYearResolver` (`PlanYearDefinition.PlanYearStart.Year` ?? `EffectiveDate.Year`), `IPlanLimitValidator` (hard-validates both individual and family caps; fails closed on missing year)
- `ChoBenefitPlanProvider` becomes an instance class that projects the new field, resolves the ACA cap, and gates `IsAcaCapEnforced` by `PublishedAt ≥ 2026-04-28` cutoff (G8 transition support per the ratified plan)
- Controller catches `PlanLimitValidationException` → 400 with structured payload (`planYear`, `field`, `supplied`, `cap`)

**Configuration** (`schemas/aca-oop-limits/`):
- `limits.json` with 2024–2027 caps. **2026 reflects the revised premium adjustment methodology ($10,600/$21,200), superseding the original NBPP 2026 finalization.** 2027 marked as a projection until CMS publishes the 2027 final rule.
- `README.md` documents source attribution, update cadence, methodology change, and explicitly distinguishes ACA cost-sharing max from IRS HSA-qualified HDHP max.

**Telemetry**:
- New counter `cho.benefit_plan.plan_limit_validation_failures.total` with `cho.caller` / `cho.tenant_id` / `cho.reason` dimensions (`PlanYearNotConfigured` | `IndividualOopExceedsAcaCap` | `FamilyOopExceedsAcaCap`).

**Documentation**:
- New `docs/architecture/family-accumulator-models.md` covers Embedded vs Aggregate semantics, ACA cap enforcement, plan-year resolution, the `IsAcaCapEnforced` gated rollout, and out-of-scope list.
- `docs/architecture/plan-versioning.md` updated to call out `FamilyAccumulatorModel` as identity-bearing (no bypass method).

## Tests

- **+7 engine tests** in `AccumulatorWorkingSetAcaCapTests.cs` — cap-enforced behavior, family/cap interaction, snapshot bucket presence, pending-update record keys, gated rollout (cap not enforced → pre-5.7 semantics), null-cap fallback, Embedded no-op.
- **+23 service tests** across `PlanLimitValidatorTests.cs`, `AcaLimitsProviderTests.cs`, `ChoBenefitPlanProviderModelMappingTests.cs`, `BenefitViewServiceFamilyModelTests.cs` — validator on both modes, plan-year resolution precedence, fail-closed payload, file-loader errors, mapping propagation, gated `IsAcaCapEnforced` flag, view metadata surface.
- **Existing Aggregate engine tests are unchanged** — their dollar amounts ($3k–$12k) sit below the 2025 ACA cap of $9,200 so cap enforcement is a no-op for them. This was a premise correction in the plan phase: the prompt's framing implied test churn that turned out to be unnecessary.

## Test plan

- [x] `dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj` — clean
- [x] `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj` — clean
- [x] `dotnet test tests/CloudHealthOffice.BenefitEngine.Tests` — **50/50 passing**
- [x] `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests` — **187/187 passing** (165 baseline + 22 new × xunit theory enumeration)
- [ ] Manual: deploy to staging, publish a draft Aggregate plan with `IndividualOutOfPocketMax = $10,000` for plan year 2025 → expect 400 with `code: PLAN_LIMIT_ACA_VIOLATION`, `field: costSharing.individualOutOfPocketMax`, `cap: 9200`
- [ ] Manual: deploy to staging, publish an Aggregate plan within ACA caps → adjudicate two claims for the same member totaling $10,000 → expect member responsibility on the second claim to cap at the remaining ACA cap, not the family pool remainder

## Out of scope

- `BenefitRulePredicate` evaluation in the calc engine (still 5.10 territory)
- `Unknown=0` enum migration on `FamilyAccumulatorModel` and `AccumulatorType` (deferred to a follow-up "BenefitEngine enum hygiene" PR per PR #705 convention; ratified G4)
- `accumulator-service` standalone schema work (typed-column store; never sees the new bucket; ratified G1)
- Portal UX distinguishing the two models visually (DTO mirror only; future UX PR can pick this up; ratified G2)
- `BenefitResolutionResult` shape changes (the existing `AccumulatorSnapshot` already surfaces the new bucket via enum-name-string keying; ratified G7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)