### PR TITLE
Claims 5.3 — Claim Submission API (canonical V1 surface)

### DIFF
--- a/docs/architecture/claim-submission-api.md
+++ b/docs/architecture/claim-submission-api.md
@@ -1,0 +1,226 @@
+# Claim Submission API
+
+## Why
+
+Capability 5.3 ships the canonical V1 surface for claim submission.
+Before 5.3, the only submission path was the legacy
+`POST /api/claims` on `ClaimsController`, which:
+
+- Accepted the internal domain `Claim` model directly (coupling
+  callers to internal shape changes)
+- Emitted no `ClaimVersionEvent` — the version-event chain shipped
+  in 5.1a had zero production consumers
+- Had no tenant-routing seam, so future vendor adapters had no
+  hook on the write path
+
+5.3 introduces `POST /api/v1/claims` accepting `AdapterClaim` (the
+vendor-neutral DTO from 5.2) and orchestrating: structural
+validation → adapter call → `ClaimVersionSubmitted` event
+emission. The legacy `POST /api/claims` is marked `[Obsolete]` and
+internally routes through the same orchestration path so the
+audit chain has no gaps for legacy-submitted claims while the
+endpoint remains operational. Capability 5.13 (Phase 1 closer)
+removes the legacy controller entirely.
+
+## Topology
+
+```
+                     ┌───────────────────────────────────┐
+   POST /api/v1/claims   │                                   │   POST /api/claims
+   (AdapterClaim,        │                                   │   (Claim, [Obsolete],
+    canonical)           ▼                                   ▼   Deprecation header)
+                ┌────────────────────┐         ┌────────────────────┐
+                │ ClaimsV1Controller │         │  ClaimsController  │
+                │       (5.3)        │         │     (legacy)       │
+                └─────────┬──────────┘         └─────────┬──────────┘
+                          │  AdapterClaim                │ Claim → AdapterClaim.From()
+                          ▼                              ▼
+                          ┌──────────────────────────────────┐
+                          │     IClaimSubmissionService      │
+                          │     (canonical orchestrator)     │
+                          └──────────────────┬───────────────┘
+                                             │
+                       ┌─────────────────────┼─────────────────────┐
+                       ▼                     ▼                     ▼
+              Validate (structural)   IClaimAdapter.SubmitClaimAsync   IClaimVersionEventPublisher
+                                       (tenant-routed via factory)     .PublishVersionSubmittedAsync
+                                                                       (Mongo append-only)
+```
+
+## Interface
+
+```csharp
+public interface IClaimSubmissionService
+{
+    Task<ClaimSubmissionResult> SubmitAsync(
+        AdapterClaim claim,
+        string tenantId,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+}
+```
+
+The result is structured rather than exception-based on
+validation failure so the controller maps to HTTP status codes
+without catching exceptions on the happy path:
+
+```csharp
+public class ClaimSubmissionResult
+{
+    public bool Success { get; set; }
+    public AdapterClaim? Claim { get; set; }                  // populated on success
+    public ClaimSubmissionFailureKind? FailureKind { get; set; }
+    public IReadOnlyList<ValidationError> Errors { get; set; } = Array.Empty<ValidationError>();
+}
+
+public enum ClaimSubmissionFailureKind
+{
+    Validation = 1,        // → controller maps to 400
+    NotImplemented = 2,    // → controller maps to 501
+}
+```
+
+## Validation set
+
+5.3's submission service validates structural shape only.
+Eligibility checks, code coherence, member-plan validity, NCCI
+prevalidation, and COB checks are the scope of capability 5.4
+(Pre-Adjudication Scrubbing). 5.4 will wire `ClaimsScrubEngine`
+into the submission flow as a pipeline stage between the adapter
+call and the event emission; the submission service shape is
+deliberately narrow so 5.4's refactor stays small.
+
+| Field | Rule | Error code |
+|---|---|---|
+| `MemberId` | non-empty | `Required` |
+| `BillingProviderNPI` | non-empty | `Required` |
+| `ServiceDateFrom`/`ServiceDateTo` | from <= to (when both set) | `InvalidDateRange` |
+| `ClaimLines` | at least one line | `MinCount` |
+| `ClaimLines[i].ProcedureCode` | non-empty per line | `Required` |
+| `TotalChargeAmount` | recomputed as sum of line charges | (silent overwrite) |
+
+Caller-supplied `TotalChargeAmount` is overwritten by the
+computed sum before validation runs — same semantic as the legacy
+controller pre-5.3.
+
+## Event emission semantics
+
+On successful submission, the service emits a
+`ClaimVersionEvent` of type `ClaimVersionSubmitted` via
+`IClaimVersionEventPublisher.PublishVersionSubmittedAsync`. The
+publisher (5.1a) is the system-of-record for the audit chain;
+events are appended to a Mongo `ClaimVersionEvents` collection
+with a deterministic `EventId="submitted:{Id}"` for idempotency.
+
+5.3 preserves the 5.1a payload shape — `versionId`,
+`versionNumber`, `claimNumber`, `submittedDate`. Expanding the
+payload is **not** in 5.3's scope; the first downstream consumer
+is capability 5.5's `ClaimAdjudicationOrchestrator`, and any
+payload-shape decision is properly made when 5.5 declares its
+trigger needs.
+
+### Degraded-mode posture
+
+The Mongo claim row in the main store is the system of record
+for the claim itself; `IClaimVersionEventPublisher` is the
+notification stream for the audit chain. If event emission fails
+(Mongo outage, persistent index conflict), the submission service
+**logs loudly and returns success** — same posture as the Kafka
+`IClaimEventPublisher` documented at
+`Services/ClaimEventPublisher.cs:18-22`. Operators see the error
+log; the audit chain may have a gap for the affected claim that
+can be backfilled from logs if needed.
+
+The submission's success contract is "the canonical claim row
+exists in the store"; the audit-chain emission is best-effort
+notification on top of that.
+
+## Tenant routing
+
+Submission goes through `ClaimAdapterFactory.GetAdapterAsync(tenantId)`
+which consults tenant-service configuration cached for 5 minutes.
+For the current production tenant set the factory always resolves
+to `ChoClaimAdapter` — a near pass-through over `IClaimRepository`.
+
+Tenants configured for `qnxt`, `facets`, or `healthedge` resolve
+to stub adapters that throw `NotImplementedException`. The
+submission service catches this and returns:
+
+```csharp
+ClaimSubmissionResult.AdapterNotImplemented(...)
+```
+
+…which the controller maps to `501 Not Implemented` with a
+structured error body:
+
+```json
+{
+  "error": "Claim submission is not implemented for this tenant's configured platform",
+  "errors": [{ "field": "", "code": "AdapterNotImplemented", "message": "..." }]
+}
+```
+
+`501` is the semantically correct status for "this tenant's
+configuration points at a vendor adapter we don't support yet."
+`500` would conflate with bug-shaped failures; `503` would
+conflate with transient unavailability.
+
+## Legacy deprecation path
+
+The legacy `POST /api/claims` continues to function until
+capability 5.13 removes it. To keep the audit chain continuous
+during the deprecation window:
+
+1. The endpoint is marked `[Obsolete("Use POST /api/v1/claims …")]`
+2. Every response carries `Deprecation: true` and
+   `Link: </api/v1/claims>; rel="successor-version"` per
+   RFC 8594 / RFC 9745
+3. The controller method internally calls
+   `IClaimSubmissionService.SubmitAsync(...)` — same orchestrator
+   the V1 endpoint uses. The legacy controller maps `Claim →
+   AdapterClaim` via `AdapterClaim.From(claim)`, calls the
+   service, and maps the response back via `result.Claim.ToClaim()`
+   for the 201 contract pre-existing callers depend on. The 5.2
+   round-trip mapper is loss-less per
+   `SubmitClaimAsync_round_trips_AdapterClaim_losslessly`.
+
+The `Sunset` header is intentionally omitted until 5.13 schedules
+removal; emitting `Sunset` with a placeholder date would be
+misleading.
+
+## What stays unchanged
+
+- **Domain `Claim` model** — 5.1a settled
+- **`IClaimRepository`** — interface and implementations
+  unchanged (5.1a)
+- **`IClaimAdapter`** — interface unchanged (5.2)
+- **`AdapterClaim` round-trip mappers** — unchanged (5.2)
+- **`IClaimVersionEventPublisher`** — interface and implementation
+  unchanged (5.1a). Payload shape decision deferred to capability
+  5.5 when there's a real consumer
+- **Kafka `IClaimEventPublisher`** — `ClaimPendedEvent` and
+  `ClaimFinalizedEvent` continue to emit from PUT paths exactly
+  as before; submission emission is Mongo-only
+- **`accumulator-service` consumer contract** — unchanged
+- **`ClaimAcknowledgmentService`** — 277CA generation stays
+  pull-shaped; event-driven 277CA emission is deferred to a
+  Phase 2 enhancement when there's a real consumer
+- **837 inbound parser** — not introduced in 5.3; Phase 2
+  capability when a real customer integration requires it
+- **`ClaimsV1Controller` GET response shape** — `EobSearchResponse`
+  preserved exactly. Adapter migration is an internal-only
+  change; portal Member Details dialog sees an identical
+  contract
+- **`IExplanationOfBenefitProjector`** — accepts domain `Claim`
+  (unchanged); the V1 GET round-trips `AdapterClaim → Claim` via
+  `.ToClaim()` before projection. Capability 5.11 may evolve the
+  projector to consume `AdapterClaim` directly
+
+## Cross-references
+
+- `claim-versioning.md` — `ClaimVersionEvent` chain semantics
+  (5.1a)
+- `claim-adapter-pattern.md` — tenant-routed adapters (5.2)
+- `adjudication-api-stabilization.md` — Phase 1 closer scope
+  (5.13 removes the legacy controller)

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
@@ -16,6 +17,7 @@ public class ClaimsController : ControllerBase
     private readonly IClaimAcknowledgmentService _ackService;
     private readonly IMpipAdjudicationEnhancer _mpipEnhancer;
     private readonly IClaimEventPublisher _eventPublisher;
