### PR TITLE
BP 5.8 — FHIR InsurancePlan projection + fhir-service proxy

### DIFF
--- a/docs/architecture/fhir-conformance.md
+++ b/docs/architecture/fhir-conformance.md
@@ -7,9 +7,9 @@ conformance to, what we test against, and where the gaps are.
 
 | IG / profile                                     | Resources covered today                       | Posture                                                 |
 |--------------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
-| US Core 6.1.0                                    | Patient, Practitioner, PractitionerRole, Organization | Required elements asserted by unit tests          |
-| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner, PractitionerRole, Organization (subset) | Fields CHO has data for; extensions deferred to 5.17 |
-| FHIR R4 Bundle (`searchset`)                     | Practitioner, PractitionerRole, Organization search | Hand-built JsonObject, asserted by unit tests     |
+| US Core 6.1.0                                    | Patient, Practitioner, PractitionerRole, Organization, InsurancePlan | Required elements asserted by unit tests          |
+| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner, PractitionerRole, Organization, InsurancePlan (subset) | Fields CHO has data for; extensions deferred to 5.17 / BP 5.9 |
+| FHIR R4 Bundle (`searchset`)                     | Practitioner, PractitionerRole, Organization, InsurancePlan search | Hand-built JsonObject, asserted by unit tests     |
 | FHIR R4 OperationOutcome                         | All error responses                           | Typed `OperationOutcome` model + hand-built JsonObject  |
 
 `meta.profile` values emitted on each resource:
@@ -29,6 +29,12 @@ conformance to, what we test against, and where the gaps are.
   `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Organization`
   (two source entities: `Organization` network → `type=ins`;
   `Provider` with `ProviderType=Organization` → `type=prov`)
+- InsurancePlan (benefit-plan-service, capability BP 5.8) —
+  `http://hl7.org/fhir/us/core/StructureDefinition/us-core-insuranceplan`
+  and
+  `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-InsurancePlan`
+  (source entity: `BenefitPlan` head Published version; non-Active
+  versions return null per the empirical Provider 5.7 stance)
 
 ## Phase 2 / deferred
 
@@ -36,8 +42,11 @@ conformance to, what we test against, and where the gaps are.
 |--------------------------------------------------|--------------------------------------------------------|
 | Plan-Net 1.1.0 extended Organization extensions  | Capability 5.17 (accessibility, languages, populations)|
 | Plan-Net 1.1.0 Organization.endpoint             | Phase 2 (Plan-Net publishing URLs)                     |
+| Plan-Net 1.1.0 InsurancePlan.endpoint            | Capability BP 5.9 (Plan Documents)                     |
+| Plan-Net 1.1.0 InsurancePlan.coverageArea / contact / alias | Phase 2 (BenefitPlan needs the fields)        |
 | Plan-Net 1.1.0 Bundle composite                  | Capability 5.18                                        |
 | Plan-Net extended extensions (Practitioner)      | Capability 5.17                                        |
+| Coverage.class slice → InsurancePlan reference   | Capability BP 5.8 follow-up — see fhir-insuranceplan-projection.md |
 | CMS-0057-F unauthenticated Provider Directory    | Capability 5.19                                        |
 | Inferno test suite (Provider Directory)          | Separate Phase 2 capability                            |
 | US Core 6.1.0 Practitioner.gender                | Capability 5.17 (Provider entity gains the field)      |
@@ -58,6 +67,8 @@ classes:
 
 - [FhirOrganizationProjectorTests](../../tests/CloudHealthOffice.ProviderService.Tests/Services/FhirOrganizationProjectorTests.cs)
   — provider-service Organization projection (both source entities).
+- [FhirInsurancePlanProjectorTests](../../src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs)
+  — benefit-plan-service InsurancePlan projection (capability BP 5.8).
 
 Conformance regressions surface as failing unit tests. There is no
 network-driven conformance suite in CI yet (see *Inferno* below).
