### PR TITLE
Claims 5.2 — Adapter pattern foundation

### DIFF
--- a/docs/architecture/claim-adapter-pattern.md
+++ b/docs/architecture/claim-adapter-pattern.md
@@ -1,0 +1,188 @@
+# Claim Adapter Pattern
+
+## Why
+
+Some tenants will eventually source their claims from external core
+platforms (QNXT, Facets, HealthEdge) instead of CHO's internal
+`claims-service`. This pattern introduces a thin abstraction
+(`IClaimAdapter`) selected at request time by tenant configuration,
+mirroring the existing `IProviderAdapter` and `IBenefitPlanAdapter`
+seams.
+
+For every tenant currently in production the factory resolves to the
+default `ChoClaimAdapter`, which is a near pass-through over the
+existing `IClaimRepository`. So this PR introduces the seam without
+changing observable behavior — capability 5.3 (Submission API) is
+the first capability that wires controllers through the adapter.
+
+## Topology
+
+```
+                  ┌─────────────────────────┐
+   POST /claims   │ ClaimsController        │  GET /claims/{id}
+   GET  /claims   │ ClaimsV1Controller      │  POST /claims/search
+                  └────────────┬────────────┘
+                               │ (every request)
+                       ┌───────▼────────┐
+                       │ Factory        │  ── reads tenant cfg ──▶ tenant-service
+                       └───────┬────────┘     (cached 5 min)
+                               │
+            ┌──────────────────┼──────────────────┬───────────────────┐
+            ▼                  ▼                  ▼                   ▼
+        Cho (active)        QNXT (stub)       Facets (stub)      HealthEdge (stub)
+```
+
+## Interface
+
+```csharp
+public interface IClaimAdapter
+{
+    string Platform { get; }
+
+    Task<ClaimAdapterResponse>            GetClaimAsync(...);
+    Task<ClaimAdapterResponse>            GetClaimByNumberAsync(...);
+    Task<ClaimAdapterResponse>            GetClaimVersionAsync(...);
+    Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(...);
+    Task<ClaimAdapterResponse>            SubmitClaimAsync(...);
+    Task<ClaimSearchAdapterResponse>      SearchClaimsAsync(...);
+    Task<ClaimSearchAdapterResponse>      SearchClaimsForMemberAsync(...);
+}
+```
+
+Every response envelope carries a `Platform` string, an optional
+`RawResponse` audit field, and the normalized payload. Payload shape
+uses vendor-neutral DTOs — `AdapterClaim`, `AdapterClaimLine`,
+`AdapterDiagnosisCode`, `AdapterAdjudicationResult`, and
+`AdapterLineAdjudicationResult` — that mirror their domain
+counterparts field-for-field with `From(...)` / `To*()` round-trip
+mappers. This matches `AdapterProvider` and `AdapterBenefitPlan` from
+the sibling services.
+
+`ListClaimVersionsAsync` is the one capability not present on the
+provider or benefit-plan adapters; claims chains routinely produce
+many versions per chain (submission → adjudication → adjustment →
+reversal), and capabilities 5.11 (FHIR `Bundle` of all
+`ClaimResponse` versions) and 5.12 (Adjustment Workflow chain
+visualization) need vendor-neutral access to the full version list.
+
+## What stays off the adapter
+
+Three CHO-internal surfaces are deliberately not on the adapter
+interface:
+
+| Surface | Why it stays off the adapter |
+|---|---|
+| `IClaimRepository.UpdateAdjudicationProjectionAsync` | Projection-metadata bypass for adjudication writes. The 5.5 orchestrator writes adjudication state via this CHO-internal seam; vendor systems own their own adjudication state, so the same surface doesn't generalize. |
+| `IClaimVersionEventPublisher` | Mongo append-only system-of-record audit chain (5.1a). Claims version events are CHO-internal; a vendor system has its own audit equivalent. |
+| `IClaimEventPublisher` (Kafka) | Operational event stream. Same logic — CHO-internal. |
+| `GetClaimsSummaryAsync`, `GetAccumulatorTotalsAsync` | Operational and accumulator-service boundaries. Stays on `IClaimRepository`; consumers hit the repo directly until/unless a vendor surface needs the equivalent. |
+
+## Routing & tenant configuration
+
+The factory consults tenant-service via HTTP and reads:
+
+```
+GET /api/v1/tenants/{tenantId}
+  → response.configuration.claimsPlatform.platform        (string)
+  → response.configuration.claimsPlatform.platformSettings (object)
+```
+
+The matching adapter is selected case-insensitively by its `Platform`
+property. Allowed values today:
+
+| Platform string | Adapter                 | Status                                |
+|-----------------|-------------------------|---------------------------------------|
+| `cho`           | `ChoClaimAdapter`       | Active                                |
+| `qnxt`          | `QnxtClaimAdapter`      | Stub — `NotImplementedException`      |
+| `facets`        | `FacetsClaimAdapter`    | Stub — `NotImplementedException`      |
+| `healthedge`    | `HealthEdgeClaimAdapter`| Stub — `NotImplementedException`      |
+
+On any failure (HTTP error, JSON parse error, unknown platform) the
+factory warns and falls back to `cho`. A per-tenant
+`(platform, settings)` tuple is cached in the singleton
+`ClaimTenantConfigCache` for 5 minutes (thread-safe via
+`ConcurrentDictionary`).
+
+The `claimsPlatform` field is additive on the tenant-service
+configuration document — existing tenant docs without the field
+default to `cho`. No tenant-service code change is required for this
+capability.
+
+## DI lifetimes
+
+```csharp
+// Singleton — must outlive a single request so the TTL cache survives.
+services.AddSingleton<ClaimTenantConfigCache>();
+
+// Scoped — Cho wraps the scoped IClaimRepository.
+services.AddScoped<IClaimAdapter, ChoClaimAdapter>();
+services.AddScoped<IClaimAdapter, QnxtClaimAdapter>();
+services.AddScoped<IClaimAdapter, FacetsClaimAdapter>();
+services.AddScoped<IClaimAdapter, HealthEdgeClaimAdapter>();
+services.AddScoped<ClaimAdapterFactory>();
+
+services.AddHttpClient(ClaimTenantConfigCache.HttpClientName)
+        .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+```
+
+Identical lifetime mix to `provider-service` and `benefit-plan-service`.
+The Singleton cache only consumes other singletons, and the Scoped
+factory consuming the Singleton cache is the established direction
+(no DI validation issues).
+
+## Coexistence with `IClaimRepository`
+
+5.2 ships the adapter alongside the repository. Both abstractions
+remain in use after this capability:
+
+- `IClaimRepository` — direct data access; controllers continue to
+  inject it directly; CHO-internal services (5.5 orchestrator, 5.10
+  remittance, 5.12 adjustment workflow) consume it on the write path.
+- `IClaimAdapter` — vendor-neutral abstraction; capability 5.3 wires
+  the V1 submission controller through the factory; capabilities 5.11
+  (FHIR projection) and beyond consume it for vendor-neutral reads.
+
+Submission writes via `SubmitClaimAsync` delegate straight to
+`CreateAsync`, which already initializes the version chain
+(`ClaimVersionId=Id`, `VersionNumber=1`,
+`VersionState=Submitted`) per capability 5.1a. The adapter does not
+emit version events itself — that wiring is the submission service's
+concern in capability 5.3.
+
+## Adding a new adapter
+
+1. Create `<Vendor>ClaimAdapter` in `src/services/claims-service/Adapters/`,
+   implementing `IClaimAdapter` with a constant `Platform` string
+   (lowercase, no hyphens).
+2. Translate vendor-specific request/response shapes to/from the
+   `AdapterClaim` DTO and the seven response envelopes.
+3. Register the adapter in `Program.cs` as
+   `AddScoped<IClaimAdapter, <Vendor>ClaimAdapter>()`.
+4. Update the tenant `claimsPlatform.platform` config to the new
+   value for any tenant that should use it.
+
+## Testing
+
+The adapter tests live at `tests/CloudHealthOffice.ClaimsService.Tests/Adapters/`:
+
+- `ClaimAdapterFactoryTests` — tenant routing, case-insensitive
+  match, fallback on HTTP failure, fallback on unknown platform,
+  cache TTL, settings isolation.
+- `ChoClaimAdapterTests` — repository delegation for each method,
+  including a `SubmitClaimAsync` test that explicitly verifies the
+  `AdapterClaim` round-trip is lossless on the submission path.
+- `StubClaimAdapterTests` — every vendor stub method throws
+  `NotImplementedException` carrying the migration TODO and the doc
+  reference.
+- `ClaimTenantConfigCacheTests` — cache hit/miss, JSON shape, HTTP
+  failure fallback, defensive URL encoding for tenant ids.
+
+## Cross-references
+
+- `docs/architecture/provider-adapter-pattern.md` — sibling pattern
+  for provider directory backends.
+- `docs/architecture/benefit-plan-adapter-pattern.md` — sibling
+  pattern for benefit-plan retrieval.
+- `docs/architecture/claim-versioning.md` — versioning scaffolding
+  (5.1a) the adapter relies on for `ClaimVersionId`, `VersionState`,
+  `GetLatestVersionAsync`, `GetVersionAsync`, `ListVersionsAsync`.

--- a/src/services/claims-service/Adapters/ChoClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/ChoClaimAdapter.cs
@@ -145,6 +145,10 @@ public class ChoClaimAdapter : IClaimAdapter
         var domain = request.Claim.ToClaim();
         var created = await _repository.CreateAsync(domain);
 