+    private readonly IClaimSubmissionService _submissionService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ClaimsController> _logger;
 
@@ -25,6 +27,7 @@ public class ClaimsController : ControllerBase
         IClaimAcknowledgmentService ackService,
         IMpipAdjudicationEnhancer mpipEnhancer,
         IClaimEventPublisher eventPublisher,
+        IClaimSubmissionService submissionService,
         IConfiguration configuration,
         ILogger<ClaimsController> logger)
     {
@@ -33,6 +36,7 @@ public class ClaimsController : ControllerBase
         _ackService = ackService;
         _mpipEnhancer = mpipEnhancer;
         _eventPublisher = eventPublisher;
+        _submissionService = submissionService;
         _configuration = configuration;
         _logger = logger;
     }
@@ -60,37 +64,102 @@ public class ClaimsController : ControllerBase
         HttpContext?.Items["TenantId"]?.ToString() ?? string.Empty;
 
     /// <summary>
-    /// Submit new claim (837 transaction)
+    /// Submit new claim (837 transaction). Deprecated — use
+    /// <c>POST /api/v1/claims</c> which accepts <c>AdapterClaim</c>
+    /// and emits <c>ClaimVersionSubmitted</c> events. Internally
+    /// routes through <see cref="IClaimSubmissionService"/> so the
+    /// audit chain stays continuous until capability 5.13 removes
+    /// this endpoint.
     /// </summary>
     [HttpPost]
