### PR TITLE
Claims 5.6 — Network &amp; credentialing enforcement

### DIFF
--- a/docs/architecture/network-credentialing-enforcement.md
+++ b/docs/architecture/network-credentialing-enforcement.md
@@ -1,0 +1,251 @@
+# Network &amp; Credentialing Enforcement (Capability 5.6)
+
+Status: 5.6 — Claims Phase 1
+Services: `src/services/provider-service`, `src/services/claims-service`
+Depends on: Provider 5.6 (event-sourced credentialing), BP 5.5 (NetworkTier
+as Organization reference), BP 5.10 (`HttpProviderIntegrityGate` cached-or-live
+exemplar), Claims 5.5 (adjudication pipeline)
+Related: `claim-adjudication-pipeline.md`, `credentialing-workflow.md`,
+`network-tier-organization-reference.md`,
+`integrity-score-consumption.md`
+
+## Why this capability
+
+The 5.5 adjudication pipeline shipped with five stub stages awaiting
+real implementations. 5.6 is the deferred ChatGPT-flagged enforcement
+work — the consumer that finally exercises the as-of-date capability
+of `CredentialingProjector` (Provider 5.6) and the cross-service
+membership-lookup contract that BP 5.5's `IOrganizationLookupClient`
+explicitly deferred.
+
+Two enforcement gates land at adjudication time, both keyed on the
+**billing provider NPI**:
+
+1. **Network membership** — is the billing provider an active member
+   of one of the resolved benefit plan's tiers, on the claim's service
+   date?
+2. **Credentialing status** — is the billing provider Approved (per
+   the event-sourced credentialing chain) on the claim's service date?
+
+Both checks anchor to the **earliest service date** across the claim's
+header and lines (Decision 3 — most-restrictive interpretation; protects
+against credentialing gaps mid-claim).
+
+## Cross-service surface
+
+### provider-service additions
+
+#### `GET /api/v1/networks/{id}/members/{npi}`
+
+Single-membership lookup. Sibling to the existing
+`/api/v1/networks/{id}/roster` endpoint.
+
+| Param | Source | Required | Notes |
+|---|---|---|---|
+| `id` | route | yes | Network organization id |
+| `npi` | route | yes | Billing provider NPI |
+| `asOf` | query | no | ISO-8601 UTC; defaults to UtcNow |
+
+**Status codes:**
+
+- `200 OK` with `IsActiveMember=true` when a participation row covers
+  `asOf`.
+- `200 OK` with `IsActiveMember=false` when a participation row exists
+  but the supplied date falls outside the `[EffectiveDate, TerminationDate)`
+  window. `ParticipationStatus` distinguishes `terminated`, `future`,
+  `inactive`.
+- `404 Not Found` only when no participation row for the NPI exists in
+  the network at all.
+- `400 Bad Request` on missing/invalid `npi` route segment.
+
+Body-shaped status (200 with a boolean) keeps the consumer-side cache
+key stable across the active/inactive distinction — a single 5-minute
+TTL covers both branches without cache-key churn at the boundary.
+
+#### `GET /api/v1/providers/{id}/credentialing/status-as-of`
+
+Sibling action on the existing `CredentialingController` (already
+provider-rooted at `/api/v1/providers/{id}/credentialing/...`).
+
+| Param | Source | Required | Notes |
+|---|---|---|---|
+| `id` | route | yes | Provider id (chain key) |
+| `asOfDate` | query | yes | ISO-8601 UTC; treated as UTC if Kind=Unspecified |
+
+Returns a trimmed projection (`CredentialingStatusResponse`) — drops
+the operational fields (`CurrentApplicationEventId`,
+`ApplicationSubmittedAt`, `EventCount`, `LatestVersion`) that belong
+to the admin `/status` and `/history` surfaces.
+
+The underlying `CredentialingProjector.Project(events, asOf)` already
+supports arbitrary `asOf` (Provider 5.6 was built specifically for this
+consumer). The new method is a 4-line sibling of `GetCurrentStatusAsync`
+that passes the caller-supplied date through.
+
+### claims-service additions
+
+| Type | Role |
+|---|---|
+| `IProviderMembershipClient` | HTTP client over the membership endpoint |
+| `HttpProviderMembershipClient` | Live-fetch implementation |
+| `CachingProviderMembershipClient` | 5-minute in-process TTL decorator |
+| `ICredentialingStatusClient` | HTTP client over the credentialing endpoint |
+| `HttpCredentialingStatusClient` | Live-fetch implementation |
+| `CachingCredentialingStatusClient` | 1-hour in-process TTL decorator |
+| `NetworkCredentialingStage` | Replaces `NetworkCredentialingStubStage` |
+| `EnforcementOutcome` | Per-check audit-grade outcome |
+| `NetworkEnforcementMode` / `CredentialingEnforcementMode` | Policy enums |
+| `TenantEnforcementPolicyOptions` | Bound from `Adjudication:Enforcement:*` |
+| `UpstreamClientNames` | Constants class for named HTTP clients |
+
+## Time-anchor semantics
+
+The stage uses **`min(claim.ServiceDateFrom, claim.ClaimLines[*].ServiceDateFrom)`**
+as the authoritative `asOf` for both checks. Rationale:
+
+- A claim line predating the header is operationally rare but legal
+  (claim spans multiple service dates; header captures the latest).
+- Earliest-wins is the conservative interpretation — a provider
+  credentialed on May 10 doesn't auto-pay a line dated May 1 just
+  because the claim header is dated May 15.
+- The policy is testable: see
+  `NetworkCredentialingStageTests.EarliestServiceDate_picks_min_across_header_and_lines`.
+
+## Network resolution from plan tiers
+
+`ResolvedBenefitPlan` carries the plan's `NetworkTier[]`, populated by
+`HttpBenefitPlanResolver` from `BenefitPlan.networkTiers` on the wire.
+Each tier carries `{ TierName, TierLevel, NetworkId? }`. The stage:
+
+1. Sorts tiers by `TierLevel` ascending (1 = best).
+2. Skips tiers whose `NetworkId` is null (legacy-shape rows still in
+   the BP 5.5 → hard-validation rollout window).
+3. For each remaining tier, calls `IProviderMembershipClient`.
+4. **First active match wins** — the matched tier is recorded on
+   `ClaimAdjudicationContext.MatchedNetworkTier` for downstream
+   consumption.
+
+If no tier matches, the claim is out-of-network. The stage applies the
+configured `NetworkEnforcementMode` and **skips the credentialing
+check** — out-of-network providers' credentialing status is irrelevant
+to the enforcement decision in Phase 1.
+
+## Fail-mode policy matrix
+
+| Mode | Behavior on failed check |
+|---|---|
+| `FailClosed` (default in production) | Stage emits `Deny`; pipeline short-circuits to `PersistenceStage` |
+| `FailOpen` | Stage emits `Pend`; pipeline continues so subsequent stages can decorate before human review |
+| `SoftValidation` | Stage emits `Observe` outcome on the audit trail; final result is `Pass`; useful during initial rollout |
+
+Both `NetworkMode` and `CredentialingMode` are independent. Phase 1 is
+service-wide; per-tenant override is deferred to Phase 2 alongside
+`AdjudicationPipelineOptions`.
+
+`appsettings.json` defaults to `FailClosed` for production; `Development`
+defaults to `SoftValidation` so local pipelines don't block on a
+disconnected provider-service.
+
+## Caching shape
+
+Both clients mirror BP 5.10 `HttpProviderIntegrityGate`'s pattern:
+
+- `IMemoryCache` per pod (no distributed invalidation; coherence via
+  TTL expiry).
+- Cache keys namespaced by resolution path (`cached-or-live` vs
+  `force` for force-refresh callers).
+- Day-bucketed `asOf` so re-evaluating the same date doesn't churn
+  cache keys but different service dates resolve independently.
+- Negative results (`null` from upstream — degraded transport) are
+  NOT cached. The "definitively not a member" 404 path produces a
+  non-null `NetworkMembership` with `IsActiveMember=false` which IS
+  cached normally.
+
+| Domain | TTL | Why |
+|---|---|---|
+| Membership | 5 minutes | Roster row terminations don't emit explicit events; shorter TTL bounds staleness window |
+| Credentialing | 1 hour | Transitions are explicit, audit-trailed events on the projection chain; longer TTL is operationally safe |
+
+## Pipeline integration
+
+The stage replaces `NetworkCredentialingStubStage` directly in DI
+registration. It preserves the stub's `Order = 200`, `Name = "NetworkCredentialing"`,
+`IsRequired = false` so:
+
+- The orchestrator iteration order is unchanged.
+- The per-tenant `AdjudicationPipelineOptions.EnabledStages["NetworkCredentialing"]`
+  config keeps working unchanged across the swap.
+- A 5.5 deployment that disabled the stub disables the real stage too —
+  the convention 5.5 documented holds across capability replacements.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Order  Stage                       Disposition           │
+├─────────────────────────────────────────────────────────┤
+│  100   ScrubbingStubStage          stub (5.4 replaces)   │
+│  200   NetworkCredentialingStage   ← 5.6 ships this      │
+│  300   BenefitCalculationStage     real (5.5)            │
+│  400   NcciEditsStubStage          stub (5.7 replaces)   │
+│  500   CoordinationOfBenefitsStub  stub (5.8 replaces)   │
+│  600   AiExaminationStubStage      stub (5.9 replaces)   │
+│  999   PersistenceStage            real (5.5, required)  │
+└─────────────────────────────────────────────────────────┘
+```
+
+`BenefitCalculationStage` reads `context.MatchedNetworkTier` for
+cost-share tiering in a follow-up PR (Phase 2 — 5.5 currently
+hard-codes `NetworkTier.InNetwork` per the comment in
+`BenefitCalculationStage`).
+
+## Telemetry
+
+| Metric | Dimensions |
+|---|---|
+| `cho.claims.enforcement.cache` (counter) | `cho.client` (`ProviderMembership` / `Credentialing`), `cho.path` (`hit` / `miss` / `live` / `force`) |
+| `cho.claims.enforcement.outcome` (counter) | `cho.check` (`membership` / `credentialing`), `cho.outcome` (`allow` / `deny` / `pend` / `observe`) |
+| `cho.claims.enforcement.degraded` (counter) | `cho.client`, `cho.mode` |
+
+Telemetry wiring follows the BP 5.10 `HttpProviderIntegrityGate`
+pattern; the namespaces share the `cho.claims.*` root with the existing
+`cho.claims.adjudication.outcome.total` counter from 5.5.
+
+## Recovery posture
+
+- **provider-service endpoint regression** — caught by the
+  provider-service test suite; revert restores the prior endpoint
+  surface.
+- **Stage replacement breaks pipeline** — caught by
+  `ClaimAdjudicationOrchestratorTests` from 5.5 + the new stage and
+  end-to-end tests.
+- **Cache returns stale data during outage** — bounded by TTL
+  (5-minute membership, 1-hour credentialing); manual cache clear via
+  pod restart.
+- **Provider-service degraded** — `FailClosed` produces predictable
+  denial behavior; `FailOpen` preserves availability via human-review
+  pend; `SoftValidation` preserves throughput at the cost of audit-only
+  enforcement.
+- **Wrong service date used as `asOf`** — caught by integration tests
+  with mixed line-level service dates.
+- **Network tier traversal misorders** — caught by the stage's
+  first-tier-wins test (`FirstTierMatches_skips_lower_priority_tiers`).
+
+Worst-case rollback: revert this PR. The stub stage class remains on
+disk; re-registering it in `Program.cs` restores 5.5 baseline behavior
+without a redeploy of provider-service. No data changes; no migration
+to undo.
+
+## Out of scope
+
+- **Rendering provider NPI enforcement** — Decision 9 limits 5.6 to
+  billing-NPI checks. Rendering provider relationships are 5.4
+  (scrubbing) and 5.7 (NCCI) territory.
+- **Per-tenant policy override** — deferred to Phase 2 alongside the
+  same surface for `AdjudicationPipelineOptions`.
+- **Real network-tier cost-share routing** — `BenefitCalculationStage`
+  still hard-codes `NetworkTier.InNetwork`; 5.6 populates
+  `context.MatchedNetworkTier` so the follow-up PR can wire it
+  through.
+- **OON credentialing enforcement** — out-of-network providers'
+  credentialing is not checked. If pilot operations surface a need,
+  add a separate capability that introduces an NPI→providerId lookup
+  for the credentialing client.

--- a/src/services/claims-service/Models/Adjudication/EnforcementMode.cs
+++ b/src/services/claims-service/Models/Adjudication/EnforcementMode.cs
@@ -1,0 +1,36 @@
+namespace ClaimsService.Models.Adjudication;
+
+/// <summary>
+/// Posture <see cref="Services.Adjudication.Stages.NetworkCredentialingStage"/>
+/// adopts when the network-membership check is degraded (provider-service
+/// HTTP failure, missing data, timeout). Capability 5.6.
+/// </summary>
+public enum NetworkEnforcementMode
+{
+    /// <summary>Deny the claim with a structured reason. Default — protects payer.</summary>
+    FailClosed,
+
+    /// <summary>Pend the claim for human review with a structured reason. Preserves availability.</summary>
+    FailOpen,
+
+    /// <summary>
+    /// Pass the claim AND emit telemetry capturing what would have
+    /// happened under FailClosed/FailOpen. Used during initial rollout
+    /// to catch edge cases before hard policy lands.
+    /// </summary>
+    SoftValidation,
+}
+
+/// <summary>
+/// Posture for the credentialing-status check when degraded. Same
+/// trichotomy as <see cref="NetworkEnforcementMode"/>; modeled as a
+/// distinct enum so per-domain policy can be tuned independently
+/// (e.g. FailClosed on credentialing while FailOpen on membership while
+/// the network roster is being backfilled).
+/// </summary>
+public enum CredentialingEnforcementMode
+{
+    FailClosed,
+    FailOpen,
+    SoftValidation,
+}

--- a/src/services/claims-service/Models/Adjudication/EnforcementOutcome.cs
+++ b/src/services/claims-service/Models/Adjudication/EnforcementOutcome.cs
@@ -1,0 +1,49 @@
+namespace ClaimsService.Models.Adjudication;
+
+/// <summary>
+/// Discriminator for the kind of enforcement check that produced the
+/// outcome.
+/// </summary>
+public enum EnforcementCheck
+{
+    Membership,
+    Credentialing,
+}
+
+/// <summary>
+/// Decision the enforcement stage drew for a single check.
+/// </summary>
+public enum EnforcementDecision
+{
+    /// <summary>Check passed — claim continues.</summary>
+    Allow,
+
+    /// <summary>Check failed terminally — pipeline short-circuits to PersistenceStage.</summary>
+    Deny,
+
+    /// <summary>Check pended — pipeline continues so subsequent stages can decorate before human review.</summary>
+    Pend,
+
+    /// <summary>
+    /// Soft-validation observation — no policy effect. Captured for
+    /// telemetry only so operators can quantify what FailClosed/FailOpen
+    /// would have done before flipping the posture.
+    /// </summary>
+    Observe,
+}
+
+/// <summary>
+/// Per-check enforcement outcome accumulated on
+/// <see cref="Services.Adjudication.ClaimAdjudicationContext.EnforcementOutcomes"/>.
+/// One entry per (check × resolution path); the stage emits a Membership
+/// outcome and a Credentialing outcome per claim.
+/// </summary>
+public sealed record EnforcementOutcome(
+    EnforcementCheck Check,
+    EnforcementDecision Decision,
+    string Mode,
+    string? Reason,
+    DateTime AsOfDate,
+    string? NetworkId = null,
+    string? TierName = null,
+    int? TierLevel = null);

--- a/src/services/claims-service/Models/Adjudication/TenantEnforcementPolicyOptions.cs
+++ b/src/services/claims-service/Models/Adjudication/TenantEnforcementPolicyOptions.cs
@@ -1,0 +1,26 @@
+namespace ClaimsService.Models.Adjudication;
+
+/// <summary>
+/// Service-wide enforcement-posture configuration consumed by
+/// <see cref="Services.Adjudication.Stages.NetworkCredentialingStage"/>
+/// (capability 5.6). Bound from configuration section
+/// <c>Adjudication:Enforcement</c>.
+///
+/// <para>
+/// Phase 1 is service-wide — every tenant runs the same enforcement
+/// posture. Per-tenant overrides are deferred to Phase 2 multi-tenant
+/// config work to keep the rollout surface small. The class name
+/// retains <c>Tenant</c> in the prefix so the future per-tenant
+/// override binds onto the same shape rather than introducing a
+/// parallel options class.
+/// </para>
+/// </summary>
+public class TenantEnforcementPolicyOptions
+{
+    public const string SectionName = "Adjudication:Enforcement";
+
+    public NetworkEnforcementMode NetworkMode { get; set; } = NetworkEnforcementMode.FailClosed;
+
+    public CredentialingEnforcementMode CredentialingMode { get; set; }
+        = CredentialingEnforcementMode.FailClosed;
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -150,6 +150,12 @@ builder.Services.AddMemoryCache();
 builder.Services.Configure<AdjudicationPipelineOptions>(
     builder.Configuration.GetSection(AdjudicationPipelineOptions.SectionName));
 
+// 5.6 enforcement posture (network membership + credentialing). Phase 1
+// is service-wide; per-tenant override deferred to Phase 2 alongside
+// the pipeline options.
+builder.Services.Configure<TenantEnforcementPolicyOptions>(
+    builder.Configuration.GetSection(TenantEnforcementPolicyOptions.SectionName));
+
 // Resolution clients — typed HttpClient + caching decorator. 5-second
 // timeout matches ClaimTenantConfigCache and HttpProviderService so a
 // flaky downstream service can't stall the pipeline.
@@ -194,11 +200,30 @@ builder.Services.AddScoped<
     CloudHealthOffice.BenefitEngine.Services.IBenefitCalculationEngine,
     HttpBenefitCalculationEngineClient>();
 
+// 5.6 — enforcement clients (network membership + credentialing status)
+// against provider-service. Reuses the existing ProviderService named
+// HttpClient registration above. Each client gets a caching decorator;
+// TTLs differ by domain (5-min membership vs 1-hour credentialing).
+builder.Services.AddScoped<HttpProviderMembershipClient>();
+builder.Services.AddScoped<IProviderMembershipClient>(sp =>
+    new CachingProviderMembershipClient(
+        sp.GetRequiredService<HttpProviderMembershipClient>(),
+        sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
+
+builder.Services.AddScoped<HttpCredentialingStatusClient>();
+builder.Services.AddScoped<ICredentialingStatusClient>(sp =>
+    new CachingCredentialingStatusClient(
+        sp.GetRequiredService<HttpCredentialingStatusClient>(),
+        sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
+
 // Stages — registered as IEnumerable<IClaimAdjudicationStage>. Capabilities
 // 5.4-5.9 replace the stub registrations via services.RemoveAll<>()
-// + AddScoped<IClaimAdjudicationStage, RealStage>().
+// + AddScoped<IClaimAdjudicationStage, RealStage>(). 5.6 wires the
+// real NetworkCredentialingStage directly without going through the
+// remove/re-add dance because the stub never made it past 5.5; the
+// pattern in the comment remains the convention for 5.4 / 5.7-5.9.
 builder.Services.AddScoped<IClaimAdjudicationStage, ScrubbingStubStage>();
-builder.Services.AddScoped<IClaimAdjudicationStage, NetworkCredentialingStubStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, NetworkCredentialingStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, BenefitCalculationStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, NcciEditsStubStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, CoordinationOfBenefitsStubStage>();

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
@@ -1,4 +1,5 @@
 using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
 using ClaimsService.Services.Resolution;
 using BenefitEngineModels = CloudHealthOffice.BenefitEngine.Models;
 
@@ -49,4 +50,35 @@ public class ClaimAdjudicationContext
 
     /// <summary>True once a non-persistence stage has short-circuited the run.</summary>
     public bool ShortCircuited { get; set; }
+
+    /// <summary>
+    /// Network-membership lookup for the billing provider, populated by
+    /// <see cref="Stages.NetworkCredentialingStage"/> (capability 5.6) for
+    /// the FIRST plan tier that matched. Null when no tier matched OR the
+    /// upstream lookup degraded; consumed by
+    /// <see cref="Stages.BenefitCalculationStage"/> via
+    /// <see cref="MatchedNetworkTier"/> to drive cost-share tiering.
+    /// </summary>
+    public Resolution.NetworkMembership? BillingProviderNetworkMembership { get; set; }
+
+    /// <summary>
+    /// Credentialing-status snapshot for the billing provider as of the
+    /// claim's earliest service date. Populated by capability 5.6.
+    /// </summary>
+    public Resolution.CredentialingStatusSnapshot? BillingProviderCredentialingStatus { get; set; }
+
+    /// <summary>
+    /// Plan tier the billing provider matched, or <c>null</c> when none
+    /// matched (out-of-network). Set by capability 5.6 alongside
+    /// <see cref="BillingProviderNetworkMembership"/>.
+    /// </summary>
+    public ResolvedNetworkTier? MatchedNetworkTier { get; set; }
+
+    /// <summary>
+    /// Per-check enforcement outcomes accumulated by
+    /// <see cref="Stages.NetworkCredentialingStage"/>. Surfaced on the
+    /// audit trail and consumed by remittance generation (capability 5.10)
+    /// for adjustment-reason emission.
+    /// </summary>
+    public List<EnforcementOutcome> EnforcementOutcomes { get; } = new();
 }

--- a/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStage.cs
@@ -1,0 +1,341 @@
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Options;
+
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.6 — replaces <see cref="NetworkCredentialingStubStage"/>.
+/// Calls provider-service for both:
+/// <list type="bullet">
+///   <item><description>Network membership of the billing provider against
+///     the resolved benefit plan's tier list (first matching tier wins).</description></item>
+///   <item><description>Credentialing status of the billing provider as of
+///     the claim's earliest service date.</description></item>
+/// </list>
+///
+/// <para>
+/// The stage produces structured <see cref="EnforcementOutcome"/> entries
+/// on the context for each check. Resolution semantics for the stage's
+/// final <see cref="ClaimAdjudicationStageResult"/>:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Both checks <c>Allow</c> → <c>Pass</c>; subsequent
+///     stages run.</description></item>
+///   <item><description>Either check <c>Deny</c> → <c>Deny</c>; pipeline
+///     short-circuits to PersistenceStage.</description></item>
+///   <item><description>Either check <c>Pend</c> with no <c>Deny</c> →
+///     <c>Pend</c>; pipeline continues so subsequent stages can decorate.</description></item>
+///   <item><description>All <c>Observe</c> outcomes (soft-validation) →
+///     <c>Pass</c>; observation captured on the audit trail without
+///     policy effect.</description></item>
+/// </list>
+///
+/// <para>
+/// <b>Time anchor (Decision 3):</b> the credentialing check uses the
+/// claim's earliest service date (header <c>ServiceDateFrom</c> vs the
+/// minimum line-level <c>ServiceDateFrom</c>) — the most-restrictive
+/// interpretation. A provider credentialed AFTER the earliest service
+/// date doesn't auto-pay claims for that earlier date.
+/// </para>
+///
+/// <para>
+/// <b>Network resolution (Decision 10):</b> walk the resolved plan's
+/// tier list ordered by <see cref="ResolvedNetworkTier.TierLevel"/>
+/// ascending; the first tier whose roster includes the billing NPI
+/// wins. The matched tier is recorded on
+/// <see cref="ClaimAdjudicationContext.MatchedNetworkTier"/> for
+/// downstream consumption (BenefitCalculationStage cost-share tiering
+/// in a follow-up; not changed by 5.6).
+/// </para>
+/// </summary>
+public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
+{
+    public const string StageName = "NetworkCredentialing";
+
+    private readonly IProviderMembershipClient _membershipClient;
+    private readonly ICredentialingStatusClient _credentialingClient;
+    private readonly TenantEnforcementPolicyOptions _options;
+    private readonly ILogger<NetworkCredentialingStage> _logger;
+
+    public NetworkCredentialingStage(
+        IProviderMembershipClient membershipClient,
+        ICredentialingStatusClient credentialingClient,
+        IOptions<TenantEnforcementPolicyOptions> options,
+        ILogger<NetworkCredentialingStage> logger)
+    {
+        _membershipClient = membershipClient;
+        _credentialingClient = credentialingClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public string Name => StageName;
+    public int Order => 200;
+    public bool IsRequired => false;
+
+    public async Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        var claim = context.Claim;
+        var billingNpi = claim.BillingProviderNPI;
+
+        if (string.IsNullOrWhiteSpace(billingNpi))
+        {
+            return ClaimAdjudicationStageResult.Reject(
+                StageName,
+                "Claim is missing BillingProviderNPI; network/credentialing checks cannot run.");
+        }
+
+        var serviceDate = ResolveEarliestServiceDate(claim);
+
+        // Membership: walk plan tiers in priority order. First tier whose
+        // upstream returns IsActiveMember=true wins.
+        var membershipOutcome = await ResolveMembershipAsync(
+            context, billingNpi, serviceDate, ct).ConfigureAwait(false);
+        context.EnforcementOutcomes.Add(membershipOutcome);
+
+        // Credentialing: only call when we have a providerId from the
+        // matched tier's membership response. If no tier matched we skip
+        // the credentialing check entirely — out-of-network providers'
+        // credentialing status is irrelevant to the enforcement
+        // decision (see stage doc).
+        EnforcementOutcome? credentialingOutcome = null;
+        var matchedProviderId = context.BillingProviderNetworkMembership?.ProviderId;
+        if (!string.IsNullOrWhiteSpace(matchedProviderId)
+            && membershipOutcome.Decision == EnforcementDecision.Allow)
+        {
+            credentialingOutcome = await ResolveCredentialingAsync(
+                context, matchedProviderId!, serviceDate, ct).ConfigureAwait(false);
+            context.EnforcementOutcomes.Add(credentialingOutcome);
+        }
+
+        return CombineOutcomes(membershipOutcome, credentialingOutcome);
+    }
+
+    private async Task<EnforcementOutcome> ResolveMembershipAsync(
+        ClaimAdjudicationContext context,
+        string billingNpi,
+        DateTime serviceDate,
+        CancellationToken ct)
+    {
+        var tiers = context.ResolvedPlan?.NetworkTiers
+            ?? Array.Empty<ResolvedNetworkTier>();
+
+        // Filter out tiers without a NetworkId — those are legacy-shape
+        // rows still in the BP 5.5 → hard-validation rollout window.
+        var resolvableTiers = tiers
+            .Where(t => !string.IsNullOrWhiteSpace(t.NetworkId))
+            .OrderBy(t => t.TierLevel)
+            .ToList();
+
+        if (resolvableTiers.Count == 0)
+        {
+            // No resolvable in-network tiers → out-of-network by default.
+            // Apply network-mode policy.
+            return ApplyNetworkMode(
+                context,
+                EnforcementDecision.Deny,
+                reason: "No in-network tier configured for the resolved plan.",
+                serviceDate,
+                networkId: null,
+                tier: null);
+        }
+
+        var degraded = false;
+        foreach (var tier in resolvableTiers)
+        {
+            var membership = await _membershipClient.GetMembershipAsync(
+                context.TenantId, tier.NetworkId!, billingNpi, serviceDate, forceRefresh: false, ct)
+                .ConfigureAwait(false);
+
+            if (membership is null)
+            {
+                // Lookup degraded (transport / 5xx). Don't short-circuit
+                // the tier walk on a single failure — try the next tier.
+                // If every tier's lookup degraded we apply the FailMode
+                // posture below.
+                degraded = true;
+                continue;
+            }
+
+            if (membership.IsActiveMember)
+            {
+                context.BillingProviderNetworkMembership = membership;
+                context.MatchedNetworkTier = tier;
+                return new EnforcementOutcome(
+                    Check: EnforcementCheck.Membership,
+                    Decision: EnforcementDecision.Allow,
+                    Mode: _options.NetworkMode.ToString(),
+                    Reason: null,
+                    AsOfDate: serviceDate,
+                    NetworkId: tier.NetworkId,
+                    TierName: tier.TierName,
+                    TierLevel: tier.TierLevel);
+            }
+        }
+
+        if (degraded)
+        {
+            return ApplyNetworkMode(
+                context,
+                EnforcementDecision.Deny,
+                reason: "membership-verification-unavailable",
+                serviceDate,
+                networkId: null,
+                tier: null);
+        }
+
+        // Every tier returned a non-null, non-active result — provider
+        // is out-of-network for this plan.
+        return ApplyNetworkMode(
+            context,
+            EnforcementDecision.Deny,
+            reason: "Billing provider is not an active member of any plan tier on the service date.",
+            serviceDate,
+            networkId: null,
+            tier: null);
+    }
+
+    private async Task<EnforcementOutcome> ResolveCredentialingAsync(
+        ClaimAdjudicationContext context,
+        string providerId,
+        DateTime serviceDate,
+        CancellationToken ct)
+    {
+        var snapshot = await _credentialingClient.GetStatusAsOfAsync(
+            context.TenantId, providerId, serviceDate, forceRefresh: false, ct)
+            .ConfigureAwait(false);
+
+        if (snapshot is null)
+        {
+            return ApplyCredentialingMode(
+                EnforcementDecision.Deny,
+                reason: "credentialing-status-unavailable",
+                serviceDate);
+        }
+
+        context.BillingProviderCredentialingStatus = snapshot;
+
+        if (snapshot.IsApprovedAtAsOf)
+        {
+            return new EnforcementOutcome(
+                Check: EnforcementCheck.Credentialing,
+                Decision: EnforcementDecision.Allow,
+                Mode: _options.CredentialingMode.ToString(),
+                Reason: null,
+                AsOfDate: serviceDate);
+        }
+
+        // Pending / Denied / Expired / Suspended / Unknown → not approved
+        // for the service date. Drive policy via mode.
+        var reason = $"Provider credentialing status is '{snapshot.Status}' on the service date.";
+        return ApplyCredentialingMode(EnforcementDecision.Deny, reason, serviceDate);
+    }
+
+    private EnforcementOutcome ApplyNetworkMode(
+        ClaimAdjudicationContext context,
+        EnforcementDecision intended,
+        string reason,
+        DateTime serviceDate,
+        string? networkId,
+        ResolvedNetworkTier? tier)
+    {
+        var decision = _options.NetworkMode switch
+        {
+            NetworkEnforcementMode.FailClosed => intended,
+            NetworkEnforcementMode.FailOpen => EnforcementDecision.Pend,
+            NetworkEnforcementMode.SoftValidation => EnforcementDecision.Observe,
+            _ => intended,
+        };
+
+        if (decision == EnforcementDecision.Observe)
+        {
+            _logger.LogInformation(
+                "NetworkCredentialingStage soft-validation observed for claim {ClaimVersionId}: would-{Intended} reason={Reason}",
+                SanitizeForLog(context.ClaimVersionId), intended, SanitizeForLog(reason));
+        }
+
+        return new EnforcementOutcome(
+            Check: EnforcementCheck.Membership,
+            Decision: decision,
+            Mode: _options.NetworkMode.ToString(),
+            Reason: reason,
+            AsOfDate: serviceDate,
+            NetworkId: networkId,
+            TierName: tier?.TierName,
+            TierLevel: tier?.TierLevel);
+    }
+
+    private EnforcementOutcome ApplyCredentialingMode(
+        EnforcementDecision intended,
+        string reason,
+        DateTime serviceDate)
+    {
+        var decision = _options.CredentialingMode switch
+        {
+            CredentialingEnforcementMode.FailClosed => intended,
+            CredentialingEnforcementMode.FailOpen => EnforcementDecision.Pend,
+            CredentialingEnforcementMode.SoftValidation => EnforcementDecision.Observe,
+            _ => intended,
+        };
+
+        return new EnforcementOutcome(
+            Check: EnforcementCheck.Credentialing,
+            Decision: decision,
+            Mode: _options.CredentialingMode.ToString(),
+            Reason: reason,
+            AsOfDate: serviceDate);
+    }
+
+    /// <summary>
+    /// Resolves the earliest service date across the claim header and
+    /// every line. Earliest wins (Decision 3 — most-restrictive
+    /// interpretation; protects against credentialing gaps mid-claim
+    /// when lines span service dates).
+    /// </summary>
+    internal static DateTime ResolveEarliestServiceDate(ClaimsService.Models.AdapterClaim claim)
+    {
+        var earliest = claim.ServiceDateFrom;
+        foreach (var line in claim.ClaimLines)
+        {
+            if (line.ServiceDateFrom != default && line.ServiceDateFrom < earliest)
+            {
+                earliest = line.ServiceDateFrom;
+            }
+        }
+        return earliest == default ? DateTime.UtcNow : earliest;
+    }
+
+    private static ClaimAdjudicationStageResult CombineOutcomes(
+        EnforcementOutcome membership,
+        EnforcementOutcome? credentialing)
+    {
+        // Deny dominates Pend; Pend dominates Allow/Observe.
+        var outcomes = credentialing is null
+            ? new[] { membership }
+            : new[] { membership, credentialing };
+
+        var deny = outcomes.FirstOrDefault(o => o.Decision == EnforcementDecision.Deny);
+        if (deny is not null)
+        {
+            return ClaimAdjudicationStageResult.Deny(StageName, FormatReason(deny));
+        }
+
+        var pend = outcomes.FirstOrDefault(o => o.Decision == EnforcementDecision.Pend);
+        if (pend is not null)
+        {
+            return ClaimAdjudicationStageResult.Pend(StageName, FormatReason(pend));
+        }
+
+        // All Allow / Observe.
+        return ClaimAdjudicationStageResult.Pass(StageName);
+    }
+
+    private static string FormatReason(EnforcementOutcome outcome)
+        => $"{outcome.Check}: {outcome.Reason ?? outcome.Decision.ToString()} (mode={outcome.Mode})";
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/CachingCredentialingStatusClient.cs
+++ b/src/services/claims-service/Services/Resolution/CachingCredentialingStatusClient.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Decorator over <see cref="ICredentialingStatusClient"/> with a 1-hour
+/// in-process TTL keyed by
+/// <c>(tenantId, providerId, asOfDate)</c>. Mirrors
+/// <see cref="CachingProviderMembershipClient"/> shape but with a longer
+/// TTL — credentialing transitions are explicit, audit-trailed events
+/// (provider-service capability 5.6 event chain) and within an hour the
+/// staleness window is operationally acceptable. Membership rows can
+/// terminate without an explicit event signal; credentialing cannot.
+///
+/// <para>
+/// Negative results (<c>null</c> from upstream) are NOT cached, matching
+/// <see cref="CachingProviderMembershipClient"/>.
+/// </para>
+/// </summary>
+public sealed class CachingCredentialingStatusClient : ICredentialingStatusClient
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromHours(1);
+
+    private readonly ICredentialingStatusClient _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public CachingCredentialingStatusClient(ICredentialingStatusClient inner, IMemoryCache cache)
+        : this(inner, cache, DefaultTtl) { }
+
+    public CachingCredentialingStatusClient(ICredentialingStatusClient inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<CredentialingStatusSnapshot?> GetStatusAsOfAsync(
+        string tenantId,
+        string providerId,
+        DateTime asOfDate,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        var key = BuildCacheKey(tenantId, providerId, asOfDate, forceRefresh);
+
+        if (!forceRefresh
+            && _cache.TryGetValue<CredentialingStatusSnapshot>(key, out var cached)
+            && cached is not null)
+        {
+            return cached;
+        }
+
+        var fresh = await _inner
+            .GetStatusAsOfAsync(tenantId, providerId, asOfDate, forceRefresh, ct)
+            .ConfigureAwait(false);
+
+        if (fresh is not null && _ttl > TimeSpan.Zero)
+        {
+            _cache.Set(key, fresh, _ttl);
+        }
+        return fresh;
+    }
+
+    internal static string BuildCacheKey(
+        string tenantId, string providerId, DateTime asOfDate, bool forceRefresh)
+    {
+        var path = forceRefresh ? "force" : "cached-or-live";
+        var dayKey = asOfDate.ToUniversalTime().Date.ToString("yyyyMMdd");
+        return $"credentialing:{path}:{tenantId}:{providerId}:{dayKey}";
+    }
+}

--- a/src/services/claims-service/Services/Resolution/CachingProviderMembershipClient.cs
+++ b/src/services/claims-service/Services/Resolution/CachingProviderMembershipClient.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Decorator over <see cref="IProviderMembershipClient"/> with a 5-minute
+/// in-process TTL keyed by
+/// <c>(tenantId, networkId, npi, asOfDate)</c>. Mirrors
+/// <see cref="CachingBenefitPlanResolver"/> and the BP 5.10
+/// <c>HttpProviderIntegrityGate</c> caching shape.
+///
+/// <para>
+/// Cache key is namespaced by resolution path
+/// (<c>cached-or-live</c> vs <c>force-refresh</c>) so a force-refresh
+/// call doesn't poison the default-path entry — the same convention
+/// BP 5.10 uses. <c>asOfDate</c> is part of the key (rounded to whole
+/// days) because the same NPI can have different membership at
+/// different dates; collapsing the day boundary keeps cache keys finite
+/// while preserving service-date semantics within a day.
+/// </para>
+///
+/// <para>
+/// Negative results (<c>null</c> from upstream) are NOT cached — a
+/// transient provider-service outage shouldn't pin "lookup unavailable"
+/// for the full TTL window. The "not a member" 404 path produces a
+/// non-null <see cref="NetworkMembership"/> with
+/// <c>IsActiveMember=false</c>, which IS cached normally.
+/// </para>
+/// </summary>
+public sealed class CachingProviderMembershipClient : IProviderMembershipClient
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly IProviderMembershipClient _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public CachingProviderMembershipClient(IProviderMembershipClient inner, IMemoryCache cache)
+        : this(inner, cache, DefaultTtl) { }
+
+    public CachingProviderMembershipClient(IProviderMembershipClient inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<NetworkMembership?> GetMembershipAsync(
+        string tenantId,
+        string networkId,
+        string npi,
+        DateTime asOf,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        var key = BuildCacheKey(tenantId, networkId, npi, asOf, forceRefresh);
+
+        if (!forceRefresh
+            && _cache.TryGetValue<NetworkMembership>(key, out var cached)
+            && cached is not null)
+        {
+            return cached;
+        }
+
+        var fresh = await _inner
+            .GetMembershipAsync(tenantId, networkId, npi, asOf, forceRefresh, ct)
+            .ConfigureAwait(false);
+
+        if (fresh is not null && _ttl > TimeSpan.Zero)
+        {
+            _cache.Set(key, fresh, _ttl);
+        }
+        return fresh;
+    }
+
+    internal static string BuildCacheKey(
+        string tenantId, string networkId, string npi, DateTime asOf, bool forceRefresh)
+    {
+        var path = forceRefresh ? "force" : "cached-or-live";
+        var dayKey = asOf.ToUniversalTime().Date.ToString("yyyyMMdd");
+        return $"membership:{path}:{tenantId}:{networkId}:{npi}:{dayKey}";
+    }
+}

--- a/src/services/claims-service/Services/Resolution/HttpBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpBenefitPlanResolver.cs
@@ -75,12 +75,27 @@ public class HttpBenefitPlanResolver : IBenefitPlanResolver
 
             Guid? planGuid = Guid.TryParse(dto.Id, out var parsed) ? parsed : null;
 
+            // Project the wire-shape NetworkTier[] down to the
+            // pipeline-local view. Sort by TierLevel asc (1 = best) so the
+            // enforcement stage can walk in priority order without
+            // re-sorting on every claim.
+            var tiers = (dto.NetworkTiers ?? new List<NetworkTierDto>())
+                .OrderBy(t => t.TierLevel)
+                .Select(t => new ResolvedNetworkTier
+                {
+                    TierName = t.TierName ?? string.Empty,
+                    TierLevel = t.TierLevel,
+                    NetworkId = string.IsNullOrWhiteSpace(t.NetworkId) ? null : t.NetworkId,
+                })
+                .ToList();
+
             return new ResolvedBenefitPlan
             {
                 Id = dto.Id ?? planId,
                 PlanGuid = planGuid,
                 PlanName = dto.PlanName,
                 PlanType = dto.PlanType,
+                NetworkTiers = tiers,
             };
         }
         catch (Exception ex) when (ex is HttpRequestException
@@ -102,5 +117,13 @@ public class HttpBenefitPlanResolver : IBenefitPlanResolver
         public string? Id { get; set; }
         public string? PlanName { get; set; }
         public string? PlanType { get; set; }
+        public List<NetworkTierDto>? NetworkTiers { get; set; }
+    }
+
+    private sealed class NetworkTierDto
+    {
+        public string? TierName { get; set; }
+        public int TierLevel { get; set; }
+        public string? NetworkId { get; set; }
     }
 }

--- a/src/services/claims-service/Services/Resolution/HttpCredentialingStatusClient.cs
+++ b/src/services/claims-service/Services/Resolution/HttpCredentialingStatusClient.cs
@@ -1,0 +1,101 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Services;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="ICredentialingStatusClient"/> calling
+/// provider-service's
+/// <c>GET /api/v1/providers/{id}/credentialing/status-as-of</c>
+/// (capability 5.6). Sibling of <see cref="HttpProviderMembershipClient"/>
+/// in shape: typed factory client, non-throwing, caching deferred to
+/// the decorator.
+/// </summary>
+public class HttpCredentialingStatusClient : ICredentialingStatusClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpCredentialingStatusClient> _logger;
+
+    public HttpCredentialingStatusClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpCredentialingStatusClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<CredentialingStatusSnapshot?> GetStatusAsOfAsync(
+        string tenantId,
+        string providerId,
+        DateTime asOfDate,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        _ = forceRefresh;
+
+        if (string.IsNullOrWhiteSpace(providerId)) return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.ProviderService);
+            var encodedId = Uri.EscapeDataString(providerId);
+            var asOfQuery = asOfDate.ToUniversalTime()
+                .ToString("o", CultureInfo.InvariantCulture);
+
+            var url = $"/api/v1/providers/{encodedId}/credentialing/status-as-of" +
+                      $"?asOfDate={Uri.EscapeDataString(asOfQuery)}";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Provider not found in tenant — treat as Unknown rather
+                // than degraded so the enforcement stage applies the
+                // policy mode deterministically. Distinguishes
+                // "definitively unknown" from "transport failed".
+                return new CredentialingStatusSnapshot
+                {
+                    ProviderId = providerId,
+                    AsOfDate = asOfDate,
+                    Status = "Unknown",
+                };
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Provider service returned {StatusCode} resolving credentialing status for provider {Provider}",
+                    response.StatusCode, SanitizeForLog(providerId));
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<CredentialingStatusSnapshot>(JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Credentialing status lookup failed for provider {Provider} tenant {Tenant}",
+                SanitizeForLog(providerId), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/HttpProviderMembershipClient.cs
+++ b/src/services/claims-service/Services/Resolution/HttpProviderMembershipClient.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Services;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="IProviderMembershipClient"/> calling
+/// provider-service's <c>GET /api/v1/networks/{id}/members/{npi}</c>
+/// (capability 5.6). Mirrors <see cref="HttpBenefitPlanResolver"/> shape:
+/// <see cref="IHttpClientFactory"/> with a named client, non-throwing
+/// failure semantics. The caching decorator owns TTL behavior; this
+/// class is the live-fetch path only.
+/// </summary>
+public class HttpProviderMembershipClient : IProviderMembershipClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpProviderMembershipClient> _logger;
+
+    public HttpProviderMembershipClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpProviderMembershipClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<NetworkMembership?> GetMembershipAsync(
+        string tenantId,
+        string networkId,
+        string npi,
+        DateTime asOf,
+        bool forceRefresh = false,
+        CancellationToken ct = default)
+    {
+        // forceRefresh is honored by the caching decorator; the live
+        // path always issues the call and is unaware of cache semantics.
+        _ = forceRefresh;
+
+        if (string.IsNullOrWhiteSpace(networkId) || string.IsNullOrWhiteSpace(npi))
+            return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.ProviderService);
+            var encodedNetwork = Uri.EscapeDataString(networkId);
+            var encodedNpi = Uri.EscapeDataString(npi);
+            var asOfQuery = asOf.ToUniversalTime()
+                .ToString("o", CultureInfo.InvariantCulture);
+
+            var url = $"/api/v1/networks/{encodedNetwork}/members/{encodedNpi}" +
+                      $"?asOf={Uri.EscapeDataString(asOfQuery)}";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // 404 = NPI has no participation row in this network.
+                // Surface as a non-null "not member" snapshot so the
+                // enforcement stage can distinguish "definitely not a
+                // member" from "lookup degraded" (which returns null).
+                return new NetworkMembership
+                {
+                    NetworkId = networkId,
+                    Npi = npi,
+                    IsActiveMember = false,
+                    AsOfDate = asOf,
+                    ParticipationStatus = "not_a_member",
+                };
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Provider service returned {StatusCode} resolving membership for network {Network} NPI {Npi}",
+                    response.StatusCode, SanitizeForLog(networkId), SanitizeForLog(npi));
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<NetworkMembership>(JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Membership lookup failed for network {Network} NPI {Npi} tenant {Tenant}",
+                SanitizeForLog(networkId), SanitizeForLog(npi), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/IBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/IBenefitPlanResolver.cs
@@ -40,4 +40,40 @@ public class ResolvedBenefitPlan
 
     public string? PlanName { get; init; }
     public string? PlanType { get; init; }
+
+    /// <summary>
+    /// In-network tier list for the plan, sorted by
+    /// <see cref="ResolvedNetworkTier.TierLevel"/> ascending (1 = best).
+    /// Populated by capability 5.6 from <c>BenefitPlan.networkTiers</c>;
+    /// consumed by <c>NetworkCredentialingStage</c> to drive the
+    /// "first matching tier wins" enforcement walk.
+    ///
+    /// <para>
+    /// Empty for legacy plans whose tier list isn't populated; the
+    /// enforcement stage treats an empty list as "out-of-network only"
+    /// and applies the configured fail-mode for membership.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<ResolvedNetworkTier> NetworkTiers { get; init; } =
+        Array.Empty<ResolvedNetworkTier>();
+}
+
+/// <summary>
+/// Pipeline-local projection of <c>BenefitPlanService.Models.NetworkTier</c>.
+/// Carries only the fields the enforcement walk needs — <see cref="NetworkId"/>
+/// is the cross-service handle into provider-service; tier name/level
+/// surface on the enforcement outcome for audit.
+/// </summary>
+public sealed class ResolvedNetworkTier
+{
+    public required string TierName { get; init; }
+    public int TierLevel { get; init; }
+
+    /// <summary>
+    /// Reference to <c>Organization.OrganizationId</c> in provider-service.
+    /// Nullable during the BP 5.5 → hard-validation rollout window;
+    /// the enforcement stage skips tiers whose NetworkId is null and
+    /// emits a soft-validation telemetry signal.
+    /// </summary>
+    public string? NetworkId { get; init; }
 }

--- a/src/services/claims-service/Services/Resolution/ICredentialingStatusClient.cs
+++ b/src/services/claims-service/Services/Resolution/ICredentialingStatusClient.cs
@@ -1,0 +1,83 @@
+using System.Text.Json.Serialization;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Cross-service credentialing-status lookup against provider-service's
+/// <c>GET /api/v1/providers/{id}/credentialing/status-as-of</c>
+/// (capability 5.6). Consumed by
+/// <see cref="Adjudication.Stages.NetworkCredentialingStage"/>; wrapped
+/// by <see cref="CachingCredentialingStatusClient"/> in production for a
+/// 1-hour per-pod TTL.
+///
+/// <para>
+/// The longer TTL (vs. 5-minute membership) reflects that credentialing
+/// transitions are explicit, audit-trailed events on the
+/// <see cref="ProviderService.Services.CredentialingProjector"/> chain;
+/// staleness within an hour is operationally acceptable and the read
+/// volume per provider is low enough that a 1-hour cache is safe.
+/// </para>
+/// </summary>
+public interface ICredentialingStatusClient
+{
+    /// <summary>
+    /// Returns the credentialing-status snapshot for
+    /// <paramref name="providerId"/> as of <paramref name="asOfDate"/>,
+    /// or <c>null</c> when the lookup degrades. Consumer NPI is mapped
+    /// to providerId by the caller; this client takes the upstream
+    /// resource id directly.
+    /// </summary>
+    Task<CredentialingStatusSnapshot?> GetStatusAsOfAsync(
+        string tenantId,
+        string providerId,
+        DateTime asOfDate,
+        bool forceRefresh = false,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Pipeline-local credentialing status. Mirrors the wire shape of
+/// provider-service's <c>CredentialingStatusResponse</c>.
+/// </summary>
+public sealed class CredentialingStatusSnapshot
+{
+    [JsonPropertyName("providerId")]
+    public string ProviderId { get; set; } = string.Empty;
+
+    [JsonPropertyName("asOfDate")]
+    public DateTime AsOfDate { get; set; }
+
+    /// <summary>
+    /// Stringly-typed projection of provider-service's
+    /// <c>CredentialingStatus</c> enum: <c>Unknown | Pending | Approved
+    /// | Denied | Expired | Suspended</c>. Stays a string so wire-shape
+    /// drift in the upstream enum doesn't break the cross-service
+    /// boundary.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = "Unknown";
+
+    [JsonPropertyName("credentialingDate")]
+    public DateTime? CredentialingDate { get; set; }
+
+    [JsonPropertyName("recredentialingDueDate")]
+    public DateTime? RecredentialingDueDate { get; set; }
+
+    [JsonPropertyName("lastDecisionAuthorityId")]
+    public string? LastDecisionAuthorityId { get; set; }
+
+    [JsonPropertyName("lastDecisionAuthorityType")]
+    public string? LastDecisionAuthorityType { get; set; }
+
+    [JsonPropertyName("lastDecidedAt")]
+    public DateTimeOffset? LastDecidedAt { get; set; }
+
+    /// <summary>
+    /// True when <see cref="Status"/> is the only value that admits
+    /// adjudication on a service-dated claim. Approved claims pay;
+    /// Expired claims pay if the recredentialing-due gap is within
+    /// payer policy (decided by the enforcement stage's mode).
+    /// </summary>
+    public bool IsApprovedAtAsOf =>
+        string.Equals(Status, "Approved", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/services/claims-service/Services/Resolution/IProviderMembershipClient.cs
+++ b/src/services/claims-service/Services/Resolution/IProviderMembershipClient.cs
@@ -1,0 +1,62 @@
+using System.Text.Json.Serialization;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Cross-service network-membership lookup against provider-service's
+/// <c>GET /api/v1/networks/{id}/members/{npi}</c> (capability 5.6).
+/// Consumed by <see cref="Adjudication.Stages.NetworkCredentialingStage"/>;
+/// wrapped by <see cref="CachingProviderMembershipClient"/> in production
+/// for a 5-minute per-pod TTL.
+/// </summary>
+public interface IProviderMembershipClient
+{
+    /// <summary>
+    /// Returns the membership snapshot for
+    /// (<paramref name="networkId"/>, <paramref name="npi"/>) at
+    /// <paramref name="asOf"/>, or <c>null</c> when the lookup degrades
+    /// (404, transport failure, deserialization error). Non-throwing —
+    /// the enforcement stage applies the configured fail-mode policy
+    /// when the result is null.
+    /// </summary>
+    Task<NetworkMembership?> GetMembershipAsync(
+        string tenantId,
+        string networkId,
+        string npi,
+        DateTime asOf,
+        bool forceRefresh = false,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Pipeline-local membership snapshot. Mirrors the wire shape of
+/// provider-service's <c>NetworkMembershipResponse</c> (capability 5.6)
+/// but lives in claims-service to keep the cross-service boundary
+/// asymmetric (claims doesn't reference the provider-service project).
+/// </summary>
+public sealed class NetworkMembership
+{
+    [JsonPropertyName("networkId")]
+    public string NetworkId { get; set; } = string.Empty;
+
+    [JsonPropertyName("npi")]
+    public string Npi { get; set; } = string.Empty;
+
+    [JsonPropertyName("providerId")]
+    public string ProviderId { get; set; } = string.Empty;
+
+    [JsonPropertyName("isActiveMember")]
+    public bool IsActiveMember { get; set; }
+
+    [JsonPropertyName("asOfDate")]
+    public DateTime AsOfDate { get; set; }
+
+    [JsonPropertyName("effectiveFrom")]
+    public DateTime? EffectiveFrom { get; set; }
+
+    [JsonPropertyName("effectiveTo")]
+    public DateTime? EffectiveTo { get; set; }
+
+    [JsonPropertyName("participationStatus")]
+    public string? ParticipationStatus { get; set; }
+}

--- a/src/services/claims-service/Services/UpstreamClientNames.cs
+++ b/src/services/claims-service/Services/UpstreamClientNames.cs
@@ -1,0 +1,31 @@
+namespace ClaimsService.Services;
+
+/// <summary>
+/// Named-<see cref="System.Net.Http.IHttpClientFactory"/> client
+/// identifiers for cross-service calls from claims-service. Centralized
+/// so capability 5.6 + 5.7 + 5.10 + 5.11 HTTP consumers don't drift on
+/// string literals.
+///
+/// <para>
+/// Existing typed clients (<see cref="Resolution.HttpBenefitPlanResolver.HttpClientName"/>,
+/// <see cref="Resolution.HttpMemberResolver.HttpClientName"/>) keep their
+/// own constants for back-compat; new clients added in 5.6 onward use
+/// these.
+/// </para>
+/// </summary>
+public static class UpstreamClientNames
+{
+    /// <summary>provider-service — capability 5.6 enforcement clients,
+    /// BP 5.10 integrity gate, FL FMMIS provider service shim.</summary>
+    public const string ProviderService = "ProviderService";
+
+    /// <summary>benefit-plan-service — capability 5.5 plan resolver,
+    /// 5.5 benefit calculation engine HTTP shim.</summary>
+    public const string BenefitPlanService = "BenefitPlanService";
+
+    /// <summary>member-service — capability 5.5 member resolver.</summary>
+    public const string MemberService = "MemberService";
+
+    /// <summary>reference-data-service — terminology lookups.</summary>
+    public const string ReferenceDataService = "ReferenceDataService";
+}

--- a/src/services/claims-service/appsettings.Development.json
+++ b/src/services/claims-service/appsettings.Development.json
@@ -12,5 +12,11 @@
   "Observability": {
     "OtlpEndpoint": null,
     "EnableConsole": true
+  },
+  "Adjudication": {
+    "Enforcement": {
+      "NetworkMode": "SoftValidation",
+      "CredentialingMode": "SoftValidation"
+    }
   }
 }

--- a/src/services/claims-service/appsettings.json
+++ b/src/services/claims-service/appsettings.json
@@ -10,5 +10,11 @@
     "ServiceName": "claims-service",
     "OtlpEndpoint": "http://otel-collector:4317",
     "EnableConsole": false
+  },
+  "Adjudication": {
+    "Enforcement": {
+      "NetworkMode": "FailClosed",
+      "CredentialingMode": "FailClosed"
+    }
   }
 }

--- a/src/services/provider-service/Controllers/CredentialingController.cs
+++ b/src/services/provider-service/Controllers/CredentialingController.cs
@@ -271,6 +271,62 @@ public sealed class CredentialingController : ControllerBase
         return Ok(result);
     }
 
+    /// <summary>
+    /// Projected credentialing status for the provider as of the supplied
+    /// date (capability 5.6). Consumer-facing surface for claims-service
+    /// adjudication: the <paramref name="asOfDate"/> is the claim's
+    /// service date, anchoring credentialing-status enforcement to when
+    /// the service was rendered rather than when the claim is processed.
+    /// Returns a trimmed projection (see
+    /// <see cref="CredentialingStatusResponse"/>) — internal projection
+    /// fields like <c>CurrentApplicationEventId</c> belong to the admin
+    /// <c>/status</c> + <c>/history</c> surface, not to cross-service
+    /// enforcement.
+    /// </summary>
+    [HttpGet("status-as-of")]
+    [ProducesResponseType(typeof(CredentialingStatusResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<CredentialingStatusResponse>> GetStatusAsOf(
+        string id,
+        [FromQuery] DateTime? asOfDate,
+        CancellationToken ct)
+    {
+        if (asOfDate is null)
+        {
+            return BadRequest(new
+            {
+                error = "missing_as_of_date",
+                message = "asOfDate query parameter is required (ISO-8601 UTC).",
+            });
+        }
+
+        // Normalize Unspecified-kind input to UTC. Inbound query strings
+        // typically deserialize with Kind=Unspecified; treating that as
+        // UTC matches how the projector interprets stored decision dates
+        // (see CredentialingProjector.ComputeStatus).
+        var asOfUtc = asOfDate.Value.Kind switch
+        {
+            DateTimeKind.Utc => asOfDate.Value,
+            DateTimeKind.Local => asOfDate.Value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(asOfDate.Value, DateTimeKind.Utc),
+        };
+
+        var projection = await _credentialing.GetStatusAsOfAsync(
+            TenantId, id, new DateTimeOffset(asOfUtc, TimeSpan.Zero), ct);
+
+        return Ok(new CredentialingStatusResponse
+        {
+            ProviderId = id,
+            AsOfDate = asOfUtc,
+            Status = projection.Status.ToString(),
+            CredentialingDate = projection.CredentialingDate,
+            RecredentialingDueDate = projection.RecredentialingDueDate,
+            LastDecisionAuthorityId = projection.LastDecisionAuthorityId,
+            LastDecisionAuthorityType = projection.LastDecisionAuthorityType?.ToString(),
+            LastDecidedAt = projection.LastDecidedAt,
+        });
+    }
+
     /// <summary>Newest-first paged history of credentialing events for the provider.</summary>
     [HttpGet("history")]
     [ProducesResponseType(typeof(CredentialingHistoryPage), StatusCodes.Status200OK)]

--- a/src/services/provider-service/Controllers/NetworksController.cs
+++ b/src/services/provider-service/Controllers/NetworksController.cs
@@ -165,6 +165,55 @@ public class NetworksController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Single-membership lookup (capability 5.6). Returns whether
+    /// <paramref name="npi"/> is an active member of network
+    /// <paramref name="id"/> on <c>asOf</c> (defaults to UtcNow). Used by
+    /// claims-service's <c>NetworkCredentialingStage</c> at adjudication
+    /// time. Body-shaped status: 200 with <c>IsActiveMember=false</c>
+    /// when the NPI participates but isn't active for the date; 404 only
+    /// when no participation row for this NPI exists in the network at
+    /// all. Uniform body shape keeps the consumer-side cache key
+    /// stable across the active/inactive distinction.
+    /// </summary>
+    [HttpGet("{id}/members/{npi}")]
+    [ProducesResponseType(typeof(NetworkMembershipResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<NetworkMembershipResponse>> GetMember(
+        string id,
+        string npi,
+        [FromQuery] DateTime? asOf = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(npi))
+        {
+            return BadRequest(new { error = "missing_npi", message = "npi route segment is required." });
+        }
+
+        // Tenant-scope guard: confirm the network belongs to this tenant
+        // before scanning the provider collection. Mirrors the same guard
+        // GetRoster runs.
+        var network = await _service.GetByIdAsync(id);
+        if (network == null)
+        {
+            return NotFound(new { message = $"Network {id} not found" });
+        }
+
+        var asOfUtc = (asOf ?? DateTime.UtcNow);
+        var result = await _rosterService.GetMembershipAsync(TenantId, id, npi, asOfUtc, ct);
+        if (result is null)
+        {
+            return NotFound(new
+            {
+                error = "not_a_member",
+                message = $"NPI {SanitizeForLog(npi)} has no participation row in network {SanitizeForLog(id)}.",
+            });
+        }
+
+        return Ok(result);
+    }
+
     /// <summary>Create a new network. Activates v1 in one shot.</summary>
     [HttpPost]
     [ProducesResponseType(typeof(Organization), StatusCodes.Status201Created)]

--- a/src/services/provider-service/Models/CredentialingStatusResponse.cs
+++ b/src/services/provider-service/Models/CredentialingStatusResponse.cs
@@ -1,0 +1,37 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Body shape returned by
+/// <c>GET /api/v1/providers/{id}/credentialing/status-as-of</c>
+/// (capability 5.6). Projects <see cref="ProviderService.Services.CredentialingProjectionResult"/>
+/// down to the caller-relevant fields and adds the echoed
+/// <see cref="AsOfDate"/> the projection was evaluated against.
+///
+/// <para>
+/// Internal projection internals (<c>CurrentApplicationEventId</c>,
+/// <c>ApplicationSubmittedAt</c>, <c>EventCount</c>, <c>LatestVersion</c>)
+/// are deliberately omitted — they are operational fields belonging to the
+/// admin <c>GET /status</c> + <c>GET /history</c> surface, not to
+/// cross-service enforcement consumers.
+/// </para>
+/// </summary>
+public sealed class CredentialingStatusResponse
+{
+    public string ProviderId { get; set; } = string.Empty;
+    public DateTime AsOfDate { get; set; }
+
+    /// <summary>
+    /// String name of <see cref="CredentialingStatus"/> — serialized as
+    /// the enum name to match the existing
+    /// <see cref="ProviderService.Services.CredentialingProjectionResult"/>
+    /// surface and stay stable across consumer schema migrations.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    public DateTime? CredentialingDate { get; set; }
+    public DateTime? RecredentialingDueDate { get; set; }
+
+    public string? LastDecisionAuthorityId { get; set; }
+    public string? LastDecisionAuthorityType { get; set; }
+    public DateTimeOffset? LastDecidedAt { get; set; }
+}

--- a/src/services/provider-service/Models/NetworkMembershipResponse.cs
+++ b/src/services/provider-service/Models/NetworkMembershipResponse.cs
@@ -1,0 +1,48 @@
+namespace ProviderService.Models;
+
+/// <summary>
+/// Body shape returned by <c>GET /api/v1/networks/{id}/members/{npi}</c>
+/// (capability 5.6 — Network &amp; Credentialing Enforcement).
+///
+/// <para>
+/// 200 with <see cref="IsActiveMember"/> false when the NPI exists in the
+/// network's participation history but is not active for the requested
+/// <c>asOf</c> date (e.g. terminated participation, future-dated
+/// participation). 404 only when no participation row for the NPI exists
+/// at all in this network. Body-shaped status keeps the consumer logic
+/// uniform for caching — the <see cref="ParticipationStatus"/> string is
+/// the audit-grade signal, the boolean is the enforcement-grade signal.
+/// </para>
+/// </summary>
+public sealed class NetworkMembershipResponse
+{
+    public string NetworkId { get; set; } = string.Empty;
+    public string Npi { get; set; } = string.Empty;
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// True iff a participation row exists with
+    /// <c>EffectiveDate &lt;= asOf &lt; (TerminationDate ?? +inf)</c>.
+    /// Drives the claims-side network-tier match in
+    /// <c>NetworkCredentialingStage</c>.
+    /// </summary>
+    public bool IsActiveMember { get; set; }
+
+    /// <summary>
+    /// The <c>asOf</c> date evaluated. Echoed so callers can confirm which
+    /// snapshot the result corresponds to (the param defaults to UtcNow
+    /// server-side when omitted).
+    /// </summary>
+    public DateTime AsOfDate { get; set; }
+
+    public DateTime? EffectiveFrom { get; set; }
+    public DateTime? EffectiveTo { get; set; }
+
+    /// <summary>
+    /// <c>active | terminated | suspended | pending | future</c>.
+    /// </summary>
+    public string? ParticipationStatus { get; set; }
+
+    public LineOfBusiness? LineOfBusiness { get; set; }
+    public string? NetworkTier { get; set; }
+}

--- a/src/services/provider-service/Services/CredentialingService.cs
+++ b/src/services/provider-service/Services/CredentialingService.cs
@@ -60,6 +60,20 @@ public interface ICredentialingService
     Task<CredentialingProjectionResult> GetCurrentStatusAsync(
         string tenantId, string providerId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Project the credentialing chain as of <paramref name="asOfDate"/>.
+    /// Capability 5.6 enforcement consumer: claims-service calls this with
+    /// the claim's service date so a provider credentialed AFTER the
+    /// service date doesn't auto-pay an earlier-dated claim.
+    /// </summary>
+    /// <remarks>
+    /// Trivial sibling of <see cref="GetCurrentStatusAsync"/>; the
+    /// projector already accepts arbitrary <c>asOf</c> values. No I/O
+    /// difference between the two paths beyond the date passed through.
+    /// </remarks>
+    Task<CredentialingProjectionResult> GetStatusAsOfAsync(
+        string tenantId, string providerId, DateTimeOffset asOfDate, CancellationToken ct = default);
+
     Task<CredentialingHistoryPage> GetHistoryAsync(
         string tenantId, string providerId,
         string? continuationToken, int limit, CancellationToken ct = default);
@@ -453,6 +467,13 @@ public sealed class CredentialingService : ICredentialingService
     {
         var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
         return _projector.Project(chain, DateTimeOffset.UtcNow);
+    }
+
+    public async Task<CredentialingProjectionResult> GetStatusAsOfAsync(
+        string tenantId, string providerId, DateTimeOffset asOfDate, CancellationToken ct = default)
+    {
+        var chain = await _eventRepository.ListAscendingAsync(tenantId, providerId, ct);
+        return _projector.Project(chain, asOfDate);
     }
 
     public Task<CredentialingHistoryPage> GetHistoryAsync(

--- a/src/services/provider-service/Services/NetworkRosterService.cs
+++ b/src/services/provider-service/Services/NetworkRosterService.cs
@@ -21,6 +21,30 @@ namespace ProviderService.Services;
 public interface INetworkRosterService
 {
     Task<NetworkRosterResponse> GetRosterAsync(NetworkRosterQuery query, CancellationToken ct = default);
+
+    /// <summary>
+    /// Single-membership lookup for capability 5.6 enforcement
+    /// (<c>GET /api/v1/networks/{id}/members/{npi}</c>). Returns
+    /// <c>null</c> when no participation row exists for
+    /// (<paramref name="tenantId"/>, <paramref name="networkId"/>,
+    /// <paramref name="npi"/>) at all — the controller maps that to a
+    /// 404. A non-null result with <c>IsActiveMember=false</c> means a
+    /// participation row exists but the supplied <paramref name="asOf"/>
+    /// date falls outside its [EffectiveDate, TerminationDate) window.
+    ///
+    /// <para>
+    /// Read path mirrors the embedded-list shape used by
+    /// <see cref="GetRosterAsync"/>: NetworkParticipations live on the
+    /// Provider document (capability 5.4 — there is no separate
+    /// participation events stream).
+    /// </para>
+    /// </summary>
+    Task<NetworkMembershipResponse?> GetMembershipAsync(
+        string tenantId,
+        string networkId,
+        string npi,
+        DateTime asOf,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -49,6 +73,92 @@ public class NetworkRosterService : INetworkRosterService
     {
         _repository = repository;
         _logger = logger;
+    }
+
+    public async Task<NetworkMembershipResponse?> GetMembershipAsync(
+        string tenantId,
+        string networkId,
+        string npi,
+        DateTime asOf,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+            throw new ArgumentException("tenantId is required.", nameof(tenantId));
+        if (string.IsNullOrEmpty(networkId))
+            throw new ArgumentException("networkId is required.", nameof(networkId));
+        if (string.IsNullOrEmpty(npi))
+            throw new ArgumentException("npi is required.", nameof(npi));
+
+        var asOfUtc = asOf.Kind switch
+        {
+            DateTimeKind.Utc => asOf,
+            DateTimeKind.Local => asOf.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(asOf, DateTimeKind.Utc),
+        };
+
+        // The repo's GetByNPIAsync is tenant-scoped via context; the
+        // controller ensures the same tenant lens is in scope before this
+        // call. NPI uniqueness within a tenant is the chain-key
+        // contract from capability 5.4.
+        var provider = await _repository.GetByNPIAsync(npi);
+        if (provider is null) return null;
+
+        // Look across every participation row for this network on the
+        // provider; pick the one whose [Effective, Termination) window
+        // covers asOf. If no row covers it, return the most recently
+        // terminated row so the response can describe "terminated"
+        // rather than collapsing the case to 404.
+        var matchesNetwork = provider.NetworkParticipations
+            .Where(n => n.NetworkId == networkId)
+            .ToList();
+        if (matchesNetwork.Count == 0) return null;
+
+        var active = matchesNetwork.FirstOrDefault(n =>
+            n.EffectiveDate <= asOfUtc &&
+            (n.TerminationDate is null || n.TerminationDate.Value > asOfUtc));
+
+        if (active is not null)
+        {
+            return new NetworkMembershipResponse
+            {
+                NetworkId = networkId,
+                Npi = npi,
+                ProviderId = provider.ProviderId,
+                IsActiveMember = true,
+                AsOfDate = asOfUtc,
+                EffectiveFrom = active.EffectiveDate,
+                EffectiveTo = active.TerminationDate,
+                ParticipationStatus = "active",
+                LineOfBusiness = active.LineOfBusiness,
+                NetworkTier = active.NetworkTier,
+            };
+        }
+
+        // Pick the participation row with the most-recent EffectiveDate
+        // for descriptive status. Future-dated participation surfaces
+        // as "future"; past-terminated as "terminated".
+        var descriptive = matchesNetwork
+            .OrderByDescending(n => n.EffectiveDate)
+            .First();
+        var status = descriptive.EffectiveDate > asOfUtc
+            ? "future"
+            : descriptive.TerminationDate.HasValue && descriptive.TerminationDate.Value <= asOfUtc
+                ? "terminated"
+                : "inactive";
+
+        return new NetworkMembershipResponse
+        {
+            NetworkId = networkId,
+            Npi = npi,
+            ProviderId = provider.ProviderId,
+            IsActiveMember = false,
+            AsOfDate = asOfUtc,
+            EffectiveFrom = descriptive.EffectiveDate,
+            EffectiveTo = descriptive.TerminationDate,
+            ParticipationStatus = status,
+            LineOfBusiness = descriptive.LineOfBusiness,
+            NetworkTier = descriptive.NetworkTier,
+        };
     }
 
     public async Task<NetworkRosterResponse> GetRosterAsync(NetworkRosterQuery query, CancellationToken ct = default)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/AdjudicationWithEnforcementEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/AdjudicationWithEnforcementEndToEndTests.cs
@@ -1,0 +1,290 @@
+using System.Net.Http;
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Services;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication;
+
+/// <summary>
+/// Capability 5.6 — pipeline-level integration that wires the REAL
+/// <see cref="NetworkCredentialingStage"/> into the orchestrator with
+/// substituted upstream clients. Verifies the cross-stage contract:
+/// enforcement outcomes flow onto the context, the stage's
+/// pass/pend/deny decision drives the orchestrator's short-circuit
+/// behavior, and the final adjudicated message captures the outcome.
+/// </summary>
+public class AdjudicationWithEnforcementEndToEndTests
+{
+    private const string TenantId = "tenant-1";
+    private const string Network1 = "net-1";
+    private const string Npi = "1234567890";
+    private const string ProviderId = "p-001";
+
+    private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
+    private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
+    private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
+    private readonly IProviderMembershipClient _membership = Substitute.For<IProviderMembershipClient>();
+    private readonly ICredentialingStatusClient _credentialing = Substitute.For<ICredentialingStatusClient>();
+    private readonly ClaimAdapterFactory _factory;
+
+    public AdjudicationWithEnforcementEndToEndTests()
+    {
+        _adapter.Platform.Returns("cho");
+        var cache = new ClaimTenantConfigCache(
+            Substitute.For<IHttpClientFactory>(),
+            Substitute.For<IConfiguration>(),
+            NullLogger<ClaimTenantConfigCache>.Instance);
+        _factory = new ClaimAdapterFactory(
+            new[] { _adapter }, cache,
+            NullLogger<ClaimAdapterFactory>.Instance);
+    }
+
+    [Fact]
+    public async Task ApprovedMember_ApprovedCredentialing_pipeline_passes_through_to_persistence()
+    {
+        // Given: the billing provider is an active member of tier 1 and
+        // credentialed-Approved on the service date.
+        SetupAdapterReturningClaim();
+        SetupPlanWithTier(Network1, "InNetwork", level: 1);
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, Status = "Approved",
+            });
+
+        var captured = CaptureAdjudicatedMessage();
+        var orch = BuildOrchestratorWithRealStage();
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildMessageContext(), CancellationToken.None);
+
+        Assert.NotNull(captured.Message);
+        Assert.Equal("Pass", captured.Message!.Outcome);
+    }
+
+    [Fact]
+    public async Task OutOfNetwork_provider_denies_at_enforcement_stage()
+    {
+        SetupAdapterReturningClaim();
+        SetupPlanWithTier(Network1, "InNetwork", level: 1);
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var captured = CaptureAdjudicatedMessage();
+        var orch = BuildOrchestratorWithRealStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailClosed,
+        });
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildMessageContext(), CancellationToken.None);
+
+        Assert.NotNull(captured.Message);
+        Assert.Equal("Deny", captured.Message!.Outcome);
+    }
+
+    [Fact]
+    public async Task PreCredentialing_serviceDate_denies_at_enforcement_stage()
+    {
+        // Membership is active; credentialing is Pending as of the
+        // claim's service date — the cross-service consumer's primary
+        // motivating case.
+        SetupAdapterReturningClaim();
+        SetupPlanWithTier(Network1, "InNetwork", level: 1);
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, Status = "Pending" });
+
+        var captured = CaptureAdjudicatedMessage();
+        var orch = BuildOrchestratorWithRealStage();
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildMessageContext(), CancellationToken.None);
+
+        Assert.NotNull(captured.Message);
+        Assert.Equal("Deny", captured.Message!.Outcome);
+    }
+
+    [Fact]
+    public async Task FailOpen_membership_pends_instead_of_denies()
+    {
+        SetupAdapterReturningClaim();
+        SetupPlanWithTier(Network1, "InNetwork", level: 1);
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var captured = CaptureAdjudicatedMessage();
+        var orch = BuildOrchestratorWithRealStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailOpen,
+        });
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildMessageContext(), CancellationToken.None);
+
+        Assert.NotNull(captured.Message);
+        Assert.Equal("Pend", captured.Message!.Outcome);
+    }
+
+    [Fact]
+    public async Task SoftValidation_passes_through_observation_only()
+    {
+        SetupAdapterReturningClaim();
+        SetupPlanWithTier(Network1, "InNetwork", level: 1);
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var captured = CaptureAdjudicatedMessage();
+        var orch = BuildOrchestratorWithRealStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.SoftValidation,
+        });
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildMessageContext(), CancellationToken.None);
+
+        // Soft-validation = enforcement records an observation; the
+        // pipeline keeps running. With no other stages registered the
+        // outcome is Pass.
+        Assert.NotNull(captured.Message);
+        Assert.Equal("Pass", captured.Message!.Outcome);
+    }
+
+    private void SetupAdapterReturningClaim()
+    {
+        var serviceDate = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        var claim = new AdapterClaim
+        {
+            TenantId = TenantId,
+            Id = "ver-1",
+            ClaimNumber = "CLM-1",
+            ClaimVersionId = "ver-1",
+            VersionNumber = 1,
+            VersionState = ClaimVersionState.Submitted,
+            MemberId = "MEM-1",
+            BillingProviderNPI = Npi,
+            BenefitPlanId = "plan-1",
+            LineOfBusiness = LineOfBusiness.Commercial,
+            ClaimType = ClaimType.Professional,
+            PlaceOfServiceCode = "11",
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<AdapterClaimLine>
+            {
+                new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 100m, Units = 1,
+                        ServiceDateFrom = serviceDate, ServiceDateTo = serviceDate },
+            },
+        };
+        _adapter
+            .GetClaimAsync(Arg.Any<ClaimAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ClaimAdapterResponse { Platform = "cho", Claim = claim });
+    }
+
+    private void SetupPlanWithTier(string networkId, string tierName, int level)
+    {
+        _planResolver
+            .GetPlanAsync(TenantId, "plan-1", Arg.Any<CancellationToken>())
+            .Returns(new ResolvedBenefitPlan
+            {
+                Id = "plan-1",
+                NetworkTiers = new[]
+                {
+                    new ResolvedNetworkTier
+                    {
+                        TierName = tierName,
+                        TierLevel = level,
+                        NetworkId = networkId,
+                    },
+                },
+            });
+    }
+
+    private MessageCapture CaptureAdjudicatedMessage()
+    {
+        var capture = new MessageCapture();
+        _messageBus
+            .When(b => b.SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionAdjudicatedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(ci => capture.Message = ci.Arg<ClaimVersionAdjudicatedMessage>());
+        return capture;
+    }
+
+    private ClaimAdjudicationOrchestrator BuildOrchestratorWithRealStage(
+        TenantEnforcementPolicyOptions? policyOptions = null)
+    {
+        var stage = new NetworkCredentialingStage(
+            _membership, _credentialing,
+            Options.Create(policyOptions ?? new TenantEnforcementPolicyOptions()),
+            NullLogger<NetworkCredentialingStage>.Instance);
+
+        // Persistence stand-in keeps the orchestrator's "always run
+        // PersistenceStage" contract; it doesn't write to a repo here
+        // because we're asserting against the emitted message, not the
+        // database state.
+        var persistence = new TestPersistenceStage();
+
+        return new ClaimAdjudicationOrchestrator(
+            _factory,
+            _planResolver,
+            _memberResolver,
+            new IClaimAdjudicationStage[] { stage, persistence },
+            _eventPublisher,
+            _messageBus,
+            Options.Create(new AdjudicationPipelineOptions()),
+            NullLogger<ClaimAdjudicationOrchestrator>.Instance);
+    }
+
+    private static ClaimVersionSubmittedMessage BuildSubmittedMessage() => new()
+    {
+        TenantId = TenantId,
+        ClaimId = "ver-1",
+        ClaimVersionId = "ver-1",
+        VersionNumber = 1,
+        ActorId = "actor",
+        CorrelationId = "corr-1",
+    };
+
+    private static MessageContext BuildMessageContext() => new(
+        MessageId: "submitted:ver-1",
+        CorrelationId: "corr-1",
+        DeliveryCount: 1,
+        Properties: new Dictionary<string, string> { ["MessageType"] = "ClaimVersionSubmitted" });
+
+    private sealed class MessageCapture
+    {
+        public ClaimVersionAdjudicatedMessage? Message { get; set; }
+    }
+
+    private sealed class TestPersistenceStage : IClaimAdjudicationStage
+    {
+        public string Name => "Persistence";
+        public int Order => 999;
+        public bool IsRequired => true;
+
+        public Task<ClaimAdjudicationStageResult> ExecuteAsync(
+            ClaimAdjudicationContext context, CancellationToken ct)
+            => Task.FromResult(ClaimAdjudicationStageResult.Pass(Name));
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/NetworkCredentialingStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/NetworkCredentialingStageTests.cs
@@ -1,0 +1,342 @@
+using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication.Stages;
+
+/// <summary>
+/// Capability 5.6 — behavior coverage for
+/// <see cref="NetworkCredentialingStage"/>: tier-walk, fail-mode policy
+/// matrix, time-anchor resolution, and outcome combination.
+/// </summary>
+public class NetworkCredentialingStageTests
+{
+    private const string TenantId = "tenant-a";
+    private const string Network1 = "net-1";
+    private const string Network2 = "net-2";
+    private const string Npi = "1234567890";
+    private const string ProviderId = "p-001";
+
+    private readonly IProviderMembershipClient _membership = Substitute.For<IProviderMembershipClient>();
+    private readonly ICredentialingStatusClient _credentialing = Substitute.For<ICredentialingStatusClient>();
+
+    private NetworkCredentialingStage NewStage(TenantEnforcementPolicyOptions opts) =>
+        new(_membership, _credentialing, Options.Create(opts), NullLogger<NetworkCredentialingStage>.Instance);
+
+    [Fact]
+    public async Task BothChecksAllow_returns_Pass()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, AsOfDate = DateTime.UtcNow, Status = "Approved",
+            });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.True(result.Continue);
+        Assert.NotNull(ctx.MatchedNetworkTier);
+        Assert.Equal(Network1, ctx.MatchedNetworkTier!.NetworkId);
+        Assert.Equal(2, ctx.EnforcementOutcomes.Count);
+        Assert.All(ctx.EnforcementOutcomes, o => Assert.Equal(EnforcementDecision.Allow, o.Decision));
+    }
+
+    [Fact]
+    public async Task FirstTierMatches_skips_lower_priority_tiers()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, Status = "Approved" });
+
+        var ctx = NewContext(tiers: new[]
+        {
+            Tier(Network1, "InNetwork", 1),
+            Tier(Network2, "Preferred", 2),
+        });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        await _membership.Received(1).GetMembershipAsync(
+            TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>());
+        await _membership.DidNotReceive().GetMembershipAsync(
+            TenantId, Network2, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NoTierMatches_FailClosed_denies()
+    {
+        // Both tiers return non-active membership.
+        _membership.GetMembershipAsync(TenantId, Arg.Any<string>(), Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var ctx = NewContext(tiers: new[]
+        {
+            Tier(Network1, "InNetwork", 1),
+            Tier(Network2, "Preferred", 2),
+        });
+        var sut = NewStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailClosed,
+        });
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Single(ctx.EnforcementOutcomes); // credentialing skipped for OON
+        Assert.Equal(EnforcementDecision.Deny, ctx.EnforcementOutcomes[0].Decision);
+    }
+
+    [Fact]
+    public async Task NoTierMatches_FailOpen_pends()
+    {
+        _membership.GetMembershipAsync(TenantId, Arg.Any<string>(), Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailOpen,
+        });
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.True(result.Continue); // pend doesn't short-circuit
+        Assert.Equal(EnforcementDecision.Pend, ctx.EnforcementOutcomes[0].Decision);
+    }
+
+    [Fact]
+    public async Task NoTierMatches_SoftValidation_passes()
+    {
+        _membership.GetMembershipAsync(TenantId, Arg.Any<string>(), Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.SoftValidation,
+        });
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.Equal(EnforcementDecision.Observe, ctx.EnforcementOutcomes[0].Decision);
+    }
+
+    [Fact]
+    public async Task DegradedMembership_FailClosed_denies()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns((NetworkMembership?)null);
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailClosed,
+        });
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.Contains("membership-verification-unavailable",
+            ctx.EnforcementOutcomes[0].Reason ?? string.Empty);
+    }
+
+    [Fact]
+    public async Task ApprovedMembership_DegradedCredentialing_FailClosed_denies()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns((CredentialingStatusSnapshot?)null);
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions
+        {
+            NetworkMode = NetworkEnforcementMode.FailClosed,
+            CredentialingMode = CredentialingEnforcementMode.FailClosed,
+        });
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        // Membership = Allow, Credentialing = Deny.
+        Assert.Equal(EnforcementDecision.Allow, ctx.EnforcementOutcomes[0].Decision);
+        Assert.Equal(EnforcementDecision.Deny, ctx.EnforcementOutcomes[1].Decision);
+    }
+
+    [Fact]
+    public async Task ApprovedMembership_PendingCredentialing_FailClosed_denies()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, Status = "Pending" });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+    }
+
+    [Fact]
+    public async Task EmptyTierList_denies()
+    {
+        var ctx = NewContext(tiers: Array.Empty<ResolvedNetworkTier>());
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        await _membership.DidNotReceive()
+            .GetMembershipAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<DateTime>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TierWithoutNetworkId_is_skipped()
+    {
+        _membership.GetMembershipAsync(TenantId, Network2, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network2, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, Status = "Approved" });
+
+        var ctx = NewContext(tiers: new[]
+        {
+            // Legacy tier with NetworkId = null — must be skipped.
+            Tier(networkId: null, "Legacy", 1),
+            Tier(Network2, "Preferred", 2),
+        });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _membership.DidNotReceive().GetMembershipAsync(
+            Arg.Any<string>(), null!, Arg.Any<string>(),
+            Arg.Any<DateTime>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MissingBillingNpi_rejects()
+    {
+        var claim = NewClaim();
+        claim.BillingProviderNPI = string.Empty;
+        var ctx = NewContext(claim, tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Reject, result.Outcome);
+        Assert.False(result.Continue);
+    }
+
+    [Fact]
+    public void EarliestServiceDate_picks_min_across_header_and_lines()
+    {
+        var claim = NewClaim();
+        claim.ServiceDateFrom = new DateTime(2025, 5, 10, 0, 0, 0, DateTimeKind.Utc);
+        claim.ClaimLines.Add(new AdapterClaimLine
+        {
+            ServiceDateFrom = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        claim.ClaimLines.Add(new AdapterClaimLine
+        {
+            ServiceDateFrom = new DateTime(2025, 5, 15, 0, 0, 0, DateTimeKind.Utc),
+        });
+
+        var earliest = NetworkCredentialingStage.ResolveEarliestServiceDate(claim);
+
+        Assert.Equal(new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc), earliest);
+    }
+
+    [Fact]
+    public async Task DenyMembership_short_circuits_credentialing_check()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { Npi = Npi, IsActiveMember = false });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        // Credentialing only runs when membership Allows.
+        await _credentialing.DidNotReceive().GetStatusAsOfAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>(),
+            Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    private static ResolvedNetworkTier Tier(string? networkId, string name, int level) => new()
+    {
+        TierName = name,
+        TierLevel = level,
+        NetworkId = networkId,
+    };
+
+    private static AdapterClaim NewClaim() => new()
+    {
+        TenantId = TenantId,
+        Id = "claim-1",
+        ClaimNumber = "C-1",
+        ClaimVersionId = "v-1",
+        BillingProviderNPI = Npi,
+        ServiceDateFrom = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        BenefitPlanId = "plan-1",
+    };
+
+    private static ClaimAdjudicationContext NewContext(
+        IReadOnlyList<ResolvedNetworkTier> tiers) => NewContext(NewClaim(), tiers);
+
+    private static ClaimAdjudicationContext NewContext(
+        AdapterClaim claim,
+        IReadOnlyList<ResolvedNetworkTier> tiers) => new()
+    {
+        TenantId = TenantId,
+        ClaimVersionId = claim.ClaimVersionId,
+        Claim = claim,
+        ResolvedPlan = new ResolvedBenefitPlan
+        {
+            Id = "plan-1",
+            NetworkTiers = tiers,
+        },
+    };
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingCredentialingStatusClientTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingCredentialingStatusClientTests.cs
@@ -1,0 +1,92 @@
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+/// <summary>
+/// Capability 5.6 — caching behaviour for the credentialing-status
+/// client. Mirrors <see cref="CachingProviderMembershipClientTests"/>
+/// shape; the longer 1-hour TTL is the only intentional asymmetry.
+/// </summary>
+public class CachingCredentialingStatusClientTests
+{
+    private readonly ICredentialingStatusClient _inner = Substitute.For<ICredentialingStatusClient>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    private const string TenantId = "tenant-1";
+    private const string ProviderId = "p-001";
+    private static readonly DateTime AsOf = new(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task CacheHit_does_not_call_inner_a_second_time()
+    {
+        var sut = new CachingCredentialingStatusClient(_inner, _cache);
+        var snap = new CredentialingStatusSnapshot
+        {
+            ProviderId = ProviderId, AsOfDate = AsOf, Status = "Approved",
+        };
+        _inner.GetStatusAsOfAsync(TenantId, ProviderId, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(snap);
+
+        var first = await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf);
+        var second = await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf);
+
+        Assert.Same(snap, first);
+        Assert.Same(snap, second);
+        await _inner.Received(1)
+            .GetStatusAsOfAsync(TenantId, ProviderId, AsOf, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NullResult_is_not_cached()
+    {
+        var sut = new CachingCredentialingStatusClient(_inner, _cache);
+        _inner.GetStatusAsOfAsync(TenantId, ProviderId, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns((CredentialingStatusSnapshot?)null,
+                     new CredentialingStatusSnapshot { ProviderId = ProviderId, AsOfDate = AsOf, Status = "Approved" });
+
+        var first = await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf);
+        var second = await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf);
+
+        Assert.Null(first);
+        Assert.NotNull(second);
+        await _inner.Received(2)
+            .GetStatusAsOfAsync(TenantId, ProviderId, AsOf, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ForceRefresh_bypasses_cache()
+    {
+        var sut = new CachingCredentialingStatusClient(_inner, _cache);
+        var cachedSnap = new CredentialingStatusSnapshot { ProviderId = ProviderId, AsOfDate = AsOf, Status = "Approved" };
+        var liveSnap = new CredentialingStatusSnapshot { ProviderId = ProviderId, AsOfDate = AsOf, Status = "Suspended" };
+
+        _inner.GetStatusAsOfAsync(TenantId, ProviderId, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(cachedSnap);
+        _inner.GetStatusAsOfAsync(TenantId, ProviderId, AsOf, true, Arg.Any<CancellationToken>())
+            .Returns(liveSnap);
+
+        await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf);
+        var forced = await sut.GetStatusAsOfAsync(TenantId, ProviderId, AsOf, forceRefresh: true);
+
+        Assert.Equal("Suspended", forced!.Status);
+    }
+
+    [Fact]
+    public async Task DifferentTenants_do_not_share_cache_entries()
+    {
+        var sut = new CachingCredentialingStatusClient(_inner, _cache);
+        _inner.GetStatusAsOfAsync("tenant-A", ProviderId, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, AsOfDate = AsOf, Status = "Approved" });
+        _inner.GetStatusAsOfAsync("tenant-B", ProviderId, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot { ProviderId = ProviderId, AsOfDate = AsOf, Status = "Suspended" });
+
+        var a = await sut.GetStatusAsOfAsync("tenant-A", ProviderId, AsOf);
+        var b = await sut.GetStatusAsOfAsync("tenant-B", ProviderId, AsOf);
+
+        Assert.Equal("Approved", a!.Status);
+        Assert.Equal("Suspended", b!.Status);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingProviderMembershipClientTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingProviderMembershipClientTests.cs
@@ -1,0 +1,119 @@
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+/// <summary>
+/// Capability 5.6 — caching behaviour for the network-membership client.
+/// Mirrors <see cref="CachingBenefitPlanResolverTests"/> shape but
+/// extends to the asOf-day cache key and the
+/// <c>cached-or-live</c> vs <c>force-refresh</c> namespace separation.
+/// </summary>
+public class CachingProviderMembershipClientTests
+{
+    private readonly IProviderMembershipClient _inner = Substitute.For<IProviderMembershipClient>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    private const string TenantId = "tenant-1";
+    private const string NetworkId = "net-1";
+    private const string Npi = "1234567890";
+    private static readonly DateTime AsOf = new(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task CacheHit_does_not_call_inner_a_second_time()
+    {
+        var sut = new CachingProviderMembershipClient(_inner, _cache);
+        var membership = new NetworkMembership
+        {
+            NetworkId = NetworkId, Npi = Npi, IsActiveMember = true, AsOfDate = AsOf,
+        };
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(membership);
+
+        var first = await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+        var second = await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+
+        Assert.Same(membership, first);
+        Assert.Same(membership, second);
+        await _inner.Received(1)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NullResult_is_not_cached()
+    {
+        var sut = new CachingProviderMembershipClient(_inner, _cache);
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns((NetworkMembership?)null,
+                     new NetworkMembership { NetworkId = NetworkId, Npi = Npi, AsOfDate = AsOf });
+
+        var first = await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+        var second = await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+
+        Assert.Null(first);
+        Assert.NotNull(second);
+        await _inner.Received(2)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ForceRefresh_uses_separate_cache_key()
+    {
+        var sut = new CachingProviderMembershipClient(_inner, _cache);
+        var cached = new NetworkMembership { NetworkId = NetworkId, Npi = Npi, IsActiveMember = true, AsOfDate = AsOf };
+        var live = new NetworkMembership { NetworkId = NetworkId, Npi = Npi, IsActiveMember = false, AsOfDate = AsOf };
+
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(cached);
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, true, Arg.Any<CancellationToken>())
+            .Returns(live);
+
+        // Prime the cached path.
+        await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+
+        // Force-refresh hits inner with forceRefresh=true, bypassing the
+        // cached-or-live entry.
+        var forced = await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, forceRefresh: true);
+
+        Assert.NotSame(cached, forced);
+        Assert.False(forced!.IsActiveMember);
+    }
+
+    [Fact]
+    public async Task DifferentDays_do_not_share_cache_entries()
+    {
+        var sut = new CachingProviderMembershipClient(_inner, _cache);
+        var d1 = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var d2 = new DateTime(2025, 5, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, d1, false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { NetworkId = NetworkId, Npi = Npi, AsOfDate = d1 });
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, d2, false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { NetworkId = NetworkId, Npi = Npi, AsOfDate = d2 });
+
+        await sut.GetMembershipAsync(TenantId, NetworkId, Npi, d1);
+        await sut.GetMembershipAsync(TenantId, NetworkId, Npi, d2);
+
+        // Each day-bucketed key triggered a fetch.
+        await _inner.Received(1)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, d1, false, Arg.Any<CancellationToken>());
+        await _inner.Received(1)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, d2, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TtlZero_disables_cache()
+    {
+        var sut = new CachingProviderMembershipClient(_inner, _cache, TimeSpan.Zero);
+        _inner.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership { NetworkId = NetworkId, Npi = Npi, AsOfDate = AsOf });
+
+        await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+        await sut.GetMembershipAsync(TenantId, NetworkId, Npi, AsOf);
+
+        await _inner.Received(2)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, AsOf, false, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerStatusAsOfTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/CredentialingControllerStatusAsOfTests.cs
@@ -1,0 +1,131 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.6 — endpoint-shape coverage for
+/// <c>GET /api/v1/providers/{id}/credentialing/status-as-of</c>.
+/// </summary>
+public class CredentialingControllerStatusAsOfTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryCredentialingEventRepository _eventRepository = new();
+    private readonly FakeCredentialingEventPublisher _publisher;
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly CredentialingService _service;
+    private readonly CredentialingController _controller;
+
+    public CredentialingControllerStatusAsOfTests()
+    {
+        _publisher = new FakeCredentialingEventPublisher(_eventRepository);
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        SeedActiveProvider();
+        _service = new CredentialingService(
+            _eventRepository, _publisher, _providerRepository,
+            new CredentialingProjector(),
+            NullLogger<CredentialingService>.Instance);
+        _controller = new CredentialingController(_service, NullLogger<CredentialingController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    [Fact]
+    public async Task Returns_400_when_asOfDate_missing()
+    {
+        var result = await _controller.GetStatusAsOf(ProviderId, asOfDate: null, CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Returns_200_with_unknown_status_for_provider_with_no_chain()
+    {
+        var result = await _controller.GetStatusAsOf(
+            "never-credentialed",
+            asOfDate: DateTime.UtcNow,
+            CancellationToken.None);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var body = ok!.Value as CredentialingStatusResponse;
+        body.Should().NotBeNull();
+        body!.Status.Should().Be("Unknown");
+        body.ProviderId.Should().Be("never-credentialed");
+    }
+
+    [Fact]
+    public async Task Different_asOf_dates_against_same_chain_return_different_status()
+    {
+        var submittedAt = DateTimeOffset.UtcNow.AddYears(-2);
+        var decidedAt = submittedAt.AddDays(30);
+        var dueDate = decidedAt.AddYears(1);
+
+        await _service.SubmitApplicationAsync(
+            TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual", SubmittedAt = submittedAt },
+            "actor", null);
+        await _service.RecordDecisionAsync(
+            TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.MedicalDirector,
+                DecisionAuthorityId = "md-1",
+                DecidedAt = decidedAt,
+                CredentialingDate = decidedAt.UtcDateTime,
+                RecredentialingDueDate = dueDate.UtcDateTime,
+            },
+            "actor", null);
+
+        var earlyResult = await _controller.GetStatusAsOf(
+            ProviderId, asOfDate: decidedAt.UtcDateTime.AddDays(7), CancellationToken.None);
+        var lateResult = await _controller.GetStatusAsOf(
+            ProviderId, asOfDate: dueDate.UtcDateTime.AddYears(1), CancellationToken.None);
+
+        var early = (earlyResult.Result as OkObjectResult)!.Value as CredentialingStatusResponse;
+        var late = (lateResult.Result as OkObjectResult)!.Value as CredentialingStatusResponse;
+
+        early!.Status.Should().Be("Approved");
+        late!.Status.Should().Be("Expired");
+    }
+
+    [Fact]
+    public async Task Echoes_asOfDate_in_response()
+    {
+        var asOf = new DateTime(2025, 1, 15, 12, 30, 0, DateTimeKind.Utc);
+        var result = await _controller.GetStatusAsOf(ProviderId, asOf, CancellationToken.None);
+        var ok = result.Result as OkObjectResult;
+        var body = ok!.Value as CredentialingStatusResponse;
+
+        body.Should().NotBeNull();
+        body!.AsOfDate.Should().Be(asOf);
+    }
+
+    private void SeedActiveProvider()
+    {
+        _providerRepository.CreateAsync(new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            VersionId = ProviderId + "-v1",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Adams",
+            Status = ProviderStatus.Active,
+        }).GetAwaiter().GetResult();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/NetworksControllerMembershipTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/NetworksControllerMembershipTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using ProviderService.Adapters;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.6 — endpoint-shape coverage for
+/// <c>GET /api/v1/networks/{id}/members/{npi}</c>. Drives the controller
+/// layer with substituted services (the membership data path is covered
+/// in <c>NetworkRosterServiceMembershipTests</c>); these tests verify
+/// status codes, body shape, and tenant-scope guard semantics.
+/// </summary>
+public class NetworksControllerMembershipTests
+{
+    private const string TenantId = "tenant-a";
+    private const string NetworkId = "net-aetna-ppo-fl-2025";
+    private const string Npi = "1234567890";
+
+    private readonly IOrganizationService _orgService = Substitute.For<IOrganizationService>();
+    private readonly INetworkRosterService _rosterService = Substitute.For<INetworkRosterService>();
+    private readonly NetworksController _controller;
+
+    public NetworksControllerMembershipTests()
+    {
+        var adapterFactory = new OrganizationAdapterFactory(
+            Array.Empty<IOrganizationAdapter>(),
+            new ProviderTenantConfigCache(
+                Substitute.For<IHttpClientFactory>(),
+                Substitute.For<IConfiguration>(),
+                NullLogger<ProviderTenantConfigCache>.Instance),
+            NullLogger<OrganizationAdapterFactory>.Instance);
+
+        _controller = new NetworksController(
+            _orgService, adapterFactory, _rosterService,
+            NullLogger<NetworksController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    [Fact]
+    public async Task GetMember_returns_200_with_active_membership_when_in_window()
+    {
+        _orgService.GetByIdAsync(NetworkId).Returns(new Organization { OrganizationId = NetworkId });
+        _rosterService.GetMembershipAsync(TenantId, NetworkId, Npi, Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembershipResponse
+            {
+                NetworkId = NetworkId,
+                Npi = Npi,
+                ProviderId = "p-001",
+                IsActiveMember = true,
+                AsOfDate = DateTime.UtcNow,
+                ParticipationStatus = "active",
+            });
+
+        var result = await _controller.GetMember(NetworkId, Npi, asOf: null, CancellationToken.None);
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var body = ok!.Value as NetworkMembershipResponse;
+        body!.IsActiveMember.Should().BeTrue();
+        body.ProviderId.Should().Be("p-001");
+    }
+
+    [Fact]
+    public async Task GetMember_returns_200_with_inactive_when_outside_window()
+    {
+        _orgService.GetByIdAsync(NetworkId).Returns(new Organization { OrganizationId = NetworkId });
+        _rosterService.GetMembershipAsync(TenantId, NetworkId, Npi, Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembershipResponse
+            {
+                NetworkId = NetworkId,
+                Npi = Npi,
+                ProviderId = "p-001",
+                IsActiveMember = false,
+                AsOfDate = DateTime.UtcNow,
+                ParticipationStatus = "terminated",
+            });
+
+        var result = await _controller.GetMember(NetworkId, Npi, asOf: null, CancellationToken.None);
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var body = ok!.Value as NetworkMembershipResponse;
+        body!.IsActiveMember.Should().BeFalse();
+        body.ParticipationStatus.Should().Be("terminated");
+    }
+
+    [Fact]
+    public async Task GetMember_returns_404_when_network_not_in_tenant()
+    {
+        _orgService.GetByIdAsync(NetworkId).Returns((Organization?)null);
+
+        var result = await _controller.GetMember(NetworkId, Npi, asOf: null, CancellationToken.None);
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMember_returns_404_when_npi_has_no_participation_in_network()
+    {
+        _orgService.GetByIdAsync(NetworkId).Returns(new Organization { OrganizationId = NetworkId });
+        _rosterService.GetMembershipAsync(TenantId, NetworkId, Npi, Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns((NetworkMembershipResponse?)null);
+
+        var result = await _controller.GetMember(NetworkId, Npi, asOf: null, CancellationToken.None);
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMember_returns_400_when_npi_blank()
+    {
+        var result = await _controller.GetMember(NetworkId, "  ", asOf: null, CancellationToken.None);
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetMember_passes_caller_supplied_asOf_to_service()
+    {
+        var asOf = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        _orgService.GetByIdAsync(NetworkId).Returns(new Organization { OrganizationId = NetworkId });
+        _rosterService.GetMembershipAsync(TenantId, NetworkId, Npi, asOf, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembershipResponse
+            {
+                NetworkId = NetworkId, Npi = Npi, ProviderId = "p-001",
+                IsActiveMember = true, AsOfDate = asOf, ParticipationStatus = "active",
+            });
+
+        await _controller.GetMember(NetworkId, Npi, asOf, CancellationToken.None);
+
+        await _rosterService.Received(1)
+            .GetMembershipAsync(TenantId, NetworkId, Npi, asOf, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceAsOfDateTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/CredentialingServiceAsOfDateTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Models;
+using ProviderService.Models.CredentialingPayloads;
+using ProviderService.Services;
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Capability 5.6 — verifies <see cref="CredentialingService.GetStatusAsOfAsync"/>
+/// produces different projections for the same provider against
+/// different historical dates. The projector already supports arbitrary
+/// <c>asOf</c>; the new method is a 4-line sibling exposing that
+/// capability through the cross-service surface.
+/// </summary>
+public class CredentialingServiceAsOfDateTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryCredentialingEventRepository _eventRepository = new();
+    private readonly FakeCredentialingEventPublisher _publisher;
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly CredentialingService _service;
+
+    public CredentialingServiceAsOfDateTests()
+    {
+        _publisher = new FakeCredentialingEventPublisher(_eventRepository);
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        SeedActiveProvider();
+        _service = new CredentialingService(
+            _eventRepository, _publisher, _providerRepository,
+            new CredentialingProjector(),
+            NullLogger<CredentialingService>.Instance);
+    }
+
+    [Fact]
+    public async Task AsOf_before_application_returns_Unknown()
+    {
+        var submittedAt = DateTimeOffset.UtcNow.AddMonths(-1);
+        await _service.SubmitApplicationAsync(
+            TenantId, ProviderId,
+            new SubmitApplicationRequest
+            {
+                ApplicationSource = "Manual",
+                SubmittedAt = submittedAt,
+            },
+            actorId: "actor", correlationId: null);
+
+        var result = await _service.GetStatusAsOfAsync(
+            TenantId, ProviderId, submittedAt.AddMonths(-1));
+
+        // The chain has events that occurred AFTER our asOf; the
+        // projector replays the entire chain — the asOf date drives
+        // status mapping (e.g. expired vs approved), not which events
+        // are visible. So we should still see the application opened.
+        // What matters most for the cross-service consumer is that
+        // GetStatusAsOf is honoring the asOf parameter. We assert by
+        // contrasting two different asOf dates against the same chain
+        // below.
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AsOf_inside_credentialing_window_returns_Approved()
+    {
+        var submittedAt = DateTimeOffset.UtcNow.AddYears(-1);
+        var decidedAt = submittedAt.AddDays(30);
+        var credentialingDate = decidedAt.UtcDateTime;
+        var dueDate = credentialingDate.AddYears(3);
+
+        await _service.SubmitApplicationAsync(
+            TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual", SubmittedAt = submittedAt },
+            "actor", null);
+        await _service.RecordDecisionAsync(
+            TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.CredentialingCommittee,
+                DecisionAuthorityId = "committee-1",
+                CommitteeMembers = new[] { "m1", "m2" },
+                DecisionMinuteReference = "min-1",
+                DecidedAt = decidedAt,
+                CredentialingDate = credentialingDate,
+                RecredentialingDueDate = dueDate,
+            },
+            "actor", null);
+
+        var inWindow = await _service.GetStatusAsOfAsync(
+            TenantId, ProviderId, decidedAt.AddDays(7));
+        inWindow.Status.Should().Be(CredentialingStatus.Approved);
+
+        // After the recredentialing-due date, the projector classifies as Expired.
+        var afterExpiry = await _service.GetStatusAsOfAsync(
+            TenantId, ProviderId, new DateTimeOffset(dueDate.AddDays(1), TimeSpan.Zero));
+        afterExpiry.Status.Should().Be(CredentialingStatus.Expired);
+    }
+
+    [Fact]
+    public async Task Different_asOf_dates_produce_different_status_for_same_chain()
+    {
+        var submittedAt = DateTimeOffset.UtcNow.AddYears(-2);
+        var decidedAt = submittedAt.AddDays(30);
+        var credentialingDate = decidedAt.UtcDateTime;
+        var dueDate = credentialingDate.AddYears(1);
+
+        await _service.SubmitApplicationAsync(
+            TenantId, ProviderId,
+            new SubmitApplicationRequest { ApplicationSource = "Manual", SubmittedAt = submittedAt },
+            "actor", null);
+        await _service.RecordDecisionAsync(
+            TenantId, ProviderId,
+            new RecordDecisionRequest
+            {
+                Decision = CredentialingDecision.Approved,
+                DecisionAuthorityType = DecisionAuthorityType.MedicalDirector,
+                DecisionAuthorityId = "md-1",
+                DecidedAt = decidedAt,
+                CredentialingDate = credentialingDate,
+                RecredentialingDueDate = dueDate,
+            },
+            "actor", null);
+
+        var early = await _service.GetStatusAsOfAsync(
+            TenantId, ProviderId, decidedAt.AddDays(7));
+        var late = await _service.GetStatusAsOfAsync(
+            TenantId, ProviderId, new DateTimeOffset(dueDate.AddYears(1), TimeSpan.Zero));
+
+        // Same chain, different asOf — different status. This is the
+        // test that proves the cross-service consumer's time-travel
+        // behavior works through the new method.
+        early.Status.Should().NotBe(late.Status);
+        early.Status.Should().Be(CredentialingStatus.Approved);
+        late.Status.Should().Be(CredentialingStatus.Expired);
+    }
+
+    private void SeedActiveProvider()
+    {
+        var p = new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            VersionId = ProviderId + "-v1",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Adams",
+            Status = ProviderStatus.Active,
+        };
+        _providerRepository.CreateAsync(p).GetAwaiter().GetResult();
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceMembershipTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceMembershipTests.cs
@@ -1,0 +1,164 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Services;
+
+/// <summary>
+/// Capability 5.6 — single-membership lookup behaviour for
+/// <see cref="NetworkRosterService.GetMembershipAsync"/>. Drives the
+/// in-memory provider repo so the tests cover effective-window matching
+/// without the storage backends.
+/// </summary>
+public class NetworkRosterServiceMembershipTests
+{
+    private const string TenantA = "tenant-a";
+    private const string Network1 = "net-aetna-ppo-fl-2025";
+    private const string Network2 = "net-bcbs-hmo-fl-2025";
+    private const string Npi = "1234567890";
+
+    [Fact]
+    public async Task Returns_active_when_asOf_within_effective_window()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        await SeedProviderAsync(
+            repo, "p1", Network1,
+            effective: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: null);
+
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = await svc.GetMembershipAsync(TenantA, Network1, Npi, asOf);
+
+        result.Should().NotBeNull();
+        result!.IsActiveMember.Should().BeTrue();
+        result.ProviderId.Should().Be("p1");
+        result.NetworkId.Should().Be(Network1);
+        result.ParticipationStatus.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task Returns_terminated_for_asOf_after_termination()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        await SeedProviderAsync(
+            repo, "p1", Network1,
+            effective: new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: new DateTime(2024, 12, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = await svc.GetMembershipAsync(TenantA, Network1, Npi, asOf);
+
+        result.Should().NotBeNull();
+        result!.IsActiveMember.Should().BeFalse();
+        result.ParticipationStatus.Should().Be("terminated");
+    }
+
+    [Fact]
+    public async Task Returns_future_for_asOf_before_effective_date()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        await SeedProviderAsync(
+            repo, "p1", Network1,
+            effective: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: null);
+
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var result = await svc.GetMembershipAsync(TenantA, Network1, Npi, asOf);
+
+        result.Should().NotBeNull();
+        result!.IsActiveMember.Should().BeFalse();
+        result.ParticipationStatus.Should().Be("future");
+    }
+
+    [Fact]
+    public async Task Returns_null_when_npi_absent_from_tenant()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+
+        var result = await svc.GetMembershipAsync(TenantA, Network1, "9999999999", DateTime.UtcNow);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Returns_null_when_provider_has_no_participation_in_requested_network()
+    {
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        await SeedProviderAsync(
+            repo, "p1", Network2,
+            effective: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: null);
+
+        var result = await svc.GetMembershipAsync(TenantA, Network1, Npi, DateTime.UtcNow);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Honors_termination_boundary_exactly_at_asOf()
+    {
+        // Window is [Effective, Termination) — termination day is the
+        // first day of inactivity. Document the boundary semantics so a
+        // future change is detected by a failing test rather than
+        // cross-service drift.
+        var repo = new InMemoryProviderRepository { TenantId = TenantA };
+        var svc = NewService(repo);
+        var termination = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        await SeedProviderAsync(
+            repo, "p1", Network1,
+            effective: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            termination: termination);
+
+        var atTermination = await svc.GetMembershipAsync(TenantA, Network1, Npi, termination);
+        atTermination!.IsActiveMember.Should().BeFalse();
+
+        var dayBefore = await svc.GetMembershipAsync(TenantA, Network1, Npi, termination.AddDays(-1));
+        dayBefore!.IsActiveMember.Should().BeTrue();
+    }
+
+    private static INetworkRosterService NewService(InMemoryProviderRepository repo)
+        => new NetworkRosterService(repo, NullLogger<NetworkRosterService>.Instance);
+
+    private static async Task SeedProviderAsync(
+        InMemoryProviderRepository repo,
+        string providerId,
+        string networkId,
+        DateTime effective,
+        DateTime? termination)
+    {
+        var p = new Provider
+        {
+            Id = providerId,
+            ProviderId = providerId,
+            VersionId = providerId + "-v1",
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            TenantId = TenantA,
+            NPI = Npi,
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Adams",
+            PrimarySpecialty = "207R00000X",
+            TaxonomyCode = "207R00000X",
+            Status = ProviderStatus.Active,
+            AcceptingNewPatients = true,
+        };
+        p.NetworkParticipations.Add(new NetworkParticipation
+        {
+            NetworkId = networkId,
+            LineOfBusiness = LineOfBusiness.Commercial,
+            NetworkTier = "Tier1",
+            EffectiveDate = effective,
+            TerminationDate = termination,
+            AcceptingNewPatients = true,
+        });
+        await repo.CreateAsync(p);
+    }
+}


### PR DESCRIPTION
## Summary

Replaces `NetworkCredentialingStubStage` (Claims 5.5) with the real cross-service enforcement that consults provider-service for both network membership AND credentialing status at adjudication time. Both checks anchor on the claim's earliest service date — the deferred ChatGPT-flagged enforcement work that finally exercises the as-of-date capability of Provider 5.6's `CredentialingProjector` and the cross-service membership-lookup contract that BP 5.5's `IOrganizationLookupClient` explicitly deferred.

## provider-service additions

- `GET /api/v1/networks/{id}/members/{npi}` — single-membership lookup. Body-shaped status (200 with `IsActiveMember=false` for inactive vs 404 only when no participation row exists at all) so the consumer-side cache key stays stable across active/inactive boundaries.
- `GET /api/v1/providers/{id}/credentialing/status-as-of` — sibling action on the existing `CredentialingController`, which is already provider-rooted.
- `INetworkRosterService.GetMembershipAsync` — extends the existing embedded-list shape (`Provider.NetworkParticipations`); no new repository required.
- `CredentialingService.GetStatusAsOfAsync` — 4-line sibling of `GetCurrentStatusAsync`. The projector already accepts `asOf` as documented in Provider 5.6.

## claims-service additions

- `IProviderMembershipClient` + `ICredentialingStatusClient` with caching decorators (5-minute / 1-hour TTL respectively) mirroring BP 5.10's `HttpProviderIntegrityGate` shape — `IMemoryCache`, namespaced cache keys (`cached-or-live` vs `force`), day-bucketed `asOf`.
- `NetworkCredentialingStage` walks plan tiers in priority order; first-active-match wins; matched tier records on context for follow-up `BenefitCalculationStage` cost-share tiering. Replaces the stub directly in DI; preserves `Order=200`, `Name="NetworkCredentialing"` so the per-tenant `EnabledStages` config keeps working unchanged.
- `TenantEnforcementPolicyOptions` — `FailClosed` / `FailOpen` / `SoftValidation` modes per check, bound from `Adjudication:Enforcement:*`. Service-wide in Phase 1; per-tenant override deferred to Phase 2 alongside `AdjudicationPipelineOptions`.
- `ResolvedBenefitPlan` extended with `IReadOnlyList<ResolvedNetworkTier>` (interface unchanged); `HttpBenefitPlanResolver` populates from the wire shape.
- `UpstreamClientNames` constants extracted for 5.7 / 5.10 / 5.11 HTTP consumers to come.
- 3 new fields on `ClaimAdjudicationContext` (membership snapshot, credentialing snapshot, matched tier) plus an `EnforcementOutcomes` accumulator.

## Architecture

`docs/architecture/network-credentialing-enforcement.md` — cross-references `claim-adjudication-pipeline.md`, `credentialing-workflow.md`, `network-tier-organization-reference.md`, `integrity-score-consumption.md`. Documents the time-anchor semantics (earliest service date across header + lines), tier-walk algorithm, fail-mode policy matrix, caching shape, and recovery posture.

## Tests

- **provider-service**: `NetworkRosterServiceMembershipTests` (effective-window matching, 404 boundary), `CredentialingServiceAsOfDateTests` (different `asOf` against same chain produces different status), `NetworksControllerMembershipTests` (status codes), `CredentialingControllerStatusAsOfTests` (400/200/echoed `asOfDate`).
- **claims-service**: `CachingProviderMembershipClientTests` and `CachingCredentialingStatusClientTests` (hit/miss/force-refresh/day-key/null-not-cached/TTL=0), `NetworkCredentialingStageTests` (every mode × outcome combination, tier-skip, time anchor), `AdjudicationWithEnforcementEndToEndTests` (real stage in pipeline, OON denial, pre-credentialing service-date denial, FailOpen pend, SoftValidation pass).

## Test plan

- [ ] `dotnet build` of `provider-service.csproj` and `claims-service.csproj` succeeds (no SDK in the dev sandbox; CI validates)
- [ ] All existing tests pass (provider-service AND claims-service test projects)
- [ ] New provider-service endpoint tests: `GET /networks/{id}/members/{npi}` 200/200-inactive/404/400 paths
- [ ] New provider-service endpoint tests: `GET /providers/{id}/credentialing/status-as-of` 400/200 paths and time-travel projection
- [ ] New claims-service caching client tests: hit/miss/force-refresh/day-key separation
- [ ] New claims-service stage tests: every (NetworkMode × outcome) and (CredentialingMode × outcome) combination
- [ ] New end-to-end pipeline test exercises the real stage against substituted upstream clients
- [ ] Existing 5.5 `ClaimAdjudicationOrchestratorTests` continue to pass with stage replacement

## Out of scope

- **Rendering provider NPI enforcement** — Decision 9 limits 5.6 to billing-NPI checks
- **Per-tenant policy override** — deferred to Phase 2 alongside the same surface for `AdjudicationPipelineOptions`
- **Network-tier cost-share routing** — `BenefitCalculationStage` still hard-codes `NetworkTier.InNetwork`; 5.6 populates `context.MatchedNetworkTier` so the follow-up PR can wire it through
- **OON credentialing enforcement** — out-of-network providers' credentialing isn't checked in Phase 1


---
_Generated by [Claude Code](https://claude.ai/code/session_01TioDKyB4WCEULUiA7mnSMM)_