+        _logger.LogDebug(
+            "ChoClaimAdapter submitted claim {ClaimId} (chain {ClaimVersionId} v{VersionNumber}) for tenant {TenantId}",
+            created.Id, created.ClaimVersionId, created.VersionNumber, request.TenantId);
+
         return new ClaimAdapterResponse
         {
             Platform = Platform,

--- a/src/services/claims-service/Adapters/ChoClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/ChoClaimAdapter.cs
@@ -1,0 +1,204 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Default claim adapter using CHO's internal <see cref="IClaimRepository"/>.
+/// Preserves existing behavior — for the current set of tenants the factory
+/// always resolves to this adapter and the read paths return the same rows
+/// (post-hydration) the controller served before the refactor.
+/// </summary>
+/// <remarks>
+/// Adjudication writes deliberately bypass the adapter (the adjudication
+/// orchestrator in capability 5.5 calls <c>IClaimRepository.UpdateAdjudicationProjectionAsync</c>
+/// directly — the projection-metadata bypass surface that 5.1a shipped).
+/// Version-event emission is similarly off the adapter — the system-of-record
+/// publisher (<c>IClaimVersionEventPublisher</c>) is wired by the submission
+/// service in 5.3 and the adjudication orchestrator in 5.5; the adapter
+/// itself stays simple.
+/// </remarks>
+public class ChoClaimAdapter : IClaimAdapter
+{
+    private readonly IClaimRepository _repository;
+    private readonly ILogger<ChoClaimAdapter> _logger;
+
+    public string Platform => "cho";
+
+    public ChoClaimAdapter(
+        IClaimRepository repository,
+        ILogger<ChoClaimAdapter> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<ClaimAdapterResponse> GetClaimAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+    {
+        // ClaimVersionId provided ⇒ resolve latest non-Draft version of the
+        // chain in effect at AsOf (defaults to UtcNow). This is the path the
+        // submission API (5.3) and adjustment workflow (5.12) wire onto when
+        // they surface "the current claim" by chain key. Without
+        // ClaimVersionId, fall back to per-document-id read so existing 22
+        // controller endpoints continue to behave exactly as today.
+        Claim? claim;
+        if (!string.IsNullOrEmpty(request.ClaimVersionId))
+        {
+            claim = await _repository.GetLatestVersionAsync(
+                request.ClaimVersionId, request.AsOf ?? DateTime.UtcNow);
+        }
+        else if (!string.IsNullOrEmpty(request.ClaimId))
+        {
+            claim = await _repository.GetByIdAsync(request.ClaimId);
+        }
+        else
+        {
+            throw new ArgumentException(
+                "GetClaimAsync requires either ClaimId or ClaimVersionId.",
+                nameof(request));
+        }
+
+        return new ClaimAdapterResponse
+        {
+            Platform = Platform,
+            Claim = claim is null ? null : AdapterClaim.From(claim),
+        };
+    }
+
+    public async Task<ClaimAdapterResponse> GetClaimByNumberAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.ClaimNumber))
+        {
+            throw new ArgumentException(
+                "ClaimNumber is required for GetClaimByNumberAsync.",
+                nameof(request));
+        }
+
+        var claim = await _repository.GetByClaimNumberAsync(request.ClaimNumber);
+        return new ClaimAdapterResponse
+        {
+            Platform = Platform,
+            Claim = claim is null ? null : AdapterClaim.From(claim),
+        };
+    }
+
+    public async Task<ClaimAdapterResponse> GetClaimVersionAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.ClaimVersionId) ||
+            string.IsNullOrEmpty(request.VersionId))
+        {
+            throw new ArgumentException(
+                "GetClaimVersionAsync requires both ClaimVersionId and VersionId.",
+                nameof(request));
+        }
+
+        var claim = await _repository.GetVersionAsync(
+            request.ClaimVersionId, request.VersionId);
+
+        return new ClaimAdapterResponse
+        {
+            Platform = Platform,
+            Claim = claim is null ? null : AdapterClaim.From(claim),
+        };
+    }
+
+    public async Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.ClaimVersionId))
+        {
+            throw new ArgumentException(
+                "ClaimVersionId is required for ListClaimVersionsAsync.",
+                nameof(request));
+        }
+
+        var (items, continuation) = await _repository.ListVersionsAsync(
+            request.ClaimVersionId,
+            request.PageSize,
+            request.ContinuationToken);
+
+        return new ClaimVersionListAdapterResponse
+        {
+            Platform = Platform,
+            Versions = items.Select(AdapterClaim.From).ToList(),
+            ContinuationToken = continuation,
+        };
+    }
+
+    public async Task<ClaimAdapterResponse> SubmitClaimAsync(
+        ClaimSubmissionAdapterRequest request, CancellationToken ct = default)
+    {
+        if (request.Claim is null)
+        {
+            throw new ArgumentException(
+                "Claim is required for SubmitClaimAsync.", nameof(request));
+        }
+
+        // CreateAsync seeds the version chain on the way in
+        // (ClaimVersionId=Id, VersionNumber=1, VersionState=Submitted) per
+        // 5.1a. The adapter just maps DTO → domain → DTO and lets the repo
+        // do the work; event emission is the submission service's concern
+        // (capability 5.3), not the adapter's.
+        var domain = request.Claim.ToClaim();
+        var created = await _repository.CreateAsync(domain);
+
+        return new ClaimAdapterResponse
+        {
+            Platform = Platform,
+            Claim = AdapterClaim.From(created),
+        };
+    }
+
+    public async Task<ClaimSearchAdapterResponse> SearchClaimsAsync(
+        ClaimSearchAdapterRequest request, CancellationToken ct = default)
+    {
+        var claims = await _repository.SearchAsync(
+            memberId: request.MemberId,
+            providerNPI: request.ProviderNPI,
+            serviceDateFrom: request.ServiceDateFrom,
+            serviceDateTo: request.ServiceDateTo,
+            status: request.Status,
+            lineOfBusiness: request.LineOfBusiness,
+            page: request.Page,
+            pageSize: request.PageSize);
+
+        return new ClaimSearchAdapterResponse
+        {
+            Platform = Platform,
+            Claims = claims.Select(AdapterClaim.From).ToList(),
+        };
+    }
+
+    public async Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(
+        ClaimMemberSearchAdapterRequest request, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(request.MemberId))
+        {
+            throw new ArgumentException(
+                "MemberId is required for SearchClaimsForMemberAsync.",
+                nameof(request));
+        }
+
+        var (page, totalCount) = await _repository.SearchForMemberAsync(
+            memberId: request.MemberId,
+            serviceDateFrom: request.ServiceDateFrom,
+            serviceDateTo: request.ServiceDateTo,
+            status: request.Status,
+            providerNPI: request.ProviderNPI,
+            claimType: request.ClaimType,
+            amountMin: request.AmountMin,
+            amountMax: request.AmountMax,
+            page: request.Page,
+            pageSize: request.PageSize);
+
+        return new ClaimSearchAdapterResponse
+        {
+            Platform = Platform,
+            Claims = page.Select(AdapterClaim.From).ToList(),
+            TotalCount = totalCount,
+        };
+    }
+}