+    [Obsolete("Use POST /api/v1/claims instead. The canonical V1 surface accepts AdapterClaim DTOs " +
+              "and emits ClaimVersionSubmitted events. Legacy POST /api/claims will be removed in " +
+              "capability 5.13 (Phase 1 closer).")]
     [ProducesResponseType(typeof(Claim), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<Claim>> SubmitClaim([FromBody] Claim claim)
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
+    public async Task<IActionResult> SubmitClaim([FromBody] Claim claim, CancellationToken ct = default)
     {
+        // RFC 8594 deprecation signal on every response from the legacy
+        // submission path. Sunset is intentionally omitted — capability
+        // 5.13 sets it when removal actually schedules.
+        Response.Headers["Deprecation"] = "true";
+        Response.Headers["Link"] = "</api/v1/claims>; rel=\"successor-version\"";
+
         _logger.LogInformation(
-            "Submitting claim for member {MemberId}, provider {ProviderNPI}, service date {ServiceDate}",
+            "Legacy claim submission for member {MemberId}, provider {ProviderNPI}, service date {ServiceDate}",
             SanitizeForLog(claim.MemberId), SanitizeForLog(claim.BillingProviderNPI), claim.ServiceDateFrom);
 
-        // Validate claim
-        if (claim.ClaimLines.Count == 0)
+        var tenantId = GetTenantId();
+        var actorId = ResolveActorId();
+        var correlationId = ResolveCorrelationId();
+
+        // Map domain Claim → AdapterClaim. The 5.2 round-trip mapper is
+        // loss-less per SubmitClaimAsync_round_trips_AdapterClaim_losslessly,
+        // so the canonical submission service can do its work and we map
+        // the response back to domain shape for the legacy 201 contract.
+        var result = await _submissionService.SubmitAsync(
+            AdapterClaim.From(claim), tenantId, actorId, correlationId, ct);
+
+        if (!result.Success)
         {
-            return BadRequest("Claim must have at least one service line");
+            return MapSubmissionFailure(result);
         }
 
-        // Calculate total charge (sum of lines)
-        claim.TotalChargeAmount = claim.ClaimLines.Sum(l => l.ChargeAmount * l.Units);
-
-        claim.Id = Guid.NewGuid().ToString();
-        claim.Status = ClaimStatus.Submitted;
-        claim.SubmittedDate = DateTime.UtcNow;
-        claim.CreatedDate = DateTime.UtcNow;
-        claim.LastUpdatedDate = DateTime.UtcNow;
-
-        var created = await _claimRepository.CreateAsync(claim);
-
-        _logger.LogInformation("Claim {ClaimNumber} submitted successfully", SanitizeForLog(claim.ClaimNumber));
+        var created = result.Claim!.ToClaim();
+        _logger.LogInformation(
+            "Claim {ClaimNumber} submitted successfully (legacy path)",
+            SanitizeForLog(created.ClaimNumber));
 
         return CreatedAtAction(nameof(GetClaimById), new { id = created.Id }, created);
+    }
+
+    private IActionResult MapSubmissionFailure(ClaimSubmissionResult result)
+    {
+        var errors = result.Errors.Select(e => new
+        {
+            field = e.Field,
+            code = e.Code,
+            message = e.Message
+        });
+
+        return result.FailureKind switch
+        {
+            ClaimSubmissionFailureKind.NotImplemented => StatusCode(
+                StatusCodes.Status501NotImplemented,
+                new
+                {
+                    error = "Claim submission is not implemented for this tenant's configured platform",
+                    errors
+                }),
+            _ => BadRequest(new
+            {
+                error = "Claim submission validation failed",
+                errors
+            }),
+        };
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return "system";
+    }
+
+    private string? ResolveCorrelationId()
+    {
+        if (HttpContext.Request.Headers.TryGetValue("X-Correlation-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return Activity.Current?.Id;
     }
 
     /// <summary>

--- a/src/services/claims-service/Controllers/ClaimsV1Controller.cs
+++ b/src/services/claims-service/Controllers/ClaimsV1Controller.cs
@@ -1,42 +1,113 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Text.Json.Nodes;
+using ClaimsService.Adapters;
 using ClaimsService.Fhir;
 using ClaimsService.Models;
-using ClaimsService.Repositories;
+using ClaimsService.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ClaimsService.Controllers;
 
 /// <summary>
-/// v1 claims API used by the portal Member Details dialog. Exposes a
-/// member-scoped search that projects each matching <see cref="Claim"/> into a
-/// FHIR R4 <c>ExplanationOfBenefit</c> resource — the payer-facing 835-shaped
-/// representation the Claims tab consumes. Paired with the legacy
-/// <c>/api/claims</c> surface (which stays as-is for existing callers).
+/// v1 claims API — the canonical surface for claim submission and
+/// member-scoped search.
+///
+/// <para>
+/// <b>POST</b> — capability 5.3 ships the canonical
+/// <c>POST /api/v1/claims</c> submission endpoint. Accepts an
+/// <see cref="AdapterClaim"/> (vendor-neutral DTO from 5.2),
+/// orchestrates validation + adapter call + version-event emission
+/// through <see cref="IClaimSubmissionService"/>, and returns the
+/// created claim version. Legacy <c>POST /api/claims</c> is marked
+/// <c>[Obsolete]</c> and routes through the same service so the
+/// audit chain is continuous regardless of which surface a caller
+/// picks.
+/// </para>
+///
+/// <para>
+/// <b>GET</b> — member-scoped search powering the portal Member
+/// Details Claims tab. Reads through the tenant-routed
+/// <see cref="IClaimAdapter"/> (5.2) and projects each
+/// <see cref="AdapterClaim"/> onto a FHIR R4 ExplanationOfBenefit
+/// resource via <see cref="IExplanationOfBenefitProjector"/>. The
+/// response shape (<see cref="EobSearchResponse"/>) is unchanged
+/// from the pre-5.3 repo-routed implementation — portal contract
+/// preserved.
+/// </para>
 /// </summary>
 [ApiController]
 [Route("api/v1/claims")]
 [Produces("application/json")]
 public class ClaimsV1Controller : ControllerBase
 {
-    private readonly IClaimRepository _claimRepository;
+    private readonly ClaimAdapterFactory _adapterFactory;
+    private readonly IClaimSubmissionService _submissionService;
     private readonly IExplanationOfBenefitProjector _eobProjector;
     private readonly ILogger<ClaimsV1Controller> _logger;
 
     public ClaimsV1Controller(
-        IClaimRepository claimRepository,
+        ClaimAdapterFactory adapterFactory,
+        IClaimSubmissionService submissionService,
         IExplanationOfBenefitProjector eobProjector,
         ILogger<ClaimsV1Controller> logger)
     {
-        _claimRepository = claimRepository;
+        _adapterFactory = adapterFactory;
+        _submissionService = submissionService;
         _eobProjector = eobProjector;
         _logger = logger;
     }
 
     /// <summary>
+    /// Submit a new claim through the canonical V1 surface. Accepts
+    /// <see cref="AdapterClaim"/> directly so the wire shape stays
+    /// stable as the internal <see cref="Claim"/> domain model
+    /// evolves. On success, emits a <c>ClaimVersionSubmitted</c>
+    /// audit event to the Mongo append-only stream.
+    /// </summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(AdapterClaim), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
+    public async Task<IActionResult> SubmitClaim(
+        [FromBody] AdapterClaim claim,
+        CancellationToken ct = default)
+    {
+        if (claim is null)
+        {
+            return BadRequest(new { error = "Request body is required" });
+        }
+
+        var tenantId = GetTenantId();
+
+        _logger.LogInformation(
+            "v1 claim submission: member={Member}, provider={Provider}, lines={LineCount}",
+            SanitizeForLog(claim.MemberId), SanitizeForLog(claim.BillingProviderNPI),
+            claim.ClaimLines?.Count ?? 0);
+
+        var actorId = ResolveActorId();
+        var correlationId = ResolveCorrelationId();
+
+        var result = await _submissionService.SubmitAsync(
+            claim, tenantId, actorId, correlationId, ct);
+
+        if (!result.Success)
+        {
+            return MapFailure(result);
+        }
+
+        var created = result.Claim!;
+        return CreatedAtAction(
+            nameof(SearchMemberClaims),
+            new { memberId = created.MemberId },
+            created);
+    }
+
+    /// <summary>
     /// Search claims for a member. Returns a small wrapper
-    /// <c>{ total, page, pageSize, resources[] }</c> where <c>resources</c> is
-    /// a FHIR <c>ExplanationOfBenefit</c> array (one per matching claim).
+    /// <c>{ total, page, pageSize, resources[] }</c> where <c>resources</c>
+    /// is a FHIR <c>ExplanationOfBenefit</c> array (one per matching
+    /// claim).
     /// </summary>
     [HttpGet]
     [ProducesResponseType(typeof(EobSearchResponse), StatusCodes.Status200OK)]
@@ -51,25 +122,51 @@ public class ClaimsV1Controller : ControllerBase
         [FromQuery] decimal? amountMin = null,
         [FromQuery] decimal? amountMax = null,
         [FromQuery, Range(1, int.MaxValue)] int page = 1,
-        [FromQuery, Range(1, 100)] int pageSize = 20)
+        [FromQuery, Range(1, 100)] int pageSize = 20,
+        CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(memberId))
             return BadRequest(new { error = "memberId is required" });
+
+        var tenantId = TryGetTenantId();
 
         _logger.LogInformation(
             "v1 claims member search: member={Member}, status={Status}, type={Type}, amount=[{Min},{Max}]",
             SanitizeForLog(memberId), status, claimType, amountMin, amountMax);
 
-        var (claims, total) = await _claimRepository.SearchForMemberAsync(
-            memberId, serviceDateFrom, serviceDateTo, status,
-            providerNPI, claimType, amountMin, amountMax,
-            page, pageSize);
+        var adapter = await _adapterFactory.GetAdapterAsync(tenantId, ct);
+        var adapterResponse = await adapter.SearchClaimsForMemberAsync(
+            new ClaimMemberSearchAdapterRequest
+            {
+                TenantId = tenantId,
+                MemberId = memberId,
+                ServiceDateFrom = serviceDateFrom,
+                ServiceDateTo = serviceDateTo,
+                Status = status,
+                ProviderNPI = providerNPI,
+                ClaimType = claimType,
+                AmountMin = amountMin,
+                AmountMax = amountMax,
+                Page = page,
+                PageSize = pageSize,
+            },
+            ct);
 
         var resources = new JsonArray();
-        foreach (var claim in claims)
+        foreach (var adapterClaim in adapterResponse.Claims)
         {
-            resources.Add(_eobProjector.Project(claim));
+            // Round-trip AdapterClaim → Claim for the existing projector
+            // contract. The 5.2 mapper is loss-less per
+            // SubmitClaimAsync_round_trips_AdapterClaim_losslessly.
+            // Capability 5.11 may evolve the projector to consume
+            // AdapterClaim directly; that's 5.11's scope.
+            resources.Add(_eobProjector.Project(adapterClaim.ToClaim()));
         }
+
+        // Adapters that don't surface a TotalCount fall back to the page
+        // size — defensive, only reachable for vendor adapters that
+        // currently throw NotImplementedException on this method anyway.
+        var total = adapterResponse.TotalCount ?? adapterResponse.Claims.Count;
 
         return Ok(new EobSearchResponse
         {
@@ -78,6 +175,68 @@ public class ClaimsV1Controller : ControllerBase
             PageSize = pageSize,
             Resources = resources
         });
+    }
+
+    private IActionResult MapFailure(ClaimSubmissionResult result)
+    {
+        var errors = result.Errors.Select(e => new
+        {
+            field = e.Field,
+            code = e.Code,
+            message = e.Message
+        });
+
+        return result.FailureKind switch
+        {
+            ClaimSubmissionFailureKind.NotImplemented => StatusCode(
+                StatusCodes.Status501NotImplemented,
+                new
+                {
+                    error = "Claim submission is not implemented for this tenant's configured platform",
+                    errors
+                }),
+            _ => BadRequest(new
+            {
+                error = "Claim submission validation failed",
+                errors
+            }),
+        };
+    }
+
+    private string GetTenantId()
+    {
+        var tenantId = HttpContext?.Items["TenantId"]?.ToString();
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new InvalidOperationException(
+                "TenantId not found in HttpContext. Ensure tenant middleware is configured.");
+        }
+        return tenantId;
+    }
+
+    private string TryGetTenantId() =>
+        HttpContext?.Items["TenantId"]?.ToString() ?? string.Empty;
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return "system";
+    }
+
+    private string? ResolveCorrelationId()
+    {
+        if (HttpContext.Request.Headers.TryGetValue("X-Correlation-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return Activity.Current?.Id;
     }
 
     private static string SanitizeForLog(string? value)

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -118,6 +118,13 @@ builder.Services.AddScoped<IClaimAdapter, FacetsClaimAdapter>();
 builder.Services.AddScoped<IClaimAdapter, HealthEdgeClaimAdapter>();
 builder.Services.AddScoped<ClaimAdapterFactory>();
 
+// Canonical claim submission orchestration (5.3). Wraps the
+// adapter call with structural validation and ClaimVersionSubmitted
+// event emission. Both POST /api/v1/claims and the deprecated
+// legacy POST /api/claims route through this single seam so the
+// version-event chain has no gaps.
+builder.Services.AddScoped<IClaimSubmissionService, ClaimSubmissionService>();
+
 builder.Services.AddChoObservability(builder.Configuration);
 
 var app = builder.Build();

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -514,9 +514,9 @@ public class ClaimRepository : IClaimRepository
         // Initialize the version chain if the caller hasn't done so. New claims
         // start at VersionState=Submitted (matching the existing default
         // ClaimStatus.Submitted on uninitialized rows). Capability 5.3
-        // (Submission API) refines this to Draft → Submitted via an explicit
-        // workflow; until then, claim creation through the existing 22
-        // controller endpoints continues to behave as before.
+        // (Submission API) ratified this Submitted-on-create behavior — there
+        // is no Draft state in the canonical payer submission flow; Draft is
+        // reserved for the future adjustment workflow (capability 5.12).
         if (string.IsNullOrEmpty(claim.ClaimVersionId))
         {
             claim.ClaimVersionId = claim.Id;

--- a/src/services/claims-service/Services/ClaimSubmissionService.cs
+++ b/src/services/claims-service/Services/ClaimSubmissionService.cs
@@ -1,0 +1,311 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+
+namespace ClaimsService.Services;
+
+/// <summary>
+/// Orchestrates canonical claim submission for the v1 surface
+/// (capability 5.3). Sits between the controller and the adapter:
+/// validates the inbound <see cref="AdapterClaim"/>, resolves the
+/// tenant-routed <see cref="IClaimAdapter"/>, calls
+/// <c>SubmitClaimAsync</c>, and emits a <c>ClaimVersionSubmitted</c>
+/// event via the existing 5.1a <see cref="IClaimVersionEventPublisher"/>
+/// on success.
+///
+/// <para>
+/// Both the canonical V1 endpoint and the legacy
+/// <c>POST /api/claims</c> endpoint route through this single
+/// orchestration path so the version-event chain has no gaps for
+/// legacy-submitted claims while the legacy controller remains
+/// operational (it is removed by capability 5.13).
+/// </para>
+/// </summary>
+public interface IClaimSubmissionService
+{
+    /// <summary>
+    /// Submit a claim through the tenant-routed adapter and emit a
+    /// <c>ClaimVersionSubmitted</c> event on success. Returns a
+    /// structured <see cref="ClaimSubmissionResult"/> rather than
+    /// throwing on validation failure so the controller can map to
+    /// HTTP status codes without catching exceptions on the happy
+    /// path.
+    /// </summary>
+    /// <param name="claim">Canonical vendor-neutral claim payload.</param>
+    /// <param name="tenantId">Tenant id resolved by the controller from
+    /// <c>HttpContext.Items["TenantId"]</c>.</param>
+    /// <param name="actorId">Caller identity (sub claim, X-User-Id
+    /// header, or "system") — flows into the version event ActorId
+    /// field for the audit chain.</param>
+    /// <param name="correlationId">Correlation id from the request
+    /// activity or X-Correlation-Id header — flows into the version
+    /// event so downstream consumers can join.</param>
+    Task<ClaimSubmissionResult> SubmitAsync(
+        AdapterClaim claim,
+        string tenantId,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Failure-mode discriminator on <see cref="ClaimSubmissionResult"/>.
+/// Lets the controller map results to specific HTTP status codes
+/// without re-deriving the disposition from error contents.
+/// </summary>
+public enum ClaimSubmissionFailureKind
+{
+    /// <summary>Structural validation failed; controller maps to 400.</summary>
+    Validation = 1,
+
+    /// <summary>Tenant routes to a stub vendor adapter that does not
+    /// implement submission yet; controller maps to 501.</summary>
+    NotImplemented = 2,
+}
+
+/// <summary>
+/// Result envelope returned by <see cref="IClaimSubmissionService.SubmitAsync"/>.
+/// On success, <see cref="Claim"/> carries the canonical post-create
+/// claim version (with assigned ids and seeded version chain). On
+/// failure, <see cref="FailureKind"/> + <see cref="Errors"/> carry
+/// enough detail for the controller to produce a structured response.
+/// </summary>
+public class ClaimSubmissionResult
+{
+    public bool Success { get; set; }
+
+    /// <summary>Created claim with assigned id, ClaimVersionId, VersionNumber=1, VersionState=Submitted. Null on failure.</summary>
+    public AdapterClaim? Claim { get; set; }
+
+    /// <summary>Discriminator for HTTP status mapping; null on success.</summary>
+    public ClaimSubmissionFailureKind? FailureKind { get; set; }
+
+    public IReadOnlyList<ValidationError> Errors { get; set; } = Array.Empty<ValidationError>();
+
+    public static ClaimSubmissionResult Ok(AdapterClaim claim) =>
+        new() { Success = true, Claim = claim };
+
+    public static ClaimSubmissionResult ValidationFailed(IReadOnlyList<ValidationError> errors) =>
+        new() { Success = false, FailureKind = ClaimSubmissionFailureKind.Validation, Errors = errors };
+
+    public static ClaimSubmissionResult AdapterNotImplemented(string message) =>
+        new()
+        {
+            Success = false,
+            FailureKind = ClaimSubmissionFailureKind.NotImplemented,
+            Errors = new[]
+            {
+                new ValidationError
+                {
+                    Field = string.Empty,
+                    Code = "AdapterNotImplemented",
+                    Message = message
+                }
+            }
+        };
+}
+
+/// <summary>
+/// Field-level validation error surfaced by the submission service.
+/// Mirrored in controller responses so callers can highlight specific
+/// inputs.
+/// </summary>
+public class ValidationError
+{
+    /// <summary>Property path that failed validation (e.g. "MemberId", "ClaimLines[0].ProcedureCode").</summary>
+    public string Field { get; set; } = string.Empty;
+
+    /// <summary>Stable error code (e.g. "Required", "MinCount", "InvalidDateRange").</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Human-readable message.</summary>
+    public string Message { get; set; } = string.Empty;
+}
+
+public class ClaimSubmissionService : IClaimSubmissionService
+{
+    private readonly ClaimAdapterFactory _adapterFactory;
+    private readonly IClaimVersionEventPublisher _eventPublisher;
+    private readonly ILogger<ClaimSubmissionService> _logger;
+
+    public ClaimSubmissionService(
+        ClaimAdapterFactory adapterFactory,
+        IClaimVersionEventPublisher eventPublisher,
+        ILogger<ClaimSubmissionService> logger)
+    {
+        _adapterFactory = adapterFactory;
+        _eventPublisher = eventPublisher;
+        _logger = logger;
+    }
+
+    public async Task<ClaimSubmissionResult> SubmitAsync(
+        AdapterClaim claim,
+        string tenantId,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required", nameof(tenantId));
+
+        // Force the tenantId onto the claim so adapter implementations and
+        // the repository see a consistent value regardless of what the
+        // caller supplied in the body. The HttpContext-resolved tenant is
+        // authoritative.
+        claim.TenantId = tenantId;
+
+        // Compute total charge from the lines BEFORE validating, so the
+        // caller-supplied total doesn't influence the validation outcome
+        // (legacy POST has always recomputed; preserve that semantic).
+        if (claim.ClaimLines is { Count: > 0 })
+        {
+            claim.TotalChargeAmount = claim.ClaimLines.Sum(l => l.ChargeAmount * l.Units);
+        }
+
+        var validationErrors = Validate(claim);
+        if (validationErrors.Count > 0)
+        {
+            _logger.LogInformation(
+                "Claim submission rejected: {ErrorCount} validation error(s) for member {Member}",
+                validationErrors.Count, SanitizeForLog(claim.MemberId));
+            return ClaimSubmissionResult.ValidationFailed(validationErrors);
+        }
+
+        var adapter = await _adapterFactory.GetAdapterAsync(tenantId, ct);
+
+        ClaimAdapterResponse adapterResponse;
+        try
+        {
+            adapterResponse = await adapter.SubmitClaimAsync(
+                new ClaimSubmissionAdapterRequest
+                {
+                    TenantId = tenantId,
+                    Claim = claim,
+                    CorrelationId = correlationId,
+                },
+                ct);
+        }
+        catch (NotImplementedException ex)
+        {
+            // Vendor stub adapters (qnxt/facets/healthedge) signal "not
+            // wired up yet" via NotImplementedException. Surface as 501
+            // with the adapter's own message so operators know which
+            // tenant configuration is the gap.
+            _logger.LogWarning(ex,
+                "Adapter for tenant {TenantId} does not implement claim submission",
+                SanitizeForLog(tenantId));
+            return ClaimSubmissionResult.AdapterNotImplemented(ex.Message);
+        }
+
+        var created = adapterResponse.Claim
+            ?? throw new InvalidOperationException(
+                $"Adapter '{adapterResponse.Platform}' returned a null claim from SubmitClaimAsync.");
+
+        // Emit the ClaimVersionSubmitted audit event. The Mongo append-only
+        // stream is the system-of-record for the version chain; this is
+        // the first production consumer of IClaimVersionEventPublisher
+        // (5.1a shipped the publisher with no callers).
+        //
+        // Degraded-mode posture: the claim row in the main store is the
+        // source of truth. If event emission fails (Mongo outage, etc.)
+        // we log loudly but DO NOT fail the submission — same posture as
+        // the Kafka IClaimEventPublisher. The audit chain may have a gap
+        // for the affected claim that operators can backfill from logs.
+        try
+        {
+            var domainClaim = created.ToClaim();
+            await _eventPublisher.PublishVersionSubmittedAsync(domainClaim, actorId, correlationId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionSubmitted event emission failed for claim {ClaimId} (chain {ClaimVersionId}); " +
+                "submission persisted, audit chain has a gap",
+                SanitizeForLog(created.Id), SanitizeForLog(created.ClaimVersionId));
+        }
+
+        _logger.LogInformation(
+            "Claim {ClaimId} submitted via adapter {Platform} (chain {ClaimVersionId} v{VersionNumber}) for tenant {TenantId}",
+            SanitizeForLog(created.Id), SanitizeForLog(adapterResponse.Platform),
+            SanitizeForLog(created.ClaimVersionId), created.VersionNumber, SanitizeForLog(tenantId));
+
+        return ClaimSubmissionResult.Ok(created);
+    }
+
+    /// <summary>
+    /// Structural validation only — field presence, basic shape,
+    /// service-date sanity. Eligibility checks, code coherence, and
+    /// member/plan validity are 5.4 (Pre-Adjudication Scrubbing) scope
+    /// and not duplicated here.
+    /// </summary>
+    private static List<ValidationError> Validate(AdapterClaim claim)
+    {
+        var errors = new List<ValidationError>();
+
+        if (string.IsNullOrWhiteSpace(claim.MemberId))
+        {
+            errors.Add(new ValidationError
+            {
+                Field = nameof(AdapterClaim.MemberId),
+                Code = "Required",
+                Message = "MemberId is required"
+            });
+        }
+
+        if (string.IsNullOrWhiteSpace(claim.BillingProviderNPI))
+        {
+            errors.Add(new ValidationError
+            {
+                Field = nameof(AdapterClaim.BillingProviderNPI),
+                Code = "Required",
+                Message = "BillingProviderNPI is required"
+            });
+        }
+
+        if (claim.ServiceDateFrom != default &&
+            claim.ServiceDateTo != default &&
+            claim.ServiceDateFrom > claim.ServiceDateTo)
+        {
+            errors.Add(new ValidationError
+            {
+                Field = nameof(AdapterClaim.ServiceDateFrom),
+                Code = "InvalidDateRange",
+                Message = "ServiceDateFrom must be on or before ServiceDateTo"
+            });
+        }
+
+        if (claim.ClaimLines is null || claim.ClaimLines.Count == 0)
+        {
+            errors.Add(new ValidationError
+            {
+                Field = nameof(AdapterClaim.ClaimLines),
+                Code = "MinCount",
+                Message = "Claim must have at least one service line"
+            });
+        }
+        else
+        {
+            for (var i = 0; i < claim.ClaimLines.Count; i++)
+            {
+                var line = claim.ClaimLines[i];
+                if (string.IsNullOrWhiteSpace(line.ProcedureCode))
+                {
+                    errors.Add(new ValidationError
+                    {
+                        Field = $"{nameof(AdapterClaim.ClaimLines)}[{i}].{nameof(AdapterClaimLine.ProcedureCode)}",
+                        Code = "Required",
+                        Message = "ProcedureCode is required on every service line"
+                    });
+                }
+            }
+        }
+
+        return errors;
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -1,3 +1,4 @@
+using ClaimsService.Adapters;
 using ClaimsService.EDI.Florida;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
@@ -14,6 +15,9 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
     public IClaimRepository ClaimRepository { get; } = Substitute.For<IClaimRepository>();
     public IClaimAcknowledgmentService AcknowledgmentService { get; } = Substitute.For<IClaimAcknowledgmentService>();
     public IAiExaminationAuditRepository AuditRepository { get; } = Substitute.For<IAiExaminationAuditRepository>();
+    public IClaimSubmissionService SubmissionService { get; } = Substitute.For<IClaimSubmissionService>();
+    public IClaimAdapter ClaimAdapter { get; } = CreateChoStubAdapter();
+    public IClaimVersionEventPublisher VersionEventPublisher { get; } = Substitute.For<IClaimVersionEventPublisher>();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -21,13 +25,17 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
 
         builder.ConfigureServices(services =>
         {
-            // Remove real repository and acknowledgment service registrations
+            // Remove real repository, services, and adapter registrations.
             var descriptorsToRemove = services
                 .Where(d => d.ServiceType == typeof(IClaimRepository)
                          || d.ServiceType == typeof(IClaimAcknowledgmentService)
                          || d.ServiceType == typeof(IProviderService)
                          || d.ServiceType == typeof(ITenantComplianceConfigService)
-                         || d.ServiceType == typeof(IAiExaminationAuditRepository))
+                         || d.ServiceType == typeof(IAiExaminationAuditRepository)
+                         || d.ServiceType == typeof(IClaimSubmissionService)
+                         || d.ServiceType == typeof(IClaimAdapter)
+                         || d.ServiceType == typeof(ClaimAdapterFactory)
+                         || d.ServiceType == typeof(ClaimTenantConfigCache))
                 .ToList();
 
             foreach (var descriptor in descriptorsToRemove)
@@ -54,15 +62,49 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                 services.Remove(descriptor);
             }
 
-            // Re-register a Noop publisher so any controller path that
-            // injects IClaimVersionEventPublisher still resolves cleanly.
-            services.AddScoped<IClaimVersionEventPublisher, NoopClaimVersionEventPublisher>();
+            // Also remove the existing IClaimVersionEventPublisher registration
+            // (Mongo or Noop) — tests inject their own mock so they can
+            // assert on emission without touching infrastructure.
+            var publisherDescriptors = services
+                .Where(d => d.ServiceType == typeof(IClaimVersionEventPublisher))
+                .ToList();
+            foreach (var descriptor in publisherDescriptors)
+            {
+                services.Remove(descriptor);
+            }
 
             services.AddSingleton(ClaimRepository);
             services.AddSingleton(AcknowledgmentService);
             services.AddSingleton(Substitute.For<IProviderService>());
             services.AddSingleton(Substitute.For<ITenantComplianceConfigService>());
             services.AddSingleton(AuditRepository);
+            services.AddSingleton(VersionEventPublisher);
+
+            // V1 controller depends on ClaimAdapterFactory directly (5.2 +
+            // 5.3 wiring). Register a real factory whose only registered
+            // adapter is the stub (default "cho" platform), and a real
+            // ClaimTenantConfigCache that won't actually call out because
+            // we never trigger a cache miss to a live URL.
+            services.AddSingleton<IClaimAdapter>(_ => ClaimAdapter);
+
+            // Reuse the configuration / HTTP client factory already registered
+            // by AddChoInfrastructure.
+            services.AddScoped<ClaimAdapterFactory>();
+            services.AddSingleton<ClaimTenantConfigCache>();
+
+            // Submission service is mocked by default so tests can assert on
+            // controller-level behavior (validation passthrough,
+            // CreatedAtAction, deprecation headers) without standing up the
+            // full orchestration. Tests that need the real service
+            // (ClaimSubmissionServiceTests) instantiate it directly.
+            services.AddSingleton(SubmissionService);
         });
+    }
+
+    private static IClaimAdapter CreateChoStubAdapter()
+    {
+        var adapter = Substitute.For<IClaimAdapter>();
+        adapter.Platform.Returns("cho");
+        return adapter;
     }
 }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerDeprecationTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerDeprecationTests.cs
@@ -5,6 +5,7 @@ using ClaimsService.Controllers;
 using ClaimsService.Models;
 using ClaimsService.Services;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using Xunit;
 
 namespace CloudHealthOffice.ClaimsService.Tests;
@@ -34,7 +35,7 @@ public class ClaimsControllerDeprecationTests : IClassFixture<ClaimsApiFactory>
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
 
-        _service.ClearReceivedCalls();
+        _service.ClearSubstitute();
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerDeprecationTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerDeprecationTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using ClaimsService.Controllers;
+using ClaimsService.Models;
+using ClaimsService.Services;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+/// <summary>
+/// Capability 5.3 deprecation coverage for the legacy
+/// <c>POST /api/claims</c> endpoint. Asserts:
+/// <list type="bullet">
+///   <item><c>[Obsolete]</c> attribute is present with a migration message</item>
+///   <item><c>Deprecation</c> + <c>Link</c> response headers per RFC 8594</item>
+///   <item>Internal call routes through <see cref="IClaimSubmissionService"/></item>
+///   <item>Response shape (domain <see cref="Claim"/>) is unchanged</item>
+/// </list>
+/// Sunset header is intentionally omitted — capability 5.13 schedules
+/// removal and sets it then.
+/// </summary>
+public class ClaimsControllerDeprecationTests : IClassFixture<ClaimsApiFactory>
+{
+    private readonly ClaimsApiFactory _factory;
+    private readonly HttpClient _client;
+    private readonly IClaimSubmissionService _service;
+
+    public ClaimsControllerDeprecationTests(ClaimsApiFactory factory)
+    {
+        _factory = factory;
+        _service = factory.SubmissionService;
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+
+        _service.ClearReceivedCalls();
+    }
+
+    [Fact]
+    public void LegacyPost_HasObsoleteAttribute_WithMigrationMessage()
+    {
+        var method = typeof(ClaimsController).GetMethod(nameof(ClaimsController.SubmitClaim))!;
+        var obsolete = method.GetCustomAttribute<ObsoleteAttribute>();
+        Assert.NotNull(obsolete);
+        Assert.Contains("/api/v1/claims", obsolete!.Message ?? string.Empty);
+        Assert.Contains("5.13", obsolete.Message ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task LegacyPost_OnSuccess_ReturnsDeprecationHeaders()
+    {
+        var claim = BuildLegacyClaim();
+        StubServiceSuccess();
+
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        Assert.True(response.Headers.TryGetValues("Deprecation", out var dep));
+        Assert.Equal("true", dep!.First());
+
+        Assert.True(response.Headers.TryGetValues("Link", out var link));
+        Assert.Contains("/api/v1/claims", link!.First());
+        Assert.Contains("rel=\"successor-version\"", link.First());
+
+        Assert.False(response.Headers.Contains("Sunset"),
+            "Sunset header should be omitted until capability 5.13 schedules removal");
+    }
+
+    [Fact]
+    public async Task LegacyPost_OnFailure_StillReturnsDeprecationHeaders()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ClaimSubmissionResult.ValidationFailed(new[]
+            {
+                new ValidationError { Field = "MemberId", Code = "Required", Message = "MemberId is required" }
+            }));
+
+        var response = await _client.PostAsJsonAsync("/api/claims", BuildLegacyClaim());
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.True(response.Headers.Contains("Deprecation"));
+        Assert.True(response.Headers.Contains("Link"));
+    }
+
+    [Fact]
+    public async Task LegacyPost_RoutesThroughSubmissionService_WithMappedAdapterClaim()
+    {
+        AdapterClaim? captured = null;
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                captured = ci.Arg<AdapterClaim>();
+                captured.Id = "round-trip-id";
+                captured.ClaimVersionId = "round-trip-id";
+                captured.VersionNumber = 1;
+                captured.VersionState = ClaimVersionState.Submitted;
+                return ClaimSubmissionResult.Ok(captured);
+            });
+
+        var claim = BuildLegacyClaim();
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(captured);
+        Assert.Equal(claim.MemberId, captured!.MemberId);
+        Assert.Equal(claim.BillingProviderNPI, captured.BillingProviderNPI);
+        Assert.Equal(claim.ClaimLines.Count, captured.ClaimLines.Count);
+    }
+
+    [Fact]
+    public async Task LegacyPost_PreservesResponseShape_DomainClaim()
+    {
+        StubServiceSuccess();
+
+        var response = await _client.PostAsJsonAsync("/api/claims", BuildLegacyClaim());
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        // Round-trip: response body must deserialize as the legacy domain
+        // Claim shape (NOT AdapterClaim) — that's the contract pre-existing
+        // callers depend on.
+        var domain = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(domain);
+        Assert.Equal("round-trip-id", domain!.Id);
+        Assert.Equal(ClaimStatus.Submitted, domain.Status);
+        Assert.Equal(ClaimVersionState.Submitted, domain.VersionState);
+        Assert.Equal(1, domain.VersionNumber);
+    }
+
+    private void StubServiceSuccess()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var c = ci.Arg<AdapterClaim>();
+                c.Id = "round-trip-id";
+                c.ClaimVersionId = "round-trip-id";
+                c.VersionNumber = 1;
+                c.VersionState = ClaimVersionState.Submitted;
+                c.Status = ClaimStatus.Submitted;
+                return ClaimSubmissionResult.Ok(c);
+            });
+    }
+
+    private static Claim BuildLegacyClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new Claim
+        {
+            TenantId = "test-tenant",
+            ClaimNumber = "CLM-LEGACY-001",
+            MemberId = "MEM-LEGACY",
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<ClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                }
+            }
+        };
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -14,12 +14,14 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
     private readonly HttpClient _client;
     private readonly IClaimRepository _repo;
     private readonly IClaimAcknowledgmentService _ackService;
