### PR TITLE
BP 5.9 — Plan Documents → FHIR Endpoint projection

### DIFF
--- a/docs/architecture/fhir-conformance.md
+++ b/docs/architecture/fhir-conformance.md
@@ -8,7 +8,7 @@ conformance to, what we test against, and where the gaps are.
 | IG / profile                                     | Resources covered today                       | Posture                                                 |
 |--------------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | US Core 6.1.0                                    | Patient, Practitioner, PractitionerRole, Organization, InsurancePlan | Required elements asserted by unit tests          |
-| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner, PractitionerRole, Organization, InsurancePlan (subset) | Fields CHO has data for; extensions deferred to 5.17 / BP 5.9 |
+| Da Vinci PDex Plan-Net 1.1.0                     | Practitioner, PractitionerRole, Organization, InsurancePlan (subset), Endpoint | Fields CHO has data for; extensions deferred to 5.17 |
 | FHIR R4 Bundle (`searchset`)                     | Practitioner, PractitionerRole, Organization, InsurancePlan search | Hand-built JsonObject, asserted by unit tests     |
 | FHIR R4 OperationOutcome                         | All error responses                           | Typed `OperationOutcome` model + hand-built JsonObject  |
 
@@ -35,15 +35,23 @@ conformance to, what we test against, and where the gaps are.
   `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-InsurancePlan`
   (source entity: `BenefitPlan` head Published version; non-Active
   versions return null per the empirical Provider 5.7 stance)
+- Endpoint (benefit-plan-service, capability BP 5.9) —
+  `http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint`
+  (source entity: `BenefitPlan.Documents[]` on the head Published
+  version; one Endpoint per projectable `PlanDocumentReference`,
+  internal `documentreference/{id}` references are skipped per
+  Decision 4)
 
 ## Phase 2 / deferred
 
 | IG / capability                                  | Status                                                 |
 |--------------------------------------------------|--------------------------------------------------------|
 | Plan-Net 1.1.0 extended Organization extensions  | Capability 5.17 (accessibility, languages, populations)|
-| Plan-Net 1.1.0 Organization.endpoint             | Phase 2 (Plan-Net publishing URLs)                     |
-| Plan-Net 1.1.0 InsurancePlan.endpoint            | Capability BP 5.9 (Plan Documents)                     |
+| Plan-Net 1.1.0 Organization.endpoint             | Phase 2 (Plan-Net publishing URLs; provider-side)      |
 | Plan-Net 1.1.0 InsurancePlan.coverageArea / contact / alias | Phase 2 (BenefitPlan needs the fields)        |
+| Plan-Net 1.1.0 Endpoint?organization=            | Phase 2 — Endpoint is only referenced by InsurancePlan today; no Organization→Endpoint link |
+| `Endpoint.managingOrganization`                  | Phase 2 — depends on Payer-Organization linking (BP 5.8 Decision 12) |
+| FHIR `DocumentReference` projection              | Phase 2 — lives in member-document-service when it lands; carries hash exposure that Plan-Net `Endpoint` has no slot for (BP 5.9 Decision 7) |
 | Plan-Net 1.1.0 Bundle composite                  | Capability 5.18                                        |
 | Plan-Net extended extensions (Practitioner)      | Capability 5.17                                        |
 | Coverage.class slice → InsurancePlan reference   | Capability BP 5.8 follow-up — see fhir-insuranceplan-projection.md |
@@ -69,6 +77,8 @@ classes:
   — provider-service Organization projection (both source entities).
 - [FhirInsurancePlanProjectorTests](../../src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs)
   — benefit-plan-service InsurancePlan projection (capability BP 5.8).
+- [FhirEndpointProjectorTests](../../src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirEndpointProjectorTests.cs)
+  — benefit-plan-service Endpoint projection (capability BP 5.9).
 
 Conformance regressions surface as failing unit tests. There is no
 network-driven conformance suite in CI yet (see *Inferno* below).
@@ -128,6 +138,16 @@ Defined today (see
   for `plan.identifier` carrying the tier name.
 - `plan-id` system (capability BP 5.8) — CHO-canonical identifier
   system for `InsurancePlan.identifier[0]` carrying `BenefitPlan.PlanId`.
+- `CodeSystem/endpoint-connection-type` (capability BP 5.9) —
+  CHO-canonical CodeSystem for `Endpoint.connectionType`. Publishes
+  one code, `static-document`, because the HL7
+  `endpoint-connection-type` CodeSystem has no "static downloadable
+  document" code (Decision 1).
+- `CodeSystem/plan-document-type` (capability BP 5.9) — CHO-canonical
+  CodeSystem for `Endpoint.payloadType.coding`. One code per
+  `PlanDocumentType` enum value (`sbc`, `eoc`, `formulary`, `spd`,
+  `mrf`, `other`). Plan-Net does not bind `payloadType`; no standard
+  FHIR CodeSystem covers SBC / EOC / SPD / MRF (Decision 3).
 
 A legacy URL
 `https://cloudhealthoffice.com/fhir/StructureDefinition/provider-verification`
@@ -141,5 +161,6 @@ uses of this URL.
 - [fhir-practitionerrole-projection.md](fhir-practitionerrole-projection.md) — capability 5.8 details.
 - [fhir-organization-projection.md](fhir-organization-projection.md) — capability 5.9 details.
 - [fhir-insuranceplan-projection.md](fhir-insuranceplan-projection.md) — capability BP 5.8 details.
+- [fhir-endpoint-projection.md](fhir-endpoint-projection.md) — capability BP 5.9 details (Plan Documents → FHIR Endpoint).
 - [provider-versioning.md](provider-versioning.md) — version-state semantics that drive `Practitioner.active` and `PractitionerRole.active`.
 - [family-accumulator-models.md](family-accumulator-models.md) — BP 5.7 (FamilyAccumulatorModel + ACA cap), source of the BP 5.8 custom extensions.

--- a/docs/architecture/fhir-endpoint-projection.md
+++ b/docs/architecture/fhir-endpoint-projection.md
@@ -1,0 +1,214 @@
+# FHIR Endpoint Projection (Capability BP 5.9)
+
+> Projects CHO's `BenefitPlan.Documents[]` (already-modeled
+> `PlanDocumentReference`) into Plan-Net IG 1.1.0 conformant `Endpoint`
+> resources, dereferenceable at `/fhir/r4/Endpoint/{id}` and referenced
+> from `InsurancePlan.endpoint[]`. Closes the BP 5.8 deferral on the
+> `endpoint[]` slot and establishes the Endpoint pattern for the rest
+> of the FHIR surface.
+
+## Why
+
+BP 5.8 shipped `InsurancePlan` with an empty `endpoint: []`. BP 5.9
+fills it. Three CMS-adjacent regulatory surfaces motivate the work:
+
+1. **ACA SBC** (45 CFR §147.200) — payers must publish a Summary of
+   Benefits and Coverage; the URL must be discoverable.
+1. **CMS Transparency in Coverage** (45 CFR §147.211) — payers must
+   publish in-network and out-of-network machine-readable rate files
+   (MRFs) at known URLs.
+1. **CMS-0057-F** — formulary URL discoverability for member-facing
+   apps via the Patient Access API.
+
+## Architecture
+
+```
+external client
+       │  GET /fhir/r4/Endpoint/{EndpointId}
+       ▼
+┌──────────────────┐                  ┌─────────────────────────────┐
+│ fhir-service     │   typed proxy    │ benefit-plan-service        │
+│ Endpoint         │ ───────────────▶ │ FhirEndpointController      │
+│ Controller       │   /fhir/Endpoint │  ▶ FhirEndpointProjector    │
+└──────────────────┘   /{id}          └─────────────────────────────┘
+```
+
+The fhir-service `EndpointController` is a thin proxy over
+benefit-plan-service's `FhirEndpointController` — same `BenefitPlanService`
+typed `HttpClient` registration that the BP 5.8 `InsurancePlanController`
+uses, and the same `FhirControllerBase.ProxyUpstreamServiceAsync`
+status-translation rule.
+
+Inside benefit-plan-service the projector is hand-built (`JsonObject`,
+no `Hl7.Fhir.R4` dep) and is consumed in two places:
+
+- `FhirEndpointController` — read + search returns full `Endpoint`
+  resources.
+- `FhirInsurancePlanProjector` (BP 5.8) — calls
+  `IFhirEndpointProjector.OrderedProjectableDocuments(plan)` to populate
+  `InsurancePlan.endpoint[]` with `Reference(Endpoint/{id})` entries.
+  Both surfaces share one ordering rule (Decision 8) so a Reference
+  always resolves to the Endpoint that its order would predict.
+
+## Source-of-truth mapping
+
+| FHIR `Endpoint` element | Source on `PlanDocumentReference` / parent plan | Notes |
+|---|---|---|
+| `id` | `PlanDocumentReference.Id` (verbatim) | Decision 2 |
+| `status` | derived | Decision 5 |
+| `connectionType` | constant `static-document` under CHO CodeSystem | Decision 1 |
+| `name` | `DisplayName` ?? per-DocType display | |
+| `payloadType[].coding` | `DocType` mapped to CHO CodeSystem | Decision 3 |
+| `payloadMimeType[]` | `ContentType` | Decision 6 — pass-through, no inference |
+| `address` | `Location` (HTTPS only) | Decision 4 |
+| `period.start` | `EffectiveDate` (when present) | |
+| `meta.profile` | Plan-Net `plannet-Endpoint` | |
+
+## Decisions
+
+### Decision 1 — `connectionType`
+
+The HL7 `http://terminology.hl7.org/CodeSystem/endpoint-connection-type`
+CodeSystem has no code for "static downloadable document"; available
+codes are FHIR-protocol-shaped (`hl7-fhir-rest`, `direct-project`,
+`dicom-*`).
+
+CHO publishes a CodeSystem
+`http://fhir.cloudhealthoffice.com/CodeSystem/endpoint-connection-type`
+with one code, `static-document`. Emit it as the sole coding under
+`Endpoint.connectionType`. A future capability swaps in a standard
+code if HL7 publishes one. Misusing `hl7-fhir-rest` for a PDF link
+would be dishonest.
+
+### Decision 2 — `Endpoint.id`
+
+`PlanDocumentReference.Id` (verbatim) — matches the BP 5.8 stance for
+`InsurancePlan.id = BenefitPlan.PlanId` (use the source-system
+identifier directly). The 64-char FHIR id limit is comfortable for a
+GUID. Operators don't author Endpoint IDs; they author plan IDs and
+documents.
+
+### Decision 3 — `payloadType` codings
+
+CHO publishes a CodeSystem
+`http://fhir.cloudhealthoffice.com/CodeSystem/plan-document-type`
+with one code per `PlanDocumentType` enum value:
+
+| Enum | Code | Display |
+|---|---|---|
+| SBC | `sbc` | Summary of Benefits and Coverage |
+| EOC | `eoc` | Evidence of Coverage |
+| Formulary | `formulary` | Drug Formulary |
+| SPD | `spd` | Summary Plan Description |
+| MachineReadableRateFile | `mrf` | Machine-Readable Rate File |
+| Other | `other` | Other Plan Document |
+
+Plan-Net IG does not bind `payloadType`; no standard FHIR CodeSystem
+covers SBC / EOC / SPD / MRF.
+
+### Decision 4 — `address`
+
+The URL the `PlanDocumentReference.Location` field carries when it is
+HTTPS. When `Location` is the reserved internal
+`documentreference/{id}` form (Phase 2 forward-compat), the document
+is **not** projectable to an Endpoint — Endpoints require an external
+address. The projector skips such documents. The skip is a normal
+projection outcome, not an error: the document still exists on the
+plan, it just isn't surfaced through the Endpoint slot.
+
+### Decision 5 — `status`
+
+Derived from `PlanDocumentReference.EffectiveDate` and the parent
+plan's lifecycle:
+
+- `active` — `EffectiveDate` is null OR `≤ now` AND the parent plan
+  version is Published and not retired.
+- `off` — `EffectiveDate > now` (future-dated).
+- `off` — parent plan is retired (terminated and termination is in
+  the past).
+- `entered-in-error` is never emitted (CHO has no soft-delete state
+  for plan documents today).
+
+### Decision 6 — `payloadMimeType`
+
+Pass through `PlanDocumentReference.ContentType` when present. Skip
+the field when null. No inference (don't guess `application/pdf` for
+a `.pdf` URL — operators authored ContentType when they had it).
+
+### Decision 7 — Hash exposure
+
+`PlanDocumentReference.ContentHashSha256` is base64-SHA256, matching
+`Attachment.hash`. Plan-Net's `Endpoint` profile has no
+`Attachment`-shaped slot, so hash exposure has nowhere to land. It
+waits for the Phase 2 `DocumentReference` projection in
+member-document-service.
+
+### Decision 8 — `InsurancePlan.endpoint[]` ordering
+
+Stable: `(DocType ordinal, EffectiveDate desc, Id)` where DocType
+ordinal is `SBC=1, EOC=2, Formulary=3, SPD=4, MRF=5, Other=6`. SBC is
+the consumer-facing document — Plan-Net member-app consumers expect
+it first.
+
+The same ordering applies to the search-Bundle entry order, so a
+collection consumer sees a deterministic, predictable shape regardless
+of plan authoring history.
+
+## Validation
+
+`PlanDocumentValidation.ValidateLocation` is wired into
+`ValidateDocuments` next to `ValidateHash`. It accepts:
+
+- HTTPS URLs (the operator-authored external address Endpoint
+  projection requires).
+- The reserved `documentreference/{id}` form (Phase 2 forward-compat;
+  rejects bare `documentreference/`).
+
+Plain HTTP, relative URLs, and other schemes are rejected with a
+field-name-aware message. Producer-boundary only — setter-side
+validation would break Mongo hydration for any historical malformed
+document, same trust posture as `ValidateHash`.
+
+## Search surface
+
+`GET /fhir/r4/Endpoint?…` honors a deliberately small subset of FHIR
+search parameters:
+
+- `_id` — token. Bare value or empty-system-pipe form. Other
+  system|value pairs return an empty bundle (FHIR token semantics —
+  unknown system, no match).
+- `status` — token. `active` / `off` filter the projected status.
+- `connection-type` — token. Only `static-document` matches today
+  (Decision 1).
+
+`organization=` is **deferred** — Endpoint is currently only
+referenced by InsurancePlan; there is no Organization→Endpoint link.
+Provider 5.x deferred its own `Organization.endpoint[]` to Phase 2.
+
+## Tenant scoping
+
+Same as BP 5.8 InsurancePlan — requests honor the existing
+`TenantMiddleware` mechanism. Wrong-tenant lookups return 404 rather
+than 200 with empty payload. Public CMS-0057-F unauthenticated access
+is a Phase 2 capability.
+
+## Out of scope / explicit deferrals
+
+| Item | Why deferred |
+|---|---|
+| `DocumentReference` resource projection | Phase 2 migration to member-document-service. `Endpoint` is enough for Plan-Net; `DocumentReference` is the Patient-Access shape and lives in member-document-service when it lands. |
+| `Endpoint?organization=` search | No Organization→Endpoint link today. Provider 5.x deferred `Organization.endpoint[]` to Phase 2. |
+| `Endpoint.managingOrganization` | Same reason — payer-Organization linking is a future capability (BP 5.8 Decision 12). |
+| Document content fetching / HEAD probing for hash verification | Out-of-band. Plan author warrants the URL; CHO does not act as a CDN. |
+| Multi-language `Endpoint.name` | `PlanDocumentReference.DisplayName` is single-locale today. Phase 2 i18n. |
+| Versioned `Endpoint.id` (e.g. include `meta.versionId`) | Same stance as InsurancePlan — FHIR resource versioning is separate from BP 5.1 plan-version chain. |
+
+## Cross references
+
+- [fhir-insuranceplan-projection.md](fhir-insuranceplan-projection.md)
+  — capability BP 5.8 details; the projector consumed here populates
+  `InsurancePlan.endpoint[]`.
+- [fhir-conformance.md](fhir-conformance.md) — running ledger of the
+  CHO conformance posture.
+- [`schemas/plan-documents/`](../../schemas/plan-documents/) — the
+  operator-facing `PlanDocumentType` reference.

