### PR TITLE
Claims 5.5 — Adjudication pipeline foundation

### DIFF
--- a/docs/architecture/claim-adjudication-pipeline.md
+++ b/docs/architecture/claim-adjudication-pipeline.md
@@ -1,0 +1,273 @@
+# Claim Adjudication Pipeline (Capability 5.5)
+
+> **Status — Phase 1 foundation, April 2026.** Ships the orchestrator,
+> stage interface, BenefitCalculation + Persistence stages, five stub
+> stages, Service Bus trigger transport, and resolver clients. Capabilities
+> 5.4 / 5.6 / 5.7 / 5.8 / 5.9 each replace one stub stage via DI swap.
+
+## Why this exists
+
+Before 5.5 the claim version chain ended at `Submitted` and stayed there
+forever — there was no production code path that produced an
+`AdjudicationResult` on a claim. The 5.1a projection-bypass method
+`IClaimRepository.UpdateAdjudicationProjectionAsync` had been registered
+on the repository interface since January 2026 with zero callers.
+
+5.5 introduces the orchestration seam that turns a submitted claim into
+an adjudicated one. It is the architecturally load-bearing PR of Claims
+Phase 1: every subsequent claims-Phase-1 capability replaces one stage in
+this pipeline rather than building its own orchestration.
+
+## Pipeline shape
+
+```
+POST /api/v1/claims                                     (capability 5.3)
+   │
+   ├─ Mongo append-only ClaimVersionSubmitted event     (system of record)
+   └─ Service Bus → claim-version-events                (trigger transport)
+                              │
+                              ▼
+            adjudication-orchestrator subscription      (capability 5.5)
+                              │
+                              ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  IClaimAdjudicationOrchestrator                              │
+   │   ├── re-fetch via IClaimAdapter.GetClaimAsync(...)          │
+   │   ├── resolve plan (cached)  • resolve member (cached)       │
+   │   └── iterate stages by Order ascending:                     │
+   │                                                              │
+   │       100  ScrubbingStubStage           (5.4 replaces)       │
+   │       200  NetworkCredentialingStubStage (5.6 replaces)      │
+   │       300  BenefitCalculationStage      ★ real (5.5)         │
+   │       400  NcciEditsStubStage           (5.7 replaces)       │
+   │       500  CoordinationOfBenefitsStubStage (5.8 replaces)    │
+   │       600  AiExaminationStubStage       (5.9 replaces)       │
+   │       999  PersistenceStage             ★ real (5.5)         │
+   └──────────────────────────────────────────────────────────────┘
+                              │
+   ┌──────────────────────────┴───────────────────────────────────┐
+   │  Mongo append-only ClaimVersionAdjudicated event             │
+   │  Service Bus → claim-version-events (MessageType=Adjudicated)│
+   └──────────────────────────────────────────────────────────────┘
+```
+
+After PersistenceStage runs, the orchestrator emits a
+`ClaimVersionAdjudicatedMessage` back onto the same topic. Future
+capabilities (5.10 remittance, 5.12 adjustment workflow, ...) attach
+their own subscriptions filtered on `MessageType=ClaimVersionAdjudicated`.
+
+## Decisions
+
+### D1 — Service Bus is the trigger transport
+
+`IMessageBus` (the platform's canonical async-messaging abstraction). Not
+Mongo change streams (no service uses them; new pattern), not Kafka
+(`IMessageBus` doc says "Kafka usage stays on its own dedicated client —
+IMessageBus is not a Kafka facade").
+
+### D2 — Single broad topic + per-consumer subscription
+
+Topic `claim-version-events`; subscription `adjudication-orchestrator`.
+Mirrors `appeals-api`'s `payer-appeal-status-updates` topic +
+`clearinghouse-push` subscription pattern. New downstream subscribers
+(5.10, 5.12) add their own subscriptions to the same topic with their own
+filter rules.
+
+### D3 — Bicep delta lives in `main.bicep`
+
+Topic + subscription + correlation filter (`MessageType=ClaimVersionSubmitted`)
+declared in `infrastructure/azure/main.bicep`. No new
+`claims-service.bicep` module — the service has nothing else infra-specific
+that warrants one.
+
+### D4 — Dual emission on submission
+
+`ClaimSubmissionService` emits **both** the Mongo append-only event
+(system-of-record audit chain — preserved from 5.3) **and** the Service
+Bus topic message (NEW trigger transport). Order: Mongo first, Service
+Bus second. Service Bus failure does not fail the submission (degraded
+mode); the audit chain captures every submission either way.
+
+### D5 — Synchronous pipeline within one Service Bus message
+
+When the orchestrator consumes a `ClaimVersionSubmittedMessage`, all
+stages run sequentially in the message handler. Async-between-stages is
+not in scope. If 5.9 (AI examination) needs async semantics it adds a
+separate subscription rather than fragmenting the main pipeline.
+
+### D6 — Stage ordering is fixed in code, not config
+
+Per-tenant configuration (`AdjudicationPipelineOptions.EnabledStages`)
+controls only **whether** a stage runs, never the order. Stage ordering
+is platform-level architecture (NCCI before COB before persistence,
+etc.); tenant-configurable order would produce inconsistent adjudication
+across tenants. Pattern parity:
+`BenefitCalculationEngine`'s internal phase ordering is also fixed.
+
+### D7 — Short-circuit on terminal stage failure
+
+`Reject` and `Deny` outcomes set `Continue=false`; remaining
+non-persistence stages skip. PersistenceStage **always** runs (forced
+via `IsRequired=true`) so the version chain captures the failure
+outcome. `Pend` is recoverable — pipeline continues so subsequent stages
+can decorate the result before the claim ends up in a human-review queue.
+
+### D8 — Stage interface
+
+```csharp
+public interface IClaimAdjudicationStage
+{
+    string Name { get; }                  // for telemetry + EnabledStages key
+    int Order { get; }                    // 100/200/300/.../999
+    bool IsRequired { get; }              // true → bypasses EnabledStages + short-circuit
+    Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context, CancellationToken ct);
+}
+```
+
+`ClaimAdjudicationContext` is **mutable**. Stages append outcomes to
+`StageResults`, decorate the building `AdjudicationResult` /
+`LineAdjudicationResults`, and set `BenefitResolutionResult` /
+`ResolvedPlan` / `ResolvedMember` as they pass through. Single-threaded
+within one message handler so mutability is safe.
+
+### D9 — PersistenceStage uses the bypass method
+
+`PersistenceStage` calls
+`IClaimRepository.UpdateAdjudicationProjectionAsync(...)`, **not**
+`UpdateAsync`. Reasons:
+
+- Adjudication state is operationally distinct from claim identity — the
+  whole purpose of the bypass pattern.
+- Adjudication writes must not produce a new claim version row;
+  per-version churn is reserved for adjustments (5.12) and reversals.
+- 5th instance of the projection-bypass pattern across the platform
+  (Provider integrity, Provider credentialing, Provider panel-gating, BP
+  network tiers, claims adjudication).
+
+### D10 — Resolution clients are cached HTTP clients
+
+`IBenefitPlanResolver` calls benefit-plan-service's
+`GET /api/v1/plans/{id}`; `IMemberResolver` calls member-service's
+`GET /api/v1/members/{memberId}`. Both wrapped with a 5-minute in-process
+TTL via `IMemoryCache`, keyed by `(tenantId, id)`. Pattern parity with
+BP 5.6's `CachingServiceCategoryMappingRepository`. Negative results are
+not cached so a transient downstream outage doesn't pin "missing".
+
+### D11 — Adjudicated event emission
+
+After the pipeline completes (regardless of outcome), the orchestrator
+emits **both** the Mongo append-only `ClaimVersionAdjudicated` audit
+event and the Service Bus `ClaimVersionAdjudicatedMessage`. Same
+degraded-mode posture as the submission service: each emission is
+wrapped independently and a failure logs but does not unwind the run.
+
+### D12 — Idempotency via deterministic MessageId
+
+`ClaimVersionSubmittedMessage` carries `MessageId =
+"submitted:{ClaimVersionId}"`; `ClaimVersionAdjudicatedMessage` carries
+`MessageId = "adjudicated:{ClaimVersionId}"`. The Bicep topic enables
+native Service Bus duplicate detection (`requiresDuplicateDetection: true`
+with a 1-hour window). The orchestrator further hardens the idempotent
+read path: if a re-delivery fires for an already-adjudicated claim
+(`AdapterClaim.AdjudicationResult` populated with
+`AllowedAmount > 0`), the handler logs and completes the message
+without re-running the pipeline.
+
+### D13 — Replace mode only in Phase 1
+
+`BenefitCalculationStage` calls
+`IBenefitCalculationEngine.CalculateAsync(...)`, not the operating-mode
+variant. Augment-mode comparison ships in Phase 2 once a real legacy
+adjudication result is available to compare against.
+
+### D14 — Engine is consumed via HTTP shim from claims-service
+
+`HttpBenefitCalculationEngineClient` implements `IBenefitCalculationEngine`
+in claims-service by calling benefit-plan-service's existing
+`POST /api/v1/adjudication/calculate-benefits` endpoint. The engine ships
+as a class library (BP 5.10) but its host-side collaborators
+(`IBenefitPlanProvider`, `IAccumulatorService`, `IBenefitRuleGate`,
+`IServiceCategoryResolver`) are wired in benefit-plan-service against
+benefit-plan-service's data stores. Standing them up inside claims-service
+would mean importing the entire plan + accumulator data layer — that's a
+Phase 2 split. The shim consumes the canonical engine through the same
+HTTP surface portal/preview features already use.
+
+`HttpBenefitCalculationEngineClient` only implements the
+`CalculateAsync` member; `CalculateWithModeAsync` and `ReverseClaimAsync`
+throw `NotImplementedException` because the pipeline doesn't use them.
+Adding those surfaces is a follow-up driven by capability 5.12 (adjustment
+workflow).
+
+## Configuration
+
+```json
+{
+  "Messaging": {
+    "Backend": "Auto",
+    "ServiceBusConnectionString": "..."
+  },
+  "Adjudication": {
+    "Pipeline": {
+      "EnabledStages": {
+        "Scrubbing": true,
+        "NetworkCredentialing": true,
+        "BenefitCalculation": true,
+        "NcciEdits": true,
+        "CoordinationOfBenefits": true,
+        "AiExamination": true
+      }
+    }
+  },
+  "Services": {
+    "BenefitPlanService": "http://benefit-plan-service:8080",
+    "MemberService": "http://member-service:8080"
+  }
+}
+```
+
+A missing key in `EnabledStages` is treated as enabled. `Persistence` is
+always enabled regardless.
+
+## Runtime guarantees and failure modes
+
+| Failure | Behavior |
+|---|---|
+| Submission Service Bus emission fails | Submission still returns 201; Mongo audit chain captures the event; operators can replay. |
+| Subscription consumer crashes mid-run | Service Bus abandons the message; redelivers up to `MaxDeliveryCount=10`; then DLQs. |
+| Stage throws (non-required) | Treated as `Reject`; pipeline short-circuits to PersistenceStage; failure outcome is captured on the version. |
+| `UpdateAdjudicationProjectionAsync` returns false | PersistenceStage returns `Reject`; orchestrator continues (no further work) and emits the adjudicated event with that outcome. |
+| `UpdateAdjudicationProjectionAsync` throws | PersistenceStage rethrows; Service Bus abandons the message and redelivers. |
+| Re-delivery for already-adjudicated claim | Orchestrator detects via populated `AdjudicationResult` and completes the message without re-running the pipeline. |
+
+## Replacement contract for stub stages
+
+Capabilities 5.4 / 5.6 / 5.7 / 5.8 / 5.9 each ship a real stage that:
+
+1. Implements `IClaimAdjudicationStage` with the **same `Name`** and
+   **same `Order`** as the stub it replaces. Same `Name` keeps tenant
+   `EnabledStages` config working unchanged across the swap; same
+   `Order` keeps platform-level pipeline semantics stable.
+2. Removes the stub registration via `services.RemoveAll<StubStage>()`
+   and adds the real registration.
+3. Adds its own collaborators (engine integrations, downstream
+   resolvers) to the DI graph.
+4. Adds its own configuration section if it needs feature flags or
+   tunables — does NOT extend `AdjudicationPipelineOptions`.
+5. Updates this document with its real stage's behavior.
+
+## Cross-references
+
+- [`claim-versioning.md`](./claim-versioning.md) — version chain that
+  PersistenceStage's bypass writes against
+- [`claim-adapter-pattern.md`](./claim-adapter-pattern.md) — adapter
+  surface the orchestrator uses for canonical claim reads
+- [`claim-submission-api.md`](./claim-submission-api.md) — entry point
+  that emits `ClaimVersionSubmittedMessage`
+- [`adjudication-api-stabilization.md`](./adjudication-api-stabilization.md)
+  — Phase 1 closer, capability 5.13
+- [`accumulator-service.md`](./accumulator-service.md) — Kafka stream
+  that stays independent of this Service Bus topic
+- [`benefit-plan-adapter-pattern.md`](./benefit-plan-adapter-pattern.md)
+  — plan resolution surface the resolver decorator caches

--- a/infrastructure/azure/main.bicep
+++ b/infrastructure/azure/main.bicep
@@ -278,6 +278,60 @@ resource sbTopicEdi837ClaimsSubRiskScorer 'Microsoft.ServiceBus/namespaces/topic
   }
 }
 
+// ─── Claim version events (capability 5.5 — adjudication pipeline) ───
+//
+// Canonical lifecycle topic for the claims-service adjudication pipeline.
+// 5.5 ships the producer (ClaimSubmissionService dual-emit + orchestrator
+// adjudicated emission) and one subscription (adjudication-orchestrator).
+// Future capabilities add their own subscriptions filtered by the
+// MessageType application property:
+//   5.10 remittance generation       → MessageType=ClaimVersionAdjudicated
+//   5.12 adjustment workflow         → MessageType=ClaimVersionAdjusted
+//
+// Native Service Bus duplicate detection is enabled so the deterministic
+// MessageId values the producer sets ("submitted:{ClaimVersionId}",
+// "adjudicated:{ClaimVersionId}") catch retries cleanly.
+resource sbTopicClaimVersionEvents 'Microsoft.ServiceBus/namespaces/topics@2022-10-01-preview' = {
+  parent: sb
+  name: 'claim-version-events'
+  properties: {
+    maxSizeInMegabytes: 1024
+    defaultMessageTimeToLive: 'P14D'
+    requiresDuplicateDetection: true
+    duplicateDetectionHistoryTimeWindow: 'PT1H'
+  }
+}
+
+resource sbTopicClaimVersionEventsSubAdjudication 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2022-10-01-preview' = {
+  parent: sbTopicClaimVersionEvents
+  name: 'adjudication-orchestrator'
+  properties: {
+    maxDeliveryCount: 10
+    lockDuration: 'PT5M'
+    deadLetteringOnMessageExpiration: true
+    deadLetteringOnFilterEvaluationExceptions: true
+  }
+}
+
+// Correlation filter — only ClaimVersionSubmitted messages drive the
+// adjudication pipeline. Adjudicated/Paid/etc. messages emitted onto the
+// same topic by the orchestrator and other future producers are routed
+// to other subscriptions (5.10/5.12). Replacing the default $Default rule
+// with this named correlation filter happens automatically when the
+// rules collection is declared.
+resource sbTopicClaimVersionEventsSubAdjudicationRule 'Microsoft.ServiceBus/namespaces/topics/subscriptions/rules@2022-10-01-preview' = {
+  parent: sbTopicClaimVersionEventsSubAdjudication
+  name: 'submitted-only'
+  properties: {
+    filterType: 'CorrelationFilter'
+    correlationFilter: {
+      properties: {
+        MessageType: 'ClaimVersionSubmitted'
+      }
+    }
+  }
+}
+
 // Build SB connection string AFTER sbAuth exists
 var serviceBusConnectionStringGenerated = empty(serviceBusConnectionString)
   ? sbAuth.listKeys().primaryConnectionString