+    private readonly IClaimSubmissionService _submissionService;
 
     public ClaimsControllerTests(ClaimsApiFactory factory)
     {
         _factory = factory;
         _repo = factory.ClaimRepository;
         _ackService = factory.AcknowledgmentService;
+        _submissionService = factory.SubmissionService;
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
     }
@@ -62,81 +64,67 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // SUBMIT CLAIM
+    // SUBMIT CLAIM (legacy POST /api/claims)
+    //
+    // Capability 5.3 routed legacy submission through IClaimSubmissionService;
+    // the controller is a thin adapter that maps Claim ↔ AdapterClaim around
+    // the canonical service. Detailed validation / event-emission coverage
+    // lives on ClaimSubmissionServiceTests; the tests below assert the
+    // controller wires correctly and emits the deprecation signal.
     // ═══════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task SubmitClaim_ValidClaim_Returns201WithIdAssigned()
+    public async Task SubmitClaim_ValidClaim_RoutesThroughSubmissionService_Returns201()
     {
         var claim = CreateValidClaim();
 
-        _repo.CreateAsync(Arg.Any<Claim>())
-            .Returns(ci => ci.Arg<Claim>());
-
-        var response = await _client.PostAsJsonAsync("/api/claims", claim);
-
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-
-        var created = await response.Content.ReadFromJsonAsync<Claim>();
-        Assert.NotNull(created);
-        Assert.NotNull(created.Id);
-        Assert.NotEmpty(created.Id);
-        Assert.Equal(ClaimStatus.Submitted, created.Status);
-    }
-
-    [Fact]
-    public async Task SubmitClaim_ZeroLines_Returns400()
-    {
-        var claim = CreateValidClaim(lines: new List<ClaimLine>());
-
-        var response = await _client.PostAsJsonAsync("/api/claims", claim);
-
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-    }
-
-    [Fact]
-    public async Task SubmitClaim_CalculatesTotalChargeFromLines()
-    {
-        var serviceDate = new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc);
-        var lines = new List<ClaimLine>
-        {
-            new()
-            {
-                LineNumber = 1,
-                ProcedureCode = "99213",
-                ChargeAmount = 150.00m,
-                Units = 2,
-                ServiceDateFrom = serviceDate,
-                ServiceDateTo = serviceDate,
-                DiagnosisPointers = new List<int> { 1 }
-            },
-            new()
-            {
-                LineNumber = 2,
-                ProcedureCode = "85025",
-                ChargeAmount = 35.50m,
-                Units = 1,
-                ServiceDateFrom = serviceDate,
-                ServiceDateTo = serviceDate,
-                DiagnosisPointers = new List<int> { 1 }
-            }
-        };
-        var claim = CreateValidClaim(lines: lines);
-
-        Claim? capturedClaim = null;
-        _repo.CreateAsync(Arg.Any<Claim>())
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), "test-tenant",
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
-                capturedClaim = ci.Arg<Claim>();
-                return capturedClaim;
+                var inbound = ci.Arg<AdapterClaim>();
+                inbound.Id = "assigned-by-adapter";
+                inbound.ClaimVersionId = "assigned-by-adapter";
+                inbound.VersionNumber = 1;
+                inbound.VersionState = ClaimVersionState.Submitted;
+                inbound.Status = ClaimStatus.Submitted;
+                return ClaimSubmissionResult.Ok(inbound);
             });
 
         var response = await _client.PostAsJsonAsync("/api/claims", claim);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        Assert.NotNull(capturedClaim);
