### PR TITLE
BP 5.10 — Adjudication API Stabilization (Phase 1 closer)

### DIFF
--- a/docs/architecture/adjudication-api-stabilization.md
+++ b/docs/architecture/adjudication-api-stabilization.md
@@ -1,0 +1,288 @@
+# Adjudication API Stabilization (Capability BP 5.10)
+
+**Status:** Implemented in BP 5.10. Closes Benefit Plan Phase 1.
+
+This capability wires two existing-but-deferred seams into the
+adjudication hot path so the engine actually consumes the model the
+plan author wrote down:
+
+1. **Effective-date filtering** on `ServiceCategoryResolver`
+   (BP 5.6 captured `EffectiveStart` / `EffectiveEnd` / `IsActive` —
+   nothing read them).
+2. **`BenefitRulePredicate` evaluation** during benefit lookup
+   (BP 5.4 shipped the model + evaluator + unit tests — nothing read
+   them at adjudication time).
+
+The X12-alias deferral (operator text labels vs X12 5010 codes) stays
+as a Phase 2 capability with its posture recorded explicitly here so
+the next person to read the code knows why the surface is shaped the
+way it is.
+
+## Effective-date filtering on ServiceCategoryResolver
+
+`IServiceCategoryResolver.ResolveAsync` gains a non-optional
+`DateOnly serviceDate` parameter, positioned right after
+`benefitPlanId`. The breaking signature change is mechanical at the
+call sites — both engine callers (`BenefitCalculationEngine`'s DRG
+path and per-line path) already have `request.ServiceDate` in scope.
+
+`ServiceCategoryResolver.FindMatch` filters mappings before iterating
+rules:
+
+```text
+mapping is in effect for serviceDate iff
+  mapping.IsActive == true
+  AND (mapping.EffectiveStart is null OR mapping.EffectiveStart <= serviceDate)
+  AND (mapping.EffectiveEnd   is null OR mapping.EffectiveEnd   >= serviceDate)
+```
+
+Both bounds are **inclusive**. `null` bound = open. `IsActive == false`
+filters the row regardless of date — operators use `IsActive` as an
+emergency kill switch independent of the date window.
+
+**Worked example.** A mapping authored with
+`EffectiveStart = 2026-01-01, EffectiveEnd = 2026-12-31` does **not**
+match a 2025-12-15 service date even when it's the only mapping the
+tenant has authored — the resolver falls through to tenant-default
+mappings, then to the POS-based inference fallback.
+
+**Service date semantics.** "Service date" is the **claim line's**
+service date, not the adjudication date. A claim adjudicated in 2027
+for service performed on 2026-08-15 hits 2026 mappings. This matters
+for retroactive adjudication and for delayed claims processing.
+
+**Filtering is in-memory.** The repo seam (`GetMappingsAsync`) is
+unchanged — filtering runs over the cached mapping list. No backend
+round-trip per service date.
+
+**Producer-boundary validation.** The
+`ServiceCategoryMappingsController` rejects requests where
+`EffectiveEnd < EffectiveStart` with a 400 (`effective_window_invalid`,
+field-level message `"effectiveEnd must be on or after
+effectiveStart"`). Backfill of historical malformed rows is
+operator-driven; the validation gate prevents new bad rows from being
+authored.
+
+**Telemetry.** Counter
+`cho.benefit_plan.scm_filtered_by_effective_window.total` (dimensions:
+`cho.tenant_id`, `cho.scope = plan|tenant`) increments per call when
+filtering removes ≥1 row from a non-empty mapping set. Gives operators
+a signal that effective-date authoring is doing real work.
+
+## BenefitRulePredicate evaluation in adjudication
+
+`BenefitRulePredicate` (model + evaluator) was introduced in BP 5.4
+and lived as dead state on the wire until BP 5.10 wired it into the
+engine.
+
+### Request-shape extension
+
+A new `MemberContext` record on `BenefitResolutionRequest` carries
+member demographics + diagnosis context fed to predicate evaluation:
+
+```csharp
+public record MemberContext
+{
+    public int? AgeYears { get; init; }
+    public BenefitMemberGender? Gender { get; init; }
+    public IReadOnlyCollection<string>? DiagnosisCodes { get; init; }
+}
+
+public MemberContext? Member { get; init; }
+```
+
+`Member` is **optional**. When the caller doesn't supply demographic
+context, the engine falls back to the per-line `DiagnosisCodes` for
+the diagnosis facet (so a single-dx claim still gates correctly even
+when the controller hasn't plumbed member-level dx into
+`MemberContext`).
+
+### Evaluation point
+
+After `ServiceCategoryResolver` returns a non-null
+`ServiceCategoryMatch`, the engine calls into `IBenefitRuleGate` to
+pick the applicable benefit:
+
+1. Look up every `BenefitCategoryConfig` whose `ServiceTypeCode`
+   matches via `BenefitPlanConfig.GetCategories(code)`.
+2. Iterate in declaration order (matches `BenefitPlan.Benefits`
+   order at the projection seam).
+3. Return the first benefit whose
+   `BenefitCategoryConfig.Predicate` is satisfied by the member
+   encounter, or `null` if every candidate's predicate rejects.
+
+### Worked example — pediatric vs adult office visit
+
+A plan authors two benefits with `ServiceCategory = "98"`:
+
+| Benefit                       | Predicate                  |
+|-------------------------------|----------------------------|
+| Pediatric Office Visit        | `MemberAgeMin = 0, MemberAgeMax = 17` |
+| Adult Office Visit            | `MemberAgeMin = 18`        |
+
+Both project to one engine config with two `BenefitCategoryConfig`
+entries sharing `ServiceTypeCode = "98"`. The rule gate picks the
+right one per encounter; the rest of the cost-sharing waterfall runs
+against the gate's choice.
+
+### Decisions
+
+#### Decision 1 — multiple benefits with the same ServiceCategory
+
+The pre-BP-5.10 projection (`ChoBenefitPlanProvider.MapToConfig`)
+projected every `Benefit` to its own `BenefitCategoryConfig` but the
+lookup helper `GetCategory` used `FirstOrDefault` and effectively
+deduplicated by service type code. The second benefit was unreachable.
+
+BP 5.10 splits the lookup:
+
+- `GetFirstCategory(code)` — legacy any-match. Kept for callers that
+  don't need predicate evaluation (limit checks, audit lookups).
+- `GetCategories(code)` — full ordered set. Used by the rule gate.
+- `GetCategory(code)` — `[Obsolete]` shim that delegates to
+  `GetFirstCategory`. Removed in a follow-up PR after the deprecation
+  cycle.
+
+The first-match result is unchanged when no `Benefit` carries
+predicates, so existing pinned tests (DRG path, line-level path) keep
+passing without rewriting.
+
+#### Decision 2 — effective-date semantics
+
+`EffectiveStart <= serviceDate <= EffectiveEnd` AND
+`IsActive == true`. Both bounds inclusive. `null` bound = open.
+`IsActive == false` filters regardless of window. Service date is the
+claim line's service date, not the adjudication date.
+
+#### Decision 3 — null-MemberContext posture
+
+The default `BenefitRulePredicate.Evaluate(null context) => false`
+is the right posture *for callers that own the context*. The engine
+hot path doesn't always own it (today, never; tomorrow, usually). Two
+postures available:
+
+- **A — strict:** always require `MemberContext`. The engine fails
+  any request without one. Forces the controller to source DOB /
+  gender / diagnoses on every call.
+- **B — best-effort:** when `MemberContext` is null, skip predicate
+  evaluation entirely. Every benefit is considered applicable.
+  Predicate-rejected denials only happen when the caller chose to
+  supply context.
+
+**Decision: B (best-effort).** Phase 1 plans authored today don't use
+`Rules`. The Argo workflow doesn't supply demographics today. Going
+strict would fail every adjudication on day one. Going best-effort
+lets the feature roll out per-tenant as plan authors start using
+`Rules` and as the controller starts plumbing `MemberContext` from
+coverage fetches.
+
+When `MemberContext` is non-null, predicate evaluation is **strict**
+— context-required facets that the context can't satisfy fail closed
+(unchanged from the existing `BenefitRulePredicate.Evaluate`
+semantics).
+
+Counter
+`cho.benefit_plan.predicate_skipped_no_member_context.total`
+(dimensions: `cho.tenant_id`, `cho.service_type_code`) fires when the
+gate encounters a benefit with a non-null predicate AND null
+`MemberContext`. Operators see "this plan has rules but my caller
+isn't supplying context" without reading engine logs.
+
+#### Decision 4 — Benefit.Rules as List<BenefitRulePredicate>?
+
+The model is a list. BP 5.10 projects only the first non-null
+predicate. Multi-predicate AND semantics is Phase 2 — it warrants its
+own design pass (rare in authored plans today; want operator-visible
+signal first).
+
+Counter `cho.benefit_plan.predicate_multi_rule_truncated.total`
+(dimension: `cho.tenant_id`) fires when projection sees a
+`Benefit.Rules.Count > 1`, plus a structured warning log naming the
+plan + benefit so operators see if multi-predicate rules are being
+authored in the wild.
+
+#### Decision 5 — resolver signature breaking change
+
+`IServiceCategoryResolver.ResolveAsync` gains `DateOnly serviceDate`
+as a non-optional parameter. Breaking. The two engine callers
+(`BenefitCalculationEngine`) already have `request.ServiceDate` in
+scope; the change is mechanical at the call sites and the test
+fixtures. The interface is internal-to-CHO and not consumed by any
+external artifact (no client SDK, no FHIR contract). The breaking
+change costs nothing externally.
+
+#### Decision 6 — denial code for predicate-rejected benefit
+
+`96` (Non-covered charge[s]). Reusing the existing code is correct:
+from the X12 835 perspective, the service is genuinely not covered
+for this member-and-encounter combination. The narrative description
+distinguishes it from a missing-mapping `96`:
+
+| Path | Code | Description |
+|------|------|-------------|
+| Mapping resolved, category matched, predicate rejected | `96` | `"Benefit category {ServiceTypeCode} matched but no rule predicate is satisfied for this member encounter"` |
+| Mapping resolved, category not configured | `96` | `"No benefit configured for service type {ServiceTypeCode}"` |
+| Mapping resolved, category not covered | `96` | `"{description} is not covered under this plan"` |
+| Mapping not resolved | `18` | `"No benefit category mapping for procedure code"` |
+
+The narratives are operator-facing — they're also what surfaces in
+the explanation-of-benefits tooling.
+
+## Phase 2 deferrals
+
+Recorded explicitly so the next person reading the code knows the
+shape of the surface and why these aren't BP 5.10:
+
+| Item | Rationale |
+|------|-----------|
+| `ServiceTypeCodeAlias` table for X12 5010 ↔ free-text translation | Real translation surface that needs its own bundle authoring story, alias-precedence rules, and a real-world data audit. The SCM seed bundle ships operator-friendly text labels and works today; the alias is an enhancement, not a closer. |
+| Multi-predicate `Benefit.Rules` AND semantics | The model carries `List<BenefitRulePredicate>?` but BP 5.10 projects only the first. Most authored plans use one predicate per benefit; multi-predicate is rare and warrants its own design pass. |
+| Member DOB → `AgeYears` plumbing in `AdjudicationController` | The controller wires up `MemberContext` on the request when caller-supplied; AgeYears computation from a Coverage-fetched DOB at the controller seam is a follow-up. |
+| `UpdatedBy` / `UpdatedAt` audit fields on `ServiceCategoryMapping` | Service-wide audit-pattern initiative tracked separately. |
+| Telemetry-driven hard-validation flip on legacy `EffectiveEnd < EffectiveStart` | Producer-boundary 400 ships in BP 5.10. Backfill of any historical malformed rows is operator-driven. |
+| `BenefitRuleEvaluationContext.HasRelatedEncounter` wiring at the controller | Encounter-history lookup belongs in claims-service / encounter-service. The model + evaluator path supports it; nothing in BP 5.10 supplies it. Predicates that require it fail closed when the supplier function is null — same posture as the existing evaluator. |
+
+## What this closes
+
+- **Benefit Plan Phase 1** (capabilities BP 5.1 → BP 5.10) ships.
+- The two BP-internal "deferred to BP 5.10" markers in
+  `service-category-mapping.md` and `declarative-benefit-model.md`
+  flip to shipped.
+- The engine adjudicates against the model the plan author actually
+  wrote down — age- and gender-restricted benefits are honoured;
+  time-bounded mappings are honoured; the "silent no-op" hazard on
+  authoring is removed.
+
+## Benefit Plan Phase 1 — capability ledger
+
+| Capability | Title                                                  | Status | Reference doc                                           |
+|------------|--------------------------------------------------------|--------|---------------------------------------------------------|
+| BP 5.1     | Plan Identity & Versioning                             | Shipped | `plan-versioning.md`                                    |
+| BP 5.2     | Benefit Plan Adapter Pattern                           | Shipped | `benefit-plan-adapter-pattern.md`                       |
+| BP 5.3     | Plan-Year Definition Foundation                        | Shipped | `plan-year-definition.md`                               |
+| BP 5.4     | Declarative Benefit Model + BenefitRulePredicate model | Shipped | `declarative-benefit-model.md`                          |
+| BP 5.5     | NetworkTier ↔ Organization reference                   | Shipped | `network-tier-organization-reference.md`                |
+| BP 5.6     | Service Category Mapping                               | Shipped | `service-category-mapping.md`                           |
+| BP 5.7     | Family Accumulator Models + ACA cap                    | Shipped | `family-accumulator-models.md`                          |
+| BP 5.8     | FHIR InsurancePlan projection                          | Shipped | `fhir-insuranceplan-projection.md`                      |
+| BP 5.9     | Benefits Viewer                                        | Shipped | `benefits-viewer.md`                                    |
+| BP 5.10    | Adjudication API Stabilization (Phase 1 closer)        | **Shipped (this doc)** | `adjudication-api-stabilization.md`         |
+
+Phase 2 picks up: X12 alias table, multi-predicate AND semantics,
+member-DOB plumbing into the adjudication request, service-wide audit
+fields on `ServiceCategoryMapping`, and encounter-history wiring for
+related-encounter predicates.
+
+## File map
+
+| File | Role |
+|------|------|
+| `src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitRulePredicate.cs` | Predicate model + evaluator + context, moved into the engine domain so the engine can reference it without a circular dependency on benefit-plan-service. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Services/ServiceCategoryResolver.cs` | Effective-date filtering + `serviceDate` parameter on `ResolveAsync`. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitRuleGate.cs` | New `IBenefitRuleGate` + default implementation; the predicate-aware benefit selector. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitCalculationEngine.cs` | Routes through the rule gate after category resolution; threads `request.ServiceDate` into the resolver. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs` | `BenefitCategoryConfig.Predicate` field, `GetFirstCategory` / `GetCategories` lookup pair. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitEngineMetrics.cs` | Engine-side counters for the SCM-window-filter and skipped-no-context paths. |
+| `src/engines/CloudHealthOffice.BenefitEngine/Models/BenefitModels.cs` | `MemberContext` record + `BenefitResolutionRequest.Member` field. |
+| `src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs` | Projects `Benefit.Rules[0]` onto `BenefitCategoryConfig.Predicate`; emits the multi-rule truncated counter. |
+| `src/services/benefit-plan-service/Controllers/ServiceCategoryMappingsController.cs` | 400 on `EffectiveEnd < EffectiveStart`. |

--- a/docs/architecture/declarative-benefit-model.md
+++ b/docs/architecture/declarative-benefit-model.md
@@ -135,10 +135,14 @@ Evaluation rules:
   `HasRelatedEncounter` source fails closed: we'd rather decline a
   benefit than admit one we can't verify.
 
-5.4 establishes the predicate type and its in-process evaluator. The
-calculation engine doesn't read the predicate yet (Strategy A — see
-below); 5.7 / 5.10 will wire the predicate into the adjudication hot
-path so age- and diagnosis-restricted benefits are evaluated correctly.
+5.4 established the predicate type and its in-process evaluator;
+**BP 5.10** wires it into the adjudication hot path through
+`IBenefitRuleGate` so age-, gender-, and diagnosis-restricted
+benefits are evaluated correctly. See
+[`adjudication-api-stabilization.md`](adjudication-api-stabilization.md)
+for the rule-gate placement, the null-`MemberContext` posture
+(Decision 3), and the projection-shape change that lets a plan author
+multiple benefits with the same `ServiceCategory` (Decision 1).
 
 ## Engine integration: Strategy A (deferred type-awareness)
 

--- a/docs/architecture/family-accumulator-models.md
+++ b/docs/architecture/family-accumulator-models.md
@@ -185,8 +185,9 @@ nudge to surface the cap before submit.
 
 ## Out of scope for 5.7
 
-- `BenefitRulePredicate` evaluation in the calc engine (deferred to
-  5.10).
+- `BenefitRulePredicate` evaluation in the calc engine — shipped in
+  **BP 5.10**; see
+  [`adjudication-api-stabilization.md`](adjudication-api-stabilization.md).
 - `Unknown=0` migration on `FamilyAccumulatorModel` and
   `AccumulatorType` enums (deferred to a follow-up "BenefitEngine enum
   hygiene" PR — see PR #705 convention).

--- a/docs/architecture/service-category-mapping.md
+++ b/docs/architecture/service-category-mapping.md
@@ -178,28 +178,27 @@ This produces a known incoherence with X12 5010 standards:
 **operator-friendly text labels** matching the plan-author convention.
 A plan with `Benefit.ServiceCategory = "Office Visit"` adjudicates
 correctly against the seeded `Office Visit` mapping. X12 5010 alignment
-is **deferred** to a future capability (likely **BP 5.10 Adjudication
-API Stabilization** or a dedicated translation-layer follow-up) that
-introduces a `ServiceTypeCodeAlias` table joining canonical X12 codes
-to operator text labels.
+remains a **Phase 2** capability — a dedicated translation-layer
+follow-up will introduce a `ServiceTypeCodeAlias` table joining
+canonical X12 codes to operator text labels.
 
 This decision is recorded explicitly so future changes to either
 surface honour the constraint that they must remain key-equal until the
 translation-layer capability lands.
 
-## Effective-date fields (additive, deferred wiring)
+## Effective-date fields (shipped in BP 5.10)
 
 The `ServiceCategoryMapping` entity carries `EffectiveStart`,
-`EffectiveEnd`, and `IsActive` fields as of BP 5.6. **The resolver does
-not yet filter on these** — they're authoring metadata captured for
-forward compatibility. A future capability (likely BP 5.10) wires
-effective-date filtering into `ServiceCategoryResolver` once the X12
-coherence loop closes and operators start authoring time-bounded
-mappings (e.g. annual CMS quarterly updates).
+`EffectiveEnd`, and `IsActive` fields as of BP 5.6. As of **BP 5.10**
+the resolver filters on these fields against the claim line's service
+date — see
+[`adjudication-api-stabilization.md`](adjudication-api-stabilization.md)
+for the inclusive-bound semantics, the `IsActive` kill-switch posture,
+and the producer-boundary 400 on `EffectiveEnd < EffectiveStart`.
 
 The entity also carries `CreatedAt` (DateTimeOffset, populated by the
-storage backends on insert if unset). Unlike the effective-date fields
-this one **is** consumed today — the storage backends sort by
+storage backends on insert if unset). Like the effective-date fields,
+this one is consumed today — the storage backends sort by
 `CreatedAt DESC` so the resolver's first-match-wins iteration is
 deterministic across seeder version-bump re-applies. `UpdatedBy`,
 `UpdatedAt`, and operator audit fields remain deferred to a service-
@@ -210,8 +209,8 @@ wide audit-pattern initiative.
 - **Bulk import / validate endpoints** — file-format UX, partial-failure
   semantics, and dry-run mode warrant their own design pass. The CRUD
   surface unblocks the common authoring case.
-- **Effective-date resolver filtering** — fields are present, the
-  resolver doesn't filter on them yet (deferred to BP 5.10).
+- **Effective-date resolver filtering** — shipped in **BP 5.10**. See
+  [`adjudication-api-stabilization.md`](adjudication-api-stabilization.md).
 - **Audit fields** (`UpdatedBy`, `UpdatedAt`) — deferred to a service-
   wide audit-pattern initiative. `CreatedAt` is in scope (added in BP
   5.6 to drive deterministic resolver ordering across re-applies — see
@@ -219,12 +218,11 @@ wide audit-pattern initiative.
 - **Version chain on mapping documents** — mappings are operational
   reference data; updates are last-write-wins with operational audit
   via structured request logging.
-- **`BenefitRulePredicate` evaluation** — out of scope per the explicit
-  note in
-  [`BenefitRulePredicate.cs:14`](../../src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs);
-  deferred to BP 5.7 / BP 5.10.
-- **X12 ↔ free-text translation layer** — the load-bearing future
-  capability that closes the incoherence documented above.
+- **`BenefitRulePredicate` evaluation** — shipped in **BP 5.10**. See
+  [`adjudication-api-stabilization.md`](adjudication-api-stabilization.md).
+- **X12 ↔ free-text translation layer** — Phase 2 capability;
+  unchanged from BP 5.6 — the load-bearing follow-up that closes the
+  incoherence documented above.
 
 ## Operating notes
 

--- a/src/engines/CloudHealthOffice.BenefitEngine/Configuration/BenefitEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Configuration/BenefitEngineRegistration.cs
@@ -37,6 +37,7 @@ public static class BenefitEngineServiceCollectionExtensions
         // Core engine (always registered)
         services.AddScoped<IBenefitCalculationEngine, BenefitCalculationEngine>();
         services.AddScoped<IServiceCategoryResolver, ServiceCategoryResolver>();
+        services.AddScoped<IBenefitRuleGate, BenefitRuleGate>();
 
         return new BenefitEngineBuilder(services);
     }

--- a/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitDomain.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitDomain.cs
@@ -159,11 +159,10 @@ public class ServiceCategoryMapping
     public string ServiceTypeDescription { get; set; } = default!;
     public List<ProcedureCodeRule> Rules { get; set; } = [];
 
-    // Authoring metadata (capability BP 5.6). Resolver-side filtering on
-    // EffectiveStart/EffectiveEnd/IsActive is deferred — these fields are
-    // additive today so authors can record window/lifecycle intent without
-    // changing adjudication behavior. A future capability (BP 5.10 closer)
-    // wires effective-date filtering into ServiceCategoryResolver.
+    // Authoring metadata. ServiceCategoryResolver filters mappings by
+    // these fields against the claim line's service date as of capability
+    // BP 5.10 — see docs/architecture/adjudication-api-stabilization.md
+    // for the inclusive-bound semantics and IsActive kill-switch posture.
     public DateOnly? EffectiveStart { get; set; }
     public DateOnly? EffectiveEnd { get; set; }
     public bool IsActive { get; set; } = true;

--- a/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitRulePredicate.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Domain/BenefitRulePredicate.cs
@@ -1,18 +1,21 @@
 using System.Text.Json.Serialization;
 
-namespace BenefitPlanService.Models.Benefits;
+namespace CloudHealthOffice.BenefitEngine.Domain;
 
 /// <summary>
-/// Declarative gate that restricts when a <see cref="Benefit"/> applies to
-/// a given member encounter. All facets are optional — an unset facet is
+/// Declarative gate that restricts when a benefit applies to a given
+/// member encounter. All facets are optional — an unset facet is
 /// "no opinion" and never blocks the benefit. A predicate evaluates to
 /// true (benefit applies) only when every set facet matches the supplied
 /// <see cref="BenefitRuleEvaluationContext"/>.
 ///
 /// <para>
-/// 5.4 introduces the predicate shape and its in-process evaluator.
-/// Wiring it into the <c>BenefitCalculationEngine</c> hot path is deferred
-/// (Strategy A); 5.7 / 5.10 will exercise predicates during adjudication.
+/// BP 5.4 introduced the predicate shape and its in-process evaluator;
+/// BP 5.10 (Adjudication API Stabilization) consumes it from the
+/// <c>BenefitCalculationEngine</c> hot path through
+/// <c>IBenefitRuleGate</c>. The type lives in the engine domain so the
+/// engine and the benefit-plan-service can share it without a
+/// circular reference.
 /// </para>
 /// </summary>
 public class BenefitRulePredicate

--- a/src/engines/CloudHealthOffice.BenefitEngine/Models/BenefitModels.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Models/BenefitModels.cs
@@ -57,6 +57,31 @@ public record BenefitResolutionRequest
     /// COB context. Null for primary claims.
     /// </summary>
     public CobInfo? Cob { get; init; }
+
+    /// <summary>
+    /// Member demographics + diagnosis context fed into
+    /// <see cref="Domain.BenefitRulePredicate"/> evaluation during the
+    /// adjudication hot path (capability BP 5.10). Optional. When null,
+    /// the engine skips predicate evaluation entirely and treats every
+    /// candidate benefit as applicable — see Decision 3 in
+    /// <c>docs/architecture/adjudication-api-stabilization.md</c>.
+    /// </summary>
+    public MemberContext? Member { get; init; }
+}
+
+/// <summary>
+/// Optional member-and-encounter context supplied by the caller for
+/// declarative benefit-rule evaluation. Populated from coverage
+/// information / member demographics at the controller seam. When the
+/// caller can't supply a field it is left null and the predicate
+/// either ignores the missing facet (no opinion) or fails closed
+/// (context-required facets) — see <see cref="Domain.BenefitRulePredicate.Evaluate"/>.
+/// </summary>
+public record MemberContext
+{
+    public int? AgeYears { get; init; }
+    public BenefitMemberGender? Gender { get; init; }
+    public IReadOnlyCollection<string>? DiagnosisCodes { get; init; }
 }
 
 public record CobInfo

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitCalculationEngine.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitCalculationEngine.cs
@@ -60,6 +60,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
     private readonly IServiceCategoryResolver _categoryResolver;
     private readonly IBenefitPlanProvider _planProvider;
     private readonly IAccumulatorService _accumulatorService;
+    private readonly IBenefitRuleGate _ruleGate;
     private readonly ILogger<BenefitCalculationEngine> _logger;
 
     private static string SanitizeForLog(string? value) =>
@@ -69,11 +70,13 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
         IServiceCategoryResolver categoryResolver,
         IBenefitPlanProvider planProvider,
         IAccumulatorService accumulatorService,
+        IBenefitRuleGate ruleGate,
         ILogger<BenefitCalculationEngine> logger)
     {
         _categoryResolver = categoryResolver;
         _planProvider = planProvider;
         _accumulatorService = accumulatorService;
+        _ruleGate = ruleGate;
         _logger = logger;
     }
 
@@ -299,7 +302,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
         // Resolve benefit category from the first line (all lines share the category for DRG)
         var firstLine = request.Lines.OrderBy(l => l.LineNumber).First();
         var categoryMatch = await _categoryResolver.ResolveAsync(
-            plan.TenantId, request.BenefitPlanId,
+            plan.TenantId, request.BenefitPlanId, request.ServiceDate,
             firstLine.ProcedureCode, firstLine.CodeType ?? "CPT",
             firstLine.PlaceOfService, firstLine.Modifiers,
             firstLine.RevenueCode, ct);
@@ -314,8 +317,29 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
             };
         }
 
-        var benefitCategory = plan.GetCategory(categoryMatch.ServiceTypeCode);
-        if (benefitCategory is null || !benefitCategory.IsCovered)
+        var candidates = plan.GetCategories(categoryMatch.ServiceTypeCode);
+        if (candidates.Count == 0)
+        {
+            return new BenefitResolutionResult
+            {
+                Success = false,
+                DenialReasonCode = "96",
+                DenialReasonDescription = "Service not covered under this plan"
+            };
+        }
+
+        var benefitCategory = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, firstLine);
+        if (benefitCategory is null)
+        {
+            return new BenefitResolutionResult
+            {
+                Success = false,
+                DenialReasonCode = "96",
+                DenialReasonDescription = $"Benefit category {categoryMatch.ServiceTypeCode} matched but no rule predicate is satisfied for this member encounter"
+            };
+        }
+
+        if (!benefitCategory.IsCovered)
         {
             return new BenefitResolutionResult
             {
@@ -413,7 +437,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
         var allowedAmount = request.AllowedAmounts.GetValueOrDefault(line.LineNumber, billedAmount);
 
         var categoryMatch = await _categoryResolver.ResolveAsync(
-            plan.TenantId, request.BenefitPlanId,
+            plan.TenantId, request.BenefitPlanId, request.ServiceDate,
             line.ProcedureCode, line.CodeType ?? "CPT",
             line.PlaceOfService, line.Modifiers,
             line.RevenueCode, ct);
@@ -425,12 +449,26 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
                 "No benefit category mapping for procedure code");
         }
 
-        var benefitCategory = plan.GetCategory(categoryMatch.ServiceTypeCode);
-        if (benefitCategory is null)
+        var candidates = plan.GetCategories(categoryMatch.ServiceTypeCode);
+        if (candidates.Count == 0)
         {
             return CreateDeniedLine(line, billedAmount, allowedAmount,
                 "96", "Non-covered charge(s)",
                 $"No benefit configured for service type {categoryMatch.ServiceTypeCode}");
+        }
+
+        // Capability BP 5.10: route through the rule gate so plans that
+        // author multiple benefits with the same ServiceCategory (e.g.
+        // pediatric vs adult Office Visit) pick the right one per
+        // member encounter. Returns null only when every candidate's
+        // BenefitRulePredicate rejects.
+        var benefitCategory = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, line);
+        if (benefitCategory is null)
+        {
+            return CreateDeniedLine(line, billedAmount, allowedAmount,
+                "96", "Non-covered charge(s)",
+                $"Benefit category {categoryMatch.ServiceTypeCode} matched but no rule predicate is satisfied for this member encounter",
+                categoryMatch.ServiceTypeCode, categoryMatch.ServiceTypeDescription);
         }
 
         if (!benefitCategory.IsCovered)

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitCalculationEngine.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitCalculationEngine.cs
@@ -317,18 +317,18 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
             };
         }
 
-        var candidates = plan.GetCategories(categoryMatch.ServiceTypeCode);
-        if (candidates.Count == 0)
+        var gateResult = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, firstLine);
+        if (gateResult.CandidateCount == 0)
         {
             return new BenefitResolutionResult
             {
                 Success = false,
                 DenialReasonCode = "96",
-                DenialReasonDescription = "Service not covered under this plan"
+                DenialReasonDescription = $"No benefit configured for service type {categoryMatch.ServiceTypeCode}"
             };
         }
 
-        var benefitCategory = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, firstLine);
+        var benefitCategory = gateResult.Selected;
         if (benefitCategory is null)
         {
             return new BenefitResolutionResult
@@ -345,7 +345,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
             {
                 Success = false,
                 DenialReasonCode = "96",
-                DenialReasonDescription = "Service not covered under this plan"
+                DenialReasonDescription = $"{benefitCategory.ServiceTypeDescription} is not covered under this plan"
             };
         }
 
@@ -372,7 +372,11 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
                 LineNumber = line.LineNumber,
                 IsCovered = true,
                 ServiceTypeCode = categoryMatch.ServiceTypeCode,
-                ServiceTypeDescription = categoryMatch.ServiceTypeDescription,
+                // Use the picked benefit's description so plans authoring
+                // multiple benefits per service-type code (e.g. Pediatric
+                // vs Adult Office Visit) report the selected benefit's
+                // label rather than the resolver/system label.
+                ServiceTypeDescription = benefitCategory.ServiceTypeDescription,
                 AuthRequired = benefitCategory.AuthRequired,
                 AuthFound = true,
                 BilledAmount = line.BilledAmount,
@@ -449,34 +453,38 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
                 "No benefit category mapping for procedure code");
         }
 
-        var candidates = plan.GetCategories(categoryMatch.ServiceTypeCode);
-        if (candidates.Count == 0)
-        {
-            return CreateDeniedLine(line, billedAmount, allowedAmount,
-                "96", "Non-covered charge(s)",
-                $"No benefit configured for service type {categoryMatch.ServiceTypeCode}");
-        }
-
         // Capability BP 5.10: route through the rule gate so plans that
         // author multiple benefits with the same ServiceCategory (e.g.
         // pediatric vs adult Office Visit) pick the right one per
-        // member encounter. Returns null only when every candidate's
-        // BenefitRulePredicate rejects.
-        var benefitCategory = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, line);
+        // member encounter. The result distinguishes "no benefit
+        // configured" (CandidateCount == 0) from "configured but every
+        // predicate rejected" (CandidateCount > 0, Selected == null).
+        var gateResult = _ruleGate.PickApplicable(plan, categoryMatch.ServiceTypeCode, request, line);
+        if (gateResult.CandidateCount == 0)
+        {
+            return CreateDeniedLine(line, billedAmount, allowedAmount,
+                "96", $"No benefit configured for service type {categoryMatch.ServiceTypeCode}",
+                serviceTypeCode: categoryMatch.ServiceTypeCode,
+                serviceTypeDescription: categoryMatch.ServiceTypeDescription);
+        }
+
+        var benefitCategory = gateResult.Selected;
         if (benefitCategory is null)
         {
             return CreateDeniedLine(line, billedAmount, allowedAmount,
-                "96", "Non-covered charge(s)",
+                "96",
                 $"Benefit category {categoryMatch.ServiceTypeCode} matched but no rule predicate is satisfied for this member encounter",
-                categoryMatch.ServiceTypeCode, categoryMatch.ServiceTypeDescription);
+                serviceTypeCode: categoryMatch.ServiceTypeCode,
+                serviceTypeDescription: categoryMatch.ServiceTypeDescription);
         }
 
         if (!benefitCategory.IsCovered)
         {
             return CreateDeniedLine(line, billedAmount, allowedAmount,
-                "96", "Non-covered charge(s)",
-                $"{categoryMatch.ServiceTypeDescription} is not covered under this plan",
-                categoryMatch.ServiceTypeCode, categoryMatch.ServiceTypeDescription);
+                "96",
+                $"{benefitCategory.ServiceTypeDescription} is not covered under this plan",
+                serviceTypeCode: categoryMatch.ServiceTypeCode,
+                serviceTypeDescription: benefitCategory.ServiceTypeDescription);
         }
 
         var limitCheck = CheckLimits(benefitCategory, accumulators, line);
@@ -485,7 +493,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
             return CreateDeniedLine(line, billedAmount, allowedAmount,
                 limitCheck.DenialCode!, limitCheck.DenialDescription!,
                 limitCheck.DenialDescription,
-                categoryMatch.ServiceTypeCode, categoryMatch.ServiceTypeDescription);
+                categoryMatch.ServiceTypeCode, benefitCategory.ServiceTypeDescription);
         }
 
         var networkTierForRules = request.IsEmergency ? NetworkTier.InNetwork : request.NetworkTier;
@@ -497,7 +505,7 @@ public class BenefitCalculationEngine : IBenefitCalculationEngine
             line, billedAmount, allowedAmount,
             costShareRules, accumulators, request.NetworkTier,
             request.IsEmergency, plan,
-            categoryMatch.ServiceTypeCode, categoryMatch.ServiceTypeDescription,
+            categoryMatch.ServiceTypeCode, benefitCategory.ServiceTypeDescription,
             benefitCategory.AuthRequired);
 
         if (request.Cob is { PayerSequence: 2 } cob)

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitEngineMetrics.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitEngineMetrics.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.Metrics;
+
+namespace CloudHealthOffice.BenefitEngine.Services;
+
+/// <summary>
+/// Engine-internal counters that don't depend on
+/// <c>CloudHealthOffice.Infrastructure</c> (the engine project sits
+/// below the shared infra assembly). All instruments share the
+/// canonical <c>"CloudHealthOffice"</c> meter name so OpenTelemetry /
+/// Prometheus exporters need only one subscription regardless of
+/// which assembly defines the instrument.
+/// </summary>
+internal static class BenefitEngineMetrics
+{
+    private const string MeterName = "CloudHealthOffice";
+
+    private static readonly Meter Meter = new(MeterName,
+        typeof(BenefitEngineMetrics).Assembly.GetName().Version?.ToString() ?? "0.0.0");
+
+    /// <summary>
+    /// Counter incremented when <see cref="ServiceCategoryResolver"/>
+    /// drops one or more rows from a non-empty mapping set because
+    /// they fell outside the claim's effective window or carry
+    /// <c>IsActive == false</c>. Operators read this to confirm
+    /// time-bounded mapping authoring is producing real filtering
+    /// activity. Dimensions: <c>cho.tenant_id</c>, <c>cho.scope</c>
+    /// (<c>plan</c> | <c>tenant</c>).
+    /// </summary>
+    public static readonly Counter<long> ScmFilteredByEffectiveWindow =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.scm_filtered_by_effective_window.total",
+            unit: "{filter}",
+            description: "Service-category mappings dropped by effective-window/IsActive filtering (BP 5.10)");
+
+    /// <summary>
+    /// Counter incremented when <c>BenefitRuleGate</c> meets a
+    /// candidate benefit carrying a non-null
+    /// <see cref="Domain.BenefitRulePredicate"/> but the request did
+    /// not supply <c>MemberContext</c>. Drives the per-tenant signal
+    /// "this plan has rules but my caller isn't supplying context".
+    /// Dimensions: <c>cho.tenant_id</c>,
+    /// <c>cho.service_type_code</c>.
+    /// </summary>
+    public static readonly Counter<long> PredicateSkippedNoMemberContext =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.predicate_skipped_no_member_context.total",
+            unit: "{skip}",
+            description: "Benefits with predicates encountered without a MemberContext (BP 5.10)");
+}

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitRuleGate.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitRuleGate.cs
@@ -30,18 +30,39 @@ namespace CloudHealthOffice.BenefitEngine.Services;
 public interface IBenefitRuleGate
 {
     /// <summary>
-    /// Returns the first <see cref="BenefitCategoryConfig"/> whose
+    /// Walk every <see cref="BenefitCategoryConfig"/> whose
     /// service-type code matches <paramref name="serviceTypeCode"/>
-    /// AND whose predicate is satisfied for the supplied member
-    /// encounter, or <c>null</c> when every candidate's predicate
-    /// rejects.
+    /// and pick the first whose predicate is satisfied for the
+    /// supplied member encounter. The result distinguishes
+    /// "no configured candidate" from "candidates configured but
+    /// every predicate rejected" so the calculation engine can emit
+    /// the right denial narrative without re-querying the plan.
     /// </summary>
-    BenefitCategoryConfig? PickApplicable(
+    BenefitRuleGateResult PickApplicable(
         BenefitPlanConfig plan,
         string serviceTypeCode,
         BenefitResolutionRequest request,
         ClaimLineInput? line);
 }
+
+/// <summary>
+/// Outcome of <see cref="IBenefitRuleGate.PickApplicable"/>.
+/// </summary>
+/// <param name="Selected">
+/// The picked benefit. Null when <paramref name="CandidateCount"/> is 0
+/// (no benefit configured) or when every candidate's predicate
+/// rejected the encounter.
+/// </param>
+/// <param name="CandidateCount">
+/// Number of <see cref="BenefitCategoryConfig"/> entries whose
+/// service-type code matched, before predicate evaluation. Lets
+/// callers distinguish "no benefit configured" (CandidateCount = 0)
+/// from "configured but predicates rejected" (CandidateCount &gt; 0,
+/// Selected = null) without re-querying the plan.
+/// </param>
+public readonly record struct BenefitRuleGateResult(
+    BenefitCategoryConfig? Selected,
+    int CandidateCount);
 
 public sealed class BenefitRuleGate : IBenefitRuleGate
 {
@@ -52,7 +73,7 @@ public sealed class BenefitRuleGate : IBenefitRuleGate
         _logger = logger;
     }
 
-    public BenefitCategoryConfig? PickApplicable(
+    public BenefitRuleGateResult PickApplicable(
         BenefitPlanConfig plan,
         string serviceTypeCode,
         BenefitResolutionRequest request,
@@ -61,7 +82,7 @@ public sealed class BenefitRuleGate : IBenefitRuleGate
         var candidates = plan.GetCategories(serviceTypeCode);
         if (candidates.Count == 0)
         {
-            return null;
+            return new BenefitRuleGateResult(null, 0);
         }
 
         var memberContext = request.Member;
@@ -79,7 +100,7 @@ public sealed class BenefitRuleGate : IBenefitRuleGate
                     new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId),
                     new KeyValuePair<string, object?>("cho.service_type_code", serviceTypeCode));
             }
-            return candidates[0];
+            return new BenefitRuleGateResult(candidates[0], candidates.Count);
         }
 
         var evalContext = BuildEvaluationContext(memberContext, line);
@@ -89,20 +110,23 @@ public sealed class BenefitRuleGate : IBenefitRuleGate
             if (candidate.Predicate is null)
             {
                 // No predicate ⇒ unconditionally applicable.
-                return candidate;
+                return new BenefitRuleGateResult(candidate, candidates.Count);
             }
 
             if (candidate.Predicate.Evaluate(evalContext))
             {
-                return candidate;
+                return new BenefitRuleGateResult(candidate, candidates.Count);
             }
         }
 
-        _logger.LogInformation(
-            "BenefitRuleGate: no candidate predicate satisfied for plan {PlanId} serviceTypeCode={ServiceTypeCode} ({CandidateCount} candidates)",
-            plan.Id, serviceTypeCode, candidates.Count);
+        // Hot-path log — Debug level so a high predicate-reject rate
+        // doesn't flood operator dashboards. Telemetry-side, predicate
+        // rejections surface through the line-level 96 denials.
+        _logger.LogDebug(
+            "BenefitRuleGate: no candidate predicate satisfied for tenant {TenantId} plan {PlanId} service type {ServiceTypeCode} ({CandidateCount} candidates)",
+            plan.TenantId, plan.Id, serviceTypeCode, candidates.Count);
 
-        return null;
+        return new BenefitRuleGateResult(null, candidates.Count);
     }
 
     private static BenefitRuleEvaluationContext BuildEvaluationContext(

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitRuleGate.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/BenefitRuleGate.cs
@@ -1,0 +1,128 @@
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CloudHealthOffice.BenefitEngine.Services;
+
+/// <summary>
+/// Selects the applicable <see cref="BenefitCategoryConfig"/> for a
+/// claim line given the resolved service-type code (capability BP 5.10).
+///
+/// <para>
+/// The plan projection may carry multiple benefits with the same
+/// <c>ServiceTypeCode</c> — for example a plan that authors a
+/// "Pediatric Office Visit (age 0-17)" and an "Adult Office Visit
+/// (age 18+)" benefit, both projecting to service-type code <c>98</c>.
+/// The gate walks those candidates in declaration order and returns
+/// the first whose <see cref="BenefitCategoryConfig.Predicate"/> is
+/// satisfied for the supplied <see cref="MemberContext"/>.
+/// </para>
+///
+/// <para>
+/// Posture (Decision 3): when <see cref="MemberContext"/> is null the
+/// gate <b>skips predicate evaluation</b> and returns the first
+/// candidate as-is. This is the best-effort posture — predicates only
+/// gate adjudication when the caller chose to supply context. A
+/// non-null context activates strict evaluation; predicates that
+/// can't be satisfied with the supplied context fail closed.
+/// </para>
+/// </summary>
+public interface IBenefitRuleGate
+{
+    /// <summary>
+    /// Returns the first <see cref="BenefitCategoryConfig"/> whose
+    /// service-type code matches <paramref name="serviceTypeCode"/>
+    /// AND whose predicate is satisfied for the supplied member
+    /// encounter, or <c>null</c> when every candidate's predicate
+    /// rejects.
+    /// </summary>
+    BenefitCategoryConfig? PickApplicable(
+        BenefitPlanConfig plan,
+        string serviceTypeCode,
+        BenefitResolutionRequest request,
+        ClaimLineInput? line);
+}
+
+public sealed class BenefitRuleGate : IBenefitRuleGate
+{
+    private readonly ILogger<BenefitRuleGate> _logger;
+
+    public BenefitRuleGate(ILogger<BenefitRuleGate> logger)
+    {
+        _logger = logger;
+    }
+
+    public BenefitCategoryConfig? PickApplicable(
+        BenefitPlanConfig plan,
+        string serviceTypeCode,
+        BenefitResolutionRequest request,
+        ClaimLineInput? line)
+    {
+        var candidates = plan.GetCategories(serviceTypeCode);
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var memberContext = request.Member;
+
+        // Decision 3 best-effort: when MemberContext is null, skip
+        // predicate evaluation entirely and return the first candidate.
+        // Emit the no-context counter once per call when at least one
+        // candidate carries a predicate so operators see the per-tenant
+        // signal.
+        if (memberContext is null)
+        {
+            if (candidates.Any(c => c.Predicate is not null))
+            {
+                BenefitEngineMetrics.PredicateSkippedNoMemberContext.Add(1,
+                    new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId),
+                    new KeyValuePair<string, object?>("cho.service_type_code", serviceTypeCode));
+            }
+            return candidates[0];
+        }
+
+        var evalContext = BuildEvaluationContext(memberContext, line);
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Predicate is null)
+            {
+                // No predicate ⇒ unconditionally applicable.
+                return candidate;
+            }
+
+            if (candidate.Predicate.Evaluate(evalContext))
+            {
+                return candidate;
+            }
+        }
+
+        _logger.LogInformation(
+            "BenefitRuleGate: no candidate predicate satisfied for plan {PlanId} serviceTypeCode={ServiceTypeCode} ({CandidateCount} candidates)",
+            plan.Id, serviceTypeCode, candidates.Count);
+
+        return null;
+    }
+
+    private static BenefitRuleEvaluationContext BuildEvaluationContext(
+        MemberContext member,
+        ClaimLineInput? line)
+    {
+        // When the request didn't carry diagnoses but the line under
+        // adjudication does, fall back to the line-level diagnosis
+        // codes so a single-dx claim still gates correctly.
+        IReadOnlyCollection<string>? dx = member.DiagnosisCodes;
+        if ((dx is null || dx.Count == 0) && line is not null && line.DiagnosisCodes.Count > 0)
+        {
+            dx = line.DiagnosisCodes;
+        }
+
+        return new BenefitRuleEvaluationContext
+        {
+            MemberAgeYears = member.AgeYears,
+            MemberGender = member.Gender,
+            DiagnosisCodes = dx,
+        };
+    }
+}

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
@@ -151,16 +151,6 @@ public record BenefitPlanConfig
             string.Equals(c.ServiceTypeCode, serviceTypeCode, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// Compatibility shim for pre-BP-5.10 callers. Behaves identically
-    /// to <see cref="GetFirstCategory"/>. Will be removed after a
-    /// deprecation cycle — see
-    /// docs/architecture/adjudication-api-stabilization.md.
-    /// </summary>
-    [Obsolete("Renamed to GetFirstCategory. New callers that need predicate-aware selection should use GetCategories + IBenefitRuleGate. See docs/architecture/adjudication-api-stabilization.md.")]
-    public BenefitCategoryConfig? GetCategory(string serviceTypeCode)
-        => GetFirstCategory(serviceTypeCode);
-
-    /// <summary>
     /// Returns every <see cref="BenefitCategoryConfig"/> whose
     /// <c>ServiceTypeCode</c> matches, preserving authoring order. Used
     /// by <c>IBenefitRuleGate</c> to walk candidate benefits and pick

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Providers.cs
@@ -127,15 +127,50 @@ public record BenefitPlanConfig
     /// </summary>
     public InpatientPricingMethod DefaultInpatientPricingMethod { get; init; } = InpatientPricingMethod.PerLine;
 
-    // Benefit categories
+    // Benefit categories. Multiple entries may share the same
+    // ServiceTypeCode after BP 5.10 — projection no longer
+    // deduplicates so the rule gate can pick the correct benefit per
+    // member encounter via BenefitRulePredicate evaluation. Use
+    // GetCategories(code) for predicate-aware lookup;
+    // GetFirstCategory(code) is the legacy any-match shim.
     public List<BenefitCategoryConfig> Categories { get; init; } = [];
 
     // Cross-reference
     public string? QnxtPlanId { get; init; }
 
-    public BenefitCategoryConfig? GetCategory(string serviceTypeCode)
+    /// <summary>
+    /// Legacy any-match accessor — returns the first
+    /// <see cref="BenefitCategoryConfig"/> whose <c>ServiceTypeCode</c>
+    /// matches. Kept for callers that don't need predicate evaluation
+    /// (e.g. limit checks, audit lookups). For benefit selection during
+    /// adjudication go through <see cref="GetCategories"/> + the rule
+    /// gate so age/gender/diagnosis predicates are honoured.
+    /// </summary>
+    public BenefitCategoryConfig? GetFirstCategory(string serviceTypeCode)
         => Categories.FirstOrDefault(c =>
             string.Equals(c.ServiceTypeCode, serviceTypeCode, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Compatibility shim for pre-BP-5.10 callers. Behaves identically
+    /// to <see cref="GetFirstCategory"/>. Will be removed after a
+    /// deprecation cycle — see
+    /// docs/architecture/adjudication-api-stabilization.md.
+    /// </summary>
+    [Obsolete("Renamed to GetFirstCategory. New callers that need predicate-aware selection should use GetCategories + IBenefitRuleGate. See docs/architecture/adjudication-api-stabilization.md.")]
+    public BenefitCategoryConfig? GetCategory(string serviceTypeCode)
+        => GetFirstCategory(serviceTypeCode);
+
+    /// <summary>
+    /// Returns every <see cref="BenefitCategoryConfig"/> whose
+    /// <c>ServiceTypeCode</c> matches, preserving authoring order. Used
+    /// by <c>IBenefitRuleGate</c> to walk candidate benefits and pick
+    /// the first whose <see cref="BenefitCategoryConfig.Predicate"/>
+    /// is satisfied for the current member encounter.
+    /// </summary>
+    public IReadOnlyList<BenefitCategoryConfig> GetCategories(string serviceTypeCode)
+        => Categories
+            .Where(c => string.Equals(c.ServiceTypeCode, serviceTypeCode, StringComparison.OrdinalIgnoreCase))
+            .ToList();
 }
 
 public record BenefitCategoryConfig
@@ -160,6 +195,16 @@ public record BenefitCategoryConfig
     // Cost sharing
     public IReadOnlyList<CostShareRuleConfig> InNetworkCostSharing { get; init; } = [];
     public IReadOnlyList<CostShareRuleConfig> OutOfNetworkCostSharing { get; init; } = [];
+
+    /// <summary>
+    /// Optional declarative gate (capability BP 5.10) that restricts
+    /// when this benefit applies to the member encounter. Carries the
+    /// originating <see cref="BenefitRulePredicate"/> the projection
+    /// was built from. <c>null</c> means the benefit is unconditionally
+    /// applicable for any encounter that resolves to its
+    /// <see cref="ServiceTypeCode"/>.
+    /// </summary>
+    public BenefitRulePredicate? Predicate { get; init; }
 }
 
 public record CostShareRuleConfig

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/ServiceCategoryResolver.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/ServiceCategoryResolver.cs
@@ -22,10 +22,21 @@ public interface IServiceCategoryResolver
     /// <summary>
     /// Resolve a procedure code to a service type code.
     /// Returns null if no mapping is found (which would be an adjudication error).
+    ///
+    /// <para>
+    /// <paramref name="serviceDate"/> is the claim line's service date,
+    /// used to filter mappings by their inclusive
+    /// <see cref="Domain.ServiceCategoryMapping.EffectiveStart"/> /
+    /// <see cref="Domain.ServiceCategoryMapping.EffectiveEnd"/> window
+    /// and the <see cref="Domain.ServiceCategoryMapping.IsActive"/>
+    /// kill-switch (capability BP 5.10). A claim adjudicated in 2027
+    /// for service performed on 2026-08-15 hits 2026 mappings.
+    /// </para>
     /// </summary>
     Task<ServiceCategoryMatch?> ResolveAsync(
         string tenantId,
         Guid benefitPlanId,
+        DateOnly serviceDate,
         string procedureCode,
         string codeType,
         string placeOfService,
@@ -61,6 +72,7 @@ public class ServiceCategoryResolver : IServiceCategoryResolver
     public async Task<ServiceCategoryMatch?> ResolveAsync(
         string tenantId,
         Guid benefitPlanId,
+        DateOnly serviceDate,
         string procedureCode,
         string codeType,
         string placeOfService,
@@ -70,7 +82,8 @@ public class ServiceCategoryResolver : IServiceCategoryResolver
     {
         // 1. Try plan-specific overrides first
         var planMappings = await _repo.GetMappingsAsync(tenantId, benefitPlanId, ct);
-        var match = FindMatch(planMappings, procedureCode, codeType, placeOfService, modifiers, revenueCode);
+        var match = FindMatch(planMappings, serviceDate, procedureCode, codeType, placeOfService, modifiers, revenueCode,
+            tenantId, "plan");
         if (match is not null)
         {
             return match with { MatchedBy = "PlanOverride" };
@@ -78,7 +91,8 @@ public class ServiceCategoryResolver : IServiceCategoryResolver
 
         // 2. Try tenant-level defaults (BenefitPlanId = null)
         var tenantMappings = await _repo.GetMappingsAsync(tenantId, null, ct);
-        match = FindMatch(tenantMappings, procedureCode, codeType, placeOfService, modifiers, revenueCode);
+        match = FindMatch(tenantMappings, serviceDate, procedureCode, codeType, placeOfService, modifiers, revenueCode,
+            tenantId, "tenant");
         if (match is not null)
         {
             return match with { MatchedBy = "TenantDefault" };
@@ -103,13 +117,37 @@ public class ServiceCategoryResolver : IServiceCategoryResolver
 
     private ServiceCategoryMatch? FindMatch(
         IReadOnlyList<ServiceCategoryMapping> mappings,
+        DateOnly serviceDate,
         string procedureCode,
         string codeType,
         string placeOfService,
         IReadOnlyList<string> modifiers,
-        string? revenueCode)
+        string? revenueCode,
+        string tenantId,
+        string scope)
     {
+        // Filter by IsActive + the inclusive [EffectiveStart, EffectiveEnd]
+        // window against the claim line's service date (capability BP 5.10).
+        // null bound = open; IsActive=false drops the row regardless of
+        // window. Filtering is in-memory over the cached list — the repo
+        // seam (GetMappingsAsync) is unchanged.
+        var filtered = new List<ServiceCategoryMapping>(mappings.Count);
         foreach (var mapping in mappings)
+        {
+            if (IsInEffect(mapping, serviceDate))
+            {
+                filtered.Add(mapping);
+            }
+        }
+
+        if (mappings.Count > 0 && filtered.Count < mappings.Count)
+        {
+            BenefitEngineMetrics.ScmFilteredByEffectiveWindow.Add(1,
+                new KeyValuePair<string, object?>("cho.tenant_id", tenantId),
+                new KeyValuePair<string, object?>("cho.scope", scope));
+        }
+
+        foreach (var mapping in filtered)
         {
             // Evaluate rules in priority order
             var sortedRules = mapping.Rules.OrderBy(r => r.Priority);
@@ -131,6 +169,14 @@ public class ServiceCategoryResolver : IServiceCategoryResolver
         }
 
         return null;
+    }
+
+    private static bool IsInEffect(ServiceCategoryMapping mapping, DateOnly serviceDate)
+    {
+        if (!mapping.IsActive) return false;
+        if (mapping.EffectiveStart is { } start && serviceDate < start) return false;
+        if (mapping.EffectiveEnd is { } end && serviceDate > end) return false;
+        return true;
     }
 
     private static bool RuleMatches(

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/ServiceCategoryMappingsControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/ServiceCategoryMappingsControllerTests.cs
@@ -132,6 +132,49 @@ public sealed class ServiceCategoryMappingsControllerTests
     }
 
     [Fact]
+    public async Task Create_Returns_400_When_EffectiveEnd_Before_EffectiveStart()
+    {
+        // Capability BP 5.10 — reject impossible effective windows at
+        // the producer boundary so the resolver doesn't silently filter
+        // them out during adjudication.
+        var (controller, _, _) = Build(adminEnabled: true, tenantId: "tenant-a");
+        var bad = ValidRequest();
+        bad.EffectiveStart = new DateOnly(2026, 6, 1);
+        bad.EffectiveEnd = new DateOnly(2026, 1, 1);
+
+        var result = await controller.Create(bad, default);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Create_Accepts_Valid_Effective_Window()
+    {
+        var (controller, _, _) = Build(adminEnabled: true, tenantId: "tenant-a");
+        var ok = ValidRequest();
+        ok.EffectiveStart = new DateOnly(2026, 1, 1);
+        ok.EffectiveEnd = new DateOnly(2026, 12, 31);
+
+        var result = await controller.Create(ok, default);
+
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task Update_Returns_400_When_EffectiveEnd_Before_EffectiveStart()
+    {
+        var (controller, store, _) = Build(adminEnabled: true, tenantId: "tenant-a");
+        var seeded = await store.CreateAsync(Mapping("tenant-a", null, "Office Visit"));
+        var bad = ValidRequest();
+        bad.EffectiveStart = new DateOnly(2026, 6, 1);
+        bad.EffectiveEnd = new DateOnly(2026, 1, 1);
+
+        var result = await controller.Update(seeded.Id, bad, default);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
     public async Task Update_Returns_404_For_Missing_Mapping()
     {
         var (controller, _, _) = Build(adminEnabled: true, tenantId: "tenant-a");

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/BenefitRulePredicateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/BenefitRulePredicateTests.cs
@@ -1,4 +1,5 @@
 using BenefitPlanService.Models.Benefits;
+using CloudHealthOffice.BenefitEngine.Domain;
 
 namespace BenefitPlanService.Tests.Models.Benefits;
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
@@ -1,7 +1,8 @@
 using System.Text.Json;
 using BenefitPlanService.Models;
 using BenefitPlanService.Models.Benefits;
-using CloudHealthOffice.BenefitEngine.Domain;
+using BenefitRulePredicate = CloudHealthOffice.BenefitEngine.Domain.BenefitRulePredicate;
+using BenefitMemberGender = CloudHealthOffice.BenefitEngine.Domain.BenefitMemberGender;
 
 namespace BenefitPlanService.Tests.Models.Benefits;
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Models/Benefits/TypedBenefitSerializationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using BenefitPlanService.Models;
 using BenefitPlanService.Models.Benefits;
+using CloudHealthOffice.BenefitEngine.Domain;
 
 namespace BenefitPlanService.Tests.Models.Benefits;
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
@@ -1,7 +1,9 @@
 using BenefitPlanService.Models;
+using BenefitPlanService.Models.Benefits;
 using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
 using BenefitPlanService.Tests.Fakes;
+using CloudHealthOffice.BenefitEngine.Domain;
 using CloudHealthOffice.BenefitEngine.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
@@ -119,6 +121,88 @@ public sealed class ChoBenefitPlanProviderModelMappingTests
         var config = provider.MapToConfig(plan);
 
         config.IsAcaCapEnforced.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MapToConfig_Projects_TwoBenefitsSameServiceCategory_AsTwoEntries()
+    {
+        // BP 5.10 — projection no longer deduplicates by ServiceCategory.
+        // The rule gate consumes the duplicates and picks one per encounter.
+        var provider = Build();
+        var plan = SamplePlan();
+        plan.Benefits.Add(new MedicalBenefit { ServiceCategory = "98", Description = "Pediatric Office Visit" });
+        plan.Benefits.Add(new MedicalBenefit { ServiceCategory = "98", Description = "Adult Office Visit" });
+
+        var config = provider.MapToConfig(plan);
+
+        var pediatric = config.Categories.FirstOrDefault(c => c.ServiceTypeDescription == "Pediatric Office Visit");
+        var adult = config.Categories.FirstOrDefault(c => c.ServiceTypeDescription == "Adult Office Visit");
+        pediatric.Should().NotBeNull();
+        adult.Should().NotBeNull();
+        config.GetCategories("98").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void MapToConfig_Carries_Predicate_From_NonEmpty_Rules()
+    {
+        var provider = Build();
+        var plan = SamplePlan();
+        plan.Benefits.Add(new MedicalBenefit
+        {
+            ServiceCategory = "98",
+            Description = "Pediatric Office Visit",
+            Rules = new List<BenefitRulePredicate>
+            {
+                new() { MemberAgeMin = 0, MemberAgeMax = 17 },
+            },
+        });
+
+        var config = provider.MapToConfig(plan);
+
+        var category = config.GetCategories("98").Single();
+        category.Predicate.Should().NotBeNull();
+        category.Predicate!.MemberAgeMax.Should().Be(17);
+    }
+
+    [Fact]
+    public void MapToConfig_NullRules_LeavesPredicateNull()
+    {
+        var provider = Build();
+        var plan = SamplePlan();
+        plan.Benefits.Add(new MedicalBenefit
+        {
+            ServiceCategory = "98",
+            Description = "Office Visit",
+            Rules = null,
+        });
+
+        var config = provider.MapToConfig(plan);
+
+        config.GetCategories("98").Single().Predicate.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToConfig_MultiplePredicates_TruncatesToFirst_AndPreservesOrder()
+    {
+        // Decision 4 — multi-predicate AND semantics is Phase 2; the
+        // projection collapses to the first non-null entry.
+        var provider = Build();
+        var plan = SamplePlan();
+        var first = new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 };
+        var second = new BenefitRulePredicate { RequiredDiagnosisCodes = new() { "Z00.00" } };
+        plan.Benefits.Add(new MedicalBenefit
+        {
+            ServiceCategory = "98",
+            Description = "Pediatric Wellness",
+            Rules = new List<BenefitRulePredicate> { first, second },
+        });
+
+        var config = provider.MapToConfig(plan);
+
+        var category = config.GetCategories("98").Single();
+        category.Predicate.Should().NotBeNull();
+        category.Predicate!.MemberAgeMax.Should().Be(17, "first predicate is preserved; second is truncated");
+        category.Predicate.RequiredDiagnosisCodes.Should().BeNull();
     }
 
     [Fact]

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
@@ -3,9 +3,9 @@ using BenefitPlanService.Models.Benefits;
 using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
 using BenefitPlanService.Tests.Fakes;
-using CloudHealthOffice.BenefitEngine.Domain;
 using CloudHealthOffice.BenefitEngine.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using BenefitRulePredicate = CloudHealthOffice.BenefitEngine.Domain.BenefitRulePredicate;
 using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
 using ModelFamilyAccumulatorModel = BenefitPlanService.Models.FamilyAccumulatorModel;
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ServiceCategoryResolverIntegrationTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ServiceCategoryResolverIntegrationTests.cs
@@ -46,6 +46,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
 
         var match = await resolver.ResolveAsync(
             "tenant-a", planId,
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99213", codeType: "CPT", placeOfService: "11",
             modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -66,6 +67,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
 
         var match = await resolver.ResolveAsync(
             "tenant-a", planId,
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99213", codeType: "CPT", placeOfService: "11",
             modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -81,6 +83,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
 
         var match = await resolver.ResolveAsync(
             "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99213", codeType: "CPT", placeOfService: "11",
             modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -96,6 +99,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
 
         var match = await resolver.ResolveAsync(
             "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99213", codeType: "CPT", placeOfService: "99",
             modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -146,6 +150,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
 
         var match = await resolver.ResolveAsync(
             "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99213", codeType: "CPT", placeOfService: "11",
             modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -174,6 +179,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
         {
             var match = await resolver.ResolveAsync(
                 "tenant-a", planId,
+                serviceDate: new DateOnly(2026, 4, 1),
                 procedureCode: code, codeType: "CPT", placeOfService: "11",
                 modifiers: Array.Empty<string>(), revenueCode: null);
 
@@ -184,6 +190,7 @@ public sealed class ServiceCategoryResolverIntegrationTests
         // Outside-range fall through to POS fallback.
         var outOfRange = await resolver.ResolveAsync(
             "tenant-a", planId,
+            serviceDate: new DateOnly(2026, 4, 1),
             procedureCode: "99216", codeType: "CPT", placeOfService: "11",
             modifiers: Array.Empty<string>(), revenueCode: null);
         outOfRange!.MatchedBy.Should().Be("SystemDefault");

--- a/src/services/benefit-plan-service/Controllers/ServiceCategoryMappingsController.cs
+++ b/src/services/benefit-plan-service/Controllers/ServiceCategoryMappingsController.cs
@@ -309,6 +309,17 @@ public sealed class ServiceCategoryMappingsController : ControllerBase
                 return BadRequest(new { error = "rule_code_type_required" });
             }
         }
+        // Capability BP 5.10 — reject impossible effective windows at
+        // the producer boundary so the resolver doesn't have to silently
+        // filter them out at adjudication time.
+        if (request.EffectiveStart is { } start && request.EffectiveEnd is { } end && end < start)
+        {
+            return BadRequest(new
+            {
+                error = "effective_window_invalid",
+                message = "effectiveEnd must be on or after effectiveStart",
+            });
+        }
         return null;
     }
 

--- a/src/services/benefit-plan-service/Dockerfile
+++ b/src/services/benefit-plan-service/Dockerfile
@@ -24,6 +24,13 @@ COPY src/engines/CloudHealthOffice.ClaimsScrubEngine/ src/engines/CloudHealthOff
 COPY src/engines/CloudHealthOffice.NcciEngine/ src/engines/CloudHealthOffice.NcciEngine/
 COPY src/engines/CloudHealthOffice.ProviderEnrollmentService/ src/engines/CloudHealthOffice.ProviderEnrollmentService/
 COPY src/engines/CloudHealthOffice.PriorAuthRuleEngine/ src/engines/CloudHealthOffice.PriorAuthRuleEngine/
+# benefit-plan-service.csproj declares <Content Include="..\..\..\schemas\..."> for
+# the SystemDefaultMappingSeeder seed bundle (BP 5.6) and the AcaLimitsProvider OOP
+# limits file (BP 5.7); MSBuild copies them to the build output via
+# CopyToOutputDirectory="PreserveNewest". Without these COPY lines the build fails
+# with MSB3030 "Could not copy the file ... because it was not found."
+COPY schemas/service-category-mappings/ schemas/service-category-mappings/
+COPY schemas/aca-oop-limits/ schemas/aca-oop-limits/
 RUN dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj -c Release --no-restore
 
 # Publish stage

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using BenefitPlanService.Models.Benefits;
-using CloudHealthOffice.BenefitEngine.Domain;
+using BenefitRulePredicate = CloudHealthOffice.BenefitEngine.Domain.BenefitRulePredicate;
 
 namespace BenefitPlanService.Models;
 

--- a/src/services/benefit-plan-service/Models/BenefitPlan.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlan.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using BenefitPlanService.Models.Benefits;
+using CloudHealthOffice.BenefitEngine.Domain;
 
 namespace BenefitPlanService.Models;
 

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using BenefitPlanService.Models.Benefits;
+using CloudHealthOffice.BenefitEngine.Domain;
 
 namespace BenefitPlanService.Models;
 

--- a/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
+++ b/src/services/benefit-plan-service/Models/BenefitPlanAdapterResponse.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 using BenefitPlanService.Models.Benefits;
-using CloudHealthOffice.BenefitEngine.Domain;
+using BenefitRulePredicate = CloudHealthOffice.BenefitEngine.Domain.BenefitRulePredicate;
 
 namespace BenefitPlanService.Models;
 

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
@@ -152,7 +152,8 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
     /// </summary>
     private BenefitRulePredicate? ProjectPredicate(BenefitPlan plan, Benefit benefit)
     {
-        if (benefit.Rules is not { Count: > 0 } rules)
+        var rules = benefit.Rules;
+        if (rules is null || rules.Count == 0)
         {
             return null;
         }

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
@@ -2,6 +2,7 @@ using BenefitPlanService.Models;
 using BenefitPlanService.Repositories;
 using CloudHealthOffice.BenefitEngine.Domain;
 using CloudHealthOffice.BenefitEngine.Services;
+using CloudHealthOffice.Infrastructure.Observability;
 using EnginePlanType = CloudHealthOffice.BenefitEngine.Domain.PlanType;
 using ModelPlanType = BenefitPlanService.Models.PlanType;
 using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
@@ -58,6 +59,11 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
 
     internal BenefitPlanConfig MapToConfig(BenefitPlan plan)
     {
+        // BP 5.10: project every Benefit to its own BenefitCategoryConfig
+        // and carry the originating BenefitRulePredicate (if any) so the
+        // engine's rule gate can pick the right benefit per encounter.
+        // Order matches BenefitPlan.Benefits order — the first authored
+        // benefit wins when no predicate gates the choice.
         var categories = plan.Benefits
             .Select(b => new BenefitCategoryConfig
             {
@@ -68,7 +74,8 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
                 VisitLimit = b.VisitLimit,
                 DollarLimit = b.AnnualMaximum ?? b.LifetimeMaximum,
                 InNetworkCostSharing = BuildInNetworkCostSharing(b),
-                OutOfNetworkCostSharing = BuildOutOfNetworkCostSharing(b)
+                OutOfNetworkCostSharing = BuildOutOfNetworkCostSharing(b),
+                Predicate = ProjectPredicate(plan, b),
             })
             .ToList();
 
@@ -134,6 +141,37 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
     /// </summary>
     private static bool ResolveIsAcaCapEnforced(BenefitPlan plan)
         => AcaCapEnforcementPolicy.IsEnforced(plan);
+
+    /// <summary>
+    /// Capability BP 5.10 — project the originating
+    /// <see cref="BenefitRulePredicate"/> from <see cref="Benefit.Rules"/>
+    /// onto the engine config. Multi-predicate-AND semantics is a
+    /// Phase 2 capability (Decision 4); for now we collapse to the
+    /// first non-null entry and emit a counter so operators see when
+    /// multi-predicate authoring is happening in the wild.
+    /// </summary>
+    private BenefitRulePredicate? ProjectPredicate(BenefitPlan plan, Benefit benefit)
+    {
+        if (benefit.Rules is not { Count: > 0 } rules)
+        {
+            return null;
+        }
+
+        if (rules.Count > 1)
+        {
+            ChoMetrics.PredicateMultiRuleTruncated.Add(1,
+                new KeyValuePair<string, object?>("cho.tenant_id", plan.TenantId));
+            _logger.LogWarning(
+                "Benefit projection collapsed multi-predicate rules to first entry (Phase 2): tenant={Tenant} planId={PlanId} versionId={VersionId} benefitId={BenefitId} ruleCount={RuleCount}",
+                SanitizeForLog(plan.TenantId),
+                SanitizeForLog(plan.PlanId),
+                SanitizeForLog(plan.VersionId),
+                SanitizeForLog(benefit.Id),
+                rules.Count);
+        }
+
+        return rules.FirstOrDefault(r => r is not null);
+    }
 
     private static EngineFamilyAccumulatorModel MapFamilyAccumulatorModel(ModelFamilyAccumulatorModel model)
         => model switch

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -160,6 +160,24 @@ public static class ChoMetrics
             description: "Network-tier mapping outcomes processed by the NetworkId backfill, by outcome");
 
     /// <summary>
+    /// Counter tracking benefits projected by
+    /// <c>ChoBenefitPlanProvider.MapToConfig</c> whose <c>Rules</c>
+    /// list carried more than one <c>BenefitRulePredicate</c>
+    /// (capability BP 5.10). The projection collapses the list to its
+    /// first non-null entry — multi-predicate-AND semantics is a
+    /// Phase 2 capability. The counter sizes that backlog: when the
+    /// counter is non-zero across tenants, multi-predicate authoring
+    /// is happening in the wild and Phase 2 design needs to land
+    /// before truncation becomes load-bearing. Dimensions:
+    /// <c>cho.tenant_id</c>.
+    /// </summary>
+    public static readonly Counter<long> PredicateMultiRuleTruncated =
+        Meter.CreateCounter<long>(
+            "cho.benefit_plan.predicate_multi_rule_truncated.total",
+            unit: "{benefit}",
+            description: "Benefits projected with Rules.Count > 1; only the first predicate is consumed (BP 5.10)");
+
+    /// <summary>
     /// Counter tracking <c>HttpProviderIntegrityGate</c>'s cached-or-live
     /// decision path (capability 5.10). Dimensions: <c>cho.path</c>
     /// (<c>cached_hit</c> | <c>stale_fallback</c> | <c>null_fallback</c>

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitCalculationEngineTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitCalculationEngineTests.cs
@@ -497,6 +497,7 @@ public class BenefitCalculationEngineTests
             new FixedCategoryResolver("98", "Office Visit"),
             new InMemoryBenefitPlanProvider(plan),
             accService,
+            new BenefitRuleGate(NullLogger<BenefitRuleGate>.Instance),
             NullLogger<BenefitCalculationEngine>.Instance);
 
         await engine.ReverseClaimAsync(
@@ -521,6 +522,7 @@ public class BenefitCalculationEngineTests
             new FixedCategoryResolver("98", "Office Visit"),
             new InMemoryBenefitPlanProvider(plan),
             accService,
+            new BenefitRuleGate(NullLogger<BenefitRuleGate>.Instance),
             NullLogger<BenefitCalculationEngine>.Instance);
 
         var request = CreateRequest(plan.Id, lines: ("99213", 200m, 150m, "11"));
@@ -712,6 +714,147 @@ public class BenefitCalculationEngineTests
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    // FEATURE 6: BENEFIT RULE PREDICATE GATING (BP 5.10)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Two benefits with the same ServiceCategory + a member context
+    /// that satisfies the second predicate ⇒ the second benefit is
+    /// selected by the rule gate.
+    /// </summary>
+    [Fact]
+    public async Task Predicate_TwoBenefitsSameCategory_AdultEncounterPicksAdultBenefit()
+    {
+        var pediatric = new BenefitCategoryConfig
+        {
+            ServiceTypeCode = "98",
+            ServiceTypeDescription = "Pediatric Office Visit",
+            IsCovered = true,
+            Predicate = new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 },
+            InNetworkCostSharing =
+            [
+                new CostShareRuleConfig { CostShareType = CostShareType.Copay, CopayAmount = 10,
+                    CopayApplicationMode = CopayApplicationMode.InsteadOfDeductible },
+            ],
+        };
+        var adult = new BenefitCategoryConfig
+        {
+            ServiceTypeCode = "98",
+            ServiceTypeDescription = "Adult Office Visit",
+            IsCovered = true,
+            Predicate = new BenefitRulePredicate { MemberAgeMin = 18 },
+            InNetworkCostSharing =
+            [
+                new CostShareRuleConfig { CostShareType = CostShareType.Copay, CopayAmount = 50,
+                    CopayApplicationMode = CopayApplicationMode.InsteadOfDeductible },
+            ],
+        };
+        var plan = new BenefitPlanConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = "test-tenant",
+            PlanName = "Test",
+            IndividualDeductible = 0,
+            IndividualOopMax = 5000,
+            FamilyOopMax = 10000,
+            Categories = [pediatric, adult],
+        };
+        var engine = CreateEngine(plan, categoryCode: "98");
+
+        var request = CreateRequest(plan.Id, lines: ("99213", 100m, 100m, "11")) with
+        {
+            Member = new MemberContext { AgeYears = 42 },
+        };
+
+        var result = await engine.CalculateAsync(request);
+
+        var line = result.Lines.Single();
+        Assert.True(line.IsCovered);
+        Assert.Equal("Adult Office Visit", line.ServiceTypeDescription);
+        Assert.Equal(50m, line.CopayAmount);
+    }
+
+    /// <summary>
+    /// All candidate predicates reject ⇒ the engine denies with code
+    /// 96 + the predicate-specific narrative (distinct from the
+    /// "service not covered" 96).
+    /// </summary>
+    [Fact]
+    public async Task Predicate_AllRejected_DeniesWithPredicateNarrative()
+    {
+        var maternity = new BenefitCategoryConfig
+        {
+            ServiceTypeCode = "98",
+            ServiceTypeDescription = "Maternity Office Visit",
+            IsCovered = true,
+            Predicate = new BenefitRulePredicate { MemberGender = BenefitMemberGender.Female },
+        };
+        var plan = new BenefitPlanConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = "test-tenant",
+            PlanName = "Test",
+            Categories = [maternity],
+        };
+        var engine = CreateEngine(plan, categoryCode: "98");
+
+        var request = CreateRequest(plan.Id, lines: ("99213", 100m, 100m, "11")) with
+        {
+            Member = new MemberContext { AgeYears = 42, Gender = BenefitMemberGender.Male },
+        };
+
+        var result = await engine.CalculateAsync(request);
+
+        var line = result.Lines.Single();
+        Assert.False(line.IsCovered);
+        Assert.Equal("96", line.DenialReasonCode);
+        Assert.Contains("rule predicate", line.DenialReasonDescription, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Decision 3 — null MemberContext means predicates are skipped
+    /// entirely. Existing pre-BP-5.10 tests (which never supply
+    /// MemberContext) keep working unchanged: the first candidate is
+    /// returned regardless of its predicate.
+    /// </summary>
+    [Fact]
+    public async Task Predicate_NullMemberContext_PicksFirstCandidate_BackwardsCompatible()
+    {
+        var pediatric = new BenefitCategoryConfig
+        {
+            ServiceTypeCode = "98",
+            ServiceTypeDescription = "Pediatric Office Visit",
+            IsCovered = true,
+            Predicate = new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 },
+            InNetworkCostSharing =
+            [
+                new CostShareRuleConfig { CostShareType = CostShareType.Copay, CopayAmount = 10,
+                    CopayApplicationMode = CopayApplicationMode.InsteadOfDeductible },
+            ],
+        };
+        var plan = new BenefitPlanConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = "test-tenant",
+            PlanName = "Test",
+            IndividualDeductible = 0,
+            IndividualOopMax = 5000,
+            FamilyOopMax = 10000,
+            Categories = [pediatric],
+        };
+        var engine = CreateEngine(plan, categoryCode: "98");
+
+        var request = CreateRequest(plan.Id, lines: ("99213", 100m, 100m, "11"));
+        // Member is null — engine must skip the predicate.
+
+        var result = await engine.CalculateAsync(request);
+
+        var line = result.Lines.Single();
+        Assert.True(line.IsCovered);
+        Assert.Equal(10m, line.CopayAmount);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // TEST HELPER
     // ═══════════════════════════════════════════════════════════════════
 
@@ -731,10 +874,11 @@ public class BenefitCalculationEngineTests
             plan, existingDeductible, existingOop, existingVisitCount, categoryCode,
             familyModel, familyDeductible, existingFamilyDeductible, existingFamilyOop);
         var categoryResolver = new FixedCategoryResolver(categoryCode,
-            plan.GetCategory(categoryCode)?.ServiceTypeDescription ?? "Unknown");
+            plan.GetFirstCategory(categoryCode)?.ServiceTypeDescription ?? "Unknown");
+        var ruleGate = new BenefitRuleGate(NullLogger<BenefitRuleGate>.Instance);
 
         return new BenefitCalculationEngine(
-            categoryResolver, planProvider, accumulatorService,
+            categoryResolver, planProvider, accumulatorService, ruleGate,
             NullLogger<BenefitCalculationEngine>.Instance);
     }
 }
@@ -909,9 +1053,9 @@ internal class FixedCategoryResolver : IServiceCategoryResolver
     }
 
     public Task<ServiceCategoryMatch?> ResolveAsync(
-        string tenantId, Guid benefitPlanId, string procedureCode,
-        string codeType, string placeOfService, IReadOnlyList<string> modifiers,
-        string? revenueCode, CancellationToken ct)
+        string tenantId, Guid benefitPlanId, DateOnly serviceDate,
+        string procedureCode, string codeType, string placeOfService,
+        IReadOnlyList<string> modifiers, string? revenueCode, CancellationToken ct)
     {
         return Task.FromResult<ServiceCategoryMatch?>(new ServiceCategoryMatch
         {

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitRuleGateTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitRuleGateTests.cs
@@ -1,0 +1,174 @@
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Models;
+using CloudHealthOffice.BenefitEngine.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CloudHealthOffice.BenefitEngine.Tests;
+
+/// <summary>
+/// Capability BP 5.10 — contract tests for <see cref="BenefitRuleGate"/>.
+/// Pins the Decision 3 best-effort posture (null MemberContext skips
+/// predicate evaluation), the predicate-driven selection of one of
+/// several benefits sharing a ServiceTypeCode, and the all-rejected
+/// null-return path the engine maps to a 96 denial.
+/// </summary>
+public class BenefitRuleGateTests
+{
+    private static BenefitPlanConfig PlanWith(params BenefitCategoryConfig[] categories) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = "tenant-a",
+        PlanName = "Test",
+        Categories = categories.ToList(),
+    };
+
+    private static BenefitCategoryConfig Cat(
+        string code = "98",
+        string description = "Office Visit",
+        BenefitRulePredicate? predicate = null) => new()
+    {
+        ServiceTypeCode = code,
+        ServiceTypeDescription = description,
+        IsCovered = true,
+        Predicate = predicate,
+    };
+
+    private static BenefitResolutionRequest Request(
+        Guid planId,
+        MemberContext? member = null,
+        params string[] dx) => new()
+    {
+        MemberId = "MBR-001",
+        SubscriberId = "SUB-001",
+        BenefitPlanId = planId,
+        ServiceDate = new DateOnly(2026, 4, 1),
+        ClaimId = Guid.NewGuid().ToString(),
+        Member = member,
+        Lines =
+        [
+            new ClaimLineInput
+            {
+                LineNumber = 1,
+                ProcedureCode = "99213",
+                PlaceOfService = "11",
+                BilledAmount = 200m,
+                DiagnosisCodes = dx.ToList(),
+            }
+        ],
+    };
+
+    private static IBenefitRuleGate Gate() =>
+        new BenefitRuleGate(NullLogger<BenefitRuleGate>.Instance);
+
+    [Fact]
+    public void NullMemberContext_ReturnsFirstCandidate_RegardlessOfPredicates()
+    {
+        var first = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 });
+        var second = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 18 });
+        var plan = PlanWith(first, second);
+        var request = Request(plan.Id, member: null);
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Same(first, picked);
+    }
+
+    [Fact]
+    public void NoPredicates_ReturnsFirstCandidate()
+    {
+        var first = Cat();
+        var second = Cat();
+        var plan = PlanWith(first, second);
+        var request = Request(plan.Id, member: new MemberContext { AgeYears = 30 });
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Same(first, picked);
+    }
+
+    [Fact]
+    public void TwoCandidatesSameCode_PredicateSelectsSecond()
+    {
+        var pediatric = Cat(description: "Pediatric Office Visit",
+            predicate: new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 });
+        var adult = Cat(description: "Adult Office Visit",
+            predicate: new BenefitRulePredicate { MemberAgeMin = 18 });
+        var plan = PlanWith(pediatric, adult);
+        var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Same(adult, picked);
+    }
+
+    [Fact]
+    public void AllPredicatesReject_ReturnsNull()
+    {
+        var pediatric = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 });
+        var senior = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 65 });
+        var plan = PlanWith(pediatric, senior);
+        var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Null(picked);
+    }
+
+    [Fact]
+    public void NoCandidates_ReturnsNull()
+    {
+        var plan = PlanWith();
+        var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
+
+        var picked = Gate().PickApplicable(plan, "98", request, line: null);
+
+        Assert.Null(picked);
+    }
+
+    [Fact]
+    public void NullPredicateAlongsidePredicates_NullPredicateWinsByOrder()
+    {
+        // First candidate has no predicate → unconditionally applicable.
+        var unconditional = Cat();
+        var pediatric = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 });
+        var plan = PlanWith(unconditional, pediatric);
+        var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Same(unconditional, picked);
+    }
+
+    [Fact]
+    public void DxFallbackToLine_WhenMemberContextHasNoDx()
+    {
+        var maternity = Cat(description: "Maternity",
+            predicate: new BenefitRulePredicate
+            {
+                RequiredDiagnosisCodes = new List<string> { "Z34.00" }
+            });
+        var plan = PlanWith(maternity);
+        var request = Request(plan.Id,
+            member: new MemberContext { AgeYears = 28 },
+            dx: "Z34.00");
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Same(maternity, picked);
+    }
+
+    [Fact]
+    public void GenderPredicate_RejectsMismatchedMember()
+    {
+        var female = Cat(description: "Maternity",
+            predicate: new BenefitRulePredicate { MemberGender = BenefitMemberGender.Female });
+        var plan = PlanWith(female);
+        var request = Request(plan.Id,
+            member: new MemberContext { AgeYears = 28, Gender = BenefitMemberGender.Male });
+
+        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+
+        Assert.Null(picked);
+    }
+}

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitRuleGateTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/BenefitRuleGateTests.cs
@@ -69,9 +69,10 @@ public class BenefitRuleGateTests
         var plan = PlanWith(first, second);
         var request = Request(plan.Id, member: null);
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Same(first, picked);
+        Assert.Same(first, result.Selected);
+        Assert.Equal(2, result.CandidateCount);
     }
 
     [Fact]
@@ -82,9 +83,10 @@ public class BenefitRuleGateTests
         var plan = PlanWith(first, second);
         var request = Request(plan.Id, member: new MemberContext { AgeYears = 30 });
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Same(first, picked);
+        Assert.Same(first, result.Selected);
+        Assert.Equal(2, result.CandidateCount);
     }
 
     [Fact]
@@ -97,33 +99,36 @@ public class BenefitRuleGateTests
         var plan = PlanWith(pediatric, adult);
         var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Same(adult, picked);
+        Assert.Same(adult, result.Selected);
+        Assert.Equal(2, result.CandidateCount);
     }
 
     [Fact]
-    public void AllPredicatesReject_ReturnsNull()
+    public void AllPredicatesReject_ReturnsNullSelectedWithCandidateCount()
     {
         var pediatric = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 0, MemberAgeMax = 17 });
         var senior = Cat(predicate: new BenefitRulePredicate { MemberAgeMin = 65 });
         var plan = PlanWith(pediatric, senior);
         var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Null(picked);
+        Assert.Null(result.Selected);
+        Assert.Equal(2, result.CandidateCount);
     }
 
     [Fact]
-    public void NoCandidates_ReturnsNull()
+    public void NoCandidates_ReturnsNullSelectedWithZeroCandidateCount()
     {
         var plan = PlanWith();
         var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
 
-        var picked = Gate().PickApplicable(plan, "98", request, line: null);
+        var result = Gate().PickApplicable(plan, "98", request, line: null);
 
-        Assert.Null(picked);
+        Assert.Null(result.Selected);
+        Assert.Equal(0, result.CandidateCount);
     }
 
     [Fact]
@@ -135,9 +140,9 @@ public class BenefitRuleGateTests
         var plan = PlanWith(unconditional, pediatric);
         var request = Request(plan.Id, member: new MemberContext { AgeYears = 42 });
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Same(unconditional, picked);
+        Assert.Same(unconditional, result.Selected);
     }
 
     [Fact]
@@ -153,9 +158,9 @@ public class BenefitRuleGateTests
             member: new MemberContext { AgeYears = 28 },
             dx: "Z34.00");
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Same(maternity, picked);
+        Assert.Same(maternity, result.Selected);
     }
 
     [Fact]
@@ -167,8 +172,9 @@ public class BenefitRuleGateTests
         var request = Request(plan.Id,
             member: new MemberContext { AgeYears = 28, Gender = BenefitMemberGender.Male });
 
-        var picked = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
+        var result = Gate().PickApplicable(plan, "98", request, request.Lines[0]);
 
-        Assert.Null(picked);
+        Assert.Null(result.Selected);
+        Assert.Equal(1, result.CandidateCount);
     }
 }

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/ServiceCategoryResolverEffectiveDateTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/ServiceCategoryResolverEffectiveDateTests.cs
@@ -1,0 +1,200 @@
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace CloudHealthOffice.BenefitEngine.Tests;
+
+/// <summary>
+/// Capability BP 5.10 — pin effective-date filtering on
+/// <see cref="ServiceCategoryResolver"/>. The resolver consults
+/// <see cref="ServiceCategoryMapping.EffectiveStart"/>,
+/// <see cref="ServiceCategoryMapping.EffectiveEnd"/>, and
+/// <see cref="ServiceCategoryMapping.IsActive"/> against the claim
+/// line's service date. Both bounds are inclusive; null means open;
+/// IsActive=false drops the row regardless of window.
+/// </summary>
+public class ServiceCategoryResolverEffectiveDateTests
+{
+    private static IServiceCategoryResolver Build(params ServiceCategoryMapping[] mappings)
+    {
+        var repo = new InMemoryMappingRepo(mappings);
+        return new ServiceCategoryResolver(repo, NullLogger<ServiceCategoryResolver>.Instance);
+    }
+
+    private static ServiceCategoryMapping Mapping(
+        string code,
+        DateOnly? start = null,
+        DateOnly? end = null,
+        bool isActive = true) => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = "tenant-a",
+        BenefitPlanId = null,
+        ServiceTypeCode = code,
+        ServiceTypeDescription = code,
+        EffectiveStart = start,
+        EffectiveEnd = end,
+        IsActive = isActive,
+        Rules = new List<ProcedureCodeRule>
+        {
+            new() { Priority = 10, CodeType = "CPT", CodePattern = "99213" }
+        }
+    };
+
+    [Fact]
+    public async Task MatchInWindow_ReturnsMapping()
+    {
+        var resolver = Build(Mapping("Office Visit",
+            start: new DateOnly(2026, 1, 1),
+            end: new DateOnly(2026, 12, 31)));
+
+        var match = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 6, 15),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        Assert.NotNull(match);
+        Assert.Equal("Office Visit", match!.ServiceTypeCode);
+        Assert.Equal("TenantDefault", match.MatchedBy);
+    }
+
+    [Fact]
+    public async Task EffectiveStartFuture_ServiceDateToday_FallsThroughToPosFallback()
+    {
+        var resolver = Build(Mapping("Office Visit",
+            start: new DateOnly(2027, 1, 1)));
+
+        var match = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 6, 15),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        // Mapping was filtered out → resolver falls through to POS-11
+        // inference, which yields service-type 98 with MatchedBy=SystemDefault.
+        Assert.NotNull(match);
+        Assert.Equal("98", match!.ServiceTypeCode);
+        Assert.Equal("SystemDefault", match.MatchedBy);
+    }
+
+    [Fact]
+    public async Task EffectiveEndPast_ServiceDateInsidePast_Matches()
+    {
+        var resolver = Build(Mapping("Office Visit (CMS 2025)",
+            start: new DateOnly(2025, 1, 1),
+            end: new DateOnly(2025, 12, 31)));
+
+        var match = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2025, 8, 15),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        Assert.NotNull(match);
+        Assert.Equal("Office Visit (CMS 2025)", match!.ServiceTypeCode);
+    }
+
+    [Fact]
+    public async Task IsActiveFalse_NeverMatches_EvenWhenWindowCovers()
+    {
+        var resolver = Build(Mapping("Office Visit",
+            start: new DateOnly(2026, 1, 1),
+            end: new DateOnly(2026, 12, 31),
+            isActive: false));
+
+        var match = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 6, 15),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        // Filtered out → falls through to POS fallback
+        Assert.NotNull(match);
+        Assert.Equal("SystemDefault", match!.MatchedBy);
+    }
+
+    [Fact]
+    public async Task BothBoundsNull_AlwaysMatches()
+    {
+        var resolver = Build(Mapping("Office Visit"));
+
+        var matchPast = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2010, 1, 1),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+        var matchFuture = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2050, 12, 31),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        Assert.Equal("Office Visit", matchPast!.ServiceTypeCode);
+        Assert.Equal("Office Visit", matchFuture!.ServiceTypeCode);
+    }
+
+    [Fact]
+    public async Task DeterministicAcrossRuns_ReplayingFixtureYieldsSameMatch()
+    {
+        var resolver = Build(
+            Mapping("Office Visit (2025)",
+                start: new DateOnly(2025, 1, 1),
+                end: new DateOnly(2025, 12, 31)),
+            Mapping("Office Visit (2026)",
+                start: new DateOnly(2026, 1, 1),
+                end: new DateOnly(2026, 12, 31)));
+
+        for (var i = 0; i < 5; i++)
+        {
+            var match = await resolver.ResolveAsync(
+                "tenant-a", Guid.NewGuid(),
+                serviceDate: new DateOnly(2026, 6, 15),
+                procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+                modifiers: Array.Empty<string>(), revenueCode: null);
+
+            Assert.NotNull(match);
+            Assert.Equal("Office Visit (2026)", match!.ServiceTypeCode);
+        }
+    }
+
+    [Fact]
+    public async Task InclusiveBounds_MatchOnEdgeDates()
+    {
+        var resolver = Build(Mapping("Office Visit",
+            start: new DateOnly(2026, 1, 1),
+            end: new DateOnly(2026, 12, 31)));
+
+        var matchStart = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 1, 1),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+        var matchEnd = await resolver.ResolveAsync(
+            "tenant-a", Guid.NewGuid(),
+            serviceDate: new DateOnly(2026, 12, 31),
+            procedureCode: "99213", codeType: "CPT", placeOfService: "11",
+            modifiers: Array.Empty<string>(), revenueCode: null);
+
+        Assert.Equal("Office Visit", matchStart!.ServiceTypeCode);
+        Assert.Equal("Office Visit", matchEnd!.ServiceTypeCode);
+    }
+
+    private sealed class InMemoryMappingRepo : IServiceCategoryMappingRepository
+    {
+        private readonly List<ServiceCategoryMapping> _mappings;
+
+        public InMemoryMappingRepo(IEnumerable<ServiceCategoryMapping> mappings)
+            => _mappings = mappings.ToList();
+
+        public Task<IReadOnlyList<ServiceCategoryMapping>> GetMappingsAsync(
+            string tenantId, Guid? benefitPlanId, CancellationToken ct = default)
+        {
+            IReadOnlyList<ServiceCategoryMapping> result = _mappings
+                .Where(m => m.TenantId == tenantId && m.BenefitPlanId == benefitPlanId)
+                .ToList();
+            return Task.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes Benefit Plan Phase 1 by wiring the two existing-but-deferred
seams into the adjudication hot path:

1. **Effective-date filtering** on `ServiceCategoryResolver` —
   BP 5.6 captured `EffectiveStart` / `EffectiveEnd` / `IsActive`;
   nothing read them. BP 5.10 wires them into `ResolveAsync` against
   the claim line's service date with inclusive bounds and an
   `IsActive` kill-switch.
2. **`BenefitRulePredicate` evaluation** during benefit lookup —
   BP 5.4 shipped the model + evaluator + unit tests; nothing
   consumed them at adjudication time. BP 5.10 introduces
   `IBenefitRuleGate` between category resolution and the cost-share
   waterfall so plans authoring multiple benefits with the same
   `ServiceCategory` (e.g. Pediatric vs Adult Office Visit) get the
   right one per member encounter.

The X12-alias deferral stays as a first-class Phase 2 capability
with the posture recorded explicitly in the new architecture doc.

### Decisions worth pulling out

- **Decision 3 (`MemberContext` null posture):** **best-effort.**
  When the caller doesn't supply `MemberContext`, the engine skips
  predicate evaluation entirely. Existing pinned tests keep passing
  unchanged; the feature rolls out per-tenant as plan authors start
  using `Rules` and as the controller starts plumbing demographics.
  Counter `cho.benefit_plan.predicate_skipped_no_member_context.total`
  surfaces the gap.
- **Decision 1 (multi-benefit-same-ServiceCategory):** projection
  stops deduplicating; `GetCategory` is renamed `GetFirstCategory`
  and an `[Obsolete]` shim points new callers at `GetCategories`.
  Removed in a follow-up after the deprecation cycle.
- **Decision 5 (resolver signature):** `ResolveAsync` gains a
  non-optional `DateOnly serviceDate`. Breaking. The interface is
  internal-to-CHO and not consumed by any external artifact, so the
  breakage costs nothing externally.
- **Decision 6 (denial code for predicate-rejected benefit):** `96`
  with a predicate-specific narrative ("Benefit category {code}
  matched but no rule predicate is satisfied for this member
  encounter") so operators can tell it apart from "Service not
  covered".

### Phase 1 ledger

| Capability | Title | Status |
|---|---|---|
| BP 5.1 → BP 5.9 | Identity, adapters, plan-year, declarative benefits, network tier, SCM, family accumulator + ACA cap, FHIR InsurancePlan, Benefits Viewer | Shipped |
| BP 5.10 | Adjudication API Stabilization (Phase 1 closer) | **This PR** |

Phase 2 picks up: X12 alias table, multi-predicate AND semantics,
member-DOB plumbing into the adjudication request, service-wide
audit fields, encounter-history wiring for related-encounter
predicates.

## File map

- **Engine** —
  `Domain/BenefitRulePredicate.cs` (moved from benefit-plan-service so
  the engine can reference it without a circular dep);
  `Models/BenefitModels.cs` (`MemberContext` + `Member` field);
  `Services/Providers.cs` (`Predicate` field, `GetCategories`,
  `GetFirstCategory`, `[Obsolete] GetCategory` shim);
  `Services/ServiceCategoryResolver.cs` (effective-date filter,
  signature change);
  `Services/BenefitRuleGate.cs` (new, +
  `Services/BenefitEngineMetrics.cs`);
  `Services/BenefitCalculationEngine.cs` (routes through the gate,
  threads `request.ServiceDate` to the resolver);
  `Configuration/BenefitEngineRegistration.cs` (DI for
  `IBenefitRuleGate`).
- **Service** —
  `Services/ChoBenefitPlanProvider.cs` (project `Predicate`,
  emit `cho.benefit_plan.predicate_multi_rule_truncated.total`);
  `Controllers/ServiceCategoryMappingsController.cs` (400 on
  `EffectiveEnd < EffectiveStart`).
- **Tests** — new
  `tests/CloudHealthOffice.BenefitEngine.Tests/BenefitRuleGateTests.cs`
  (8 cases) and `…/ServiceCategoryResolverEffectiveDateTests.cs`
  (7 cases) plus extensions to existing engine and service test files
  (predicate-driven adjudication, projection collapse, validation
  paths).
- **Docs** —
  `docs/architecture/adjudication-api-stabilization.md` (new,
  consolidates decisions + Phase 1 capability ledger);
  `service-category-mapping.md`, `declarative-benefit-model.md`,
  `family-accumulator-models.md` get the deferred-to-5.10 markers
  flipped to "shipped".

## Test plan

- [ ] `dotnet build cloudhealthoffice-main.sln` clean
- [ ] `tests/CloudHealthOffice.BenefitEngine.Tests` passes —
      existing scenarios keep working without supplying
      `MemberContext` (Decision 3 in action) plus the new
      effective-date and rule-gate cases.
- [ ] `src/services/benefit-plan-service/BenefitPlanService.Tests`
      passes — `ServiceCategoryResolverIntegrationTests` thread the
      new `serviceDate` parameter; SCM controller new 400 cases pass;
      provider projection picks up `Predicate` and the multi-rule
      counter.
- [ ] Existing claim-adjudication integration tests pass without
      supplying `MemberContext` (best-effort posture).
- [ ] Repo-wide grep for `BP 5.10` / `deferred to BP 5.10` shows no
      stale "deferred" markers.

https://claude.ai/code/session_01PfZBoLeGAnPNDHF3Nngyj3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfZBoLeGAnPNDHF3Nngyj3)_