@@ -554,6 +608,7 @@ output cosmosDbConnectionId string = enableManagedApiConnections && enableCosmos
 output claimRiskScorerFunctionName string = enableClaimRiskScorer ? claimRiskScorerFunc.name : 'disabled'
 output claimRiskScorerFunctionUrl string = enableClaimRiskScorer ? 'https://${claimRiskScorerFunc.properties.defaultHostName}' : 'disabled'
 output edi837ClaimsTopicName string = sbTopicEdi837Claims.name
+output claimVersionEventsTopicName string = sbTopicClaimVersionEvents.name
 
 // Deployment Key Vault outputs
 output deploymentKeyVaultName string = enableDeploymentKeyVault ? deploymentKeyVault.outputs.keyVaultName : 'disabled'

--- a/src/services/claims-service/Dockerfile
+++ b/src/services/claims-service/Dockerfile
@@ -12,12 +12,19 @@ COPY src/Directory.Build.props src/
 COPY src/services/claims-service/claims-service.csproj src/services/claims-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj src/services/shared/CloudHealthOffice.Infrastructure/
 COPY src/services/shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj src/services/shared/CloudHealthOffice.Events/
+# 5.5 — BenefitCalculationStage calls IBenefitCalculationEngine via the
+# HttpBenefitCalculationEngineClient shim, which transitively pulls in
+# BenefitEngine + OperatingMode at compile time.
+COPY src/engines/CloudHealthOffice.BenefitEngine/CloudHealthOffice.BenefitEngine.csproj src/engines/CloudHealthOffice.BenefitEngine/
+COPY src/engines/CloudHealthOffice.OperatingMode/CloudHealthOffice.OperatingMode.csproj src/engines/CloudHealthOffice.OperatingMode/
 RUN dotnet restore src/services/claims-service/claims-service.csproj
 
 # Copy source code and build
 COPY src/services/claims-service/ src/services/claims-service/
 COPY src/services/shared/CloudHealthOffice.Infrastructure/ src/services/shared/CloudHealthOffice.Infrastructure/
 COPY src/services/shared/CloudHealthOffice.Events/ src/services/shared/CloudHealthOffice.Events/
+COPY src/engines/CloudHealthOffice.BenefitEngine/ src/engines/CloudHealthOffice.BenefitEngine/
+COPY src/engines/CloudHealthOffice.OperatingMode/ src/engines/CloudHealthOffice.OperatingMode/
 RUN dotnet build src/services/claims-service/claims-service.csproj -c Release --no-restore
 
 # Publish stage