-        // 150 * 2 + 35.50 * 1 = 335.50
-        Assert.Equal(335.50m, capturedClaim.TotalChargeAmount);
+        Assert.True(response.Headers.Contains("Deprecation"));
+
+        var created = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(created);
+        Assert.Equal("assigned-by-adapter", created.Id);
+        Assert.Equal(ClaimStatus.Submitted, created.Status);
+    }
+
+    [Fact]
+    public async Task SubmitClaim_ValidationFailure_Returns400_WithDeprecationHeader()
+    {
+        var claim = CreateValidClaim(lines: new List<ClaimLine>());
+
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ClaimSubmissionResult.ValidationFailed(new[]
+            {
+                new ValidationError
+                {
+                    Field = "ClaimLines",
+                    Code = "MinCount",
+                    Message = "Claim must have at least one service line"
+                }
+            }));
+
+        var response = await _client.PostAsJsonAsync("/api/claims", claim);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.True(response.Headers.Contains("Deprecation"));
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerSubmissionTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerSubmissionTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Models;
+using ClaimsService.Services;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+/// <summary>
+/// Canonical V1 submission endpoint coverage (capability 5.3 —
+/// <c>POST /api/v1/claims</c>). Asserts:
+/// <list type="bullet">
+///   <item>201 with the canonical AdapterClaim on success</item>
+///   <item>400 ProblemDetails-shaped body on validation failure</item>
+///   <item>501 when the tenant routes to a stub vendor adapter</item>
+///   <item>actorId / correlationId resolution from HttpContext flow into the service</item>
+/// </list>
+/// Detailed orchestration coverage is on
+/// <see cref="ClaimSubmissionServiceTests"/>; this suite exercises
+/// the controller's HTTP shape only.
+/// </summary>
+public class ClaimsV1ControllerSubmissionTests : IClassFixture<ClaimsApiFactory>
+{
+    private readonly ClaimsApiFactory _factory;
+    private readonly HttpClient _client;
+    private readonly IClaimSubmissionService _service;
+
+    public ClaimsV1ControllerSubmissionTests(ClaimsApiFactory factory)
+    {
+        _factory = factory;
+        _service = factory.SubmissionService;
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+
+        _service.ClearReceivedCalls();
+    }
+
+    [Fact]
+    public async Task Submit_ValidClaim_Returns201_WithCreatedClaim()
+    {
+        var inbound = BuildAdapterClaim();
+
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), "test-tenant",
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var c = ci.Arg<AdapterClaim>();
+                c.Id = "claim-id-1";
+                c.ClaimVersionId = "claim-id-1";
+                c.VersionNumber = 1;
+                c.VersionState = ClaimVersionState.Submitted;
+                c.Status = ClaimStatus.Submitted;
+                return ClaimSubmissionResult.Ok(c);
+            });
+
+        var response = await _client.PostAsJsonAsync("/api/v1/claims", inbound);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var body = await response.Content.ReadFromJsonAsync<AdapterClaim>();
+        Assert.NotNull(body);
+        Assert.Equal("claim-id-1", body!.Id);
+        Assert.Equal(1, body.VersionNumber);
+        Assert.Equal(ClaimVersionState.Submitted, body.VersionState);
+
+        // Location header should point at the member-search GET so the
+        // portal can pull the new claim by member id without a separate
+        // round-trip to discover the URL.
+        Assert.NotNull(response.Headers.Location);
+        Assert.Contains("memberId=" + inbound.MemberId, response.Headers.Location!.OriginalString);
+    }
+
+    [Fact]
+    public async Task Submit_ValidationFailure_Returns400_WithFieldErrors()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ClaimSubmissionResult.ValidationFailed(new[]
+            {
+                new ValidationError { Field = "MemberId", Code = "Required", Message = "MemberId is required" },
+                new ValidationError { Field = "ClaimLines", Code = "MinCount", Message = "Claim must have at least one service line" }
+            }));
+
+        var inbound = BuildAdapterClaim();
+        inbound.MemberId = string.Empty;
+        inbound.ClaimLines.Clear();
+
+        var response = await _client.PostAsJsonAsync("/api/v1/claims", inbound);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var errors = doc.RootElement.GetProperty("errors").EnumerateArray().ToList();
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(errors, e => e.GetProperty("field").GetString() == "MemberId");
+        Assert.Contains(errors, e => e.GetProperty("field").GetString() == "ClaimLines");
+    }
+
+    [Fact]
+    public async Task Submit_AdapterNotImplemented_Returns501()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ClaimSubmissionResult.AdapterNotImplemented(
+                "QNXT claim adapter not yet implemented."));
+
+        var response = await _client.PostAsJsonAsync("/api/v1/claims", BuildAdapterClaim());
+        Assert.Equal(HttpStatusCode.NotImplemented, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.Contains("AdapterNotImplemented", json);
+    }
+
+    [Fact]
+    public async Task Submit_ForwardsActorIdFromXUserIdHeader()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+        client.DefaultRequestHeaders.Add("X-User-Id", "examiner-7");
+
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), "test-tenant",
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ClaimSubmissionResult.Ok(ci.Arg<AdapterClaim>()));
+
+        var response = await client.PostAsJsonAsync("/api/v1/claims", BuildAdapterClaim());
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        await _service.Received(1).SubmitAsync(
+            Arg.Any<AdapterClaim>(),
+            "test-tenant",
+            "examiner-7",
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Submit_ForwardsCorrelationIdFromHeader()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+        client.DefaultRequestHeaders.Add("X-Correlation-Id", "trace-abc-123");
+
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ClaimSubmissionResult.Ok(ci.Arg<AdapterClaim>()));
+
+        var response = await client.PostAsJsonAsync("/api/v1/claims", BuildAdapterClaim());
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        await _service.Received(1).SubmitAsync(
+            Arg.Any<AdapterClaim>(),
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            "trace-abc-123",
+            Arg.Any<CancellationToken>());
+    }
+
+    private static AdapterClaim BuildAdapterClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new AdapterClaim
+        {
+            ClaimNumber = "CLM-V1-0001",
+            MemberId = "MEM-V1",
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150.00m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                }
+            }
+        };
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerSubmissionTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerSubmissionTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using ClaimsService.Models;
 using ClaimsService.Services;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using Xunit;
 
 namespace CloudHealthOffice.ClaimsService.Tests;