@@ -97,6 +108,26 @@ Defined today (see
   panel-gating fields on `NetworkParticipation` (capability 5.5).
 - `CodeSystem/line-of-business` (capability 5.8) — internal CodeSystem
   for the LOB codings emitted inside `accepted-lobs` sub-extensions.
+- `insuranceplan-family-accumulator-model` extension (capability BP 5.8) —
+  emitted on InsurancePlan; `valueCode` Embedded | Aggregate sourced from
+  `BenefitPlan.FamilyAccumulatorModel` (BP 5.7).
+- `insuranceplan-aca-cap-enforced` extension (capability BP 5.8) —
+  emitted on InsurancePlan AND on the ACA-cap `plan.generalCost` entry;
+  `valueBoolean=true` only when `AcaCapEnforcementPolicy.IsEnforced(plan)`
+  returns true (Aggregate-mode + post-2026-04-28-cutoff plans).
+- `CodeSystem/plan-product-shape` (capability BP 5.8) — CHO-canonical
+  CodeSystem for the InsurancePlan.type product-shape coding (HMO / PPO /
+  EPO / POS / HDHP / Medicaid / Medicare / Commercial).
+- `CodeSystem/insuranceplan-general-cost-type` (capability BP 5.8) —
+  CHO-canonical CodeSystem for `plan.generalCost.type` (deductible /
+  out-of-pocket-max / aca-individual-cap).
+- `CodeSystem/insuranceplan-cost-qualifier` (capability BP 5.8) —
+  CHO-canonical CodeSystem for `cost.qualifiers` (in-network /
+  out-of-network / copay / coinsurance).
+- `CodeSystem/network-tier` (capability BP 5.8) — CHO-canonical system
+  for `plan.identifier` carrying the tier name.
+- `plan-id` system (capability BP 5.8) — CHO-canonical identifier
+  system for `InsurancePlan.identifier[0]` carrying `BenefitPlan.PlanId`.
 
 A legacy URL
 `https://cloudhealthoffice.com/fhir/StructureDefinition/provider-verification`
@@ -108,4 +139,7 @@ uses of this URL.
 
 - [fhir-practitioner-projection.md](fhir-practitioner-projection.md) — capability 5.7 details.
 - [fhir-practitionerrole-projection.md](fhir-practitionerrole-projection.md) — capability 5.8 details.
+- [fhir-organization-projection.md](fhir-organization-projection.md) — capability 5.9 details.
+- [fhir-insuranceplan-projection.md](fhir-insuranceplan-projection.md) — capability BP 5.8 details.
 - [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `Practitioner.active` and `PractitionerRole.active`.
+- [family-accumulator-models.md](family-accumulator-models.md) — BP 5.7 (FamilyAccumulatorModel + ACA cap), source of the BP 5.8 custom extensions.

--- a/docs/architecture/fhir-insuranceplan-projection.md
+++ b/docs/architecture/fhir-insuranceplan-projection.md
@@ -1,0 +1,223 @@
+# FHIR InsurancePlan Projection (Capability BP 5.8)
+
+> Projects CHO's `BenefitPlan` entity into a Plan-Net IG 1.1.0 +
+> US Core 6.1.0 conformant `InsurancePlan` resource. Adds
+> `/fhir/r4/InsurancePlan/*` to the public FHIR surface, completing
+> the Plan-Net Provider Directory bundle (Practitioner +
+> PractitionerRole + Organization + InsurancePlan + Coverage) for
+> external consumers.
+
+## Why
+
+Provider Phase 1 (capabilities 5.7 / 5.8 / 5.9) shipped the FHIR
+projections for the provider-side resources. CHO had no
+`/fhir/r4/InsurancePlan/*` URL surface; consumers could read
+Practitioner / PractitionerRole / Organization / Coverage but could
+not read the insurance plan offering itself.
+
+This capability adds it. `BenefitPlan` is the source entity in
+benefit-plan-service; the projector is hand-built (no
+`Hl7.Fhir.R4` dependency, mirroring the Provider 5.7 / 5.8 / 5.9
+pattern) and the controller proxies through fhir-service so the
+single FHIR façade convention is preserved.
+
+## Architecture
+
+```
+external client
+       │  GET /fhir/r4/InsurancePlan/{PlanId}
+       ▼
+┌──────────────────┐                  ┌─────────────────────────────┐
+│ fhir-service     │   typed proxy    │ benefit-plan-service        │
+│ InsurancePlan    │ ───────────────▶ │ FhirInsurancePlanController │
+│ Controller       │   /fhir/Insurance│  ▶ FhirInsurancePlanProjector │
+└──────────────────┘   Plan/{id}      └─────────────────────────────┘
+                                                │
+                                  IOrganizationLookupClient (BP 5.5)
+                                  ▼
+                                 provider-service
+                                 (Organization name enrichment)
+```
+
+Two-hop pattern matches Provider 5.7 / 5.8 / 5.9 verbatim. The
+proxy helper that translates upstream 5xx → 502 OperationOutcome
+was extracted to `FhirControllerBase.ProxyUpstreamServiceAsync` in
+this PR — both `ProviderDirectoryController` and the new
+`InsurancePlanController` share one status-translation rule.
+
+## Identifier shape
+
+`InsurancePlan.id` carries `BenefitPlan.PlanId` — the operator-
+authored human-meaningful identifier that consumers see on member ID
+cards and SBC documents. Examples: `AUR-GOLD-PPO-2026`,
+`HELIX-SILVER-EPO-2026`. Tenant scoping disambiguates the rare case
+where two tenants happen to use the same value.
+
+`InsurancePlan.identifier[0]` is `{ system: PlanIdSystem, value: PlanId }`
+under the CHO canonical system
+`http://fhir.cloudhealthoffice.com/plan-id`.
+
+`meta.versionId` is left absent; FHIR-canonical resource versioning is
+a separate concern from the BP 5.1 plan-version chain. A future
+capability may surface `meta.versionId = BenefitPlan.VersionId` when
+external consumers ask for it.
+
+## Field-set classification
+
+### In scope (BP 5.8)
+
+| FHIR element | Source | Notes |
+|---|---|---|
+| `identifier` | `BenefitPlan.PlanId` | CHO canonical system |
+| `status` | derived | `active` when in effective window; `retired` when terminated |
+| `type` | `BenefitPlan.PlanType` | Two codings: HL7 `medical` + CHO product shape (HMO/PPO/etc.) |
+| `name` | `BenefitPlan.PlanName` | |
+| `period` | `EffectiveDate` / `TerminationDate` | |
+| `ownedBy` | `BenefitPlan.Payer` | display-only Reference (Decision 12) |
+| `network[]` | `NetworkTiers[].NetworkId` | All non-null tiers, ordered by `TierLevel` (Decision 10) |
+| `coverage[].type` | `Benefit.BenefitType` | text-only (BP 5.6 incoherence) |
+| `coverage[].network` | top-level `network[]` repeated | |
+| `coverage[].benefit[]` | `BenefitPlan.Benefits` grouped by type | |
+| `coverage[].benefit[].type` | `Benefit.ServiceCategory` | text-only (BP 5.6 incoherence) |
+| `coverage[].benefit[].requirement` | `PriorAuthRequired` + `Limitations` | combined string |
+| `coverage[].benefit[].limit[]` | `VisitLimit`, `AnnualMaximum`, `LifetimeMaximum` | |
+| `plan[]` | one per `NetworkTier` with non-null `NetworkId` | |
+| `plan[].identifier` | `TierName` under CHO `network-tier` system | |
+| `plan[].type` | text-only `Tier {TierLevel}` | |
+| `plan[].network` | tier-specific Organization reference | |
+| `plan[].generalCost[]` | `CostSharing` deductible + OOP max + (Aggregate + post-cutoff) ACA cap | |
+| `plan[].specificCost[]` | per-Benefit copay + coinsurance per network tier | |
+
+### Deferred to BP 5.9 (Plan Documents)
+
+| FHIR element | Why deferred |
+|---|---|
+| `endpoint[]` | Plan-Net `Endpoint` references (SBC URL, formulary URL, machine-readable rate file) require the BP 5.9 Plan Documents projection. This PR emits an empty array; BP 5.9 will populate it. |
+
+### Deferred to Phase 2 / future capabilities
+
+| FHIR element | Reason |
+|---|---|
+| `alias[]` | `BenefitPlan` has no DBA / alternative-name field today. |
+| `contact[]` | `BenefitPlan` has no contact info field. |
+| `coverageArea[]` | `BenefitPlan` has no geographic coverage area field. |
+| `administeredBy` | `BenefitPlan` has no TPA reference field. |
+| `description` | `BenefitPlan` has no plan-level description (only per-Benefit). |
+| `plan[].coverageArea` | Same as above. |
+| `ownedBy` Reference | `Payer` is a free-text string; a future "Payer Organization Linking" capability migrates this slot from `display`-only to a real `Reference`. |
+
+## Cost-sharing emission
+
+### `plan[].generalCost[]`
+
+One entry per network tier × (Individual / Family) × (Deductible / OOP-max).
+On the primary in-network tier, an additional ACA-cap entry projects the
+per-member 45 CFR §156.130 cap **when the plan is Aggregate-mode AND
+`AcaCapEnforcementPolicy.IsEnforced` returns true**.
+
+The ACA-cap entry carries a CHO sub-extension
+`insuranceplan-aca-cap-enforced=true` so standard Plan-Net consumers see
+the cap as a real cost limit while CHO-aware consumers can disambiguate
+it from a real plan-level individual cap (Decision 11 dual emission).
+
+### `plan[].specificCost[]`
+
+One `category` entry per benefit type group (medical / pharmacy / dental
+/ vision / behavioralHealth / dme / maternity / preventive). Each
+benefit emits up to 2 `cost` entries per network tier (copay,
+coinsurance) with 2-element `qualifiers` arrays:
+
+```json
+"qualifiers": [
+  { "coding": [{ "system": "http://fhir.cloudhealthoffice.com/CodeSystem/insuranceplan-cost-qualifier", "code": "in-network" }] },
+  { "coding": [{ "system": "http://fhir.cloudhealthoffice.com/CodeSystem/insuranceplan-cost-qualifier", "code": "copay" }] }
+]
+```
+
+If conformance testing rejects the 2-element-array shape, the projector
+falls back to one cost entry per single qualifier (4 → 8 cost entries
+per benefit). Currently 2-element per the Plan-Net IG examples we
+checked during plan phase.
+
+## CHO custom extensions
+
+Two top-level extensions on `InsurancePlan`. Naming follows the
+empirical Provider 5.7 / 5.8 / 5.9 convention
+`{resource-lowercase}-{slug}` (no `cho-` prefix; that prefix is
+appeals-domain-specific):
+
+| URL | Source | Type |
+|---|---|---|
+| `http://fhir.cloudhealthoffice.com/StructureDefinition/insuranceplan-family-accumulator-model` | `BenefitPlan.FamilyAccumulatorModel` (BP 5.7) | `valueCode = Embedded \| Aggregate` |
+| `http://fhir.cloudhealthoffice.com/StructureDefinition/insuranceplan-aca-cap-enforced` | `AcaCapEnforcementPolicy.IsEnforced(plan)` | `valueBoolean = true` (only emitted when true) |
+
+`AcaCapEnforcementPolicy` is the single source of truth for the
+"is the cap enforced" decision — both this projector AND
+`ChoBenefitPlanProvider.ResolveIsAcaCapEnforced` (engine-config
+projection) call into it. Cutoff is pinned at
+`2026-04-28 00:00:00 UTC` per the BP 5.7 G8 rollout.
+
+## End-to-end Plan-Net navigation
+
+After this PR ships, the chain
+`Practitioner → PractitionerRole.organization → Organization →
+InsurancePlan.network → Organization` resolves end-to-end through the
+fhir-service public surface. `InsurancePlan.network[]` references emit
+as `Organization/{networkId}`; consumers dereference via
+`/fhir/r4/Organization/{networkId}` which fhir-service proxies to
+provider-service per Provider 5.9.
+
+## Known gaps
+
+### Coverage.class slice → InsurancePlan reference (deferred)
+
+Plan-Net IG 1.1.0 joins `Coverage` to `InsurancePlan` via
+`Coverage.class[type=plan].value = PlanId`. fhir-service's
+`CoverageController` (mock-adapter-backed today) does **not** emit a
+`class` slice. After this PR, `InsurancePlan` resources are
+dereferenceable directly via `/fhir/r4/InsurancePlan/{PlanId}` and via
+the `PractitionerRole → Organization → InsurancePlan.network`
+traversal, but **NOT** via `Coverage.class`.
+
+A future capability ("Coverage.class slice for InsurancePlan
+reference") updates the Coverage projector to emit:
+
+```json
+"class": [{
+  "type": { "coding": [{
+    "system": "http://terminology.hl7.org/CodeSystem/coverage-class",
+    "code": "plan"
+  }] },
+  "value": "{PlanId}"
+}]
+```
+
+This PR does NOT modify `CoverageController`; the gap is documented
+and tracked.
+
+### `InsurancePlan.type` standard-coding discrimination
+
+For Phase 1 every projected plan emits `medical` as the standard
+coding. Authoring a dental-only / vision-only / drug-only plan today
+would project an inaccurate standard coding. A future capability
+introduces `BenefitPlan.CoverageScope` (or equivalent) and the
+projector switches on it. The CHO product-shape coding (HMO / PPO /
+HDHP / etc.) is always accurate because plan authors set it directly.
+
+## Testing
+
+| Test file | What it pins |
+|---|---|
+| `BenefitPlanService.Tests/Services/AcaCapEnforcementPolicyTests.cs` | Policy delegation + cutoff pinning + parity with BP 5.7 inline rule |
+| `BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs` | US Core / Plan-Net structure, network projection, coverage grouping, cost-sharing, ACA-cap emission, deterministic output |
+| `BenefitPlanService.Tests/Controllers/FhirInsurancePlanControllerTests.cs` | Read 200/400/404, search bundle shape, identifier token parsing, name + status filtering, tenant scoping |
+| `tests/CloudHealthOffice.FhirService.Tests/Controllers/InsurancePlanControllerProxyTests.cs` | URL forwarding, query-string passthrough, 4xx verbatim, 5xx → 502 OperationOutcome without body leak, transport faults |
+
+## References
+
+- [Plan-Net IG 1.1.0 InsurancePlan profile](http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-InsurancePlan)
+- [US Core 6.1.0 InsurancePlan profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-insuranceplan)
+- [`family-accumulator-models.md`](./family-accumulator-models.md) — BP 5.7 (FamilyAccumulatorModel + ACA cap rollout)
+- [`network-tier-organization-reference.md`](./network-tier-organization-reference.md) — BP 5.5 (NetworkTier as Organization Reference)
+- [`fhir-organization-projection.md`](./fhir-organization-projection.md) — Provider 5.9 (Organization projection that this PR's `network[]` references resolve to)
+- [`fhir-conformance.md`](./fhir-conformance.md) — running ledger of CHO FHIR conformance posture

--- a/docs/architecture/network-tier-organization-reference.md
+++ b/docs/architecture/network-tier-organization-reference.md
@@ -298,3 +298,11 @@ them were all deferred to the consumer that genuinely needs them.
   the same `HttpClient("ProviderService")` registration.
 - [`network-participation-backfill.md`](./network-participation-backfill.md)
   — Provider 5.5 backfill pattern this capability mirrors.
+- [`fhir-insuranceplan-projection.md`](./fhir-insuranceplan-projection.md) —
+  Capability BP 5.8. The `NetworkTier.NetworkId` field this capability
+  introduced is the source for `InsurancePlan.network[]` references in
+  the FHIR projection. Each tier with a non-null `NetworkId` projects
+  as `Organization/{networkId}`, dereferenceable via fhir-service's
+  `/fhir/r4/Organization/{id}` endpoint (which proxies to
+  provider-service per Provider 5.9). End-to-end Plan-Net navigation
+  resolves through this chain.

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirInsurancePlanControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirInsurancePlanControllerTests.cs
@@ -1,0 +1,272 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using BenefitPlanService.Controllers;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+using BenefitPlanService.Repositories;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Controllers;
+
+/// <summary>
+/// Capability BP 5.8 — FHIR InsurancePlan endpoint behavior, search
+/// parameter semantics, tenant scoping, FHIR OperationOutcome on errors.
+/// Mirrors the shape of <c>FhirPractitionerControllerTests</c> in
+/// provider-service. Uses an in-memory repository fake so the
+/// controller can exercise the full read / search path without Cosmos
+/// or Mongo.
+/// </summary>
+public sealed class FhirInsurancePlanControllerTests
+{
+    private const string Tenant = "tenant-a";
+
+    [Fact]
+    public async Task ReadInsurancePlan_returns_404_for_missing_plan()
+    {
+        var (controller, _) = Build();
+
+        var result = await controller.ReadInsurancePlan("does-not-exist", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("OperationOutcome");
+        content.Content.Should().Contain("not-found");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_returns_400_for_blank_id()
+    {
+        var (controller, _) = Build();
+
+        var result = await controller.ReadInsurancePlan(" ", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+        content.Content.Should().Contain("invalid");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_returns_projected_fhir_for_active_plan()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "GOLD-2026"));
+
+        var result = await controller.ReadInsurancePlan("GOLD-2026", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+
+        var json = JsonNode.Parse(content.Content!)!.AsObject();
+        json["resourceType"]!.GetValue<string>().Should().Be("InsurancePlan");
+        json["id"]!.GetValue<string>().Should().Be("GOLD-2026");
+        json["status"]!.GetValue<string>().Should().Be("active");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_scopes_by_tenant()
+    {
+        var (controller, repo) = Build();
+        var otherTenant = SamplePlan(planId: "ISOLATED");
+        otherTenant.TenantId = "tenant-b";
+        await repo.CreateAsync(otherTenant);
+
+        var result = await controller.ReadInsurancePlan("ISOLATED", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404,
+            "tenant-a must not see tenant-b's plan even when the PlanId matches");
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_returns_searchset_bundle()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1", name: "Aurelian Gold"));
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-2", name: "Aurelian Silver"));
+
+        var result = await controller.SearchInsurancePlans(
+            identifier: null, name: null, status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+
+        bundle["resourceType"]!.GetValue<string>().Should().Be("Bundle");
+        bundle["type"]!.GetValue<string>().Should().Be("searchset");
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_by_identifier_returns_single_match()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1"));
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-2"));
+
+        var result = await controller.SearchInsurancePlans(
+            identifier: "PLAN-1", name: null, status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        bundle["entry"]!.AsArray()[0]!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be("PLAN-1");
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_by_identifier_with_system_pipe()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1"));
+
+        var qualified = $"{ChoBenefitPlanFhirUrls.PlanIdSystem}|PLAN-1";
+        var result = await controller.SearchInsurancePlans(
+            identifier: qualified, name: null, status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_by_unknown_identifier_system_returns_empty()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1"));
+
+        var result = await controller.SearchInsurancePlans(
+            identifier: "http://other-system|PLAN-1",
+            name: null, status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_filters_by_name_substring()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1", name: "Aurelian Gold"));
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-2", name: "Aurelian Silver"));
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-3", name: "Helix Bronze"));
+
+        var result = await controller.SearchInsurancePlans(
+            identifier: null, name: "Aurelian", status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_status_active_filters_terminated_plans()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "ACTIVE", name: "Active"));
+        var retired = SamplePlan(planId: "RETIRED", name: "Retired");
+        retired.EffectiveDate = DateTime.UtcNow.AddYears(-2);
+        retired.TerminationDate = DateTime.UtcNow.AddDays(-30);
+        await repo.CreateAsync(retired);
+
+        var activeOnly = await controller.SearchInsurancePlans(
+            identifier: null, name: null, status: "active", _count: 50, _page: 1, default);
+        var activeBundle = JsonNode.Parse((activeOnly as ContentResult)!.Content!)!.AsObject();
+        activeBundle["total"]!.GetValue<int>().Should().Be(1);
+        activeBundle["entry"]!.AsArray()[0]!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be("ACTIVE");
+
+        var retiredOnly = await controller.SearchInsurancePlans(
+            identifier: null, name: null, status: "retired", _count: 50, _page: 1, default);
+        var retiredBundle = JsonNode.Parse((retiredOnly as ContentResult)!.Content!)!.AsObject();
+        retiredBundle["total"]!.GetValue<int>().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_emits_application_fhir_json_content_type()
+    {
+        var (controller, repo) = Build();
+        await repo.CreateAsync(SamplePlan(planId: "PLAN-1"));
+
+        var result = await controller.ReadInsurancePlan("PLAN-1", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+
+        content.ContentType.Should().StartWith("application/fhir+json");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static (FhirInsurancePlanController controller, InMemoryBenefitPlanRepository repo) Build()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var controller = new FhirInsurancePlanController(
+            repo,
+            new FhirInsurancePlanProjector(),
+            new StubOrganizationLookup(),
+            new StubAcaLimits(),
+            new PlanYearResolver(),
+            NullLogger<FhirInsurancePlanController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = Tenant;
+        controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+        return (controller, repo);
+    }
+
+    private static BenefitPlan SamplePlan(string planId, string? name = null) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        PlanId = planId,
+        PlanName = name ?? planId,
+        Payer = "AurelianHealth",
+        EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        VersionState = PlanVersionState.Published,
+        VersionNumber = 1,
+        VersionId = Guid.NewGuid().ToString(),
+        PublishedAt = DateTime.UtcNow,
+        FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded,
+        Benefits = new List<Benefit>
+        {
+            new MedicalBenefit { ServiceCategory = "Office Visit", InNetworkCopay = 25m },
+        },
+        NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        },
+        CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_000m,
+            FamilyDeductible = 2_000m,
+            IndividualOutOfPocketMax = 5_000m,
+            FamilyOutOfPocketMax = 10_000m,
+        },
+    };
+
+    private sealed class StubOrganizationLookup : IOrganizationLookupClient
+    {
+        public Task<OrganizationLookupResult?> GetOrganizationAsync(
+            string networkId, CancellationToken ct = default)
+            => Task.FromResult<OrganizationLookupResult?>(
+                new OrganizationLookupResult
+                {
+                    OrganizationId = networkId,
+                    Name = $"Network {networkId}",
+                    EffectiveDate = DateTime.UtcNow.AddYears(-1),
+                });
+    }
+
+    private sealed class StubAcaLimits : IAcaLimitsProvider
+    {
+        public AcaLimits? GetForPlanYear(int planYear)
+            => new(planYear, 10_600m, 21_200m);
+
+        public IReadOnlyCollection<int> ConfiguredPlanYears => new[] { 2026 };
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirInsurancePlanControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirInsurancePlanControllerTests.cs
@@ -187,6 +187,42 @@ public sealed class FhirInsurancePlanControllerTests
     }
 
     [Fact]
+    public async Task SearchInsurancePlans_dedupes_to_head_published_per_PlanId()
+    {
+        var (controller, repo) = Build();
+
+        // v1 published, v2 published (the head).
+        var v1 = SamplePlan(planId: "PLAN-DUPE", name: "Dupe v1");
+        v1.VersionNumber = 1;
+        await repo.CreateAsync(v1);
+
+        var v2 = SamplePlan(planId: "PLAN-DUPE", name: "Dupe v2");
+        v2.VersionNumber = 2;
+        await repo.CreateAsync(v2);
+
+        // A draft and a superseded row that must NOT surface in search.
+        var draft = SamplePlan(planId: "PLAN-DRAFT", name: "Draft");
+        draft.VersionState = PlanVersionState.Draft;
+        await repo.CreateAsync(draft);
+
+        var superseded = SamplePlan(planId: "PLAN-OLD", name: "Old");
+        superseded.VersionState = PlanVersionState.Superseded;
+        await repo.CreateAsync(superseded);
+
+        var result = await controller.SearchInsurancePlans(
+            identifier: null, name: null, status: null, _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        var entries = bundle["entry"]!.AsArray();
+
+        entries.Should().HaveCount(1, "draft + superseded must be filtered, dupe collapses to head");
+        entries[0]!["resource"]!["id"]!.GetValue<string>().Should().Be("PLAN-DUPE");
+        // Head version v2 wins over v1 even though both are Published.
+        entries[0]!["resource"]!["name"]!.GetValue<string>().Should().Be("Dupe v2");
+    }
+
+    [Fact]
     public async Task ReadInsurancePlan_emits_application_fhir_json_content_type()
     {
         var (controller, repo) = Build();

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaCapEnforcementPolicyTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/AcaCapEnforcementPolicyTests.cs
@@ -1,0 +1,120 @@
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.8 — verifies the extracted <see cref="AcaCapEnforcementPolicy"/>
+/// preserves the BP 5.7 G8 gating semantics that previously lived inline
+/// in <c>ChoBenefitPlanProvider.ResolveIsAcaCapEnforced</c>. Both the
+/// engine-config projection and the FHIR InsurancePlan projection now
+/// call <see cref="AcaCapEnforcementPolicy.IsEnforced"/>; this test
+/// pins the rule so neither call site can drift.
+/// </summary>
+public sealed class AcaCapEnforcementPolicyTests
+{
+    [Fact]
+    public void Embedded_plan_is_never_enforced()
+    {
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded,
+            PublishedAt = DateTime.UtcNow,
+            VersionState = PlanVersionState.Published,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Aggregate_draft_with_no_PublishedAt_is_treated_as_post_cutoff()
+    {
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+            PublishedAt = null,
+            VersionState = PlanVersionState.Draft,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeTrue(
+            "drafts will be published after the cutoff by definition");
+    }
+
+    [Fact]
+    public void Aggregate_plan_published_at_or_after_cutoff_is_enforced()
+    {
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+            PublishedAt = AcaCapEnforcementPolicy.CutoffUtc,
+            VersionState = PlanVersionState.Published,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Aggregate_plan_published_after_cutoff_is_enforced()
+    {
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+            PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(7),
+            VersionState = PlanVersionState.Published,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Aggregate_legacy_plan_published_before_cutoff_is_not_enforced()
+    {
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+            PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(-1),
+            VersionState = PlanVersionState.Published,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeFalse(
+            "legacy Aggregate plans don't get a surprise mid-year cap");
+    }
+
+    [Fact]
+    public void Local_kind_PublishedAt_is_normalized_to_utc()
+    {
+        // PublishedAt without a Kind annotation is conventionally UTC on
+        // the wire but Local in some test scaffolding. The policy must
+        // normalize either way so the comparison is stable.
+        var localBefore = DateTime.SpecifyKind(
+            AcaCapEnforcementPolicy.CutoffUtc.AddDays(-1).ToLocalTime(),
+            DateTimeKind.Local);
+
+        var plan = new BenefitPlan
+        {
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate,
+            PublishedAt = localBefore,
+            VersionState = PlanVersionState.Published,
+        };
+
+        AcaCapEnforcementPolicy.IsEnforced(plan).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cutoff_matches_BP_5_7_ratified_value()
+    {
+        // Pinned to 2026-04-28 00:00 UTC by the BP 5.7 G8 rollout. The
+        // FHIR projector emits the aca-cap-enforced extension based on
+        // this exact instant; changing it without coordinating with
+        // active plan documents would surprise consumers mid-year.
+        AcaCapEnforcementPolicy.CutoffUtc.Should().Be(
+            new DateTime(2026, 4, 28, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Throws_on_null_plan()
+    {
+        Action act = () => AcaCapEnforcementPolicy.IsEnforced(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
@@ -439,6 +439,42 @@ public sealed class FhirInsurancePlanProjectorTests
     }
 
     [Fact]
+    public void GeneralCost_emits_aca_cap_only_on_primary_in_network_tier()
+    {
+        // Decision 11 contract — the per-member cap projects on exactly
+        // one generalCost block, the lowest-TierLevel in-network tier.
+        // A plan with Tier 1 + Tier 2 Preferred (both in-network) plus
+        // an OON tier must emit the cap exactly once.
+        var plan = MakePlan();
+        plan.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+        plan.PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(1);
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1 In-Network",  TierLevel = 1, NetworkId = "net-pri" },
+            new() { TierName = "Tier 2 Preferred",   TierLevel = 2, NetworkId = "net-sec" },
+            new() { TierName = "Out-of-Network",     TierLevel = 3, NetworkId = "net-oon" },
+        };
+        plan.CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_000m,
+            IndividualOutOfPocketMax = 5_000m,
+        };
+
+        var result = _projector.Project(plan, networks: null,
+            acaLimits: new AcaLimits(2026, 10_600m, 21_200m))!;
+
+        var planArray = result["plan"]!.AsArray();
+        var acaEntries = planArray
+            .SelectMany(p => p!["generalCost"]?.AsArray() ?? new JsonArray())
+            .Where(g =>
+                g!["type"]!["coding"]?.AsArray()[0]?["code"]?.GetValue<string>() == "aca-individual-cap")
+            .ToList();
+
+        acaEntries.Should().ContainSingle(
+            "the ACA cap must not duplicate across in-network tiers");
+    }
+
+    [Fact]
     public void GeneralCost_does_not_emit_aca_cap_for_embedded_plan()
     {
         var plan = MakePlan();

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
@@ -1,0 +1,638 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+using BenefitPlanService.Services;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.8 — projector correctness, US Core / Plan-Net profile
+/// structure assertions, edge cases (non-Active version returns null,
+/// network enrichment, family-accumulator extension emission, ACA-cap
+/// extension emission, cost-sharing projection across tiers).
+/// </summary>
+public sealed class FhirInsurancePlanProjectorTests
+{
+    private readonly FhirInsurancePlanProjector _projector = new();
+
+    // ── status / version filtering ──────────────────────────────────────
+
+    [Fact]
+    public void Projects_active_published_plan()
+    {
+        var plan = MakePlan();
+
+        var result = _projector.Project(plan);
+
+        result.Should().NotBeNull();
+        result!["resourceType"]!.GetValue<string>().Should().Be("InsurancePlan");
+        result["id"]!.GetValue<string>().Should().Be(plan.PlanId);
+        result["status"]!.GetValue<string>().Should().Be("active");
+    }
+
+    [Fact]
+    public void Returns_null_for_non_published_versions()
+    {
+        var plan = MakePlan();
+        plan.VersionState = PlanVersionState.Draft;
+
+        _projector.Project(plan).Should().BeNull();
+
+        plan.VersionState = PlanVersionState.Superseded;
+        _projector.Project(plan).Should().BeNull();
+    }
+
+    [Fact]
+    public void Returns_retired_status_when_terminated()
+    {
+        var plan = MakePlan();
+        plan.EffectiveDate = DateTime.UtcNow.AddYears(-2);
+        plan.TerminationDate = DateTime.UtcNow.AddDays(-30);
+
+        var result = _projector.Project(plan);
+
+        result.Should().NotBeNull();
+        result!["status"]!.GetValue<string>().Should().Be("retired");
+    }
+
+    [Fact]
+    public void Returns_null_for_future_effective_plan()
+    {
+        var plan = MakePlan();
+        plan.EffectiveDate = DateTime.UtcNow.AddDays(30);
+
+        _projector.Project(plan).Should().BeNull();
+    }
+
+    // ── identifier / type / name ────────────────────────────────────────
+
+    [Fact]
+    public void Emits_PlanId_identifier_under_cho_system()
+    {
+        var plan = MakePlan();
+
+        var result = _projector.Project(plan)!;
+
+        var identifier = result["identifier"]!.AsArray();
+        identifier.Should().HaveCount(1);
+        identifier[0]!["use"]!.GetValue<string>().Should().Be("official");
+        identifier[0]!["system"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.PlanIdSystem);
+        identifier[0]!["value"]!.GetValue<string>().Should().Be(plan.PlanId);
+    }
+
+    [Fact]
+    public void Type_emits_two_codings_per_decision_8a()
+    {
+        var plan = MakePlan();
+        plan.PlanType = PlanType.HMO;
+
+        var result = _projector.Project(plan)!;
+
+        var type = result["type"]!.AsArray();
+        type.Should().HaveCount(1);
+        var codings = type[0]!["coding"]!.AsArray();
+        codings.Should().HaveCount(2);
+
+        codings[0]!["system"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.InsurancePlanTypeSystem);
+        codings[0]!["code"]!.GetValue<string>().Should().Be("medical");
+
+        codings[1]!["system"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.PlanProductShapeSystem);
+        codings[1]!["code"]!.GetValue<string>().Should().Be("HMO");
+    }
+
+    [Fact]
+    public void Emits_name_period_and_owned_by()
+    {
+        var plan = MakePlan();
+        plan.PlanName = "Aurelian Gold PPO 2026";
+        plan.Payer = "AurelianHealth";
+
+        var result = _projector.Project(plan)!;
+
+        result["name"]!.GetValue<string>().Should().Be("Aurelian Gold PPO 2026");
+        result["period"]!["start"]!.GetValue<string>()
+            .Should().StartWith(plan.EffectiveDate.ToString("yyyy-MM-dd"));
+        result["ownedBy"]!["display"]!.GetValue<string>().Should().Be("AurelianHealth");
+        result["ownedBy"]!.AsObject()
+            .ContainsKey("reference").Should().BeFalse(
+                "Decision 12 — display-only ownedBy until Payer→Organization linking lands");
+    }
+
+    [Fact]
+    public void Emits_empty_endpoint_array_for_BP_5_9_deferral()
+    {
+        var plan = MakePlan();
+
+        var result = _projector.Project(plan)!;
+
+        result["endpoint"]!.AsArray().Should().BeEmpty(
+            "Plan Documents projection is BP 5.9; emit empty array so consumers see " +
+            "'no documents projected yet' rather than 'field unsupported'");
+    }
+
+    // ── meta + profiles ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Emits_us_core_and_plan_net_profiles()
+    {
+        var plan = MakePlan();
+
+        var result = _projector.Project(plan)!;
+
+        var profiles = result["meta"]!["profile"]!.AsArray()
+            .Select(n => n!.GetValue<string>()).ToList();
+        profiles.Should().Contain(ChoBenefitPlanFhirUrls.UsCoreInsurancePlanProfile);
+        profiles.Should().Contain(ChoBenefitPlanFhirUrls.PlanNetInsurancePlanProfile);
+    }
+
+    // ── network references (Decision 10) ────────────────────────────────
+
+    [Fact]
+    public void Emits_all_non_null_NetworkId_tiers_at_top_level_ordered_by_TierLevel()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Out-of-Network", TierLevel = 3, NetworkId = "net-oon" },
+            new() { TierName = "Tier 1 In-Network", TierLevel = 1, NetworkId = "net-pri" },
+            new() { TierName = "Tier 2 Preferred", TierLevel = 2, NetworkId = "net-sec" },
+        };
+
+        var result = _projector.Project(plan)!;
+        var refs = result["network"]!.AsArray()
+            .Select(n => n!["reference"]!.GetValue<string>()).ToList();
+
+        refs.Should().Equal(
+            "Organization/net-pri",
+            "Organization/net-sec",
+            "Organization/net-oon");
+    }
+
+    [Fact]
+    public void Skips_NetworkTiers_with_null_NetworkId()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-1" },
+            new() { TierName = "Tier 2", TierLevel = 2, NetworkId = null },
+        };
+
+        var result = _projector.Project(plan)!;
+        var refs = result["network"]!.AsArray()
+            .Select(n => n!["reference"]!.GetValue<string>()).ToList();
+
+        refs.Should().ContainSingle().Which.Should().Be("Organization/net-1");
+    }
+
+    [Fact]
+    public void Enriches_network_references_with_display_when_lookup_provided()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+
+        var lookup = new[]
+        {
+            new OrganizationLookupResult
+            {
+                OrganizationId = "net-pri",
+                Name = "Aurelian Primary Network",
+            }
+        };
+
+        var result = _projector.Project(plan, lookup, acaLimits: null)!;
+        var topLevel = result["network"]!.AsArray()[0]!.AsObject();
+        topLevel["display"]!.GetValue<string>().Should().Be("Aurelian Primary Network");
+    }
+
+    [Fact]
+    public void Omits_display_when_no_lookup_provided()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+
+        var result = _projector.Project(plan)!;
+        var topLevel = result["network"]!.AsArray()[0]!.AsObject();
+        topLevel.ContainsKey("display").Should().BeFalse();
+    }
+
+    // ── coverage[] grouping ─────────────────────────────────────────────
+
+    [Fact]
+    public void Coverage_groups_benefits_by_BenefitType_discriminator()
+    {
+        var plan = MakePlan();
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit { ServiceCategory = "Office Visit" },
+            new PharmacyBenefit { ServiceCategory = "Generic" },
+            new MedicalBenefit { ServiceCategory = "Specialist" },
+        };
+
+        var result = _projector.Project(plan)!;
+
+        var coverage = result["coverage"]!.AsArray();
+        coverage.Should().HaveCount(2);
+
+        var medical = coverage.FirstOrDefault(c =>
+            c!["type"]!["text"]!.GetValue<string>() == "Medical");
+        medical.Should().NotBeNull();
+        medical!["benefit"]!.AsArray().Should().HaveCount(2);
+
+        var pharmacy = coverage.FirstOrDefault(c =>
+            c!["type"]!["text"]!.GetValue<string>() == "Pharmacy");
+        pharmacy.Should().NotBeNull();
+        pharmacy!["benefit"]!.AsArray().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Coverage_benefit_emits_text_only_type_per_BP_5_6_incoherence()
+    {
+        var plan = MakePlan();
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit { ServiceCategory = "Mental Health Inpatient" },
+        };
+
+        var result = _projector.Project(plan)!;
+
+        var benefitType = result["coverage"]!.AsArray()[0]!["benefit"]!.AsArray()[0]!["type"]!.AsObject();
+        benefitType.ContainsKey("coding").Should().BeFalse(
+            "BP 5.6 X12↔ServiceCategory incoherence — emit text-only until BP 5.10 lands");
+        benefitType["text"]!.GetValue<string>().Should().Be("Mental Health Inpatient");
+    }
+
+    [Fact]
+    public void Coverage_benefit_requirement_combines_prior_auth_and_limitations()
+    {
+        var plan = MakePlan();
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit
+            {
+                ServiceCategory = "MRI",
+                PriorAuthRequired = true,
+                Limitations = "Not covered for cosmetic indications.",
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var requirement = result["coverage"]!.AsArray()[0]!["benefit"]!.AsArray()[0]!
+            ["requirement"]!.GetValue<string>();
+
+        requirement.Should().Contain("Prior authorization required");
+        requirement.Should().Contain("cosmetic indications");
+    }
+
+    [Fact]
+    public void Coverage_benefit_emits_visit_and_dollar_limits()
+    {
+        var plan = MakePlan();
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit
+            {
+                ServiceCategory = "Physical Therapy",
+                VisitLimit = 60,
+                VisitLimitPeriod = "year",
+                AnnualMaximum = 5_000m,
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var limit = result["coverage"]!.AsArray()[0]!["benefit"]!.AsArray()[0]!["limit"]!.AsArray();
+
+        limit.Should().HaveCount(2);
+        limit[0]!["value"]!["value"]!.GetValue<double>().Should().Be(60);
+        limit[0]!["value"]!["unit"]!.GetValue<string>().Should().Be("year");
+        limit[1]!["value"]!["currency"]!.GetValue<string>().Should().Be("USD");
+        limit[1]!["value"]!["value"]!.GetValue<double>().Should().Be(5_000);
+    }
+
+    // ── plan[] with generalCost (Decision 11) ───────────────────────────
+
+    [Fact]
+    public void Plan_emits_one_entry_per_NetworkTier_with_NetworkId()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1 In-Network", TierLevel = 1, NetworkId = "net-pri" },
+            new() { TierName = "Out-of-Network", TierLevel = 2, NetworkId = "net-oon" },
+        };
+        plan.CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_000m,
+            FamilyDeductible = 2_000m,
+            IndividualOutOfPocketMax = 5_000m,
+            FamilyOutOfPocketMax = 10_000m,
+            OutNetworkIndividualDeductible = 3_000m,
+            OutNetworkFamilyDeductible = 6_000m,
+            OutNetworkIndividualOutOfPocketMax = 12_000m,
+            OutNetworkFamilyOutOfPocketMax = 24_000m,
+        };
+
+        var result = _projector.Project(plan)!;
+        var planArray = result["plan"]!.AsArray();
+        planArray.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GeneralCost_emits_individual_and_family_with_correct_groupSize()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_500m,
+            FamilyDeductible = 3_000m,
+            IndividualOutOfPocketMax = 6_000m,
+            FamilyOutOfPocketMax = 12_000m,
+        };
+
+        var result = _projector.Project(plan)!;
+        var general = result["plan"]!.AsArray()[0]!["generalCost"]!.AsArray();
+
+        var indDed = general.FirstOrDefault(g =>
+            g!["type"]!["text"]!.GetValue<string>() == "Deductible" &&
+            g["groupSize"]!.GetValue<int>() == 1);
+        indDed.Should().NotBeNull();
+        indDed!["cost"]!["value"]!.GetValue<double>().Should().Be(1_500);
+
+        var famOop = general.FirstOrDefault(g =>
+            g!["type"]!["text"]!.GetValue<string>() == "Out-of-Pocket Maximum" &&
+            g["groupSize"]!.GetValue<int>() == 2);
+        famOop.Should().NotBeNull();
+        famOop!["cost"]!["value"]!.GetValue<double>().Should().Be(12_000);
+    }
+
+    [Fact]
+    public void GeneralCost_emits_aca_cap_entry_for_aggregate_when_enforced_with_limits()
+    {
+        var plan = MakePlan();
+        plan.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+        plan.PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(1);
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1 In-Network", TierLevel = 1, NetworkId = "net-pri" },
+        };
+
+        var acaLimits = new AcaLimits(2026, 10_600m, 21_200m);
+        var result = _projector.Project(plan, networks: null, acaLimits: acaLimits)!;
+
+        var general = result["plan"]!.AsArray()[0]!["generalCost"]!.AsArray();
+        var acaEntry = general.FirstOrDefault(g =>
+            g!["type"]!["coding"]!.AsArray()[0]!["code"]!.GetValue<string>() == "aca-individual-cap");
+
+        acaEntry.Should().NotBeNull(
+            "Decision 11 dual emission — ACA cap projects as a generalCost entry");
+        acaEntry!["groupSize"]!.GetValue<int>().Should().Be(1);
+        acaEntry["cost"]!["value"]!.GetValue<double>().Should().Be(10_600);
+        acaEntry["comment"]!.GetValue<string>().Should().Contain("45 CFR §156.130");
+
+        // Per-cost extension flag — Decision 11 disambiguates from a real
+        // plan-level individual cap.
+        var ext = acaEntry["extension"]!.AsArray();
+        ext.Should().ContainSingle();
+        ext[0]!["url"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.AcaCapEnforcedExt);
+        ext[0]!["valueBoolean"]!.GetValue<bool>().Should().BeTrue();
+    }
+
+    [Fact]
+    public void GeneralCost_does_not_emit_aca_cap_for_legacy_aggregate_plan()
+    {
+        var plan = MakePlan();
+        plan.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+        plan.PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(-30); // legacy
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_000m,
+            IndividualOutOfPocketMax = 5_000m,
+        };
+
+        var result = _projector.Project(plan, networks: null,
+            acaLimits: new AcaLimits(2026, 10_600m, 21_200m))!;
+
+        var general = result["plan"]!.AsArray()[0]!["generalCost"]!.AsArray();
+        general.Should().NotBeEmpty();
+        general.Any(g =>
+            g!["type"]!["coding"]?.AsArray()[0]?["code"]?.GetValue<string>() == "aca-individual-cap")
+            .Should().BeFalse(
+                "legacy Aggregate plans (PublishedAt < cutoff) don't emit the ACA cap");
+    }
+
+    [Fact]
+    public void GeneralCost_does_not_emit_aca_cap_for_embedded_plan()
+    {
+        var plan = MakePlan();
+        plan.FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded;
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.CostSharing = new CostSharing
+        {
+            IndividualDeductible = 1_000m,
+            IndividualOutOfPocketMax = 5_000m,
+        };
+
+        var result = _projector.Project(plan, networks: null,
+            acaLimits: new AcaLimits(2026, 10_600m, 21_200m))!;
+
+        var general = result["plan"]!.AsArray()[0]!["generalCost"]!.AsArray();
+        general.Should().NotBeEmpty();
+        general.Any(g =>
+            g!["type"]!["coding"]?.AsArray()[0]?["code"]?.GetValue<string>() == "aca-individual-cap")
+            .Should().BeFalse("Embedded plans never emit the ACA cap entry");
+    }
+
+    // ── plan[].specificCost ─────────────────────────────────────────────
+
+    [Fact]
+    public void SpecificCost_emits_per_benefit_cost_with_two_qualifiers()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1 In-Network", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit
+            {
+                ServiceCategory = "Office Visit",
+                InNetworkCopay = 25m,
+                InNetworkCoinsurance = 0.20m,
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var specific = result["plan"]!.AsArray()[0]!["specificCost"]!.AsArray();
+
+        specific.Should().HaveCount(1);
+        var costs = specific[0]!["benefit"]!.AsArray()[0]!["cost"]!.AsArray();
+        costs.Should().HaveCount(2);
+
+        var copay = costs.FirstOrDefault(c =>
+            c!["qualifiers"]!.AsArray().Any(q =>
+                q!["coding"]!.AsArray()[0]!["code"]!.GetValue<string>() == "copay"));
+        copay.Should().NotBeNull();
+        copay!["value"]!["currency"]!.GetValue<string>().Should().Be("USD");
+        copay["value"]!["value"]!.GetValue<double>().Should().Be(25);
+
+        var coins = costs.FirstOrDefault(c =>
+            c!["qualifiers"]!.AsArray().Any(q =>
+                q!["coding"]!.AsArray()[0]!["code"]!.GetValue<string>() == "coinsurance"));
+        coins.Should().NotBeNull();
+        coins!["value"]!["unit"]!.GetValue<string>().Should().Be("%");
+        coins["value"]!["value"]!.GetValue<double>().Should().Be(20);
+    }
+
+    [Fact]
+    public void Coinsurance_above_one_is_treated_as_already_in_percent()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit
+            {
+                ServiceCategory = "Specialist",
+                InNetworkCoinsurance = 30m, // already a percent value
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var costs = result["plan"]!.AsArray()[0]!["specificCost"]!.AsArray()[0]!
+            ["benefit"]!.AsArray()[0]!["cost"]!.AsArray();
+        costs[0]!["value"]!["value"]!.GetValue<double>().Should().Be(30);
+    }
+
+    // ── extensions (Decision 13) ────────────────────────────────────────
+
+    [Fact]
+    public void Top_level_extension_includes_family_accumulator_model()
+    {
+        var plan = MakePlan();
+        plan.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+
+        var result = _projector.Project(plan)!;
+        var extensions = result["extension"]!.AsArray();
+
+        var fam = extensions.FirstOrDefault(e =>
+            e!["url"]!.GetValue<string>() == ChoBenefitPlanFhirUrls.FamilyAccumulatorModelExt);
+        fam.Should().NotBeNull();
+        fam!["valueCode"]!.GetValue<string>().Should().Be("Aggregate");
+    }
+
+    [Fact]
+    public void Top_level_aca_cap_extension_only_emitted_when_enforced()
+    {
+        var enforced = MakePlan();
+        enforced.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+        enforced.PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(1);
+
+        var enforcedResult = _projector.Project(enforced)!;
+        var enforcedExt = enforcedResult["extension"]!.AsArray()
+            .Any(e => e!["url"]!.GetValue<string>() == ChoBenefitPlanFhirUrls.AcaCapEnforcedExt);
+        enforcedExt.Should().BeTrue();
+
+        var legacy = MakePlan();
+        legacy.FamilyAccumulatorModel = FamilyAccumulatorModel.Aggregate;
+        legacy.PublishedAt = AcaCapEnforcementPolicy.CutoffUtc.AddDays(-30);
+
+        var legacyResult = _projector.Project(legacy)!;
+        var legacyExt = legacyResult["extension"]!.AsArray()
+            .Any(e => e!["url"]!.GetValue<string>() == ChoBenefitPlanFhirUrls.AcaCapEnforcedExt);
+        legacyExt.Should().BeFalse();
+    }
+
+    // ── deterministic output ────────────────────────────────────────────
+
+    [Fact]
+    public void Repeated_projection_produces_identical_json()
+    {
+        var plan = MakePlan();
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit
+            {
+                ServiceCategory = "Office Visit",
+                InNetworkCopay = 25m,
+            },
+        };
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+
+        var first = _projector.Project(plan)!;
+        var second = _projector.Project(plan)!;
+
+        first.ToJsonString().Should().Be(second.ToJsonString());
+    }
+
+    [Fact]
+    public void Network_references_can_be_round_tripped_to_json()
+    {
+        var plan = MakePlan();
+        plan.NetworkTiers = new List<NetworkTier>
+        {
+            new() { TierName = "Tier 1", TierLevel = 1, NetworkId = "net-pri" },
+        };
+        plan.Benefits = new List<Benefit>
+        {
+            new MedicalBenefit { ServiceCategory = "Office Visit" },
+        };
+
+        var result = _projector.Project(plan)!;
+        // Coverage entry repeats top-level networks. If the projector
+        // accidentally shared JsonNode identity instead of cloning,
+        // ToJsonString() would throw "node already has a parent."
+        var roundTripped = JsonNode.Parse(result.ToJsonString())!.AsObject();
+        roundTripped["coverage"]!.AsArray()[0]!["network"]!.AsArray()[0]!["reference"]!
+            .GetValue<string>().Should().Be("Organization/net-pri");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static BenefitPlan MakePlan() => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = "tenant-a",
+        PlanId = "AUR-GOLD-PPO-2026",
+        PlanName = "Aurelian Gold PPO 2026",
+        Payer = "AurelianHealth",
+        EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        VersionState = PlanVersionState.Published,
+        VersionNumber = 1,
+        VersionId = Guid.NewGuid().ToString(),
+        PublishedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded,
+        Benefits = new List<Benefit>(),
+        NetworkTiers = new List<NetworkTier>(),
+        CostSharing = new CostSharing(),
+    };
+}

--- a/src/services/benefit-plan-service/Controllers/FhirInsurancePlanController.cs
+++ b/src/services/benefit-plan-service/Controllers/FhirInsurancePlanController.cs
@@ -1,0 +1,329 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Middleware;
+using BenefitPlanService.Models;
+using BenefitPlanService.Repositories;
+using BenefitPlanService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BenefitPlanService.Controllers;
+
+/// <summary>
+/// FHIR R4 InsurancePlan read + search endpoint (capability BP 5.8).
+/// benefit-plan-service is the canonical authority on the projection;
+/// fhir-service proxies <c>/fhir/r4/InsurancePlan/*</c> requests here so
+/// CHO retains a single FHIR façade for external consumers while each
+/// domain service owns its own projection (mirrors provider-service's
+/// <c>FhirPractitionerController</c> / <c>FhirOrganizationController</c>
+/// for the Plan-Net Provider Directory bundle).
+///
+/// <para>
+/// Tenant scoping per Decision 7: requests honor the existing
+/// <see cref="Middleware.TenantMiddleware"/> mechanism. Authenticated /
+/// header-scoped callers see their tenant's plans only. Public
+/// CMS-0057-F unauthenticated access is a Phase 2 capability.
+/// </para>
+/// </summary>
+[ApiController]
+[Route("fhir")]
+public class FhirInsurancePlanController : ControllerBase
+{
+    private const string FhirContentType = "application/fhir+json";
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+
+    private readonly IBenefitPlanRepository _repository;
+    private readonly IFhirInsurancePlanProjector _projector;
+    private readonly IOrganizationLookupClient _organizationLookup;
+    private readonly IAcaLimitsProvider _acaLimits;
+    private readonly IPlanYearResolver _planYearResolver;
+    private readonly ILogger<FhirInsurancePlanController> _logger;
+
+    public FhirInsurancePlanController(
+        IBenefitPlanRepository repository,
+        IFhirInsurancePlanProjector projector,
+        IOrganizationLookupClient organizationLookup,
+        IAcaLimitsProvider acaLimits,
+        IPlanYearResolver planYearResolver,
+        ILogger<FhirInsurancePlanController> logger)
+    {
+        _repository = repository;
+        _projector = projector;
+        _organizationLookup = organizationLookup;
+        _acaLimits = acaLimits;
+        _planYearResolver = planYearResolver;
+        _logger = logger;
+    }
+
+    private string TenantId
+        => HttpContext.GetTenantId() ?? throw new InvalidOperationException("Tenant context missing");
+
+    /// <summary>
+    /// FHIR InsurancePlan read by PlanId. The path segment is the FHIR
+    /// resource <c>id</c>, which capability BP 5.8 maps to
+    /// <see cref="BenefitPlan.PlanId"/> per Decision 6 (the
+    /// operator-supplied human-meaningful identifier consumers see on
+    /// member ID cards and SBC documents). Tenant scoping disambiguates
+    /// the rare case where two tenants happen to use the same value.
+    /// </summary>
+    [HttpGet("InsurancePlan/{id}")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> ReadInsurancePlan(string id, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return FhirOperationOutcome(400, "invalid", "InsurancePlan id is required.");
+        }
+
+        BenefitPlan? plan;
+        try
+        {
+            plan = await _repository.GetByPlanIdAsync(id, TenantId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "InsurancePlan read failed for PlanId {PlanId}", SanitizeForLog(id));
+            return FhirOperationOutcome(500, "exception", "InsurancePlan read failed.");
+        }
+
+        if (plan is null)
+        {
+            return FhirOperationOutcome(404, "not-found", $"InsurancePlan/{id} not found.");
+        }
+
+        var projected = await ProjectAsync(plan, ct);
+        if (projected is null)
+        {
+            // Plan exists but no Active version satisfies the effective
+            // window. Mirrors Provider 5.7's stance — a non-Active
+            // version of a resource has no public FHIR projection.
+            return FhirOperationOutcome(404, "not-found", $"InsurancePlan/{id} not found.");
+        }
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = projected.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    /// <summary>
+    /// FHIR InsurancePlan search. Honors a deliberately small subset of
+    /// FHIR search parameters: <c>identifier</c>, <c>name</c>,
+    /// <c>status</c>, <c>_count</c>, <c>_page</c>. Other Plan-Net search
+    /// parameters (<c>type</c>, <c>owned-by</c>, <c>administered-by</c>,
+    /// <c>address</c>) are deferred — CHO's search backend doesn't index
+    /// them today.
+    /// </summary>
+    [HttpGet("InsurancePlan")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> SearchInsurancePlans(
+        [FromQuery] string? identifier,
+        [FromQuery] string? name,
+        [FromQuery] string? status,
+        [FromQuery] int _count = DefaultPageSize,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        var pageSize = Math.Clamp(_count, 1, MaxPageSize);
+        var page = Math.Max(1, _page);
+
+        // identifier is a token parameter. We accept either bare value
+        // or system|value where system is the CHO PlanIdSystem. If the
+        // caller supplied identifier= but the system is something we
+        // don't know, FHIR token semantics require us to return zero
+        // matches rather than ignore the filter — the empty bundle is
+        // a no-match response, not an error.
+        if (!string.IsNullOrEmpty(identifier))
+        {
+            var resolvedPlanId = ParsePlanIdentifier(identifier);
+            if (string.IsNullOrEmpty(resolvedPlanId))
+            {
+                return await BuildBundleResponseAsync(Array.Empty<BenefitPlan>(), ct);
+            }
+            var plan = await _repository.GetByPlanIdAsync(resolvedPlanId, TenantId);
+            return await BuildBundleResponseAsync(
+                plan is null ? Array.Empty<BenefitPlan>() : new[] { plan },
+                ct);
+        }
+
+        IEnumerable<BenefitPlan> results;
+        try
+        {
+            results = await _repository.SearchAsync(
+                tenantId: TenantId,
+                lineOfBusiness: null,
+                planType: null,
+                metalLevel: null,
+                page: page,
+                pageSize: pageSize);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "InsurancePlan search failed for tenant {TenantId}", SanitizeForLog(TenantId));
+            return FhirOperationOutcome(500, "exception", "InsurancePlan search failed.");
+        }
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            results = results.Where(p =>
+                !string.IsNullOrEmpty(p.PlanName) &&
+                p.PlanName.Contains(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(status))
+        {
+            results = status.ToLowerInvariant() switch
+            {
+                "active" => results.Where(p => !p.TerminationDate.HasValue || p.TerminationDate.Value >= DateTime.UtcNow),
+                "retired" => results.Where(p => p.TerminationDate.HasValue && p.TerminationDate.Value < DateTime.UtcNow),
+                _ => results,
+            };
+        }
+
+        return await BuildBundleResponseAsync(results, ct);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private async Task<JsonObject?> ProjectAsync(BenefitPlan plan, CancellationToken ct)
+    {
+        var networks = await ResolveNetworksAsync(plan, ct);
+        var acaLimits = ResolveAcaLimits(plan);
+        return _projector.Project(plan, networks, acaLimits);
+    }
+
+    /// <summary>
+    /// Pre-fetch every distinct <c>NetworkId</c> from the plan's
+    /// NetworkTiers via <see cref="IOrganizationLookupClient"/> and pass
+    /// the resulting list to the projector. Keeps the projector pure
+    /// (no DI / I/O) and lets the controller cache or coalesce lookups
+    /// in the future without changing the projector contract.
+    /// </summary>
+    private async Task<IReadOnlyList<OrganizationLookupResult>?> ResolveNetworksAsync(
+        BenefitPlan plan, CancellationToken ct)
+    {
+        if (plan.NetworkTiers is null || plan.NetworkTiers.Count == 0) return null;
+
+        var distinctIds = plan.NetworkTiers
+            .Where(t => !string.IsNullOrWhiteSpace(t.NetworkId))
+            .Select(t => t.NetworkId!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (distinctIds.Count == 0) return null;
+
+        var resolved = new List<OrganizationLookupResult>(distinctIds.Count);
+        foreach (var id in distinctIds)
+        {
+            try
+            {
+                var org = await _organizationLookup.GetOrganizationAsync(id, ct);
+                if (org is not null) resolved.Add(org);
+            }
+            catch (Exception ex)
+            {
+                // Lookup failures are non-fatal — the projection is
+                // still valid without display-text enrichment. Log and
+                // continue so an unreachable provider-service doesn't
+                // gate the InsurancePlan surface.
+                _logger.LogWarning(ex,
+                    "Organization lookup failed for network {NetworkId}; projecting without display enrichment",
+                    SanitizeForLog(id));
+            }
+        }
+
+        return resolved;
+    }
+
+    private AcaLimits? ResolveAcaLimits(BenefitPlan plan)
+    {
+        if (plan.FamilyAccumulatorModel != FamilyAccumulatorModel.Aggregate) return null;
+        if (!AcaCapEnforcementPolicy.IsEnforced(plan)) return null;
+
+        var planYear = _planYearResolver.Resolve(plan);
+        return _acaLimits.GetForPlanYear(planYear);
+    }
+
+    private async Task<IActionResult> BuildBundleResponseAsync(
+        IEnumerable<BenefitPlan> plans, CancellationToken ct)
+    {
+        var entries = new JsonArray();
+        foreach (var plan in plans)
+        {
+            var projected = await ProjectAsync(plan, ct);
+            if (projected is null) continue;
+            entries.Add(new JsonObject
+            {
+                ["resource"] = projected,
+                ["search"] = new JsonObject { ["mode"] = "match" },
+            });
+        }
+
+        var bundle = new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "searchset",
+            ["total"] = entries.Count,
+            ["entry"] = entries,
+        };
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = bundle.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    private IActionResult FhirOperationOutcome(int status, string code, string diagnostics)
+    {
+        var outcome = new JsonObject
+        {
+            ["resourceType"] = "OperationOutcome",
+            ["issue"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["severity"] = "error",
+                    ["code"] = code,
+                    ["diagnostics"] = diagnostics,
+                }
+            },
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = outcome.ToJsonString(),
+            StatusCode = status,
+        };
+    }
+
+    private static string? ParsePlanIdentifier(string identifier)
+    {
+        if (string.IsNullOrEmpty(identifier)) return null;
+
+        var pipe = identifier.IndexOf('|');
+        if (pipe >= 0)
+        {
+            var system = identifier[..pipe];
+            var value = identifier[(pipe + 1)..];
+            if (string.IsNullOrEmpty(system)
+                || string.Equals(system, ChoBenefitPlanFhirUrls.PlanIdSystem, StringComparison.OrdinalIgnoreCase))
+            {
+                return value;
+            }
+            // Unknown system — caller intent is ambiguous; reject is the
+            // FHIR-correct response but we treat as no-match here so the
+            // search returns an empty bundle rather than a 400 (consistent
+            // with the parameter being optional).
+            return null;
+        }
+        return identifier;
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Controllers/FhirInsurancePlanController.cs
+++ b/src/services/benefit-plan-service/Controllers/FhirInsurancePlanController.cs
@@ -79,6 +79,14 @@ public class FhirInsurancePlanController : ControllerBase
         {
             plan = await _repository.GetByPlanIdAsync(id, TenantId);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Caller cancelled (client disconnect, server abort).
+            // Propagate rather than turn it into a logged 500 — the
+            // pipeline maps cancellation to its standard 499/aborted
+            // shape and avoids polluting metrics with phantom errors.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "InsurancePlan read failed for PlanId {PlanId}", SanitizeForLog(id));
@@ -147,41 +155,129 @@ public class FhirInsurancePlanController : ControllerBase
                 ct);
         }
 
-        IEnumerable<BenefitPlan> results;
+        // Pagination correctness — `IBenefitPlanRepository.SearchAsync`
+        // returns every version row (Draft / Published / Superseded)
+        // ordered by PlanName, with no head-Published filter. Naively
+        // paginating that and projecting in-place produces short pages
+        // (the projector returns null for non-Published) and lets a
+        // single PlanId surface multiple versions in the same response.
+        //
+        // Until the repository grows a head-Published search seam,
+        // collect across repo pages, dedupe to the head Published
+        // version per PlanId, apply the name / status / effective-window
+        // filters, then page in-memory. Capped by `RepoScanLimit` so
+        // a degenerate large-tenant scan can't run unbounded.
+        List<BenefitPlan> matches;
         try
         {
-            results = await _repository.SearchAsync(
-                tenantId: TenantId,
-                lineOfBusiness: null,
-                planType: null,
-                metalLevel: null,
-                page: page,
-                pageSize: pageSize);
+            matches = await CollectFilteredHeadVersionsAsync(name, status, ct);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            _logger.LogError(ex, "InsurancePlan search failed for tenant {TenantId}", SanitizeForLog(TenantId));
+            throw;
+        }
+        catch (Exception)
+        {
+            // CollectFilteredHeadVersionsAsync already logged the
+            // underlying repo failure; emit a FHIR-compliant error
+            // surface here.
             return FhirOperationOutcome(500, "exception", "InsurancePlan search failed.");
         }
 
-        if (!string.IsNullOrEmpty(name))
+        var pageItems = matches
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize);
+
+        return await BuildBundleResponseAsync(pageItems, ct);
+    }
+
+    /// <summary>
+    /// Hard cap on how many repo pages a single InsurancePlan search
+    /// will scan. At <c>RepoChunkSize=200</c> rows per page that's
+    /// 10,000 versions — well above any tenant's authored plan-version
+    /// count today. If a real workload pushes against this, the right
+    /// move is a head-Published seam on the repo, not raising the cap.
+    /// </summary>
+    private const int RepoScanLimit = 50;
+    private const int RepoChunkSize = 200;
+
+    private async Task<List<BenefitPlan>> CollectFilteredHeadVersionsAsync(
+        string? nameFilter, string? statusFilter, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        // PlanId → head Published version, keyed in iteration order so
+        // PlanName sort from the repo is preserved.
+        var headByPlanId = new Dictionary<string, BenefitPlan>(StringComparer.Ordinal);
+
+        for (var repoPage = 1; repoPage <= RepoScanLimit; repoPage++)
         {
-            results = results.Where(p =>
-                !string.IsNullOrEmpty(p.PlanName) &&
-                p.PlanName.Contains(name, StringComparison.OrdinalIgnoreCase));
+            ct.ThrowIfCancellationRequested();
+
+            IEnumerable<BenefitPlan> chunk;
+            try
+            {
+                chunk = await _repository.SearchAsync(
+                    tenantId: TenantId,
+                    lineOfBusiness: null,
+                    planType: null,
+                    metalLevel: null,
+                    page: repoPage,
+                    pageSize: RepoChunkSize);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "InsurancePlan search failed for tenant {TenantId} (repo page {RepoPage})",
+                    SanitizeForLog(TenantId), repoPage);
+                throw;
+            }
+
+            var chunkList = chunk as IList<BenefitPlan> ?? chunk.ToList();
+            if (chunkList.Count == 0) break;
+
+            foreach (var plan in chunkList)
+            {
+                if (plan.VersionState != PlanVersionState.Published) continue;
+                if (plan.EffectiveDate > now) continue;
+
+                // Dedupe to the head Published version per PlanId. Repo
+                // ordering is by PlanName not VersionNumber, so we keep
+                // the row with the highest VersionNumber we've seen.
+                if (headByPlanId.TryGetValue(plan.PlanId, out var existing) &&
+                    existing.VersionNumber >= plan.VersionNumber)
+                {
+                    continue;
+                }
+                headByPlanId[plan.PlanId] = plan;
+            }
+
+            if (chunkList.Count < RepoChunkSize) break; // repo exhausted
         }
 
-        if (!string.IsNullOrEmpty(status))
+        IEnumerable<BenefitPlan> filtered = headByPlanId.Values;
+
+        if (!string.IsNullOrEmpty(nameFilter))
         {
-            results = status.ToLowerInvariant() switch
+            filtered = filtered.Where(p =>
+                !string.IsNullOrEmpty(p.PlanName) &&
+                p.PlanName.Contains(nameFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(statusFilter))
+        {
+            filtered = statusFilter.ToLowerInvariant() switch
             {
-                "active" => results.Where(p => !p.TerminationDate.HasValue || p.TerminationDate.Value >= DateTime.UtcNow),
-                "retired" => results.Where(p => p.TerminationDate.HasValue && p.TerminationDate.Value < DateTime.UtcNow),
-                _ => results,
+                "active" => filtered.Where(p => !p.TerminationDate.HasValue || p.TerminationDate.Value >= now),
+                "retired" => filtered.Where(p => p.TerminationDate.HasValue && p.TerminationDate.Value < now),
+                _ => filtered,
             };
         }
 
-        return await BuildBundleResponseAsync(results, ct);
+        return filtered.OrderBy(p => p.PlanName, StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     // ── helpers ────────────────────────────────────────────────────────
@@ -215,10 +311,18 @@ public class FhirInsurancePlanController : ControllerBase
         var resolved = new List<OrganizationLookupResult>(distinctIds.Count);
         foreach (var id in distinctIds)
         {
+            ct.ThrowIfCancellationRequested();
             try
             {
                 var org = await _organizationLookup.GetOrganizationAsync(id, ct);
                 if (org is not null) resolved.Add(org);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Caller cancelled — don't keep enriching networks the
+                // response will never reach. Propagate so the pipeline
+                // returns its standard cancellation shape.
+                throw;
             }
             catch (Exception ex)
             {

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -314,6 +314,15 @@ builder.Services.AddHttpClient(HttpProviderIntegrityGate.VerificationServiceClie
 });
 builder.Services.AddSingleton<IProviderIntegrityGate, HttpProviderIntegrityGate>();
 
+// ── FHIR InsurancePlan Projector (capability BP 5.8) ─────────────────────────
+// Stateless, hand-built JsonObject projector. Mirrors provider-service's
+// FhirPractitionerProjector / FhirOrganizationProjector — no Hl7.Fhir.R4
+// dependency. Consumed by FhirInsurancePlanController; fhir-service proxies
+// /fhir/r4/InsurancePlan/* requests to that controller via a typed
+// HttpClient("BenefitPlanService") registration on the fhir-service side.
+// See docs/architecture/fhir-insuranceplan-projection.md.
+builder.Services.AddSingleton<IFhirInsurancePlanProjector, FhirInsurancePlanProjector>();
+
 // ── Network-Tier → Organization Reference (5.5) ──────────────────────────────
 // Read-side lookup against provider-service capability 5.3 Organization
 // entity. Reuses the ProviderService HttpClient registered above. Backfill

--- a/src/services/benefit-plan-service/Services/AcaCapEnforcementPolicy.cs
+++ b/src/services/benefit-plan-service/Services/AcaCapEnforcementPolicy.cs
@@ -1,0 +1,66 @@
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Single source of truth for the "is the ACA per-member cap enforced
+/// for this plan" decision (capability BP 5.7 G8 gated rollout).
+/// Consumed by:
+///
+/// <list type="bullet">
+///   <item><see cref="ChoBenefitPlanProvider"/> when projecting
+///         <see cref="BenefitPlan"/> onto the engine's
+///         <c>BenefitPlanConfig.IsAcaCapEnforced</c>.</item>
+///   <item><see cref="FhirInsurancePlanProjector"/> when emitting the
+///         <c>insuranceplan-aca-cap-enforced</c> CHO extension on the
+///         FHIR projection (capability BP 5.8 Decision 13).</item>
+/// </list>
+///
+/// <para>
+/// Extracted as a static helper rather than an interface because the
+/// decision is a pure function of (FamilyAccumulatorModel, PublishedAt)
+/// and a fixed UTC cutoff. No per-tenant knobs, no I/O, no DI surface.
+/// Two consumers + one cutoff = one helper.
+/// </para>
+///
+/// <para>
+/// See <c>docs/architecture/family-accumulator-models.md</c> for the
+/// rollout posture and <c>docs/architecture/fhir-insuranceplan-projection.md</c>
+/// for the projection-side use of <see cref="IsEnforced"/>.
+/// </para>
+/// </summary>
+public static class AcaCapEnforcementPolicy
+{
+    /// <summary>
+    /// Cutoff that distinguishes legacy plans (hydrate with
+    /// <c>IsAcaCapEnforced = false</c>) from post-5.7 publishes (which set
+    /// it true automatically). Plans with <see cref="BenefitPlan.PublishedAt"/>
+    /// at or after this UTC instant get runtime ACA cap enforcement on
+    /// Aggregate mode; legacy plans behave as they did pre-5.7 until an
+    /// operator amends + republishes them.
+    /// </summary>
+    public static readonly DateTime CutoffUtc =
+        new(2026, 4, 28, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// True when <paramref name="plan"/> is Aggregate-mode AND has been
+    /// (or will be) published at or after <see cref="CutoffUtc"/>.
+    /// Drafts (<c>PublishedAt</c> null) are treated as post-cutoff because
+    /// any subsequent publish will be after the cutoff.
+    /// </summary>
+    public static bool IsEnforced(BenefitPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (plan.FamilyAccumulatorModel != FamilyAccumulatorModel.Aggregate)
+            return false;
+
+        if (!plan.PublishedAt.HasValue) return true;
+
+        var publishedAt = plan.PublishedAt.Value.Kind == DateTimeKind.Utc
+            ? plan.PublishedAt.Value
+            : plan.PublishedAt.Value.ToUniversalTime();
+
+        return publishedAt >= CutoffUtc;
+    }
+}

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanFhirUrls.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanFhirUrls.cs
@@ -1,0 +1,132 @@
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Canonical URLs for FHIR artifacts the benefit-plan-service projector
+/// emits (capability BP 5.8 — FHIR InsurancePlan Projection). Mirrors the
+/// convention in provider-service's <c>ChoProviderFhirUrls</c> and
+/// fhir-service's <c>ChoFhirCanonicalUrls</c> (base
+/// <c>http://fhir.cloudhealthoffice.com/</c>).
+///
+/// <para>
+/// CHO custom-extension URIs follow the empirical Provider 5.7/5.8/5.9
+/// convention <c>{resource-lowercase}-{slug}</c> (no <c>cho-</c> prefix);
+/// the Appeals-domain <c>cho-appeal-*</c> shape is appeals-specific and
+/// does not propagate to other domains.
+/// </para>
+///
+/// <para>
+/// TODO: consolidate with fhir-service ChoFhirCanonicalUrls and
+/// provider-service ChoProviderFhirUrls when a shared FHIR-infrastructure
+/// project lands (Phase 2 cleanup PR). benefit-plan-service does not
+/// reference fhir-service today, so the constants are mirrored here.
+/// </para>
+/// </summary>
+internal static class ChoBenefitPlanFhirUrls
+{
+    public const string Base                    = "http://fhir.cloudhealthoffice.com/";
+    public const string StructureDefinitionBase = Base + "StructureDefinition/";
+    public const string CodeSystemBase          = Base + "CodeSystem/";
+
+    // ── Standard FHIR / IG profile URLs ─────────────────────────────────
+
+    public const string UsCoreInsurancePlanProfile =
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-insuranceplan";
+
+    public const string PlanNetInsurancePlanProfile =
+        "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-InsurancePlan";
+
+    /// <summary>
+    /// HL7 R4 InsurancePlan.type CodeSystem. Plan-Net IG 1.1.0 binds
+    /// <c>type.coding</c> to a value set whose codes include
+    /// <c>medical</c>, <c>dental</c>, <c>vision</c>, <c>drug</c>. Phase 1
+    /// emits <c>medical</c> as the default — every BenefitPlan today is
+    /// medical-coverage-shaped. A future capability discriminates per
+    /// authored plan type.
+    /// </summary>
+    public const string InsurancePlanTypeSystem =
+        "http://terminology.hl7.org/CodeSystem/insurance-plan-type";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for the operator-authored product shape
+    /// (<c>HMO</c> / <c>PPO</c> / <c>EPO</c> / <c>POS</c> / <c>HDHP</c> /
+    /// <c>Medicaid</c> / <c>Medicare</c> / <c>Commercial</c>). Emitted as
+    /// a second coding under <c>InsurancePlan.type</c> alongside the
+    /// standard <see cref="InsurancePlanTypeSystem"/> — Decision 8a.
+    /// </summary>
+    public const string PlanProductShapeSystem =
+        CodeSystemBase + "plan-product-shape";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for plan-level cost categories used in
+    /// <c>plan.generalCost.type</c> (e.g. <c>deductible</c>,
+    /// <c>out-of-pocket-max</c>, <c>aca-individual-cap</c>). FHIR R4
+    /// has no canonical binding for this slot; CHO publishes one so
+    /// consumers see a stable system+code pair instead of text-only
+    /// concepts.
+    /// </summary>
+    public const string PlanGeneralCostTypeSystem =
+        CodeSystemBase + "insuranceplan-general-cost-type";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for the <c>cost.qualifiers</c> codes
+    /// (<c>in-network</c> / <c>out-of-network</c> / <c>copay</c> /
+    /// <c>coinsurance</c>) emitted under
+    /// <c>plan.specificCost.benefit.cost.qualifiers</c>. Plan-Net IG 1.1.0
+    /// expects qualifier codes; the IG does not publish a canonical
+    /// CodeSystem so CHO publishes one to keep the codes stable.
+    /// </summary>
+    public const string PlanCostQualifierSystem =
+        CodeSystemBase + "insuranceplan-cost-qualifier";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for the operator-authored network tier
+    /// identifier emitted under <c>plan.identifier</c> (so a Plan-Net
+    /// consumer can look up "Tier 1" / "Tier 2" / "Out-of-Network" by
+    /// the tier name the plan author wrote). CHO does not bind these
+    /// to an external value set; plan authors author free-text tier
+    /// names and we publish them as identifiers under a CHO base.
+    /// </summary>
+    public const string NetworkTierSystem =
+        CodeSystemBase + "network-tier";
+
+    /// <summary>
+    /// Identifier system used for <c>InsurancePlan.identifier[0]</c>.
+    /// Carries <c>BenefitPlan.PlanId</c> (operator-authored) per
+    /// Decision 6 — the human-meaningful identifier consumers see on
+    /// member ID cards and SBC documents. Tenant scoping disambiguates
+    /// when two tenants happen to use the same value.
+    /// </summary>
+    public const string PlanIdSystem =
+        Base + "plan-id";
+
+    // ── CHO custom extensions for benefit-plan-specific data ─────────────
+
+    /// <summary>
+    /// CHO extension carrying <see cref="Models.FamilyAccumulatorModel"/>
+    /// (capability BP 5.7). Emitted on <c>InsurancePlan</c> as
+    /// <c>valueCode</c> (<c>Embedded</c> | <c>Aggregate</c>) so consumers
+    /// can render the model choice without walking <c>generalCost</c> /
+    /// <c>specificCost</c> heuristics. Decision 13.
+    /// </summary>
+    public const string FamilyAccumulatorModelExt =
+        StructureDefinitionBase + "insuranceplan-family-accumulator-model";
+
+    /// <summary>
+    /// CHO extension carrying the resolved
+    /// <see cref="AcaCapEnforcementPolicy.IsEnforced"/> flag. Emitted on
+    /// <c>InsurancePlan</c> as <c>valueBoolean</c>; only present when
+    /// enforcement is active for the plan. Plan-Net IG 1.1.0 has no
+    /// native extension for "ACA per-member cap enforcement state"; CHO
+    /// publishes one. Decision 13.
+    ///
+    /// <para>
+    /// Also emitted as a sub-extension on the per-member ACA-cap
+    /// <c>plan.generalCost</c> entry (Decision 11 dual emission) so
+    /// standard Plan-Net consumers see the cap as a real cost limit while
+    /// CHO-aware consumers can disambiguate it from a real plan-level
+    /// individual cap.
+    /// </para>
+    /// </summary>
+    public const string AcaCapEnforcedExt =
+        StructureDefinitionBase + "insuranceplan-aca-cap-enforced";
+}

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
@@ -18,15 +18,14 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
     /// <summary>
     /// Cutoff that distinguishes legacy plans (hydrate with
     /// <c>IsAcaCapEnforced=false</c>) from post-5.7 publishes (which set
-    /// it true automatically). Plans with <see cref="BenefitPlan.PublishedAt"/>
-    /// at or after this UTC instant get runtime ACA cap enforcement on
-    /// Aggregate mode; legacy plans behave as they did pre-5.7 until an
-    /// operator amends + republishes them. Transition support per the
-    /// ratified plan (G8); see
-    /// <c>docs/architecture/family-accumulator-models.md</c>.
+    /// it true automatically). Re-exported here for callers that already
+    /// reference <see cref="ChoBenefitPlanProvider"/>; the canonical
+    /// definition lives on <see cref="AcaCapEnforcementPolicy.CutoffUtc"/>
+    /// because BP 5.8 surfaces the same enforcement state through the
+    /// FHIR InsurancePlan projector and both call sites must agree on
+    /// the wall-clock instant.
     /// </summary>
-    public static readonly DateTime AcaCapEnforcementCutoffUtc =
-        new(2026, 4, 28, 0, 0, 0, DateTimeKind.Utc);
+    public static DateTime AcaCapEnforcementCutoffUtc => AcaCapEnforcementPolicy.CutoffUtc;
 
     private readonly IBenefitPlanRepository _repo;
     private readonly IBenefitEngineTenantContext _tenantContext;
@@ -129,26 +128,12 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
     }
 
     /// <summary>
-    /// G8 gated rollout. Plans published at or after the cutoff (or that
-    /// have not been published yet, i.e. drafts) get runtime ACA cap
-    /// enforcement; legacy plans published before the cutoff hydrate with
-    /// enforcement disabled so members on existing Aggregate plans don't
-    /// see surprise mid-year caps. Re-publishing a legacy plan flips it
-    /// to enforced state automatically because PublishedAt advances.
+    /// G8 gated rollout. Delegates to <see cref="AcaCapEnforcementPolicy.IsEnforced"/>
+    /// so the engine-config projection and the FHIR InsurancePlan
+    /// projection (BP 5.8) share one decision rule.
     /// </summary>
     private static bool ResolveIsAcaCapEnforced(BenefitPlan plan)
-    {
-        if (plan.FamilyAccumulatorModel != ModelFamilyAccumulatorModel.Aggregate)
-            return false;
-
-        if (!plan.PublishedAt.HasValue) return true;
-
-        var publishedAt = plan.PublishedAt.Value.Kind == DateTimeKind.Utc
-            ? plan.PublishedAt.Value
-            : plan.PublishedAt.Value.ToUniversalTime();
-
-        return publishedAt >= AcaCapEnforcementCutoffUtc;
-    }
+        => AcaCapEnforcementPolicy.IsEnforced(plan);
 
     private static EngineFamilyAccumulatorModel MapFamilyAccumulatorModel(ModelFamilyAccumulatorModel model)
         => model switch

--- a/src/services/benefit-plan-service/Services/FhirExtensionBuilder.cs
+++ b/src/services/benefit-plan-service/Services/FhirExtensionBuilder.cs
@@ -1,0 +1,119 @@
+// TODO: extract to a shared FHIR-infrastructure project. Mirrors
+// provider-service's ProviderService.Services.FhirExtensionBuilder
+// verbatim, which itself mirrors member-service's. Deliberate
+// replication rather than a project reference because cross-service
+// projects in CHO today don't share infrastructure and adding one is
+// its own architectural decision (Phase 2 cleanup PR). Capability BP 5.8
+// — first benefit-plan-domain projector to need these helpers.
+
+using System.Text.Json.Nodes;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Small helper for assembling FHIR extension nodes. Keeps US Core /
+/// Plan-Net extension wiring DRY across resource projectors.
+/// </summary>
+internal static class FhirExtensionBuilder
+{
+    public static JsonObject Coding(string system, string code, string? display = null)
+    {
+        var coding = new JsonObject
+        {
+            ["system"] = system,
+            ["code"] = code
+        };
+        if (!string.IsNullOrEmpty(display)) coding["display"] = display;
+        return coding;
+    }
+
+    public static JsonObject ExtensionString(string url, string value) => new()
+    {
+        ["url"] = url,
+        ["valueString"] = value
+    };
+
+    public static JsonObject ExtensionBoolean(string url, bool value) => new()
+    {
+        ["url"] = url,
+        ["valueBoolean"] = value
+    };
+
+    public static JsonObject ExtensionCode(string url, string value) => new()
+    {
+        ["url"] = url,
+        ["valueCode"] = value
+    };
+
+    public static JsonObject ExtensionCoding(string url, JsonObject coding) => new()
+    {
+        ["url"] = url,
+        ["valueCoding"] = coding
+    };
+
+    public static JsonObject ExtensionCodeableConcept(string url, JsonObject codeableConcept) => new()
+    {
+        ["url"] = url,
+        ["valueCodeableConcept"] = codeableConcept
+    };
+
+    /// <summary>
+    /// Build a CodeableConcept JsonObject. Either <paramref name="coding"/>
+    /// or <paramref name="text"/> (or both) must be non-empty; a fully
+    /// empty CodeableConcept is not valid FHIR.
+    /// </summary>
+    public static JsonObject CodeableConcept(JsonObject? coding = null, string? text = null)
+    {
+        var concept = new JsonObject();
+        if (coding != null)
+        {
+            concept["coding"] = new JsonArray(coding);
+        }
+        if (!string.IsNullOrEmpty(text))
+        {
+            concept["text"] = text;
+        }
+        return concept;
+    }
+
+    /// <summary>
+    /// Build a CodeableConcept JsonObject with multiple coding entries.
+    /// </summary>
+    public static JsonObject CodeableConcept(IEnumerable<JsonObject> codings, string? text = null)
+    {
+        var concept = new JsonObject();
+        var array = new JsonArray();
+        foreach (var c in codings) array.Add(c);
+        if (array.Count > 0) concept["coding"] = array;
+        if (!string.IsNullOrEmpty(text)) concept["text"] = text;
+        return concept;
+    }
+
+    /// <summary>
+    /// Build a FHIR Money node. Currency defaults to USD because CHO is
+    /// US-only today; emitting under a CHO consumer that ever served
+    /// non-USD plans would need a per-plan currency field on
+    /// BenefitPlan, which doesn't exist.
+    /// </summary>
+    public static JsonObject Money(decimal amount, string currency = "USD") => new()
+    {
+        ["value"] = (double)amount,
+        ["currency"] = currency
+    };
+
+    /// <summary>
+    /// Build a FHIR Quantity node. Used for visit limits ("12 visits per
+    /// year") and coinsurance percentages ("20 %").
+    /// </summary>
+    public static JsonObject Quantity(decimal value, string unit, string? system = null, string? code = null)
+    {
+        var q = new JsonObject
+        {
+            ["value"] = (double)value,
+            ["unit"] = unit
+        };
+        if (!string.IsNullOrEmpty(system)) q["system"] = system;
+        if (!string.IsNullOrEmpty(code)) q["code"] = code;
+        return q;
+    }
+}

--- a/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
+++ b/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
@@ -1,0 +1,712 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
+using static BenefitPlanService.Services.FhirExtensionBuilder;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Hand-built FHIR R4 InsurancePlan projector (capability BP 5.8).
+/// Pattern mirrors provider-service's <c>FhirPractitionerProjector</c>:
+/// stateless, deterministic, no Hl7.Fhir.R4 dependency.
+/// </summary>
+public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
+{
+    // Plan-Net IG 1.1.0 cost.qualifiers codes (Decision 9). The 2-element
+    // array shape matches the Plan-Net example bundle; if conformance
+    // testing rejects this shape, fall back to one cost entry per single
+    // qualifier (4→8 cost entries per benefit).
+    private const string QualifierInNetwork    = "in-network";
+    private const string QualifierOutOfNetwork = "out-of-network";
+    private const string QualifierCopay        = "copay";
+    private const string QualifierCoinsurance  = "coinsurance";
+
+    public JsonObject? Project(BenefitPlan plan) => Project(plan, networks: null, acaLimits: null);
+
+    public JsonObject? Project(
+        BenefitPlan plan,
+        IReadOnlyList<OrganizationLookupResult>? networks,
+        AcaLimits? acaLimits)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        // Non-Active versions don't get a public projection. Drafts /
+        // Superseded versions exist for audit and amendment workflows
+        // only — the FHIR surface is the public face of the head
+        // Published version, mirroring Provider 5.7's stance.
+        if (plan.VersionState != PlanVersionState.Published) return null;
+
+        var status = ResolveStatus(plan);
+        if (status is null) return null;
+
+        var resource = new JsonObject
+        {
+            ["resourceType"] = "InsurancePlan",
+            ["id"] = plan.PlanId,
+            ["status"] = status,
+        };
+
+        // ── Identifier (PlanId) — Decision 6 ─────────────────────────
+        resource["identifier"] = new JsonArray
+        {
+            new JsonObject
+            {
+                ["use"] = "official",
+                ["system"] = ChoBenefitPlanFhirUrls.PlanIdSystem,
+                ["value"] = plan.PlanId,
+            }
+        };
+
+        // ── type (Decision 8a — two codings) ─────────────────────────
+        resource["type"] = new JsonArray { BuildTypeConcept(plan) };
+
+        // ── name ─────────────────────────────────────────────────────
+        if (!string.IsNullOrEmpty(plan.PlanName))
+        {
+            resource["name"] = plan.PlanName;
+        }
+
+        // ── period ───────────────────────────────────────────────────
+        var period = new JsonObject
+        {
+            ["start"] = ToFhirDate(plan.EffectiveDate),
+        };
+        if (plan.TerminationDate.HasValue)
+        {
+            period["end"] = ToFhirDate(plan.TerminationDate.Value);
+        }
+        resource["period"] = period;
+
+        // ── ownedBy (display-only — Decision 12) ─────────────────────
+        if (!string.IsNullOrEmpty(plan.Payer))
+        {
+            resource["ownedBy"] = new JsonObject { ["display"] = plan.Payer };
+        }
+
+        // ── endpoint (deferred to BP 5.9 — emit empty array) ────────
+        // Empty array is conformant FHIR cardinality 0..*. Documenting
+        // intent as an empty collection rather than omitting tells
+        // consumers "no documents projected yet" vs "field unsupported."
+        resource["endpoint"] = new JsonArray();
+
+        // ── network[] (top-level — Decision 10 site 1) ──────────────
+        var topLevelNetworks = BuildNetworkReferences(plan.NetworkTiers, networks);
+        if (topLevelNetworks.Count > 0)
+        {
+            resource["network"] = topLevelNetworks;
+        }
+
+        // ── coverage[] (one per benefit category) ───────────────────
+        var coverage = BuildCoverage(plan, topLevelNetworks);
+        if (coverage.Count > 0)
+        {
+            resource["coverage"] = coverage;
+        }
+
+        // ── plan[] (one per NetworkTier) ────────────────────────────
+        var planArray = BuildPlans(plan, networks, acaLimits);
+        if (planArray.Count > 0)
+        {
+            resource["plan"] = planArray;
+        }
+
+        // ── extension[] (CHO custom extensions — Decision 13) ───────
+        var extensions = BuildTopLevelExtensions(plan);
+        if (extensions.Count > 0)
+        {
+            resource["extension"] = extensions;
+        }
+
+        // ── meta ─────────────────────────────────────────────────────
+        resource["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = ToFhirInstant(ResolveLastUpdated(plan)),
+            ["profile"] = new JsonArray(
+                ChoBenefitPlanFhirUrls.UsCoreInsurancePlanProfile,
+                ChoBenefitPlanFhirUrls.PlanNetInsurancePlanProfile),
+        };
+
+        return resource;
+    }
+
+    // ── status resolution (P4: derived) ─────────────────────────────────
+
+    /// <summary>
+    /// Map the plan's lifecycle to a FHIR <c>publication-status</c> code.
+    /// Active when the head Published version's effective window contains
+    /// "now"; retired when the plan has been terminated. Pre-effective
+    /// drafts are filtered out before this method is called.
+    /// </summary>
+    private static string? ResolveStatus(BenefitPlan plan)
+    {
+        var now = DateTime.UtcNow;
+        var effective = ToUtc(plan.EffectiveDate);
+        var termination = plan.TerminationDate.HasValue ? ToUtc(plan.TerminationDate.Value) : (DateTime?)null;
+
+        if (effective > now)
+        {
+            // Future-effective — projecting before the plan starts is
+            // not part of the BP 5.8 contract. A future capability could
+            // emit "draft" but that conflicts with "non-Active versions
+            // don't project" (Provider 5.7 stance).
+            return null;
+        }
+
+        if (termination.HasValue && termination.Value < now)
+        {
+            return "retired";
+        }
+
+        return "active";
+    }
+
+    // ── type concept (Decision 8a — two codings) ────────────────────────
+
+    private static JsonObject BuildTypeConcept(BenefitPlan plan)
+    {
+        // First coding: HL7 standard insurance-plan-type. CHO defaults to
+        // "medical" for Phase 1 — every authored BenefitPlan today carries
+        // medical coverage. Dental-only / vision-only / drug-only plan
+        // discrimination is a future capability that introduces a
+        // BenefitPlan.CoverageScope or equivalent. Documenting the
+        // deferred discrimination logic in
+        // docs/architecture/fhir-insuranceplan-projection.md.
+        var standardCoding = Coding(
+            ChoBenefitPlanFhirUrls.InsurancePlanTypeSystem,
+            "medical",
+            "Medical");
+
+        // Second coding: CHO product shape. Plan authors set this; it's
+        // the right place for HMO/PPO/HDHP semantics that the standard
+        // value set doesn't cover.
+        var productCode = plan.PlanType.ToString();
+        var productCoding = Coding(
+            ChoBenefitPlanFhirUrls.PlanProductShapeSystem,
+            productCode,
+            productCode);
+
+        return CodeableConcept(new[] { standardCoding, productCoding }, text: productCode);
+    }
+
+    // ── network references ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Build top-level <c>InsurancePlan.network[]</c> emitting ALL
+    /// non-null-NetworkId tiers, ordered by TierLevel ascending
+    /// (Decision 10 revision — prompt's "first tier only" was wrong
+    /// because <c>network</c> cardinality is 0..*).
+    /// </summary>
+    private static JsonArray BuildNetworkReferences(
+        IEnumerable<NetworkTier> tiers,
+        IReadOnlyList<OrganizationLookupResult>? lookup)
+    {
+        var array = new JsonArray();
+        if (tiers is null) return array;
+
+        var ordered = tiers
+            .Where(t => !string.IsNullOrWhiteSpace(t.NetworkId))
+            .OrderBy(t => t.TierLevel)
+            .ThenBy(t => t.TierName ?? string.Empty);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var tier in ordered)
+        {
+            var networkId = tier.NetworkId!;
+            if (!seen.Add(networkId)) continue;
+
+            array.Add(BuildOrganizationReference(networkId, lookup));
+        }
+
+        return array;
+    }
+
+    private static JsonObject BuildOrganizationReference(
+        string networkId,
+        IReadOnlyList<OrganizationLookupResult>? lookup)
+    {
+        var reference = new JsonObject
+        {
+            ["reference"] = $"Organization/{networkId}",
+        };
+
+        if (lookup is not null)
+        {
+            var match = lookup.FirstOrDefault(o =>
+                string.Equals(o.OrganizationId, networkId, StringComparison.Ordinal));
+            if (match is not null && !string.IsNullOrEmpty(match.Name))
+            {
+                reference["display"] = match.Name;
+            }
+        }
+
+        return reference;
+    }
+
+    // ── coverage[] ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One <c>coverage</c> entry per benefit-type group (medical /
+    /// pharmacy / dental / vision / behavioralHealth / dme / maternity /
+    /// preventive). Each entry repeats the top-level network references
+    /// and emits per-Benefit detail under <c>benefit[]</c>.
+    /// </summary>
+    private static JsonArray BuildCoverage(BenefitPlan plan, JsonArray topLevelNetworks)
+    {
+        var coverage = new JsonArray();
+        if (plan.Benefits is null || plan.Benefits.Count == 0) return coverage;
+
+        var grouped = plan.Benefits
+            .Where(b => b is not null)
+            .GroupBy(b => b.BenefitType ?? BenefitTypeDiscriminators.Medical)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        foreach (var group in grouped)
+        {
+            var entry = new JsonObject
+            {
+                ["type"] = CodeableConcept(coding: null, text: PrettyBenefitCategory(group.Key)),
+            };
+
+            // Plan-Net cardinality on coverage.network is 0..*. Repeat the
+            // top-level set so each coverage block is self-contained.
+            if (topLevelNetworks.Count > 0)
+            {
+                var networkClone = new JsonArray();
+                foreach (var n in topLevelNetworks)
+                {
+                    networkClone.Add(CloneJsonObject(n));
+                }
+                entry["network"] = networkClone;
+            }
+
+            var benefitArray = new JsonArray();
+            foreach (var benefit in group)
+            {
+                benefitArray.Add(BuildCoverageBenefit(benefit));
+            }
+            entry["benefit"] = benefitArray;
+
+            coverage.Add(entry);
+        }
+
+        return coverage;
+    }
+
+    private static JsonObject BuildCoverageBenefit(Benefit benefit)
+    {
+        var node = new JsonObject
+        {
+            ["type"] = CodeableConcept(
+                coding: null,
+                text: !string.IsNullOrEmpty(benefit.ServiceCategory)
+                    ? benefit.ServiceCategory
+                    : benefit.Description),
+        };
+
+        // requirement — combine prior-auth flag and operator-authored
+        // limitations into a single human-readable string. FHIR
+        // cardinality is 0..1 string.
+        var requirement = BuildRequirement(benefit);
+        if (!string.IsNullOrEmpty(requirement))
+        {
+            node["requirement"] = requirement;
+        }
+
+        // limit[] — visit limits (Quantity) and dollar caps (Money).
+        var limit = new JsonArray();
+        if (benefit.VisitLimit.HasValue)
+        {
+            var unit = !string.IsNullOrEmpty(benefit.VisitLimitPeriod)
+                ? benefit.VisitLimitPeriod!
+                : "visit";
+            limit.Add(new JsonObject
+            {
+                ["value"] = Quantity(benefit.VisitLimit.Value, unit),
+            });
+        }
+        if (benefit.AnnualMaximum.HasValue)
+        {
+            limit.Add(new JsonObject
+            {
+                ["value"] = Money(benefit.AnnualMaximum.Value),
+                ["code"] = CodeableConcept(coding: null, text: "Annual maximum"),
+            });
+        }
+        if (benefit.LifetimeMaximum.HasValue)
+        {
+            limit.Add(new JsonObject
+            {
+                ["value"] = Money(benefit.LifetimeMaximum.Value),
+                ["code"] = CodeableConcept(coding: null, text: "Lifetime maximum"),
+            });
+        }
+        if (limit.Count > 0)
+        {
+            node["limit"] = limit;
+        }
+
+        return node;
+    }
+
+    private static string? BuildRequirement(Benefit benefit)
+    {
+        var parts = new List<string>(2);
+        if (benefit.PriorAuthRequired || benefit.RequiresPriorAuth)
+        {
+            parts.Add("Prior authorization required.");
+        }
+        if (!string.IsNullOrWhiteSpace(benefit.Limitations))
+        {
+            parts.Add(benefit.Limitations!.Trim());
+        }
+        return parts.Count == 0 ? null : string.Join(" ", parts);
+    }
+
+    // ── plan[] ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One <c>plan</c> entry per NetworkTier with a non-null NetworkId.
+    /// Each entry carries the tier's network reference, generalCost
+    /// (deductible + OOP max), and specificCost (per-Benefit cost
+    /// sharing scoped to this tier's in-network vs out-of-network
+    /// columns on <see cref="CostSharing"/>).
+    /// </summary>
+    private static JsonArray BuildPlans(
+        BenefitPlan plan,
+        IReadOnlyList<OrganizationLookupResult>? networks,
+        AcaLimits? acaLimits)
+    {
+        var planArray = new JsonArray();
+        if (plan.NetworkTiers is null) return planArray;
+
+        var tiers = plan.NetworkTiers
+            .Where(t => !string.IsNullOrWhiteSpace(t.NetworkId))
+            .OrderBy(t => t.TierLevel)
+            .ThenBy(t => t.TierName ?? string.Empty)
+            .ToList();
+
+        var acaEnforced = AcaCapEnforcementPolicy.IsEnforced(plan);
+
+        foreach (var tier in tiers)
+        {
+            var entry = new JsonObject();
+
+            // identifier — operator-authored TierName under CHO system.
+            var tierIdentifierValue = !string.IsNullOrEmpty(tier.TierName)
+                ? tier.TierName
+                : (tier.NetworkId ?? string.Empty);
+            entry["identifier"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["system"] = ChoBenefitPlanFhirUrls.NetworkTierSystem,
+                    ["value"] = tierIdentifierValue,
+                }
+            };
+
+            // type — text-only "Tier {TierLevel}".
+            entry["type"] = CodeableConcept(coding: null, text: $"Tier {tier.TierLevel}");
+
+            // network[] — single reference for this tier.
+            entry["network"] = new JsonArray
+            {
+                BuildOrganizationReference(tier.NetworkId!, networks),
+            };
+
+            // generalCost[] — deductible + OOP max for this tier.
+            var general = BuildGeneralCost(plan, tier, acaEnforced, acaLimits);
+            if (general.Count > 0)
+            {
+                entry["generalCost"] = general;
+            }
+
+            // specificCost[] — per-Benefit cost-sharing for this tier.
+            var specific = BuildSpecificCost(plan, tier);
+            if (specific.Count > 0)
+            {
+                entry["specificCost"] = specific;
+            }
+
+            planArray.Add(entry);
+        }
+
+        return planArray;
+    }
+
+    private static JsonArray BuildGeneralCost(
+        BenefitPlan plan,
+        NetworkTier tier,
+        bool acaEnforced,
+        AcaLimits? acaLimits)
+    {
+        var array = new JsonArray();
+        var costs = plan.CostSharing ?? new CostSharing();
+        var isInNetwork = ResolveTierIsInNetwork(tier);
+
+        // Deductibles
+        var indDeductible = isInNetwork
+            ? PreferPositive(costs.IndividualDeductible, costs.InNetworkDeductible)
+            : PreferPositive(
+                costs.OutNetworkIndividualDeductible ?? 0m,
+                costs.OutOfNetworkDeductible);
+        var famDeductible = isInNetwork
+            ? PreferPositive(costs.FamilyDeductible, 0m)
+            : (costs.OutNetworkFamilyDeductible ?? 0m);
+
+        if (indDeductible > 0)
+            array.Add(BuildGeneralCostEntry("deductible", "Deductible", 1, indDeductible,
+                $"Individual deductible ({(isInNetwork ? "in-network" : "out-of-network")})"));
+        if (famDeductible > 0)
+            array.Add(BuildGeneralCostEntry("deductible", "Deductible", 2, famDeductible,
+                $"Family deductible ({(isInNetwork ? "in-network" : "out-of-network")})"));
+
+        // OOP max
+        var indOop = isInNetwork
+            ? PreferPositive(costs.IndividualOutOfPocketMax, costs.InNetworkOutOfPocketMax)
+            : PreferPositive(
+                costs.OutNetworkIndividualOutOfPocketMax ?? 0m,
+                costs.OutOfNetworkOutOfPocketMax);
+        var famOop = isInNetwork
+            ? PreferPositive(costs.FamilyOutOfPocketMax, 0m)
+            : (costs.OutNetworkFamilyOutOfPocketMax ?? 0m);
+
+        if (indOop > 0)
+            array.Add(BuildGeneralCostEntry("out-of-pocket-max", "Out-of-Pocket Maximum", 1, indOop,
+                $"Individual out-of-pocket maximum ({(isInNetwork ? "in-network" : "out-of-network")})"));
+        if (famOop > 0)
+            array.Add(BuildGeneralCostEntry("out-of-pocket-max", "Out-of-Pocket Maximum", 2, famOop,
+                $"Family out-of-pocket maximum ({(isInNetwork ? "in-network" : "out-of-network")})"));
+
+        // ACA per-member cap (Decision 11 dual emission). Only on the
+        // primary in-network tier; out-of-network tiers don't carry the
+        // ACA cap because OON OOP is independent of ACA enforcement.
+        if (isInNetwork && acaEnforced && acaLimits is not null && acaLimits.IndividualCap > 0)
+        {
+            var entry = BuildGeneralCostEntry(
+                "aca-individual-cap",
+                "ACA Individual Cap",
+                groupSize: 1,
+                amount: acaLimits.IndividualCap,
+                comment: $"ACA per-member out-of-pocket cap (45 CFR §156.130, plan year {acaLimits.PlanYear})");
+
+            // Per-cost extension — disambiguate from a real plan-level
+            // individual cap (Decision 11). Standard Plan-Net consumers
+            // see the entry as a real cost limit; CHO-aware consumers
+            // read the flag and know it's regulatory enforcement.
+            entry["extension"] = new JsonArray
+            {
+                ExtensionBoolean(ChoBenefitPlanFhirUrls.AcaCapEnforcedExt, true),
+            };
+            array.Add(entry);
+        }
+
+        return array;
+    }
+
+    private static JsonObject BuildGeneralCostEntry(
+        string code,
+        string display,
+        int groupSize,
+        decimal amount,
+        string comment)
+    {
+        var entry = new JsonObject
+        {
+            ["type"] = CodeableConcept(
+                Coding(ChoBenefitPlanFhirUrls.PlanGeneralCostTypeSystem, code, display),
+                text: display),
+            ["groupSize"] = groupSize,
+            ["cost"] = Money(amount),
+            ["comment"] = comment,
+        };
+        return entry;
+    }
+
+    private static JsonArray BuildSpecificCost(BenefitPlan plan, NetworkTier tier)
+    {
+        var array = new JsonArray();
+        if (plan.Benefits is null || plan.Benefits.Count == 0) return array;
+
+        var isInNetwork = ResolveTierIsInNetwork(tier);
+
+        var grouped = plan.Benefits
+            .Where(b => b is not null)
+            .GroupBy(b => b.BenefitType ?? BenefitTypeDiscriminators.Medical)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        foreach (var group in grouped)
+        {
+            var benefitArray = new JsonArray();
+            foreach (var benefit in group)
+            {
+                var costs = BuildBenefitCosts(benefit, isInNetwork);
+                if (costs.Count == 0) continue;
+
+                benefitArray.Add(new JsonObject
+                {
+                    ["type"] = CodeableConcept(
+                        coding: null,
+                        text: !string.IsNullOrEmpty(benefit.ServiceCategory)
+                            ? benefit.ServiceCategory
+                            : benefit.Description),
+                    ["cost"] = costs,
+                });
+            }
+
+            if (benefitArray.Count > 0)
+            {
+                array.Add(new JsonObject
+                {
+                    ["category"] = CodeableConcept(coding: null, text: PrettyBenefitCategory(group.Key)),
+                    ["benefit"] = benefitArray,
+                });
+            }
+        }
+
+        return array;
+    }
+
+    private static JsonArray BuildBenefitCosts(Benefit benefit, bool isInNetwork)
+    {
+        var costs = new JsonArray();
+
+        decimal? copay;
+        decimal? coinsurance;
+        if (isInNetwork)
+        {
+            copay = benefit.InNetworkCopay ?? benefit.CopayAmount;
+            coinsurance = benefit.InNetworkCoinsurance ?? benefit.CoinsurancePercentage;
+        }
+        else
+        {
+            copay = benefit.OutNetworkCopay;
+            coinsurance = benefit.OutNetworkCoinsurance;
+        }
+
+        var tierQualifier = isInNetwork ? QualifierInNetwork : QualifierOutOfNetwork;
+
+        if (copay.HasValue && copay.Value >= 0)
+        {
+            costs.Add(BuildCostEntry(tierQualifier, QualifierCopay, Money(copay.Value)));
+        }
+
+        if (coinsurance.HasValue && coinsurance.Value >= 0)
+        {
+            // Coinsurance on Benefit is stored as a fraction (0.20 = 20%).
+            // FHIR Quantity for percentage uses unit "%" with the UCUM
+            // code "%" so consumers can render it cleanly.
+            var pct = coinsurance.Value <= 1m ? coinsurance.Value * 100m : coinsurance.Value;
+            costs.Add(BuildCostEntry(tierQualifier, QualifierCoinsurance,
+                Quantity(pct, "%", system: "http://unitsofmeasure.org", code: "%")));
+        }
+
+        return costs;
+    }
+
+    private static JsonObject BuildCostEntry(string tierQualifier, string typeQualifier, JsonObject value)
+    {
+        // Plan-Net IG 1.1.0 expects qualifier codes; we publish them
+        // under a CHO CodeSystem for stability (no canonical IG-published
+        // CodeSystem exists for these slots). 2-element-array shape per
+        // Decision 9. If conformance testing rejects the array shape,
+        // fall back to one cost entry per single qualifier.
+        return new JsonObject
+        {
+            ["qualifiers"] = new JsonArray
+            {
+                CodeableConcept(
+                    Coding(ChoBenefitPlanFhirUrls.PlanCostQualifierSystem, tierQualifier, tierQualifier),
+                    text: tierQualifier),
+                CodeableConcept(
+                    Coding(ChoBenefitPlanFhirUrls.PlanCostQualifierSystem, typeQualifier, typeQualifier),
+                    text: typeQualifier),
+            },
+            ["value"] = value,
+        };
+    }
+
+    // ── extensions ──────────────────────────────────────────────────────
+
+    private static JsonArray BuildTopLevelExtensions(BenefitPlan plan)
+    {
+        var array = new JsonArray();
+
+        array.Add(ExtensionCode(
+            ChoBenefitPlanFhirUrls.FamilyAccumulatorModelExt,
+            plan.FamilyAccumulatorModel.ToString()));
+
+        if (AcaCapEnforcementPolicy.IsEnforced(plan))
+        {
+            array.Add(ExtensionBoolean(ChoBenefitPlanFhirUrls.AcaCapEnforcedExt, true));
+        }
+
+        return array;
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tier is "in-network" when its TierName looks like an in-network
+    /// label or its TierLevel is 1 (the conventional best/primary tier).
+    /// Out-of-network tiers populate the OON columns on
+    /// <see cref="CostSharing"/>; in-network tiers (any of Tier 1, "In
+    /// Network", "Preferred", etc.) populate the IN columns.
+    /// </summary>
+    private static bool ResolveTierIsInNetwork(NetworkTier tier)
+    {
+        var name = tier.TierName ?? string.Empty;
+        if (name.Contains("out", StringComparison.OrdinalIgnoreCase) &&
+            name.Contains("network", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        if (name.StartsWith("OON", StringComparison.OrdinalIgnoreCase)) return false;
+        return true;
+    }
+
+    private static decimal PreferPositive(decimal first, decimal second)
+        => first > 0 ? first : second;
+
+    private static DateTime ResolveLastUpdated(BenefitPlan plan)
+    {
+        if (plan.ModifiedDate.HasValue) return plan.ModifiedDate.Value;
+        if (plan.PublishedAt.HasValue) return plan.PublishedAt.Value;
+        if (plan.UpdatedAt != default) return plan.UpdatedAt;
+        return plan.CreatedAt;
+    }
+
+    private static DateTime ToUtc(DateTime value) => value.Kind == DateTimeKind.Utc
+        ? value
+        : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+    private static string ToFhirDate(DateTime value)
+        => ToUtc(value).ToString("yyyy-MM-dd");
+
+    private static string ToFhirInstant(DateTime value)
+        => ToUtc(value).ToString("o");
+
+    private static string PrettyBenefitCategory(string discriminator) => discriminator switch
+    {
+        BenefitTypeDiscriminators.Medical => "Medical",
+        BenefitTypeDiscriminators.Dental => "Dental",
+        BenefitTypeDiscriminators.Pharmacy => "Pharmacy",
+        BenefitTypeDiscriminators.Vision => "Vision",
+        BenefitTypeDiscriminators.BehavioralHealth => "Behavioral Health",
+        BenefitTypeDiscriminators.DME => "Durable Medical Equipment",
+        BenefitTypeDiscriminators.Maternity => "Maternity",
+        BenefitTypeDiscriminators.Preventive => "Preventive",
+        _ => discriminator,
+    };
+
+    /// <summary>
+    /// Deep-clone a JsonObject so the same Reference body can be repeated
+    /// across multiple coverage[] entries without sharing node identity.
+    /// JsonObject nodes are tree-attached; reusing one would crash the
+    /// serializer with "node already has a parent."
+    /// </summary>
+    private static JsonObject CloneJsonObject(JsonNode? source)
+    {
+        return JsonNode.Parse(source?.ToJsonString() ?? "{}")?.AsObject()
+            ?? new JsonObject();
+    }
+}

--- a/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
+++ b/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
@@ -386,9 +386,20 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
             .ToList();
 
         var acaEnforced = AcaCapEnforcementPolicy.IsEnforced(plan);
+        var primaryInNetworkSeen = false;
 
         foreach (var tier in tiers)
         {
+            // The ACA per-member cap (Decision 11) projects on exactly
+            // ONE generalCost block — the primary in-network tier
+            // (lowest TierLevel among tiers we consider in-network).
+            // After sorting by TierLevel ASC above, the first tier that
+            // ResolveTierIsInNetwork classifies as in-network is the
+            // primary; subsequent in-network tiers (Tier 2 Preferred,
+            // etc.) must NOT duplicate the entry.
+            var isPrimaryInNetwork = !primaryInNetworkSeen && ResolveTierIsInNetwork(tier);
+            if (isPrimaryInNetwork) primaryInNetworkSeen = true;
+
             var entry = new JsonObject();
 
             // identifier — operator-authored TierName under CHO system.
@@ -413,8 +424,9 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
                 BuildOrganizationReference(tier.NetworkId!, networks),
             };
 
-            // generalCost[] — deductible + OOP max for this tier.
-            var general = BuildGeneralCost(plan, tier, acaEnforced, acaLimits);
+            // generalCost[] — deductible + OOP max for this tier. Only
+            // the primary in-network tier emits the ACA cap entry.
+            var general = BuildGeneralCost(plan, tier, isPrimaryInNetwork && acaEnforced, acaLimits);
             if (general.Count > 0)
             {
                 entry["generalCost"] = general;
@@ -433,10 +445,16 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
         return planArray;
     }
 
+    /// <summary>
+    /// Build <c>generalCost[]</c> for one tier. <paramref name="emitAcaCap"/>
+    /// must be true for AT MOST ONE tier in the parent <c>plan[]</c> array
+    /// (the primary in-network tier — see caller logic) so the per-member
+    /// cap doesn't duplicate across Tier 1 + Tier 2 Preferred etc.
+    /// </summary>
     private static JsonArray BuildGeneralCost(
         BenefitPlan plan,
         NetworkTier tier,
-        bool acaEnforced,
+        bool emitAcaCap,
         AcaLimits? acaLimits)
     {
         var array = new JsonArray();
@@ -477,10 +495,13 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
             array.Add(BuildGeneralCostEntry("out-of-pocket-max", "Out-of-Pocket Maximum", 2, famOop,
                 $"Family out-of-pocket maximum ({(isInNetwork ? "in-network" : "out-of-network")})"));
 
-        // ACA per-member cap (Decision 11 dual emission). Only on the
-        // primary in-network tier; out-of-network tiers don't carry the
-        // ACA cap because OON OOP is independent of ACA enforcement.
-        if (isInNetwork && acaEnforced && acaLimits is not null && acaLimits.IndividualCap > 0)
+        // ACA per-member cap (Decision 11 dual emission). Caller must
+        // restrict emitAcaCap to the primary in-network tier; the
+        // isInNetwork check here is defense-in-depth in case a future
+        // refactor flips that contract — out-of-network tiers must
+        // never carry the ACA cap because OON OOP is independent of
+        // ACA enforcement.
+        if (emitAcaCap && isInNetwork && acaLimits is not null && acaLimits.IndividualCap > 0)
         {
             var entry = BuildGeneralCostEntry(
                 "aca-individual-cap",
@@ -646,11 +667,21 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
     // ── helpers ─────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Tier is "in-network" when its TierName looks like an in-network
-    /// label or its TierLevel is 1 (the conventional best/primary tier).
-    /// Out-of-network tiers populate the OON columns on
-    /// <see cref="CostSharing"/>; in-network tiers (any of Tier 1, "In
-    /// Network", "Preferred", etc.) populate the IN columns.
+    /// Tier is "out-of-network" only when its <c>TierName</c> carries an
+    /// explicit out-of-network marker — the substring "out" + "network"
+    /// (case-insensitive), or the prefix "OON". Anything else is treated
+    /// as in-network and populates the IN columns on
+    /// <see cref="CostSharing"/>.
+    ///
+    /// <para>
+    /// <c>TierLevel</c> is intentionally NOT consulted: it's an
+    /// operator-authored ordering hint, defaults to 0 on legacy plans,
+    /// and conflating it with network classification would silently
+    /// misclassify a Tier 0 OON or a Tier 2 in-network. Future tier-name
+    /// shapes (e.g. "OOP-Preferred") that don't match either marker fall
+    /// into in-network by default — surface as a future refinement if a
+    /// concrete plan shape forces it.
+    /// </para>
     /// </summary>
     private static bool ResolveTierIsInNetwork(NetworkTier tier)
     {

--- a/src/services/benefit-plan-service/Services/IFhirInsurancePlanProjector.cs
+++ b/src/services/benefit-plan-service/Services/IFhirInsurancePlanProjector.cs
@@ -1,0 +1,89 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Projects a <see cref="BenefitPlan"/> into a FHIR R4 InsurancePlan
+/// resource (as a <see cref="JsonObject"/>) per the Plan-Net IG 1.1.0
+/// + US Core 6.1.0 InsurancePlan profiles. Pattern mirrors
+/// provider-service's <c>FhirPractitionerProjector</c>: hand-built to
+/// avoid the Hl7.Fhir.R4 transitive dep graph and keep serialization
+/// deterministic for tests.
+///
+/// <para>
+/// Returns <c>null</c> when called on a non-Active plan version
+/// (<c>VersionState != Published</c>) or when the effective window
+/// excludes "now" (terminated plans). Caller maps null to FHIR
+/// <c>OperationOutcome</c> 404. The "active" determination follows
+/// the empirical Provider 5.7 convention — a non-Active version of a
+/// resource has no public FHIR projection.
+/// </para>
+///
+/// <para>
+/// The projection emits <c>meta.profile</c> with both the US Core 6.1.0
+/// InsurancePlan profile and the Da Vinci Plan-Net 1.1.0 InsurancePlan
+/// profile. Required US Core elements (<c>identifier</c>, <c>status</c>,
+/// <c>name</c>, <c>type</c>) are honored. Plan-Net <c>network</c>,
+/// <c>coverage.benefit</c>, <c>plan.generalCost</c>, and
+/// <c>plan.specificCost</c> are emitted from the plan's NetworkTiers,
+/// Benefits, and CostSharing respectively.
+/// </para>
+///
+/// <para>
+/// Plan-Net <c>InsurancePlan.endpoint</c> (payer-published URLs for SBC,
+/// formulary, machine-readable rate file) is intentionally emitted as an
+/// empty array in capability BP 5.8 — the Plan Documents → FHIR
+/// Endpoint projection is BP 5.9 territory. Plan-Net
+/// <c>coverageArea</c>, <c>contact</c>, <c>alias</c>, and
+/// <c>administeredBy</c> are deferred to Phase 2 (CHO has no source data
+/// for them today).
+/// </para>
+///
+/// <para>
+/// The <c>InsurancePlan.ownedBy</c> reference is emitted as
+/// <c>display</c>-only carrying <see cref="BenefitPlan.Payer"/>
+/// (Decision 12) — the Payer field is a free-text string, not a
+/// reference to a payer-Organization. A future "Payer Organization
+/// Linking" capability migrates to a Reference shape.
+/// </para>
+/// </summary>
+public interface IFhirInsurancePlanProjector
+{
+    /// <summary>
+    /// Project a benefit plan without optional enrichments. Equivalent
+    /// to <see cref="Project(BenefitPlan, IReadOnlyList{OrganizationLookupResult}?, AcaLimits?)"/>
+    /// with <c>networks = null</c> and <c>acaLimits = null</c>.
+    /// </summary>
+    JsonObject? Project(BenefitPlan plan);
+
+    /// <summary>
+    /// Project a benefit plan with optional network enrichment and ACA
+    /// limit lookup.
+    ///
+    /// <para>
+    /// When <paramref name="networks"/> is non-null and contains an
+    /// entry whose <c>OrganizationId</c> matches a NetworkTier's
+    /// <c>NetworkId</c>, the projector adds <c>display</c> text to the
+    /// emitted <c>Reference</c> from
+    /// <see cref="OrganizationLookupResult.Name"/> so consumers see a
+    /// human-readable network name without dereferencing. When null or
+    /// empty, references emit without <c>display</c> text.
+    /// </para>
+    ///
+    /// <para>
+    /// When <paramref name="acaLimits"/> is non-null AND the plan is
+    /// Aggregate-mode AND <see cref="AcaCapEnforcementPolicy.IsEnforced"/>
+    /// returns true, an additional <c>plan.generalCost</c> entry surfaces
+    /// the ACA per-member individual cap (Decision 11 dual emission). The
+    /// top-level <c>insuranceplan-aca-cap-enforced</c> CHO extension is
+    /// emitted regardless of <paramref name="acaLimits"/> so consumers
+    /// always see the enforcement state; the per-cost entry is what
+    /// requires the actual cap value.
+    /// </para>
+    /// </summary>
+    JsonObject? Project(
+        BenefitPlan plan,
+        IReadOnlyList<OrganizationLookupResult>? networks,
+        AcaLimits? acaLimits);
+}

--- a/src/services/fhir-service/Controllers/FhirControllerBase.cs
+++ b/src/services/fhir-service/Controllers/FhirControllerBase.cs
@@ -1,6 +1,7 @@
 using Hl7.Fhir.Model;
 using FhirService.Middleware;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace FhirService.Controllers;
 
@@ -109,4 +110,98 @@ public abstract class FhirControllerBase : ControllerBase
         => string.IsNullOrEmpty(value) ? string.Empty
            : value.Replace("\r", string.Empty, StringComparison.Ordinal)
                   .Replace("\n", string.Empty, StringComparison.Ordinal);
+
+    // ── Generic upstream proxy helper ────────────────────────────────────────
+
+    /// <summary>
+    /// Forward a GET request to an upstream FHIR-emitting service and pass
+    /// the response through to the caller. Status pass-through, 5xx → 502
+    /// FHIR <c>OperationOutcome</c>, transport faults → 502, caller
+    /// cancellation propagates verbatim.
+    ///
+    /// <para>
+    /// Extracted in capability BP 5.8 so both the provider-service proxy
+    /// (capabilities 5.7 / 5.8 / 5.9) and the new benefit-plan-service
+    /// proxy (capability BP 5.8 InsurancePlan) share one
+    /// status-translation rule. Decision 5b — the helper takes the
+    /// upstream <see cref="HttpClient"/> as a parameter so callers can
+    /// keep using the typed-client pattern they already have.
+    /// </para>
+    ///
+    /// <para>
+    /// Logging uses the structured fields <c>{Upstream}</c>,
+    /// <c>{Resource}</c>, <c>{Status}</c>, <c>{Path}</c> so operators can
+    /// distinguish proxy failures by upstream service AND by resource
+    /// type (Practitioner / Organization / InsurancePlan / etc.) without
+    /// adding new log lines.
+    /// </para>
+    /// </summary>
+    protected async Task<IActionResult> ProxyUpstreamServiceAsync(
+        HttpClient upstream,
+        string upstreamLabel,
+        string resourceLabel,
+        string path,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(upstream);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // `path` is derived from the user-supplied URL / query string and
+        // flows into structured-log fields below. Sanitize once up front
+        // so all log sites share the same scrubbed value (CodeQL: log
+        // entries created from user input).
+        var loggablePath = SanitizeForLog(path);
+        try
+        {
+            using var response = await upstream.GetAsync(path, ct);
+            var body = await response.Content.ReadAsStringAsync(ct);
+            var contentType = response.Content.Headers.ContentType?.ToString() ?? "application/fhir+json";
+
+            // Pass status + body through verbatim. The upstream service
+            // emits FHIR OperationOutcome on 4xx, so the proxy needs to
+            // forward those without rewrapping. 5xx responses are mapped
+            // to a FHIR 502 OperationOutcome — exposing upstream 5xx
+            // bodies could leak internal detail.
+            if ((int)response.StatusCode >= 500)
+            {
+                logger.LogWarning(
+                    "{Upstream} {Resource} upstream returned {Status} for {Path}",
+                    upstreamLabel, resourceLabel, (int)response.StatusCode, loggablePath);
+                return FhirBadGateway($"{resourceLabel} upstream is unavailable.");
+            }
+
+            return new ContentResult
+            {
+                Content = body,
+                ContentType = contentType,
+                StatusCode = (int)response.StatusCode,
+            };
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogWarning(ex,
+                "{Upstream} {Resource} proxy hop failed for {Path}",
+                upstreamLabel, resourceLabel, loggablePath);
+            return FhirBadGateway($"{resourceLabel} upstream is unreachable.");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // The caller cancelled (client disconnect, server abort). Don't
+            // pretend the upstream timed out — propagate cancellation so
+            // the request pipeline returns its standard 499/aborted shape
+            // and we don't pollute logs / metrics with phantom 502s.
+            throw;
+        }
+        catch (TaskCanceledException ex)
+        {
+            // HttpClient surfaces its own configured timeout as
+            // TaskCanceledException; ct was NOT cancelled (handled above).
+            // That genuinely is an upstream-too-slow → 502.
+            logger.LogWarning(ex,
+                "{Upstream} {Resource} proxy hop timed out for {Path}",
+                upstreamLabel, resourceLabel, loggablePath);
+            return FhirBadGateway($"{resourceLabel} upstream timed out.");
+        }
+    }
 }

--- a/src/services/fhir-service/Controllers/InsurancePlanController.cs
+++ b/src/services/fhir-service/Controllers/InsurancePlanController.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace FhirService.Controllers;
+
+/// <summary>
+/// FHIR R4 InsurancePlan API controller (capability BP 5.8).
+/// Thin proxy over benefit-plan-service's <c>FhirInsurancePlanController</c>;
+/// benefit-plan-service owns the canonical CHO projection. fhir-service
+/// remains the single FHIR façade for external consumers, mirroring the
+/// 5.7/5.8/5.9 pattern for Practitioner / PractitionerRole / Organization
+/// proxied to provider-service.
+///
+/// <para>
+/// The new typed <c>HttpClient("BenefitPlanService")</c> registration in
+/// <c>Program.cs</c> propagates Tenant + Correlation headers, mirroring
+/// the <c>ProviderService</c> client. End-to-end Plan-Net navigation
+/// works after this PR ships: an external consumer can chain
+/// <c>Practitioner → PractitionerRole.organization → Organization →
+/// InsurancePlan.network</c> across the two upstream services through a
+/// single FHIR API surface.
+/// </para>
+/// </summary>
+[Route("fhir/r4")]
+public class InsurancePlanController : FhirControllerBase
+{
+    public const string BenefitPlanServiceClientName = "BenefitPlanService";
+
+    private readonly HttpClient _benefitPlanServiceClient;
+    private readonly ILogger<InsurancePlanController> _logger;
+
+    public InsurancePlanController(
+        IHttpClientFactory httpClientFactory,
+        ILogger<InsurancePlanController> logger)
+    {
+        _benefitPlanServiceClient = httpClientFactory.CreateClient(BenefitPlanServiceClientName);
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// GET /fhir/r4/InsurancePlan/{id} — read InsurancePlan by PlanId.
+    /// Proxies to benefit-plan-service /fhir/InsurancePlan/{id}; the
+    /// upstream owns the canonical CHO projection (capability BP 5.8).
+    /// The id is the operator-supplied <c>PlanId</c> per Decision 6.
+    /// </summary>
+    [HttpGet("InsurancePlan/{id}")]
+    [Produces("application/fhir+json")]
+    public Task<IActionResult> ReadInsurancePlan(string id, CancellationToken ct)
+        => ProxyBenefitPlanServiceAsync(
+            "InsurancePlan",
+            $"fhir/InsurancePlan/{Uri.EscapeDataString(id)}",
+            ct);
+
+    /// <summary>
+    /// GET /fhir/r4/InsurancePlan?identifier=&amp;name=&amp;status=&amp;_count=&amp;_page=
+    /// — search InsurancePlans. Forwards the FHIR search query string to
+    /// benefit-plan-service /fhir/InsurancePlan unchanged. The upstream
+    /// honors a deliberately small subset of Plan-Net IG search
+    /// parameters; <c>type</c>, <c>owned-by</c>, <c>administered-by</c>,
+    /// <c>address</c> are deferred until benefit-plan-service indexes them.
+    /// </summary>
+    [HttpGet("InsurancePlan")]
+    [Produces("application/fhir+json")]
+    public Task<IActionResult> SearchInsurancePlans(CancellationToken ct = default)
+    {
+        var qs = HttpContext.Request.QueryString.HasValue
+            ? HttpContext.Request.QueryString.Value
+            : string.Empty;
+        return ProxyBenefitPlanServiceAsync("InsurancePlan", $"fhir/InsurancePlan{qs}", ct);
+    }
+
+    private Task<IActionResult> ProxyBenefitPlanServiceAsync(
+        string resourceLabel,
+        string path,
+        CancellationToken ct)
+        => ProxyUpstreamServiceAsync(
+            _benefitPlanServiceClient,
+            "benefit-plan-service",
+            resourceLabel,
+            path,
+            _logger,
+            ct);
+}

--- a/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
+++ b/src/services/fhir-service/Controllers/ProviderDirectoryController.cs
@@ -76,73 +76,25 @@ public class ProviderDirectoryController : FhirControllerBase
     /// <summary>
     /// Generic proxy hop to provider-service for the FHIR resources
     /// where provider-service is the canonical authority (capability 5.7
-    /// — Practitioner; capability 5.8 — PractitionerRole). Status pass
-    /// through, 5xx → 502 OperationOutcome, transport faults → 502.
-    /// Resource label flows into structured-log fields so operators can
-    /// distinguish Practitioner vs PractitionerRole proxy failures.
+    /// — Practitioner; capability 5.8 — PractitionerRole; capability 5.9
+    /// — Organization). Thin wrapper over
+    /// <see cref="FhirControllerBase.ProxyUpstreamServiceAsync"/> — the
+    /// shared status-translation logic was extracted in capability BP 5.8
+    /// so both this controller and the new InsurancePlanController call
+    /// the same helper. Resource label flows into structured-log fields
+    /// so operators can distinguish proxy failures by resource type.
     /// </summary>
-    private async Task<IActionResult> ProxyProviderServiceAsync(
+    private Task<IActionResult> ProxyProviderServiceAsync(
         string resourceLabel,
         string path,
         CancellationToken ct)
-    {
-        // `path` is derived from the user-supplied URL / query string and
-        // flows into structured-log fields below. Sanitize once up front
-        // so all log sites share the same scrubbed value (CodeQL: log
-        // entries created from user input).
-        var loggablePath = SanitizeForLog(path);
-        try
-        {
-            using var upstream = await _providerServiceClient.GetAsync(path, ct);
-            var body = await upstream.Content.ReadAsStringAsync(ct);
-            var contentType = upstream.Content.Headers.ContentType?.ToString() ?? "application/fhir+json";
-
-            // Pass status + body through verbatim. provider-service emits
-            // FHIR OperationOutcome on 4xx, so the proxy needs to forward
-            // those without rewrapping. 5xx responses are mapped to a
-            // FHIR 502 OperationOutcome — exposing upstream 5xx bodies
-            // could leak internal detail.
-            if ((int)upstream.StatusCode >= 500)
-            {
-                _logger.LogWarning(
-                    "provider-service {Resource} upstream returned {Status} for {Path}",
-                    resourceLabel, (int)upstream.StatusCode, loggablePath);
-                return FhirBadGateway($"{resourceLabel} upstream is unavailable.");
-            }
-
-            return new ContentResult
-            {
-                Content = body,
-                ContentType = contentType,
-                StatusCode = (int)upstream.StatusCode
-            };
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogWarning(ex,
-                "provider-service {Resource} proxy hop failed for {Path}",
-                resourceLabel, loggablePath);
-            return FhirBadGateway($"{resourceLabel} upstream is unreachable.");
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // The caller cancelled (client disconnect, server abort). Don't
-            // pretend the upstream timed out — propagate cancellation so
-            // the request pipeline returns its standard 499/aborted shape
-            // and we don't pollute logs / metrics with phantom 502s.
-            throw;
-        }
-        catch (TaskCanceledException ex)
-        {
-            // HttpClient surfaces its own configured timeout as
-            // TaskCanceledException; ct was NOT cancelled (handled above).
-            // That genuinely is an upstream-too-slow → 502.
-            _logger.LogWarning(ex,
-                "provider-service {Resource} proxy hop timed out for {Path}",
-                resourceLabel, loggablePath);
-            return FhirBadGateway($"{resourceLabel} upstream timed out.");
-        }
-    }
+        => ProxyUpstreamServiceAsync(
+            _providerServiceClient,
+            "provider-service",
+            resourceLabel,
+            path,
+            _logger,
+            ct);
 
     // ── Organization (proxied to provider-service, capability 5.9) ──────────
 

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -218,6 +218,25 @@ builder.Services.AddHttpClient("ProviderService", client =>
 .AddHttpMessageHandler<TenantHeaderPropagationHandler>()
 .AddHttpMessageHandler<CorrelationIdPropagationHandler>();
 
+// ── benefit-plan-service FHIR proxy (capability BP 5.8) ─────────────────────
+// InsurancePlanController.ReadInsurancePlan / SearchInsurancePlans
+// proxies to benefit-plan-service's /fhir/InsurancePlan endpoint —
+// benefit-plan-service owns the canonical CHO InsurancePlan projection
+// (mirrors provider-service's ownership of Practitioner / PractitionerRole
+// / Organization for the rest of the Plan-Net Provider Directory bundle).
+// Tenant + correlation header propagation matches the ProviderService
+// client. See docs/architecture/fhir-insuranceplan-projection.md.
+builder.Services.AddHttpClient("BenefitPlanService", client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:BenefitPlanServiceUrl"]
+            ?? "http://benefit-plan-service.cloudhealthoffice/");
+    client.DefaultRequestHeaders.Add("Accept", "application/fhir+json");
+    client.Timeout = TimeSpan.FromSeconds(30);
+})
+.AddHttpMessageHandler<TenantHeaderPropagationHandler>()
+.AddHttpMessageHandler<CorrelationIdPropagationHandler>();
+
 // ── Da Vinci CRD / DTR / Bulk ─────────────────────────────────────────────────
 builder.Services.Configure<CrdConfig>(builder.Configuration.GetSection("Cms0057:Crd"));
 builder.Services.AddSingleton<ICrdService, CrdService>();

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/InsurancePlanControllerProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/InsurancePlanControllerProxyTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Text;
+using FhirService.Controllers;
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudHealthOffice.FhirService.Tests.Controllers;
+
+/// <summary>
+/// Capability BP 5.8 — proxy-shape coverage for the new
+/// <see cref="InsurancePlanController"/>. Mirrors the 5.7 / 5.8 / 5.9
+/// Provider-domain proxy tests: the fhir-service controller talks to a
+/// typed <c>BenefitPlanService</c> HttpClient and passes the response
+/// through.
+///
+/// Verifies:
+/// <list type="bullet">
+///   <item>read forwards GET /fhir/InsurancePlan/{id} to benefit-plan-service;</item>
+///   <item>search forwards the original FHIR query string;</item>
+///   <item>4xx and 2xx responses pass through verbatim;</item>
+///   <item>5xx responses are translated to a FHIR 502 OperationOutcome
+///         that does NOT leak the upstream body;</item>
+///   <item>upstream connection failure → 502 OperationOutcome;</item>
+///   <item>label "InsurancePlan" appears in 502 diagnostics so operators
+///         can triage by resource type;</item>
+///   <item>the BenefitPlanService HttpClient is the only client called.</item>
+/// </list>
+/// </summary>
+public class InsurancePlanControllerProxyTests
+{
+    private readonly Mock<IHttpClientFactory> _factory = new();
+    private readonly RecordingHandler _benefitPlanHandler = new();
+    private readonly InsurancePlanController _controller;
+
+    public InsurancePlanControllerProxyTests()
+    {
+        _factory.Setup(f => f.CreateClient(InsurancePlanController.BenefitPlanServiceClientName))
+            .Returns(() => new HttpClient(_benefitPlanHandler)
+            {
+                BaseAddress = new Uri("http://benefit-plan-service.test/")
+            });
+
+        _controller = new InsurancePlanController(
+            _factory.Object,
+            NullLogger<InsurancePlanController>.Instance);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_forwards_to_benefit_plan_service_with_correct_path()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"InsurancePlan\",\"id\":\"AUR-GOLD-PPO-2026\",\"status\":\"active\"}"));
+
+        var result = await _controller.ReadInsurancePlan("AUR-GOLD-PPO-2026", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"InsurancePlan\"");
+
+        _benefitPlanHandler.Calls.Should().ContainSingle();
+        var req = _benefitPlanHandler.Calls[0];
+        req.Method.Should().Be(HttpMethod.Get);
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/InsurancePlan/AUR-GOLD-PPO-2026");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_url_encodes_the_id()
+    {
+        var planId = "PLAN id with spaces";
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"InsurancePlan\",\"id\":\"x\"}"));
+
+        await _controller.ReadInsurancePlan(planId, default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().NotContain(" ");
+        req.RequestUri.AbsolutePath.Should().Contain("PLAN%20id%20with%20spaces");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_passes_404_OperationOutcome_through_verbatim()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.NotFound,
+            "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"not-found\"}]}"));
+
+        var result = await _controller.ReadInsurancePlan("does-not-exist", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.Content.Should().Contain("OperationOutcome");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_translates_upstream_5xx_to_502_OperationOutcome_without_leaking_body()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.InternalServerError,
+            "internal upstream noise that must NOT leak"));
+
+        var result = await _controller.ReadInsurancePlan("AUR-GOLD-PPO-2026", default);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        var outcome = status.Value.Should().BeOfType<OperationOutcome>().Subject;
+        outcome.Issue.Single().Code.Should().Be(OperationOutcome.IssueType.Transient);
+        outcome.Issue.Single().Diagnostics.Should().NotContain("internal upstream noise",
+            "upstream 5xx body must not leak to consumers");
+        outcome.Issue.Single().Diagnostics.Should().Contain("InsurancePlan",
+            "label should identify the resource for operator triage");
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_handles_upstream_unreachable_as_502()
+    {
+        _benefitPlanHandler.Respond(_ =>
+            throw new HttpRequestException("connection refused"));
+
+        var result = await _controller.ReadInsurancePlan("AUR-GOLD-PPO-2026", default);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        status.Value.Should().BeOfType<OperationOutcome>();
+    }
+
+    [Fact]
+    public async Task ReadInsurancePlan_propagates_caller_cancellation()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"InsurancePlan\"}"));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => _controller.ReadInsurancePlan("PLAN", cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_forwards_query_string_to_benefit_plan_service()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new QueryString(
+            "?identifier=AUR-GOLD-PPO-2026&name=Aurelian&status=active&_count=25");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchInsurancePlans(default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/InsurancePlan");
+        req.RequestUri.Query.Should().Contain("identifier=AUR-GOLD-PPO-2026");
+        req.RequestUri.Query.Should().Contain("name=Aurelian");
+        req.RequestUri.Query.Should().Contain("status=active");
+        req.RequestUri.Query.Should().Contain("_count=25");
+    }
+
+    [Fact]
+    public async Task SearchInsurancePlans_with_empty_query_string_still_hits_search_path()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchInsurancePlans(default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/InsurancePlan");
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/fhir+json")
+        };
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = new();
+        private Func<HttpRequestMessage, HttpResponseMessage> _responder =
+            _ => new HttpResponseMessage(HttpStatusCode.NotImplemented);
+
+        public void Respond(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `/fhir/r4/InsurancePlan/*` URL surface (Plan-Net IG 1.1.0 + US Core 6.1.0) sourced from `BenefitPlan`. Completes the Plan-Net Provider Directory bundle alongside Practitioner / PractitionerRole / Organization (Provider 5.7-5.9).
- New `FhirInsurancePlanProjector` (hand-built `JsonObject`, no `Hl7.Fhir.R4` dep) + `FhirInsurancePlanController` in benefit-plan-service. Typed `HttpClient("BenefitPlanService")` proxy in fhir-service.
- Extracts `ProxyUpstreamServiceAsync` to `FhirControllerBase` (Decision 5b) — `ProviderDirectoryController` keeps a thin wrapper preserving its 6 call sites byte-for-byte.
- `AcaCapEnforcementPolicy` extracted as a static helper — single source of truth between `ChoBenefitPlanProvider` (engine config projection) and `FhirInsurancePlanProjector` (FHIR projection). Cutoff pinned at `2026-04-28 00:00 UTC` per the BP 5.7 G8 rollout.

## Decisions ratified pre-execution

| # | Decision | Outcome |
|---|---|---|
| 5b | Proxy helper | Extracted to `FhirControllerBase` |
| 6 | `InsurancePlan.id` | `BenefitPlan.PlanId` (operator-authored) |
| 8a | `InsurancePlan.type` | Two codings: HL7 `medical` + CHO product-shape |
| 9 | `coverage.benefit` shape | Text-only CodeableConcept (BP 5.6 incoherence); 2-element `qualifiers` arrays |
| 10 | `network[]` projection | All non-null-NetworkId tiers (revising prompt's "first tier only") |
| 11 | ACA cap | Dual emission — `generalCost` entry + top-level extension |
| 12 | `ownedBy` | Display-only (Payer is free-text) |
| 13 | Custom extensions | `insuranceplan-family-accumulator-model`, `insuranceplan-aca-cap-enforced` |

## Premise corrections held during execution

- **P4** — `BenefitPlan` has no `Status` field; derived from `VersionState` + effective window
- **P5** — `IsAcaCapEnforced` is computed via the new `AcaCapEnforcementPolicy` (not stored)
- **P6** — `IAcaLimitsProvider` consumed via parameter, not DI on the projector
- **P7** — Coverage.class slice gap documented, not fixed (CoverageController unchanged)
- **P8** — No `description` / `alias` / `contact` projection (BenefitPlan has no source fields)

## End-to-end Plan-Net navigation

`Practitioner → PractitionerRole.organization → Organization → InsurancePlan.network → Organization` resolves end-to-end through the fhir-service public surface after this PR.

## Test plan

- [x] 22 new projector tests (`FhirInsurancePlanProjectorTests`) — US Core / Plan-Net structure, network projection, coverage grouping, cost-sharing, ACA-cap emission, deterministic output
- [x] 11 new controller tests (`FhirInsurancePlanControllerTests`) — read 200/400/404, search bundle shape, identifier token parsing, name + status filter, tenant scoping
- [x] 8 new ACA policy tests (`AcaCapEnforcementPolicyTests`) — cutoff pinning + parity with the BP 5.7 inline rule
- [x] 6 new proxy tests (`InsurancePlanControllerProxyTests`) — URL forwarding, query-string passthrough, 4xx verbatim, 5xx → 502 OperationOutcome without body leak, transport faults, cancellation
- [x] All 168 pre-existing benefit-plan-service tests still pass after `AcaCapEnforcementPolicy` extraction
- [x] All 359 fhir-service tests still pass after `ProxyUpstreamServiceAsync` extraction (existing `ProviderDirectoryController` 4xx/5xx/transport tests cover the helper change byte-for-byte)
- [x] Full solution builds clean (53 pre-existing warnings, 0 errors)

## Out of scope (deferred)

- `InsurancePlan.endpoint` — BP 5.9 (Plan Documents); empty array emitted today
- `InsurancePlan.coverageArea / contact / alias / administeredBy` — Phase 2 (BenefitPlan needs source fields)
- `Coverage.class[type=plan]` slice → InsurancePlan reference — future capability (CoverageController unchanged)
- `InsurancePlan.type` discrimination beyond `medical` default — future capability needs a coverage-scope field on BenefitPlan

## Diff envelope

19 files / +3174 / -92.

## Architecture docs

- [`docs/architecture/fhir-insuranceplan-projection.md`](docs/architecture/fhir-insuranceplan-projection.md) (new)
- `docs/architecture/fhir-conformance.md` — InsurancePlan added to in-scope ledger + extension URLs registered
- `docs/architecture/network-tier-organization-reference.md` — BP 5.5 cross-reference to BP 5.8 projection added

🤖 Generated with [Claude Code](https://claude.com/claude-code)