--- a/src/services/claims-service/Models/Adjudication/AdjudicationPipelineOptions.cs
+++ b/src/services/claims-service/Models/Adjudication/AdjudicationPipelineOptions.cs
@@ -1,0 +1,32 @@
+namespace ClaimsService.Models.Adjudication;
+
+/// <summary>
+/// Service-wide configuration for the adjudication pipeline (capability 5.5).
+/// Bound from configuration section <c>Adjudication:Pipeline</c>.
+///
+/// <para>
+/// Stage enablement is service-wide in Phase 1 — every tenant runs the
+/// same set of enabled stages. Per-tenant overrides are deferred to
+/// Phase 2 multi-tenant config work; nothing in 5.5 leaks decisions on
+/// that surface.
+/// </para>
+///
+/// <para>
+/// <see cref="Services.Adjudication.Stages.PersistenceStage"/> is
+/// always enabled regardless of this setting — its
+/// <see cref="Services.Adjudication.IClaimAdjudicationStage.IsRequired"/>
+/// flag forces the orchestrator to bypass the enablement check.
+/// </para>
+/// </summary>
+public class AdjudicationPipelineOptions
+{
+    public const string SectionName = "Adjudication:Pipeline";
+
+    /// <summary>
+    /// Map of stage <see cref="Services.Adjudication.IClaimAdjudicationStage.Name"/>
+    /// → enabled. A missing key is treated as enabled. Replace-mode for
+    /// 5.4-5.9 keeps the same name keys, so disabling a stub also
+    /// disables its real replacement after the capability ships.
+    /// </summary>
+    public Dictionary<string, bool> EnabledStages { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/services/claims-service/Models/Messaging/ClaimVersionMessages.cs
+++ b/src/services/claims-service/Models/Messaging/ClaimVersionMessages.cs
@@ -1,0 +1,89 @@
+namespace ClaimsService.Models.Messaging;
+
+/// <summary>
+/// Service Bus payload contracts for the <c>claim-version-events</c> topic
+/// (capability 5.5). The topic is the canonical claim-lifecycle notification
+/// surface; future capabilities (5.10 remittance, 5.11 FHIR projection
+/// rebuilder, 5.12 adjustment workflow) add their own subscriptions filtered
+/// by the <c>MessageType</c> application property.
+/// </summary>
+internal static class ClaimVersionEventTopics
+{
+    /// <summary>Single broad topic for the claim version lifecycle (Decision 2).</summary>
+    public const string TopicName = "claim-version-events";
+
+    /// <summary>Subscription consumed by the adjudication orchestrator.</summary>
+    public const string AdjudicationSubscriptionName = "adjudication-orchestrator";
+
+    /// <summary>
+    /// Service Bus application property used to discriminate message types.
+    /// Filter rules on each subscription select the relevant subset; producer
+    /// side sets this on every <c>SendOptions.Properties</c>.
+    /// </summary>
+    public const string MessageTypeProperty = "MessageType";
+}
+
+/// <summary>
+/// Stable string values for the <c>MessageType</c> application property.
+/// Adding new values requires a paired Bicep subscription/filter update if
+/// any subscriber wants to consume them.
+/// </summary>
+internal static class ClaimVersionMessageTypes
+{
+    public const string Submitted = "ClaimVersionSubmitted";
+    public const string Adjudicated = "ClaimVersionAdjudicated";
+}
+
+/// <summary>
+/// Emitted by <see cref="Services.ClaimSubmissionService"/> after a
+/// successful submission (capability 5.5 dual-emit modification).
+/// Triggers the adjudication pipeline.
+///
+/// <para>
+/// The payload deliberately carries identifiers, not the full claim — the
+/// orchestrator re-fetches the canonical version row through
+/// <c>IClaimAdapter.GetClaimVersionAsync</c> so the pipeline always
+/// adjudicates the latest persisted state, not a stale snapshot.
+/// </para>
+/// </summary>
+public class ClaimVersionSubmittedMessage
+{
+    public required string TenantId { get; init; }
+    public required string ClaimId { get; init; }
+    public required string ClaimVersionId { get; init; }
+    public int VersionNumber { get; init; }
+
+    /// <summary>Caller identity propagated through the audit chain.</summary>
+    public string? ActorId { get; init; }
+
+    /// <summary>Activity / X-Correlation-Id from the original submission.</summary>
+    public string? CorrelationId { get; init; }
+
+    public DateTimeOffset SubmittedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Emitted by the adjudication orchestrator after a pipeline run finishes,
+/// regardless of pass / pend / reject / deny outcome. Future subscriptions
+/// (5.10 remittance, 5.12 adjustments, ...) consume this stream.
+/// </summary>
+public class ClaimVersionAdjudicatedMessage
+{
+    public required string TenantId { get; init; }
+    public required string ClaimId { get; init; }
+    public required string ClaimVersionId { get; init; }
+    public int VersionNumber { get; init; }
+
+    /// <summary>Final terminal-or-pass outcome of the pipeline run.</summary>
+    public required string Outcome { get; init; }
+
+    /// <summary>
+    /// Highest-precedence reason from any stage that did not pass — empty
+    /// when the run completed clean.
+    /// </summary>
+    public string? Reason { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public DateTimeOffset AdjudicatedAt { get; init; } = DateTimeOffset.UtcNow;
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -1,12 +1,18 @@
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Extensions;
+using CloudHealthOffice.Infrastructure.Messaging;
 using CloudHealthOffice.Infrastructure.Observability;
 using ClaimsService.Adapters;
 using ClaimsService.EDI.Florida;
 using ClaimsService.Fhir;
 using ClaimsService.HostedServices;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Models.Messaging;
 using ClaimsService.Repositories;
 using ClaimsService.Services;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -123,7 +129,101 @@ builder.Services.AddScoped<ClaimAdapterFactory>();
 // event emission. Both POST /api/v1/claims and the deprecated
 // legacy POST /api/claims route through this single seam so the
 // version-event chain has no gaps.
+//
+// 5.5 modification: ClaimSubmissionService also emits a
+// ClaimVersionSubmittedMessage onto the claim-version-events Service
+// Bus topic so the adjudication orchestrator picks it up.
 builder.Services.AddScoped<IClaimSubmissionService, ClaimSubmissionService>();
+
+// ─── Capability 5.5 — adjudication pipeline ────────────────────────
+// Service Bus messaging shared abstraction. Resolves to InMemory in
+// Development / when no connection string is configured. In production
+// requires Messaging:ServiceBusConnectionString.
+builder.Services.AddChoMessaging(builder.Configuration, builder.Environment);
+
+// IMemoryCache backs the resolution decorators. Not previously
+// registered in claims-service — see the 5.5 plan, drift C.
+builder.Services.AddMemoryCache();
+
+// Per-tenant pipeline configuration. Phase 1 is service-wide; per-tenant
+// override is deferred to Phase 2.
+builder.Services.Configure<AdjudicationPipelineOptions>(
+    builder.Configuration.GetSection(AdjudicationPipelineOptions.SectionName));
+
+// Resolution clients — typed HttpClient + caching decorator. 5-second
+// timeout matches ClaimTenantConfigCache and HttpProviderService so a
+// flaky downstream service can't stall the pipeline.
+builder.Services.AddHttpClient(HttpBenefitPlanResolver.HttpClientName, client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:BenefitPlanService"]
+        ?? "http://benefit-plan-service:8080");
+    client.Timeout = TimeSpan.FromSeconds(5);
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+}).SetHandlerLifetime(TimeSpan.FromMinutes(5));
+builder.Services.AddScoped<HttpBenefitPlanResolver>();
+builder.Services.AddScoped<IBenefitPlanResolver>(sp =>
+    new CachingBenefitPlanResolver(
+        sp.GetRequiredService<HttpBenefitPlanResolver>(),
+        sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
+
+builder.Services.AddHttpClient(HttpMemberResolver.HttpClientName, client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:MemberService"]
+        ?? "http://member-service:8080");
+    client.Timeout = TimeSpan.FromSeconds(5);
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+}).SetHandlerLifetime(TimeSpan.FromMinutes(5));
+builder.Services.AddScoped<HttpMemberResolver>();
+builder.Services.AddScoped<IMemberResolver>(sp =>
+    new CachingMemberResolver(
+        sp.GetRequiredService<HttpMemberResolver>(),
+        sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
+
+// BenefitCalculationEngine — HTTP shim against benefit-plan-service's
+// /api/v1/adjudication/calculate-benefits endpoint. The engine ships as
+// a class library (BP 5.10) but its host-side collaborators
+// (IBenefitPlanProvider, IAccumulatorService) are wired in
+// benefit-plan-service against benefit-plan-service's data stores.
+// Standing them up inside claims-service would mean importing the
+// entire plan + accumulator data layer — that's a Phase 2 split. The
+// HTTP shim consumes the canonical engine through the same surface
+// portal/preview features already use.
+builder.Services.AddScoped<
+    CloudHealthOffice.BenefitEngine.Services.IBenefitCalculationEngine,
+    HttpBenefitCalculationEngineClient>();
+
+// Stages — registered as IEnumerable<IClaimAdjudicationStage>. Capabilities
+// 5.4-5.9 replace the stub registrations via services.RemoveAll<>()
+// + AddScoped<IClaimAdjudicationStage, RealStage>().
+builder.Services.AddScoped<IClaimAdjudicationStage, ScrubbingStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, NetworkCredentialingStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, BenefitCalculationStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, NcciEditsStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, CoordinationOfBenefitsStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, AiExaminationStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, PersistenceStage>();
+
+builder.Services.AddScoped<IClaimAdjudicationOrchestrator, ClaimAdjudicationOrchestrator>();
+
+// Subscription hosted service — the orchestrator's Service Bus
+// trigger. Factory shape defers subscription creation to ExecuteAsync
+// so the bus is fully initialised before we Subscribe.
+builder.Services.AddHostedService(sp =>
+    new SubscriptionHostedService(
+        services => services.GetRequiredService<IMessageBus>().Subscribe<ClaimVersionSubmittedMessage>(
+            ClaimVersionEventTopics.TopicName,
+            async (msg, ctx, ct) =>
+            {
+                using var scope = services.CreateScope();
+                var orchestrator = scope.ServiceProvider
+                    .GetRequiredService<IClaimAdjudicationOrchestrator>();
+                await orchestrator.AdjudicateAsync(msg, ctx, ct);
+            },
+            new SubscriptionOptions(SubscriptionName: ClaimVersionEventTopics.AdjudicationSubscriptionName)),
+        sp,
+        sp.GetRequiredService<ILogger<SubscriptionHostedService>>()));
 
 builder.Services.AddChoObservability(builder.Configuration);
 

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
@@ -1,0 +1,52 @@
+using ClaimsService.Models;
+using ClaimsService.Services.Resolution;
+using BenefitEngineModels = CloudHealthOffice.BenefitEngine.Models;
+
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// Mutable context object that flows through the adjudication pipeline.
+/// Stages append outcomes to <see cref="StageResults"/> and decorate the
+/// in-flight <see cref="AdjudicationResult"/> / <see cref="LineAdjudicationResults"/>
+/// that <see cref="Stages.PersistenceStage"/> writes back via the bypass
+/// method <c>IClaimRepository.UpdateAdjudicationProjectionAsync</c>.
+///
+/// <para>
+/// Lives only for the duration of one orchestrator invocation (one
+/// <c>ClaimVersionSubmittedMessage</c>); not shared across messages or
+/// across pods. Mutability is safe: stages run sequentially within a
+/// single Service Bus message handler (Decision 5).
+/// </para>
+/// </summary>
+public class ClaimAdjudicationContext
+{
+    public required string TenantId { get; init; }
+    public required string ClaimVersionId { get; init; }
+    public required AdapterClaim Claim { get; init; }
+    public string? CorrelationId { get; init; }
+    public string? ActorId { get; init; }
+
+    /// <summary>Plan resolved by <see cref="IBenefitPlanResolver"/> at orchestrator entry.</summary>
+    public ResolvedBenefitPlan? ResolvedPlan { get; set; }
+
+    /// <summary>Member resolved by <see cref="IMemberResolver"/> at orchestrator entry.</summary>
+    public ResolvedMember? ResolvedMember { get; set; }
+
+    /// <summary>Populated by <see cref="Stages.BenefitCalculationStage"/>.</summary>
+    public BenefitEngineModels.BenefitResolutionResult? BenefitResolutionResult { get; set; }
+
+    /// <summary>
+    /// Building <see cref="ClaimsService.Models.AdjudicationResult"/>; persisted
+    /// by <see cref="Stages.PersistenceStage"/> via the bypass method.
+    /// Initialised empty so stub stages can leave it untouched.
+    /// </summary>
+    public Models.AdjudicationResult AdjudicationResult { get; set; } = new();
+
+    public List<Models.LineAdjudicationResult> LineAdjudicationResults { get; set; } = new();
+
+    /// <summary>Append-only history of every stage's result for this run.</summary>
+    public List<ClaimAdjudicationStageResult> StageResults { get; } = new();
+
+    /// <summary>True once a non-persistence stage has short-circuited the run.</summary>
+    public bool ShortCircuited { get; set; }
+}

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
@@ -1,0 +1,264 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Options;
+
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// Concrete adjudication orchestrator. Resolves the claim through the
+/// <see cref="ClaimAdapterFactory"/> (canonical read surface — vendor
+/// systems adjudicate the same way once their adapters ship), resolves
+/// member + plan once via the cached resolvers, then iterates the
+/// registered stages in <see cref="IClaimAdjudicationStage.Order"/> order.
+/// </summary>
+public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrator
+{
+    private readonly ClaimAdapterFactory _adapterFactory;
+    private readonly IBenefitPlanResolver _planResolver;
+    private readonly IMemberResolver _memberResolver;
+    private readonly IReadOnlyList<IClaimAdjudicationStage> _stages;
+    private readonly IClaimVersionEventPublisher _eventPublisher;
+    private readonly IMessageBus _messageBus;
+    private readonly AdjudicationPipelineOptions _options;
+    private readonly ILogger<ClaimAdjudicationOrchestrator> _logger;
+
+    public ClaimAdjudicationOrchestrator(
+        ClaimAdapterFactory adapterFactory,
+        IBenefitPlanResolver planResolver,
+        IMemberResolver memberResolver,
+        IEnumerable<IClaimAdjudicationStage> stages,
+        IClaimVersionEventPublisher eventPublisher,
+        IMessageBus messageBus,
+        IOptions<AdjudicationPipelineOptions> options,
+        ILogger<ClaimAdjudicationOrchestrator> logger)
+    {
+        _adapterFactory = adapterFactory;
+        _planResolver = planResolver;
+        _memberResolver = memberResolver;
+        _stages = stages.OrderBy(s => s.Order).ToList();
+        _eventPublisher = eventPublisher;
+        _messageBus = messageBus;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task AdjudicateAsync(
+        ClaimVersionSubmittedMessage message,
+        MessageContext messageContext,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (string.IsNullOrEmpty(message.TenantId))
+            throw new ArgumentException("TenantId is required", nameof(message));
+        if (string.IsNullOrEmpty(message.ClaimVersionId))
+            throw new ArgumentException("ClaimVersionId is required", nameof(message));
+
+        _logger.LogInformation(
+            "Adjudication starting for tenant {TenantId} claim {ClaimVersionId} (delivery {DeliveryCount})",
+            SanitizeForLog(message.TenantId), SanitizeForLog(message.ClaimVersionId),
+            messageContext.DeliveryCount);
+
+        var adapter = await _adapterFactory.GetAdapterAsync(message.TenantId, ct).ConfigureAwait(false);
+        var adapterResponse = await adapter.GetClaimAsync(
+            new ClaimAdapterRequest
+            {
+                TenantId = message.TenantId,
+                ClaimId = message.ClaimId,
+                ClaimVersionId = message.ClaimVersionId,
+            },
+            ct).ConfigureAwait(false);
+
+        var claim = adapterResponse.Claim;
+        if (claim is null)
+        {
+            _logger.LogWarning(
+                "Claim {ClaimVersionId} not found via adapter; completing message with no work",
+                SanitizeForLog(message.ClaimVersionId));
+            return;
+        }
+
+        // Idempotency: the version already has adjudication data → skip
+        // and complete the message. This catches Service Bus redeliveries
+        // after a previous successful adjudication that crashed before
+        // completing the message (Decision 12).
+        if (claim.AdjudicationResult is not null && claim.AdjudicationResult.AllowedAmount > 0m)
+        {
+            _logger.LogInformation(
+                "Claim {ClaimVersionId} already adjudicated; skipping pipeline run",
+                SanitizeForLog(message.ClaimVersionId));
+            return;
+        }
+
+        var context = new ClaimAdjudicationContext
+        {
+            TenantId = message.TenantId,
+            ClaimVersionId = message.ClaimVersionId,
+            Claim = claim,
+            ActorId = message.ActorId,
+            CorrelationId = message.CorrelationId ?? messageContext.CorrelationId,
+        };
+
+        if (!string.IsNullOrWhiteSpace(claim.BenefitPlanId))
+        {
+            context.ResolvedPlan = await _planResolver
+                .GetPlanAsync(message.TenantId, claim.BenefitPlanId!, ct)
+                .ConfigureAwait(false);
+        }
+        if (!string.IsNullOrWhiteSpace(claim.MemberId))
+        {
+            context.ResolvedMember = await _memberResolver
+                .GetMemberAsync(message.TenantId, claim.MemberId, ct)
+                .ConfigureAwait(false);
+        }
+
+        await RunPipelineAsync(context, ct).ConfigureAwait(false);
+        await EmitAdjudicatedEventAsync(context, ct).ConfigureAwait(false);
+    }
+
+    private async Task RunPipelineAsync(ClaimAdjudicationContext context, CancellationToken ct)
+    {
+        foreach (var stage in _stages)
+        {
+            var enabled = IsEnabled(stage);
+            var shouldSkip = !enabled
+                || (context.ShortCircuited && !stage.IsRequired);
+
+            if (shouldSkip)
+            {
+                _logger.LogDebug(
+                    "Skipping stage {Stage} for claim {ClaimVersionId} " +
+                    "(enabled={Enabled}, shortCircuited={ShortCircuited}, required={Required})",
+                    stage.Name, SanitizeForLog(context.ClaimVersionId),
+                    enabled, context.ShortCircuited, stage.IsRequired);
+                continue;
+            }
+
+            ClaimAdjudicationStageResult result;
+            try
+            {
+                result = await stage.ExecuteAsync(context, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (!stage.IsRequired)
+            {
+                _logger.LogError(ex,
+                    "Stage {Stage} threw for claim {ClaimVersionId}; treating as Reject",
+                    stage.Name, SanitizeForLog(context.ClaimVersionId));
+                result = ClaimAdjudicationStageResult.Reject(
+                    stage.Name, $"{stage.Name} threw: {ex.GetType().Name}");
+            }
+
+            context.StageResults.Add(result);
+
+            if (!result.Continue)
+            {
+                _logger.LogInformation(
+                    "Stage {Stage} short-circuited pipeline for claim {ClaimVersionId} " +
+                    "(outcome={Outcome}, reason={Reason})",
+                    stage.Name, SanitizeForLog(context.ClaimVersionId),
+                    result.Outcome, SanitizeForLog(result.Reason));
+                context.ShortCircuited = true;
+            }
+        }
+    }
+
+    private async Task EmitAdjudicatedEventAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        var finalOutcome = ResolveFinalOutcome(context);
+        var finalReason = context.StageResults
+            .Where(r => r.Outcome != ClaimAdjudicationOutcome.Pass && !string.IsNullOrEmpty(r.Reason))
+            .Select(r => r.Reason!)
+            .FirstOrDefault();
+
+        // 1) Mongo append-only event — system-of-record audit chain. Same
+        //    degraded-mode posture as the submission service: failure here
+        //    leaves the claim adjudicated but with a gap in the version
+        //    event chain (operators can backfill from logs).
+        try
+        {
+            var domainClaim = context.Claim.ToClaim();
+            domainClaim.AdjudicationResult = context.AdjudicationResult;
+            await _eventPublisher
+                .PublishVersionAdjudicatedAsync(domainClaim, context.ActorId, context.CorrelationId, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionAdjudicated audit event emission failed for claim {ClaimVersionId}; " +
+                "adjudication persisted, audit chain has a gap",
+                SanitizeForLog(context.ClaimVersionId));
+        }
+
+        // 2) Service Bus topic emission — trigger transport for downstream
+        //    capabilities (5.10 remittance, 5.12 adjustments). Failure does
+        //    not unwind adjudication; same posture.
+        var sbMessage = new ClaimVersionAdjudicatedMessage
+        {
+            TenantId = context.TenantId,
+            ClaimId = context.Claim.Id,
+            ClaimVersionId = context.ClaimVersionId,
+            VersionNumber = context.Claim.VersionNumber,
+            Outcome = finalOutcome.ToString(),
+            Reason = finalReason,
+            CorrelationId = context.CorrelationId,
+        };
+
+        var sendOptions = new SendOptions(
+            MessageId: $"adjudicated:{context.ClaimVersionId}",
+            CorrelationId: context.CorrelationId,
+            Properties: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [ClaimVersionEventTopics.MessageTypeProperty] = ClaimVersionMessageTypes.Adjudicated,
+            });
+
+        try
+        {
+            await _messageBus
+                .SendAsync(ClaimVersionEventTopics.TopicName, sbMessage, sendOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionAdjudicated Service Bus emission failed for claim {ClaimVersionId}",
+                SanitizeForLog(context.ClaimVersionId));
+        }
+    }
+
+    private static ClaimAdjudicationOutcome ResolveFinalOutcome(ClaimAdjudicationContext context)
+    {
+        // Reject takes precedence over Deny over Pend. Pass only when no
+        // non-pass result was recorded.
+        var nonPersistence = context.StageResults
+            .Where(r => !string.Equals(r.StageName, Stages.PersistenceStage.StageName, StringComparison.Ordinal))
+            .ToList();
+
+        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Reject))
+            return ClaimAdjudicationOutcome.Reject;
+        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Deny))
+            return ClaimAdjudicationOutcome.Deny;
+        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Pend))
+            return ClaimAdjudicationOutcome.Pend;
+        return ClaimAdjudicationOutcome.Pass;
+    }
+
+    private bool IsEnabled(IClaimAdjudicationStage stage)
+    {
+        if (stage.IsRequired) return true;
+        if (_options.EnabledStages is null || _options.EnabledStages.Count == 0) return true;
+        return !_options.EnabledStages.TryGetValue(stage.Name, out var enabled) || enabled;
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
+++ b/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
@@ -1,0 +1,140 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using CloudHealthOffice.BenefitEngine.Models;
+using CloudHealthOffice.BenefitEngine.Services;
+using CloudHealthOffice.OperatingMode;
+
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// HTTP adapter that satisfies <see cref="IBenefitCalculationEngine"/> from
+/// claims-service by calling benefit-plan-service's
+/// <c>POST /api/v1/adjudication/calculate-benefits</c> endpoint.
+///
+/// <para>
+/// The benefit calculation engine ships as a class library (BP 5.10) but
+/// its host-side collaborators (<see cref="IBenefitPlanProvider"/>,
+/// <see cref="IAccumulatorService"/>, <see cref="IBenefitRuleGate"/>) are
+/// wired in benefit-plan-service against benefit-plan-service's data
+/// stores. Standing them up inside claims-service would mean importing
+/// the entire plan + accumulator data layer — that's a Phase 2 split.
+/// For 5.5 we proxy across the network so claims-service consumes the
+/// canonical engine via the same HTTP surface portal/preview features
+/// already use.
+/// </para>
+///
+/// <para>
+/// Only <see cref="CalculateAsync"/> is wired; the other interface
+/// members (<see cref="CalculateWithModeAsync"/>,
+/// <see cref="ReverseClaimAsync"/>) throw <see cref="NotImplementedException"/>
+/// because the adjudication pipeline's <see cref="Stages.BenefitCalculationStage"/>
+/// only uses CalculateAsync (Decision 13 — Replace mode only). Adding the
+/// other surfaces is a follow-up driven by demand.
+/// </para>
+/// </summary>
+public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngine
+{
+    public const string HttpClientName = "BenefitPlanService";
+    private const string CalculatePath = "/api/v1/adjudication/calculate-benefits";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<HttpBenefitCalculationEngineClient> _logger;
+
+    public HttpBenefitCalculationEngineClient(
+        IHttpClientFactory httpClientFactory,
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<HttpBenefitCalculationEngineClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+    }
+
+    public async Task<BenefitResolutionResult> CalculateAsync(
+        BenefitResolutionRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, CalculatePath)
+        {
+            Content = JsonContent.Create(request, options: JsonOptions),
+        };
+        var tenantId = ResolveTenantId();
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            httpRequest.Headers.Add("X-Tenant-ID", tenantId);
+        }
+
+        using var response = await client.SendAsync(httpRequest, ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Benefit-plan-service calculate-benefits returned {StatusCode} for claim {ClaimId}: {Body}",
+                response.StatusCode, SanitizeForLog(request.ClaimId), SanitizeForLog(body));
+            return new BenefitResolutionResult
+            {
+                Success = false,
+                DenialReasonCode = "999",
+                DenialReasonDescription =
+                    $"Benefit calculation engine returned HTTP {(int)response.StatusCode}.",
+            };
+        }
+
+        var result = await response.Content
+            .ReadFromJsonAsync<BenefitResolutionResult>(JsonOptions, ct)
+            .ConfigureAwait(false);
+
+        return result ?? new BenefitResolutionResult
+        {
+            Success = false,
+            DenialReasonCode = "999",
+            DenialReasonDescription = "Benefit calculation engine returned an empty response.",
+        };
+    }
+
+    public Task<AugmentResult<BenefitResolutionResult>> CalculateWithModeAsync(
+        BenefitResolutionRequest request,
+        IOperatingMode operatingMode,
+        string tenantId,
+        BenefitResolutionResult? legacyResult = null,
+        CancellationToken ct = default)
+    {
+        throw new NotImplementedException(
+            "HttpBenefitCalculationEngineClient does not support operating-mode-aware " +
+            "calculation. Augment-mode comparison ships in Phase 2 alongside legacy " +
+            "result production.");
+    }
+
+    public Task ReverseClaimAsync(
+        string memberId, string subscriberId,
+        Guid benefitPlanId, DateOnly serviceDate,
+        string originalClaimId,
+        CancellationToken ct = default)
+    {
+        throw new NotImplementedException(
+            "HttpBenefitCalculationEngineClient does not support accumulator reversal. " +
+            "Capability 5.12 (Adjustment Workflow) revisits the reversal surface.");
+    }
+
+    private string? ResolveTenantId()
+    {
+        var ctx = _httpContextAccessor.HttpContext;
+        if (ctx is null) return null;
+        if (ctx.Items.TryGetValue("TenantId", out var value) && value is string s) return s;
+        return null;
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Adjudication/IClaimAdjudicationOrchestrator.cs
+++ b/src/services/claims-service/Services/Adjudication/IClaimAdjudicationOrchestrator.cs
@@ -1,0 +1,29 @@
+using ClaimsService.Models.Messaging;
+using CloudHealthOffice.Infrastructure.Messaging;
+
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// Runs the adjudication pipeline end-to-end for a single claim version
+/// (capability 5.5). Triggered by a <see cref="ClaimVersionSubmittedMessage"/>
+/// arriving on the <c>claim-version-events</c> Service Bus topic; emits a
+/// <see cref="ClaimVersionAdjudicatedMessage"/> back onto the same topic
+/// after the run completes.
+///
+/// <para>
+/// Decisions worth surfacing here:
+/// </para>
+/// <list type="number">
+///   <item><description>The orchestrator is the only consumer of the adjudication subscription. Future capabilities (5.10 / 5.11 / 5.12) add their own subscriptions to the same topic with their own filter rules; they do not piggy-back on this one.</description></item>
+///   <item><description>Stage ordering is fixed in code, not config (Decision 6). Per-tenant configuration controls only enablement.</description></item>
+///   <item><description>Short-circuit on terminal stage failure routes straight to <see cref="Stages.PersistenceStage"/> (Decision 7).</description></item>
+///   <item><description>Idempotency: re-processing an already-adjudicated claim (the <see cref="Models.AdapterClaim.AdjudicationResult"/> is already populated) skips gracefully — logs and completes the message (Decision 12).</description></item>
+/// </list>
+/// </summary>
+public interface IClaimAdjudicationOrchestrator
+{
+    Task AdjudicateAsync(
+        ClaimVersionSubmittedMessage message,
+        MessageContext messageContext,
+        CancellationToken ct);
+}

--- a/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
@@ -1,0 +1,123 @@
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// A single stage in the claim adjudication pipeline (capability 5.5).
+/// Stages are registered as <c>IEnumerable&lt;IClaimAdjudicationStage&gt;</c>;
+/// the orchestrator iterates them in <see cref="Order"/> ascending order
+/// and invokes <see cref="ExecuteAsync"/> on each enabled stage.
+///
+/// <para>
+/// Stage ordering is platform-level architecture (NCCI before COB, COB
+/// before persistence, etc.) and is not configurable per-tenant. Tenant
+/// configuration controls only <em>whether</em> a stage runs, via
+/// <see cref="Models.Adjudication.AdjudicationPipelineOptions.EnabledStages"/>.
+/// </para>
+///
+/// <para>
+/// 5.5 ships two real stages — <see cref="Stages.BenefitCalculationStage"/>
+/// and <see cref="Stages.PersistenceStage"/> — plus five stub stages that
+/// capabilities 5.4, 5.6, 5.7, 5.8, and 5.9 replace via DI swap.
+/// </para>
+/// </summary>
+public interface IClaimAdjudicationStage
+{
+    /// <summary>
+    /// Stable, lower-case identifier — used both for telemetry tags and as
+    /// the key into <see cref="Models.Adjudication.AdjudicationPipelineOptions.EnabledStages"/>.
+    /// Stub-stage replacements (5.4-5.9) MUST keep the same Name so the
+    /// per-tenant enablement config keeps working unchanged.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Position in the pipeline. Conventional ordering:
+    /// 100 Scrubbing, 200 NetworkCredentialing, 300 BenefitCalculation,
+    /// 400 NcciEdits, 500 CoordinationOfBenefits, 600 AiExamination,
+    /// 999 Persistence.
+    /// </summary>
+    int Order { get; }
+
+    /// <summary>
+    /// When true, the stage runs even if explicitly disabled in
+    /// <see cref="Models.Adjudication.AdjudicationPipelineOptions"/>.
+    /// Currently only <see cref="Stages.PersistenceStage"/> is required —
+    /// without it, the version chain wouldn't capture the adjudication
+    /// outcome at all.
+    /// </summary>
+    bool IsRequired { get; }
+
+    Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// The result a stage hands back to the orchestrator. <see cref="Continue"/>
+/// false short-circuits the remainder of the pipeline (everything before
+/// the persistence stage); <see cref="Stages.PersistenceStage"/> always
+/// runs regardless because the outcome of every stage — pass, pend, or
+/// terminal failure — must be captured on the claim version.
+/// </summary>
+public class ClaimAdjudicationStageResult
+{
+    public required string StageName { get; init; }
+
+    /// <summary>
+    /// False = short-circuit to <see cref="Stages.PersistenceStage"/>; the
+    /// remaining non-persistence stages are skipped.
+    /// </summary>
+    public bool Continue { get; init; } = true;
+
+    public ClaimAdjudicationOutcome Outcome { get; init; } = ClaimAdjudicationOutcome.Pass;
+
+    public string? Reason { get; init; }
+
+    public IReadOnlyList<string> Notes { get; init; } = Array.Empty<string>();
+
+    public static ClaimAdjudicationStageResult Pass(string stageName) =>
+        new() { StageName = stageName, Continue = true, Outcome = ClaimAdjudicationOutcome.Pass };
+
+    public static ClaimAdjudicationStageResult Pend(string stageName, string reason) =>
+        new()
+        {
+            StageName = stageName,
+            Continue = true,
+            Outcome = ClaimAdjudicationOutcome.Pend,
+            Reason = reason
+        };
+
+    public static ClaimAdjudicationStageResult Reject(string stageName, string reason) =>
+        new()
+        {
+            StageName = stageName,
+            Continue = false,
+            Outcome = ClaimAdjudicationOutcome.Reject,
+            Reason = reason
+        };
+
+    public static ClaimAdjudicationStageResult Deny(string stageName, string reason) =>
+        new()
+        {
+            StageName = stageName,
+            Continue = false,
+            Outcome = ClaimAdjudicationOutcome.Deny,
+            Reason = reason
+        };
+}
+
+/// <summary>
+/// Discriminator for stage outcomes.
+/// <list type="bullet">
+///   <item><description><see cref="Pass"/> — stage approved, pipeline continues.</description></item>
+///   <item><description><see cref="Pend"/> — recoverable; pipeline continues so subsequent stages can decorate the result, then the claim ends up in a human-review queue.</description></item>
+///   <item><description><see cref="Reject"/> — terminal pre-adjudication failure (e.g., scrubbing). Subsequent stages are skipped; PersistenceStage records the rejection.</description></item>
+///   <item><description><see cref="Deny"/> — terminal benefit-side denial (e.g., not covered). Subsequent stages are skipped; PersistenceStage records the denial.</description></item>
+/// </list>
+/// </summary>
+public enum ClaimAdjudicationOutcome
+{
+    Pass = 0,
+    Pend = 1,
+    Reject = 2,
+    Deny = 3
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/AiExaminationStubStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/AiExaminationStubStage.cs
@@ -1,0 +1,25 @@
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 stub for the AI-backed examination stage. Capability 5.9
+/// replaces this with a real implementation that consults
+/// claims-examiner-service. 5.9 may revisit synchronous-vs-async semantics
+/// — if AI examination needs to run async via a separate subscription, the
+/// stub stays in place and 5.9 wires the async path elsewhere. The stub is
+/// non-blocking either way.
+/// </summary>
+public sealed class AiExaminationStubStage : IClaimAdjudicationStage
+{
+    public const string StageName = "AiExamination";
+
+    public string Name => StageName;
+    public int Order => 600;
+    public bool IsRequired => false;
+
+    public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        return Task.FromResult(ClaimAdjudicationStageResult.Pass(StageName));
+    }
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -1,0 +1,265 @@
+using ClaimsService.Models;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Models;
+using CloudHealthOffice.BenefitEngine.Services;
+using ClaimsAdj = ClaimsService.Models.AdjudicationResult;
+using ClaimsLineAdj = ClaimsService.Models.LineAdjudicationResult;
+
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 — the only "real" pipeline stage in this PR. Builds a
+/// <see cref="BenefitResolutionRequest"/> from the in-flight
+/// <see cref="ClaimAdjudicationContext"/>, calls
+/// <see cref="IBenefitCalculationEngine.CalculateAsync"/> in Replace mode,
+/// and writes the per-line + claim-level cost-share onto
+/// <see cref="ClaimAdjudicationContext.AdjudicationResult"/> +
+/// <see cref="ClaimAdjudicationContext.LineAdjudicationResults"/> for
+/// <see cref="PersistenceStage"/> to persist.
+///
+/// <para>
+/// Replace mode only in Phase 1 — Augment-mode comparison against legacy
+/// adjudication ships in Phase 2 once there's a real legacy result to
+/// compare against. The stage explicitly calls
+/// <see cref="IBenefitCalculationEngine.CalculateAsync"/> rather than the
+/// operating-mode-aware variant so the dependency surface stays minimal.
+/// </para>
+///
+/// <para>
+/// Network tier defaults to <see cref="NetworkTier.InNetwork"/> while
+/// <see cref="NetworkCredentialingStubStage"/> is in place. Capability 5.6
+/// replaces that stub with real network resolution and writes the real
+/// tier onto the context before this stage runs (Order 200 → Order 300).
+/// </para>
+/// </summary>
+public sealed class BenefitCalculationStage : IClaimAdjudicationStage
+{
+    public const string StageName = "BenefitCalculation";
+
+    private readonly IBenefitCalculationEngine _engine;
+    private readonly IMemberResolver _memberResolver;
+    private readonly ILogger<BenefitCalculationStage> _logger;
+
+    public BenefitCalculationStage(
+        IBenefitCalculationEngine engine,
+        IMemberResolver memberResolver,
+        ILogger<BenefitCalculationStage> logger)
+    {
+        _engine = engine;
+        _memberResolver = memberResolver;
+        _logger = logger;
+    }
+
+    public string Name => StageName;
+    public int Order => 300;
+    public bool IsRequired => false;
+
+    public async Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        var claim = context.Claim;
+
+        if (string.IsNullOrWhiteSpace(claim.BenefitPlanId))
+        {
+            return ClaimAdjudicationStageResult.Reject(
+                StageName,
+                "Claim is missing BenefitPlanId; benefit calculation cannot run.");
+        }
+
+        var planGuid = ResolvePlanGuid(context.ResolvedPlan, claim.BenefitPlanId);
+        if (planGuid is null)
+        {
+            return ClaimAdjudicationStageResult.Reject(
+                StageName,
+                $"BenefitPlanId '{claim.BenefitPlanId}' is not a GUID and benefit-plan-service did not resolve a Guid id.");
+        }
+
+        var subscriberId = await ResolveSubscriberIdAsync(context, ct).ConfigureAwait(false);
+        var request = BuildRequest(context, planGuid.Value, subscriberId);
+
+        BenefitResolutionResult result;
+        try
+        {
+            result = await _engine.CalculateAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Benefit calculation engine threw for claim {ClaimVersionId}",
+                SanitizeForLog(context.ClaimVersionId));
+            return ClaimAdjudicationStageResult.Reject(
+                StageName,
+                $"Benefit calculation engine threw: {ex.GetType().Name}");
+        }
+
+        context.BenefitResolutionResult = result;
+        ApplyToContext(context, result);
+
+        if (!result.Success)
+        {
+            return ClaimAdjudicationStageResult.Deny(
+                StageName,
+                result.DenialReasonDescription ?? result.DenialReasonCode ?? "Benefit denied");
+        }
+
+        return ClaimAdjudicationStageResult.Pass(StageName);
+    }
+
+    private static Guid? ResolvePlanGuid(ResolvedBenefitPlan? resolved, string benefitPlanId)
+    {
+        if (resolved?.PlanGuid is Guid resolvedGuid) return resolvedGuid;
+        return Guid.TryParse(benefitPlanId, out var parsed) ? parsed : null;
+    }
+
+    private async Task<string> ResolveSubscriberIdAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        var direct = context.Claim.SubscriberId;
+        if (!string.IsNullOrWhiteSpace(direct)) return direct;
+
+        if (context.ResolvedMember is { } already)
+        {
+            return already.SubscriberMemberId
+                ?? (already.IsSubscriber ? already.MemberId : context.Claim.MemberId);
+        }
+
+        var resolved = await _memberResolver
+            .GetMemberAsync(context.TenantId, context.Claim.MemberId, ct)
+            .ConfigureAwait(false);
+        if (resolved is not null)
+        {
+            context.ResolvedMember = resolved;
+            return resolved.SubscriberMemberId
+                ?? (resolved.IsSubscriber ? resolved.MemberId : context.Claim.MemberId);
+        }
+
+        return context.Claim.MemberId;
+    }
+
+    internal static BenefitResolutionRequest BuildRequest(
+        ClaimAdjudicationContext context,
+        Guid planGuid,
+        string subscriberId)
+    {
+        var claim = context.Claim;
+        var serviceDate = DateOnly.FromDateTime(claim.ServiceDateFrom);
+
+        return new BenefitResolutionRequest
+        {
+            ClaimId = claim.Id,
+            MemberId = claim.MemberId,
+            SubscriberId = subscriberId,
+            BenefitPlanId = planGuid,
+            ServiceDate = serviceDate,
+            NetworkTier = NetworkTier.InNetwork,
+            Lines = claim.ClaimLines.Select(BuildLine).ToList(),
+            AllowedAmounts = new Dictionary<int, decimal>(),
+            ClaimType = MapClaimType(claim.ClaimType),
+            LineOfBusiness = (int)claim.LineOfBusiness,
+            Member = BuildMemberContext(context.ResolvedMember, claim),
+        };
+    }
+
+    /// <summary>
+    /// Maps the claims-service <c>ClaimType</c> enum into the EDI-style
+    /// codes the benefit engine expects (<c>"837P"</c> / <c>"837I"</c> /
+    /// <c>"837D"</c>). The engine's DRG case-rate path checks
+    /// <c>ClaimType is not "837I"</c>; mapping is therefore correctness-
+    /// critical for institutional adjudication.
+    /// </summary>
+    internal static string MapClaimType(ClaimsService.Models.ClaimType type) => type switch
+    {
+        ClaimsService.Models.ClaimType.Professional => "837P",
+        ClaimsService.Models.ClaimType.Institutional => "837I",
+        ClaimsService.Models.ClaimType.Dental => "837D",
+        _ => "837P",
+    };
+
+    private static ClaimLineInput BuildLine(AdapterClaimLine line) => new()
+    {
+        LineNumber = line.LineNumber,
+        ProcedureCode = line.ProcedureCode,
+        Modifiers = line.Modifiers.ToList(),
+        RevenueCode = line.RevenueCode,
+        PlaceOfService = line.PlaceOfServiceCode ?? string.Empty,
+        BilledAmount = line.ChargeAmount * line.Units,
+        Units = line.Units,
+        DiagnosisCodes = new List<string>(),
+    };
+
+    private static MemberContext? BuildMemberContext(ResolvedMember? member, AdapterClaim claim)
+    {
+        if (member is null && claim.DiagnosisCodes.Count == 0) return null;
+
+        int? age = null;
+        if (member?.DateOfBirth is DateTime dob)
+        {
+            var today = DateTime.UtcNow.Date;
+            age = today.Year - dob.Year;
+            if (dob.Date > today.AddYears(-age.Value)) age--;
+        }
+
+        BenefitMemberGender? gender = member?.Gender switch
+        {
+            "Female" or "F" => BenefitMemberGender.Female,
+            "Male" or "M" => BenefitMemberGender.Male,
+            "NonBinary" or "Other" => BenefitMemberGender.NonBinary,
+            _ => null
+        };
+
+        var diagnoses = claim.DiagnosisCodes
+            .Select(d => d.Code)
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
+        return new MemberContext
+        {
+            AgeYears = age,
+            Gender = gender,
+            DiagnosisCodes = diagnoses.Count > 0 ? diagnoses : null,
+        };
+    }
+
+    internal static void ApplyToContext(
+        ClaimAdjudicationContext context,
+        BenefitResolutionResult result)
+    {
+        var totals = result.Totals;
+        var existing = context.AdjudicationResult;
+
+        context.AdjudicationResult = new ClaimsAdj
+        {
+            NetworkTier = NormalizeTier(NetworkTier.InNetwork),
+            AllowedAmount = totals.TotalAllowed,
+            DeductibleAmount = totals.TotalDeductible,
+            CoinsuranceAmount = totals.TotalCoinsurance,
+            CopayAmount = totals.TotalCopay,
+            PatientResponsibility = totals.TotalMemberResponsibility,
+            PayerPayment = totals.TotalPlanPaid,
+            DenialReasonCode = result.Success ? existing.DenialReasonCode : result.DenialReasonCode,
+            DenialReason = result.Success ? existing.DenialReason : result.DenialReasonDescription,
+            AdjustmentReasons = existing.AdjustmentReasons,
+            RemarkCodes = existing.RemarkCodes,
+            CheckNumber = existing.CheckNumber,
+            PaymentDate = existing.PaymentDate,
+        };
+
+        context.LineAdjudicationResults = result.Lines
+            .Select(l => new ClaimsLineAdj
+            {
+                AllowedAmount = l.AllowedAmount,
+                PaidAmount = l.PlanPaidAmount,
+                PatientResponsibility = l.MemberResponsibility,
+                AdjustmentReasons = new List<ClaimAdjustmentReason>(),
+            })
+            .ToList();
+    }
+
+    private static string NormalizeTier(NetworkTier tier) => tier.ToString();
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStubStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStubStage.cs
@@ -1,0 +1,24 @@
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 stub for the Coordination of Benefits (COB) stage.
+/// Capability 5.8 replaces this with a real <c>CobEngine</c>-backed
+/// implementation that decides primary / secondary / tertiary payer
+/// responsibility and adjusts the <see cref="ClaimAdjudicationContext.AdjudicationResult"/>
+/// accordingly.
+/// </summary>
+public sealed class CoordinationOfBenefitsStubStage : IClaimAdjudicationStage
+{
+    public const string StageName = "CoordinationOfBenefits";
+
+    public string Name => StageName;
+    public int Order => 500;
+    public bool IsRequired => false;
+
+    public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        return Task.FromResult(ClaimAdjudicationStageResult.Pass(StageName));
+    }
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/NcciEditsStubStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/NcciEditsStubStage.cs
@@ -1,0 +1,23 @@
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 stub for the NCCI edits stage. Capability 5.7 replaces
+/// this with a real <c>NcciEngine</c>-backed implementation. Same
+/// <see cref="IClaimAdjudicationStage.Name"/> + <see cref="IClaimAdjudicationStage.Order"/>
+/// so disabling via configuration keeps working across the swap.
+/// </summary>
+public sealed class NcciEditsStubStage : IClaimAdjudicationStage
+{
+    public const string StageName = "NcciEdits";
+
+    public string Name => StageName;
+    public int Order => 400;
+    public bool IsRequired => false;
+
+    public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        return Task.FromResult(ClaimAdjudicationStageResult.Pass(StageName));
+    }
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStubStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStubStage.cs
@@ -1,0 +1,30 @@
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 stub for the network &amp; credentialing enforcement stage.
+/// Capability 5.6 replaces this with the real implementation that consults
+/// provider-service for network membership + credentialing status, and
+/// resolves the <see cref="CloudHealthOffice.BenefitEngine.Domain.NetworkTier"/>
+/// the BenefitCalculationStage consumes.
+///
+/// <para>
+/// While this stub is in place the BenefitCalculationStage falls back to
+/// <see cref="CloudHealthOffice.BenefitEngine.Domain.NetworkTier.InNetwork"/>;
+/// see the comment in <see cref="BenefitCalculationStage"/>.
+/// </para>
+/// </summary>
+public sealed class NetworkCredentialingStubStage : IClaimAdjudicationStage
+{
+    public const string StageName = "NetworkCredentialing";
+
+    public string Name => StageName;
+    public int Order => 200;
+    public bool IsRequired => false;
+
+    public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        return Task.FromResult(ClaimAdjudicationStageResult.Pass(StageName));
+    }
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
@@ -1,0 +1,93 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Persists the in-flight <see cref="ClaimAdjudicationContext.AdjudicationResult"/>
+/// + <see cref="ClaimAdjudicationContext.LineAdjudicationResults"/> via
+/// <see cref="IClaimRepository.UpdateAdjudicationProjectionAsync"/> — the
+/// 5.1a projection-metadata bypass method.
+///
+/// <para>
+/// First production consumer of that bypass; the 5th instance of the
+/// projection-bypass pattern across the platform (Provider integrity,
+/// Provider credentialing, Provider panel-gating, BP network tiers,
+/// claims adjudication). Same justification: adjudication state is
+/// operationally distinct from claim identity, and a routine
+/// adjudication run must not produce a new claim version row — that
+/// surface is reserved for adjustments (5.12) and reversals.
+/// </para>
+///
+/// <para>
+/// PersistenceStage runs even when an upstream stage short-circuited the
+/// pipeline — capturing the rejection / denial reason on the version is
+/// the entire point of the audit chain. The orchestrator enforces that
+/// invariant by checking <see cref="IClaimAdjudicationStage.IsRequired"/>
+/// after the short-circuit decision.
+/// </para>
+/// </summary>
+public sealed class PersistenceStage : IClaimAdjudicationStage
+{
+    public const string StageName = "Persistence";
+
+    private readonly IClaimRepository _repository;
+    private readonly ILogger<PersistenceStage> _logger;
+
+    public PersistenceStage(
+        IClaimRepository repository,
+        ILogger<PersistenceStage> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public string Name => StageName;
+    public int Order => 999;
+    public bool IsRequired => true;
+
+    public async Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        try
+        {
+            var written = await _repository
+                .UpdateAdjudicationProjectionAsync(
+                    context.TenantId,
+                    context.ClaimVersionId,
+                    context.AdjudicationResult,
+                    context.LineAdjudicationResults,
+                    ct)
+                .ConfigureAwait(false);
+
+            if (!written)
+            {
+                _logger.LogWarning(
+                    "Adjudication projection bypass returned false for claim {ClaimVersionId}; " +
+                    "head row not found or version no longer current",
+                    SanitizeForLog(context.ClaimVersionId));
+                return ClaimAdjudicationStageResult.Reject(
+                    StageName,
+                    "Adjudication projection write failed — head version not found.");
+            }
+
+            return ClaimAdjudicationStageResult.Pass(StageName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to persist adjudication projection for claim {ClaimVersionId}",
+                SanitizeForLog(context.ClaimVersionId));
+            // Bubble the exception so the orchestrator's exception handler
+            // abandons the Service Bus message — Service Bus then
+            // redelivers and the next attempt re-runs the pipeline. If
+            // the failure is permanent the message lands in DLQ after
+            // MaxDeliveryCount.
+            throw;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Adjudication/Stages/ScrubbingStubStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/ScrubbingStubStage.cs
@@ -1,0 +1,24 @@
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.5 stub for the pre-adjudication scrubbing stage.
+/// Capability 5.4 replaces this with a real <c>ClaimsScrubEngine</c>-backed
+/// implementation via DI swap (same <see cref="IClaimAdjudicationStage.Name"/>,
+/// same <see cref="IClaimAdjudicationStage.Order"/>); the swap doesn't
+/// touch the orchestrator or any other stage.
+/// </summary>
+public sealed class ScrubbingStubStage : IClaimAdjudicationStage
+{
+    public const string StageName = "Scrubbing";
+
+    public string Name => StageName;
+    public int Order => 100;
+    public bool IsRequired => false;
+
+    public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        return Task.FromResult(ClaimAdjudicationStageResult.Pass(StageName));
+    }
+}

--- a/src/services/claims-service/Services/ClaimSubmissionService.cs
+++ b/src/services/claims-service/Services/ClaimSubmissionService.cs
@@ -1,5 +1,7 @@
 using ClaimsService.Adapters;
 using ClaimsService.Models;
+using ClaimsService.Models.Messaging;
+using CloudHealthOffice.Infrastructure.Messaging;
 
 namespace ClaimsService.Services;
 
@@ -125,15 +127,18 @@ public class ClaimSubmissionService : IClaimSubmissionService
 {
     private readonly ClaimAdapterFactory _adapterFactory;
     private readonly IClaimVersionEventPublisher _eventPublisher;
+    private readonly IMessageBus _messageBus;
     private readonly ILogger<ClaimSubmissionService> _logger;
 
     public ClaimSubmissionService(
         ClaimAdapterFactory adapterFactory,
         IClaimVersionEventPublisher eventPublisher,
+        IMessageBus messageBus,
         ILogger<ClaimSubmissionService> logger)
     {
         _adapterFactory = adapterFactory;
         _eventPublisher = eventPublisher;
+        _messageBus = messageBus;
         _logger = logger;
     }
 
@@ -221,6 +226,42 @@ public class ClaimSubmissionService : IClaimSubmissionService
             _logger.LogError(ex,
                 "ClaimVersionSubmitted event emission failed for claim {ClaimId} (chain {ClaimVersionId}); " +
                 "submission persisted, audit chain has a gap",
+                SanitizeForLog(created.Id), SanitizeForLog(created.ClaimVersionId));
+        }
+
+        // 5.5 dual-emit — Service Bus topic notification triggers the
+        // adjudication orchestrator. Mongo append-only above is the
+        // system-of-record audit chain; this is the trigger transport.
+        // Same degraded-mode posture: failure here logs but does not
+        // fail the submission. Operators replay missed messages from
+        // the audit chain.
+        try
+        {
+            var sbMessage = new ClaimVersionSubmittedMessage
+            {
+                TenantId = tenantId,
+                ClaimId = created.Id,
+                ClaimVersionId = created.ClaimVersionId,
+                VersionNumber = created.VersionNumber,
+                ActorId = actorId,
+                CorrelationId = correlationId,
+            };
+            var sendOptions = new SendOptions(
+                MessageId: $"submitted:{created.ClaimVersionId}",
+                CorrelationId: correlationId,
+                Properties: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [ClaimVersionEventTopics.MessageTypeProperty] = ClaimVersionMessageTypes.Submitted,
+                });
+
+            await _messageBus.SendAsync(
+                ClaimVersionEventTopics.TopicName, sbMessage, sendOptions, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionSubmitted Service Bus emission failed for claim {ClaimId} (chain {ClaimVersionId}); " +
+                "submission persisted, adjudication will not auto-trigger",
                 SanitizeForLog(created.Id), SanitizeForLog(created.ClaimVersionId));
         }
 

--- a/src/services/claims-service/Services/Resolution/CachingBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/CachingBenefitPlanResolver.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Decorator over <see cref="IBenefitPlanResolver"/> with a 5-minute
+/// in-process TTL keyed by <c>(tenantId, planId)</c>. Mirrors the
+/// BP 5.6 <see cref="BenefitPlanService.Repositories.CachingServiceCategoryMappingRepository"/>
+/// shape: read-through cache, no distributed invalidation, coherence
+/// across pods relies on TTL expiry.
+///
+/// <para>
+/// The pipeline calls <see cref="IBenefitPlanResolver.GetPlanAsync"/>
+/// once per claim. Tenants typically have a small set of active plans
+/// reused across thousands of claims, so the cache hit rate sits high
+/// and benefit-plan-service load drops by an order of magnitude under
+/// realistic claim volumes.
+/// </para>
+///
+/// <para>
+/// Negative results (resolver returned null) are not cached — a
+/// transient benefit-plan-service outage shouldn't pin "missing" for
+/// the full TTL window. Subsequent requests retry the live call.
+/// </para>
+/// </summary>
+public sealed class CachingBenefitPlanResolver : IBenefitPlanResolver
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly IBenefitPlanResolver _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public CachingBenefitPlanResolver(IBenefitPlanResolver inner, IMemoryCache cache)
+        : this(inner, cache, DefaultTtl) { }
+
+    public CachingBenefitPlanResolver(IBenefitPlanResolver inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<ResolvedBenefitPlan?> GetPlanAsync(
+        string tenantId, string planId, CancellationToken ct = default)
+    {
+        var key = BuildCacheKey(tenantId, planId);
+        if (_cache.TryGetValue<ResolvedBenefitPlan>(key, out var cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var fresh = await _inner.GetPlanAsync(tenantId, planId, ct).ConfigureAwait(false);
+        if (fresh is not null && _ttl > TimeSpan.Zero)
+        {
+            _cache.Set(key, fresh, _ttl);
+        }
+        return fresh;
+    }
+
+    internal static string BuildCacheKey(string tenantId, string planId) =>
+        $"benefitplan:{tenantId}:{planId}";
+}

--- a/src/services/claims-service/Services/Resolution/CachingMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/CachingMemberResolver.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Decorator over <see cref="IMemberResolver"/> with the same 5-minute
+/// in-process TTL as <see cref="CachingBenefitPlanResolver"/>, keyed by
+/// <c>(tenantId, memberId)</c>. Negative results are not cached so a
+/// transient member-service outage doesn't pin "missing" for the full
+/// TTL window.
+/// </summary>
+public sealed class CachingMemberResolver : IMemberResolver
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly IMemberResolver _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public CachingMemberResolver(IMemberResolver inner, IMemoryCache cache)
+        : this(inner, cache, DefaultTtl) { }
+
+    public CachingMemberResolver(IMemberResolver inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<ResolvedMember?> GetMemberAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        var key = BuildCacheKey(tenantId, memberId);
+        if (_cache.TryGetValue<ResolvedMember>(key, out var cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        var fresh = await _inner.GetMemberAsync(tenantId, memberId, ct).ConfigureAwait(false);
+        if (fresh is not null && _ttl > TimeSpan.Zero)
+        {
+            _cache.Set(key, fresh, _ttl);
+        }
+        return fresh;
+    }
+
+    internal static string BuildCacheKey(string tenantId, string memberId) =>
+        $"member:{tenantId}:{memberId}";
+}

--- a/src/services/claims-service/Services/Resolution/HttpBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpBenefitPlanResolver.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="IBenefitPlanResolver"/> calling
+/// benefit-plan-service's <c>GET /api/v1/plans/{id}</c>. Resolves a small
+/// summary view of the plan that the adjudication pipeline needs;
+/// benefit-plan-service remains the system-of-record for full plan
+/// definitions.
+///
+/// <para>
+/// Mirrors the existing <see cref="ClaimsService.EDI.Florida.HttpProviderService"/>
+/// shape: <see cref="IHttpClientFactory"/> with a named client, a 5-second
+/// timeout (configured at registration time), and non-throwing failure —
+/// returns <c>null</c> on any error so the orchestrator can degrade
+/// cleanly rather than crash the message handler.
+/// </para>
+/// </summary>
+public class HttpBenefitPlanResolver : IBenefitPlanResolver
+{
+    public const string HttpClientName = "BenefitPlanService";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpBenefitPlanResolver> _logger;
+
+    public HttpBenefitPlanResolver(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpBenefitPlanResolver> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<ResolvedBenefitPlan?> GetPlanAsync(
+        string tenantId, string planId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(planId)) return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(HttpClientName);
+            var url = $"/api/v1/plans/{Uri.EscapeDataString(planId)}";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Benefit-plan-service returned {StatusCode} resolving plan {PlanId}",
+                    response.StatusCode, SanitizeForLog(planId));
+                return null;
+            }
+
+            var dto = await response.Content
+                .ReadFromJsonAsync<BenefitPlanDto>(JsonOptions, ct)
+                .ConfigureAwait(false);
+            if (dto is null) return null;
+
+            Guid? planGuid = Guid.TryParse(dto.Id, out var parsed) ? parsed : null;
+
+            return new ResolvedBenefitPlan
+            {
+                Id = dto.Id ?? planId,
+                PlanGuid = planGuid,
+                PlanName = dto.PlanName,
+                PlanType = dto.PlanType,
+            };
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to resolve benefit plan {PlanId} for tenant {TenantId}",
+                SanitizeForLog(planId), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+
+    private sealed class BenefitPlanDto
+    {
+        public string? Id { get; set; }
+        public string? PlanName { get; set; }
+        public string? PlanType { get; set; }
+    }
+}

--- a/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
@@ -1,0 +1,111 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="IMemberResolver"/> calling member-service's
+/// <c>GET /api/v1/members/{memberId}</c>. Resolves a small summary view
+/// of the member that the adjudication pipeline needs; member-service
+/// remains the system-of-record for full member documents.
+///
+/// <para>
+/// Mirrors <see cref="ClaimsService.EDI.Florida.HttpProviderService"/>:
+/// <see cref="IHttpClientFactory"/> with a named client, non-throwing
+/// failure (returns <c>null</c>), <c>X-Tenant-ID</c> header for tenant
+/// scoping.
+/// </para>
+/// </summary>
+public class HttpMemberResolver : IMemberResolver
+{
+    public const string HttpClientName = "MemberService";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpMemberResolver> _logger;
+
+    public HttpMemberResolver(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpMemberResolver> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<ResolvedMember?> GetMemberAsync(
+        string tenantId, string memberId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(memberId)) return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(HttpClientName);
+            var url = $"/api/v1/members/{Uri.EscapeDataString(memberId)}";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Member-service returned {StatusCode} resolving member {MemberId}",
+                    response.StatusCode, SanitizeForLog(memberId));
+                return null;
+            }
+
+            var dto = await response.Content
+                .ReadFromJsonAsync<MemberDto>(JsonOptions, ct)
+                .ConfigureAwait(false);
+            if (dto is null) return null;
+
+            return new ResolvedMember
+            {
+                MemberId = dto.MemberId ?? memberId,
+                SubscriberMemberId = dto.SubscriberMemberId,
+                IsSubscriber = dto.IsSubscriber,
+                DateOfBirth = dto.DateOfBirth,
+                Gender = dto.Gender,
+                EnrollmentStatus = dto.Status,
+                EffectiveDate = dto.EffectiveDate,
+                TerminationDate = dto.TerminationDate,
+            };
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to resolve member {MemberId} for tenant {TenantId}",
+                SanitizeForLog(memberId), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+
+    private sealed class MemberDto
+    {
+        public string? MemberId { get; set; }
+        public string? SubscriberMemberId { get; set; }
+        public bool IsSubscriber { get; set; }
+        public DateTime? DateOfBirth { get; set; }
+        public string? Gender { get; set; }
+        public string? Status { get; set; }
+        public DateTime? EffectiveDate { get; set; }
+        public DateTime? TerminationDate { get; set; }
+    }
+}

--- a/src/services/claims-service/Services/Resolution/IBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/IBenefitPlanResolver.cs
@@ -1,0 +1,43 @@
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Resolves a benefit plan summary by id for the adjudication pipeline
+/// (capability 5.5). Uses a typed HTTP client against benefit-plan-service
+/// (<c>GET /api/v1/plans/{id}</c>) and is wrapped by
+/// <see cref="CachingBenefitPlanResolver"/> in production for a 5-minute
+/// per-tenant TTL. Mirrors the BP 5.6
+/// <c>CachingServiceCategoryMappingRepository</c> pattern.
+/// </summary>
+public interface IBenefitPlanResolver
+{
+    /// <summary>
+    /// Returns the plan summary, or <c>null</c> when the plan is missing
+    /// or the call fails. Failure is non-throwing — adjudication degrades
+    /// to a Reject outcome on missing plan rather than blowing up the
+    /// pipeline run.
+    /// </summary>
+    Task<ResolvedBenefitPlan?> GetPlanAsync(string tenantId, string planId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Pipeline-local view of a benefit plan. Carries only the fields the
+/// adjudication pipeline needs; full plan documents live in
+/// benefit-plan-service. Decoupled from <c>BenefitPlanService.Models.BenefitPlan</c>
+/// so claims-service does not take a project reference on benefit-plan-service.
+/// </summary>
+public class ResolvedBenefitPlan
+{
+    /// <summary>String id matching the <c>BenefitPlan.Id</c> on benefit-plan-service.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// GUID id used by the engine (<c>BenefitResolutionRequest.BenefitPlanId</c>).
+    /// Surfaced separately because the engine takes a Guid; benefit-plan-service
+    /// keeps both surfaces in sync. May be <c>null</c> when the plan doc lacks
+    /// a Guid id (legacy plans).
+    /// </summary>
+    public Guid? PlanGuid { get; init; }
+
+    public string? PlanName { get; init; }
+    public string? PlanType { get; init; }
+}

--- a/src/services/claims-service/Services/Resolution/IMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/IMemberResolver.cs
@@ -1,0 +1,45 @@
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Resolves a member summary + eligibility for the adjudication pipeline
+/// (capability 5.5). Uses a typed HTTP client against member-service
+/// (<c>GET /api/v1/members/{memberId}</c> for demographics, plus the
+/// <c>/eligibility</c> sub-resource for service-date eligibility).
+/// Wrapped by <see cref="CachingMemberResolver"/> in production with the
+/// same 5-minute per-tenant TTL as <see cref="IBenefitPlanResolver"/>.
+/// </summary>
+public interface IMemberResolver
+{
+    /// <summary>
+    /// Returns the member summary, or <c>null</c> when the member is
+    /// missing or the call fails. Failure is non-throwing — adjudication
+    /// degrades cleanly.
+    /// </summary>
+    Task<ResolvedMember?> GetMemberAsync(string tenantId, string memberId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Pipeline-local view of a member. Carries only what the adjudication
+/// pipeline needs; full member documents live in member-service.
+/// Decoupled from <c>MemberService.Models.Member</c> so claims-service
+/// does not take a project reference on member-service.
+/// </summary>
+public class ResolvedMember
+{
+    public required string MemberId { get; init; }
+    public string? SubscriberMemberId { get; init; }
+    public bool IsSubscriber { get; init; }
+
+    public DateTime? DateOfBirth { get; init; }
+    public string? Gender { get; init; }
+
+    /// <summary>
+    /// Active enrollment status from member-service (<c>"Active"</c>,
+    /// <c>"Terminated"</c>, ...). Null when the field was missing on the
+    /// resolved document.
+    /// </summary>
+    public string? EnrollmentStatus { get; init; }
+
+    public DateTime? EffectiveDate { get; init; }
+    public DateTime? TerminationDate { get; init; }
+}

--- a/src/services/claims-service/claims-service.csproj
+++ b/src/services/claims-service/claims-service.csproj
@@ -10,6 +10,11 @@
   <ItemGroup>
     <ProjectReference Include="../shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj" />
     <ProjectReference Include="../shared/CloudHealthOffice.Events/CloudHealthOffice.Events.csproj" />
+    <!-- Capability 5.5 — BenefitCalculationStage calls IBenefitCalculationEngine
+         (BP 5.10) directly. The engine ships as a class library so the same
+         calculation runs in claims-service (adjudication pipeline) and
+         benefit-plan-service (preview / what-if surface). -->
+    <ProjectReference Include="../../engines/CloudHealthOffice.BenefitEngine/CloudHealthOffice.BenefitEngine.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -3,8 +3,10 @@ using ClaimsService.EDI.Florida;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using ClaimsService.Services;
+using CloudHealthOffice.BenefitEngine.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -22,6 +24,20 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Development");
+
+        // 5.5 — force the no-op messaging backend so the orchestrator's
+        // SubscriptionHostedService starts a subscription that never
+        // dispatches, and ClaimSubmissionService's SendAsync silently
+        // succeeds. Tests that need actual adjudication-pipeline
+        // behaviour use a dedicated integration factory with
+        // Messaging:Backend=InMemory.
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Messaging:Backend"] = "Null",
+            });
+        });
 
         builder.ConfigureServices(services =>
         {
@@ -72,6 +88,20 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             {
                 services.Remove(descriptor);
             }
+
+            // 5.5 — replace the production IBenefitCalculationEngine HTTP
+            // shim so unrelated controller tests don't trigger a real HTTP
+            // call to benefit-plan-service. The SubscriptionHostedService
+            // stays registered but consumes a NullMessageBus subscription
+            // (configured above) so it's a true no-op for unrelated tests.
+            var enginePos = services
+                .Where(d => d.ServiceType == typeof(IBenefitCalculationEngine))
+                .ToList();
+            foreach (var descriptor in enginePos)
+            {
+                services.Remove(descriptor);
+            }
+            services.AddSingleton(Substitute.For<IBenefitCalculationEngine>());
 
             services.AddSingleton(ClaimRepository);
             services.AddSingleton(AcknowledgmentService);

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Json;
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.BenefitEngine.Models;
+using CloudHealthOffice.BenefitEngine.Services;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Integration;
+
+/// <summary>
+/// End-to-end coverage for capability 5.5: POST <c>/api/v1/claims</c>
+/// triggers a Service Bus message that the adjudication orchestrator
+/// consumes via <see cref="InMemoryMessageBus"/>; the pipeline runs
+/// BenefitCalculationStage against a substitute engine and PersistenceStage
+/// writes through the projection-bypass repository method.
+///
+/// <para>
+/// Test posture (Decision 19): InMemoryMessageBus stands in for
+/// Service Bus; subscription filter rules are not exercised at this
+/// layer — they're a Bicep concern verified by <c>az bicep build</c>
+/// in CI. The producer side is asserted against
+/// <see cref="SendOptions.Properties"/> in the unit-level
+/// <see cref="ClaimsService.Tests.Services.ClaimSubmissionServiceMessageBusEmissionTests"/>.
+/// </para>
+/// </summary>
+public class AdjudicationEndToEndTests : IAsyncLifetime
+{
+    private readonly AdjudicationApiFactory _factory = new();
+    private HttpClient _client = default!;
+
+    public Task InitializeAsync()
+    {
+        _client = _factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "tenant-1");
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task PostClaim_TriggersAdjudicationPipeline_AndPersistenceBypassRecordsResult()
+    {
+        var planId = Guid.NewGuid().ToString();
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        var inbound = new
+        {
+            ClaimNumber = "E2E-001",
+            MemberId = "MEM-1",
+            BillingProviderNPI = "1234567890",
+            BenefitPlanId = planId,
+            LineOfBusiness = "Commercial",
+            ClaimType = "Professional",
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new[]
+            {
+                new
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 200m,
+                    Units = 1m,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                }
+            },
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/v1/claims", inbound);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        // Drain the in-memory bus by polling for the persistence-stage
+        // write. With InMemoryMessageBus the dispatch is an async pump,
+        // so a short polling window covers the typical single-digit-
+        // millisecond handler runtime without flakiness.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline && _factory.ProjectionWrites.Count == 0)
+        {
+            await Task.Delay(20);
+        }
+
+        Assert.NotEmpty(_factory.ProjectionWrites);
+        var write = _factory.ProjectionWrites[0];
+        Assert.Equal("tenant-1", write.TenantId);
+        Assert.Equal(150m, write.Result.AllowedAmount);
+        Assert.Equal(120m, write.Result.PayerPayment);
+        Assert.Equal(30m, write.Result.PatientResponsibility);
+        Assert.Single(write.LineResults);
+    }
+
+    /// <summary>
+    /// Custom factory that opts into the Service Bus subscription, swaps
+    /// the engine for a deterministic substitute, and records the
+    /// persistence-bypass write so the test can observe it without
+    /// standing up Cosmos / Mongo.
+    /// </summary>
+    private sealed class AdjudicationApiFactory : WebApplicationFactory<Program>
+    {
+        public IClaimRepository Repository { get; } = Substitute.For<IClaimRepository>();
+        public List<ProjectionWrite> ProjectionWrites { get; } = new();
+
+        private Claim? _lastCreated;
+
+        public AdjudicationApiFactory()
+        {
+            Repository.CreateAsync(Arg.Any<Claim>())
+                .Returns(ci =>
+                {
+                    var c = ci.Arg<Claim>();
+                    if (string.IsNullOrEmpty(c.Id)) c.Id = Guid.NewGuid().ToString();
+                    if (string.IsNullOrEmpty(c.ClaimVersionId)) c.ClaimVersionId = c.Id;
+                    if (c.VersionNumber == 0) c.VersionNumber = 1;
+                    c.VersionState = ClaimVersionState.Submitted;
+                    _lastCreated = c;
+                    return c;
+                });
+
+            // Adjudication orchestrator routes through IClaimAdapter →
+            // ChoClaimAdapter → IClaimRepository.GetLatestVersionAsync(...).
+            // Return the most recently created claim to keep the pipeline
+            // running against the same row the submission produced.
+            Repository.GetLatestVersionAsync(
+                    Arg.Any<string>(), Arg.Any<DateTime>())
+                .Returns(_ => _lastCreated);
+
+            Repository.UpdateAdjudicationProjectionAsync(
+                    Arg.Any<string>(),
+                    Arg.Any<string>(),
+                    Arg.Any<AdjudicationResult>(),
+                    Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ci =>
+                {
+                    ProjectionWrites.Add(new ProjectionWrite(
+                        ci.ArgAt<string>(0),
+                        ci.ArgAt<string>(1),
+                        ci.ArgAt<AdjudicationResult>(2),
+                        ci.ArgAt<IReadOnlyList<LineAdjudicationResult>>(3)));
+                    return true;
+                });
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Messaging:Backend"] = "InMemory",
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                var toRemove = services
+                    .Where(d => d.ServiceType == typeof(IClaimRepository)
+                             || d.ServiceType.FullName?.Contains("Cosmos") == true
+                             || d.ServiceType.FullName?.Contains("Mongo") == true
+                             || d.ImplementationType?.FullName?.Contains("Cosmos") == true
+                             || d.ImplementationType?.FullName?.Contains("Mongo") == true
+                             || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
+                             || d.ServiceType == typeof(IClaimVersionEventPublisher)
+                             || d.ServiceType == typeof(IBenefitCalculationEngine)
+                             || d.ServiceType == typeof(IBenefitPlanResolver)
+                             || d.ServiceType == typeof(IMemberResolver))
+                    .ToList();
+                foreach (var descriptor in toRemove)
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddSingleton(Repository);
+                services.AddSingleton(Substitute.For<IClaimVersionEventPublisher>());
+
+                var engine = Substitute.For<IBenefitCalculationEngine>();
+                engine.CalculateAsync(
+                        Arg.Any<BenefitResolutionRequest>(),
+                        Arg.Any<CancellationToken>())
+                    .Returns(new BenefitResolutionResult
+                    {
+                        Success = true,
+                        Totals = new ClaimTotals
+                        {
+                            TotalBilled = 200m,
+                            TotalAllowed = 150m,
+                            TotalDeductible = 0m,
+                            TotalCoinsurance = 30m,
+                            TotalCopay = 0m,
+                            TotalMemberResponsibility = 30m,
+                            TotalPlanPaid = 120m,
+                        },
+                        Lines = new List<LineBenefitResult>
+                        {
+                            new()
+                            {
+                                LineNumber = 1,
+                                IsCovered = true,
+                                ServiceTypeCode = "1",
+                                ServiceTypeDescription = "Office",
+                                AllowedAmount = 150m,
+                                PlanPaidAmount = 120m,
+                                MemberResponsibility = 30m,
+                            }
+                        },
+                    });
+                services.AddSingleton(engine);
+
+                var planResolver = Substitute.For<IBenefitPlanResolver>();
+                planResolver.GetPlanAsync(
+                        Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(ci => new ResolvedBenefitPlan
+                    {
+                        Id = ci.ArgAt<string>(1),
+                        PlanGuid = Guid.TryParse(ci.ArgAt<string>(1), out var g) ? g : Guid.NewGuid(),
+                        PlanName = "Stub Plan",
+                    });
+                services.AddSingleton(planResolver);
+
+                var memberResolver = Substitute.For<IMemberResolver>();
+                memberResolver.GetMemberAsync(
+                        Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                    .Returns(ci => new ResolvedMember
+                    {
+                        MemberId = ci.ArgAt<string>(1),
+                        SubscriberMemberId = ci.ArgAt<string>(1),
+                        IsSubscriber = true,
+                    });
+                services.AddSingleton(memberResolver);
+            });
+        }
+    }
+
+    public record ProjectionWrite(
+        string TenantId,
+        string ClaimVersionId,
+        AdjudicationResult Result,
+        IReadOnlyList<LineAdjudicationResult> LineResults);
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
@@ -1,0 +1,401 @@
+using System.Net.Http;
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Services;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication;
+
+/// <summary>
+/// Capability 5.5 — orchestrator-level tests using stub stages so the
+/// pipeline contract (ordering, short-circuit, persistence-always-runs,
+/// adjudicated-event emission, idempotency) is exercised without
+/// touching <see cref="BenefitCalculationStage"/> or
+/// <see cref="PersistenceStage"/> internals.
+/// </summary>
+public class ClaimAdjudicationOrchestratorTests
+{
+    private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
+    private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
+    private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
+    private readonly ClaimAdapterFactory _factory;
+
+    public ClaimAdjudicationOrchestratorTests()
+    {
+        _adapter.Platform.Returns("cho");
+
+        var cache = new ClaimTenantConfigCache(
+            Substitute.For<IHttpClientFactory>(),
+            Substitute.For<IConfiguration>(),
+            NullLogger<ClaimTenantConfigCache>.Instance);
+
+        _factory = new ClaimAdapterFactory(
+            new[] { _adapter },
+            cache,
+            NullLogger<ClaimAdapterFactory>.Instance);
+    }
+
+    [Fact]
+    public async Task Adjudicate_RunsStagesInOrderAscending()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+            new RecordingStage("BenefitCalculation", 300, isRequired: false, executed),
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Scrubbing", "BenefitCalculation", "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_TerminalStage_ShortCircuitsButPersistenceStillRuns()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed,
+                _ => ClaimAdjudicationStageResult.Reject("Scrubbing", "structural defect")),
+            new RecordingStage("BenefitCalculation", 300, isRequired: false, executed),
+            new RecordingStage("NcciEdits", 400, isRequired: false, executed),
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Scrubbing", "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_PendOutcome_DoesNotShortCircuit()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed,
+                _ => ClaimAdjudicationStageResult.Pend("Scrubbing", "manual review")),
+            new RecordingStage("BenefitCalculation", 300, isRequired: false, executed),
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Scrubbing", "BenefitCalculation", "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_StageThrows_TreatedAsRejectAndPipelineContinuesToPersistence()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed,
+                _ => throw new InvalidOperationException("boom")),
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Scrubbing", "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_DisabledStage_IsSkipped()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed),
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var options = new AdjudicationPipelineOptions();
+        options.EnabledStages["Scrubbing"] = false;
+
+        var orch = BuildOrchestrator(stages, options);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_RequiredStage_RunsEvenIfDisabled()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        SetupAdapterReturningClaim();
+
+        var options = new AdjudicationPipelineOptions();
+        options.EnabledStages["Persistence"] = false;
+
+        var orch = BuildOrchestrator(stages, options);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal(new[] { "Persistence" }, executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_EmitsClaimVersionAdjudicatedMessage()
+    {
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        SetupAdapterReturningClaim();
+
+        ClaimVersionAdjudicatedMessage? captured = null;
+        SendOptions? capturedOptions = null;
+        _messageBus
+            .When(b => b.SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionAdjudicatedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                captured = ci.Arg<ClaimVersionAdjudicatedMessage>();
+                capturedOptions = ci.Arg<SendOptions?>();
+            });
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("ver-1", captured!.ClaimVersionId);
+        Assert.Equal("Pass", captured.Outcome);
+        Assert.Equal("adjudicated:ver-1", capturedOptions?.MessageId);
+        Assert.Equal("ClaimVersionAdjudicated", capturedOptions?.Properties?["MessageType"]);
+    }
+
+    [Fact]
+    public async Task Adjudicate_FinalOutcomeReflectsHighestPrecedenceFailure()
+    {
+        // Pend → Reject → Deny: Reject wins over Pend, Deny is suppressed
+        // when an earlier Reject already short-circuited. With Reject first
+        // the rest of the non-persistence stages don't run; Reject is the
+        // final outcome.
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, new List<string>(),
+                _ => ClaimAdjudicationStageResult.Reject("Scrubbing", "bad")),
+            new RecordingStage("BenefitCalculation", 300, isRequired: false, new List<string>(),
+                _ => ClaimAdjudicationStageResult.Pend("BenefitCalculation", "needs review")),
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        SetupAdapterReturningClaim();
+
+        ClaimVersionAdjudicatedMessage? captured = null;
+        _messageBus
+            .When(b => b.SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionAdjudicatedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(ci => captured = ci.Arg<ClaimVersionAdjudicatedMessage>());
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal("Reject", captured!.Outcome);
+        Assert.Equal("bad", captured.Reason);
+    }
+
+    [Fact]
+    public async Task Adjudicate_AlreadyAdjudicatedClaim_SkipsPipeline()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Scrubbing", 100, isRequired: false, executed),
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        var alreadyAdjudicated = BuildAdapterClaim();
+        alreadyAdjudicated.AdjudicationResult = new AdapterAdjudicationResult { AllowedAmount = 100m };
+        SetupAdapterReturning(alreadyAdjudicated);
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Empty(executed);
+        await _messageBus.DidNotReceiveWithAnyArgs().SendAsync(
+            default!, default(ClaimVersionAdjudicatedMessage)!, default, default);
+    }
+
+    [Fact]
+    public async Task Adjudicate_ClaimNotFoundViaAdapter_SkipsPipelineCleanly()
+    {
+        var executed = new List<string>();
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, executed),
+        };
+        _adapter
+            .GetClaimAsync(Arg.Any<ClaimAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ClaimAdapterResponse { Platform = "cho", Claim = null });
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Empty(executed);
+    }
+
+    [Fact]
+    public async Task Adjudicate_AdjudicatedEventPublisherFails_DoesNotBlockServiceBusEmission()
+    {
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        SetupAdapterReturningClaim();
+        _eventPublisher
+            .PublishVersionAdjudicatedAsync(
+                Arg.Any<Claim>(),
+                Arg.Any<string?>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Mongo down"));
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        // Service Bus emission must still run despite Mongo failure.
+        await _messageBus.Received(1).SendAsync(
+            "claim-version-events",
+            Arg.Any<ClaimVersionAdjudicatedMessage>(),
+            Arg.Any<SendOptions?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private ClaimAdjudicationOrchestrator BuildOrchestrator(
+        IEnumerable<IClaimAdjudicationStage> stages,
+        AdjudicationPipelineOptions? options = null)
+    {
+        return new ClaimAdjudicationOrchestrator(
+            _factory,
+            _planResolver,
+            _memberResolver,
+            stages,
+            _eventPublisher,
+            _messageBus,
+            Options.Create(options ?? new AdjudicationPipelineOptions()),
+            NullLogger<ClaimAdjudicationOrchestrator>.Instance);
+    }
+
+    private void SetupAdapterReturningClaim()
+        => SetupAdapterReturning(BuildAdapterClaim());
+
+    private void SetupAdapterReturning(AdapterClaim claim)
+    {
+        _adapter
+            .GetClaimAsync(Arg.Any<ClaimAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ClaimAdapterResponse { Platform = "cho", Claim = claim });
+    }
+
+    private static ClaimVersionSubmittedMessage BuildSubmittedMessage() => new()
+    {
+        TenantId = "tenant-1",
+        ClaimId = "ver-1",
+        ClaimVersionId = "ver-1",
+        VersionNumber = 1,
+        ActorId = "actor",
+        CorrelationId = "corr-1",
+    };
+
+    private static MessageContext BuildContext() => new(
+        MessageId: "submitted:ver-1",
+        CorrelationId: "corr-1",
+        DeliveryCount: 1,
+        Properties: new Dictionary<string, string> { ["MessageType"] = "ClaimVersionSubmitted" });
+
+    private static AdapterClaim BuildAdapterClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new AdapterClaim
+        {
+            TenantId = "tenant-1",
+            Id = "ver-1",
+            ClaimNumber = "CLM-1",
+            ClaimVersionId = "ver-1",
+            VersionNumber = 1,
+            VersionState = ClaimVersionState.Submitted,
+            MemberId = "MEM-1",
+            BillingProviderNPI = "1234567890",
+            BenefitPlanId = Guid.NewGuid().ToString(),
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 100m, Units = 1,
+                        ServiceDateFrom = serviceDate, ServiceDateTo = serviceDate },
+            },
+        };
+    }
+
+    private sealed class RecordingStage : IClaimAdjudicationStage
+    {
+        private readonly List<string> _log;
+        private readonly Func<ClaimAdjudicationContext, ClaimAdjudicationStageResult>? _behavior;
+
+        public RecordingStage(
+            string name,
+            int order,
+            bool isRequired,
+            List<string> log,
+            Func<ClaimAdjudicationContext, ClaimAdjudicationStageResult>? behavior = null)
+        {
+            Name = name;
+            Order = order;
+            IsRequired = isRequired;
+            _log = log;
+            _behavior = behavior;
+        }
+
+        public string Name { get; }
+        public int Order { get; }
+        public bool IsRequired { get; }
+
+        public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+            ClaimAdjudicationContext context, CancellationToken ct)
+        {
+            _log.Add(Name);
+            var result = _behavior is null
+                ? ClaimAdjudicationStageResult.Pass(Name)
+                : _behavior(context);
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -1,0 +1,239 @@
+using ClaimsService.Models;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.BenefitEngine.Models;
+using CloudHealthOffice.BenefitEngine.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication.Stages;
+
+public class BenefitCalculationStageTests
+{
+    private readonly IBenefitCalculationEngine _engine = Substitute.For<IBenefitCalculationEngine>();
+    private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly BenefitCalculationStage _sut;
+
+    public BenefitCalculationStageTests()
+    {
+        _sut = new BenefitCalculationStage(
+            _engine, _memberResolver, NullLogger<BenefitCalculationStage>.Instance);
+    }
+
+    [Fact]
+    public async Task Execute_HappyPath_PopulatesAdjudicationResult()
+    {
+        var planGuid = Guid.NewGuid();
+        var claim = BuildClaim(planGuid.ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult
+            {
+                Success = true,
+                Totals = new ClaimTotals
+                {
+                    TotalAllowed = 80m,
+                    TotalDeductible = 10m,
+                    TotalCoinsurance = 14m,
+                    TotalCopay = 5m,
+                    TotalMemberResponsibility = 29m,
+                    TotalPlanPaid = 51m,
+                },
+                Lines = new List<LineBenefitResult>
+                {
+                    new()
+                    {
+                        LineNumber = 1, IsCovered = true, ServiceTypeCode = "1",
+                        ServiceTypeDescription = "Office", AllowedAmount = 80m,
+                        PlanPaidAmount = 51m, MemberResponsibility = 29m,
+                    },
+                },
+            });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.True(result.Continue);
+        Assert.Equal(80m, ctx.AdjudicationResult.AllowedAmount);
+        Assert.Equal(29m, ctx.AdjudicationResult.PatientResponsibility);
+        Assert.Equal(51m, ctx.AdjudicationResult.PayerPayment);
+        Assert.Single(ctx.LineAdjudicationResults);
+        Assert.Equal(80m, ctx.LineAdjudicationResults[0].AllowedAmount);
+    }
+
+    [Fact]
+    public async Task Execute_MissingBenefitPlanId_RejectsWithoutEngineCall()
+    {
+        var claim = BuildClaim(planId: null);
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Reject, result.Outcome);
+        Assert.False(result.Continue);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_NonGuidBenefitPlanId_RejectsWhenNoResolvedGuid()
+    {
+        var claim = BuildClaim(planId: "legacy-plan-A");
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedPlan = new ResolvedBenefitPlan { Id = "legacy-plan-A", PlanGuid = null },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Reject, result.Outcome);
+        Assert.Contains("not a GUID", result.Reason);
+    }
+
+    [Fact]
+    public async Task Execute_NonGuidBenefitPlanId_UsesResolvedPlanGuidWhenAvailable()
+    {
+        var claim = BuildClaim(planId: "PLAN-FRIENDLY-NAME");
+        var resolvedGuid = Guid.NewGuid();
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+            ResolvedPlan = new ResolvedBenefitPlan { Id = "PLAN-FRIENDLY-NAME", PlanGuid = resolvedGuid },
+        };
+
+        BenefitResolutionRequest? capturedRequest = null;
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                capturedRequest = ci.Arg<BenefitResolutionRequest>();
+                return new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() };
+            });
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(resolvedGuid, capturedRequest!.BenefitPlanId);
+    }
+
+    [Fact]
+    public async Task Execute_EngineThrows_RejectsWithoutPropagating()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("engine down"));
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Reject, result.Outcome);
+        Assert.Contains("InvalidOperationException", result.Reason);
+    }
+
+    [Fact]
+    public async Task Execute_EngineReturnsFailure_DeniesAndShortCircuits()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult
+            {
+                Success = false,
+                DenialReasonCode = "96",
+                DenialReasonDescription = "Non-covered service",
+                Totals = new ClaimTotals(),
+            });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Equal("Non-covered service", result.Reason);
+    }
+
+    [Fact]
+    public async Task Execute_NoSubscriberOnClaim_FallsBackThroughResolverAndMemberId()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.SubscriberId = null;
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+        };
+        _memberResolver.GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>())
+            .Returns(new ResolvedMember { MemberId = "MEM-1", SubscriberMemberId = "SUB-7" });
+
+        BenefitResolutionRequest? captured = null;
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                captured = ci.Arg<BenefitResolutionRequest>();
+                return new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() };
+            });
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal("SUB-7", captured!.SubscriberId);
+    }
+
+    private static AdapterClaim BuildClaim(string? planId)
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new AdapterClaim
+        {
+            TenantId = "tenant-1",
+            Id = "claim-1",
+            ClaimVersionId = "claim-1",
+            ClaimNumber = "CLM-1",
+            MemberId = "MEM-1",
+            SubscriberId = "MEM-1",
+            BenefitPlanId = planId,
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 100m, Units = 1,
+                        ServiceDateFrom = serviceDate, ServiceDateTo = serviceDate },
+            },
+        };
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
@@ -1,0 +1,104 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication.Stages;
+
+public class PersistenceStageTests
+{
+    private readonly IClaimRepository _repository = Substitute.For<IClaimRepository>();
+    private readonly PersistenceStage _sut;
+
+    public PersistenceStageTests()
+    {
+        _sut = new PersistenceStage(_repository, NullLogger<PersistenceStage>.Instance);
+    }
+
+    [Fact]
+    public void OrderingAndRequirementContract_MatchSpec()
+    {
+        Assert.Equal("Persistence", _sut.Name);
+        Assert.Equal(999, _sut.Order);
+        Assert.True(_sut.IsRequired);
+    }
+
+    [Fact]
+    public async Task Execute_CallsBypassMethod_NotRegularUpdate()
+    {
+        var ctx = BuildContext();
+        ctx.AdjudicationResult = new AdjudicationResult { AllowedAmount = 75m };
+        ctx.LineAdjudicationResults = new List<LineAdjudicationResult>
+        {
+            new() { AllowedAmount = 75m, PaidAmount = 50m, PatientResponsibility = 25m },
+        };
+        _repository.UpdateAdjudicationProjectionAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<AdjudicationResult>(),
+            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _repository.Received(1).UpdateAdjudicationProjectionAsync(
+            "tenant-1",
+            "ver-1",
+            Arg.Is<AdjudicationResult>(a => a.AllowedAmount == 75m),
+            Arg.Is<IReadOnlyList<LineAdjudicationResult>>(l => l.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_BypassReturnsFalse_StageReturnsReject()
+    {
+        var ctx = BuildContext();
+        _repository.UpdateAdjudicationProjectionAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<AdjudicationResult>(),
+            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Reject, result.Outcome);
+    }
+
+    [Fact]
+    public async Task Execute_RepositoryThrows_BubblesException()
+    {
+        var ctx = BuildContext();
+        _repository.UpdateAdjudicationProjectionAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<AdjudicationResult>(),
+            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("cosmos down"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.ExecuteAsync(ctx, CancellationToken.None));
+    }
+
+    private static ClaimAdjudicationContext BuildContext() => new()
+    {
+        TenantId = "tenant-1",
+        ClaimVersionId = "ver-1",
+        Claim = new AdapterClaim
+        {
+            TenantId = "tenant-1",
+            Id = "ver-1",
+            ClaimVersionId = "ver-1",
+            MemberId = "MEM-1",
+            BillingProviderNPI = "1234567890",
+        },
+    };
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceMessageBusEmissionTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceMessageBusEmissionTests.cs
@@ -1,0 +1,177 @@
+using System.Net.Http;
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Services;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+/// <summary>
+/// Capability 5.5 — verifies the dual-emit modification on
+/// <see cref="ClaimSubmissionService"/>: after a successful submission,
+/// the service emits a <see cref="ClaimVersionSubmittedMessage"/> onto
+/// the <c>claim-version-events</c> Service Bus topic with the correct
+/// MessageType property and a deterministic MessageId, AND survives
+/// Service Bus emission failures without failing the submission
+/// (degraded-mode parity with the existing Mongo emit).
+/// </summary>
+public class ClaimSubmissionServiceMessageBusEmissionTests
+{
+    private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
+    private readonly IClaimVersionEventPublisher _publisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
+    private readonly ClaimAdapterFactory _factory;
+    private readonly ClaimSubmissionService _sut;
+
+    public ClaimSubmissionServiceMessageBusEmissionTests()
+    {
+        _adapter.Platform.Returns("cho");
+
+        var cache = new ClaimTenantConfigCache(
+            Substitute.For<IHttpClientFactory>(),
+            Substitute.For<IConfiguration>(),
+            NullLogger<ClaimTenantConfigCache>.Instance);
+
+        _factory = new ClaimAdapterFactory(
+            new[] { _adapter },
+            cache,
+            NullLogger<ClaimAdapterFactory>.Instance);
+
+        _sut = new ClaimSubmissionService(
+            _factory, _publisher, _messageBus, NullLogger<ClaimSubmissionService>.Instance);
+    }
+
+    [Fact]
+    public async Task Submit_HappyPath_EmitsClaimVersionSubmittedMessage()
+    {
+        StubAdapterCreatesClaim("ver-7", versionNumber: 1);
+
+        ClaimVersionSubmittedMessage? captured = null;
+        SendOptions? capturedOptions = null;
+        _messageBus
+            .When(b => b.SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionSubmittedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                captured = ci.Arg<ClaimVersionSubmittedMessage>();
+                capturedOptions = ci.Arg<SendOptions?>();
+            });
+
+        var result = await _sut.SubmitAsync(BuildClaim(), "tenant-x", "actor-1", "corr-99");
+
+        Assert.True(result.Success);
+        await _messageBus.Received(1).SendAsync(
+            "claim-version-events",
+            Arg.Any<ClaimVersionSubmittedMessage>(),
+            Arg.Any<SendOptions?>(),
+            Arg.Any<CancellationToken>());
+
+        Assert.NotNull(captured);
+        Assert.Equal("tenant-x", captured!.TenantId);
+        Assert.Equal("ver-7", captured.ClaimVersionId);
+        Assert.Equal("actor-1", captured.ActorId);
+        Assert.Equal("corr-99", captured.CorrelationId);
+
+        Assert.NotNull(capturedOptions);
+        Assert.Equal("submitted:ver-7", capturedOptions!.MessageId);
+        Assert.NotNull(capturedOptions.Properties);
+        Assert.Equal("ClaimVersionSubmitted", capturedOptions.Properties!["MessageType"]);
+    }
+
+    [Fact]
+    public async Task Submit_MessageBusEmissionFails_StillReturnsSuccess()
+    {
+        StubAdapterCreatesClaim("ver-9", versionNumber: 1);
+        _messageBus
+            .SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionSubmittedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Service Bus down"));
+
+        var result = await _sut.SubmitAsync(BuildClaim(), "tenant-x", "actor-1", null);
+
+        Assert.True(result.Success);
+        Assert.Equal("ver-9", result.Claim!.ClaimVersionId);
+    }
+
+    [Fact]
+    public async Task Submit_ValidationFailure_DoesNotEmit()
+    {
+        var claim = BuildClaim();
+        claim.MemberId = string.Empty;
+
+        var result = await _sut.SubmitAsync(claim, "tenant-x", "actor", null);
+
+        Assert.False(result.Success);
+        await _messageBus.DidNotReceiveWithAnyArgs().SendAsync(
+            default!, default(ClaimVersionSubmittedMessage)!, default, default);
+    }
+
+    [Fact]
+    public async Task Submit_AdapterNotImplemented_DoesNotEmit()
+    {
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Throws(new NotImplementedException("vendor adapter not wired"));
+
+        var result = await _sut.SubmitAsync(BuildClaim(), "tenant-x", "actor", null);
+
+        Assert.False(result.Success);
+        await _messageBus.DidNotReceiveWithAnyArgs().SendAsync(
+            default!, default(ClaimVersionSubmittedMessage)!, default, default);
+    }
+
+    private void StubAdapterCreatesClaim(string claimVersionId, int versionNumber)
+    {
+        _adapter
+            .SubmitClaimAsync(Arg.Any<ClaimSubmissionAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var req = ci.Arg<ClaimSubmissionAdapterRequest>();
+                req.Claim.Id = claimVersionId;
+                req.Claim.ClaimVersionId = claimVersionId;
+                req.Claim.VersionNumber = versionNumber;
+                req.Claim.VersionState = ClaimVersionState.Submitted;
+                return new ClaimAdapterResponse { Platform = "cho", Claim = req.Claim };
+            });
+    }
+
+    private static AdapterClaim BuildClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        return new AdapterClaim
+        {
+            ClaimNumber = "CLM-001",
+            MemberId = "MEM-1",
+            BillingProviderNPI = "1234567890",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate,
+                }
+            }
+        };
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimSubmissionServiceTests.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 using ClaimsService.Adapters;
 using ClaimsService.Models;
 using ClaimsService.Services;