@@ -13,7 +14,7 @@ namespace CloudHealthOffice.ClaimsService.Tests;
 /// <c>POST /api/v1/claims</c>). Asserts:
 /// <list type="bullet">
 ///   <item>201 with the canonical AdapterClaim on success</item>
-///   <item>400 ProblemDetails-shaped body on validation failure</item>
+///   <item>400 body with top-level <c>error</c> and <c>errors[]</c> fields on validation failure</item>
 ///   <item>501 when the tenant routes to a stub vendor adapter</item>
 ///   <item>actorId / correlationId resolution from HttpContext flow into the service</item>
 /// </list>
@@ -34,7 +35,7 @@ public class ClaimsV1ControllerSubmissionTests : IClassFixture<ClaimsApiFactory>
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
 
-        _service.ClearReceivedCalls();
+        _service.ClearSubstitute();
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1MemberSearchTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1MemberSearchTests.cs
@@ -1,9 +1,8 @@
 using System.Net;
-using System.Net.Http.Json;
 using System.Text.Json;
+using ClaimsService.Adapters;
 using ClaimsService.Fhir;
 using ClaimsService.Models;
-using ClaimsService.Repositories;
 using NSubstitute;
 using Xunit;
 
@@ -11,21 +10,28 @@ namespace CloudHealthOffice.ClaimsService.Tests;
 
 /// <summary>
 /// v1 member-scoped claims surface — covers the /api/v1/claims route,