--- a/docs/architecture/fhir-insuranceplan-projection.md
+++ b/docs/architecture/fhir-insuranceplan-projection.md
@@ -88,11 +88,11 @@ external consumers ask for it.
 | `plan[].generalCost[]` | `CostSharing` deductible + OOP max + (Aggregate + post-cutoff) ACA cap | |
 | `plan[].specificCost[]` | per-Benefit copay + coinsurance per network tier | |
 
-### Deferred to BP 5.9 (Plan Documents)
+### Shipped in BP 5.9 (Plan Documents)
 
-| FHIR element | Why deferred |
+| FHIR element | Where it landed |
 |---|---|
-| `endpoint[]` | Plan-Net `Endpoint` references (SBC URL, formulary URL, machine-readable rate file) require the BP 5.9 Plan Documents projection. This PR emits an empty array; BP 5.9 will populate it. |
+| `endpoint[]` | Populated by BP 5.9 — one `Reference(Endpoint/{id})` per projectable `PlanDocumentReference`, ordered by `(DocType, EffectiveDate desc, Id)` per Decision 8. Endpoint resources themselves are dereferenceable at `/fhir/r4/Endpoint/{id}`. See [`fhir-endpoint-projection.md`](fhir-endpoint-projection.md). |
 
 ### Deferred to Phase 2 / future capabilities
 