+using CloudHealthOffice.Infrastructure.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -21,6 +22,7 @@ public class ClaimSubmissionServiceTests
 {
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IClaimVersionEventPublisher _publisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly ClaimAdapterFactory _factory;
     private readonly ClaimSubmissionService _sut;
 
@@ -43,7 +45,7 @@ public class ClaimSubmissionServiceTests
             NullLogger<ClaimAdapterFactory>.Instance);
 
         _sut = new ClaimSubmissionService(
-            _factory, _publisher, NullLogger<ClaimSubmissionService>.Instance);
+            _factory, _publisher, _messageBus, NullLogger<ClaimSubmissionService>.Instance);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingBenefitPlanResolverTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingBenefitPlanResolverTests.cs
@@ -1,0 +1,71 @@
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+public class CachingBenefitPlanResolverTests
+{
+    private readonly IBenefitPlanResolver _inner = Substitute.For<IBenefitPlanResolver>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    [Fact]
+    public async Task GetPlan_CacheMiss_HitsInner_AndCachesResult()
+    {
+        var sut = new CachingBenefitPlanResolver(_inner, _cache);
+        var plan = new ResolvedBenefitPlan { Id = "p1", PlanName = "Gold PPO" };
+        _inner.GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>()).Returns(plan);
+
+        var first = await sut.GetPlanAsync("tenant-1", "p1");
+        var second = await sut.GetPlanAsync("tenant-1", "p1");
+
+        Assert.Same(plan, first);
+        Assert.Same(plan, second);
+        await _inner.Received(1).GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPlan_NullResult_NotCached()
+    {
+        var sut = new CachingBenefitPlanResolver(_inner, _cache);
+        _inner.GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>())
+            .Returns((ResolvedBenefitPlan?)null, new ResolvedBenefitPlan { Id = "p1" });
+
+        var first = await sut.GetPlanAsync("tenant-1", "p1");
+        var second = await sut.GetPlanAsync("tenant-1", "p1");
+
+        Assert.Null(first);
+        Assert.NotNull(second);
+        await _inner.Received(2).GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPlan_DifferentTenants_DoNotShareCacheEntries()
+    {
+        var sut = new CachingBenefitPlanResolver(_inner, _cache);
+        var planA = new ResolvedBenefitPlan { Id = "p1", PlanName = "A" };
+        var planB = new ResolvedBenefitPlan { Id = "p1", PlanName = "B" };
+        _inner.GetPlanAsync("tenant-A", "p1", Arg.Any<CancellationToken>()).Returns(planA);
+        _inner.GetPlanAsync("tenant-B", "p1", Arg.Any<CancellationToken>()).Returns(planB);
+
+        var a = await sut.GetPlanAsync("tenant-A", "p1");
+        var b = await sut.GetPlanAsync("tenant-B", "p1");
+
+        Assert.Equal("A", a?.PlanName);
+        Assert.Equal("B", b?.PlanName);
+    }
+
+    [Fact]
+    public async Task GetPlan_TtlZero_DisablesCache()
+    {
+        var sut = new CachingBenefitPlanResolver(_inner, _cache, TimeSpan.Zero);
+        _inner.GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>())
+            .Returns(new ResolvedBenefitPlan { Id = "p1" });
+
+        await sut.GetPlanAsync("tenant-1", "p1");
+        await sut.GetPlanAsync("tenant-1", "p1");
+
+        await _inner.Received(2).GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingMemberResolverTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingMemberResolverTests.cs
@@ -1,0 +1,60 @@
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+public class CachingMemberResolverTests
+{
+    private readonly IMemberResolver _inner = Substitute.For<IMemberResolver>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    [Fact]
+    public async Task GetMember_CacheMiss_HitsInner_AndCachesResult()
+    {
+        var sut = new CachingMemberResolver(_inner, _cache);
+        var member = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true };
+        _inner.GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>()).Returns(member);
+
+        var first = await sut.GetMemberAsync("tenant-1", "MEM-1");
+        var second = await sut.GetMemberAsync("tenant-1", "MEM-1");
+
+        Assert.Same(member, first);
+        Assert.Same(member, second);
+        await _inner.Received(1).GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMember_NullResult_NotCached()
+    {
+        var sut = new CachingMemberResolver(_inner, _cache);
+        _inner.GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>())
+            .Returns(
+                (ResolvedMember?)null,
+                new ResolvedMember { MemberId = "MEM-1" });
+
+        var first = await sut.GetMemberAsync("tenant-1", "MEM-1");
+        var second = await sut.GetMemberAsync("tenant-1", "MEM-1");
+
+        Assert.Null(first);
+        Assert.NotNull(second);
+        await _inner.Received(2).GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMember_DifferentMembers_DoNotShareCacheEntries()
+    {
+        var sut = new CachingMemberResolver(_inner, _cache);
+        _inner.GetMemberAsync("tenant-1", "MEM-1", Arg.Any<CancellationToken>())
+            .Returns(new ResolvedMember { MemberId = "MEM-1" });
+        _inner.GetMemberAsync("tenant-1", "MEM-2", Arg.Any<CancellationToken>())
+            .Returns(new ResolvedMember { MemberId = "MEM-2" });
+
+        var a = await sut.GetMemberAsync("tenant-1", "MEM-1");
+        var b = await sut.GetMemberAsync("tenant-1", "MEM-2");
+
+        Assert.Equal("MEM-1", a?.MemberId);
+        Assert.Equal("MEM-2", b?.MemberId);
+    }
+}