-/// amountRange/claimType filter pass-through, and the FHIR EOB projection
-/// produced by <see cref="ExplanationOfBenefitProjector"/>.
+/// adapter-routed reads (capability 5.3 migrated this from
+/// IClaimRepository.SearchForMemberAsync), filter pass-through, and
+/// the FHIR EOB projection produced by
+/// <see cref="ExplanationOfBenefitProjector"/>.
 /// </summary>
 public class ClaimsV1MemberSearchTests : IClassFixture<ClaimsApiFactory>
 {
     private readonly ClaimsApiFactory _factory;
     private readonly HttpClient _client;
-    private readonly IClaimRepository _repo;
+    private readonly IClaimAdapter _adapter;
 
     public ClaimsV1MemberSearchTests(ClaimsApiFactory factory)
     {
         _factory = factory;
-        _repo = factory.ClaimRepository;
+        _adapter = factory.ClaimAdapter;
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+
+        // Reset the adapter mock between tests since the factory is shared
+        // across the class fixture. Configure each test's expectations
+        // explicitly.
+        _adapter.ClearReceivedCalls();
     }
 
     [Fact]
@@ -39,13 +45,16 @@ public class ClaimsV1MemberSearchTests : IClassFixture<ClaimsApiFactory>
     public async Task SearchMemberClaims_ReturnsEobWrapperWithProjectedResources()
     {
         var claim = BuildClaim("MEM-42", "CLM-A1");
-        _repo.SearchForMemberAsync(
-                "MEM-42",
-                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<ClaimStatus?>(),
-                Arg.Any<string?>(), Arg.Any<ClaimType?>(),
-                Arg.Any<decimal?>(), Arg.Any<decimal?>(),
-                Arg.Any<int>(), Arg.Any<int>())
-            .Returns((new List<Claim> { claim }, 1));
+        _adapter
+            .SearchClaimsForMemberAsync(
+                Arg.Is<ClaimMemberSearchAdapterRequest>(r => r.MemberId == "MEM-42"),
+                Arg.Any<CancellationToken>())
+            .Returns(new ClaimSearchAdapterResponse
+            {
+                Platform = "cho",
+                Claims = new[] { AdapterClaim.From(claim) },
+                TotalCount = 1,
+            });
 
         var response = await _client.GetAsync("/api/v1/claims?memberId=MEM-42&pageSize=5");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -68,26 +77,59 @@ public class ClaimsV1MemberSearchTests : IClassFixture<ClaimsApiFactory>
     [Fact]
     public async Task SearchMemberClaims_ForwardsAmountAndClaimTypeFilters()
     {
-        _repo.SearchForMemberAsync(
-                "MEM-99",
-                Arg.Any<DateTime?>(), Arg.Any<DateTime?>(), Arg.Any<ClaimStatus?>(),
-                Arg.Any<string?>(), Arg.Any<ClaimType?>(),
-                Arg.Any<decimal?>(), Arg.Any<decimal?>(),
-                Arg.Any<int>(), Arg.Any<int>())
-            .Returns((new List<Claim>(), 0));
+        _adapter
+            .SearchClaimsForMemberAsync(
+                Arg.Any<ClaimMemberSearchAdapterRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ClaimSearchAdapterResponse
+            {
+                Platform = "cho",
+                Claims = Array.Empty<AdapterClaim>(),
+                TotalCount = 0,
+            });
 
         var response = await _client.GetAsync(
             "/api/v1/claims?memberId=MEM-99&amountMin=100&amountMax=500&claimType=Institutional&status=Paid");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        await _repo.Received(1).SearchForMemberAsync(
-            "MEM-99",
-            Arg.Any<DateTime?>(), Arg.Any<DateTime?>(),
-            ClaimStatus.Paid,
-            Arg.Any<string?>(),
-            ClaimType.Institutional,
-            100m, 500m,
-            Arg.Any<int>(), Arg.Any<int>());
+        await _adapter.Received(1).SearchClaimsForMemberAsync(
+            Arg.Is<ClaimMemberSearchAdapterRequest>(r =>
+                r.MemberId == "MEM-99" &&
+                r.AmountMin == 100m &&
+                r.AmountMax == 500m &&
+                r.ClaimType == ClaimType.Institutional &&
+                r.Status == ClaimStatus.Paid),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SearchMemberClaims_NullTotalCount_FallsBackToPageSize()
+    {
+        // Defensive fallback for adapters that don't surface a total
+        // (vendor stubs would, in theory, though they currently throw
+        // NotImplementedException before this path).
+        var claims = new[]
+        {
+            AdapterClaim.From(BuildClaim("MEM-50", "CLM-B1")),
+            AdapterClaim.From(BuildClaim("MEM-50", "CLM-B2")),
+        };
+        _adapter
+            .SearchClaimsForMemberAsync(
+                Arg.Any<ClaimMemberSearchAdapterRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new ClaimSearchAdapterResponse
+            {
+                Platform = "cho",
+                Claims = claims,
+                TotalCount = null,
+            });
+
+        var response = await _client.GetAsync("/api/v1/claims?memberId=MEM-50");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        Assert.Equal(2, doc.RootElement.GetProperty("total").GetInt32());
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1MemberSearchTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1MemberSearchTests.cs
@@ -4,6 +4,7 @@ using ClaimsService.Adapters;
 using ClaimsService.Fhir;
 using ClaimsService.Models;
 using NSubstitute;
+using NSubstitute.ClearExtensions;
 using Xunit;
 
 namespace CloudHealthOffice.ClaimsService.Tests;
@@ -28,10 +29,12 @@ public class ClaimsV1MemberSearchTests : IClassFixture<ClaimsApiFactory>
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
 
-        // Reset the adapter mock between tests since the factory is shared
-        // across the class fixture. Configure each test's expectations
-        // explicitly.
-        _adapter.ClearReceivedCalls();
+        // Reset the shared adapter substitute between tests since the
+        // factory is shared across the class fixture. ClearSubstitute()
+        // clears both received calls AND configured returns; we re-establish
+        // Platform="cho" because ClaimAdapterFactory routes by it.
+        _adapter.ClearSubstitute();
+        _adapter.Platform.Returns("cho");
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceTests.cs
@@ -1,0 +1,271 @@
+using System.Net.Http;
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+/// <summary>
+/// Coverage for the canonical orchestrator introduced in capability 5.3.
+/// Validates: structural validation rules, total-charge computation,
+/// adapter routing via factory, ClaimVersionSubmitted event emission,
+/// degraded-mode behavior when emission fails, and 501-shaped result
+/// when the resolved adapter throws NotImplementedException.
+/// </summary>
+public class ClaimSubmissionServiceTests
+{
+    private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
+    private readonly IClaimVersionEventPublisher _publisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly ClaimAdapterFactory _factory;
+    private readonly ClaimSubmissionService _sut;
+
+    public ClaimSubmissionServiceTests()
+    {
+        _adapter.Platform.Returns("cho");
+
+        // Real cache with mocked dependencies — the IHttpClientFactory mock
+        // returns null on CreateClient, which trips the cache's catch-all
+        // fallback to the "cho" default platform. Deterministic without
+        // making an HTTP call.
+        var cache = new ClaimTenantConfigCache(
+            Substitute.For<IHttpClientFactory>(),
+            Substitute.For<IConfiguration>(),
+            NullLogger<ClaimTenantConfigCache>.Instance);
+
+        _factory = new ClaimAdapterFactory(
+            new[] { _adapter },
+            cache,
+            NullLogger<ClaimAdapterFactory>.Instance);
+
+        _sut = new ClaimSubmissionService(
+            _factory, _publisher, NullLogger<ClaimSubmissionService>.Instance);
+    }
+
+    [Fact]
+    public async Task Submit_HappyPath_CallsAdapter_EmitsEvent_ReturnsCreatedClaim()
+    {
+        var inbound = BuildClaim();
+        AdapterClaim? capturedRequest = null;
+
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var req = ci.Arg<ClaimSubmissionAdapterRequest>();
+                capturedRequest = req.Claim;
+                req.Claim.Id = "new-claim-id";
+                req.Claim.ClaimVersionId = "new-claim-id";
+                req.Claim.VersionNumber = 1;
+                req.Claim.VersionState = ClaimVersionState.Submitted;
+                return new ClaimAdapterResponse
+                {
+                    Platform = "cho",
+                    Claim = req.Claim,
+                };
+            });
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor-9", "corr-1");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Claim);
+        Assert.Equal("new-claim-id", result.Claim!.Id);
+        Assert.Equal("tenant-1", capturedRequest!.TenantId);
+
+        await _publisher.Received(1).PublishVersionSubmittedAsync(
+            Arg.Is<Claim>(c => c.Id == "new-claim-id" && c.ClaimVersionId == "new-claim-id"),
+            "actor-9",
+            "corr-1",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Submit_ComputesTotalChargeFromLines_BeforeAdapterCall()
+    {
+        var inbound = BuildClaim();
+        inbound.TotalChargeAmount = 1m; // bogus caller-supplied value
+        inbound.ClaimLines = new List<AdapterClaimLine>
+        {
+            new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 150m, Units = 2,
+                    ServiceDateFrom = inbound.ServiceDateFrom, ServiceDateTo = inbound.ServiceDateTo },
+            new() { LineNumber = 2, ProcedureCode = "85025", ChargeAmount = 35.50m, Units = 1,
+                    ServiceDateFrom = inbound.ServiceDateFrom, ServiceDateTo = inbound.ServiceDateTo },
+        };
+
+        decimal? capturedTotal = null;
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedTotal = ci.Arg<ClaimSubmissionAdapterRequest>().Claim.TotalChargeAmount;
+                return new ClaimAdapterResponse { Platform = "cho", Claim = ci.Arg<ClaimSubmissionAdapterRequest>().Claim };
+            });
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+        Assert.True(result.Success);
+        Assert.Equal(150m * 2 + 35.50m, capturedTotal);
+    }
+
+    [Fact]
+    public async Task Submit_MissingMemberId_ReturnsValidationFailure()
+    {
+        var inbound = BuildClaim();
+        inbound.MemberId = string.Empty;
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Equal(ClaimSubmissionFailureKind.Validation, result.FailureKind);
+        Assert.Contains(result.Errors, e => e.Field == "MemberId" && e.Code == "Required");
+        await _adapter.DidNotReceiveWithAnyArgs().SubmitClaimAsync(default!, default);
+        await _publisher.DidNotReceiveWithAnyArgs().PublishVersionSubmittedAsync(default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task Submit_MissingBillingProviderNPI_ReturnsValidationFailure()
+    {
+        var inbound = BuildClaim();
+        inbound.BillingProviderNPI = string.Empty;
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Field == "BillingProviderNPI" && e.Code == "Required");
+    }
+
+    [Fact]
+    public async Task Submit_ZeroLines_ReturnsValidationFailure()
+    {
+        var inbound = BuildClaim();
+        inbound.ClaimLines.Clear();
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Field == "ClaimLines" && e.Code == "MinCount");
+    }
+
+    [Fact]
+    public async Task Submit_LineWithoutProcedureCode_ReturnsValidationFailure()
+    {
+        var inbound = BuildClaim();
+        inbound.ClaimLines[0].ProcedureCode = string.Empty;
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e =>
+            e.Field == "ClaimLines[0].ProcedureCode" && e.Code == "Required");
+    }
+
+    [Fact]
+    public async Task Submit_ServiceDateFromAfterServiceDateTo_ReturnsValidationFailure()
+    {
+        var inbound = BuildClaim();
+        inbound.ServiceDateFrom = new DateTime(2026, 4, 30, 0, 0, 0, DateTimeKind.Utc);
+        inbound.ServiceDateTo = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await _sut.SubmitAsync(inbound, "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e =>
+            e.Field == "ServiceDateFrom" && e.Code == "InvalidDateRange");
+    }
+
+    [Fact]
+    public async Task Submit_AdapterThrowsNotImplemented_ReturnsAdapterNotImplemented()
+    {
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new NotImplementedException("QNXT claim adapter not yet implemented."));
+
+        var result = await _sut.SubmitAsync(BuildClaim(), "tenant-1", "actor", null);
+
+        Assert.False(result.Success);
+        Assert.Equal(ClaimSubmissionFailureKind.NotImplemented, result.FailureKind);
+        Assert.Contains(result.Errors, e => e.Code == "AdapterNotImplemented");
+        await _publisher.DidNotReceiveWithAnyArgs().PublishVersionSubmittedAsync(default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task Submit_EventEmissionFails_StillReturnsSuccess()
+    {
+        // Degraded-mode: claim row in main store is system of record;
+        // event publisher failure must not fail the submission. Mirrors
+        // the Kafka publisher's documented posture.
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var req = ci.Arg<ClaimSubmissionAdapterRequest>();
+                req.Claim.Id = "claim-x";
+                req.Claim.ClaimVersionId = "claim-x";
+                req.Claim.VersionNumber = 1;
+                return new ClaimAdapterResponse { Platform = "cho", Claim = req.Claim };
+            });
+
+        _publisher
+            .PublishVersionSubmittedAsync(Arg.Any<Claim>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Mongo append-only stream unavailable"));
+
+        var result = await _sut.SubmitAsync(BuildClaim(), "tenant-1", "actor", null);
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Claim);
+        Assert.Equal("claim-x", result.Claim!.Id);
+    }
+
+    [Fact]
+    public async Task Submit_ForcesTenantIdOntoClaim()
+    {
+        var inbound = BuildClaim();
+        inbound.TenantId = "spoofed-tenant";
+
+        AdapterClaim? captured = null;
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                captured = ci.Arg<ClaimSubmissionAdapterRequest>().Claim;
+                return new ClaimAdapterResponse { Platform = "cho", Claim = ci.Arg<ClaimSubmissionAdapterRequest>().Claim };
+            });
+
+        await _sut.SubmitAsync(inbound, "real-tenant", "actor", null);
+
+        Assert.NotNull(captured);
+        Assert.Equal("real-tenant", captured!.TenantId);
+    }
+
+    private static AdapterClaim BuildClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new AdapterClaim
+        {
+            ClaimNumber = "CLM-001",
+            MemberId = "MEM-1",
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                }
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
## Summary