--- a/schemas/plan-documents/README.md
+++ b/schemas/plan-documents/README.md
@@ -1,0 +1,74 @@
+# Plan Documents — Operator Reference
+
+Operator-friendly reference for the `PlanDocumentType` codes used on
+`BenefitPlan.Documents[]` (capability **BP 5.9 — Plan Documents → FHIR
+Endpoint projection**). This directory mirrors
+[`schemas/service-category-mappings/`](../service-category-mappings/) in
+purpose: a low-friction reference that lives next to the data it
+describes.
+
+The codes here drive the `Endpoint.payloadType.coding` slot under the
+CHO CodeSystem
+`http://fhir.cloudhealthoffice.com/CodeSystem/plan-document-type`
+(BP 5.9 Decision 3). Plan-Net IG 1.1.0 does not bind `payloadType`, so
+no standard FHIR CodeSystem covers these.
+
+## Codes
+
+| Enum (`PlanDocumentType`) | Code | What it is | Regulatory anchor |
+|---|---|---|---|
+| `SBC` | `sbc` | Summary of Benefits and Coverage | ACA, 45 CFR §147.200 |
+| `EOC` | `eoc` | Evidence of Coverage / Certificate of Coverage | State insurance code; carrier-specific |
+| `Formulary` | `formulary` | Drug formulary (covered medications + tiering) | CMS-0057-F (Patient Access API formulary discoverability) |
+| `SPD` | `spd` | Summary Plan Description | ERISA, 29 CFR §2520.102-2 |
+| `MachineReadableRateFile` | `mrf` | In-network and out-of-network rate files | CMS Transparency in Coverage, 45 CFR §147.211 |
+| `Other` | `other` | Anything that doesn't fit a typed slot above | — |
+
+## Authoring conventions
+
+A `PlanDocumentReference` carries:
+
+| Field | Notes |
+|---|---|
+| `id` | GUID. Becomes `Endpoint.id` verbatim (Decision 2). |
+| `docType` | One of the enum values above. Drives FHIR `payloadType` and the BP 5.8 `InsurancePlan.endpoint[]` ordering (SBC first, then EOC, Formulary, SPD, MRF, Other). |
+| `location` | HTTPS URL **or** the reserved `documentreference/{id}` form (Phase 2 forward-compat). HTTP, relative URLs, and other schemes are rejected at producer boundaries by `PlanDocumentValidation.ValidateLocation`. |
+| `displayName` | Optional. Surfaces as `Endpoint.name`; falls back to the per-DocType display when absent. Single-locale today. |
+| `contentType` | Optional MIME type. Pass-through to `Endpoint.payloadMimeType` — no inference (operators authored ContentType when they had it). |
+| `contentHashSha256` | Optional. Base64-encoded SHA-256, exactly 32 decoded bytes (matches `Attachment.hash`). Validated at producer boundaries via `PlanDocumentValidation.ValidateHash`. **Not currently exposed in `Endpoint`** — Plan-Net's `Endpoint` profile has no `Attachment`-shaped slot; hash exposure waits for the Phase 2 `DocumentReference` projection. |
+| `effectiveDate` | Optional. Surfaces as `Endpoint.period.start`; future-dated documents emit `Endpoint.status = "off"`. |
+| `version` | Optional. Free-text version string. Not currently surfaced in the FHIR `Endpoint` projection. |
+
+### When to choose `MachineReadableRateFile` vs `Other`
+
+`MachineReadableRateFile` is the right choice for any document that
+implements the CMS Transparency in Coverage rate-file format
+(in-network rate file, out-of-network allowed-amount file). Pre-BP-5.9
+plans that stored MRFs under `Other` continue to round-trip without
+migration; new plans should use `mrf` so the FHIR projection is
+lossless.
+
+Use `Other` only when none of the typed codes fit — for example, a
+state-specific addendum or a member-handbook supplement.
+
+## Validation
+
+`PlanDocumentValidation.ValidateDocuments` is wired at every plan-write
+boundary in `BenefitPlansController` (create, update, amend). It calls:
+
+- `ValidateLocation` — must be HTTPS or `documentreference/{id}`.
+- `ValidateHash` — when `contentHashSha256` is set, must be Base64
+  SHA-256 (32 decoded bytes).
+
+The validator throws `ArgumentException` with `ParamName` set to the
+field path so clients can surface a clean field-level error
+(`documents[2].location`, `documents[2].contentHashSha256`).
+
+## Related
+
+- Architecture doc:
+  [`docs/architecture/fhir-endpoint-projection.md`](../../docs/architecture/fhir-endpoint-projection.md)
+- BP 5.8 InsurancePlan projection:
+  [`docs/architecture/fhir-insuranceplan-projection.md`](../../docs/architecture/fhir-insuranceplan-projection.md)
+- Conformance ledger:
+  [`docs/architecture/fhir-conformance.md`](../../docs/architecture/fhir-conformance.md)

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirEndpointControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/FhirEndpointControllerTests.cs
@@ -1,0 +1,322 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Controllers;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BenefitPlanService.Tests.Controllers;
+
+/// <summary>
+/// Capability BP 5.9 — FHIR Endpoint endpoint behavior, search parameter
+/// semantics, tenant scoping, FHIR OperationOutcome on errors. Mirrors
+/// <see cref="FhirInsurancePlanControllerTests"/>.
+/// </summary>
+public sealed class FhirEndpointControllerTests
+{
+    private const string Tenant = "tenant-a";
+
+    [Fact]
+    public async Task ReadEndpoint_returns_404_for_missing_id()
+    {
+        var (controller, _) = Build();
+
+        var result = await controller.ReadEndpoint("does-not-exist", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("OperationOutcome");
+        content.Content.Should().Contain("not-found");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_returns_400_for_blank_id()
+    {
+        var (controller, _) = Build();
+
+        var result = await controller.ReadEndpoint(" ", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(400);
+        content.Content.Should().Contain("invalid");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_returns_projected_endpoint_for_published_plan_document()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "GOLD-2026");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+            ContentType = "application/pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.ReadEndpoint("doc-sbc", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+
+        var json = JsonNode.Parse(content.Content!)!.AsObject();
+        json["resourceType"]!.GetValue<string>().Should().Be("Endpoint");
+        json["id"]!.GetValue<string>().Should().Be("doc-sbc");
+        json["status"]!.GetValue<string>().Should().Be("active");
+        json["address"]!.GetValue<string>().Should().Be("https://example.com/sbc.pdf");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_scopes_by_tenant()
+    {
+        var (controller, repo) = Build();
+        var otherTenant = SamplePlan(planId: "ISOLATED");
+        otherTenant.TenantId = "tenant-b";
+        otherTenant.Documents.Add(new PlanDocumentReference
+        {
+            Id = "isolated-doc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        await repo.CreateAsync(otherTenant);
+
+        var result = await controller.ReadEndpoint("isolated-doc", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404,
+            "tenant-a must not see tenant-b's endpoints even when ids match");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_returns_404_when_plan_is_not_published()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "DRAFT-2026");
+        plan.VersionState = PlanVersionState.Draft;
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "draft-doc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.ReadEndpoint("draft-doc", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404,
+            "non-published plans don't surface their endpoints");
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_returns_searchset_bundle()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-form",
+            DocType = PlanDocumentType.Formulary,
+            Location = "https://example.com/formulary.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.SearchEndpoints(
+            _id: null, status: null, connectionType: null,
+            _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+
+        bundle["resourceType"]!.GetValue<string>().Should().Be("Bundle");
+        bundle["type"]!.GetValue<string>().Should().Be("searchset");
+        bundle["total"]!.GetValue<int>().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_by_id_returns_single_match()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-form",
+            DocType = PlanDocumentType.Formulary,
+            Location = "https://example.com/formulary.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.SearchEndpoints(
+            _id: "doc-sbc", status: null, connectionType: null,
+            _count: 50, _page: 1, default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        var bundle = JsonNode.Parse(content.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+        bundle["entry"]!.AsArray()[0]!["resource"]!["id"]!.GetValue<string>()
+            .Should().Be("doc-sbc");
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_by_status_filters_correctly()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-active",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/a.pdf",
+        });
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-future",
+            DocType = PlanDocumentType.EOC,
+            Location = "https://example.com/b.pdf",
+            EffectiveDate = DateTime.UtcNow.AddDays(30),
+        });
+        await repo.CreateAsync(plan);
+
+        var activeOnly = await controller.SearchEndpoints(
+            _id: null, status: "active", connectionType: null,
+            _count: 50, _page: 1, default);
+        var activeBundle = JsonNode.Parse((activeOnly as ContentResult)!.Content!)!.AsObject();
+        activeBundle["total"]!.GetValue<int>().Should().Be(1);
+
+        var offOnly = await controller.SearchEndpoints(
+            _id: null, status: "off", connectionType: null,
+            _count: 50, _page: 1, default);
+        var offBundle = JsonNode.Parse((offOnly as ContentResult)!.Content!)!.AsObject();
+        offBundle["total"]!.GetValue<int>().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_by_connection_type_static_document_returns_matches()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var matching = await controller.SearchEndpoints(
+            _id: null, status: null,
+            connectionType: ChoBenefitPlanFhirUrls.EndpointConnectionTypeStaticDocument,
+            _count: 50, _page: 1, default);
+        var bundle = JsonNode.Parse((matching as ContentResult)!.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_by_unknown_connection_type_returns_empty()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.SearchEndpoints(
+            _id: null, status: null, connectionType: "hl7-fhir-rest",
+            _count: 50, _page: 1, default);
+        var bundle = JsonNode.Parse((result as ContentResult)!.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_skips_internal_reference_documents()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-internal",
+            DocType = PlanDocumentType.SBC,
+            Location = "documentreference/abc-123",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.SearchEndpoints(
+            _id: null, status: null, connectionType: null,
+            _count: 50, _page: 1, default);
+        var bundle = JsonNode.Parse((result as ContentResult)!.Content!)!.AsObject();
+        bundle["total"]!.GetValue<int>().Should().Be(0,
+            "internal documentreference/{id} entries are skipped per Decision 4");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_emits_application_fhir_json_content_type()
+    {
+        var (controller, repo) = Build();
+        var plan = SamplePlan(planId: "PLAN-1");
+        plan.Documents.Add(new PlanDocumentReference
+        {
+            Id = "doc-sbc",
+            DocType = PlanDocumentType.SBC,
+            Location = "https://example.com/sbc.pdf",
+        });
+        await repo.CreateAsync(plan);
+
+        var result = await controller.ReadEndpoint("doc-sbc", default);
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+
+        content.ContentType.Should().StartWith("application/fhir+json");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static (FhirEndpointController controller, InMemoryBenefitPlanRepository repo) Build()
+    {
+        var repo = new InMemoryBenefitPlanRepository();
+        var controller = new FhirEndpointController(
+            repo,
+            new FhirEndpointProjector(),
+            NullLogger<FhirEndpointController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = Tenant;
+        controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+        return (controller, repo);
+    }
+
+    private static BenefitPlan SamplePlan(string planId) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = Tenant,
+        PlanId = planId,
+        PlanName = planId,
+        Payer = "AurelianHealth",
+        EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        VersionState = PlanVersionState.Published,
+        VersionNumber = 1,
+        VersionId = Guid.NewGuid().ToString(),
+        PublishedAt = DateTime.UtcNow,
+        Documents = new List<PlanDocumentReference>(),
+    };
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirEndpointProjectorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirEndpointProjectorTests.cs
@@ -1,0 +1,298 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+using BenefitPlanService.Services;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Capability BP 5.9 — projector correctness for
+/// <see cref="FhirEndpointProjector"/>. Mirrors the BP 5.8
+/// <see cref="FhirInsurancePlanProjectorTests"/> test surface (one Endpoint
+/// per projectable PlanDocumentReference, ordering, status derivation,
+/// determinism, internal-reference skip).
+/// </summary>
+public sealed class FhirEndpointProjectorTests
+{
+    private readonly FhirEndpointProjector _projector = new();
+
+    // ── projection happy path ───────────────────────────────────────────
+
+    [Fact]
+    public void Projects_one_endpoint_per_projectable_document()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            new()
+            {
+                Id = "doc-sbc",
+                DocType = PlanDocumentType.SBC,
+                Location = "https://example.com/sbc.pdf",
+                ContentType = "application/pdf",
+            },
+            new()
+            {
+                Id = "doc-formulary",
+                DocType = PlanDocumentType.Formulary,
+                Location = "https://example.com/formulary.pdf",
+                ContentType = "application/pdf",
+            },
+        };
+
+        var endpoints = _projector.ProjectAll(plan);
+
+        endpoints.Should().HaveCount(2);
+        endpoints[0]!["resourceType"]!.GetValue<string>().Should().Be("Endpoint");
+    }
+
+    [Fact]
+    public void Endpoint_id_is_PlanDocumentReference_id_verbatim()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("doc-sbc", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        plan.Documents.Add(doc);
+
+        var endpoint = _projector.Project(plan, doc)!;
+
+        endpoint["id"]!.GetValue<string>().Should().Be("doc-sbc",
+            "Decision 2 — Endpoint.id is the source-system identifier verbatim");
+    }
+
+    [Fact]
+    public void Connection_type_carries_static_document_under_cho_system()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("doc-sbc", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+
+        var endpoint = _projector.Project(plan, doc)!;
+
+        var coding = endpoint["connectionType"]!.AsObject();
+        coding["system"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.EndpointConnectionTypeSystem);
+        coding["code"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.EndpointConnectionTypeStaticDocument);
+    }
+
+    [Fact]
+    public void PayloadType_coding_uses_per_DocType_code_under_cho_system()
+    {
+        var plan = MakePlan();
+        var sbc = MakeDoc("doc-sbc", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        var mrf = MakeDoc("doc-mrf", PlanDocumentType.MachineReadableRateFile, "https://example.com/mrf.json");
+
+        var sbcCoding = _projector.Project(plan, sbc)!["payloadType"]!.AsArray()[0]!["coding"]!.AsArray()[0]!;
+        sbcCoding["system"]!.GetValue<string>()
+            .Should().Be(ChoBenefitPlanFhirUrls.PlanDocumentTypeSystem);
+        sbcCoding["code"]!.GetValue<string>().Should().Be("sbc");
+
+        var mrfCoding = _projector.Project(plan, mrf)!["payloadType"]!.AsArray()[0]!["coding"]!.AsArray()[0]!;
+        mrfCoding["code"]!.GetValue<string>().Should().Be("mrf");
+    }
+
+    [Fact]
+    public void Address_passes_through_https_location_verbatim()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("doc-eoc", PlanDocumentType.EOC, "https://example.com/eoc.pdf");
+
+        var endpoint = _projector.Project(plan, doc)!;
+
+        endpoint["address"]!.GetValue<string>().Should().Be("https://example.com/eoc.pdf");
+    }
+
+    [Fact]
+    public void PayloadMimeType_passes_through_when_set_and_omitted_when_null()
+    {
+        var plan = MakePlan();
+        var withMime = MakeDoc("doc-1", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        withMime.ContentType = "application/pdf";
+        var noMime = MakeDoc("doc-2", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        noMime.ContentType = null;
+
+        var withMimeEndpoint = _projector.Project(plan, withMime)!;
+        withMimeEndpoint["payloadMimeType"]!.AsArray()[0]!.GetValue<string>()
+            .Should().Be("application/pdf");
+
+        var noMimeEndpoint = _projector.Project(plan, noMime)!;
+        noMimeEndpoint.AsObject().ContainsKey("payloadMimeType").Should().BeFalse(
+            "Decision 6 — pass-through only; never infer ContentType");
+    }
+
+    [Fact]
+    public void Name_prefers_DisplayName_then_falls_back_to_DocType_display()
+    {
+        var plan = MakePlan();
+        var withDisplay = MakeDoc("doc-1", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        withDisplay.DisplayName = "2026 Aurelian Gold SBC";
+        var noDisplay = MakeDoc("doc-2", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        noDisplay.DisplayName = null;
+
+        _projector.Project(plan, withDisplay)!["name"]!.GetValue<string>()
+            .Should().Be("2026 Aurelian Gold SBC");
+        _projector.Project(plan, noDisplay)!["name"]!.GetValue<string>()
+            .Should().Be("Summary of Benefits and Coverage");
+    }
+
+    [Fact]
+    public void Meta_profile_is_plan_net_endpoint()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("doc-sbc", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+
+        var endpoint = _projector.Project(plan, doc)!;
+
+        var profiles = endpoint["meta"]!["profile"]!.AsArray()
+            .Select(n => n!.GetValue<string>()).ToList();
+        profiles.Should().Contain(ChoBenefitPlanFhirUrls.PlanNetEndpointProfile);
+    }
+
+    // ── status derivation (Decision 5) ──────────────────────────────────
+
+    [Fact]
+    public void Status_active_when_effective_date_is_null_or_in_past()
+    {
+        var plan = MakePlan();
+        var nullEffective = MakeDoc("d1", PlanDocumentType.SBC, "https://example.com/a.pdf");
+        var pastEffective = MakeDoc("d2", PlanDocumentType.SBC, "https://example.com/b.pdf");
+        pastEffective.EffectiveDate = DateTime.UtcNow.AddYears(-1);
+
+        _projector.Project(plan, nullEffective)!["status"]!.GetValue<string>().Should().Be("active");
+        _projector.Project(plan, pastEffective)!["status"]!.GetValue<string>().Should().Be("active");
+    }
+
+    [Fact]
+    public void Status_off_when_document_is_future_dated()
+    {
+        var plan = MakePlan();
+        var future = MakeDoc("d1", PlanDocumentType.SBC, "https://example.com/a.pdf");
+        future.EffectiveDate = DateTime.UtcNow.AddDays(30);
+
+        _projector.Project(plan, future)!["status"]!.GetValue<string>().Should().Be("off");
+    }
+
+    [Fact]
+    public void Status_off_when_parent_plan_is_retired()
+    {
+        var plan = MakePlan();
+        plan.EffectiveDate = DateTime.UtcNow.AddYears(-2);
+        plan.TerminationDate = DateTime.UtcNow.AddDays(-30);
+        var doc = MakeDoc("d1", PlanDocumentType.SBC, "https://example.com/a.pdf");
+
+        _projector.Project(plan, doc)!["status"]!.GetValue<string>().Should().Be("off",
+            "retired parent plans retire their endpoints too");
+    }
+
+    // ── version + projectability gates ──────────────────────────────────
+
+    [Fact]
+    public void Returns_null_when_plan_is_not_published()
+    {
+        var plan = MakePlan();
+        plan.VersionState = PlanVersionState.Draft;
+        var doc = MakeDoc("d1", PlanDocumentType.SBC, "https://example.com/a.pdf");
+        plan.Documents.Add(doc);
+
+        _projector.Project(plan, doc).Should().BeNull();
+        _projector.ProjectAll(plan).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Returns_null_for_internal_documentreference_location()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("d1", PlanDocumentType.SBC, "documentreference/abc-123");
+
+        _projector.Project(plan, doc).Should().BeNull(
+            "Decision 4 — internal references aren't externally addressable");
+    }
+
+    [Fact]
+    public void OrderedProjectableDocuments_skips_non_projectable_entries()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            MakeDoc("d-external", PlanDocumentType.SBC, "https://example.com/a.pdf"),
+            MakeDoc("d-internal", PlanDocumentType.EOC, "documentreference/x"),
+        };
+
+        var ordered = _projector.OrderedProjectableDocuments(plan);
+        ordered.Should().HaveCount(1);
+        ordered[0]!.Id.Should().Be("d-external");
+    }
+
+    // ── ordering (Decision 8) ───────────────────────────────────────────
+
+    [Fact]
+    public void Documents_order_by_DocType_then_EffectiveDate_desc_then_Id()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            new() { Id = "z-other", DocType = PlanDocumentType.Other, Location = "https://example.com/o.pdf" },
+            new() { Id = "a-spd",   DocType = PlanDocumentType.SPD,   Location = "https://example.com/spd.pdf" },
+            new() { Id = "b-mrf",   DocType = PlanDocumentType.MachineReadableRateFile, Location = "https://example.com/mrf.json" },
+            new() { Id = "c-eoc",   DocType = PlanDocumentType.EOC,   Location = "https://example.com/eoc.pdf" },
+            new() { Id = "d-form",  DocType = PlanDocumentType.Formulary, Location = "https://example.com/f.pdf" },
+            new() { Id = "e-sbc",   DocType = PlanDocumentType.SBC,   Location = "https://example.com/sbc.pdf" },
+        };
+
+        var ordered = _projector.OrderedProjectableDocuments(plan)
+            .Select(d => d.Id).ToList();
+
+        ordered.Should().Equal("e-sbc", "c-eoc", "d-form", "a-spd", "b-mrf", "z-other");
+    }
+
+    // ── determinism ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Repeated_projection_produces_identical_json()
+    {
+        var plan = MakePlan();
+        var doc = MakeDoc("doc-sbc", PlanDocumentType.SBC, "https://example.com/sbc.pdf");
+        doc.ContentType = "application/pdf";
+        doc.EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        doc.DisplayName = "2026 SBC";
+        plan.Documents.Add(doc);
+
+        var first = _projector.Project(plan, doc)!;
+        var second = _projector.Project(plan, doc)!;
+        first.ToJsonString().Should().Be(second.ToJsonString());
+    }
+
+    [Fact]
+    public void ProjectAll_returns_empty_for_non_published_plan()
+    {
+        var plan = MakePlan();
+        plan.VersionState = PlanVersionState.Superseded;
+        plan.Documents.Add(MakeDoc("d1", PlanDocumentType.SBC, "https://example.com/a.pdf"));
+
+        _projector.ProjectAll(plan).Should().BeEmpty();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static BenefitPlan MakePlan() => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = "tenant-a",
+        PlanId = "AUR-GOLD-PPO-2026",
+        PlanName = "Aurelian Gold PPO 2026",
+        Payer = "AurelianHealth",
+        EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        PlanType = PlanType.PPO,
+        LineOfBusiness = LineOfBusiness.Commercial,
+        VersionState = PlanVersionState.Published,
+        VersionNumber = 1,
+        VersionId = Guid.NewGuid().ToString(),
+        PublishedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Documents = new List<PlanDocumentReference>(),
+    };
+
+    private static PlanDocumentReference MakeDoc(string id, PlanDocumentType type, string location) => new()
+    {
+        Id = id,
+        DocType = type,
+        Location = location,
+    };
+}

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/FhirInsurancePlanProjectorTests.cs
@@ -122,15 +122,123 @@ public sealed class FhirInsurancePlanProjectorTests
     }
 
     [Fact]
-    public void Emits_empty_endpoint_array_for_BP_5_9_deferral()
+    public void Emits_endpoint_references_for_published_plan_documents()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            new()
+            {
+                Id = "doc-eoc",
+                DocType = PlanDocumentType.EOC,
+                Location = "https://example.com/eoc.pdf",
+            },
+            new()
+            {
+                Id = "doc-sbc",
+                DocType = PlanDocumentType.SBC,
+                Location = "https://example.com/sbc.pdf",
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var endpoint = result["endpoint"]!.AsArray();
+
+        endpoint.Should().HaveCount(2);
+        // Decision 8 — SBC (consumer-facing) before EOC.
+        endpoint[0]!["reference"]!.GetValue<string>().Should().Be("Endpoint/doc-sbc");
+        endpoint[1]!["reference"]!.GetValue<string>().Should().Be("Endpoint/doc-eoc");
+
+        // BP 5.8 Reference convention — no display field; the Endpoint
+        // resource itself carries the operator-authored name.
+        endpoint[0]!.AsObject().ContainsKey("display").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Endpoint_references_skip_internal_documentreference_locations()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            new()
+            {
+                Id = "doc-external",
+                DocType = PlanDocumentType.SBC,
+                Location = "https://example.com/sbc.pdf",
+            },
+            new()
+            {
+                Id = "doc-internal",
+                DocType = PlanDocumentType.EOC,
+                Location = "documentreference/abc-123",
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var endpoint = result["endpoint"]!.AsArray();
+
+        endpoint.Should().HaveCount(1,
+            "internal documentreference/{id} entries are not externally addressable; " +
+            "Endpoint requires an external URL");
+        endpoint[0]!["reference"]!.GetValue<string>().Should().Be("Endpoint/doc-external");
+    }
+
+    [Fact]
+    public void Endpoint_references_order_within_DocType_by_EffectiveDate_then_Id()
+    {
+        var plan = MakePlan();
+        plan.Documents = new List<PlanDocumentReference>
+        {
+            new()
+            {
+                Id = "sbc-old",
+                DocType = PlanDocumentType.SBC,
+                Location = "https://example.com/sbc-old.pdf",
+                EffectiveDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            },
+            new()
+            {
+                Id = "sbc-new",
+                DocType = PlanDocumentType.SBC,
+                Location = "https://example.com/sbc-new.pdf",
+                EffectiveDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            },
+            new()
+            {
+                Id = "mrf",
+                DocType = PlanDocumentType.MachineReadableRateFile,
+                Location = "https://example.com/mrf.json",
+            },
+            new()
+            {
+                Id = "formulary",
+                DocType = PlanDocumentType.Formulary,
+                Location = "https://example.com/formulary.pdf",
+            },
+        };
+
+        var result = _projector.Project(plan)!;
+        var refs = result["endpoint"]!.AsArray()
+            .Select(n => n!["reference"]!.GetValue<string>()).ToList();
+
+        // Decision 8: SBC (1), EOC (2), Formulary (3), SPD (4), MRF (5), Other (6).
+        // Within DocType, EffectiveDate desc then Id.
+        refs.Should().Equal(
+            "Endpoint/sbc-new",
+            "Endpoint/sbc-old",
+            "Endpoint/formulary",
+            "Endpoint/mrf");
+    }
+
+    [Fact]
+    public void Endpoint_array_is_empty_when_plan_has_no_documents()
     {
         var plan = MakePlan();
 
         var result = _projector.Project(plan)!;
 
         result["endpoint"]!.AsArray().Should().BeEmpty(
-            "Plan Documents projection is BP 5.9; emit empty array so consumers see " +
-            "'no documents projected yet' rather than 'field unsupported'");
+            "no projectable documents → empty array (cardinality 0..*)");
     }
 
     // ── meta + profiles ─────────────────────────────────────────────────

--- a/src/services/benefit-plan-service/Controllers/FhirEndpointController.cs
+++ b/src/services/benefit-plan-service/Controllers/FhirEndpointController.cs
@@ -1,0 +1,353 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Middleware;
+using BenefitPlanService.Models;
+using BenefitPlanService.Repositories;
+using BenefitPlanService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BenefitPlanService.Controllers;
+
+/// <summary>
+/// FHIR R4 Endpoint read + search (capability BP 5.9 — Plan Documents →
+/// FHIR Endpoint projection). benefit-plan-service is the canonical
+/// authority on the projection; fhir-service proxies
+/// <c>/fhir/r4/Endpoint/*</c> requests here. Pattern mirrors
+/// <see cref="FhirInsurancePlanController"/> byte-for-byte modulo the
+/// route. Tenant scoping per BP 5.8 — see <c>TenantMiddleware</c>.
+///
+/// <para>
+/// Endpoint resources are sourced from <see cref="BenefitPlan.Documents"/>.
+/// Their FHIR id (Decision 2) is the underlying
+/// <see cref="PlanDocumentReference.Id"/> verbatim. The search surface
+/// honors <c>?_id</c>, <c>?status</c>, and <c>?connection-type</c>.
+/// <c>?organization=</c> is deferred — Endpoint is currently only
+/// referenced by InsurancePlan (no Organization link).
+/// </para>
+/// </summary>
+[ApiController]
+[Route("fhir")]
+public class FhirEndpointController : ControllerBase
+{
+    private const string FhirContentType = "application/fhir+json";
+    private const int DefaultPageSize = 50;
+    private const int MaxPageSize = 200;
+
+    private readonly IBenefitPlanRepository _repository;
+    private readonly IFhirEndpointProjector _projector;
+    private readonly ILogger<FhirEndpointController> _logger;
+
+    public FhirEndpointController(
+        IBenefitPlanRepository repository,
+        IFhirEndpointProjector projector,
+        ILogger<FhirEndpointController> logger)
+    {
+        _repository = repository;
+        _projector = projector;
+        _logger = logger;
+    }
+
+    private string TenantId
+        => HttpContext.GetTenantId() ?? throw new InvalidOperationException("Tenant context missing");
+
+    /// <summary>
+    /// FHIR Endpoint read by id. The path segment is the
+    /// <see cref="PlanDocumentReference.Id"/> (Decision 2). Tenant scoping
+    /// enforced — wrong-tenant lookups return 404 rather than 200 with an
+    /// empty payload.
+    /// </summary>
+    [HttpGet("Endpoint/{id}")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> ReadEndpoint(string id, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return FhirOperationOutcome(400, "invalid", "Endpoint id is required.");
+        }
+
+        var match = await FindEndpointAsync(id, ct);
+        if (match is null)
+        {
+            return FhirOperationOutcome(404, "not-found", $"Endpoint/{id} not found.");
+        }
+
+        var projected = _projector.Project(match.Value.Plan, match.Value.Document);
+        if (projected is null)
+        {
+            // Plan exists and document was found but the document is not
+            // projectable — non-Published parent or internal-reference
+            // location. Both surface as 404 to consumers.
+            return FhirOperationOutcome(404, "not-found", $"Endpoint/{id} not found.");
+        }
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = projected.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    /// <summary>
+    /// FHIR Endpoint search. Honors <c>_id</c>, <c>status</c>, and
+    /// <c>connection-type</c>. <c>organization=</c> is deferred (no
+    /// Organization→Endpoint link today). Pagination follows the BP 5.8
+    /// InsurancePlan pattern.
+    /// </summary>
+    [HttpGet("Endpoint")]
+    [Produces(FhirContentType)]
+    public async Task<IActionResult> SearchEndpoints(
+        [FromQuery(Name = "_id")] string? _id,
+        [FromQuery] string? status,
+        [FromQuery(Name = "connection-type")] string? connectionType,
+        [FromQuery] int _count = DefaultPageSize,
+        [FromQuery] int _page = 1,
+        CancellationToken ct = default)
+    {
+        var pageSize = Math.Clamp(_count, 1, MaxPageSize);
+        var page = Math.Max(1, _page);
+
+        // _id is a token parameter. Bare value or system|value where the
+        // system is empty — there is no canonical CHO Endpoint identifier
+        // system because Endpoint.id is the only authority (Decision 2).
+        if (!string.IsNullOrEmpty(_id))
+        {
+            var resolvedId = ParseTokenValue(_id);
+            if (string.IsNullOrEmpty(resolvedId))
+            {
+                return BuildBundle(Array.Empty<JsonObject>());
+            }
+            var match = await FindEndpointAsync(resolvedId, ct);
+            if (match is null) return BuildBundle(Array.Empty<JsonObject>());
+
+            var projected = _projector.Project(match.Value.Plan, match.Value.Document);
+            return BuildBundle(projected is null
+                ? Array.Empty<JsonObject>()
+                : new[] { projected });
+        }
+
+        // connection-type filter — only "static-document" matches today
+        // (Decision 1 — CHO publishes one code). Any other value yields
+        // a no-match bundle without scanning, FHIR token semantics.
+        if (!string.IsNullOrEmpty(connectionType))
+        {
+            var resolvedConn = ParseTokenValue(connectionType);
+            if (!string.Equals(resolvedConn,
+                    ChoBenefitPlanFhirUrls.EndpointConnectionTypeStaticDocument,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return BuildBundle(Array.Empty<JsonObject>());
+            }
+        }
+
+        List<JsonObject> matches;
+        try
+        {
+            matches = await CollectAllEndpointsAsync(status, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return FhirOperationOutcome(500, "exception", "Endpoint search failed.");
+        }
+
+        var pageItems = matches
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return BuildBundle(pageItems);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private const int RepoScanLimit = 50;
+    private const int RepoChunkSize = 200;
+
+    /// <summary>
+    /// Locate a (plan, document) pair whose document id matches the
+    /// requested endpoint id within the caller's tenant. The repository
+    /// has no document-id index today; we collect head-Published versions
+    /// page-by-page and scan their <c>Documents</c> arrays.
+    /// </summary>
+    private async Task<(BenefitPlan Plan, PlanDocumentReference Document)?> FindEndpointAsync(
+        string endpointId, CancellationToken ct)
+    {
+        await foreach (var plan in EnumerateHeadPublishedPlansAsync(ct))
+        {
+            if (plan.Documents is null || plan.Documents.Count == 0) continue;
+
+            var doc = plan.Documents.FirstOrDefault(d =>
+                d is not null && string.Equals(d.Id, endpointId, StringComparison.Ordinal));
+            if (doc is not null) return (plan, doc);
+        }
+        return null;
+    }
+
+    private async Task<List<JsonObject>> CollectAllEndpointsAsync(
+        string? statusFilter, CancellationToken ct)
+    {
+        var endpoints = new List<JsonObject>();
+
+        await foreach (var plan in EnumerateHeadPublishedPlansAsync(ct))
+        {
+            if (plan.Documents is null || plan.Documents.Count == 0) continue;
+
+            foreach (var doc in _projector.OrderedProjectableDocuments(plan))
+            {
+                var projected = _projector.Project(plan, doc);
+                if (projected is null) continue;
+
+                if (!string.IsNullOrEmpty(statusFilter)
+                    && !string.Equals(
+                        projected["status"]?.GetValue<string>(),
+                        statusFilter,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                endpoints.Add(projected);
+            }
+        }
+        return endpoints;
+    }
+
+    private async IAsyncEnumerable<BenefitPlan> EnumerateHeadPublishedPlansAsync(
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var seenHead = new Dictionary<string, BenefitPlan>(StringComparer.Ordinal);
+
+        for (var repoPage = 1; repoPage <= RepoScanLimit; repoPage++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            IEnumerable<BenefitPlan> chunk;
+            try
+            {
+                chunk = await _repository.SearchAsync(
+                    tenantId: TenantId,
+                    lineOfBusiness: null,
+                    planType: null,
+                    metalLevel: null,
+                    page: repoPage,
+                    pageSize: RepoChunkSize);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Endpoint search failed for tenant {TenantId} (repo page {RepoPage})",
+                    SanitizeForLog(TenantId), repoPage);
+                throw;
+            }
+
+            var chunkList = chunk as IList<BenefitPlan> ?? chunk.ToList();
+            if (chunkList.Count == 0) break;
+
+            foreach (var plan in chunkList)
+            {
+                if (plan.VersionState != PlanVersionState.Published) continue;
+                if (plan.EffectiveDate > now) continue;
+
+                if (seenHead.TryGetValue(plan.PlanId, out var existing) &&
+                    existing.VersionNumber >= plan.VersionNumber)
+                {
+                    continue;
+                }
+                seenHead[plan.PlanId] = plan;
+            }
+
+            if (chunkList.Count < RepoChunkSize) break;
+        }
+
+        foreach (var plan in seenHead.Values)
+        {
+            yield return plan;
+        }
+    }
+
+    private IActionResult BuildBundle(IReadOnlyCollection<JsonObject> resources)
+    {
+        var entries = new JsonArray();
+        foreach (var resource in resources)
+        {
+            entries.Add(new JsonObject
+            {
+                ["resource"] = resource,
+                ["search"] = new JsonObject { ["mode"] = "match" },
+            });
+        }
+
+        var bundle = new JsonObject
+        {
+            ["resourceType"] = "Bundle",
+            ["type"] = "searchset",
+            ["total"] = entries.Count,
+            ["entry"] = entries,
+        };
+
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = bundle.ToJsonString(),
+            StatusCode = 200,
+        };
+    }
+
+    private IActionResult FhirOperationOutcome(int status, string code, string diagnostics)
+    {
+        var outcome = new JsonObject
+        {
+            ["resourceType"] = "OperationOutcome",
+            ["issue"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["severity"] = "error",
+                    ["code"] = code,
+                    ["diagnostics"] = diagnostics,
+                }
+            },
+        };
+        return new ContentResult
+        {
+            ContentType = FhirContentType,
+            Content = outcome.ToJsonString(),
+            StatusCode = status,
+        };
+    }
+
+    /// <summary>
+    /// Parse a FHIR token-shaped query parameter. Returns the token's
+    /// value component, or null when the input is malformed / a
+    /// system|value pair whose system we don't recognize. The Endpoint
+    /// surface has no canonical identifier system today (Decision 2 —
+    /// the FHIR id IS the identifier), so any non-empty system part
+    /// rejects.
+    /// </summary>
+    private static string? ParseTokenValue(string token)
+    {
+        if (string.IsNullOrEmpty(token)) return null;
+
+        var pipe = token.IndexOf('|');
+        if (pipe < 0) return token;
+
+        var system = token[..pipe];
+        var value  = token[(pipe + 1)..];
+        if (string.IsNullOrEmpty(system)) return value;
+        return null;
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/benefit-plan-service/Controllers/FhirEndpointController.cs
+++ b/src/services/benefit-plan-service/Controllers/FhirEndpointController.cs
@@ -139,10 +139,24 @@ public class FhirEndpointController : ControllerBase
             }
         }
 
+        // status is also a FHIR token (system|value | bare value). Run it
+        // through ParseTokenValue so a system|value pair with an unknown
+        // system yields no-match semantics consistent with _id and
+        // connection-type. Copilot review BP 5.9.
+        string? resolvedStatus = null;
+        if (!string.IsNullOrEmpty(status))
+        {
+            resolvedStatus = ParseTokenValue(status);
+            if (string.IsNullOrEmpty(resolvedStatus))
+            {
+                return BuildBundle(Array.Empty<JsonObject>());
+            }
+        }
+
         List<JsonObject> matches;
         try
         {
-            matches = await CollectAllEndpointsAsync(status, ct);
+            matches = await CollectAllEndpointsAsync(resolvedStatus, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -189,31 +203,47 @@ public class FhirEndpointController : ControllerBase
     private async Task<List<JsonObject>> CollectAllEndpointsAsync(
         string? statusFilter, CancellationToken ct)
     {
-        var endpoints = new List<JsonObject>();
-
+        // First collect (plan, document) pairs; sort across plans by the
+        // canonical Decision 8 key BEFORE projecting + paging so paging is
+        // deterministic regardless of repository iteration order. Copilot
+        // review BP 5.9 — Decision 8 ordering must apply to the bundle, not
+        // just to the per-plan slice.
+        var pairs = new List<(BenefitPlan Plan, PlanDocumentReference Document)>();
         await foreach (var plan in EnumerateHeadPublishedPlansAsync(ct))
         {
             if (plan.Documents is null || plan.Documents.Count == 0) continue;
 
             foreach (var doc in _projector.OrderedProjectableDocuments(plan))
             {
-                var projected = _projector.Project(plan, doc);
-                if (projected is null) continue;
-
-                if (!string.IsNullOrEmpty(statusFilter)
-                    && !string.Equals(
-                        projected["status"]?.GetValue<string>(),
-                        statusFilter,
-                        StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                endpoints.Add(projected);
+                pairs.Add((plan, doc));
             }
+        }
+
+        var sortedPairs = pairs
+            .OrderBy(p => FhirEndpointProjector.DocTypeOrdinal(p.Document.DocType))
+            .ThenByDescending(p => p.Document.EffectiveDate ?? DateTime.MinValue)
+            .ThenBy(p => p.Document.Id, StringComparer.Ordinal);
+
+        var endpoints = new List<JsonObject>();
+        foreach (var (plan, doc) in sortedPairs)
+        {
+            var projected = _projector.Project(plan, doc);
+            if (projected is null) continue;
+
+            if (!string.IsNullOrEmpty(statusFilter)
+                && !string.Equals(
+                    projected["status"]?.GetValue<string>(),
+                    statusFilter,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            endpoints.Add(projected);
         }
         return endpoints;
     }
+
 
     private async IAsyncEnumerable<BenefitPlan> EnumerateHeadPublishedPlansAsync(
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
@@ -267,7 +297,15 @@ public class FhirEndpointController : ControllerBase
             if (chunkList.Count < RepoChunkSize) break;
         }
 
-        foreach (var plan in seenHead.Values)
+        // Dictionary value enumeration order is not contractually
+        // guaranteed; emit in a stable order so callers (FindEndpointAsync
+        // / CollectAllEndpointsAsync) see the same plan sequence across
+        // runs. Sort by PlanName then PlanId, matching the BP 5.8
+        // InsurancePlan search ordering. Copilot review BP 5.9.
+        var ordered = seenHead.Values
+            .OrderBy(p => p.PlanName ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(p => p.PlanId, StringComparer.Ordinal);
+        foreach (var plan in ordered)
         {
             yield return plan;
         }

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -481,26 +481,41 @@ public class PlanDocumentReference
     public string? DisplayName { get; set; }
 }
 
+/// <summary>
+/// Plan document type discriminator.
+///
+/// <para>
+/// Numeric values are explicit and APPEND-ONLY. The Mongo backend
+/// (<c>BenefitPlanRepositoryMongo</c>) serializes enums as Int32 by
+/// default — inserting a new value mid-list would shift the integer
+/// codes of every value after it and silently corrupt every persisted
+/// <c>docType</c> field. New entries must be appended after
+/// <c>Other</c> with the next unused integer.
+/// </para>
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PlanDocumentType
 {
     /// <summary>Summary of Benefits and Coverage (ACA mandated).</summary>
-    SBC,
+    SBC = 0,
     /// <summary>Evidence of Coverage / Certificate of Coverage.</summary>
-    EOC,
+    EOC = 1,
     /// <summary>Drug formulary.</summary>
-    Formulary,
+    Formulary = 2,
     /// <summary>Summary Plan Description (ERISA).</summary>
-    SPD,
+    SPD = 3,
+    /// <summary>Catch-all for plan documents that don't fit the named types.</summary>
+    Other = 4,
     /// <summary>
     /// Machine-Readable Rate File (CMS Transparency in Coverage,
     /// 45 CFR §147.211). Promoted to a first-class type in BP 5.9 so the
     /// FHIR Endpoint projection is lossless; pre-BP-5.9 plan authors who
     /// stored MRFs under <see cref="Other"/> continue to round-trip
-    /// without migration.
+    /// without migration. Appended after <c>Other</c> with explicit value
+    /// 5 so existing persisted Mongo Int32 codes for <c>Other</c> keep
+    /// their meaning.
     /// </summary>
-    MachineReadableRateFile,
-    Other
+    MachineReadableRateFile = 5,
 }
 
 /// <summary>

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -492,6 +492,14 @@ public enum PlanDocumentType
     Formulary,
     /// <summary>Summary Plan Description (ERISA).</summary>
     SPD,
+    /// <summary>
+    /// Machine-Readable Rate File (CMS Transparency in Coverage,
+    /// 45 CFR §147.211). Promoted to a first-class type in BP 5.9 so the
+    /// FHIR Endpoint projection is lossless; pre-BP-5.9 plan authors who
+    /// stored MRFs under <see cref="Other"/> continue to round-trip
+    /// without migration.
+    /// </summary>
+    MachineReadableRateFile,
     Other
 }
 

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -323,6 +323,15 @@ builder.Services.AddSingleton<IProviderIntegrityGate, HttpProviderIntegrityGate>
 // See docs/architecture/fhir-insuranceplan-projection.md.
 builder.Services.AddSingleton<IFhirInsurancePlanProjector, FhirInsurancePlanProjector>();
 
+// ── FHIR Endpoint Projector (capability BP 5.9) ──────────────────────────────
+// Stateless, hand-built. Projects PlanDocumentReference[] from a published
+// BenefitPlan into FHIR Endpoint resources (one per externally-addressable
+// document). Consumed by FhirEndpointController and by
+// FhirInsurancePlanProjector to populate InsurancePlan.endpoint[] with
+// Reference(Endpoint/{id}) entries. See
+// docs/architecture/fhir-endpoint-projection.md.
+builder.Services.AddSingleton<IFhirEndpointProjector, FhirEndpointProjector>();
+
 // ── Network-Tier → Organization Reference (5.5) ──────────────────────────────
 // Read-side lookup against provider-service capability 5.3 Organization
 // entity. Reuses the ProviderService HttpClient registered above. Backfill

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanFhirUrls.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanFhirUrls.cs
@@ -129,4 +129,46 @@ internal static class ChoBenefitPlanFhirUrls
     /// </summary>
     public const string AcaCapEnforcedExt =
         StructureDefinitionBase + "insuranceplan-aca-cap-enforced";
+
+    // ── BP 5.9 Endpoint projection ───────────────────────────────────────
+
+    /// <summary>
+    /// Plan-Net IG 1.1.0 Endpoint profile. Capability BP 5.9 — every
+    /// projected <c>Endpoint</c> resource carries this profile in its
+    /// <c>meta.profile</c> alongside the FHIR R4 base.
+    /// </summary>
+    public const string PlanNetEndpointProfile =
+        "http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for <c>Endpoint.connectionType</c>
+    /// (Decision 1 in BP 5.9). The HL7
+    /// <c>http://terminology.hl7.org/CodeSystem/endpoint-connection-type</c>
+    /// CodeSystem does not have a code for "static downloadable document"
+    /// — its codes are FHIR-protocol-shaped (<c>hl7-fhir-rest</c>,
+    /// <c>direct-project</c>, <c>dicom-*</c>). CHO publishes one code,
+    /// <see cref="EndpointConnectionTypeStaticDocument"/>, under this
+    /// system. A future capability swaps in a standard code if HL7
+    /// publishes one.
+    /// </summary>
+    public const string EndpointConnectionTypeSystem =
+        CodeSystemBase + "endpoint-connection-type";
+
+    /// <summary>
+    /// The single CHO-published code under
+    /// <see cref="EndpointConnectionTypeSystem"/>: the endpoint serves a
+    /// downloadable static document (PDF, JSON, etc.).
+    /// </summary>
+    public const string EndpointConnectionTypeStaticDocument = "static-document";
+
+    /// <summary>
+    /// CHO-canonical CodeSystem for <c>Endpoint.payloadType.coding</c>
+    /// (Decision 3 in BP 5.9). One code per
+    /// <see cref="Models.PlanDocumentType"/> enum value
+    /// (<c>sbc</c>, <c>eoc</c>, <c>formulary</c>, <c>spd</c>, <c>mrf</c>,
+    /// <c>other</c>). Plan-Net IG 1.1.0 does not bind <c>payloadType</c>;
+    /// no standard FHIR CodeSystem covers SBC / EOC / SPD / MRF.
+    /// </summary>
+    public const string PlanDocumentTypeSystem =
+        CodeSystemBase + "plan-document-type";
 }

--- a/src/services/benefit-plan-service/Services/FhirEndpointProjector.cs
+++ b/src/services/benefit-plan-service/Services/FhirEndpointProjector.cs
@@ -93,7 +93,7 @@ internal sealed class FhirEndpointProjector : IFhirEndpointProjector
         // ── meta ─────────────────────────────────────────────────────
         resource["meta"] = new JsonObject
         {
-            ["lastUpdated"] = ToFhirInstant(ResolveLastUpdated(plan, document)),
+            ["lastUpdated"] = ToFhirInstant(ResolveLastUpdated(plan)),
             ["profile"] = new JsonArray(
                 ChoBenefitPlanFhirUrls.PlanNetEndpointProfile),
         };
@@ -217,9 +217,11 @@ internal sealed class FhirEndpointProjector : IFhirEndpointProjector
 
     /// <summary>
     /// Decision 8 ordering — SBC consumer-facing first; matches member-app
-    /// consumer expectations.
+    /// consumer expectations. Exposed (assembly-internal) so
+    /// <see cref="Controllers.FhirEndpointController"/> can apply the same
+    /// ordering across plans when sorting the cross-plan search bundle.
     /// </summary>
-    private static int DocTypeOrdinal(PlanDocumentType docType) => docType switch
+    internal static int DocTypeOrdinal(PlanDocumentType docType) => docType switch
     {
         PlanDocumentType.SBC                     => 1,
         PlanDocumentType.EOC                     => 2,
@@ -236,9 +238,17 @@ internal sealed class FhirEndpointProjector : IFhirEndpointProjector
         return PlanDocumentTypeDisplay(document.DocType);
     }
 
-    private static DateTime ResolveLastUpdated(BenefitPlan plan, PlanDocumentReference document)
+    /// <summary>
+    /// FHIR <c>meta.lastUpdated</c> is "the instant the resource was last
+    /// updated by the server" — NOT the document's effective window date.
+    /// Future-dated documents (status=off per Decision 5) would otherwise
+    /// produce a future <c>lastUpdated</c>, which violates the FHIR
+    /// contract and breaks consumer cache-freshness logic. Mirror the
+    /// InsurancePlan projector: prefer the plan's modify/publish/create
+    /// timestamps. Copilot review BP 5.9.
+    /// </summary>
+    private static DateTime ResolveLastUpdated(BenefitPlan plan)
     {
-        if (document.EffectiveDate.HasValue) return document.EffectiveDate.Value;
         if (plan.ModifiedDate.HasValue) return plan.ModifiedDate.Value;
         if (plan.PublishedAt.HasValue) return plan.PublishedAt.Value;
         if (plan.UpdatedAt != default) return plan.UpdatedAt;

--- a/src/services/benefit-plan-service/Services/FhirEndpointProjector.cs
+++ b/src/services/benefit-plan-service/Services/FhirEndpointProjector.cs
@@ -1,0 +1,257 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+using static BenefitPlanService.Services.FhirExtensionBuilder;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Hand-built FHIR R4 <c>Endpoint</c> projector (capability BP 5.9 — Plan
+/// Documents → FHIR Endpoint projection). Mirrors
+/// <see cref="FhirInsurancePlanProjector"/>: stateless, deterministic, no
+/// Hl7.Fhir.R4 dependency.
+///
+/// <para>
+/// Source-of-truth: <see cref="BenefitPlan.Documents"/>. One Endpoint per
+/// <see cref="PlanDocumentReference"/> whose <c>Location</c> is an
+/// external HTTPS URL (Decision 4 — internal
+/// <c>documentreference/{id}</c> references skip projection).
+/// </para>
+/// </summary>
+internal sealed class FhirEndpointProjector : IFhirEndpointProjector
+{
+    /// <summary>
+    /// The reserved internal-reference prefix (Phase 2 forward-compat).
+    /// Documents whose <c>Location</c> starts with this string are not
+    /// projected to an Endpoint — Endpoints require an external address.
+    /// Matches the docstring shape on
+    /// <see cref="PlanDocumentReference.Location"/>.
+    /// </summary>
+    public const string InternalReferencePrefix = "documentreference/";
+
+    public JsonObject? Project(BenefitPlan plan, PlanDocumentReference document)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (!IsPlanProjectable(plan)) return null;
+        if (!IsDocumentProjectable(document)) return null;
+
+        var status = ResolveStatus(plan, document);
+
+        var resource = new JsonObject
+        {
+            ["resourceType"] = "Endpoint",
+            ["id"] = document.Id,
+            ["status"] = status,
+        };
+
+        // ── connectionType (Decision 1) ──────────────────────────────
+        // Plan-Net's Endpoint profile binds connectionType to a slot the
+        // HL7 endpoint-connection-type CodeSystem can't fill for static
+        // documents — CHO publishes one code, "static-document".
+        resource["connectionType"] = Coding(
+            ChoBenefitPlanFhirUrls.EndpointConnectionTypeSystem,
+            ChoBenefitPlanFhirUrls.EndpointConnectionTypeStaticDocument,
+            "Static downloadable document");
+
+        // ── name ─────────────────────────────────────────────────────
+        var name = ResolveName(document);
+        if (!string.IsNullOrEmpty(name))
+        {
+            resource["name"] = name;
+        }
+
+        // ── payloadType (Decision 3) ─────────────────────────────────
+        resource["payloadType"] = new JsonArray
+        {
+            CodeableConcept(
+                Coding(
+                    ChoBenefitPlanFhirUrls.PlanDocumentTypeSystem,
+                    PlanDocumentTypeCode(document.DocType),
+                    PlanDocumentTypeDisplay(document.DocType)),
+                text: PlanDocumentTypeDisplay(document.DocType)),
+        };
+
+        // ── payloadMimeType (Decision 6 — pass-through) ──────────────
+        if (!string.IsNullOrWhiteSpace(document.ContentType))
+        {
+            resource["payloadMimeType"] = new JsonArray { document.ContentType };
+        }
+
+        // ── address (Decision 4 — operator-authored Location) ────────
+        resource["address"] = document.Location;
+
+        // ── period — track the document's effective window ──────────
+        if (document.EffectiveDate.HasValue)
+        {
+            resource["period"] = new JsonObject
+            {
+                ["start"] = ToFhirDate(document.EffectiveDate.Value),
+            };
+        }
+
+        // ── meta ─────────────────────────────────────────────────────
+        resource["meta"] = new JsonObject
+        {
+            ["lastUpdated"] = ToFhirInstant(ResolveLastUpdated(plan, document)),
+            ["profile"] = new JsonArray(
+                ChoBenefitPlanFhirUrls.PlanNetEndpointProfile),
+        };
+
+        return resource;
+    }
+
+    public JsonArray ProjectAll(BenefitPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var array = new JsonArray();
+        if (!IsPlanProjectable(plan)) return array;
+
+        foreach (var doc in OrderedProjectableDocuments(plan))
+        {
+            var projected = Project(plan, doc);
+            if (projected is not null) array.Add(projected);
+        }
+        return array;
+    }
+
+    public IReadOnlyList<PlanDocumentReference> OrderedProjectableDocuments(BenefitPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (!IsPlanProjectable(plan) || plan.Documents is null || plan.Documents.Count == 0)
+        {
+            return Array.Empty<PlanDocumentReference>();
+        }
+
+        return plan.Documents
+            .Where(d => d is not null && IsDocumentProjectable(d))
+            .OrderBy(d => DocTypeOrdinal(d.DocType))
+            .ThenByDescending(d => d.EffectiveDate ?? DateTime.MinValue)
+            .ThenBy(d => d.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // ── projection gates ────────────────────────────────────────────────
+
+    /// <summary>
+    /// A plan with a non-Published version state has no public FHIR
+    /// projection (mirrors <see cref="FhirInsurancePlanProjector"/>'s
+    /// stance). Future-effective plans likewise — projecting before the
+    /// plan starts is not part of the BP 5.9 contract.
+    /// </summary>
+    private static bool IsPlanProjectable(BenefitPlan plan)
+    {
+        if (plan.VersionState != PlanVersionState.Published) return false;
+        if (ToUtc(plan.EffectiveDate) > DateTime.UtcNow) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Endpoints require an external address (Decision 4). Internal
+    /// <c>documentreference/{id}</c> references are deferred to Phase 2;
+    /// they are not projected to an Endpoint.
+    /// Empty / whitespace locations also don't project — but those should
+    /// have been rejected by
+    /// <see cref="PlanDocumentValidation.ValidateLocation(string?, string)"/>
+    /// at the producer boundary.
+    /// </summary>
+    private static bool IsDocumentProjectable(PlanDocumentReference document)
+    {
+        if (string.IsNullOrWhiteSpace(document.Location)) return false;
+        if (document.Location.StartsWith(InternalReferencePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    // ── status (Decision 5) ─────────────────────────────────────────────
+
+    private static string ResolveStatus(BenefitPlan plan, PlanDocumentReference document)
+    {
+        var now = DateTime.UtcNow;
+
+        if (document.EffectiveDate.HasValue && ToUtc(document.EffectiveDate.Value) > now)
+        {
+            return "off";
+        }
+
+        if (plan.TerminationDate.HasValue && ToUtc(plan.TerminationDate.Value) < now)
+        {
+            // A retired parent plan retires its endpoints too. The
+            // document's URL may still resolve, but the operator's
+            // authored intent is "no longer current member-facing
+            // material" — surfacing it as off keeps Plan-Net consumers
+            // honest.
+            return "off";
+        }
+
+        return "active";
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static string PlanDocumentTypeCode(PlanDocumentType docType) => docType switch
+    {
+        PlanDocumentType.SBC                     => "sbc",
+        PlanDocumentType.EOC                     => "eoc",
+        PlanDocumentType.Formulary               => "formulary",
+        PlanDocumentType.SPD                     => "spd",
+        PlanDocumentType.MachineReadableRateFile => "mrf",
+        PlanDocumentType.Other                   => "other",
+        _                                        => "other",
+    };
+
+    private static string PlanDocumentTypeDisplay(PlanDocumentType docType) => docType switch
+    {
+        PlanDocumentType.SBC                     => "Summary of Benefits and Coverage",
+        PlanDocumentType.EOC                     => "Evidence of Coverage",
+        PlanDocumentType.Formulary               => "Drug Formulary",
+        PlanDocumentType.SPD                     => "Summary Plan Description",
+        PlanDocumentType.MachineReadableRateFile => "Machine-Readable Rate File",
+        PlanDocumentType.Other                   => "Other Plan Document",
+        _                                        => "Other Plan Document",
+    };
+
+    /// <summary>
+    /// Decision 8 ordering — SBC consumer-facing first; matches member-app
+    /// consumer expectations.
+    /// </summary>
+    private static int DocTypeOrdinal(PlanDocumentType docType) => docType switch
+    {
+        PlanDocumentType.SBC                     => 1,
+        PlanDocumentType.EOC                     => 2,
+        PlanDocumentType.Formulary               => 3,
+        PlanDocumentType.SPD                     => 4,
+        PlanDocumentType.MachineReadableRateFile => 5,
+        PlanDocumentType.Other                   => 6,
+        _                                        => 99,
+    };
+
+    private static string? ResolveName(PlanDocumentReference document)
+    {
+        if (!string.IsNullOrWhiteSpace(document.DisplayName)) return document.DisplayName;
+        return PlanDocumentTypeDisplay(document.DocType);
+    }
+
+    private static DateTime ResolveLastUpdated(BenefitPlan plan, PlanDocumentReference document)
+    {
+        if (document.EffectiveDate.HasValue) return document.EffectiveDate.Value;
+        if (plan.ModifiedDate.HasValue) return plan.ModifiedDate.Value;
+        if (plan.PublishedAt.HasValue) return plan.PublishedAt.Value;
+        if (plan.UpdatedAt != default) return plan.UpdatedAt;
+        return plan.CreatedAt;
+    }
+
+    private static DateTime ToUtc(DateTime value) => value.Kind == DateTimeKind.Utc
+        ? value
+        : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+    private static string ToFhirDate(DateTime value)
+        => ToUtc(value).ToString("yyyy-MM-dd");
+
+    private static string ToFhirInstant(DateTime value)
+        => ToUtc(value).ToString("o");
+}

--- a/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
+++ b/src/services/benefit-plan-service/Services/FhirInsurancePlanProjector.cs
@@ -21,6 +21,19 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
     private const string QualifierCopay        = "copay";
     private const string QualifierCoinsurance  = "coinsurance";
 
+    private readonly IFhirEndpointProjector _endpointProjector;
+
+    public FhirInsurancePlanProjector()
+        : this(new FhirEndpointProjector())
+    {
+    }
+
+    public FhirInsurancePlanProjector(IFhirEndpointProjector endpointProjector)
+    {
+        _endpointProjector = endpointProjector
+            ?? throw new ArgumentNullException(nameof(endpointProjector));
+    }
+
     public JsonObject? Project(BenefitPlan plan) => Project(plan, networks: null, acaLimits: null);
 
     public JsonObject? Project(
@@ -83,11 +96,13 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
             resource["ownedBy"] = new JsonObject { ["display"] = plan.Payer };
         }
 
-        // ── endpoint (deferred to BP 5.9 — emit empty array) ────────
-        // Empty array is conformant FHIR cardinality 0..*. Documenting
-        // intent as an empty collection rather than omitting tells
-        // consumers "no documents projected yet" vs "field unsupported."
-        resource["endpoint"] = new JsonArray();
+        // ── endpoint (BP 5.9 — Plan Documents → Reference(Endpoint)) ─
+        // One Reference per projectable PlanDocumentReference, ordered
+        // per Decision 8 (SBC, EOC, Formulary, SPD, MRF, Other; within
+        // type, EffectiveDate desc, then Id). Internal
+        // documentreference/{id} entries are skipped — Endpoints require
+        // an external address. See fhir-endpoint-projection.md.
+        resource["endpoint"] = BuildEndpointReferences(plan);
 
         // ── network[] (top-level — Decision 10 site 1) ──────────────
         var topLevelNetworks = BuildNetworkReferences(plan.NetworkTiers, networks);
@@ -186,6 +201,35 @@ public sealed class FhirInsurancePlanProjector : IFhirInsurancePlanProjector
             productCode);
 
         return CodeableConcept(new[] { standardCoding, productCoding }, text: productCode);
+    }
+
+    // ── endpoint references (BP 5.9) ────────────────────────────────────
+
+    /// <summary>
+    /// Build the <c>endpoint[]</c> array for the projected InsurancePlan.
+    /// Defers projectability + ordering to
+    /// <see cref="IFhirEndpointProjector.OrderedProjectableDocuments(BenefitPlan)"/>
+    /// so the Reference shape and the Endpoint resource always agree.
+    ///
+    /// <para>
+    /// References are emitted as <c>{"reference":"Endpoint/{id}"}</c> per
+    /// the BP 5.8 Reference convention — no <c>display</c> field, since
+    /// the Endpoint resource itself carries the operator-authored name
+    /// and consumers fetch it via the bundled Reference. Decision 8
+    /// ordering applied.
+    /// </para>
+    /// </summary>
+    private JsonArray BuildEndpointReferences(BenefitPlan plan)
+    {
+        var array = new JsonArray();
+        foreach (var doc in _endpointProjector.OrderedProjectableDocuments(plan))
+        {
+            array.Add(new JsonObject
+            {
+                ["reference"] = $"Endpoint/{doc.Id}",
+            });
+        }
+        return array;
     }
 
     // ── network references ──────────────────────────────────────────────

--- a/src/services/benefit-plan-service/Services/IFhirEndpointProjector.cs
+++ b/src/services/benefit-plan-service/Services/IFhirEndpointProjector.cs
@@ -1,0 +1,80 @@
+using System.Text.Json.Nodes;
+using BenefitPlanService.Models;
+
+namespace BenefitPlanService.Services;
+
+/// <summary>
+/// Projects a <see cref="PlanDocumentReference"/> attached to a published
+/// <see cref="BenefitPlan"/> into a FHIR R4 Endpoint resource (capability
+/// BP 5.9 — Plan Documents → FHIR Endpoint projection). Pattern mirrors
+/// <see cref="IFhirInsurancePlanProjector"/>: hand-built to avoid the
+/// Hl7.Fhir.R4 transitive dep graph and keep serialization deterministic
+/// for tests.
+///
+/// <para>
+/// One <c>Endpoint</c> resource is emitted per <c>PlanDocumentReference</c>
+/// whose <c>Location</c> is an external HTTPS URL. Documents whose
+/// <c>Location</c> is the reserved internal <c>documentreference/{id}</c>
+/// form (Phase 2 forward-compat) are NOT projectable to an Endpoint —
+/// Endpoints require an external address. The projector skips such
+/// documents and the caller increments
+/// <c>cho.benefit_plan.endpoint_skipped_internal_reference.total</c>.
+/// </para>
+///
+/// <para>
+/// The projection emits <c>meta.profile</c> with the Da Vinci Plan-Net
+/// 1.1.0 Endpoint profile. <c>connectionType</c> carries a single CHO
+/// CodeSystem coding (<c>static-document</c>, Decision 1) because the
+/// HL7 <c>endpoint-connection-type</c> CodeSystem has no code for
+/// "static downloadable document." <c>payloadType.coding</c> carries a
+/// CHO CodeSystem coding mapped from <c>PlanDocumentType</c>
+/// (Decision 3) because Plan-Net does not bind the slot.
+/// </para>
+///
+/// <para>
+/// <c>Endpoint.id</c> is <see cref="PlanDocumentReference.Id"/> verbatim
+/// (Decision 2) — matches the BP 5.8 stance for
+/// <c>InsurancePlan.id = BenefitPlan.PlanId</c> (use the source-system
+/// identifier directly).
+/// </para>
+///
+/// <para>
+/// Hash exposure (<see cref="PlanDocumentReference.ContentHashSha256"/>)
+/// is intentionally not projected here — Plan-Net's <c>Endpoint</c> profile
+/// has no <c>Attachment</c>-shaped slot for it. Hash exposure waits for
+/// the Phase 2 <c>DocumentReference</c> projection in
+/// member-document-service.
+/// </para>
+/// </summary>
+public interface IFhirEndpointProjector
+{
+    /// <summary>
+    /// Project a single <see cref="PlanDocumentReference"/> into a FHIR
+    /// <c>Endpoint</c> resource. Returns <c>null</c> when the document is
+    /// not projectable — either the parent plan is non-Published, or the
+    /// document's <c>Location</c> is the reserved internal
+    /// <c>documentreference/{id}</c> form (skip-internal-reference per
+    /// Decision 4).
+    /// </summary>
+    JsonObject? Project(BenefitPlan plan, PlanDocumentReference document);
+
+    /// <summary>
+    /// Project every projectable document on <paramref name="plan"/>.
+    /// Documents are emitted in the order returned by
+    /// <see cref="OrderedProjectableDocuments(BenefitPlan)"/> (Decision 8 —
+    /// SBC before EOC before Formulary before SPD before MRF before Other;
+    /// within DocType, EffectiveDate desc, then Id).
+    /// Returns an empty array when the plan is not Published or has no
+    /// projectable documents.
+    /// </summary>
+    JsonArray ProjectAll(BenefitPlan plan);
+
+    /// <summary>
+    /// Enumerate the plan's documents that <see cref="Project"/> would
+    /// emit, in the canonical Decision 8 order. Used by
+    /// <see cref="IFhirInsurancePlanProjector"/> to build
+    /// <c>InsurancePlan.endpoint[]</c> as <c>Reference(Endpoint/{id})</c>
+    /// without re-projecting the documents.
+    /// </summary>
+    IReadOnlyList<PlanDocumentReference> OrderedProjectableDocuments(BenefitPlan plan);
+}

--- a/src/services/benefit-plan-service/Services/IFhirInsurancePlanProjector.cs
+++ b/src/services/benefit-plan-service/Services/IFhirInsurancePlanProjector.cs
@@ -32,12 +32,17 @@ namespace BenefitPlanService.Services;
 ///
 /// <para>
 /// Plan-Net <c>InsurancePlan.endpoint</c> (payer-published URLs for SBC,
-/// formulary, machine-readable rate file) is intentionally emitted as an
-/// empty array in capability BP 5.8 — the Plan Documents → FHIR
-/// Endpoint projection is BP 5.9 territory. Plan-Net
+/// formulary, machine-readable rate file) is populated by capability
+/// BP 5.9 via the Plan Documents → FHIR Endpoint projection. Each
+/// projectable <see cref="PlanDocumentReference"/> on the plan emits one
+/// <c>Reference(Endpoint/{id})</c>; the Endpoint resources themselves
+/// are dereferenceable at <c>/fhir/r4/Endpoint/{id}</c>. Documents whose
+/// <c>Location</c> is the reserved internal <c>documentreference/{id}</c>
+/// form are skipped (Phase 2 forward-compat). See
+/// <c>docs/architecture/fhir-endpoint-projection.md</c>. Plan-Net
 /// <c>coverageArea</c>, <c>contact</c>, <c>alias</c>, and
-/// <c>administeredBy</c> are deferred to Phase 2 (CHO has no source data
-/// for them today).
+/// <c>administeredBy</c> remain deferred to Phase 2 (CHO has no source
+/// data for them today).
 /// </para>
 ///
 /// <para>

--- a/src/services/benefit-plan-service/Services/PlanDocumentValidation.cs
+++ b/src/services/benefit-plan-service/Services/PlanDocumentValidation.cs
@@ -50,13 +50,11 @@ public static class PlanDocumentValidation
     /// <summary>
     /// The reserved internal-reference prefix that
     /// <see cref="PlanDocumentReference.Location"/> may carry once Phase 2
-    /// migrates plan documents into member-document-service. Until then
-    /// the format is documented but not produced by any active code path.
-    /// Mirrors the constant used by
+    /// migrates plan documents into member-document-service. Sourced from
     /// <see cref="FhirEndpointProjector.InternalReferencePrefix"/> so the
-    /// validator and the projector agree on the literal.
+    /// validator and the projector cannot drift. Copilot review BP 5.9.
     /// </summary>
-    public const string InternalReferencePrefix = "documentreference/";
+    public const string InternalReferencePrefix = FhirEndpointProjector.InternalReferencePrefix;
 
     /// <summary>
     /// Validate a document <c>Location</c>. The Location must be either

--- a/src/services/benefit-plan-service/Services/PlanDocumentValidation.cs
+++ b/src/services/benefit-plan-service/Services/PlanDocumentValidation.cs
@@ -48,9 +48,71 @@ public static class PlanDocumentValidation
     }
 
     /// <summary>
+    /// The reserved internal-reference prefix that
+    /// <see cref="PlanDocumentReference.Location"/> may carry once Phase 2
+    /// migrates plan documents into member-document-service. Until then
+    /// the format is documented but not produced by any active code path.
+    /// Mirrors the constant used by
+    /// <see cref="FhirEndpointProjector.InternalReferencePrefix"/> so the
+    /// validator and the projector agree on the literal.
+    /// </summary>
+    public const string InternalReferencePrefix = "documentreference/";
+
+    /// <summary>
+    /// Validate a document <c>Location</c>. The Location must be either
+    /// an HTTPS URL (the operator-authored external address Endpoint
+    /// projection expects) or the reserved internal reference of the form
+    /// <c>documentreference/{id}</c> (Phase 2 forward-compat).
+    ///
+    /// <para>
+    /// Null or empty input is rejected — Location is <c>[Required]</c> on
+    /// the model. HTTP (plaintext) is rejected because every regulatory
+    /// surface this projection serves (ACA SBC publication, CMS
+    /// Transparency in Coverage MRFs, CMS-0057-F formulary discoverability)
+    /// requires HTTPS. Producer-boundary only — setter-side validation
+    /// would break Mongo hydration for any historical malformed document
+    /// (same trust posture as <see cref="ValidateHash"/>).
+    /// </para>
+    /// </summary>
+    public static void ValidateLocation(string? location, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(location))
+        {
+            throw new ArgumentException(
+                $"{fieldName} is required.",
+                fieldName);
+        }
+
+        if (location.StartsWith(InternalReferencePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            // Reserved internal-reference form. Beyond the prefix we
+            // accept any non-empty body — the resolver in Phase 2 owns
+            // any further shape constraints. We DO require a non-empty
+            // body so "documentreference/" alone is rejected as
+            // malformed.
+            if (location.Length <= InternalReferencePrefix.Length)
+            {
+                throw new ArgumentException(
+                    $"{fieldName} must include an id after '{InternalReferencePrefix}'; got '{location}'.",
+                    fieldName);
+            }
+            return;
+        }
+
+        if (!Uri.TryCreate(location, UriKind.Absolute, out var uri)
+            || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"{fieldName} must be an HTTPS URL or '{InternalReferencePrefix}{{id}}'; got '{location}'.",
+                fieldName);
+        }
+    }
+
+    /// <summary>
     /// Validate every document attached to a plan. Iterates each entry and
-    /// delegates to <see cref="ValidateHash"/>, labelling the field with
-    /// the document index so the caller can report which document failed.
+    /// delegates to <see cref="ValidateHash"/> and
+    /// <see cref="ValidateLocation"/>, labelling each field with the
+    /// document index so the caller can report which document failed.
     /// </summary>
     public static void ValidateDocuments(IEnumerable<PlanDocumentReference>? documents)
     {
@@ -59,6 +121,7 @@ public static class PlanDocumentValidation
         var index = 0;
         foreach (var doc in documents)
         {
+            ValidateLocation(doc.Location, $"documents[{index}].location");
             ValidateHash(doc.ContentHashSha256, $"documents[{index}].contentHashSha256");
             index++;
         }

--- a/src/services/fhir-service/Controllers/EndpointController.cs
+++ b/src/services/fhir-service/Controllers/EndpointController.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace FhirService.Controllers;
+
+/// <summary>
+/// FHIR R4 Endpoint API controller (capability BP 5.9 — Plan Documents →
+/// FHIR Endpoint projection). Thin proxy over benefit-plan-service's
+/// <c>FhirEndpointController</c>; benefit-plan-service owns the canonical
+/// CHO Endpoint projection. Mirrors
+/// <see cref="InsurancePlanController"/> byte-for-byte modulo the route.
+///
+/// <para>
+/// Reuses the existing <c>HttpClient("BenefitPlanService")</c> typed
+/// client registration in <c>Program.cs</c> — the same client that
+/// proxies <c>InsurancePlan</c>. Tenant + Correlation header propagation
+/// already configured there flows verbatim.
+/// </para>
+/// </summary>
+[Route("fhir/r4")]
+public class EndpointController : FhirControllerBase
+{
+    private readonly HttpClient _benefitPlanServiceClient;
+    private readonly ILogger<EndpointController> _logger;
+
+    public EndpointController(
+        IHttpClientFactory httpClientFactory,
+        ILogger<EndpointController> logger)
+    {
+        _benefitPlanServiceClient =
+            httpClientFactory.CreateClient(InsurancePlanController.BenefitPlanServiceClientName);
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// GET /fhir/r4/Endpoint/{id} — read Endpoint by
+    /// <see cref="BenefitPlanService.Models.PlanDocumentReference.Id"/>.
+    /// Proxies to benefit-plan-service /fhir/Endpoint/{id}; the upstream
+    /// owns the canonical CHO projection (capability BP 5.9 Decision 2).
+    /// </summary>
+    [HttpGet("Endpoint/{id}")]
+    [Produces("application/fhir+json")]
+    public Task<IActionResult> ReadEndpoint(string id, CancellationToken ct)
+        => ProxyBenefitPlanServiceAsync(
+            "Endpoint",
+            $"fhir/Endpoint/{Uri.EscapeDataString(id)}",
+            ct);
+
+    /// <summary>
+    /// GET /fhir/r4/Endpoint?_id=&amp;status=&amp;connection-type=&amp;_count=&amp;_page=
+    /// — search Endpoints. Forwards the FHIR search query string to
+    /// benefit-plan-service /fhir/Endpoint unchanged. The upstream honors
+    /// <c>_id</c>, <c>status</c>, and <c>connection-type</c>;
+    /// <c>organization=</c> is deferred (no Organization→Endpoint link
+    /// today).
+    /// </summary>
+    [HttpGet("Endpoint")]
+    [Produces("application/fhir+json")]
+    public Task<IActionResult> SearchEndpoints(CancellationToken ct = default)
+    {
+        var qs = HttpContext.Request.QueryString.HasValue
+            ? HttpContext.Request.QueryString.Value
+            : string.Empty;
+        return ProxyBenefitPlanServiceAsync("Endpoint", $"fhir/Endpoint{qs}", ct);
+    }
+
+    private Task<IActionResult> ProxyBenefitPlanServiceAsync(
+        string resourceLabel,
+        string path,
+        CancellationToken ct)
+        => ProxyUpstreamServiceAsync(
+            _benefitPlanServiceClient,
+            "benefit-plan-service",
+            resourceLabel,
+            path,
+            _logger,
+            ct);
+}

--- a/src/services/fhir-service/Controllers/EndpointController.cs
+++ b/src/services/fhir-service/Controllers/EndpointController.cs
@@ -1,3 +1,4 @@
+using FhirService.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FhirService.Controllers;
@@ -26,8 +27,11 @@ public class EndpointController : FhirControllerBase
         IHttpClientFactory httpClientFactory,
         ILogger<EndpointController> logger)
     {
+        // Pull the typed HttpClient name from UpstreamClientNames so the
+        // controller doesn't take a dependency on a sibling controller's
+        // implementation detail. Copilot review BP 5.9.
         _benefitPlanServiceClient =
-            httpClientFactory.CreateClient(InsurancePlanController.BenefitPlanServiceClientName);
+            httpClientFactory.CreateClient(UpstreamClientNames.BenefitPlanService);
         _logger = logger;
     }
 

--- a/src/services/fhir-service/Controllers/InsurancePlanController.cs
+++ b/src/services/fhir-service/Controllers/InsurancePlanController.cs
@@ -1,3 +1,4 @@
+using FhirService.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FhirService.Controllers;
@@ -23,7 +24,13 @@ namespace FhirService.Controllers;
 [Route("fhir/r4")]
 public class InsurancePlanController : FhirControllerBase
 {
-    public const string BenefitPlanServiceClientName = "BenefitPlanService";
+    /// <summary>
+    /// Back-compat alias for tests that referenced the controller-local
+    /// constant before BP 5.9 extracted the canonical name into
+    /// <see cref="UpstreamClientNames.BenefitPlanService"/>. New code
+    /// should use the shared constant directly.
+    /// </summary>
+    public const string BenefitPlanServiceClientName = UpstreamClientNames.BenefitPlanService;
 
     private readonly HttpClient _benefitPlanServiceClient;
     private readonly ILogger<InsurancePlanController> _logger;
@@ -32,7 +39,7 @@ public class InsurancePlanController : FhirControllerBase
         IHttpClientFactory httpClientFactory,
         ILogger<InsurancePlanController> logger)
     {
-        _benefitPlanServiceClient = httpClientFactory.CreateClient(BenefitPlanServiceClientName);
+        _benefitPlanServiceClient = httpClientFactory.CreateClient(UpstreamClientNames.BenefitPlanService);
         _logger = logger;
     }
 

--- a/src/services/fhir-service/Services/UpstreamClientNames.cs
+++ b/src/services/fhir-service/Services/UpstreamClientNames.cs
@@ -1,0 +1,19 @@
+namespace FhirService.Services;
+
+/// <summary>
+/// Names of the typed <see cref="System.Net.Http.HttpClient"/> instances
+/// fhir-service registers via <c>IHttpClientFactory</c> for upstream
+/// service proxies (capabilities 5.7+ provider-service hops, BP 5.8+
+/// benefit-plan-service hops). Centralised so individual controllers can
+/// reuse the names without taking a dependency on a sibling controller's
+/// implementation detail (Copilot review BP 5.9).
+/// </summary>
+internal static class UpstreamClientNames
+{
+    /// <summary>
+    /// Typed HttpClient for benefit-plan-service. Used by
+    /// <see cref="Controllers.InsurancePlanController"/> (BP 5.8) and
+    /// <see cref="Controllers.EndpointController"/> (BP 5.9).
+    /// </summary>
+    public const string BenefitPlanService = "BenefitPlanService";
+}

--- a/tests/CloudHealthOffice.BenefitPlanService.Tests/PlanDocumentValidationTests.cs
+++ b/tests/CloudHealthOffice.BenefitPlanService.Tests/PlanDocumentValidationTests.cs
@@ -64,8 +64,8 @@ public class PlanDocumentValidationTests
     {
         var docs = new List<PlanDocumentReference>
         {
-            new() { DocType = PlanDocumentType.SBC, Location = "a", ContentHashSha256 = ValidSha256Base64 },
-            new() { DocType = PlanDocumentType.EOC, Location = "b", ContentHashSha256 = "not-base64!" },
+            new() { DocType = PlanDocumentType.SBC, Location = "https://example.com/a.pdf", ContentHashSha256 = ValidSha256Base64 },
+            new() { DocType = PlanDocumentType.EOC, Location = "https://example.com/b.pdf", ContentHashSha256 = "not-base64!" },
         };
 
         var ex = Assert.Throws<ArgumentException>(
@@ -77,5 +77,67 @@ public class PlanDocumentValidationTests
     public void ValidateDocuments_accepts_null_collection()
     {
         PlanDocumentValidation.ValidateDocuments(null);
+    }
+
+    // ── ValidateLocation (capability BP 5.9) ────────────────────────────
+
+    [Fact]
+    public void ValidateLocation_accepts_https_url()
+    {
+        PlanDocumentValidation.ValidateLocation("https://example.com/sbc.pdf", "location");
+    }
+
+    [Fact]
+    public void ValidateLocation_accepts_internal_documentreference_form()
+    {
+        PlanDocumentValidation.ValidateLocation("documentreference/abc-123", "location");
+    }
+
+    [Fact]
+    public void ValidateLocation_rejects_null_or_empty()
+    {
+        Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateLocation(null, "location"));
+        Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateLocation(string.Empty, "location"));
+    }
+
+    [Fact]
+    public void ValidateLocation_rejects_plain_http()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateLocation("http://example.com/sbc.pdf", "location"));
+        Assert.Equal("location", ex.ParamName);
+        Assert.Contains("HTTPS", ex.Message);
+    }
+
+    [Fact]
+    public void ValidateLocation_rejects_relative_url()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateLocation("/relative/sbc.pdf", "location"));
+        Assert.Equal("location", ex.ParamName);
+    }
+
+    [Fact]
+    public void ValidateLocation_rejects_documentreference_prefix_without_id()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateLocation("documentreference/", "location"));
+        Assert.Equal("location", ex.ParamName);
+    }
+
+    [Fact]
+    public void ValidateDocuments_validates_location_field()
+    {
+        var docs = new List<PlanDocumentReference>
+        {
+            new() { DocType = PlanDocumentType.SBC, Location = "https://example.com/a.pdf" },
+            new() { DocType = PlanDocumentType.EOC, Location = "ftp://example.com/b.pdf" },
+        };
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => PlanDocumentValidation.ValidateDocuments(docs));
+        Assert.Equal("documents[1].location", ex.ParamName);
     }
 }

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/EndpointControllerProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/EndpointControllerProxyTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Text;
+using FhirService.Controllers;
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace CloudHealthOffice.FhirService.Tests.Controllers;
+
+/// <summary>
+/// Capability BP 5.9 — proxy-shape coverage for the new
+/// <see cref="EndpointController"/>. Mirrors
+/// <c>InsurancePlanControllerProxyTests</c> verbatim modulo the route. The
+/// fhir-service controller talks to the same typed
+/// <c>BenefitPlanService</c> HttpClient that
+/// <see cref="InsurancePlanController"/> uses.
+///
+/// Verifies:
+/// <list type="bullet">
+///   <item>read forwards GET /fhir/Endpoint/{id} to benefit-plan-service;</item>
+///   <item>search forwards the original FHIR query string;</item>
+///   <item>4xx and 2xx responses pass through verbatim;</item>
+///   <item>5xx responses are translated to a FHIR 502 OperationOutcome
+///         that does NOT leak the upstream body;</item>
+///   <item>upstream connection failure → 502 OperationOutcome;</item>
+///   <item>label "Endpoint" appears in 502 diagnostics so operators can
+///         triage by resource type.</item>
+/// </list>
+/// </summary>
+public class EndpointControllerProxyTests
+{
+    private readonly Mock<IHttpClientFactory> _factory = new();
+    private readonly RecordingHandler _benefitPlanHandler = new();
+    private readonly EndpointController _controller;
+
+    public EndpointControllerProxyTests()
+    {
+        _factory.Setup(f => f.CreateClient(InsurancePlanController.BenefitPlanServiceClientName))
+            .Returns(() => new HttpClient(_benefitPlanHandler)
+            {
+                BaseAddress = new Uri("http://benefit-plan-service.test/")
+            });
+
+        _controller = new EndpointController(
+            _factory.Object,
+            NullLogger<EndpointController>.Instance);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_forwards_to_benefit_plan_service_with_correct_path()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Endpoint\",\"id\":\"doc-sbc\",\"status\":\"active\"}"));
+
+        var result = await _controller.ReadEndpoint("doc-sbc", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(200);
+        content.ContentType.Should().StartWith("application/fhir+json");
+        content.Content.Should().Contain("\"resourceType\":\"Endpoint\"");
+
+        _benefitPlanHandler.Calls.Should().ContainSingle();
+        var req = _benefitPlanHandler.Calls[0];
+        req.Method.Should().Be(HttpMethod.Get);
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/Endpoint/doc-sbc");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_url_encodes_the_id()
+    {
+        var endpointId = "doc id with spaces";
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Endpoint\",\"id\":\"x\"}"));
+
+        await _controller.ReadEndpoint(endpointId, default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().NotContain(" ");
+        req.RequestUri.AbsolutePath.Should().Contain("doc%20id%20with%20spaces");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_passes_404_OperationOutcome_through_verbatim()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.NotFound,
+            "{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"severity\":\"error\",\"code\":\"not-found\"}]}"));
+
+        var result = await _controller.ReadEndpoint("does-not-exist", default);
+
+        var content = result.Should().BeOfType<ContentResult>().Subject;
+        content.StatusCode.Should().Be(404);
+        content.Content.Should().Contain("OperationOutcome");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_translates_upstream_5xx_to_502_OperationOutcome_without_leaking_body()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.InternalServerError,
+            "internal upstream noise that must NOT leak"));
+
+        var result = await _controller.ReadEndpoint("doc-sbc", default);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        var outcome = status.Value.Should().BeOfType<OperationOutcome>().Subject;
+        outcome.Issue.Single().Code.Should().Be(OperationOutcome.IssueType.Transient);
+        outcome.Issue.Single().Diagnostics.Should().NotContain("internal upstream noise",
+            "upstream 5xx body must not leak to consumers");
+        outcome.Issue.Single().Diagnostics.Should().Contain("Endpoint",
+            "label should identify the resource for operator triage");
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_handles_upstream_unreachable_as_502()
+    {
+        _benefitPlanHandler.Respond(_ =>
+            throw new HttpRequestException("connection refused"));
+
+        var result = await _controller.ReadEndpoint("doc-sbc", default);
+
+        var status = result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(502);
+        status.Value.Should().BeOfType<OperationOutcome>();
+    }
+
+    [Fact]
+    public async Task ReadEndpoint_propagates_caller_cancellation()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Endpoint\"}"));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Func<Task> act = () => _controller.ReadEndpoint("doc-sbc", cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_forwards_query_string_to_benefit_plan_service()
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.QueryString = new QueryString(
+            "?_id=doc-sbc&status=active&connection-type=static-document&_count=25");
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchEndpoints(default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/Endpoint");
+        req.RequestUri.Query.Should().Contain("_id=doc-sbc");
+        req.RequestUri.Query.Should().Contain("status=active");
+        req.RequestUri.Query.Should().Contain("connection-type=static-document");
+        req.RequestUri.Query.Should().Contain("_count=25");
+    }
+
+    [Fact]
+    public async Task SearchEndpoints_with_empty_query_string_still_hits_search_path()
+    {
+        _benefitPlanHandler.Respond(_ => Json(HttpStatusCode.OK,
+            "{\"resourceType\":\"Bundle\",\"type\":\"searchset\",\"total\":0,\"entry\":[]}"));
+
+        await _controller.SearchEndpoints(default);
+
+        var req = _benefitPlanHandler.Calls.Single();
+        req.RequestUri!.AbsolutePath.Should().Be("/fhir/Endpoint");
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/fhir+json")
+        };
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Calls { get; } = new();
+        private Func<HttpRequestMessage, HttpResponseMessage> _responder =
+            _ => new HttpResponseMessage(HttpStatusCode.NotImplemented);
+
+        public void Respond(Func<HttpRequestMessage, HttpResponseMessage> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls.Add(request);
+            return Task.FromResult(_responder(request));
+        }
+    }
+}