### PR DESCRIPTION
## Summary

Capability 5.5 — the architecturally load-bearing PR of Claims Phase 1.
Introduces the orchestration seam that turns a submitted claim into an
adjudicated one. After this ships, capabilities 5.4 / 5.6 / 5.7 / 5.8 / 5.9
each become parallel-shippable PRs that swap one stub stage; 5.10 / 5.12 add
their own subscriptions to the same Service Bus topic.

### What's in the box

- **Orchestrator + stage seam** — `IClaimAdjudicationOrchestrator`,
  `IClaimAdjudicationStage`, `ClaimAdjudicationContext`. Stages registered
  as `IEnumerable<IClaimAdjudicationStage>`, sorted by `Order`, replaceable
  one-at-a-time via DI swap.
- **Two real stages**:
  - `BenefitCalculationStage` calls `IBenefitCalculationEngine` (BP 5.10)
    via the new `HttpBenefitCalculationEngineClient` shim against
    benefit-plan-service's existing `/api/v1/adjudication/calculate-benefits`
    endpoint. The engine ships as a class library but its data-layer
    collaborators (`IBenefitPlanProvider`, `IAccumulatorService`, …) are
    wired in benefit-plan-service; the shim consumes the canonical engine
    over HTTP rather than importing the full plan/accumulator data layer.
  - `PersistenceStage` is the **first production consumer** of 5.1a's
    `UpdateAdjudicationProjectionAsync` bypass method (the 5th instance
    of the projection-bypass pattern across the platform).
