### PR TITLE
Claims 5.5 follow-up — address Copilot review comments + fix E2E test

### DIFF
--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -194,6 +194,12 @@ builder.Services.AddScoped<
     CloudHealthOffice.BenefitEngine.Services.IBenefitCalculationEngine,
     HttpBenefitCalculationEngineClient>();
 
+// Scoped tenant context — the orchestrator pins the tenant id on this
+// holder before stages run so the HTTP shim can send X-Tenant-ID
+// downstream from a background Service Bus subscription that has no
+// HttpContext. Scoped lifetime keeps each orchestrator run isolated.
+builder.Services.AddScoped<IAdjudicationTenantContext, AdjudicationTenantContext>();
+
 // Stages — registered as IEnumerable<IClaimAdjudicationStage>. Capabilities
 // 5.4-5.9 replace the stub registrations via services.RemoveAll<>()
 // + AddScoped<IClaimAdjudicationStage, RealStage>().

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
@@ -23,6 +23,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
     private readonly IReadOnlyList<IClaimAdjudicationStage> _stages;
     private readonly IClaimVersionEventPublisher _eventPublisher;
     private readonly IMessageBus _messageBus;
+    private readonly IAdjudicationTenantContext _tenantContext;
     private readonly AdjudicationPipelineOptions _options;
     private readonly ILogger<ClaimAdjudicationOrchestrator> _logger;
 
@@ -33,6 +34,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         IEnumerable<IClaimAdjudicationStage> stages,
         IClaimVersionEventPublisher eventPublisher,
         IMessageBus messageBus,
+        IAdjudicationTenantContext tenantContext,
         IOptions<AdjudicationPipelineOptions> options,
         ILogger<ClaimAdjudicationOrchestrator> logger)
     {
@@ -42,6 +44,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         _stages = stages.OrderBy(s => s.Order).ToList();
         _eventPublisher = eventPublisher;
         _messageBus = messageBus;
+        _tenantContext = tenantContext;
         _options = options.Value;
         _logger = logger;
     }
@@ -56,6 +59,11 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
             throw new ArgumentException("TenantId is required", nameof(message));
         if (string.IsNullOrEmpty(message.ClaimVersionId))
             throw new ArgumentException("ClaimVersionId is required", nameof(message));
+
+        // Pin the tenant id onto the scope so the engine + resolver
+        // HTTP shims (which run from this background subscription, with
+        // no HttpContext) can still send X-Tenant-ID downstream.
+        _tenantContext.TenantId = message.TenantId;
 
         _logger.LogInformation(
             "Adjudication starting for tenant {TenantId} claim {ClaimVersionId} (delivery {DeliveryCount})",
@@ -84,8 +92,12 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         // Idempotency: the version already has adjudication data → skip
         // and complete the message. This catches Service Bus redeliveries
         // after a previous successful adjudication that crashed before
-        // completing the message (Decision 12).
-        if (claim.AdjudicationResult is not null && claim.AdjudicationResult.AllowedAmount > 0m)
+        // completing the message (Decision 12). Any non-null
+        // AdjudicationResult — including denials with AllowedAmount=0 —
+        // counts; the bypass write only fires after a stage produces an
+        // outcome, so its presence is a reliable "pipeline already ran"
+        // marker.
+        if (claim.AdjudicationResult is not null)
         {
             _logger.LogInformation(
                 "Claim {ClaimVersionId} already adjudicated; skipping pipeline run",
@@ -174,8 +186,11 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         CancellationToken ct)
     {
         var finalOutcome = ResolveFinalOutcome(context);
+        // Reason follows the same precedence rule as outcome
+        // (Reject > Deny > Pend > Pass) so the emitted message's Outcome
+        // and Reason agree on which stage drove the result.
         var finalReason = context.StageResults
-            .Where(r => r.Outcome != ClaimAdjudicationOutcome.Pass && !string.IsNullOrEmpty(r.Reason))
+            .Where(r => r.Outcome == finalOutcome && !string.IsNullOrEmpty(r.Reason))
             .Select(r => r.Reason!)
             .FirstOrDefault();
 
@@ -238,16 +253,18 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
     private static ClaimAdjudicationOutcome ResolveFinalOutcome(ClaimAdjudicationContext context)
     {
         // Reject takes precedence over Deny over Pend. Pass only when no
-        // non-pass result was recorded.
-        var nonPersistence = context.StageResults
-            .Where(r => !string.Equals(r.StageName, Stages.PersistenceStage.StageName, StringComparison.Ordinal))
-            .ToList();
+        // non-pass result was recorded by any stage — including
+        // PersistenceStage, whose Reject (e.g.
+        // UpdateAdjudicationProjectionAsync returned false) MUST surface
+        // on the emitted event so subscribers don't see a Pass for a
+        // claim whose adjudication never persisted.
+        var results = context.StageResults;
 
-        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Reject))
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Reject))
             return ClaimAdjudicationOutcome.Reject;