--- a/tests/CloudHealthOffice.FhirService.Tests/Controllers/EndpointControllerProxyTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Controllers/EndpointControllerProxyTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using FhirService.Controllers;
+using FhirService.Services;
 using FluentAssertions;
 using Hl7.Fhir.Model;
 using Microsoft.AspNetCore.Http;
@@ -38,7 +39,7 @@ public class EndpointControllerProxyTests
 
     public EndpointControllerProxyTests()
     {
-        _factory.Setup(f => f.CreateClient(InsurancePlanController.BenefitPlanServiceClientName))
+        _factory.Setup(f => f.CreateClient(UpstreamClientNames.BenefitPlanService))
             .Returns(() => new HttpClient(_benefitPlanHandler)
             {
                 BaseAddress = new Uri("http://benefit-plan-service.test/")


### PR DESCRIPTION
## Summary

Closes the BP 5.8 `InsurancePlan.endpoint[]` deferral. Projects
`BenefitPlan.Documents[]` (`PlanDocumentReference`) onto Plan-Net IG
1.1.0 `Endpoint` resources, dereferenceable at `/fhir/r4/Endpoint/{id}`
and referenced from `InsurancePlan.endpoint[]`.

Three CMS-adjacent regulatory surfaces motivate this — ACA SBC
publication (45 CFR §147.200), CMS Transparency in Coverage MRFs
(45 CFR §147.211), and CMS-0057-F formulary discoverability — all of
which need a discoverable URL surface in CHO's FHIR API.

### What's included

- **Model** — `PlanDocumentType.MachineReadableRateFile` so MRFs are
  first-class instead of hiding under `Other`.
- **Projector** — new hand-built `FhirEndpointProjector`
  (`JsonObject`, no `Hl7.Fhir.R4` dep, mirrors BP 5.8). One Endpoint
  per externally-addressable `PlanDocumentReference`. Skips internal
  `documentreference/{id}` references per Decision 4.
- **InsurancePlan wiring** — `FhirInsurancePlanProjector` now emits a
  real `endpoint[]` (`Reference(Endpoint/{id})` per projectable
  document), ordered SBC, EOC, Formulary, SPD, MRF, Other (Decision 8).
- **Controllers** — `FhirEndpointController` in benefit-plan-service
  (read + search by `_id` / `status` / `connection-type`,
  tenant-scoped). `EndpointController` in fhir-service is a thin proxy
  reusing the BP 5.8 `BenefitPlanService` typed `HttpClient`.
- **Validation** — `PlanDocumentValidation.ValidateLocation` enforces
  HTTPS or the reserved `documentreference/{id}` form at producer
  boundaries, mirroring `ValidateHash`.
- **CHO CodeSystems** — `endpoint-connection-type` (single code
  `static-document`, Decision 1) and `plan-document-type` (one code
  per `PlanDocumentType`, Decision 3).
- **Docs + seed** — new
  `docs/architecture/fhir-endpoint-projection.md`, conformance ledger
  update, BP 5.8 doc deferral row updated, operator-facing
  `schemas/plan-documents/README.md`.

### Decisions

See [`docs/architecture/fhir-endpoint-projection.md`](https://github.com/aurelianware/cloudhealthoffice/blob/claude/plan-documents-fhir-endpoint-t5jsI/docs/architecture/fhir-endpoint-projection.md)
for the eight decision blocks (ID shape, connectionType code source,
payloadType binding, address shape, status derivation,
payloadMimeType pass-through, hash exposure deferral, ordering).

### Out of scope / explicit deferrals

- `DocumentReference` resource projection — Phase 2 (member-document-service).
- `Endpoint?organization=` search — no Organization→Endpoint link today.
- `Endpoint.managingOrganization` — depends on payer-Organization linking.
- Hash exposure on `Endpoint` — Plan-Net's `Endpoint` profile has no
  `Attachment` slot; waits for the Phase 2 `DocumentReference` projection.

## Test plan

- [ ] `dotnet build cloudhealthoffice-main.sln` clean across the BP 5.9
      changes (verified in CI; no .NET SDK in this dev environment).
- [ ] `FhirEndpointProjectorTests` — happy path, ID determinism,
      ordering, status derivation, internal-reference skip,
      payloadMimeType pass-through, name fallback, non-Published plan
      filter.
- [ ] `FhirEndpointControllerTests` — read 200 / 400 / 404, search by
      `_id` / `status` / `connection-type`, tenant scoping,
      content-type, internal-reference filtering.
- [ ] `EndpointControllerProxyTests` — URL forwarding, query-string
      passthrough, 4xx verbatim, 5xx → 502 OperationOutcome without
      body leak, transport faults, cancellation.
- [ ] `FhirInsurancePlanProjectorTests` — `endpoint[]` ordering,
      Reference shape (no `display`), internal-reference skip, empty
      array when no documents.
- [ ] `PlanDocumentValidationTests` — HTTPS pass, HTTP fail,
      `documentreference/{id}` pass, malformed value fail, field-name
      label.
- [ ] BP 5.8 regression suite still green.

https://claude.ai/code/session_01SDNEeVvYCWAxm6z7WqEAjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDNEeVvYCWAxm6z7WqEAjK)_