- **Five stub stages** (Scrubbing, NetworkCredentialing, NcciEdits,
  CoordinationOfBenefits, AiExamination) — same `Name` + `Order` as their
  real replacements so per-tenant `EnabledStages` config keeps working
  unchanged across the swap by 5.4 / 5.6 / 5.7 / 5.8 / 5.9.
- **Service Bus trigger transport** — `claim-version-events` topic;
  `ClaimSubmissionService` dual-emits Mongo audit + Service Bus message
  on submission; orchestrator consumes the `adjudication-orchestrator`
  subscription and emits `ClaimVersionAdjudicatedMessage` when the run
  completes.
- **Cached HTTP resolvers** — `IBenefitPlanResolver` and `IMemberResolver`
  with 5-minute `IMemoryCache` decorators, mirroring BP 5.6's
  `CachingServiceCategoryMappingRepository` shape.
- **Bicep delta in `main.bicep`** — topic + subscription with a
  `CorrelationFilter` on `MessageType=ClaimVersionSubmitted`, native
  Service Bus duplicate detection enabled to back the deterministic
  `MessageId` idempotency keys.
- **Architecture doc** — `docs/architecture/claim-adjudication-pipeline.md`
  capturing all 14 ratified decisions.

### Decisions worth re-raising in review

- **Decision 14 (engine consumed via HTTP shim from claims-service)** —
  this is the one decision that was finalised during code phase, not in
  the plan-first gate. Rationale captured in the architecture doc and in
  `HttpBenefitCalculationEngineClient`'s class-level comment. Alternative
  considered: register the engine in-process and import benefit-plan-service's
  data layer. Rejected as Phase 2 split.