-        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Deny))
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Deny))
             return ClaimAdjudicationOutcome.Deny;
-        if (nonPersistence.Any(r => r.Outcome == ClaimAdjudicationOutcome.Pend))
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Pend))
             return ClaimAdjudicationOutcome.Pend;
         return ClaimAdjudicationOutcome.Pass;
     }

--- a/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
+++ b/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
@@ -44,15 +44,18 @@ public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngi
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAdjudicationTenantContext _tenantContext;
     private readonly ILogger<HttpBenefitCalculationEngineClient> _logger;
 
     public HttpBenefitCalculationEngineClient(
         IHttpClientFactory httpClientFactory,
         IHttpContextAccessor httpContextAccessor,
+        IAdjudicationTenantContext tenantContext,
         ILogger<HttpBenefitCalculationEngineClient> logger)
     {
         _httpClientFactory = httpClientFactory;
         _httpContextAccessor = httpContextAccessor;
+        _tenantContext = tenantContext;
         _logger = logger;
     }
 
@@ -127,8 +130,19 @@ public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngi
             "Capability 5.12 (Adjustment Workflow) revisits the reversal surface.");
     }
 
+    /// <summary>
+    /// Tenant id sourced from the scoped <see cref="IAdjudicationTenantContext"/>
+    /// first (set by the orchestrator before each pipeline run from a
+    /// background subscription) and falling back to the inbound HTTP
+    /// request's resolved tenant. Either route ensures benefit-plan-service
+    /// receives the <c>X-Tenant-ID</c> header it requires regardless of
+    /// whether the engine is invoked from the orchestrator or from a
+    /// future synchronous controller path.
+    /// </summary>
     private string? ResolveTenantId()
     {
+        if (!string.IsNullOrEmpty(_tenantContext.TenantId)) return _tenantContext.TenantId;
+
         var ctx = _httpContextAccessor.HttpContext;
         if (ctx is null) return null;
         if (ctx.Items.TryGetValue("TenantId", out var value) && value is string s) return s;

--- a/src/services/claims-service/Services/Adjudication/IAdjudicationTenantContext.cs
+++ b/src/services/claims-service/Services/Adjudication/IAdjudicationTenantContext.cs
@@ -1,0 +1,31 @@
+namespace ClaimsService.Services.Adjudication;
+
+/// <summary>
+/// Scoped tenant context for the adjudication pipeline. Background
+/// Service Bus consumers create their own DI scope per message and have
+/// no <see cref="Microsoft.AspNetCore.Http.HttpContext"/>; without an
+/// ambient way to carry the tenant id, downstream HTTP clients cannot
+/// set the <c>X-Tenant-ID</c> header that benefit-plan-service /
+/// member-service / etc. require.
+///
+/// <para>
+/// Lifetime is Scoped so each orchestrator run gets a fresh holder
+/// inside its own scope; consumers (HTTP shims) read the same instance
+/// within that scope.
+/// </para>
+/// </summary>
+public interface IAdjudicationTenantContext
+{
+    /// <summary>The tenant id for the current adjudication run, or null if not set.</summary>
+    string? TenantId { get; set; }
+}
+
+/// <summary>
+/// Default in-memory holder used by the orchestrator scope. Not thread-
+/// safe — one instance per scope, set once before stages run, read by
+/// stage-side HTTP shims within the same scope.
+/// </summary>
+public sealed class AdjudicationTenantContext : IAdjudicationTenantContext
+{
+    public string? TenantId { get; set; }
+}

--- a/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
@@ -22,10 +22,14 @@ namespace ClaimsService.Services.Adjudication;
 public interface IClaimAdjudicationStage
 {
     /// <summary>
-    /// Stable, lower-case identifier — used both for telemetry tags and as
-    /// the key into <see cref="Models.Adjudication.AdjudicationPipelineOptions.EnabledStages"/>.
-    /// Stub-stage replacements (5.4-5.9) MUST keep the same Name so the
-    /// per-tenant enablement config keeps working unchanged.
+    /// Stable identifier — used both for telemetry tags and as the key
+    /// into <see cref="Models.Adjudication.AdjudicationPipelineOptions.EnabledStages"/>.
+    /// Stage names use PascalCase (e.g. <c>"Scrubbing"</c>,
+    /// <c>"Persistence"</c>); the EnabledStages dictionary is built with
+    /// <see cref="StringComparer.OrdinalIgnoreCase"/> so config-side
+    /// casing variants resolve correctly. Stub-stage replacements
+    /// (5.4-5.9) MUST keep the same Name so the per-tenant enablement
+    /// config keeps working unchanged.
     /// </summary>
     string Name { get; }
 

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -147,6 +147,10 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
         var claim = context.Claim;
         var serviceDate = DateOnly.FromDateTime(claim.ServiceDateFrom);
 
+        var pointerToCode = claim.DiagnosisCodes
+            .Where(d => !string.IsNullOrWhiteSpace(d.Code))
+            .ToDictionary(d => d.PointerNumber, d => d.Code);
+
         return new BenefitResolutionRequest
         {
             ClaimId = claim.Id,
@@ -155,11 +159,11 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             BenefitPlanId = planGuid,
             ServiceDate = serviceDate,
             NetworkTier = NetworkTier.InNetwork,
-            Lines = claim.ClaimLines.Select(BuildLine).ToList(),
+            Lines = claim.ClaimLines.Select(l => BuildLine(l, claim, pointerToCode)).ToList(),
             AllowedAmounts = new Dictionary<int, decimal>(),
             ClaimType = MapClaimType(claim.ClaimType),
             LineOfBusiness = (int)claim.LineOfBusiness,
-            Member = BuildMemberContext(context.ResolvedMember, claim),
+            Member = BuildMemberContext(context.ResolvedMember, claim, serviceDate),
         };
     }
 
@@ -178,28 +182,59 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
         _ => "837P",
     };
 