Capability 5.3 ships the canonical V1 claim-submission surface, ties together the four prior foundation patterns (versioning + adapter + event publisher + projection-bypass), and unblocks the pipeline cluster (5.4-5.9).

- **Canonical `POST /api/v1/claims`** accepting `AdapterClaim` (5.2 vendor-neutral DTO), orchestrated through new `IClaimSubmissionService` → validate → adapter `SubmitClaimAsync` → emit `ClaimVersionSubmitted` event.
- **`IClaimVersionEventPublisher` first production consumer.** 5.1a shipped the publisher with no callers; 5.3 wires submission events to the Mongo append-only audit chain. **5.1a payload preserved unchanged** — payload-shape decisions stay deferred to capability 5.5 when there's a real consumer.
- **`ClaimsV1Controller` GET** migrated from `IClaimRepository.SearchForMemberAsync` to adapter-routed read; `EobSearchResponse` shape preserved (portal Member Details contract). Round-trip `AdapterClaim → Claim` before projection keeps `IExplanationOfBenefitProjector` untouched.
- **Legacy `POST /api/claims` deprecated** — `[Obsolete]` attribute with explicit migration message, RFC 8594 `Deprecation: true` + `Link: </api/v1/claims>; rel="successor-version"` response headers. Internally routes through the same submission service so the version-event chain has no gaps for legacy submitters until 5.13 removes the controller. `Sunset` header intentionally omitted — 5.13 sets it when removal schedules.
- **Stub vendor adapters** (qnxt/facets/healthedge) → `NotImplementedException` caught by submission service → mapped to **501 Not Implemented**.
- **Degraded-mode event emission** — try/catch wrapper local to the submission service. Mongo claim row is system of record; event publisher is notification stream. Failure logs loudly but does not fail the submission. Mirrors Kafka publisher posture. **No modification to `MongoClaimVersionEventPublisher`** (5.1a infrastructure preserved).
- **Validation set** is structural-only: member id, billing NPI, line count ≥ 1, procedure code per line, service-date sanity, computed total charge from line sums. Eligibility / code-coherence / NCCI prevalidation defer to capability 5.4 (Pre-Adjudication Scrubbing).
- **Stale comment correction** in `ClaimRepository.CreateAsync` — promised "Draft → Submitted" refinement is now ratified as Submitted-on-create.
- **Anonymous-object error responses** match sibling-service convention; no RFC 7807 ProblemDetails introduced.
- **Architecture doc** at `docs/architecture/claim-submission-api.md` records the surface, event semantics, deprecation path, and degraded-mode posture.

### Plan-First decisions ratified

| Decision | Outcome |
|---|---|
| 3 — initial state | `Submitted` (no `Draft`); `Draft` enum value retained for 5.12 |
| 4 — event emission | `IClaimVersionEventPublisher.PublishVersionSubmittedAsync(claim, actorId, correlationId, ct)` |
| 5 — payload shape | **Keep existing 5.1a payload unchanged** (Risk 4 discipline) |
| 6 — deprecation headers | `Deprecation` + `Link` only; `Sunset` omitted until 5.13 |
| 7 — legacy POST internal call | Yes; round-trip via `AdapterClaim.From/.ToClaim()` |
| 8 — validation set | Structural-only; defer eligibility/coherence to 5.4 |
| 9 — V1 GET migration | Adapter-routed; round-trip to `Claim` for projector |
| 10 — service interface | `ClaimSubmissionResult` + `ClaimSubmissionFailureKind` enum |
| 11 — error shape | Anonymous-object responses; no ProblemDetails |
| 12 — stub adapter | 501 Not Implemented |
| 13 — emission failure | Try/catch in submission service; log-and-swallow |

### Out of scope (explicitly preserved)

Domain `Claim` model, `IClaimRepository`, `IClaimAdapter`, `AdapterClaim` mappers, Kafka `IClaimEventPublisher`, accumulator-service consumer contract, `ClaimAcknowledgmentService`, 837 inbound parser (Phase 2), 20 non-POST legacy endpoints, fhir-service, `IExplanationOfBenefitProjector`, Cosmos partition strategy, `MongoClaimVersionEventPublisher`.

## Test plan

- [ ] `dotnet build src/services/claims-service` clean
- [ ] `dotnet test tests/CloudHealthOffice.ClaimsService.Tests` green:
  - [ ] `ClaimsV1ControllerSubmissionTests` — 201 happy path with Location header, 400 on validation failure, 501 on stub adapter, X-User-Id/X-Correlation-Id flow into service
  - [ ] `ClaimsV1MemberSearchTests` — adapter-routed reads, filter pass-through, null-TotalCount fallback, EOB projection unchanged
  - [ ] `ClaimSubmissionServiceTests` — orchestration, all validation rules, total-charge recomputation, NotImplementedException handling, **degraded-mode event emission failure still returns success**, tenant-id forced onto claim
  - [ ] `ClaimsControllerDeprecationTests` — `[Obsolete]` reflection, Deprecation+Link headers (success path AND failure path), Sunset absent, internal routing through submission service, response shape preserved as domain `Claim`
  - [ ] `ClaimsControllerTests.SubmitClaim_*` (updated) — legacy POST routes through submission service mock and returns deprecation headers
  - [ ] Existing `AiExaminationEndpointsTests`, `ChoClaimAdapterTests`, `ClaimVersionEventPublisherTests`, `ClaimRepositoryVersioningTests`, etc. unchanged and green
- [ ] Manual: confirm portal Member Details Claims tab works against the adapter-routed GET (response shape identical)
- [ ] Manual: submit a claim through `POST /api/v1/claims`, verify a `ClaimVersionEvents` row with `EventType=ClaimVersionSubmitted` and `EventId=submitted:{Id}`
- [ ] Manual: submit a claim through legacy `POST /api/claims`, verify same audit row appears AND response carries `Deprecation: true` + `Link: </api/v1/claims>; rel="successor-version"`

## After this PR

- 5.4 Pre-Adjudication Scrubbing wires `ClaimsScrubEngine` between adapter call and event emission
- 5.5 Adjudication Pipeline consumes `ClaimVersionSubmitted` events from Mongo (5.3's emission is the trigger source)
- 5.13 mechanically removes legacy `ClaimsController`

https://claude.ai/code/session_01FVdCcyzN3z3Tf5MYF9rTx3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVdCcyzN3z3Tf5MYF9rTx3)_