- **Pipeline ordering is fixed in code (Decision 6)**; tenant config
  controls only enablement.
- **PersistenceStage always runs** even on terminal short-circuit, so the
  version chain captures the failure outcome (Decision 7).
- **Idempotency** combines Service Bus native duplicate detection (Bicep
  `requiresDuplicateDetection: true`) + deterministic MessageId
  (`submitted:{ClaimVersionId}`, `adjudicated:{ClaimVersionId}`) + an
  orchestrator-side guard that no-ops when the claim is already
  adjudicated (Decision 12).

## Test plan

- [ ] `dotnet build src/services/claims-service` cleanly
- [ ] `dotnet test tests/CloudHealthOffice.ClaimsService.Tests` passes
- [ ] Existing `ClaimSubmissionServiceTests` still pass after the dual-emit
      modification
- [ ] `ClaimAdjudicationOrchestratorTests` covers stage ordering, short-
      circuit, persistence-always-runs, idempotency, adjudicated-event
      emission, final-outcome precedence
- [ ] `BenefitCalculationStageTests` covers the happy path, the missing /
      non-GUID `BenefitPlanId` rejection paths, engine throws, engine
      returns failure → Deny, subscriber-id fallback through `IMemberResolver`
- [ ] `PersistenceStageTests` confirms the bypass method is called (not
      `UpdateAsync`), false-return → Reject, throw → bubbles
- [ ] Caching decorators verify cache hit / miss, no negative caching,
      per-tenant key isolation, TTL=0 disables cache
- [ ] `ClaimSubmissionServiceMessageBusEmissionTests` asserts emission
      with the correct deterministic `MessageId`, `MessageType` property,
      and degraded-mode behaviour on Service Bus failure
- [ ] `AdjudicationEndToEndTests` (POST → InMemoryMessageBus →
      orchestrator → BenefitCalculationStage → PersistenceStage) drains
      the bus and asserts on the projection write
- [ ] `az bicep build infrastructure/azure/main.bicep` validates clean

https://claude.ai/code/session_0127j8UZw76Bd4QxRkCRiWZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_0127j8UZw76Bd4QxRkCRiWZ7)_