-    private static ClaimLineInput BuildLine(AdapterClaimLine line) => new()
+    private static ClaimLineInput BuildLine(
+        AdapterClaimLine line,
+        AdapterClaim claim,
+        IReadOnlyDictionary<int, string> pointerToCode)
     {
-        LineNumber = line.LineNumber,
-        ProcedureCode = line.ProcedureCode,
-        Modifiers = line.Modifiers.ToList(),
-        RevenueCode = line.RevenueCode,
-        PlaceOfService = line.PlaceOfServiceCode ?? string.Empty,
-        BilledAmount = line.ChargeAmount * line.Units,
-        Units = line.Units,
-        DiagnosisCodes = new List<string>(),
-    };
+        // POS falls back to the claim-level value when the line override
+        // is missing — ServiceCategoryResolver uses POS for rule matching
+        // and for system-level fallback inference, so dropping it would
+        // shift category resolution.
+        var pos = !string.IsNullOrEmpty(line.PlaceOfServiceCode)
+            ? line.PlaceOfServiceCode
+            : claim.PlaceOfServiceCode;
 
-    private static MemberContext? BuildMemberContext(ResolvedMember? member, AdapterClaim claim)
+        // Map the line's DiagnosisPointers (e.g. [1, 3]) to the
+        // corresponding ICD codes from the claim-level diagnosis list.
+        // Unknown pointers (no diagnosis at that position) drop silently
+        // — the engine treats missing diagnoses as "no opinion" rather
+        // than an error.
+        var diagnosesForLine = line.DiagnosisPointers
+            .Where(pointerToCode.ContainsKey)
+            .Select(p => pointerToCode[p])
+            .ToList();
+
+        return new ClaimLineInput
+        {
+            LineNumber = line.LineNumber,
+            ProcedureCode = line.ProcedureCode,
+            Modifiers = line.Modifiers.ToList(),
+            RevenueCode = line.RevenueCode,
+            PlaceOfService = pos ?? string.Empty,
+            BilledAmount = line.ChargeAmount * line.Units,
+            Units = line.Units,
+            DiagnosisCodes = diagnosesForLine,
+        };
+    }
+
+    private static MemberContext? BuildMemberContext(
+        ResolvedMember? member,
+        AdapterClaim claim,
+        DateOnly serviceDate)
     {
         if (member is null && claim.DiagnosisCodes.Count == 0) return null;
 
         int? age = null;
         if (member?.DateOfBirth is DateTime dob)
         {
-            var today = DateTime.UtcNow.Date;
-            age = today.Year - dob.Year;
-            if (dob.Date > today.AddYears(-age.Value)) age--;
+            // Age at the encounter, not at adjudication time. For
+            // retrospective claims this can shift the age band by years
+            // and change which benefit rules apply (pediatric / adult /
+            // senior / Medicare-eligible).
+            var encounter = serviceDate.ToDateTime(TimeOnly.MinValue);
+            age = encounter.Year - dob.Year;
+            if (dob.Date > encounter.AddYears(-age.Value)) age--;
         }
 
         BenefitMemberGender? gender = member?.Gender switch

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -58,20 +58,24 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
     {
         var planId = Guid.NewGuid().ToString();
         var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-        var inbound = new
+        // Send the typed AdapterClaim so System.Text.Json's enum binder
+        // resolves LineOfBusiness/ClaimType correctly. Anonymous-object
+        // payloads with string enum values fail the controller's model
+        // binding (no JsonStringEnumConverter on the inbound path).
+        var inbound = new AdapterClaim
         {
             ClaimNumber = "E2E-001",
             MemberId = "MEM-1",
             BillingProviderNPI = "1234567890",
             BenefitPlanId = planId,
-            LineOfBusiness = "Commercial",
-            ClaimType = "Professional",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
             PlaceOfServiceCode = "11",
             ServiceDateFrom = serviceDate,
             ServiceDateTo = serviceDate,
-            ClaimLines = new[]
+            ClaimLines = new List<AdapterClaimLine>
             {
-                new
+                new()
                 {
                     LineNumber = 1,
                     ProcedureCode = "99213",

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
@@ -308,6 +308,7 @@ public class ClaimAdjudicationOrchestratorTests
             stages,
             _eventPublisher,
             _messageBus,
+            new AdjudicationTenantContext(),
             Options.Create(options ?? new AdjudicationPipelineOptions()),
             NullLogger<ClaimAdjudicationOrchestrator>.Instance);
     }


### PR DESCRIPTION
## Summary

Follow-up to the merged PR #731. Resolves the **8 Copilot review
comments** that landed after #731 was merged, plus fixes the
`AdjudicationEndToEndTests` failure that slipped through the original
CI window.

### Review-comment resolutions (all from PR #731)

| File | Line | Fix |
|---|---|---|
| `IClaimAdjudicationStage.cs` | 30 | Doc said "lower-case identifier" but stages use PascalCase. Updated doc to reflect actual contract + `OrdinalIgnoreCase` config dictionary. |
| `ClaimAdjudicationOrchestrator.cs` | 94 | Idempotency guard treated `AllowedAmount = 0` as unadjudicated — would re-run pipeline on legitimate denials. Now any non-null `AdjudicationResult` counts. |
| `ClaimAdjudicationOrchestrator.cs` | 250 | `ResolveFinalOutcome` excluded `PersistenceStage`. A persistence Reject (bypass returned false) silently emitted Pass. Now includes all stage results. |
| `ClaimAdjudicationOrchestrator.cs` | 180 | `finalReason` was first-non-Pass-in-execution-order; could surface a Pend reason for a Deny outcome. Now follows the same precedence as `ResolveFinalOutcome`. |
| `BenefitCalculationStage.cs` | 187 | Line POS dropped the claim-level fallback when the line override was missing. ServiceCategoryResolver's POS-based rule matching now sees the right value. |
| `BenefitCalculationStage.cs` | 191 | Line `DiagnosisCodes` was always empty. Now mapped from `DiagnosisPointers` → claim-level `DiagnosisCodes`. |
| `BenefitCalculationStage.cs` | 203 | `AgeYears` computed against `DateTime.UtcNow`. Retrospective claims hit the wrong age band. Now computed at the encounter `ServiceDate`. |
| `HttpBenefitCalculationEngineClient.cs` | 136 | Tenant id resolved only from `HttpContext` — null in the background subscription, so every engine call would fail with "tenant context missing". New scoped `IAdjudicationTenantContext` is pinned by the orchestrator before stages run; the shim reads from it first, falls back to `HttpContext`. |

### E2E test fix

`AdjudicationEndToEndTests.PostClaim_TriggersAdjudicationPipeline...`
was sending an anonymous object with string enum values
(`LineOfBusiness = "Commercial"`). The controller's inbound JSON binder
has no `JsonStringEnumConverter` configured, so it rejected the payload
with `400`. Switched to the typed `AdapterClaim` so binding round-trips
correctly.

### Test coverage

- 34 / 34 capability-5.5 tests pass locally
  (`ClaimAdjudicationOrchestratorTests`, `BenefitCalculationStageTests`,
  `PersistenceStageTests`, `Caching*ResolverTests`,
  `ClaimSubmissionServiceMessageBusEmissionTests`,
  `AdjudicationEndToEndTests`)
- The 3 `ClaimRepositoryVersioningTests` MongoDB timeouts I see locally
  are sandbox-disk-constrained — CI runs them fine.

## Test plan

- [ ] `dotnet build src/services/claims-service` clean
- [ ] `dotnet test tests/CloudHealthOffice.ClaimsService.Tests` passes
      (including the previously-failing `AdjudicationEndToEndTests`)
- [ ] PR #731's merged behaviour is preserved — all surface contracts
      are additive (new ctor parameters via DI; new scoped service)

https://claude.ai/code/session_0127j8UZw76Bd4QxRkCRiWZ7

---
_Generated by [Claude Code](https://claude.ai/code/session_0127j8UZw76Bd4QxRkCRiWZ7)_