--- a/src/services/claims-service/Adapters/ClaimAdapterFactory.cs
+++ b/src/services/claims-service/Adapters/ClaimAdapterFactory.cs
@@ -1,0 +1,70 @@
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Resolves the correct <see cref="IClaimAdapter"/> at runtime based on
+/// tenant configuration. Mirrors
+/// <c>ProviderService.Adapters.ProviderAdapterFactory</c> and
+/// <c>BenefitPlanService.Adapters.BenefitPlanAdapterFactory</c>.
+///
+/// <para>
+/// Tenant config is fetched from tenant-service (cached 5 minutes via
+/// <see cref="ClaimTenantConfigCache"/>) and matched against each adapter's
+/// <see cref="IClaimAdapter.Platform"/> property (case-insensitive). On any
+/// failure or unknown platform the factory falls back to <c>"cho"</c> so a
+/// flaky tenant-service never breaks claim reads.
+/// </para>
+/// </summary>
+public class ClaimAdapterFactory
+{
+    private readonly IEnumerable<IClaimAdapter> _adapters;
+    private readonly ClaimTenantConfigCache _cache;
+    private readonly ILogger<ClaimAdapterFactory> _logger;
+
+    public ClaimAdapterFactory(
+        IEnumerable<IClaimAdapter> adapters,
+        ClaimTenantConfigCache cache,
+        ILogger<ClaimAdapterFactory> logger)
+    {
+        _adapters = adapters;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Get the claim adapter configured for the given tenant. Returns the
+    /// CHO adapter when no specific configuration is found.
+    /// </summary>
+    public async Task<IClaimAdapter> GetAdapterAsync(string tenantId, CancellationToken ct = default)
+    {
+        var (platform, _) = await _cache.GetAsync(tenantId, ct);
+        return ResolveAdapter(platform);
+    }
+
+    /// <summary>
+    /// Get the adapter and a copy of the tenant's platform-settings
+    /// dictionary (callers may mutate the copy without affecting the cache).
+    /// </summary>
+    public async Task<(IClaimAdapter Adapter, Dictionary<string, string> Settings)> GetAdapterWithSettingsAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        var (platform, settings) = await _cache.GetAsync(tenantId, ct);
+        return (ResolveAdapter(platform), new Dictionary<string, string>(settings));
+    }
+
+    private IClaimAdapter ResolveAdapter(string platform)
+    {
+        var adapter = _adapters.FirstOrDefault(a =>
+            string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase));
+
+        if (adapter == null)
+        {
+            _logger.LogWarning(
+                "No claim adapter found for platform '{Platform}', falling back to 'cho'",
+                platform);
+            adapter = _adapters.First(a =>
+                string.Equals(a.Platform, ClaimTenantConfigCache.DefaultPlatform, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return adapter;
+    }
+}

--- a/src/services/claims-service/Adapters/ClaimTenantConfigCache.cs
+++ b/src/services/claims-service/Adapters/ClaimTenantConfigCache.cs
@@ -1,0 +1,112 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Singleton cache for per-tenant claim platform configuration. Holds state
+/// across requests so the factory itself can stay scoped (the CHO adapter
+/// wraps the scoped <see cref="Repositories.IClaimRepository"/>, so the
+/// factory and adapters must be scoped — but the cache must outlive a single
+/// request).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>ProviderService.Adapters.ProviderTenantConfigCache</c> and
+/// <c>BenefitPlanService.Adapters.BenefitPlanTenantConfigCache</c>: 5-minute
+/// TTL, thread-safe via <see cref="ConcurrentDictionary{TKey,TValue}"/>, and
+/// a graceful fallback to <c>"cho"</c> on any HTTP/JSON failure so a flaky
+/// tenant-service never breaks claim reads.
+/// </remarks>
+public class ClaimTenantConfigCache
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ClaimTenantConfigCache> _logger;
+
+    private readonly ConcurrentDictionary<string, (string Platform, Dictionary<string, string> Settings, DateTime ExpiresAt)> _cache = new();
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
+
+    public const string DefaultPlatform = "cho";
+    public const string HttpClientName = "ClaimsDefault";
+
+    public ClaimTenantConfigCache(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<ClaimTenantConfigCache> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolve <c>(platform, platformSettings)</c> for the given tenant,
+    /// hitting tenant-service on cache miss. Defaults to <c>("cho", new())</c>
+    /// when the tenant has no <c>claimsPlatform</c> config or the call fails.
+    /// </summary>
+    public async Task<(string Platform, Dictionary<string, string> Settings)> GetAsync(
+        string tenantId, CancellationToken ct = default)
+    {
+        if (_cache.TryGetValue(tenantId, out var cached) && cached.ExpiresAt > DateTime.UtcNow)
+        {
+            return (cached.Platform, cached.Settings);
+        }
+
+        try
+        {
+            var tenantUrl = _configuration["Services:TenantService"]
+                ?? "http://tenant-service.cloudhealthoffice/api/v1";
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+            // Encode the tenantId path segment defensively — the value flows
+            // from JWT/header via TenantMiddleware, and a crafted id with '/'
+            // or '?' would otherwise alter the request path or query.
+            var encodedTenantId = Uri.EscapeDataString(tenantId);
+            var response = await httpClient.GetAsync($"{tenantUrl}/tenants/{encodedTenantId}", ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = await response.Content.ReadAsStringAsync(ct);
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                if (root.TryGetProperty("configuration", out var config) &&
+                    config.TryGetProperty("claimsPlatform", out var claimsConfig) &&
+                    claimsConfig.TryGetProperty("platform", out var platformProp))
+                {
+                    var platform = platformProp.GetString() ?? DefaultPlatform;
+                    var settings = new Dictionary<string, string>();
+
+                    if (claimsConfig.TryGetProperty("platformSettings", out var settingsProp))
+                    {
+                        foreach (var prop in settingsProp.EnumerateObject())
+                        {
+                            settings[prop.Name] = prop.Value.GetString() ?? string.Empty;
+                        }
+                    }
+
+                    _cache[tenantId] = (platform, settings, DateTime.UtcNow.Add(CacheDuration));
+                    return (platform, settings);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to fetch claims tenant config for {TenantId}, using default adapter",
+                SanitizeForLog(tenantId));
+        }
+
+        var defaultSettings = new Dictionary<string, string>();
+        _cache[tenantId] = (DefaultPlatform, defaultSettings, DateTime.UtcNow.Add(CacheDuration));
+        return (DefaultPlatform, defaultSettings);
+    }
+
+    /// <summary>Test seam — drops all cached entries.</summary>
+    public void Clear() => _cache.Clear();
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/src/services/claims-service/Adapters/FacetsClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/FacetsClaimAdapter.cs
@@ -1,0 +1,51 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose claims live in TriZetto Facets. All
+/// methods throw <see cref="NotImplementedException"/> with a clear
+/// migration TODO until the Facets integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(facets-claims): integrate with the Facets claim API (CLM transaction
+/// set on the Facets claims stack). Reference doc:
+/// docs/architecture/claim-adapter-pattern.md.
+/// </remarks>
+public class FacetsClaimAdapter : IClaimAdapter
+{
+    private const string Todo =
+        "Facets claim adapter not yet implemented. " +
+        "TODO(facets-claims): integrate with the Facets claim API. " +
+        "See docs/architecture/claim-adapter-pattern.md.";
+
+    public string Platform => "facets";
+
+    public Task<ClaimAdapterResponse> GetClaimAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimByNumberAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimVersionAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> SubmitClaimAsync(
+        ClaimSubmissionAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsAsync(
+        ClaimSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(
+        ClaimMemberSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/claims-service/Adapters/HealthEdgeClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/HealthEdgeClaimAdapter.cs
@@ -1,0 +1,51 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose claims live in HealthEdge HealthRules
+/// Payor. All methods throw <see cref="NotImplementedException"/> with a
+/// clear migration TODO until the HealthEdge integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(healthedge-claims): integrate with the HealthEdge HealthRules Payor
+/// claim API. Reference doc:
+/// docs/architecture/claim-adapter-pattern.md.
+/// </remarks>
+public class HealthEdgeClaimAdapter : IClaimAdapter
+{
+    private const string Todo =
+        "HealthEdge claim adapter not yet implemented. " +
+        "TODO(healthedge-claims): integrate with the HealthEdge HealthRules Payor claim API. " +
+        "See docs/architecture/claim-adapter-pattern.md.";
+
+    public string Platform => "healthedge";
+
+    public Task<ClaimAdapterResponse> GetClaimAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimByNumberAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimVersionAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> SubmitClaimAsync(
+        ClaimSubmissionAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsAsync(
+        ClaimSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(
+        ClaimMemberSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/claims-service/Adapters/IClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/IClaimAdapter.cs
@@ -1,0 +1,101 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Abstraction for claim platforms. Each tenant can be configured to use a
+/// different adapter (CHO, QNXT, Facets, HealthEdge, ...). The adapter
+/// normalizes platform-specific responses into a common, vendor-neutral
+/// format designed to project cleanly onto a future FHIR <c>Claim</c> /
+/// <c>ClaimResponse</c> resource (capability 5.11).
+/// </summary>
+/// <remarks>
+/// Mirrors <c>ProviderService.Adapters.IProviderAdapter</c> and
+/// <c>BenefitPlanService.Adapters.IBenefitPlanAdapter</c>. The selection
+/// mechanism (factory consults tenant-service config and falls back to
+/// "cho") is identical.
+///
+/// <para>
+/// The interface is read-mostly: <c>SubmitClaimAsync</c> is the only write
+/// path and just delegates to the repository's existing <c>CreateAsync</c>.
+/// Adjudication writes (<c>UpdateAdjudicationProjectionAsync</c>) and
+/// version-event emission (<c>IClaimVersionEventPublisher</c>) stay on the
+/// CHO-internal repository / publisher seams — vendor systems own their own
+/// adjudication state and audit chains, so those surfaces are deliberately
+/// not on the adapter boundary.
+/// </para>
+/// </remarks>
+public interface IClaimAdapter
+{
+    /// <summary>
+    /// Platform identifier matching <c>configuration.claimsPlatform.platform</c>
+    /// on the tenant. Resolution by the factory is case-insensitive.
+    /// </summary>
+    string Platform { get; }
+
+    /// <summary>
+    /// Fetch a single claim. When <see cref="ClaimAdapterRequest.ClaimVersionId"/>
+    /// is set the CHO adapter resolves the latest non-Draft version of the
+    /// chain in effect at <see cref="ClaimAdapterRequest.AsOf"/>; otherwise
+    /// it looks up the per-version document by <see cref="ClaimAdapterRequest.ClaimId"/>.
+    /// Returns a response with <c>Claim == null</c> when not found.
+    /// </summary>
+    Task<ClaimAdapterResponse> GetClaimAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetch a single claim by payer-assigned claim number
+    /// (<see cref="ClaimAdapterRequest.ClaimNumber"/>). Returns a response
+    /// with <c>Claim == null</c> when not found.
+    /// </summary>
+    Task<ClaimAdapterResponse> GetClaimByNumberAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Fetch a specific version row identified by
+    /// <see cref="ClaimAdapterRequest.ClaimVersionId"/> +
+    /// <see cref="ClaimAdapterRequest.VersionId"/>. Returns a response with
+    /// <c>Claim == null</c> when the version is not found.
+    /// </summary>
+    Task<ClaimAdapterResponse> GetClaimVersionAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// List versions of a claim chain newest-first, paginated with a
+    /// continuation token. Vendor adapters surface their own version
+    /// histories the same way so capability 5.11 (FHIR <c>Bundle</c> of all
+    /// <c>ClaimResponse</c> versions) and 5.12 (Adjustment Workflow chain
+    /// visualization) work uniformly across platforms.
+    /// </summary>
+    Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Submit a new claim. The CHO adapter delegates to
+    /// <c>IClaimRepository.CreateAsync</c>, which already initializes the
+    /// version chain (<c>ClaimVersionId=Id</c>, <c>VersionNumber=1</c>,
+    /// <c>VersionState=Submitted</c>). Event emission is deferred to the
+    /// submission service that wires this method (capability 5.3) — the
+    /// adapter itself stays out of the lifecycle-event seam.
+    /// </summary>
+    Task<ClaimAdapterResponse> SubmitClaimAsync(
+        ClaimSubmissionAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// General claim search with the canonical filter set
+    /// (member, provider, service-date range, status, line of business),
+    /// returning the requested page. Mirrors
+    /// <c>IClaimRepository.SearchAsync</c>.
+    /// </summary>
+    Task<ClaimSearchAdapterResponse> SearchClaimsAsync(
+        ClaimSearchAdapterRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Member-scoped claim search powering the portal Member Details
+    /// dialog. Always requires <see cref="ClaimMemberSearchAdapterRequest.MemberId"/>
+    /// and adds amount-range / claim-type filters on top of the canonical
+    /// search set. Mirrors <c>IClaimRepository.SearchForMemberAsync</c>.
+    /// </summary>
+    Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(
+        ClaimMemberSearchAdapterRequest request, CancellationToken ct = default);
+}

--- a/src/services/claims-service/Adapters/QnxtClaimAdapter.cs
+++ b/src/services/claims-service/Adapters/QnxtClaimAdapter.cs
@@ -1,0 +1,51 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Adapters;
+
+/// <summary>
+/// Stub adapter for tenants whose claims live in QNXT (TriZetto / Cognizant).
+/// All methods throw <see cref="NotImplementedException"/> with a clear
+/// migration TODO until the QNXT integration ships.
+/// </summary>
+/// <remarks>
+/// TODO(qnxt-claims): integrate with the QNXT claim transaction API
+/// (CLAIM_INQ on the QNXT claims stack). Reference doc:
+/// docs/architecture/claim-adapter-pattern.md.
+/// </remarks>
+public class QnxtClaimAdapter : IClaimAdapter
+{
+    private const string Todo =
+        "QNXT claim adapter not yet implemented. " +
+        "TODO(qnxt-claims): integrate with the QNXT claim transaction API. " +
+        "See docs/architecture/claim-adapter-pattern.md.";
+
+    public string Platform => "qnxt";
+
+    public Task<ClaimAdapterResponse> GetClaimAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimByNumberAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> GetClaimVersionAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(
+        ClaimAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimAdapterResponse> SubmitClaimAsync(
+        ClaimSubmissionAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsAsync(
+        ClaimSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+
+    public Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(
+        ClaimMemberSearchAdapterRequest request, CancellationToken ct = default)
+        => throw new NotImplementedException(Todo);
+}

--- a/src/services/claims-service/Models/ClaimAdapterRequest.cs
+++ b/src/services/claims-service/Models/ClaimAdapterRequest.cs
@@ -1,0 +1,125 @@
+namespace ClaimsService.Models;
+
+/// <summary>
+/// Vendor-neutral request envelope passed to <see cref="Adapters.IClaimAdapter"/>
+/// read methods. A single shape covers <c>GetClaimAsync</c>,
+/// <c>GetClaimByNumberAsync</c>, <c>GetClaimVersionAsync</c>, and
+/// <c>ListClaimVersionsAsync</c>; per-method required fields are documented on
+/// the individual properties below. Search and submission have their own
+/// dedicated request types.
+/// </summary>
+public class ClaimAdapterRequest
+{
+    /// <summary>Tenant id resolved by the request middleware. Required by all methods.</summary>
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Per-version document id (<see cref="Claim.Id"/>). Required by
+    /// <c>GetClaimAsync</c> when <see cref="ClaimVersionId"/> is not set;
+    /// ignored otherwise.
+    /// </summary>
+    public string? ClaimId { get; set; }
+
+    /// <summary>
+    /// Payer-assigned claim number (<see cref="Claim.ClaimNumber"/>). Required
+    /// by <c>GetClaimByNumberAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? ClaimNumber { get; set; }
+
+    /// <summary>
+    /// Stable per-chain identifier (<see cref="Claim.ClaimVersionId"/>).
+    /// Optional on <c>GetClaimAsync</c> — when set, the CHO adapter calls
+    /// <c>GetLatestVersionAsync(ClaimVersionId, AsOf ?? UtcNow)</c> instead of
+    /// the per-document-id read. Required by <c>GetClaimVersionAsync</c> and
+    /// <c>ListClaimVersionsAsync</c>.
+    /// </summary>
+    public string? ClaimVersionId { get; set; }
+
+    /// <summary>
+    /// Specific version document id within a chain. Required by
+    /// <c>GetClaimVersionAsync</c>; ignored otherwise.
+    /// </summary>
+    public string? VersionId { get; set; }
+
+    /// <summary>
+    /// Effective date used to resolve which version of a chain applies.
+    /// Optional on <c>GetClaimAsync</c> with a <see cref="ClaimVersionId"/>;
+    /// when null, callers and adapter implementations should treat it as
+    /// <see cref="DateTime.UtcNow"/> at call time.
+    /// </summary>
+    public DateTime? AsOf { get; set; }
+
+    /// <summary>
+    /// Page size for paged results — used by <c>ListClaimVersionsAsync</c>.
+    /// </summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Continuation token for paged results — used by
+    /// <c>ListClaimVersionsAsync</c>. Null requests the first page.
+    /// </summary>
+    public string? ContinuationToken { get; set; }
+
+    /// <summary>
+    /// Platform-specific configuration sourced from
+    /// <c>configuration.claimsPlatform.platformSettings</c> on the tenant
+    /// document (e.g. QNXT base URL, Facets credential reference). Adapters
+    /// read what they need; the factory passes the value through unchanged.
+    /// </summary>
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}
+
+/// <summary>
+/// Vendor-neutral request envelope for <see cref="Adapters.IClaimAdapter.SearchClaimsAsync"/>.
+/// Mirrors the canonical filter set on <c>IClaimRepository.SearchAsync</c>.
+/// </summary>
+public class ClaimSearchAdapterRequest
+{
+    public string TenantId { get; set; } = string.Empty;
+    public string? MemberId { get; set; }
+    public string? ProviderNPI { get; set; }
+    public DateTime? ServiceDateFrom { get; set; }
+    public DateTime? ServiceDateTo { get; set; }
+    public ClaimStatus? Status { get; set; }
+    public LineOfBusiness? LineOfBusiness { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}
+
+/// <summary>
+/// Vendor-neutral request envelope for
+/// <see cref="Adapters.IClaimAdapter.SearchClaimsForMemberAsync"/>. Mirrors the
+/// portal Member Details dialog filter set on
+/// <c>IClaimRepository.SearchForMemberAsync</c> (member id required; amount
+/// range and claim type filters added).
+/// </summary>
+public class ClaimMemberSearchAdapterRequest
+{
+    public string TenantId { get; set; } = string.Empty;
+    public string MemberId { get; set; } = string.Empty;
+    public DateTime? ServiceDateFrom { get; set; }
+    public DateTime? ServiceDateTo { get; set; }
+    public ClaimStatus? Status { get; set; }
+    public string? ProviderNPI { get; set; }
+    public ClaimType? ClaimType { get; set; }
+    public decimal? AmountMin { get; set; }
+    public decimal? AmountMax { get; set; }
+    public int Page { get; set; } = 1;
+    public int PageSize { get; set; } = 50;
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}
+
+/// <summary>
+/// Vendor-neutral request envelope for <see cref="Adapters.IClaimAdapter.SubmitClaimAsync"/>.
+/// Carries the canonical <see cref="AdapterClaim"/> rather than the domain
+/// type so vendor adapters can populate from their own payloads without
+/// taking a hard dependency on the CHO domain model.
+/// </summary>
+public class ClaimSubmissionAdapterRequest
+{
+    public string TenantId { get; set; } = string.Empty;
+    public AdapterClaim Claim { get; set; } = new();
+    public string? CorrelationId { get; set; }
+    public Dictionary<string, string> PlatformSettings { get; set; } = new();
+}

--- a/src/services/claims-service/Models/ClaimAdapterResponse.cs
+++ b/src/services/claims-service/Models/ClaimAdapterResponse.cs
@@ -1,0 +1,415 @@
+namespace ClaimsService.Models;
+
+/// <summary>
+/// Vendor-neutral response envelope returned by the single-claim read methods
+/// on <see cref="Adapters.IClaimAdapter"/>: <c>GetClaimAsync</c>,
+/// <c>GetClaimByNumberAsync</c>, <c>GetClaimVersionAsync</c>, and
+/// <c>SubmitClaimAsync</c>.
+///
+/// <para>
+/// The payload <see cref="Claim"/> is shaped to project cleanly onto a future
+/// FHIR <c>Claim</c> / <c>ClaimResponse</c> resource (capability 5.11): the
+/// version-chain fields map onto <c>Claim.identifier</c> +
+/// <c>ClaimResponse.related</c>, the line items map onto <c>Claim.item</c>,
+/// the diagnosis codes map onto <c>Claim.diagnosis</c>, and the adjudication
+/// fields map onto <c>ClaimResponse.adjudication</c>.
+/// </para>
+/// </summary>
+public class ClaimAdapterResponse
+{
+    /// <summary>Adapter that produced the response (e.g. "cho", "qnxt").</summary>
+    public string Platform { get; set; } = string.Empty;
+
+    /// <summary>Optional raw vendor response retained for audit / debugging.</summary>
+    public string? RawResponse { get; set; }
+
+    /// <summary>Claim payload. Null when the requested claim is not found.</summary>
+    public AdapterClaim? Claim { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for <see cref="Adapters.IClaimAdapter.ListClaimVersionsAsync"/>.
+/// Versions are returned newest-first; <see cref="ContinuationToken"/> is null
+/// when the caller has reached the end of the chain.
+/// </summary>
+public class ClaimVersionListAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Page of version rows (never null; may be empty).</summary>
+    public IReadOnlyList<AdapterClaim> Versions { get; set; } = Array.Empty<AdapterClaim>();
+
+    /// <summary>Opaque token for the next page; null when exhausted.</summary>
+    public string? ContinuationToken { get; set; }
+}
+
+/// <summary>
+/// Vendor-neutral response envelope for the search methods on
+/// <see cref="Adapters.IClaimAdapter"/>: <c>SearchClaimsAsync</c> and
+/// <c>SearchClaimsForMemberAsync</c>.
+/// </summary>
+public class ClaimSearchAdapterResponse
+{
+    public string Platform { get; set; } = string.Empty;
+    public string? RawResponse { get; set; }
+
+    /// <summary>Page of claims returned by the adapter (never null; may be empty).</summary>
+    public IReadOnlyList<AdapterClaim> Claims { get; set; } = Array.Empty<AdapterClaim>();
+
+    /// <summary>Total matching count when the platform reports it; null otherwise.</summary>
+    public int? TotalCount { get; set; }
+}
+
+/// <summary>
+/// Normalized claim DTO. Field shape mirrors <see cref="Claim"/> so the CHO
+/// pass-through is lossless; round-trip mappers <see cref="From"/> and
+/// <see cref="ToClaim"/> let consumers convert back to the domain type
+/// without any information loss. Mirrors <c>AdapterProvider</c> and
+/// <c>AdapterBenefitPlan</c>.
+///
+/// <para>
+/// The DTO carries every field on <see cref="Claim"/> — including the
+/// CHO-internal <see cref="PendDetails"/> and <see cref="AiExamination"/>
+/// surfaces — so the CHO pass-through is lossless. Vendor adapters that don't
+/// expose an equivalent leave those fields null on read; CHO round-trip
+/// stays whole.
+/// </para>
+/// </summary>
+public class AdapterClaim
+{
+    public string TenantId { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public string ClaimNumber { get; set; } = string.Empty;
+
+    public string MemberId { get; set; } = string.Empty;
+    public string? SubscriberId { get; set; }
+    public string? BenefitPlanId { get; set; }
+    public string? CoverageId { get; set; }
+
+    public string? SubscriberFirstName { get; set; }
+    public string? SubscriberLastName { get; set; }
+    public string? PatientFirstName { get; set; }
+    public string? PatientLastName { get; set; }
+    public string? PatientRelationship { get; set; }
+
+    public LineOfBusiness LineOfBusiness { get; set; }
+
+    public string BillingProviderNPI { get; set; } = string.Empty;
+    public string? BillingProviderName { get; set; }
+    public string? RenderingProviderNPI { get; set; }
+    public string? RenderingProviderName { get; set; }
+    public string? FacilityNPI { get; set; }
+    public string? FacilityName { get; set; }
+    public string PlaceOfServiceCode { get; set; } = "11";
+
+    public ClaimType ClaimType { get; set; } = ClaimType.Professional;
+    public string ClaimFrequencyCode { get; set; } = "1";
+    public decimal TotalChargeAmount { get; set; }
+    public DateTime ServiceDateFrom { get; set; }
+    public DateTime ServiceDateTo { get; set; }
+
+    public List<AdapterDiagnosisCode> DiagnosisCodes { get; set; } = new();
+    public List<AdapterClaimLine> ClaimLines { get; set; } = new();
+
+    public ClaimStatus Status { get; set; } = ClaimStatus.Submitted;
+    public DateTime SubmittedDate { get; set; }
+    public DateTime? ReceivedDate { get; set; }
+    public DateTime? AdjudicatedDate { get; set; }
+    public DateTime? PaidDate { get; set; }
+
+    public AdapterAdjudicationResult? AdjudicationResult { get; set; }
+    public PendDetails? PendDetails { get; set; }
+    public AiExamination? AiExamination { get; set; }
+
+    public string? PriorAuthorizationNumber { get; set; }
+    public string? ReferralNumber { get; set; }
+    public string? ClaimNotes { get; set; }
+    public string? EDI837ControlNumber { get; set; }
+    public string? EDI835ControlNumber { get; set; }
+
+    // Version-chain identity (5.1)
+    public string ClaimVersionId { get; set; } = string.Empty;
+    public int VersionNumber { get; set; }
+    public ClaimVersionState VersionState { get; set; }
+    public string? PredecessorVersionId { get; set; }
+    public DateTime? PublishedAt { get; set; }
+    public string? PublishedBy { get; set; }
+    public DateTime? SupersededAt { get; set; }
+    public string? SupersededByVersionId { get; set; }
+
+    public DateTime CreatedDate { get; set; }
+    public DateTime LastUpdatedDate { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? LastUpdatedBy { get; set; }
+
+    public static AdapterClaim From(Claim src) => new()
+    {
+        TenantId = src.TenantId,
+        Id = src.Id,
+        ClaimNumber = src.ClaimNumber,
+        MemberId = src.MemberId,
+        SubscriberId = src.SubscriberId,
+        BenefitPlanId = src.BenefitPlanId,
+        CoverageId = src.CoverageId,
+        SubscriberFirstName = src.SubscriberFirstName,
+        SubscriberLastName = src.SubscriberLastName,
+        PatientFirstName = src.PatientFirstName,
+        PatientLastName = src.PatientLastName,
+        PatientRelationship = src.PatientRelationship,
+        LineOfBusiness = src.LineOfBusiness,
+        BillingProviderNPI = src.BillingProviderNPI,
+        BillingProviderName = src.BillingProviderName,
+        RenderingProviderNPI = src.RenderingProviderNPI,
+        RenderingProviderName = src.RenderingProviderName,
+        FacilityNPI = src.FacilityNPI,
+        FacilityName = src.FacilityName,
+        PlaceOfServiceCode = src.PlaceOfServiceCode,
+        ClaimType = src.ClaimType,
+        ClaimFrequencyCode = src.ClaimFrequencyCode,
+        TotalChargeAmount = src.TotalChargeAmount,
+        ServiceDateFrom = src.ServiceDateFrom,
+        ServiceDateTo = src.ServiceDateTo,
+        DiagnosisCodes = src.DiagnosisCodes.Select(AdapterDiagnosisCode.From).ToList(),
+        ClaimLines = src.ClaimLines.Select(AdapterClaimLine.From).ToList(),
+        Status = src.Status,
+        SubmittedDate = src.SubmittedDate,
+        ReceivedDate = src.ReceivedDate,
+        AdjudicatedDate = src.AdjudicatedDate,
+        PaidDate = src.PaidDate,
+        AdjudicationResult = src.AdjudicationResult is null
+            ? null
+            : AdapterAdjudicationResult.From(src.AdjudicationResult),
+        PendDetails = src.PendDetails,
+        AiExamination = src.AiExamination,
+        PriorAuthorizationNumber = src.PriorAuthorizationNumber,
+        ReferralNumber = src.ReferralNumber,
+        ClaimNotes = src.ClaimNotes,
+        EDI837ControlNumber = src.EDI837ControlNumber,
+        EDI835ControlNumber = src.EDI835ControlNumber,
+        ClaimVersionId = src.ClaimVersionId,
+        VersionNumber = src.VersionNumber,
+        VersionState = src.VersionState,
+        PredecessorVersionId = src.PredecessorVersionId,
+        PublishedAt = src.PublishedAt,
+        PublishedBy = src.PublishedBy,
+        SupersededAt = src.SupersededAt,
+        SupersededByVersionId = src.SupersededByVersionId,
+        CreatedDate = src.CreatedDate,
+        LastUpdatedDate = src.LastUpdatedDate,
+        CreatedBy = src.CreatedBy,
+        LastUpdatedBy = src.LastUpdatedBy,
+    };
+
+    public Claim ToClaim() => new()
+    {
+        TenantId = TenantId,
+        Id = Id,
+        ClaimNumber = ClaimNumber,
+        MemberId = MemberId,
+        SubscriberId = SubscriberId,
+        BenefitPlanId = BenefitPlanId,
+        CoverageId = CoverageId,
+        SubscriberFirstName = SubscriberFirstName,
+        SubscriberLastName = SubscriberLastName,
+        PatientFirstName = PatientFirstName,
+        PatientLastName = PatientLastName,
+        PatientRelationship = PatientRelationship,
+        LineOfBusiness = LineOfBusiness,
+        BillingProviderNPI = BillingProviderNPI,
+        BillingProviderName = BillingProviderName,
+        RenderingProviderNPI = RenderingProviderNPI,
+        RenderingProviderName = RenderingProviderName,
+        FacilityNPI = FacilityNPI,
+        FacilityName = FacilityName,
+        PlaceOfServiceCode = PlaceOfServiceCode,
+        ClaimType = ClaimType,
+        ClaimFrequencyCode = ClaimFrequencyCode,
+        TotalChargeAmount = TotalChargeAmount,
+        ServiceDateFrom = ServiceDateFrom,
+        ServiceDateTo = ServiceDateTo,
+        DiagnosisCodes = DiagnosisCodes.Select(d => d.ToDiagnosisCode()).ToList(),
+        ClaimLines = ClaimLines.Select(l => l.ToClaimLine()).ToList(),
+        Status = Status,
+        SubmittedDate = SubmittedDate,
+        ReceivedDate = ReceivedDate,
+        AdjudicatedDate = AdjudicatedDate,
+        PaidDate = PaidDate,
+        AdjudicationResult = AdjudicationResult?.ToAdjudicationResult(),
+        PendDetails = PendDetails,
+        AiExamination = AiExamination,
+        PriorAuthorizationNumber = PriorAuthorizationNumber,
+        ReferralNumber = ReferralNumber,
+        ClaimNotes = ClaimNotes,
+        EDI837ControlNumber = EDI837ControlNumber,
+        EDI835ControlNumber = EDI835ControlNumber,
+        ClaimVersionId = ClaimVersionId,
+        VersionNumber = VersionNumber,
+        VersionState = VersionState,
+        PredecessorVersionId = PredecessorVersionId,
+        PublishedAt = PublishedAt,
+        PublishedBy = PublishedBy,
+        SupersededAt = SupersededAt,
+        SupersededByVersionId = SupersededByVersionId,
+        CreatedDate = CreatedDate,
+        LastUpdatedDate = LastUpdatedDate,
+        CreatedBy = CreatedBy,
+        LastUpdatedBy = LastUpdatedBy,
+    };
+}
+
+/// <summary>Vendor-neutral diagnosis-code DTO mirroring <see cref="DiagnosisCode"/>.</summary>
+public class AdapterDiagnosisCode
+{
+    public string Code { get; set; } = string.Empty;
+    public string CodeQualifier { get; set; } = "ABK";
+    public int PointerNumber { get; set; }
+    public string? Description { get; set; }
+
+    public static AdapterDiagnosisCode From(DiagnosisCode src) => new()
+    {
+        Code = src.Code,
+        CodeQualifier = src.CodeQualifier,
+        PointerNumber = src.PointerNumber,
+        Description = src.Description,
+    };
+
+    public DiagnosisCode ToDiagnosisCode() => new()
+    {
+        Code = Code,
+        CodeQualifier = CodeQualifier,
+        PointerNumber = PointerNumber,
+        Description = Description,
+    };
+}
+
+/// <summary>Vendor-neutral claim-line DTO mirroring <see cref="ClaimLine"/>.</summary>
+public class AdapterClaimLine
+{
+    public int LineNumber { get; set; }
+    public string ProcedureCode { get; set; } = string.Empty;
+    public string? ProcedureDescription { get; set; }
+    public List<string> Modifiers { get; set; } = new();
+    public List<int> DiagnosisPointers { get; set; } = new();
+    public decimal Units { get; set; } = 1;
+    public decimal ChargeAmount { get; set; }
+    public DateTime ServiceDateFrom { get; set; }
+    public DateTime ServiceDateTo { get; set; }
+    public string? PlaceOfServiceCode { get; set; }
+    public string? RevenueCode { get; set; }
+    public decimal? MpipMultiplierApplied { get; set; }
+    public AdapterLineAdjudicationResult? AdjudicationResult { get; set; }
+
+    public static AdapterClaimLine From(ClaimLine src) => new()
+    {
+        LineNumber = src.LineNumber,
+        ProcedureCode = src.ProcedureCode,
+        ProcedureDescription = src.ProcedureDescription,
+        Modifiers = src.Modifiers.ToList(),
+        DiagnosisPointers = src.DiagnosisPointers.ToList(),
+        Units = src.Units,
+        ChargeAmount = src.ChargeAmount,
+        ServiceDateFrom = src.ServiceDateFrom,
+        ServiceDateTo = src.ServiceDateTo,
+        PlaceOfServiceCode = src.PlaceOfServiceCode,
+        RevenueCode = src.RevenueCode,
+        MpipMultiplierApplied = src.MpipMultiplierApplied,
+        AdjudicationResult = src.AdjudicationResult is null
+            ? null
+            : AdapterLineAdjudicationResult.From(src.AdjudicationResult),
+    };
+
+    public ClaimLine ToClaimLine() => new()
+    {
+        LineNumber = LineNumber,
+        ProcedureCode = ProcedureCode,
+        ProcedureDescription = ProcedureDescription,
+        Modifiers = Modifiers.ToList(),
+        DiagnosisPointers = DiagnosisPointers.ToList(),
+        Units = Units,
+        ChargeAmount = ChargeAmount,
+        ServiceDateFrom = ServiceDateFrom,
+        ServiceDateTo = ServiceDateTo,
+        PlaceOfServiceCode = PlaceOfServiceCode,
+        RevenueCode = RevenueCode,
+        MpipMultiplierApplied = MpipMultiplierApplied,
+        AdjudicationResult = AdjudicationResult?.ToLineAdjudicationResult(),
+    };
+}
+
+/// <summary>Vendor-neutral claim-level adjudication-result DTO mirroring <see cref="AdjudicationResult"/>.</summary>
+public class AdapterAdjudicationResult
+{
+    public string? NetworkTier { get; set; }
+    public decimal AllowedAmount { get; set; }
+    public decimal DeductibleAmount { get; set; }
+    public decimal CoinsuranceAmount { get; set; }
+    public decimal CopayAmount { get; set; }
+    public decimal PatientResponsibility { get; set; }
+    public decimal PayerPayment { get; set; }
+    public string? DenialReasonCode { get; set; }
+    public string? DenialReason { get; set; }
+    public List<ClaimAdjustmentReason> AdjustmentReasons { get; set; } = new();
+    public List<string> RemarkCodes { get; set; } = new();
+    public string? CheckNumber { get; set; }
+    public DateTime? PaymentDate { get; set; }
+
+    public static AdapterAdjudicationResult From(AdjudicationResult src) => new()
+    {
+        NetworkTier = src.NetworkTier,
+        AllowedAmount = src.AllowedAmount,
+        DeductibleAmount = src.DeductibleAmount,
+        CoinsuranceAmount = src.CoinsuranceAmount,
+        CopayAmount = src.CopayAmount,
+        PatientResponsibility = src.PatientResponsibility,
+        PayerPayment = src.PayerPayment,
+        DenialReasonCode = src.DenialReasonCode,
+        DenialReason = src.DenialReason,
+        AdjustmentReasons = src.AdjustmentReasons.ToList(),
+        RemarkCodes = src.RemarkCodes.ToList(),
+        CheckNumber = src.CheckNumber,
+        PaymentDate = src.PaymentDate,
+    };
+
+    public AdjudicationResult ToAdjudicationResult() => new()
+    {
+        NetworkTier = NetworkTier,
+        AllowedAmount = AllowedAmount,
+        DeductibleAmount = DeductibleAmount,
+        CoinsuranceAmount = CoinsuranceAmount,
+        CopayAmount = CopayAmount,
+        PatientResponsibility = PatientResponsibility,
+        PayerPayment = PayerPayment,
+        DenialReasonCode = DenialReasonCode,
+        DenialReason = DenialReason,
+        AdjustmentReasons = AdjustmentReasons.ToList(),
+        RemarkCodes = RemarkCodes.ToList(),
+        CheckNumber = CheckNumber,
+        PaymentDate = PaymentDate,
+    };
+}
+
+/// <summary>Vendor-neutral line-level adjudication-result DTO mirroring <see cref="LineAdjudicationResult"/>.</summary>
+public class AdapterLineAdjudicationResult
+{
+    public decimal AllowedAmount { get; set; }
+    public decimal PaidAmount { get; set; }
+    public decimal PatientResponsibility { get; set; }
+    public List<ClaimAdjustmentReason> AdjustmentReasons { get; set; } = new();
+
+    public static AdapterLineAdjudicationResult From(LineAdjudicationResult src) => new()
+    {
+        AllowedAmount = src.AllowedAmount,
+        PaidAmount = src.PaidAmount,
+        PatientResponsibility = src.PatientResponsibility,
+        AdjustmentReasons = src.AdjustmentReasons.ToList(),
+    };
+
+    public LineAdjudicationResult ToLineAdjudicationResult() => new()
+    {
+        AllowedAmount = AllowedAmount,
+        PaidAmount = PaidAmount,
+        PatientResponsibility = PatientResponsibility,
+        AdjustmentReasons = AdjustmentReasons.ToList(),
+    };
+}

--- a/src/services/claims-service/Models/ClaimAdapterResponse.cs
+++ b/src/services/claims-service/Models/ClaimAdapterResponse.cs
@@ -7,7 +7,7 @@ namespace ClaimsService.Models;
 /// <c>SubmitClaimAsync</c>.
 ///
 /// <para>
-/// The payload <see cref="AdapterClaim"/> exposed by <see cref="Claim"/> is
+/// The payload <see cref="AdapterClaim"/> exposed by <see cref="ClaimAdapterResponse.Claim"/> is
 /// shaped to project cleanly onto a future FHIR <c>Claim</c> /
 /// <c>ClaimResponse</c> resource (capability 5.11): the version-chain fields
 /// map onto <c>Claim.identifier</c> + <c>ClaimResponse.related</c>, the line

--- a/src/services/claims-service/Models/ClaimAdapterResponse.cs
+++ b/src/services/claims-service/Models/ClaimAdapterResponse.cs
@@ -7,12 +7,13 @@ namespace ClaimsService.Models;
 /// <c>SubmitClaimAsync</c>.
 ///
 /// <para>
-/// The payload <see cref="Claim"/> is shaped to project cleanly onto a future
-/// FHIR <c>Claim</c> / <c>ClaimResponse</c> resource (capability 5.11): the
-/// version-chain fields map onto <c>Claim.identifier</c> +
-/// <c>ClaimResponse.related</c>, the line items map onto <c>Claim.item</c>,
-/// the diagnosis codes map onto <c>Claim.diagnosis</c>, and the adjudication
-/// fields map onto <c>ClaimResponse.adjudication</c>.
+/// The payload <see cref="AdapterClaim"/> exposed by <see cref="Claim"/> is
+/// shaped to project cleanly onto a future FHIR <c>Claim</c> /
+/// <c>ClaimResponse</c> resource (capability 5.11): the version-chain fields
+/// map onto <c>Claim.identifier</c> + <c>ClaimResponse.related</c>, the line
+/// items map onto <c>Claim.item</c>, the diagnosis codes map onto
+/// <c>Claim.diagnosis</c>, and the adjudication fields map onto
+/// <c>ClaimResponse.adjudication</c>.
 /// </para>
 /// </summary>
 public class ClaimAdapterResponse

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -1,6 +1,7 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Extensions;
 using CloudHealthOffice.Infrastructure.Observability;
+using ClaimsService.Adapters;
 using ClaimsService.EDI.Florida;
 using ClaimsService.Fhir;
 using ClaimsService.HostedServices;
@@ -101,6 +102,21 @@ builder.Services.AddScoped<IMpipAdjudicationEnhancer, MpipAdjudicationEnhancer>(
 builder.Services.AddSingleton<ClaimEventPublisher>();
 builder.Services.AddSingleton<IClaimEventPublisher>(sp => sp.GetRequiredService<ClaimEventPublisher>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ClaimEventPublisher>());
+
+// Claim adapter pattern (5.2 — tenant-routed claims backends). Cache is
+// singleton (TTL across requests); adapters and factory are scoped because
+// the CHO adapter wraps the scoped IClaimRepository. Tenant-service HTTP
+// client uses a 5-second timeout so a flaky tenant-service can't stall claim
+// reads — the cache falls back to "cho" on any failure.
+builder.Services.AddHttpClient(ClaimTenantConfigCache.HttpClientName)
+    .SetHandlerLifetime(TimeSpan.FromMinutes(5))
+    .ConfigureHttpClient(c => c.Timeout = TimeSpan.FromSeconds(5));
+builder.Services.AddSingleton<ClaimTenantConfigCache>();
+builder.Services.AddScoped<IClaimAdapter, ChoClaimAdapter>();
+builder.Services.AddScoped<IClaimAdapter, QnxtClaimAdapter>();
+builder.Services.AddScoped<IClaimAdapter, FacetsClaimAdapter>();
+builder.Services.AddScoped<IClaimAdapter, HealthEdgeClaimAdapter>();
+builder.Services.AddScoped<ClaimAdapterFactory>();
 
 builder.Services.AddChoObservability(builder.Configuration);
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ChoClaimAdapterTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ChoClaimAdapterTests.cs
@@ -1,0 +1,384 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Adapters;
+
+public class ChoClaimAdapterTests
+{
+    private const string Tenant = "tenant-a";
+
+    private static ChoClaimAdapter Build(IClaimRepository repo)
+        => new(repo, NullLogger<ChoClaimAdapter>.Instance);
+
+    private static Claim SampleClaim(string id = "c-1", string claimNumber = "CN-001")
+        => new()
+        {
+            Id = id,
+            TenantId = Tenant,
+            ClaimNumber = claimNumber,
+            MemberId = "M1",
+            BillingProviderNPI = "1234567890",
+            ClaimType = ClaimType.Professional,
+            Status = ClaimStatus.Submitted,
+            TotalChargeAmount = 100m,
+            ServiceDateFrom = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+            ServiceDateTo = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+            SubmittedDate = new DateTime(2026, 1, 6, 0, 0, 0, DateTimeKind.Utc),
+            ClaimVersionId = id,
+            VersionNumber = 1,
+            VersionState = ClaimVersionState.Submitted,
+            ClaimLines = new List<ClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    Modifiers = new List<string> { "25" },
+                    DiagnosisPointers = new List<int> { 1 },
+                    Units = 1,
+                    ChargeAmount = 100m,
+                    ServiceDateFrom = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+                    ServiceDateTo = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+                },
+            },
+            DiagnosisCodes = new List<DiagnosisCode>
+            {
+                new() { Code = "E11.9", CodeQualifier = "ABK", PointerNumber = 1 },
+            },
+        };
+
+    [Fact]
+    public void Platform_is_cho()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        Build(repo).Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetClaimAsync_uses_GetByIdAsync_when_only_ClaimId_provided()
+    {
+        var claim = SampleClaim("c-1");
+        var repo = Substitute.For<IClaimRepository>();
+        repo.GetByIdAsync("c-1").Returns(claim);
+
+        var resp = await Build(repo).GetClaimAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimId = "c-1",
+        });
+
+        resp.Platform.Should().Be("cho");
+        resp.Claim.Should().NotBeNull();
+        resp.Claim!.Id.Should().Be("c-1");
+        await repo.Received(1).GetByIdAsync("c-1");
+        await repo.DidNotReceive().GetLatestVersionAsync(Arg.Any<string>(), Arg.Any<DateTime>());
+    }
+
+    [Fact]
+    public async Task GetClaimAsync_uses_GetLatestVersionAsync_when_ClaimVersionId_provided()
+    {
+        var claim = SampleClaim("c-2");
+        var asOf = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+        var repo = Substitute.For<IClaimRepository>();
+        repo.GetLatestVersionAsync("chain-2", asOf).Returns(claim);
+
+        var resp = await Build(repo).GetClaimAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimVersionId = "chain-2",
+            AsOf = asOf,
+        });
+
+        resp.Claim!.Id.Should().Be("c-2");
+        await repo.Received(1).GetLatestVersionAsync("chain-2", asOf);
+        await repo.DidNotReceive().GetByIdAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task GetClaimAsync_returns_null_payload_when_not_found()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        repo.GetByIdAsync("missing").Returns((Claim?)null);
+
+        var resp = await Build(repo).GetClaimAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimId = "missing",
+        });
+
+        resp.Claim.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetClaimAsync_throws_when_neither_id_provided()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        await Build(repo).Invoking(a => a.GetClaimAsync(new ClaimAdapterRequest { TenantId = Tenant }))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetClaimByNumberAsync_delegates_to_repo()
+    {
+        var claim = SampleClaim("c-3", "CN-XYZ");
+        var repo = Substitute.For<IClaimRepository>();
+        repo.GetByClaimNumberAsync("CN-XYZ").Returns(claim);
+
+        var resp = await Build(repo).GetClaimByNumberAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimNumber = "CN-XYZ",
+        });
+
+        resp.Claim!.ClaimNumber.Should().Be("CN-XYZ");
+    }
+
+    [Fact]
+    public async Task GetClaimByNumberAsync_throws_when_claim_number_missing()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        await Build(repo).Invoking(a => a.GetClaimByNumberAsync(new ClaimAdapterRequest { TenantId = Tenant }))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task GetClaimVersionAsync_delegates_to_repo()
+    {
+        var claim = SampleClaim("c-4");
+        claim.VersionNumber = 3;
+        var repo = Substitute.For<IClaimRepository>();
+        repo.GetVersionAsync("chain-4", "v-3").Returns(claim);
+
+        var resp = await Build(repo).GetClaimVersionAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimVersionId = "chain-4",
+            VersionId = "v-3",
+        });
+
+        resp.Claim!.VersionNumber.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetClaimVersionAsync_throws_when_either_id_missing()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        await Build(repo).Invoking(a => a.GetClaimVersionAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant, ClaimVersionId = "chain-only"
+        })).Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ListClaimVersionsAsync_returns_versions_and_continuation_token()
+    {
+        var first = SampleClaim("v-1");
+        first.VersionNumber = 2;
+        var second = SampleClaim("v-2");
+        second.VersionNumber = 1;
+        var repo = Substitute.For<IClaimRepository>();
+        repo.ListVersionsAsync("chain-5", 10, null)
+            .Returns((new List<Claim> { first, second }, "next-page-token"));
+
+        var resp = await Build(repo).ListClaimVersionsAsync(new ClaimAdapterRequest
+        {
+            TenantId = Tenant,
+            ClaimVersionId = "chain-5",
+            PageSize = 10,
+        });
+
+        resp.Versions.Should().HaveCount(2);
+        resp.Versions[0].Id.Should().Be("v-1");
+        resp.ContinuationToken.Should().Be("next-page-token");
+    }
+
+    [Fact]
+    public async Task ListClaimVersionsAsync_throws_when_chain_id_missing()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        await Build(repo).Invoking(a => a.ListClaimVersionsAsync(new ClaimAdapterRequest { TenantId = Tenant }))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+    /// <summary>
+    /// AdapterClaim → Claim → IClaimRepository.CreateAsync → Claim → AdapterClaim.
+    /// The most important test on the AdapterClaim DTO decision: the round-trip
+    /// must be lossless on the submission path. Every domain field present on
+    /// the input AdapterClaim must reach CreateAsync intact, and every field
+    /// the repo sets must surface on the response AdapterClaim.
+    /// </summary>
+    [Fact]
+    public async Task SubmitClaimAsync_round_trips_AdapterClaim_losslessly()
+    {
+        var domainClaim = SampleClaim("c-submit");
+        domainClaim.SubscriberId = "S1";
+        domainClaim.BenefitPlanId = "BP-1";
+        domainClaim.PriorAuthorizationNumber = "PA-42";
+        domainClaim.AdjudicationResult = new AdjudicationResult
+        {
+            NetworkTier = "InNetwork",
+            AllowedAmount = 80m,
+            DeductibleAmount = 10m,
+            CoinsuranceAmount = 5m,
+            CopayAmount = 5m,
+            PatientResponsibility = 20m,
+            PayerPayment = 60m,
+            RemarkCodes = new List<string> { "N123" },
+        };
+        domainClaim.PendDetails = new PendDetails
+        {
+            PendCode = "NCCI",
+            PendReason = "NCCI pair edit",
+            PendedAt = new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc),
+        };
+        domainClaim.AiExamination = new AiExamination
+        {
+            RecommendedDisposition = "Approve",
+            ConfidenceScore = 0.88,
+            Rationale = "Modifier 59 supports separate procedure",
+            ModelId = "claude-opus-4-7",
+            PromptVersion = "ncci-pend-v1",
+        };
+
+        // Round-trip the input through the DTO (mirrors how a real consumer
+        // would build a submission request) and capture what the repo sees.
+        var inputAdapter = AdapterClaim.From(domainClaim);
+
+        Claim? captured = null;
+        var repo = Substitute.For<IClaimRepository>();
+        repo.CreateAsync(Arg.Do<Claim>(c => captured = c)).Returns(call => call.Arg<Claim>());
+
+        var resp = await Build(repo).SubmitClaimAsync(new ClaimSubmissionAdapterRequest
+        {
+            TenantId = Tenant,
+            Claim = inputAdapter,
+            CorrelationId = "corr-1",
+        });
+
+        // 1. Repo received the fully-mapped domain Claim.
+        captured.Should().NotBeNull();
+        captured!.Id.Should().Be("c-submit");
+        captured.ClaimNumber.Should().Be("CN-001");
+        captured.SubscriberId.Should().Be("S1");
+        captured.BenefitPlanId.Should().Be("BP-1");
+        captured.PriorAuthorizationNumber.Should().Be("PA-42");
+        captured.ClaimLines.Should().HaveCount(1);
+        captured.ClaimLines[0].ProcedureCode.Should().Be("99213");
+        captured.ClaimLines[0].Modifiers.Should().Equal("25");
+        captured.DiagnosisCodes.Should().HaveCount(1);
+        captured.DiagnosisCodes[0].Code.Should().Be("E11.9");
+        captured.AdjudicationResult.Should().NotBeNull();
+        captured.AdjudicationResult!.AllowedAmount.Should().Be(80m);
+        captured.AdjudicationResult.RemarkCodes.Should().Equal("N123");
+        captured.PendDetails.Should().NotBeNull();
+        captured.PendDetails!.PendCode.Should().Be("NCCI");
+        captured.AiExamination.Should().NotBeNull();
+        captured.AiExamination!.RecommendedDisposition.Should().Be("Approve");
+        captured.AiExamination.ConfidenceScore.Should().Be(0.88);
+        captured.ClaimVersionId.Should().Be("c-submit");
+        captured.VersionNumber.Should().Be(1);
+        captured.VersionState.Should().Be(ClaimVersionState.Submitted);
+
+        // 2. Response wraps back into AdapterClaim with all fields preserved.
+        resp.Platform.Should().Be("cho");
+        resp.Claim.Should().NotBeNull();
+        resp.Claim!.Id.Should().Be("c-submit");
+        resp.Claim.SubscriberId.Should().Be("S1");
+        resp.Claim.PriorAuthorizationNumber.Should().Be("PA-42");
+        resp.Claim.ClaimLines.Should().HaveCount(1);
+        resp.Claim.ClaimLines[0].Modifiers.Should().Equal("25");
+        resp.Claim.AdjudicationResult.Should().NotBeNull();
+        resp.Claim.AdjudicationResult!.AllowedAmount.Should().Be(80m);
+        resp.Claim.PendDetails!.PendCode.Should().Be("NCCI");
+        resp.Claim.AiExamination!.ConfidenceScore.Should().Be(0.88);
+    }
+
+    [Fact]
+    public async Task SubmitClaimAsync_delegates_to_CreateAsync_only_no_event_publisher_calls()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        repo.CreateAsync(Arg.Any<Claim>()).Returns(call => call.Arg<Claim>());
+
+        await Build(repo).SubmitClaimAsync(new ClaimSubmissionAdapterRequest
+        {
+            TenantId = Tenant,
+            Claim = AdapterClaim.From(SampleClaim()),
+        });
+
+        // Only CreateAsync is called — Update / projection bypass / publisher
+        // are explicitly NOT on the adapter's submission path. 5.3 is the
+        // capability that wires event emission for submissions.
+        await repo.Received(1).CreateAsync(Arg.Any<Claim>());
+        await repo.DidNotReceive().UpdateAsync(Arg.Any<Claim>());
+        await repo.DidNotReceive().UpdateAdjudicationProjectionAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<AdjudicationResult>(),
+            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchClaimsAsync_passes_filters_through_to_repo()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        repo.SearchAsync(
+            "M1", "1234567890",
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Utc),
+            ClaimStatus.Submitted, LineOfBusiness.Commercial, 2, 25)
+            .Returns(new List<Claim> { SampleClaim("s-1"), SampleClaim("s-2") });
+
+        var resp = await Build(repo).SearchClaimsAsync(new ClaimSearchAdapterRequest
+        {
+            TenantId = Tenant,
+            MemberId = "M1",
+            ProviderNPI = "1234567890",
+            ServiceDateFrom = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ServiceDateTo = new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Utc),
+            Status = ClaimStatus.Submitted,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            Page = 2,
+            PageSize = 25,
+        });
+
+        resp.Claims.Should().HaveCount(2);
+        resp.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task SearchClaimsForMemberAsync_returns_page_with_total_count()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        repo.SearchForMemberAsync(
+            "M9",
+            Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
+            Arg.Any<ClaimStatus?>(), Arg.Any<string?>(),
+            Arg.Any<ClaimType?>(),
+            Arg.Any<decimal?>(), Arg.Any<decimal?>(),
+            1, 50)
+            .Returns(((IReadOnlyList<Claim>)new List<Claim> { SampleClaim("m-1") }, 17));
+
+        var resp = await Build(repo).SearchClaimsForMemberAsync(new ClaimMemberSearchAdapterRequest
+        {
+            TenantId = Tenant,
+            MemberId = "M9",
+        });
+
+        resp.Claims.Should().HaveCount(1);
+        resp.TotalCount.Should().Be(17);
+    }
+
+    [Fact]
+    public async Task SearchClaimsForMemberAsync_throws_when_member_id_missing()
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        await Build(repo).Invoking(a => a.SearchClaimsForMemberAsync(new ClaimMemberSearchAdapterRequest
+        {
+            TenantId = Tenant
+        })).Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimAdapterFactoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimAdapterFactoryTests.cs
@@ -1,0 +1,161 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Adapters;
+
+public class ClaimAdapterFactoryTests
+{
+    private static (ClaimAdapterFactory factory,
+                    ClaimTenantConfigCache cache,
+                    FakeHttpMessageHandler handler,
+                    StubClaimAdapter cho,
+                    StubClaimAdapter qnxt) BuildFactory(
+        FakeHttpMessageHandler handler,
+        params IClaimAdapter[] extra)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Services:TenantService"] = "http://tenant-service.test/api/v1",
+        }).Build();
+
+        var cache = new ClaimTenantConfigCache(
+            new StubHttpClientFactory(handler),
+            config,
+            NullLogger<ClaimTenantConfigCache>.Instance);
+
+        var cho = new StubClaimAdapter("cho");
+        var qnxt = new StubClaimAdapter("qnxt");
+        var adapters = new List<IClaimAdapter> { cho, qnxt };
+        adapters.AddRange(extra);
+
+        var factory = new ClaimAdapterFactory(
+            adapters, cache, NullLogger<ClaimAdapterFactory>.Instance);
+        return (factory, cache, handler, cho, qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_returns_cho_when_tenant_has_no_platform_config()
+    {
+        var handler = FakeHttpMessageHandler.Json("""{"configuration": {}}""");
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-1");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_returns_configured_platform()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"claimsPlatform": {"platform": "qnxt"}}}""");
+        var (factory, _, _, _, qnxt) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-q");
+
+        adapter.Should().BeSameAs(qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_matches_platform_case_insensitively()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"claimsPlatform": {"platform": "QNXT"}}}""");
+        var (factory, _, _, _, qnxt) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-q");
+
+        adapter.Should().BeSameAs(qnxt);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_on_unknown_platform()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"claimsPlatform": {"platform": "snowflake"}}}""");
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-x");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_on_http_failure()
+    {
+        var handler = FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.InternalServerError);
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-y");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_falls_back_to_cho_when_http_throws()
+    {
+        var handler = FakeHttpMessageHandler.Throw(new HttpRequestException("network down"));
+        var (factory, _, _, cho, _) = BuildFactory(handler);
+
+        var adapter = await factory.GetAdapterAsync("tenant-z");
+
+        adapter.Should().BeSameAs(cho);
+    }
+
+    [Fact]
+    public async Task GetAdapterAsync_caches_tenant_lookup()
+    {
+        var handler = FakeHttpMessageHandler.Json(
+            """{"configuration": {"claimsPlatform": {"platform": "qnxt"}}}""");
+        var (factory, _, h, _, qnxt) = BuildFactory(handler);
+
+        var first = await factory.GetAdapterAsync("tenant-cache");
+        var second = await factory.GetAdapterAsync("tenant-cache");
+
+        first.Should().BeSameAs(qnxt);
+        second.Should().BeSameAs(qnxt);
+        h.RequestCount.Should().Be(1, "second call should be served from cache");
+    }
+
+    [Fact]
+    public async Task GetAdapterWithSettingsAsync_returns_isolated_copy_of_settings()
+    {
+        var handler = FakeHttpMessageHandler.Json("""
+            {"configuration": {"claimsPlatform": {"platform": "qnxt", "platformSettings": {"qnxt:baseUrl": "https://qnxt.example/"}}}}
+            """);
+        var (factory, _, _, _, _) = BuildFactory(handler);
+
+        var (_, settings) = await factory.GetAdapterWithSettingsAsync("tenant-s");
+        settings["qnxt:baseUrl"].Should().Be("https://qnxt.example/");
+
+        // Mutating the returned dict must not affect the next call.
+        settings["qnxt:baseUrl"] = "https://attacker.example/";
+
+        var (_, fresh) = await factory.GetAdapterWithSettingsAsync("tenant-s");
+        fresh["qnxt:baseUrl"].Should().Be("https://qnxt.example/");
+    }
+
+    private sealed class StubClaimAdapter : IClaimAdapter
+    {
+        public string Platform { get; }
+        public StubClaimAdapter(string platform) { Platform = platform; }
+
+        public Task<ClaimAdapterResponse> GetClaimAsync(ClaimAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimAdapterResponse { Platform = Platform });
+        public Task<ClaimAdapterResponse> GetClaimByNumberAsync(ClaimAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimAdapterResponse { Platform = Platform });
+        public Task<ClaimAdapterResponse> GetClaimVersionAsync(ClaimAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimAdapterResponse { Platform = Platform });
+        public Task<ClaimVersionListAdapterResponse> ListClaimVersionsAsync(ClaimAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimVersionListAdapterResponse { Platform = Platform });
+        public Task<ClaimAdapterResponse> SubmitClaimAsync(ClaimSubmissionAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimAdapterResponse { Platform = Platform });
+        public Task<ClaimSearchAdapterResponse> SearchClaimsAsync(ClaimSearchAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimSearchAdapterResponse { Platform = Platform });
+        public Task<ClaimSearchAdapterResponse> SearchClaimsForMemberAsync(ClaimMemberSearchAdapterRequest r, CancellationToken ct = default)
+            => Task.FromResult(new ClaimSearchAdapterResponse { Platform = Platform });
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimTenantConfigCacheTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimTenantConfigCacheTests.cs
@@ -1,0 +1,138 @@
+using ClaimsService.Adapters;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Adapters;
+
+public class ClaimTenantConfigCacheTests
+{
+    private static ClaimTenantConfigCache Build(FakeHttpMessageHandler handler)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Services:TenantService"] = "http://tenant-service.test/api/v1",
+        }).Build();
+        return new ClaimTenantConfigCache(
+            new StubHttpClientFactory(handler),
+            config,
+            NullLogger<ClaimTenantConfigCache>.Instance);
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_default_when_configuration_block_absent()
+    {
+        var cache = Build(FakeHttpMessageHandler.Json("""{}"""));
+
+        var (platform, settings) = await cache.GetAsync("t-1");
+
+        platform.Should().Be("cho");
+        settings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_default_when_claimsPlatform_block_absent()
+    {
+        var cache = Build(FakeHttpMessageHandler.Json("""{"configuration": {"otherStuff": true}}"""));
+
+        var (platform, _) = await cache.GetAsync("t-2");
+
+        platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAsync_returns_configured_platform_and_settings()
+    {
+        var handler = FakeHttpMessageHandler.Json("""
+            {"configuration": {"claimsPlatform": {"platform": "qnxt", "platformSettings": {"qnxt:baseUrl": "https://q.example/"}}}}
+            """);
+        var cache = Build(handler);
+
+        var (platform, settings) = await cache.GetAsync("t-3");
+
+        platform.Should().Be("qnxt");
+        settings["qnxt:baseUrl"].Should().Be("https://q.example/");
+    }
+
+    [Fact]
+    public async Task GetAsync_falls_back_to_default_on_http_error()
+    {
+        var cache = Build(FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var (platform, _) = await cache.GetAsync("t-4");
+
+        platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAsync_falls_back_to_default_on_thrown_exception()
+    {
+        var cache = Build(FakeHttpMessageHandler.Throw(new HttpRequestException("boom")));
+
+        var (platform, _) = await cache.GetAsync("t-5");
+
+        platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAsync_caches_within_TTL()
+    {
+        var handler = FakeHttpMessageHandler.Json("""
+            {"configuration": {"claimsPlatform": {"platform": "facets"}}}
+            """);
+        var cache = Build(handler);
+
+        var first = await cache.GetAsync("t-6");
+        var second = await cache.GetAsync("t-6");
+
+        first.Platform.Should().Be("facets");
+        second.Platform.Should().Be("facets");
+        handler.RequestCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetAsync_caches_default_after_failure()
+    {
+        // Failure responses are cached with the default — repeated calls during
+        // the TTL window do NOT hammer tenant-service. Mirrors Provider/BP.
+        var cache = Build(FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.InternalServerError));
+
+        await cache.GetAsync("t-7");
+        await cache.GetAsync("t-7");
+
+        // Two calls, only one HTTP miss expected — but the failure body still
+        // populates the cache. Assert the second call returns cho without
+        // invoking the handler again would require handler tracking; we assert
+        // the simpler invariant: the cache returns cho consistently and Clear
+        // resets it.
+        var afterClear = await cache.GetAsync("t-7");
+        afterClear.Platform.Should().Be("cho");
+
+        cache.Clear();
+        var afterReset = await cache.GetAsync("t-7");
+        afterReset.Platform.Should().Be("cho");
+    }
+
+    [Fact]
+    public async Task GetAsync_url_encodes_tenant_id()
+    {
+        // Defensive encoding: a tenant id with '/' or '?' must not alter the
+        // request path. Mirrors the Uri.EscapeDataString call in the cache.
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(req =>
+        {
+            captured = req;
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"configuration": {}}""",
+                    System.Text.Encoding.UTF8, "application/json"),
+            };
+        });
+        var cache = Build(handler);
+
+        await cache.GetAsync("weird/tenant?id");
+
+        captured.Should().NotBeNull();
+        captured!.RequestUri!.AbsoluteUri.Should().Contain("weird%2Ftenant%3Fid");
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimTenantConfigCacheTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimTenantConfigCacheTests.cs
@@ -95,22 +95,20 @@ public class ClaimTenantConfigCacheTests
     {
         // Failure responses are cached with the default — repeated calls during
         // the TTL window do NOT hammer tenant-service. Mirrors Provider/BP.
-        var cache = Build(FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.InternalServerError));
+        var handler = FakeHttpMessageHandler.Status(System.Net.HttpStatusCode.InternalServerError);
+        var cache = Build(handler);
 
-        await cache.GetAsync("t-7");
-        await cache.GetAsync("t-7");
+        var first = await cache.GetAsync("t-7");
+        var second = await cache.GetAsync("t-7");
 
-        // Two calls, only one HTTP miss expected — but the failure body still
-        // populates the cache. Assert the second call returns cho without
-        // invoking the handler again would require handler tracking; we assert
-        // the simpler invariant: the cache returns cho consistently and Clear
-        // resets it.
-        var afterClear = await cache.GetAsync("t-7");
-        afterClear.Platform.Should().Be("cho");
+        first.Platform.Should().Be("cho");
+        second.Platform.Should().Be("cho");
+        handler.RequestCount.Should().Be(1);
 
         cache.Clear();
         var afterReset = await cache.GetAsync("t-7");
         afterReset.Platform.Should().Be("cho");
+        handler.RequestCount.Should().Be(2);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/FakeHttpMessageHandler.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/FakeHttpMessageHandler.cs
@@ -1,0 +1,48 @@
+using System.Net;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Adapters;
+
+/// <summary>
+/// Test helper: returns scripted responses for each HTTP call. Tracks the
+/// number of requests so we can assert on cache hits.
+/// </summary>
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+    public int RequestCount { get; private set; }
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder;
+    }
+
+    public static FakeHttpMessageHandler Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+        => new(_ => new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+        });
+
+    public static FakeHttpMessageHandler Status(HttpStatusCode status)
+        => new(_ => new HttpResponseMessage(status));
+
+    public static FakeHttpMessageHandler Throw(Exception exception)
+        => new(_ => throw exception);
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        return Task.FromResult(_responder(request));
+    }
+}
+
+/// <summary>
+/// Minimal <see cref="IHttpClientFactory"/> that hands out an
+/// <see cref="HttpClient"/> wrapping the supplied handler.
+/// </summary>
+internal sealed class StubHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpMessageHandler _handler;
+    public StubHttpClientFactory(HttpMessageHandler handler) { _handler = handler; }
+    public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/StubClaimAdapterTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/StubClaimAdapterTests.cs
@@ -1,0 +1,101 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using FluentAssertions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Adapters;
+
+public class StubClaimAdapterTests
+{
+    public static IEnumerable<object[]> Stubs() => new[]
+    {
+        new object[] { new QnxtClaimAdapter(), "qnxt", "qnxt-claims" },
+        new object[] { new FacetsClaimAdapter(), "facets", "facets-claims" },
+        new object[] { new HealthEdgeClaimAdapter(), "healthedge", "healthedge-claims" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public void Platform_returns_expected_string(IClaimAdapter adapter, string expected, string _)
+    {
+        adapter.Platform.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetClaimAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimAdapterRequest { TenantId = "t", ClaimId = "c" };
+        var act = () => adapter.GetClaimAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain("TODO");
+        ex.Which.Message.Should().Contain(todoMarker);
+        ex.Which.Message.Should().Contain("docs/architecture/claim-adapter-pattern.md");
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetClaimByNumberAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimAdapterRequest { TenantId = "t", ClaimNumber = "CN-1" };
+        var act = () => adapter.GetClaimByNumberAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task GetClaimVersionAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimAdapterRequest { TenantId = "t", ClaimVersionId = "cv", VersionId = "v" };
+        var act = () => adapter.GetClaimVersionAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task ListClaimVersionsAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimAdapterRequest { TenantId = "t", ClaimVersionId = "cv" };
+        var act = () => adapter.ListClaimVersionsAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task SubmitClaimAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimSubmissionAdapterRequest { TenantId = "t", Claim = new AdapterClaim() };
+        var act = () => adapter.SubmitClaimAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task SearchClaimsAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimSearchAdapterRequest { TenantId = "t" };
+        var act = () => adapter.SearchClaimsAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+
+    [Theory]
+    [MemberData(nameof(Stubs))]
+    public async Task SearchClaimsForMemberAsync_throws_with_migration_TODO(IClaimAdapter adapter, string _, string todoMarker)
+    {
+        var request = new ClaimMemberSearchAdapterRequest { TenantId = "t", MemberId = "M1" };
+        var act = () => adapter.SearchClaimsForMemberAsync(request);
+
+        var ex = await act.Should().ThrowAsync<NotImplementedException>();
+        ex.Which.Message.Should().Contain(todoMarker);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `IClaimAdapter` as the vendor-neutral seam over claims retrieval and submission. Mirrors `IProviderAdapter` / `IBenefitPlanAdapter`: case-insensitive `Platform` routing, `ClaimTenantConfigCache` (5-minute TTL, graceful fallback to `"cho"`), `ClaimAdapterFactory`, and three vendor stubs (Qnxt / Facets / HealthEdge) carrying structured TODO messages.
- `ChoClaimAdapter` wraps `IClaimRepository` — read methods delegate by id, chain key, claim number, or version pair; `SubmitClaimAsync` delegates straight to `CreateAsync` (which already seeds the version chain per 5.1a). Adjudication writes, version-event publishing, and accumulator queries deliberately stay off the adapter — those are CHO-internal seams that don't generalize across vendor systems.
- Pure additive — no controller migration in 5.2; that's 5.3 territory. `ClaimsController` continues to inject `IClaimRepository` directly.

## What's in the box

| Area | Files |
|---|---|
| Adapter interface + implementations | `src/services/claims-service/Adapters/IClaimAdapter.cs`, `ChoClaimAdapter.cs`, `QnxtClaimAdapter.cs`, `FacetsClaimAdapter.cs`, `HealthEdgeClaimAdapter.cs` |
| Tenant config + factory | `src/services/claims-service/Adapters/ClaimTenantConfigCache.cs`, `ClaimAdapterFactory.cs` |
| Vendor-neutral DTOs (with `From`/`To*` round-trip mappers) | `src/services/claims-service/Models/ClaimAdapterRequest.cs`, `ClaimAdapterResponse.cs` (carries `AdapterClaim`, `AdapterClaimLine`, `AdapterDiagnosisCode`, `AdapterAdjudicationResult`, `AdapterLineAdjudicationResult`) |
| DI wiring | `src/services/claims-service/Program.cs` (Singleton cache, Scoped factory + adapters, `ClaimsDefault` HttpClient) |
| Tests (~500 LoC) | `tests/CloudHealthOffice.ClaimsService.Tests/Adapters/ClaimAdapterFactoryTests.cs`, `ChoClaimAdapterTests.cs`, `StubClaimAdapterTests.cs`, `ClaimTenantConfigCacheTests.cs`, `FakeHttpMessageHandler.cs` |
| Doc | `docs/architecture/claim-adapter-pattern.md` |

## Plan-First catches worth recording

- **Premise inversion on `AdapterMetadata`/domain types corrected** — Provider/BP both use vendor-neutral DTOs (`AdapterProvider`, `AdapterBenefitPlan`) with round-trip mappers, not domain types. `AdapterClaim` is pattern-parity-correct, not a deviation.
- **`ListClaimVersionsAsync` is on the adapter** even though Provider/BP don't have an equivalent — claims chains routinely produce many versions per chain, and capabilities 5.11 (FHIR `Bundle` of `ClaimResponse` versions) and 5.12 (Adjustment Workflow chain visualization) need vendor-neutral access.
- **`SubmitClaimAsync` is pure delegation to `CreateAsync`** — no event emission today. 5.3 (Submission API) decides whether the adapter or the submission service is the event-emission boundary; not pre-wired in 5.2.

## Test plan

- [ ] CI builds claims-service + ClaimsService.Tests
- [ ] `ClaimAdapterFactoryTests` — routing, fallback (HTTP failure / unknown platform), cache TTL, settings isolation
- [ ] `ChoClaimAdapterTests` — repo delegation, including explicit `AdapterClaim ↔ Claim` lossless round-trip on `SubmitClaimAsync`
- [ ] `StubClaimAdapterTests` — every vendor stub method throws `NotImplementedException` carrying the migration TODO + doc reference
- [ ] `ClaimTenantConfigCacheTests` — cache hit/miss, JSON shape, HTTP failure fallback, defensive URL encoding for tenant ids
- [ ] DI container resolves cleanly at startup (Singleton cache + Scoped factory + Scoped adapters)
- [ ] Existing 22 `ClaimsController` endpoints continue to function unchanged

## Out of scope (deferred to later capabilities)

- 5.3 — wire `ClaimsV1Controller` through the factory for the canonical V1 submission path
- 5.5 — adjudication orchestrator consumes the adapter for reads; writes via `IClaimRepository.UpdateAdjudicationProjectionAsync`
- 5.11 — `FhirClaimProjector` consumes the adapter for vendor-neutral reads
- 5.12 — Adjustment Workflow chain visualization consumes `ListClaimVersionsAsync`

https://claude.ai/code/session_01Ht4yKAhykjDQSQqCFqLvpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht4yKAhykjDQSQqCFqLvpM)_