### PR TITLE
Claims 5.12a — Adjustment Workflow chain + re-adjudication

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -154,11 +154,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      # Install the gitleaks OSS CLI directly rather than the
+      # gitleaks/gitleaks-action wrapper. The CLI is MIT-licensed; the
+      # Action wrapper started enforcing a paid GITLEAKS_LICENSE check
+      # (with a fail-closed posture when its account-type lookup HTTP
+      # call times out). The CLI runs the same scan with no license
+      # gate, no behavior change for legitimate findings.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /tmp gitleaks
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: gitleaks detect --redact --verbose --no-banner --exit-code 1 --source .
 
   security-summary:
     name: Security Summary

--- a/docs/architecture/claim-adjustment-workflow.md
+++ b/docs/architecture/claim-adjustment-workflow.md
@@ -1,0 +1,239 @@
+# Claim Adjustment Workflow (Capability 5.12a)
+
+## What this capability ships
+
+5.12a ships the **operator-initiated adjustment workflow** that
+exercises the 5.1a versioning infrastructure for the first time
+in production. An authorized operator submits a corrected claim
+that re-runs the full 6-stage adjudication pipeline; the
+predecessor version is superseded and prepared for reversal; the
+new version is created as a fresh row on the same
+`ClaimVersionId` chain with `PredecessorVersionId` set.
+
+5.12a is the **first half** of the 5.12 capability, split per the
+Plan-First ratification. 5.12b ships the payment-service
+`ReversalRunService` that batches the predecessor accumulator
+reversal (via the BP engine) + 835 reversal envelope emission +
+the predecessor's final transition to `ClaimStatus.Voided`.
+
+## Surface
+
+### claims-service
+
+| Endpoint | Behavior |
+|---|---|
+| `POST /api/v1/claims/{predecessorClaimId}/adjustments` | Create new adjustment. Idempotent on `Idempotency-Key` header (same key + same body → 200; same key + different body → 409). |
+| `GET /api/v1/claims/{predecessorClaimId}/adjustments` | List adjustments scoped to a predecessor (Phase 1 returns 0 or 1 row). |
+| `GET /api/v1/adjustments?status=...` | Filtered list across the tenant. Consumed by 5.12b's `ReversalRunService` for batch creation. |
+| `GET /api/v1/adjustments/{id}` | Fetch a single adjustment by id. |
+
+### benefit-plan-service
+
+| Endpoint | Behavior |
+|---|---|
+| `POST /api/v1/adjudication/reverse-claim` | Idempotent reversal of a claim's accumulator impact via `IBenefitCalculationEngine.ReverseClaimAsync`. The engine path was already wired through `ChoAccumulatorService.ReverseAsync` with `IsReversed=true` journaling since BP 5.10; 5.12a only adds the HTTP wrapper. Returns `204 No Content` on success. |
+
+## Lifecycle (Decision 18 — ratified order)
+
+```
+       operator submits adjustment
+                 │
+                 ▼
+   ┌─────────────────────────────┐
+   │  AwaitingReadjudication     │  ← initial state on creation
+   │  - new version persisted    │
+   │  - predecessor superseded   │
+   │  - pipeline running async   │
+   └──────────────┬──────────────┘
+                  │ (5.12b — pipeline finalize callback,
+                  │  not shipped in 5.12a)
+                  ▼
+   ┌─────────────────────────────┐
+   │  PendingReversal            │  ← new version Adjudicated/Paid;
+   │  - predecessor accums still │     predecessor still has impact
+   │    booked                   │
+   │  - awaiting ReversalRun     │
+   └──────────────┬──────────────┘
+                  │ (5.12b — operator runs ReversalRun;
+                  │  BP engine reversal + predecessor void
+                  │  + reversal 835 emission)
+                  ▼
+   ┌─────────────────────────────┐
+   │  Active                     │  ← terminal happy-path
+   │  - accumulators unwound     │
+   │  - predecessor Voided       │
+   │  - reversal 835 emitted     │
+   └─────────────────────────────┘
+
+   Off-path: any step's unrecoverable failure → Failed
+             (FailureReason carries diagnostic)
+```
+
+**Why this order matters.** The original prompt specified
+`PendingReversal → AwaitingReadjudication → Active`, which is
+impossible: re-adjudication must run *before* the reversal can
+batch (the new version anchors what the reversal is replacing).
+Plan-First caught the inversion. The corrected order reflects
+the actual workflow: re-adjudication runs synchronously
+(via `IClaimSubmissionService.SubmitAsync`), the pipeline runs
+asynchronously via the existing Service Bus subscription, and
+reversal is the operator-batched terminal step.
+
+## Cross-service event surface
+
+5.12a emits **three new signals**, all keyed to the predecessor:
+
+| Signal | Transport | Consumer |
+|---|---|---|
+| `ClaimVersionSuperseded` | Mongo `ClaimVersionEvents` stream | Audit/lineage. 5.5 path. |
+| `ClaimVersionReversed` (NEW, value `7`) | Mongo `ClaimVersionEvents` stream | Audit/lineage; future FHIR `_history`. |
+| `ClaimVersionReversedMessage` (NEW) | Service Bus `claim-version-events` topic, MessageType=`ClaimVersionReversed` | 5.12b `ReversalRunService` reactive batch trigger. |
+
+The new version's submission emits the standard
+`ClaimVersionSubmitted` (Mongo + Service Bus) per 5.5; that's
+not a 5.12a-new signal — it's the existing dual-emit path being
+exercised on a versioned-row creation.
+
+## Decision 16 — accumulator-service drift acceptance
+
+Per the Plan-First Decision 16 ratification, accumulator
+reversal is routed through the **BP engine path** (BP service
+exposes the new HTTP endpoint; engine internals already journal
+`IsReversed=true` per claim with idempotency). The
+**accumulator-service `AccumulatorSnapshot` Kafka projection
+will briefly drift** after a reversal until its next refresh
+cycle.
+
+This drift is **acceptable** because:
+
+1. **Source of truth is the engine `AccumulatorDocument`** — the
+   member-facing accumulator state and the next adjudication
+   pipeline run both read through the BP engine, which sees
+   the reversed state immediately.
+2. **`AccumulatorSnapshot` is an internal read projection**
+   used for member-portal historical reads and operator audit
+   panes. A bounded drift window (≤ next snapshot rebuild) is
+   operationally acceptable for those consumers.
+3. **The accumulator-service Kafka consumer is non-reversal-aware**
+   today: dedupe is keyed by `(TenantId, ClaimId)` and never
+   reads `FinalStatus`, so emitting a "Reversed" event for the
+   predecessor would be silently dropped as duplicate. Routing
+   reversal through the engine path avoids the silent-drop
+   bug entirely.
+
+**Recovery path.** If member-portal reads surface stale
+accumulator amounts after a reversal:
+
+- Operators can trigger a snapshot rebuild for the affected
+  member by replaying recent finalize events (existing tooling).
+- Phase 2 will extend `accumulator-service.ClaimFinalizedConsumer`
+  with EventId-keyed dedup + signed deltas + a `Reverse` branch
+  on `ApplyClaimFinalizedAsync` (~150 LOC) so the snapshot
+  stream becomes reversal-native. Tracked as a deferred
+  follow-up; not gated on 5.12a or 5.12b.
+
+## AI examination on adjustment versions (Gap 6)
+
+The new version runs **fresh AI examination** — the
+predecessor's `Claim.AiExamination` snapshot is not carried
+over. The adjustment service zeroes
+`AdapterClaim.AiExamination`, `AdapterClaim.PendDetails`, and
+`AdapterClaim.AdjudicationResult` on the corrected payload
+before persistence so a stale predecessor signal cannot leak
+into the new version's pipeline run.
+
+The predecessor's `AiExamination` remains accessible via
+`PredecessorVersionId` chain navigation for audit
+reconstruction.
+
+## Why `ClaimFinalizationService.VoidAsync` extends rather than
+splits (Gap 1)
+
+`ClaimFinalizationService` already owns the
+Adjudicated → Paid transition with the unified
+version-event-emission + Kafka-emission posture. Extending it
+with a sibling `VoidAsync` keeps both lifecycle writes inside
+one service, sharing:
+
+- The repository projection-bypass write paths
+  (`MarkVoidedProjectionAsync` / `MarkSupersededProjectionAsync`
+  added in 5.12a)
+- The dual-emit `IClaimVersionEventPublisher` +
+  `IClaimEventPublisher` posture
+- The idempotency conventions (already-Voided is a no-op, same
+  shape as already-Paid)
+- The error-mapping enums (`ClaimVoidOutcome` mirrors
+  `ClaimFinalizationOutcome` shape)
+
+A sibling `IClaimVoidService` would have duplicated all of the
+above for one method.
+
+## Constraints (deferred to Phase 2)
+
+- **Adjustment chain depth > 1** (Decision 11). Phase 1 enforces
+  depth=1 via the `(TenantId, ClaimVersionId)` unique index on
+  `ClaimAdjustment` + an explicit `predecessor.PredecessorVersionId == null`
+  check in the service layer. Phase 2 widens the key with a
+  generation field.
+- **Programmatic / event-driven adjustment triggers** (Decision 1).
+  Phase 1 ships operator-initiated only; no
+  claims-examiner-service auto-recommendation, no inbound 837
+  corrected-claim parser.
+- **Auto-reverse mode** (Decision 2). Phase 1 ships manual-batched
+  reversal via 5.12b `ReversalRun`; no automatic reversal on
+  adjustment creation.
+- **Partial-edit semantics** (Decision 4). Phase 1 ships full
+  re-adjudication only — operator submits a full corrected
+  payload; the new version runs through all 6 pipeline stages.
+- **Reversal-only operations without re-adjudication.** Pure
+  voids (operator decides claim should be deleted, no
+  replacement) are captured by the existing
+  `ClaimVersionVoided` semantic but do not flow through 5.12b's
+  `ReversalRun` queue in Phase 1.
+- **`AccumulatorSnapshot` reversal-native consumer**
+  (Decision 16). See drift-acceptance section above.
+- **Predecessor void via `ReversalRun`** (Gap 1 follow-up).
+  5.12a wires `ClaimFinalizationService.VoidAsync`; 5.12b's
+  `ReversalRunService` invokes it as the terminal step of a
+  reversal batch.
+- **FHIR `_history` operation.** 5.12a's chain becomes the
+  foundation; the operation lands in a future capability.
+
+## Cross-references
+
+- [claim-versioning.md](claim-versioning.md) — 5.1a versioning
+  fields + Mongo event chain. 5.12a is the first production
+  consumer of `Claim.PredecessorVersionId`.
+- [claim-adjudication-pipeline.md](claim-adjudication-pipeline.md)
+  — 5.5 orchestrator + pipeline stages. Re-adjudication of an
+  adjustment version runs the same pipeline unchanged; the
+  PersistenceStage handles `PredecessorVersionId != null`
+  transparently.
+- [claim-remittance-generation.md](claim-remittance-generation.md)
+  — 5.10 PaymentRun + `ClaimFinalizationService`. 5.12a
+  extends `ClaimFinalizationService` with `VoidAsync`. The
+  5.12b `ReversalRun` is structurally separate from
+  PaymentRun (distinct controller, distinct repository,
+  distinct envelope type) but shares
+  `BatchEraGeneratorService` + `CarcRarcMappingService`
+  extensions.
+- [accumulator-service.md](accumulator-service.md) — see
+  Decision 16 drift-acceptance section above for how 5.12a
+  interacts with the `AccumulatorSnapshot` projection.
+
+## Code touchpoints
+
+| Surface | Path |
+|---|---|
+| `ClaimAdjustment` aggregate | `src/services/claims-service/Models/ClaimAdjustment.cs` |
+| `ClaimAdjustmentRequest` / list filter | `src/services/claims-service/Models/ClaimAdjustmentRequest.cs` |
+| Repository (Mongo + Cosmos noop) | `src/services/claims-service/Repositories/ClaimAdjustmentRepository.cs` |
+| Service | `src/services/claims-service/Services/ClaimAdjustmentService.cs` |
+| Controller | `src/services/claims-service/Controllers/ClaimAdjustmentsController.cs` |
+| `ClaimVersionReversed = 7` enum value | `src/services/claims-service/Models/ClaimVersionEvent.cs` |
+| `ClaimVersionReversedMessage` | `src/services/claims-service/Models/Messaging/ClaimVersionMessages.cs` |
+| `IClaimVersionEventPublisher.PublishVersionReversedAsync` | `src/services/claims-service/Services/ClaimVersionEventPublisher.cs` |
+| Supersession + void projection bypass | `src/services/claims-service/Repositories/ClaimRepository.cs` (+ Mongo sibling) |
+| `ClaimFinalizationService.VoidAsync` | `src/services/claims-service/Services/ClaimFinalizationService.cs` |
+| `HttpBenefitCalculationEngineClient.ReverseClaimAsync` (real wire) | `src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs` |
+| BP `POST /api/v1/adjudication/reverse-claim` | `src/services/benefit-plan-service/Controllers/AdjudicationController.cs` |

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -90,11 +90,24 @@ public class AdjudicationController : ControllerBase
     private string TenantId => HttpContext.GetTenantId()
         ?? throw new InvalidOperationException("Tenant context missing");
 
+    /// <summary>
+    /// Replace control characters (CR, LF, tab, etc.) with underscore so
+    /// caller-controlled string values cannot forge log lines or split a
+    /// single log entry into multiple. Mirrors
+    /// <c>RelationshipShim.SanitizeForLog</c> in member-service so CodeQL's
+    /// cs/log-forging rule recognizes it as a sanitizer (the prior
+    /// CR/LF-only Replace pattern was not picked up as a sanitizer).
+    /// </summary>
     private static string SanitizeForLog(string? value)
     {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var buffer = new System.Text.StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            buffer.Append(char.IsControl(ch) ? '_' : ch);
+        }
+        if (buffer.Length > 256) buffer.Length = 256;
+        return buffer.ToString();
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -602,6 +602,67 @@ public class AdjudicationController : ControllerBase
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    // POST /api/v1/adjudication/reverse-claim
+    //
+    // Capability 5.12a — exposes the existing
+    // IBenefitCalculationEngine.ReverseClaimAsync surface over HTTP.
+    // The engine method has been wired through
+    // ChoAccumulatorService.ReverseAsync with IsReversed=true journaling
+    // since BP 5.10; only the HTTP surface was missing. claims-service
+    // calls this endpoint via HttpBenefitCalculationEngineClient.
+    //
+    // Idempotent: the engine's ReverseAsync call is keyed on
+    // OriginalClaimId; a second call against the same claim is a no-op.
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Reverse the accumulator impact of a previously adjudicated claim
+    /// (capability 5.12). Idempotent on <c>OriginalClaimId</c>. Returns
+    /// 204 No Content on success.
+    /// </summary>
+    [HttpPost("reverse-claim")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ReverseClaim(
+        [FromBody] ReverseClaimRequest request,
+        CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { error = "Request body is required" });
+        }
+        if (string.IsNullOrWhiteSpace(request.MemberId))
+        {
+            return BadRequest(new { error = "MemberId is required" });
+        }
+        if (string.IsNullOrWhiteSpace(request.OriginalClaimId))
+        {
+            return BadRequest(new { error = "OriginalClaimId is required" });
+        }
+        if (request.BenefitPlanId == Guid.Empty)
+        {
+            return BadRequest(new { error = "BenefitPlanId is required" });
+        }
+
+        _logger.LogInformation(
+            "Reversing claim {OriginalClaimId} for member {MemberId}, plan {PlanId}, service date {ServiceDate}",
+            SanitizeForLog(request.OriginalClaimId),
+            SanitizeForLog(request.MemberId),
+            request.BenefitPlanId,
+            request.ServiceDate);
+
+        await _benefitEngine.ReverseClaimAsync(
+            request.MemberId,
+            request.SubscriberId ?? string.Empty,
+            request.BenefitPlanId,
+            request.ServiceDate,
+            request.OriginalClaimId,
+            ct);
+
+        return NoContent();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // POST /api/v1/adjudication/resolve-rates
     //
     // Standalone rate resolution (replaces Argo step 7).
@@ -1029,4 +1090,19 @@ public record AdjudicationLineResponse
     public string? ServiceTypeCode { get; init; }
     public bool IsCovered { get; init; }
     public List<AdjustmentReason> AdjustmentReasons { get; init; } = [];
+}
+
+/// <summary>
+/// Wire payload for <c>POST /api/v1/adjudication/reverse-claim</c>
+/// (capability 5.12). Mirrors the
+/// <see cref="IBenefitCalculationEngine.ReverseClaimAsync"/> signature
+/// directly so the controller is a thin adapter over the engine call.
+/// </summary>
+public class ReverseClaimRequest
+{
+    public string MemberId { get; set; } = string.Empty;
+    public string? SubscriberId { get; set; }
+    public Guid BenefitPlanId { get; set; }
+    public DateOnly ServiceDate { get; set; }
+    public string OriginalClaimId { get; set; } = string.Empty;
 }

--- a/src/services/claims-service/Controllers/ClaimAdjustmentsController.cs
+++ b/src/services/claims-service/Controllers/ClaimAdjustmentsController.cs
@@ -25,16 +25,13 @@ public class ClaimAdjustmentsController : ControllerBase
 {
     private readonly IClaimAdjustmentService _adjustmentService;
     private readonly IClaimAdjustmentRepository _adjustmentRepository;
-    private readonly ILogger<ClaimAdjustmentsController> _logger;
 
     public ClaimAdjustmentsController(
         IClaimAdjustmentService adjustmentService,
-        IClaimAdjustmentRepository adjustmentRepository,
-        ILogger<ClaimAdjustmentsController> logger)
+        IClaimAdjustmentRepository adjustmentRepository)
     {
         _adjustmentService = adjustmentService;
         _adjustmentRepository = adjustmentRepository;
-        _logger = logger;
     }
 
     /// <summary>
@@ -67,7 +64,11 @@ public class ClaimAdjustmentsController : ControllerBase
         }
         if (!ModelState.IsValid)
         {
-            return BadRequest(new { error = "Validation failed", details = ModelState });
+            // ValidationProblem produces a sanitized ProblemDetails body
+            // that surfaces only validation errors — never the inbound
+            // payload. Echoing ModelState directly can leak PHI from the
+            // submitted claim into the 400 response.
+            return ValidationProblem(ModelState);
         }
 
         var tenantId = GetTenantId();
@@ -106,11 +107,21 @@ public class ClaimAdjustmentsController : ControllerBase
                 error = result.Message,
                 predecessorClaimId = result.Predecessor!.Id,
             }),
-            ClaimAdjustmentOutcome.SubmissionFailed => BadRequest(new
+            ClaimAdjustmentOutcome.SubmissionFailed => result.SubmissionFailureKind switch
             {
-                error = result.Message,
-                errors = result.SubmissionErrors.Select(e => new { field = e.Field, code = e.Code, message = e.Message }),
-            }),
+                ClaimSubmissionFailureKind.NotImplemented => StatusCode(
+                    StatusCodes.Status501NotImplemented,
+                    new
+                    {
+                        error = result.Message,
+                        errors = result.SubmissionErrors.Select(e => new { field = e.Field, code = e.Code, message = e.Message }),
+                    }),
+                _ => BadRequest(new
+                {
+                    error = result.Message,
+                    errors = result.SubmissionErrors.Select(e => new { field = e.Field, code = e.Code, message = e.Message }),
+                }),
+            },
             _ => StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = "Unhandled adjustment outcome" }),
         };
@@ -159,7 +170,11 @@ public class ClaimAdjustmentsController : ControllerBase
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(new { error = "Validation failed", details = ModelState });
+            // ValidationProblem produces a sanitized ProblemDetails body
+            // that surfaces only validation errors — never the inbound
+            // payload. Echoing ModelState directly can leak PHI from the
+            // submitted claim into the 400 response.
+            return ValidationProblem(ModelState);
         }
 
         var tenantId = GetTenantId();

--- a/src/services/claims-service/Controllers/ClaimAdjustmentsController.cs
+++ b/src/services/claims-service/Controllers/ClaimAdjustmentsController.cs
@@ -1,0 +1,274 @@
+using System.Diagnostics;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClaimsService.Controllers;
+
+/// <summary>
+/// Operator-initiated adjustment workflow surface (capability 5.12a).
+/// Three endpoints:
+/// <list type="bullet">
+///   <item><c>POST /api/v1/claims/{predecessorClaimId}/adjustments</c> — create adjustment (Decision 6 idempotent on <c>Idempotency-Key</c> header).</item>
+///   <item><c>GET /api/v1/claims/{predecessorClaimId}/adjustments</c> — list adjustments scoped to a predecessor (Phase 1 returns 0 or 1 per Decision 11).</item>
+///   <item><c>GET /api/v1/adjustments/{id}</c> — fetch a single adjustment by id.</item>
+/// </list>
+///
+/// <para>Gap 3 list filter (<c>GET /api/v1/adjustments?status=...</c>) is
+/// served by the same controller via the
+/// <see cref="ListAdjustments"/> action.</para>
+/// </summary>
+[ApiController]
+[Produces("application/json")]
+public class ClaimAdjustmentsController : ControllerBase
+{
+    private readonly IClaimAdjustmentService _adjustmentService;
+    private readonly IClaimAdjustmentRepository _adjustmentRepository;
+    private readonly ILogger<ClaimAdjustmentsController> _logger;
+
+    public ClaimAdjustmentsController(
+        IClaimAdjustmentService adjustmentService,
+        IClaimAdjustmentRepository adjustmentRepository,
+        ILogger<ClaimAdjustmentsController> logger)
+    {
+        _adjustmentService = adjustmentService;
+        _adjustmentRepository = adjustmentRepository;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Create a new adjustment for the predecessor claim. Per Decision 6
+    /// the <c>Idempotency-Key</c> header is required — same key + same
+    /// body returns the existing adjustment with 200; same key +
+    /// different body returns 409 Conflict.
+    /// </summary>
+    [HttpPost("api/v1/claims/{predecessorClaimId}/adjustments")]
+    [ProducesResponseType(typeof(ClaimAdjustmentResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ClaimAdjustmentResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
+    public async Task<IActionResult> CreateAdjustment(
+        [FromRoute] string predecessorClaimId,
+        [FromBody] ClaimAdjustmentRequest request,
+        [FromHeader(Name = "Idempotency-Key")] string? idempotencyKey,
+        CancellationToken ct = default)
+    {
+        if (request == null)
+        {
+            return BadRequest(new { error = "Request body is required" });
+        }
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return BadRequest(new { error = "Idempotency-Key header is required" });
+        }
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new { error = "Validation failed", details = ModelState });
+        }
+
+        var tenantId = GetTenantId();
+        var actorId = ResolveActorId();
+        var correlationId = ResolveCorrelationId();
+
+        var result = await _adjustmentService.CreateAdjustmentAsync(
+            predecessorClaimId, request, idempotencyKey, tenantId, actorId, correlationId, ct);
+
+        return result.Outcome switch
+        {
+            ClaimAdjustmentOutcome.Created => CreatedAtAction(
+                nameof(GetAdjustment),
+                new { id = result.Adjustment!.Id },
+                ClaimAdjustmentResponse.FromDomain(result.Adjustment!)),
+            ClaimAdjustmentOutcome.AlreadyExists => Ok(ClaimAdjustmentResponse.FromDomain(result.Adjustment!)),
+            ClaimAdjustmentOutcome.IdempotencyConflict => Conflict(new
+            {
+                error = result.Message,
+                existingAdjustmentId = result.Adjustment!.Id,
+            }),
+            ClaimAdjustmentOutcome.ConflictingAdjustment => Conflict(new
+            {
+                error = result.Message,
+                existingAdjustmentId = result.Adjustment!.Id,
+                existingStatus = result.Adjustment.Status.ToString(),
+            }),
+            ClaimAdjustmentOutcome.PredecessorNotFound => NotFound(new { error = result.Message }),
+            ClaimAdjustmentOutcome.InvalidSourceState => UnprocessableEntity(new
+            {
+                error = result.Message,
+                predecessorStatus = result.Predecessor!.Status.ToString(),
+            }),
+            ClaimAdjustmentOutcome.DepthLimitExceeded => UnprocessableEntity(new
+            {
+                error = result.Message,
+                predecessorClaimId = result.Predecessor!.Id,
+            }),
+            ClaimAdjustmentOutcome.SubmissionFailed => BadRequest(new
+            {
+                error = result.Message,
+                errors = result.SubmissionErrors.Select(e => new { field = e.Field, code = e.Code, message = e.Message }),
+            }),
+            _ => StatusCode(StatusCodes.Status500InternalServerError,
+                new { error = "Unhandled adjustment outcome" }),
+        };
+    }
+
+    /// <summary>
+    /// List adjustments scoped to a single predecessor claim. Phase 1
+    /// returns at most one row per Decision 11 (depth=1 invariant).
+    /// </summary>
+    [HttpGet("api/v1/claims/{predecessorClaimId}/adjustments")]
+    [ProducesResponseType(typeof(ClaimAdjustmentListResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdjustmentsForClaim(
+        [FromRoute] string predecessorClaimId,
+        CancellationToken ct = default)
+    {
+        var tenantId = GetTenantId();
+        var (page, total) = await _adjustmentRepository.ListAsync(
+            tenantId,
+            new ClaimAdjustmentListFilter
+            {
+                PredecessorClaimId = predecessorClaimId,
+                Page = 1,
+                PageSize = 50,
+            },
+            ct);
+
+        return Ok(new ClaimAdjustmentListResponse
+        {
+            Total = total,
+            Page = 1,
+            PageSize = 50,
+            Items = page.Select(ClaimAdjustmentResponse.FromDomain).ToList(),
+        });
+    }
+
+    /// <summary>
+    /// Filtered list across all adjustments for the tenant (Gap 3
+    /// ratification). Consumed by the future 5.12b ReversalRunService
+    /// for batch creation.
+    /// </summary>
+    [HttpGet("api/v1/adjustments")]
+    [ProducesResponseType(typeof(ClaimAdjustmentListResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListAdjustments(
+        [FromQuery] ClaimAdjustmentListFilter filter,
+        CancellationToken ct = default)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(new { error = "Validation failed", details = ModelState });
+        }
+
+        var tenantId = GetTenantId();
+        var (page, total) = await _adjustmentRepository.ListAsync(tenantId, filter, ct);
+
+        return Ok(new ClaimAdjustmentListResponse
+        {
+            Total = total,
+            Page = filter.Page,
+            PageSize = filter.PageSize,
+            Items = page.Select(ClaimAdjustmentResponse.FromDomain).ToList(),
+        });
+    }
+
+    [HttpGet("api/v1/adjustments/{id}")]
+    [ProducesResponseType(typeof(ClaimAdjustmentResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetAdjustment(
+        [FromRoute] string id,
+        CancellationToken ct = default)
+    {
+        var tenantId = GetTenantId();
+        var adjustment = await _adjustmentRepository.GetByIdAsync(tenantId, id, ct);
+        if (adjustment == null)
+        {
+            return NotFound(new { error = $"Adjustment {id} not found" });
+        }
+        return Ok(ClaimAdjustmentResponse.FromDomain(adjustment));
+    }
+
+    private string GetTenantId()
+    {
+        var tenantId = HttpContext?.Items["TenantId"]?.ToString();
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            throw new InvalidOperationException(
+                "TenantId not found in HttpContext. Ensure tenant middleware is configured.");
+        }
+        return tenantId;
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return "system";
+    }
+
+    private string? ResolveCorrelationId()
+    {
+        if (HttpContext.Request.Headers.TryGetValue("X-Correlation-Id", out var header) &&
+            !string.IsNullOrEmpty(header.ToString()))
+        {
+            return header.ToString();
+        }
+        return Activity.Current?.Id;
+    }
+}
+
+/// <summary>
+/// Wire-shape DTO for the adjustment surface. Mirrors
+/// <see cref="ClaimAdjustment"/> minus the IdempotencyKey/RequestHash
+/// internal-state fields.
+/// </summary>
+public class ClaimAdjustmentResponse
+{
+    public string Id { get; set; } = string.Empty;
+    public string ClaimVersionId { get; set; } = string.Empty;
+    public string PredecessorClaimId { get; set; } = string.Empty;
+    public string PredecessorVersionId { get; set; } = string.Empty;
+    public string NewClaimId { get; set; } = string.Empty;
+    public string AdjustmentReason { get; set; } = string.Empty;
+    public string? Notes { get; set; }
+    public ClaimAdjustmentStatus Status { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ReadjudicationCompletedAt { get; set; }
+    public DateTime? ReversalCompletedAt { get; set; }
+    public string? ReversalRunId { get; set; }
+    public string? FailureReason { get; set; }
+
+    public static ClaimAdjustmentResponse FromDomain(ClaimAdjustment src) => new()
+    {
+        Id = src.Id,
+        ClaimVersionId = src.ClaimVersionId,
+        PredecessorClaimId = src.PredecessorClaimId,
+        PredecessorVersionId = src.PredecessorVersionId,
+        NewClaimId = src.NewClaimId,
+        AdjustmentReason = src.AdjustmentReason,
+        Notes = src.Notes,
+        Status = src.Status,
+        CreatedBy = src.CreatedBy,
+        CreatedAt = src.CreatedAt,
+        ReadjudicationCompletedAt = src.ReadjudicationCompletedAt,
+        ReversalCompletedAt = src.ReversalCompletedAt,
+        ReversalRunId = src.ReversalRunId,
+        FailureReason = src.FailureReason,
+    };
+}
+
+public class ClaimAdjustmentListResponse
+{
+    public int Total { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public List<ClaimAdjustmentResponse> Items { get; set; } = new();
+}

--- a/src/services/claims-service/HostedServices/ClaimAdjustmentIndexInitializer.cs
+++ b/src/services/claims-service/HostedServices/ClaimAdjustmentIndexInitializer.cs
@@ -1,0 +1,75 @@
+using ClaimsService.Models;
+using MongoDB.Driver;
+
+namespace ClaimsService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the <c>ClaimAdjustments</c>
+/// collection (capability 5.12a) once at startup. Mirrors
+/// <see cref="ClaimVersionEventIndexInitializer"/> — a hosted service so
+/// repository construction stays side-effect free regardless of
+/// scoped-resolution frequency.
+///
+/// The indexes are what enforce 5.12a's correctness invariants:
+/// the depth=1 invariant (one in-flight ClaimAdjustment per chain)
+/// AND the Idempotency-Key uniqueness per tenant. Without these
+/// unique indexes the early-placeholder-insert pattern in
+/// <c>ClaimAdjustmentService.CreateAdjustmentAsync</c> cannot serialize
+/// concurrent requests on the same chain or with the same idempotency
+/// key.
+///
+/// Idempotent: Mongo silently no-ops an index that already exists with
+/// the same spec.
+/// </summary>
+public sealed class ClaimAdjustmentIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly string _collectionName;
+    private readonly ILogger<ClaimAdjustmentIndexInitializer> _logger;
+
+    public ClaimAdjustmentIndexInitializer(
+        IMongoDatabase db,
+        IConfiguration configuration,
+        ILogger<ClaimAdjustmentIndexInitializer> logger)
+    {
+        _db = db;
+        _collectionName = configuration["CosmosDb:ClaimAdjustmentsContainer"] ?? "ClaimAdjustments";
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<ClaimAdjustment>(_collectionName);
+        var keys = Builders<ClaimAdjustment>.IndexKeys;
+
+        var indexes = new[]
+        {
+            // Depth=1 invariant per Decision 11: at most one adjustment per chain per tenant.
+            new CreateIndexModel<ClaimAdjustment>(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.ClaimVersionId),
+                new CreateIndexOptions { Unique = true, Name = "tenant_chain_unique" }),
+
+            // Idempotency-Key uniqueness per Decision 6.
+            new CreateIndexModel<ClaimAdjustment>(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.IdempotencyKey),
+                new CreateIndexOptions { Unique = true, Name = "tenant_idempotency_unique" }),
+
+            // Status + createdAt for the 5.12b ReversalRun batch query.
+            new CreateIndexModel<ClaimAdjustment>(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.Status).Descending(x => x.CreatedAt)),
+
+            // Predecessor lookup for the chain-scoped GET endpoint.
+            new CreateIndexModel<ClaimAdjustment>(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.PredecessorClaimId)),
+        };
+
+        collection.Indexes.CreateMany(indexes, cancellationToken);
+
+        _logger.LogInformation(
+            "ClaimAdjustment indexes ensured on collection '{Collection}'.",
+            _collectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/claims-service/Models/ClaimAdjustment.cs
+++ b/src/services/claims-service/Models/ClaimAdjustment.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel.DataAnnotations;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace ClaimsService.Models;
+
+/// <summary>
+/// Operator-initiated adjustment aggregate (capability 5.12). One row per
+/// adjustment workflow tracks the cross-version transition: a predecessor
+/// version is superseded, a new version is created with
+/// <see cref="Claim.PredecessorVersionId"/> set to the predecessor, the
+/// new version re-runs the full 6-stage adjudication pipeline (5.4–5.9),
+/// and (in 5.12b) a payment-service ReversalRun batches the predecessor
+/// payment reversal + 835 reversal envelope.
+///
+/// <para>
+/// Lifecycle (ratified Decision 18 — corrects original prompt's inverted
+/// order): <c>AwaitingReadjudication</c> → <c>PendingReversal</c> →
+/// <c>Active</c>. <c>Failed</c> is a terminal off-path state if any step
+/// hits an unrecoverable error. The new version's pipeline runs
+/// asynchronously via the existing Service Bus
+/// <c>claim-version-events</c> subscription, so there is a real interval
+/// between supersession and pipeline completion that operators see as
+/// <c>AwaitingReadjudication</c>; once the new version reaches
+/// Adjudicated/Paid the adjustment transitions to <c>PendingReversal</c>
+/// (waiting for ReversalRun to actually unwind the predecessor's
+/// accumulator impact).
+/// </para>
+///
+/// <para>
+/// Per Decision 14 we deliberately do NOT add an
+/// <c>AdjustmentPending</c> value to <see cref="ClaimStatus"/>; per-claim
+/// status stays unchanged so the legacy 22 controller endpoints + the
+/// accumulator-service Kafka contract are not perturbed. Adjustment
+/// state is captured solely on this aggregate.
+/// </para>
+///
+/// <para>
+/// Per Decision 11 the adjustment chain depth is capped at 1 in Phase 1.
+/// The uniqueness key is <c>(TenantId, ClaimVersionId)</c> — at most one
+/// in-flight adjustment per claim chain. Adjustment-of-adjustment is
+/// deferred to Phase 2 (which will widen the key to include a generation
+/// field).
+/// </para>
+/// </summary>
+[BsonIgnoreExtraElements]
+public class ClaimAdjustment
+{
+    [Required]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    [StringLength(100)]
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Chain key — same value as the predecessor's
+    /// <see cref="Claim.ClaimVersionId"/> AND the new version's
+    /// <c>ClaimVersionId</c>. Both versions of the claim share this
+    /// identifier; the per-row <see cref="Claim.Id"/>s differ. The unique
+    /// index <c>(TenantId, ClaimVersionId)</c> enforces depth=1.
+    /// </summary>
+    [Required]
+    [StringLength(100)]
+    public string ClaimVersionId { get; set; } = string.Empty;
+
+    /// <summary>The predecessor claim row id (the version being adjusted).</summary>
+    [Required]
+    [StringLength(64)]
+    public string PredecessorClaimId { get; set; } = string.Empty;
+
+    /// <summary>The predecessor's per-version VersionId (same as PredecessorClaimId today; preserved separately for forward-compat).</summary>
+    [Required]
+    [StringLength(64)]
+    public string PredecessorVersionId { get; set; } = string.Empty;
+
+    /// <summary>The new (replacement) claim row id created by the adjustment.</summary>
+    [Required]
+    [StringLength(64)]
+    public string NewClaimId { get; set; } = string.Empty;
+
+    /// <summary>Operator-supplied reason for the adjustment (audit context).</summary>
+    [Required]
+    [StringLength(500)]
+    public string AdjustmentReason { get; set; } = string.Empty;
+
+    /// <summary>Optional free-text notes from the operator.</summary>
+    [StringLength(2000)]
+    public string? Notes { get; set; }
+
+    [Required]
+    public ClaimAdjustmentStatus Status { get; set; } = ClaimAdjustmentStatus.AwaitingReadjudication;
+
+    /// <summary>
+    /// Operator-supplied idempotency key (per Decision 6). Same key + same
+    /// body returns the existing adjustment with 200; same key + different
+    /// body returns 409 Conflict; different key creates a new adjustment.
+    /// Stored to support replay deduplication across pod restarts.
+    /// </summary>
+    [Required]
+    [StringLength(128)]
+    public string IdempotencyKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Stable hash of the request body that produced this adjustment.
+    /// Used together with <see cref="IdempotencyKey"/> to detect
+    /// "same key, different body" 409s.
+    /// </summary>
+    [Required]
+    [StringLength(128)]
+    public string RequestHash { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(200)]
+    public string CreatedBy { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Set when the new version's pipeline reaches a terminal Adjudicated/Paid/Denied
+    /// state and the adjustment transitions to <see cref="ClaimAdjustmentStatus.PendingReversal"/>.
+    /// </summary>
+    public DateTime? ReadjudicationCompletedAt { get; set; }
+
+    /// <summary>Set when the 5.12b ReversalRun completes; transitions to <see cref="ClaimAdjustmentStatus.Active"/>.</summary>
+    public DateTime? ReversalCompletedAt { get; set; }
+
+    /// <summary>FK to payment-service ReversalRun (populated in 5.12b execution path).</summary>
+    [StringLength(64)]
+    public string? ReversalRunId { get; set; }
+
+    /// <summary>Free-text failure reason captured when the adjustment lands in <see cref="ClaimAdjustmentStatus.Failed"/>.</summary>
+    [StringLength(2000)]
+    public string? FailureReason { get; set; }
+}
+
+/// <summary>
+/// Lifecycle states for <see cref="ClaimAdjustment"/>. Order ratified by
+/// Decision 18 — re-adjudication runs first (asynchronously via the existing
+/// Service Bus pipeline), then ReversalRun (5.12b) batches the predecessor
+/// reversal. The original prompt's inverted order
+/// (PendingReversal → AwaitingReadjudication) was caught at plan phase.
+/// </summary>
+public enum ClaimAdjustmentStatus
+{
+    /// <summary>
+    /// Predecessor superseded; new version persisted with
+    /// <see cref="Claim.PredecessorVersionId"/> set; pipeline running
+    /// asynchronously. Most adjustments leave this state within seconds.
+    /// </summary>
+    AwaitingReadjudication = 1,
+
+    /// <summary>
+    /// New version reached terminal pipeline state; predecessor still has
+    /// active accumulator impact + provider payment; awaiting 5.12b
+    /// ReversalRun to unwind. Operator-batched via
+    /// <c>POST /api/v1/reversal-runs</c>.
+    /// </summary>
+    PendingReversal = 2,
+
+    /// <summary>
+    /// ReversalRun completed; predecessor accumulators reversed via BP
+    /// engine (Decision 16); predecessor claim Voided; reversal 835 emitted.
+    /// Terminal happy-path state.
+    /// </summary>
+    Active = 3,
+
+    /// <summary>
+    /// Off-path terminal state when any step (supersession write, pipeline
+    /// run, reversal call, void transition) hit an unrecoverable error.
+    /// Manual operator triage required; <see cref="ClaimAdjustment.FailureReason"/>
+    /// carries the diagnostic.
+    /// </summary>
+    Failed = 4,
+}

--- a/src/services/claims-service/Models/ClaimAdjustmentRequest.cs
+++ b/src/services/claims-service/Models/ClaimAdjustmentRequest.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClaimsService.Models;
+
+/// <summary>
+/// Operator-supplied request body for
+/// <c>POST /api/v1/claims/{predecessorClaimId}/adjustments</c>
+/// (capability 5.12). Carries the corrected claim payload (same
+/// vendor-neutral <see cref="AdapterClaim"/> shape as the canonical 5.3
+/// submission surface) plus operator metadata for the audit chain.
+///
+/// <para>
+/// The <c>Idempotency-Key</c> request header (per Decision 6) is the
+/// dedup signal — same key + same body returns the existing adjustment
+/// with 200; same key + different body returns 409. The body itself does
+/// not carry the key — it lives in the header so callers can retry the
+/// same payload deterministically.
+/// </para>
+/// </summary>
+public class ClaimAdjustmentRequest
+{
+    /// <summary>Operator-supplied reason. Required for the audit trail.</summary>
+    [Required]
+    [StringLength(500, MinimumLength = 1)]
+    public string AdjustmentReason { get; set; } = string.Empty;
+
+    /// <summary>Optional free-text notes; capped at 2000 characters.</summary>
+    [StringLength(2000)]
+    public string? Notes { get; set; }
+
+    /// <summary>
+    /// Corrected claim payload — same shape as 5.3 submission. The
+    /// adjustment service overrides identity-bearing fields
+    /// (<c>Id</c>, <c>ClaimVersionId</c>, <c>VersionNumber</c>,
+    /// <c>VersionState</c>, <c>PredecessorVersionId</c>,
+    /// <c>SubmittedDate</c>) so callers can supply the corrected
+    /// content of the prior version without worrying about chain
+    /// bookkeeping. Per Decision 6 this is full-payload (not
+    /// partial-edit); per Decision 4 the new version runs the full
+    /// 6-stage pipeline unchanged.
+    /// </summary>
+    [Required]
+    public AdapterClaim CorrectedClaim { get; set; } = new();
+}
+
+/// <summary>
+/// Query string filters for
+/// <c>GET /api/v1/adjustments?status=...&amp;...</c> (Gap 3 ratification).
+/// Mirrors PaymentRunCriteria filter shape so 5.12b's ReversalRunService
+/// has a single query path for batch creation.
+/// </summary>
+public class ClaimAdjustmentListFilter
+{
+    public ClaimAdjustmentStatus? Status { get; set; }
+    public string? PredecessorClaimId { get; set; }
+    public string? CreatedBy { get; set; }
+    public DateTime? CreatedFrom { get; set; }
+    public DateTime? CreatedTo { get; set; }
+
+    [Range(1, int.MaxValue)]
+    public int Page { get; set; } = 1;
+
+    [Range(1, 200)]
+    public int PageSize { get; set; } = 50;
+}

--- a/src/services/claims-service/Models/ClaimVersionEvent.cs
+++ b/src/services/claims-service/Models/ClaimVersionEvent.cs
@@ -12,13 +12,14 @@ namespace ClaimsService.Models;
 /// <see cref="EventId"/> for idempotency, monotonic per-aggregate
 /// <see cref="Version"/>, partition key <c>{TenantId}:{ClaimVersionId}</c>.
 ///
-/// Six event types cover the lifecycle transitions of a claim version:
+/// Seven event types cover the lifecycle transitions of a claim version:
 /// <see cref="ClaimVersionEventType.ClaimVersionSubmitted"/>,
 /// <see cref="ClaimVersionEventType.ClaimVersionAdjudicated"/>,
 /// <see cref="ClaimVersionEventType.ClaimVersionPaid"/>,
 /// <see cref="ClaimVersionEventType.ClaimVersionDenied"/>,
 /// <see cref="ClaimVersionEventType.ClaimVersionSuperseded"/>,
-/// <see cref="ClaimVersionEventType.ClaimVersionVoided"/>.
+/// <see cref="ClaimVersionEventType.ClaimVersionVoided"/>,
+/// <see cref="ClaimVersionEventType.ClaimVersionReversed"/>.
 ///
 /// Notes:
 /// - <c>Pended</c> is not a version transition; pended claims remain in
@@ -102,5 +103,12 @@ public enum ClaimVersionEventType
     ClaimVersionDenied = 4,
     /// <summary>This version was superseded by an adjustment version. Mirrors <c>ProviderVersionSuperseded</c>.</summary>
     ClaimVersionSuperseded = 5,
-    ClaimVersionVoided = 6
+    ClaimVersionVoided = 6,
+    /// <summary>
+    /// This version's accumulator impact (deductible/OOPM applied, payment to provider) was reversed
+    /// as part of a 5.12 adjustment workflow. Distinct from <see cref="ClaimVersionSuperseded"/>:
+    /// supersession marks the chain transition; <see cref="ClaimVersionReversed"/> signals downstream
+    /// consumers (audit/lineage, future FHIR _history) that the prior accumulator state must be unwound.
+    /// </summary>
+    ClaimVersionReversed = 7
 }

--- a/src/services/claims-service/Models/Messaging/ClaimVersionMessages.cs
+++ b/src/services/claims-service/Models/Messaging/ClaimVersionMessages.cs
@@ -32,6 +32,7 @@ internal static class ClaimVersionMessageTypes
 {
     public const string Submitted = "ClaimVersionSubmitted";
     public const string Adjudicated = "ClaimVersionAdjudicated";
+    public const string Reversed = "ClaimVersionReversed";
 }
 
 /// <summary>
@@ -86,4 +87,45 @@ public class ClaimVersionAdjudicatedMessage
     public string? CorrelationId { get; init; }
 
     public DateTimeOffset AdjudicatedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Emitted by <see cref="Services.IClaimAdjustmentService"/> after the
+/// predecessor version has been superseded as part of a 5.12 adjustment
+/// workflow. Distinct from <c>ClaimVersionSuperseded</c>: this message
+/// signals downstream consumers (audit/lineage, future FHIR _history,
+/// payment-service ReversalRun queue) that the predecessor's accumulator
+/// impact and provider payment must be reversed.
+///
+/// <para>
+/// The new version's pipeline run emits a separate
+/// <see cref="ClaimVersionSubmittedMessage"/> via the standard submission
+/// path; this message is purely the supersession + reversal-intent signal.
+/// </para>
+/// </summary>
+public class ClaimVersionReversedMessage
+{
+    public required string TenantId { get; init; }
+
+    /// <summary>The predecessor claim row id (the version being reversed).</summary>
+    public required string ClaimId { get; init; }
+
+    /// <summary>Chain key — stable across all versions of the claim.</summary>
+    public required string ClaimVersionId { get; init; }
+
+    /// <summary>The predecessor's per-version VersionId.</summary>
+    public required string PredecessorVersionId { get; init; }
+
+    /// <summary>The new (replacement) claim row id created by the adjustment.</summary>
+    public required string SupersessorClaimId { get; init; }
+
+    /// <summary>Operator-supplied reason for the adjustment (audit context).</summary>
+    public required string AdjustmentReason { get; init; }
+
+    /// <summary>Caller identity propagated through the audit chain.</summary>
+    public string? ActorId { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public DateTimeOffset OccurredAt { get; init; } = DateTimeOffset.UtcNow;
 }

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -45,9 +45,11 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
 
     // 5.12a — ClaimAdjustment aggregate persistence (Mongo per Gap 4
     // ratification). Indexes (chain-uniqueness for depth=1, idempotency,
-    // status+createdAt for ReversalRun batch queries) created on first
-    // resolution.
+    // status+createdAt for ReversalRun batch queries) are created once
+    // at startup by ClaimAdjustmentIndexInitializer so scoped repository
+    // resolution stays side-effect free.
     builder.Services.AddScoped<IClaimAdjustmentRepository, ClaimAdjustmentRepositoryMongo>();
+    builder.Services.AddHostedService<ClaimAdjustmentIndexInitializer>();
 }
 else
 {

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -42,6 +42,12 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     // MongoProviderVersionEventPublisher / MongoPlanVersionEventPublisher.
     builder.Services.AddScoped<IClaimVersionEventPublisher, MongoClaimVersionEventPublisher>();
     builder.Services.AddHostedService<ClaimVersionEventIndexInitializer>();
+
+    // 5.12a — ClaimAdjustment aggregate persistence (Mongo per Gap 4
+    // ratification). Indexes (chain-uniqueness for depth=1, idempotency,
+    // status+createdAt for ReversalRun batch queries) created on first
+    // resolution.
+    builder.Services.AddScoped<IClaimAdjustmentRepository, ClaimAdjustmentRepositoryMongo>();
 }
 else
 {
@@ -64,6 +70,12 @@ else
     // Noop publisher logs a warning so ops can spot the missing wiring
     // without breaking the lifecycle path.
     builder.Services.AddScoped<IClaimVersionEventPublisher, NoopClaimVersionEventPublisher>();
+
+    // 5.12a — Cosmos-only deployments throw on adjustment writes per
+    // Gap 4 ratification. Reads return null/empty; the noop is fail-loud
+    // on writes so the missing capability surfaces immediately rather
+    // than silently dropping audit data.
+    builder.Services.AddScoped<IClaimAdjustmentRepository, ClaimAdjustmentRepositoryCosmosNoop>();
 }
 
 // FHIR R4 ExplanationOfBenefit projector — hand-built JsonObject to avoid
@@ -82,6 +94,14 @@ builder.Services.AddScoped<IClaimAcknowledgmentService, ClaimAcknowledgmentServi
 // non-zero-payment remittances; zero-payment Denied transitions stay
 // on the legacy direct-write path until 5.12.
 builder.Services.AddScoped<IClaimFinalizationService, ClaimFinalizationService>();
+
+// 5.12a — Adjustment workflow service. Owns the supersession transition,
+// invokes IClaimSubmissionService for re-adjudication, emits
+// ClaimVersionSuperseded + ClaimVersionReversed events. Lifecycle ratified
+// by Decision 18: AwaitingReadjudication → PendingReversal → Active.
+// 5.12b's payment-service ReversalRunService consumes the resulting
+// PendingReversal rows.
+builder.Services.AddScoped<IClaimAdjustmentService, ClaimAdjustmentService>();
 
 // Inter-service HTTP clients
 builder.Services.AddHttpClient("ProviderService", client =>

--- a/src/services/claims-service/Repositories/ClaimAdjustmentRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimAdjustmentRepository.cs
@@ -1,0 +1,213 @@
+using ClaimsService.Models;
+using Microsoft.AspNetCore.Http;
+using MongoDB.Driver;
+
+namespace ClaimsService.Repositories;
+
+/// <summary>
+/// Persistence surface for the <see cref="ClaimAdjustment"/> aggregate
+/// (capability 5.12). Mongo-only with a Cosmos noop fallback per Gap 4
+/// ratification — adjustment rows are operational state best fit by
+/// Mongo's append/query semantics, not domain snapshots. The Cosmos noop
+/// throws on writes so deployments pinned to Cosmos surface the missing
+/// capability immediately rather than silently dropping audit data.
+///
+/// <para>
+/// Uniqueness key (Gap 5 ratification): <c>(TenantId, ClaimVersionId)</c>
+/// — at most one in-flight adjustment per claim chain. Naturally enforces
+/// Decision 11's depth=1 invariant in Phase 1; forward-compat with
+/// depth&gt;1 by widening the key with a generation field in Phase 2.
+/// </para>
+///
+/// <para>
+/// Idempotency on <see cref="ClaimAdjustment.IdempotencyKey"/> is enforced
+/// in the service layer (not the repository) via
+/// <see cref="GetByIdempotencyKeyAsync"/> — same key + same hash returns
+/// the existing row; same key + different hash returns 409.
+/// </para>
+/// </summary>
+public interface IClaimAdjustmentRepository
+{
+    /// <summary>Insert a new ClaimAdjustment row. Throws on uniqueness collision.</summary>
+    Task<ClaimAdjustment> CreateAsync(ClaimAdjustment adjustment, CancellationToken ct = default);
+
+    Task<ClaimAdjustment?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up by chain key — returns the in-flight (depth-1 invariant)
+    /// adjustment for the chain if any. Used by the service layer to enforce
+    /// Decision 11 (no concurrent adjustments per chain).
+    /// </summary>
+    Task<ClaimAdjustment?> GetByClaimVersionIdAsync(string tenantId, string claimVersionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Look up by operator-supplied idempotency key (Decision 6). Returns the
+    /// existing adjustment row if any; service layer compares
+    /// <see cref="ClaimAdjustment.RequestHash"/> to detect 409 cases.
+    /// </summary>
+    Task<ClaimAdjustment?> GetByIdempotencyKeyAsync(string tenantId, string idempotencyKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Filter + paginate. Filters not supplied are not applied. Returns
+    /// (page, totalCount). The 5.12b ReversalRunService consumes this via
+    /// the controller's HTTP surface to batch <c>PendingReversal</c> rows.
+    /// </summary>
+    Task<(IReadOnlyList<ClaimAdjustment> Page, int TotalCount)> ListAsync(
+        string tenantId, ClaimAdjustmentListFilter filter, CancellationToken ct = default);
+
+    /// <summary>
+    /// Mutates an existing adjustment row (e.g. status transitions, reversal-run linkage).
+    /// Throws when the row is missing. Does not enforce a state-machine guard at
+    /// the repository layer — the service layer owns the lifecycle ordering.
+    /// </summary>
+    Task<ClaimAdjustment> UpdateAsync(ClaimAdjustment adjustment, CancellationToken ct = default);
+}
+
+public sealed class ClaimAdjustmentRepositoryMongo : IClaimAdjustmentRepository
+{
+    private readonly IMongoCollection<ClaimAdjustment> _collection;
+    private readonly ILogger<ClaimAdjustmentRepositoryMongo> _logger;
+
+    public ClaimAdjustmentRepositoryMongo(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<ClaimAdjustmentRepositoryMongo> logger)
+    {
+        var collectionName = configuration["CosmosDb:ClaimAdjustmentsContainer"] ?? "ClaimAdjustments";
+        _collection = database.GetCollection<ClaimAdjustment>(collectionName);
+        _logger = logger;
+
+        var keys = Builders<ClaimAdjustment>.IndexKeys;
+        var indexes = new List<CreateIndexModel<ClaimAdjustment>>
+        {
+            // Depth=1 invariant: at most one adjustment per chain per tenant.
+            new(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.ClaimVersionId),
+                new CreateIndexOptions { Unique = true, Name = "tenant_chain_unique" }),
+            // Idempotency lookup.
+            new(
+                keys.Ascending(x => x.TenantId).Ascending(x => x.IdempotencyKey),
+                new CreateIndexOptions { Unique = true, Name = "tenant_idempotency_unique" }),
+            // List filter — status + createdAt for the ReversalRun batch query.
+            new(keys.Ascending(x => x.TenantId).Ascending(x => x.Status).Descending(x => x.CreatedAt)),
+            // Predecessor lookup for the chain-scoped GET endpoint.
+            new(keys.Ascending(x => x.TenantId).Ascending(x => x.PredecessorClaimId)),
+        };
+        _collection.Indexes.CreateMany(indexes);
+    }
+
+    public async Task<ClaimAdjustment> CreateAsync(ClaimAdjustment adjustment, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(adjustment);
+        if (string.IsNullOrEmpty(adjustment.Id))
+        {
+            adjustment.Id = Guid.NewGuid().ToString();
+        }
+        await _collection.InsertOneAsync(adjustment, cancellationToken: ct);
+        return adjustment;
+    }
+
+    public async Task<ClaimAdjustment?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        var b = Builders<ClaimAdjustment>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.Id, id));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<ClaimAdjustment?> GetByClaimVersionIdAsync(string tenantId, string claimVersionId, CancellationToken ct = default)
+    {
+        var b = Builders<ClaimAdjustment>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.ClaimVersionId, claimVersionId));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<ClaimAdjustment?> GetByIdempotencyKeyAsync(string tenantId, string idempotencyKey, CancellationToken ct = default)
+    {
+        var b = Builders<ClaimAdjustment>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.IdempotencyKey, idempotencyKey));
+        return await _collection.Find(filter).FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<(IReadOnlyList<ClaimAdjustment> Page, int TotalCount)> ListAsync(
+        string tenantId, ClaimAdjustmentListFilter filter, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        var b = Builders<ClaimAdjustment>.Filter;
+        var clauses = new List<FilterDefinition<ClaimAdjustment>> { b.Eq(x => x.TenantId, tenantId) };
+        if (filter.Status.HasValue) clauses.Add(b.Eq(x => x.Status, filter.Status.Value));
+        if (!string.IsNullOrEmpty(filter.PredecessorClaimId)) clauses.Add(b.Eq(x => x.PredecessorClaimId, filter.PredecessorClaimId));
+        if (!string.IsNullOrEmpty(filter.CreatedBy)) clauses.Add(b.Eq(x => x.CreatedBy, filter.CreatedBy));
+        if (filter.CreatedFrom.HasValue) clauses.Add(b.Gte(x => x.CreatedAt, filter.CreatedFrom.Value));
+        if (filter.CreatedTo.HasValue) clauses.Add(b.Lte(x => x.CreatedAt, filter.CreatedTo.Value));
+
+        var combined = b.And(clauses);
+        var total = (int)await _collection.CountDocumentsAsync(combined, cancellationToken: ct);
+        var page = await _collection.Find(combined)
+            .SortByDescending(x => x.CreatedAt)
+            .Skip((filter.Page - 1) * filter.PageSize)
+            .Limit(filter.PageSize)
+            .ToListAsync(ct);
+        return (page, total);
+    }
+
+    public async Task<ClaimAdjustment> UpdateAsync(ClaimAdjustment adjustment, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(adjustment);
+        var b = Builders<ClaimAdjustment>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, adjustment.TenantId), b.Eq(x => x.Id, adjustment.Id));
+        var result = await _collection.ReplaceOneAsync(filter, adjustment, cancellationToken: ct);
+        if (result.MatchedCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"ClaimAdjustment {adjustment.Id} for tenant {adjustment.TenantId} not found for update.");
+        }
+        return adjustment;
+    }
+}
+
+/// <summary>
+/// Cosmos-environment fallback. Per Gap 4 ratification, ClaimAdjustment
+/// rows are Mongo-only in Phase 1 — the Cosmos write path is not
+/// implemented. This impl throws on writes (so a Cosmos-only deployment
+/// fails loudly the moment an operator submits an adjustment, rather
+/// than silently dropping audit data) and returns null/empty on reads
+/// (consistent with the no-data-here contract).
+/// </summary>
+public sealed class ClaimAdjustmentRepositoryCosmosNoop : IClaimAdjustmentRepository
+{
+    private readonly ILogger<ClaimAdjustmentRepositoryCosmosNoop> _logger;
+
+    public ClaimAdjustmentRepositoryCosmosNoop(ILogger<ClaimAdjustmentRepositoryCosmosNoop> logger)
+        => _logger = logger;
+
+    public Task<ClaimAdjustment> CreateAsync(ClaimAdjustment adjustment, CancellationToken ct = default)
+    {
+        _logger.LogError(
+            "ClaimAdjustment persistence is not implemented for Cosmos environments. " +
+            "Configure MongoDb:ConnectionString to enable capability 5.12.");
+        throw new NotImplementedException(
+            "ClaimAdjustment persistence requires MongoDB. Cosmos persistence is deferred (Gap 4 ratification).");
+    }
+
+    public Task<ClaimAdjustment?> GetByIdAsync(string tenantId, string id, CancellationToken ct = default)
+        => Task.FromResult<ClaimAdjustment?>(null);
+
+    public Task<ClaimAdjustment?> GetByClaimVersionIdAsync(string tenantId, string claimVersionId, CancellationToken ct = default)
+        => Task.FromResult<ClaimAdjustment?>(null);
+
+    public Task<ClaimAdjustment?> GetByIdempotencyKeyAsync(string tenantId, string idempotencyKey, CancellationToken ct = default)
+        => Task.FromResult<ClaimAdjustment?>(null);
+
+    public Task<(IReadOnlyList<ClaimAdjustment> Page, int TotalCount)> ListAsync(
+        string tenantId, ClaimAdjustmentListFilter filter, CancellationToken ct = default)
+        => Task.FromResult<(IReadOnlyList<ClaimAdjustment>, int)>((Array.Empty<ClaimAdjustment>(), 0));
+
+    public Task<ClaimAdjustment> UpdateAsync(ClaimAdjustment adjustment, CancellationToken ct = default)
+    {
+        _logger.LogError(
+            "ClaimAdjustment update is not implemented for Cosmos environments. " +
+            "Configure MongoDb:ConnectionString to enable capability 5.12.");
+        throw new NotImplementedException(
+            "ClaimAdjustment persistence requires MongoDB. Cosmos persistence is deferred (Gap 4 ratification).");
+    }
+}

--- a/src/services/claims-service/Repositories/ClaimAdjustmentRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimAdjustmentRepository.cs
@@ -1,5 +1,4 @@
 using ClaimsService.Models;
-using Microsoft.AspNetCore.Http;
 using MongoDB.Driver;
 
 namespace ClaimsService.Repositories;
@@ -61,39 +60,29 @@ public interface IClaimAdjustmentRepository
     /// the repository layer — the service layer owns the lifecycle ordering.
     /// </summary>
     Task<ClaimAdjustment> UpdateAsync(ClaimAdjustment adjustment, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete an adjustment row. Used by the service layer to release the
+    /// chain-uniqueness lock when an early-stage failure leaves a placeholder
+    /// row blocking the chain (e.g. submission rejected, supersession write
+    /// failed before any version events fired). Returns true if a row was
+    /// removed; false if no row matched.
+    /// </summary>
+    Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default);
 }
 
 public sealed class ClaimAdjustmentRepositoryMongo : IClaimAdjustmentRepository
 {
     private readonly IMongoCollection<ClaimAdjustment> _collection;
-    private readonly ILogger<ClaimAdjustmentRepositoryMongo> _logger;
 
     public ClaimAdjustmentRepositoryMongo(
         IMongoDatabase database,
-        IConfiguration configuration,
-        ILogger<ClaimAdjustmentRepositoryMongo> logger)
+        IConfiguration configuration)
     {
         var collectionName = configuration["CosmosDb:ClaimAdjustmentsContainer"] ?? "ClaimAdjustments";
         _collection = database.GetCollection<ClaimAdjustment>(collectionName);
-        _logger = logger;
-
-        var keys = Builders<ClaimAdjustment>.IndexKeys;
-        var indexes = new List<CreateIndexModel<ClaimAdjustment>>
-        {
-            // Depth=1 invariant: at most one adjustment per chain per tenant.
-            new(
-                keys.Ascending(x => x.TenantId).Ascending(x => x.ClaimVersionId),
-                new CreateIndexOptions { Unique = true, Name = "tenant_chain_unique" }),
-            // Idempotency lookup.
-            new(
-                keys.Ascending(x => x.TenantId).Ascending(x => x.IdempotencyKey),
-                new CreateIndexOptions { Unique = true, Name = "tenant_idempotency_unique" }),
-            // List filter — status + createdAt for the ReversalRun batch query.
-            new(keys.Ascending(x => x.TenantId).Ascending(x => x.Status).Descending(x => x.CreatedAt)),
-            // Predecessor lookup for the chain-scoped GET endpoint.
-            new(keys.Ascending(x => x.TenantId).Ascending(x => x.PredecessorClaimId)),
-        };
-        _collection.Indexes.CreateMany(indexes);
+        // Index creation moved to ClaimAdjustmentIndexInitializer hosted
+        // service so scoped repository resolution stays side-effect free.
     }
 
     public async Task<ClaimAdjustment> CreateAsync(ClaimAdjustment adjustment, CancellationToken ct = default)
@@ -163,6 +152,14 @@ public sealed class ClaimAdjustmentRepositoryMongo : IClaimAdjustmentRepository
         }
         return adjustment;
     }
+
+    public async Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        var b = Builders<ClaimAdjustment>.Filter;
+        var filter = b.And(b.Eq(x => x.TenantId, tenantId), b.Eq(x => x.Id, id));
+        var result = await _collection.DeleteOneAsync(filter, ct);
+        return result.DeletedCount > 0;
+    }
 }
 
 /// <summary>
@@ -210,4 +207,7 @@ public sealed class ClaimAdjustmentRepositoryCosmosNoop : IClaimAdjustmentReposi
         throw new NotImplementedException(
             "ClaimAdjustment persistence requires MongoDB. Cosmos persistence is deferred (Gap 4 ratification).");
     }
+
+    public Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default)
+        => Task.FromResult(false);
 }

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -123,6 +123,55 @@ public interface IClaimRepository
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
         PendDetails? pendDetails = null);
+
+    /// <summary>
+    /// Supersession projection bypass for capability 5.12. Patches
+    /// <c>SupersededAt</c>, <c>SupersededByVersionId</c>, and
+    /// <c>VersionState=Adjusted</c> on a single claim row identified by
+    /// <paramref name="tenantId"/> + <paramref name="claimId"/> regardless
+    /// of its current terminal state. Required because the
+    /// <see cref="UpdateAsync"/> terminal-state guard would reject a
+    /// Paid → Adjusted transition (Paid is terminal).
+    ///
+    /// <para>
+    /// 6th instance of the projection-metadata bypass pattern (Provider
+    /// 5.4.5 integrity, Provider 5.6 credentialing, Provider 5.7+
+    /// panel-gating, BP 5.5 network tiers, Claims 5.5 adjudication
+    /// projection). The <c>Status</c> field is not touched here — the
+    /// predecessor stays Paid until the 5.12b ReversalRun explicitly
+    /// transitions it to Voided via <see cref="MarkVoidedProjectionAsync"/>.
+    /// </para>
+    ///
+    /// Returns true on success, false when no row matched the filter.
+    /// </summary>
+    Task<bool> MarkSupersededProjectionAsync(
+        string tenantId,
+        string claimId,
+        string supersessorVersionId,
+        DateTime supersededAt,
+        string? actorId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Void projection bypass for capability 5.12 — terminal transition
+    /// from Paid/Adjusted → Voided. Patches <c>Status=Voided</c>,
+    /// <c>VersionState=Voided</c>, and <c>LastUpdatedDate/By</c>.
+    /// Bypasses the <see cref="UpdateAsync"/> terminal-state guard (the
+    /// guard exists to force adjustments through the explicit-new-version
+    /// path; this method IS that explicit path's terminal write).
+    ///
+    /// Wired in 5.12a so <see cref="Services.IClaimFinalizationService.VoidAsync"/>
+    /// has a write path; actual invocation occurs in 5.12b's
+    /// <c>ReversalRunService</c>.
+    ///
+    /// Returns true on success, false when no row matched the filter.
+    /// </summary>
+    Task<bool> MarkVoidedProjectionAsync(
+        string tenantId,
+        string claimId,
+        DateTime voidedAt,
+        string? actorId,
+        CancellationToken ct = default);
 }
 
 public class ClaimRepository : IClaimRepository
@@ -916,6 +965,97 @@ public class ClaimRepository : IClaimRepository
             if (amount > 0) totals.Add(new AccumulatorTotalEntry { AccumulatorType = "Copay",       NetworkTier = tier, AccumulatedAmount = amount });
 
         return new AccumulatorTotalsResponse { Totals = totals };
+    }
+
+    public async Task<bool> MarkSupersededProjectionAsync(
+        string tenantId,
+        string claimId,
+        string supersessorVersionId,
+        DateTime supersededAt,
+        string? actorId,
+        CancellationToken ct = default)
+    {
+        // Pre-read for tenant isolation — Cosmos partition is claim.Id; we
+        // read by id then enforce tenant match before patching. Mirrors the
+        // tenant-isolation pattern in GetByIdAsync.
+        Claim? existing;
+        try
+        {
+            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(claimId), cancellationToken: ct);
+            existing = read.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+
+        if (existing == null || existing.TenantId != tenantId) return false;
+
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/supersededAt", supersededAt),
+            PatchOperation.Set("/supersededByVersionId", supersessorVersionId),
+            PatchOperation.Set("/versionState", ClaimVersionState.Adjusted),
+            PatchOperation.Set("/lastUpdatedDate", DateTime.UtcNow),
+            PatchOperation.Set("/lastUpdatedBy", actorId),
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<Claim>(
+                claimId,
+                new PartitionKey(claimId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> MarkVoidedProjectionAsync(
+        string tenantId,
+        string claimId,
+        DateTime voidedAt,
+        string? actorId,
+        CancellationToken ct = default)
+    {
+        Claim? existing;
+        try
+        {
+            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(claimId), cancellationToken: ct);
+            existing = read.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+
+        if (existing == null || existing.TenantId != tenantId) return false;
+
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/status", ClaimStatus.Voided),
+            PatchOperation.Set("/versionState", ClaimVersionState.Voided),
+            PatchOperation.Set("/lastUpdatedDate", voidedAt),
+            PatchOperation.Set("/lastUpdatedBy", actorId),
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<Claim>(
+                claimId,
+                new PartitionKey(claimId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
     }
 
     private sealed class HeadIdResult

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -579,4 +579,50 @@ public class ClaimRepositoryMongo : IClaimRepository
 
         return new AccumulatorTotalsResponse { Totals = totals };
     }
+
+    public async Task<bool> MarkSupersededProjectionAsync(
+        string tenantId,
+        string claimId,
+        string supersessorVersionId,
+        DateTime supersededAt,
+        string? actorId,
+        CancellationToken ct = default)
+    {
+        var b = Builders<Claim>.Filter;
+        var filter = b.And(
+            b.Eq(c => c.TenantId, tenantId),
+            b.Eq(c => c.Id, claimId));
+
+        var update = Builders<Claim>.Update
+            .Set(c => c.SupersededAt, supersededAt)
+            .Set(c => c.SupersededByVersionId, supersessorVersionId)
+            .Set(c => c.VersionState, ClaimVersionState.Adjusted)
+            .Set(c => c.LastUpdatedDate, DateTime.UtcNow)
+            .Set(c => c.LastUpdatedBy, actorId);
+
+        var result = await _collection.UpdateOneAsync(filter, update, cancellationToken: ct);
+        return result.MatchedCount > 0;
+    }
+
+    public async Task<bool> MarkVoidedProjectionAsync(
+        string tenantId,
+        string claimId,
+        DateTime voidedAt,
+        string? actorId,
+        CancellationToken ct = default)
+    {
+        var b = Builders<Claim>.Filter;
+        var filter = b.And(
+            b.Eq(c => c.TenantId, tenantId),
+            b.Eq(c => c.Id, claimId));
+
+        var update = Builders<Claim>.Update
+            .Set(c => c.Status, ClaimStatus.Voided)
+            .Set(c => c.VersionState, ClaimVersionState.Voided)
+            .Set(c => c.LastUpdatedDate, voidedAt)
+            .Set(c => c.LastUpdatedBy, actorId);
+
+        var result = await _collection.UpdateOneAsync(filter, update, cancellationToken: ct);
+        return result.MatchedCount > 0;
+    }
 }

--- a/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
+++ b/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
@@ -132,6 +132,8 @@ public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngi
             throw new ArgumentException("memberId is required", nameof(memberId));
         if (string.IsNullOrWhiteSpace(originalClaimId))
             throw new ArgumentException("originalClaimId is required", nameof(originalClaimId));
+        if (benefitPlanId == Guid.Empty)
+            throw new ArgumentException("benefitPlanId is required", nameof(benefitPlanId));
 
         var client = _httpClientFactory.CreateClient(HttpClientName);
         var payload = new ReverseClaimRequest

--- a/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
+++ b/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
@@ -24,18 +24,21 @@ namespace ClaimsService.Services.Adjudication;
 /// </para>
 ///
 /// <para>
-/// Only <see cref="CalculateAsync"/> is wired; the other interface
-/// members (<see cref="CalculateWithModeAsync"/>,
-/// <see cref="ReverseClaimAsync"/>) throw <see cref="NotImplementedException"/>
-/// because the adjudication pipeline's <see cref="Stages.BenefitCalculationStage"/>
-/// only uses CalculateAsync (Decision 13 — Replace mode only). Adding the
-/// other surfaces is a follow-up driven by demand.
+/// 5.5 wired <see cref="CalculateAsync"/>. Capability 5.12a wires
+/// <see cref="ReverseClaimAsync"/> through to BP service's new
+/// <c>POST /api/v1/adjudication/reverse-claim</c> endpoint (Gap D15
+/// ratification — engine-side <c>BenefitCalculationEngine.ReverseClaimAsync</c>
+/// has been wired through <c>ChoAccumulatorService.ReverseAsync</c> with
+/// <c>IsReversed=true</c> journaling since BP 5.10; only the HTTP
+/// surface was missing). <see cref="CalculateWithModeAsync"/> remains
+/// deferred to Phase 2.
 /// </para>
 /// </summary>
 public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngine
 {
     public const string HttpClientName = "BenefitPlanService";
     private const string CalculatePath = "/api/v1/adjudication/calculate-benefits";
+    private const string ReversePath = "/api/v1/adjudication/reverse-claim";
 
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -119,15 +122,66 @@ public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngi
             "result production.");
     }
 
-    public Task ReverseClaimAsync(
+    public async Task ReverseClaimAsync(
         string memberId, string subscriberId,
         Guid benefitPlanId, DateOnly serviceDate,
         string originalClaimId,
         CancellationToken ct = default)
     {
-        throw new NotImplementedException(
-            "HttpBenefitCalculationEngineClient does not support accumulator reversal. " +
-            "Capability 5.12 (Adjustment Workflow) revisits the reversal surface.");
+        if (string.IsNullOrWhiteSpace(memberId))
+            throw new ArgumentException("memberId is required", nameof(memberId));
+        if (string.IsNullOrWhiteSpace(originalClaimId))
+            throw new ArgumentException("originalClaimId is required", nameof(originalClaimId));
+
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        var payload = new ReverseClaimRequest
+        {
+            MemberId = memberId,
+            SubscriberId = subscriberId,
+            BenefitPlanId = benefitPlanId,
+            ServiceDate = serviceDate,
+            OriginalClaimId = originalClaimId,
+        };
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, ReversePath)
+        {
+            Content = JsonContent.Create(payload, options: JsonOptions),
+        };
+        var tenantId = ResolveTenantId();
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            httpRequest.Headers.Add("X-Tenant-ID", tenantId);
+        }
+
+        using var response = await client.SendAsync(httpRequest, ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            _logger.LogError(
+                "Benefit-plan-service reverse-claim returned {StatusCode} for original claim {OriginalClaimId}: {Body}",
+                response.StatusCode, SanitizeForLog(originalClaimId), SanitizeForLog(body));
+            // The engine contract is "throws on failure" — caller (5.12b
+            // ReversalRunService) catches and surfaces as ClaimAdjustment
+            // failure with manual triage required.
+            throw new HttpRequestException(
+                $"Benefit calculation engine reversal returned HTTP {(int)response.StatusCode} " +
+                $"for original claim {originalClaimId}");
+        }
+
+        _logger.LogInformation(
+            "Reversed accumulator impact for original claim {OriginalClaimId} (member {MemberId}, plan {PlanId})",
+            SanitizeForLog(originalClaimId), SanitizeForLog(memberId), benefitPlanId);
+    }
+
+    /// <summary>Wire payload for BP <c>POST /api/v1/adjudication/reverse-claim</c>.</summary>
+    private sealed class ReverseClaimRequest
+    {
+        public string MemberId { get; set; } = string.Empty;
+        public string SubscriberId { get; set; } = string.Empty;
+        public Guid BenefitPlanId { get; set; }
+        public DateOnly ServiceDate { get; set; }
+        public string OriginalClaimId { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/src/services/claims-service/Services/ClaimAdjustmentService.cs
+++ b/src/services/claims-service/Services/ClaimAdjustmentService.cs
@@ -1,0 +1,473 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ClaimsService.Models;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Repositories;
+using CloudHealthOffice.Infrastructure.Messaging;
+
+namespace ClaimsService.Services;
+
+/// <summary>
+/// Operator-initiated adjustment workflow service (capability 5.12a).
+/// Owns the supersession transition + new-version creation + Service Bus
+/// emission that together make a Phase 1 adjustment. The 5.12b
+/// payment-service ReversalRunService consumes the resulting
+/// <c>PendingReversal</c> ClaimAdjustment rows to batch the predecessor
+/// reversal + 835 reversal envelope.
+///
+/// <para>
+/// Lifecycle ratified by Decision 18: <c>AwaitingReadjudication</c> →
+/// <c>PendingReversal</c> → <c>Active</c>. The new version's pipeline
+/// runs asynchronously via the existing Service Bus
+/// <c>claim-version-events</c> subscription, so the service ends in
+/// <c>AwaitingReadjudication</c>; the transition to
+/// <c>PendingReversal</c> is owned by the orchestrator-finalize callback
+/// path (5.12b) once the new version reaches Adjudicated/Paid.
+/// </para>
+///
+/// <para>
+/// Idempotency (Decision 6): the operator-supplied
+/// <c>Idempotency-Key</c> request header is the dedup signal. Same key +
+/// same body → return existing adjustment (200); same key + different
+/// body → 409 Conflict; different key → create new adjustment.
+/// </para>
+///
+/// <para>
+/// AI examination semantics (Gap 6): the new version runs AI examination
+/// fresh (predecessor's <see cref="Claim.AiExamination"/> snapshot is
+/// ignored). The service zeroes
+/// <see cref="AdapterClaim.AiExamination"/>,
+/// <see cref="AdapterClaim.PendDetails"/>, and
+/// <see cref="AdapterClaim.AdjudicationResult"/> on the corrected
+/// payload before persistence so a stale predecessor signal cannot leak
+/// through.
+/// </para>
+/// </summary>
+public interface IClaimAdjustmentService
+{
+    Task<ClaimAdjustmentResult> CreateAdjustmentAsync(
+        string predecessorClaimId,
+        ClaimAdjustmentRequest request,
+        string idempotencyKey,
+        string tenantId,
+        string actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome discriminator on <see cref="ClaimAdjustmentResult"/>. Lets
+/// the controller map results to specific HTTP status codes without
+/// re-deriving disposition from message contents.
+/// </summary>
+public enum ClaimAdjustmentOutcome
+{
+    /// <summary>New adjustment created; predecessor superseded; new version persisted; pipeline triggered. 201.</summary>
+    Created = 1,
+    /// <summary>Same Idempotency-Key + same RequestHash → return existing row. 200.</summary>
+    AlreadyExists = 2,
+    /// <summary>Same Idempotency-Key + different RequestHash → 409.</summary>
+    IdempotencyConflict = 3,
+    /// <summary>Predecessor not in Paid/Denied/PartiallyPaid → 422 (Decision 12).</summary>
+    InvalidSourceState = 4,
+    /// <summary>Predecessor itself is an adjustment of a prior version → 422 (Decision 11; depth=1 only in Phase 1).</summary>
+    DepthLimitExceeded = 5,
+    /// <summary>An in-flight adjustment already exists for the chain → 409.</summary>
+    ConflictingAdjustment = 6,
+    /// <summary>Predecessor claim id not found for the tenant → 404.</summary>
+    PredecessorNotFound = 7,
+    /// <summary>Submission service rejected the corrected payload (validation or vendor adapter NotImplemented). 400 / 501.</summary>
+    SubmissionFailed = 8,
+}
+
+public class ClaimAdjustmentResult
+{
+    public ClaimAdjustmentOutcome Outcome { get; init; }
+    public ClaimAdjustment? Adjustment { get; init; }
+    public AdapterClaim? NewVersion { get; init; }
+    public Claim? Predecessor { get; init; }
+    public string? Message { get; init; }
+
+    /// <summary>Carried through on <see cref="ClaimAdjustmentOutcome.SubmissionFailed"/> so the controller can surface field-level detail.</summary>
+    public IReadOnlyList<ValidationError> SubmissionErrors { get; init; } = Array.Empty<ValidationError>();
+
+    public static ClaimAdjustmentResult Created(ClaimAdjustment adjustment, AdapterClaim newVersion) =>
+        new() { Outcome = ClaimAdjustmentOutcome.Created, Adjustment = adjustment, NewVersion = newVersion };
+
+    public static ClaimAdjustmentResult AlreadyExists(ClaimAdjustment existing) =>
+        new() { Outcome = ClaimAdjustmentOutcome.AlreadyExists, Adjustment = existing };
+
+    public static ClaimAdjustmentResult IdempotencyConflict(ClaimAdjustment existing, string message) =>
+        new() { Outcome = ClaimAdjustmentOutcome.IdempotencyConflict, Adjustment = existing, Message = message };
+
+    public static ClaimAdjustmentResult InvalidSourceState(Claim predecessor, string message) =>
+        new() { Outcome = ClaimAdjustmentOutcome.InvalidSourceState, Predecessor = predecessor, Message = message };
+
+    public static ClaimAdjustmentResult DepthLimitExceeded(Claim predecessor, string message) =>
+        new() { Outcome = ClaimAdjustmentOutcome.DepthLimitExceeded, Predecessor = predecessor, Message = message };
+
+    public static ClaimAdjustmentResult ConflictingAdjustment(ClaimAdjustment existing, string message) =>
+        new() { Outcome = ClaimAdjustmentOutcome.ConflictingAdjustment, Adjustment = existing, Message = message };
+
+    public static ClaimAdjustmentResult PredecessorNotFound(string message) =>
+        new() { Outcome = ClaimAdjustmentOutcome.PredecessorNotFound, Message = message };
+
+    public static ClaimAdjustmentResult SubmissionFailed(string message, IReadOnlyList<ValidationError> errors) =>
+        new() { Outcome = ClaimAdjustmentOutcome.SubmissionFailed, Message = message, SubmissionErrors = errors };
+}
+
+public class ClaimAdjustmentService : IClaimAdjustmentService
+{
+    private readonly IClaimRepository _claimRepository;
+    private readonly IClaimAdjustmentRepository _adjustmentRepository;
+    private readonly IClaimSubmissionService _submissionService;
+    private readonly IClaimVersionEventPublisher _versionEventPublisher;
+    private readonly IMessageBus _messageBus;
+    private readonly ILogger<ClaimAdjustmentService> _logger;
+
+    public ClaimAdjustmentService(
+        IClaimRepository claimRepository,
+        IClaimAdjustmentRepository adjustmentRepository,
+        IClaimSubmissionService submissionService,
+        IClaimVersionEventPublisher versionEventPublisher,
+        IMessageBus messageBus,
+        ILogger<ClaimAdjustmentService> logger)
+    {
+        _claimRepository = claimRepository;
+        _adjustmentRepository = adjustmentRepository;
+        _submissionService = submissionService;
+        _versionEventPublisher = versionEventPublisher;
+        _messageBus = messageBus;
+        _logger = logger;
+    }
+
+    public async Task<ClaimAdjustmentResult> CreateAdjustmentAsync(
+        string predecessorClaimId,
+        ClaimAdjustmentRequest request,
+        string idempotencyKey,
+        string tenantId,
+        string actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(predecessorClaimId))
+            throw new ArgumentException("predecessorClaimId is required", nameof(predecessorClaimId));
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+            throw new ArgumentException("idempotencyKey is required", nameof(idempotencyKey));
+        if (string.IsNullOrWhiteSpace(tenantId))
+            throw new ArgumentException("tenantId is required", nameof(tenantId));
+        if (string.IsNullOrWhiteSpace(actorId))
+            throw new ArgumentException("actorId is required", nameof(actorId));
+
+        // Step 1 — idempotency check. Operator may retry the same request
+        // (network blip, double-click, replay). Same key + same body → return
+        // the existing adjustment with 200; same key + different body → 409.
+        var requestHash = ComputeRequestHash(predecessorClaimId, request);
+        var existing = await _adjustmentRepository.GetByIdempotencyKeyAsync(tenantId, idempotencyKey, ct);
+        if (existing != null)
+        {
+            if (string.Equals(existing.RequestHash, requestHash, StringComparison.Ordinal))
+            {
+                _logger.LogInformation(
+                    "Adjustment {AdjustmentId} replay (same Idempotency-Key {Key}, same body); returning existing",
+                    Sanitize(existing.Id), Sanitize(idempotencyKey));
+                return ClaimAdjustmentResult.AlreadyExists(existing);
+            }
+
+            _logger.LogWarning(
+                "Adjustment Idempotency-Key {Key} replay with different body; returning 409",
+                Sanitize(idempotencyKey));
+            return ClaimAdjustmentResult.IdempotencyConflict(
+                existing,
+                $"Idempotency-Key '{idempotencyKey}' already used with a different request body");
+        }
+
+        // Step 2 — predecessor lookup + source-state validation (Decision 12).
+        var predecessor = await _claimRepository.GetByIdAsync(predecessorClaimId);
+        if (predecessor == null || predecessor.TenantId != tenantId)
+        {
+            _logger.LogInformation(
+                "Adjustment requested for unknown predecessor {ClaimId}",
+                Sanitize(predecessorClaimId));
+            return ClaimAdjustmentResult.PredecessorNotFound(
+                $"Predecessor claim {predecessorClaimId} not found for tenant {tenantId}");
+        }
+
+        if (predecessor.Status is not (ClaimStatus.Paid or ClaimStatus.Denied or ClaimStatus.PartiallyPaid))
+        {
+            _logger.LogWarning(
+                "Adjustment rejected for {ClaimId}: source state {Status} not in Paid/Denied/PartiallyPaid",
+                Sanitize(predecessor.Id), predecessor.Status);
+            return ClaimAdjustmentResult.InvalidSourceState(
+                predecessor,
+                $"Predecessor must be Paid, Denied, or PartiallyPaid to adjust; current status is {predecessor.Status}");
+        }
+
+        // Step 3 — depth=1 check (Decision 11). Predecessor's
+        // PredecessorVersionId must be null (i.e. predecessor must be a
+        // first-generation claim, not itself an adjustment).
+        if (!string.IsNullOrEmpty(predecessor.PredecessorVersionId))
+        {
+            _logger.LogWarning(
+                "Adjustment rejected for {ClaimId}: predecessor is itself an adjustment (depth>1 deferred to Phase 2)",
+                Sanitize(predecessor.Id));
+            return ClaimAdjustmentResult.DepthLimitExceeded(
+                predecessor,
+                "Adjustment-of-adjustment is not supported in Phase 1; predecessor must be a first-generation claim");
+        }
+
+        // Step 4 — chain-lock check. The Mongo unique index on
+        // (TenantId, ClaimVersionId) enforces depth=1 globally; this
+        // explicit pre-check returns a clean 409 before we attempt the
+        // insert (better operator UX than a swallowed duplicate-key error).
+        var chainKey = string.IsNullOrEmpty(predecessor.ClaimVersionId) ? predecessor.Id : predecessor.ClaimVersionId;
+        var inflight = await _adjustmentRepository.GetByClaimVersionIdAsync(tenantId, chainKey, ct);
+        if (inflight != null)
+        {
+            _logger.LogWarning(
+                "Adjustment rejected for chain {ChainKey}: in-flight adjustment {AdjustmentId} already exists",
+                Sanitize(chainKey), Sanitize(inflight.Id));
+            return ClaimAdjustmentResult.ConflictingAdjustment(
+                inflight,
+                $"Chain {chainKey} already has an in-flight adjustment {inflight.Id} in status {inflight.Status}");
+        }
+
+        // Step 5 — prepare the corrected claim payload. Override
+        // identity-bearing fields so the new version is a fresh row that
+        // joins the existing chain. Per Gap 6, zero stale signals from the
+        // predecessor (AI rationale, pend reasons, prior adjudication) so
+        // the pipeline runs the corrected facts cleanly.
+        var corrected = request.CorrectedClaim;
+        corrected.TenantId = tenantId;
+        corrected.Id = string.Empty;                            // CreateAsync generates a fresh id
+        corrected.ClaimVersionId = chainKey;                    // Stays on the same chain
+        corrected.VersionNumber = predecessor.VersionNumber + 1;
+        corrected.VersionState = ClaimVersionState.Submitted;
+        corrected.PredecessorVersionId = predecessor.Id;        // Per-row id of the version being amended
+        corrected.PublishedAt = null;
+        corrected.PublishedBy = null;
+        corrected.SupersededAt = null;
+        corrected.SupersededByVersionId = null;
+        corrected.SubmittedDate = DateTime.UtcNow;
+        corrected.AdjudicatedDate = null;
+        corrected.PaidDate = null;
+        corrected.AdjudicationResult = null;
+        corrected.PendDetails = null;
+        corrected.AiExamination = null;                          // Gap 6 — fresh AI examination
+        corrected.Status = ClaimStatus.Submitted;
+        corrected.CreatedDate = DateTime.UtcNow;
+        corrected.LastUpdatedDate = DateTime.UtcNow;
+        corrected.CreatedBy = actorId;
+        corrected.LastUpdatedBy = actorId;
+        corrected.EDI835ControlNumber = null;                    // Reversal/payment control numbers belong to the new version's lifecycle
+
+        // Step 6 — submit the new version through the canonical submission
+        // path. SubmitAsync emits ClaimVersionSubmitted to the audit chain
+        // AND ClaimVersionSubmittedMessage to the Service Bus topic, which
+        // triggers the existing adjudication orchestrator subscription.
+        // Re-adjudication is just a normal pipeline run on a new row.
+        var submission = await _submissionService.SubmitAsync(corrected, tenantId, actorId, correlationId, ct);
+        if (!submission.Success)
+        {
+            var errSummary = string.Join("; ", submission.Errors.Select(e => $"{e.Field}:{e.Code}"));
+            _logger.LogWarning(
+                "Adjustment submission failed for predecessor {ClaimId}: {ErrorSummary}",
+                Sanitize(predecessor.Id), Sanitize(errSummary));
+            return ClaimAdjustmentResult.SubmissionFailed(
+                "Corrected claim failed validation",
+                submission.Errors);
+        }
+
+        var newVersion = submission.Claim!;
+
+        // Step 7 — supersede the predecessor via the projection-bypass
+        // write (the regular UpdateAsync path rejects terminal-state
+        // mutations). Patches SupersededAt + SupersededByVersionId +
+        // VersionState=Adjusted on the predecessor row. Status field is
+        // NOT touched here — predecessor stays Paid until 5.12b's
+        // ReversalRun explicitly transitions it to Voided via VoidAsync.
+        var supersededAt = DateTime.UtcNow;
+        var supersedeOk = await _claimRepository.MarkSupersededProjectionAsync(
+            tenantId, predecessor.Id, newVersion.Id, supersededAt, actorId, ct);
+        if (!supersedeOk)
+        {
+            _logger.LogError(
+                "Failed to supersede predecessor {ClaimId} after new version {NewClaimId} was created; manual triage required",
+                Sanitize(predecessor.Id), Sanitize(newVersion.Id));
+            // Do not roll back the new version — the audit chain shows the
+            // submission, the operator can re-trigger supersession, and a
+            // ReversalRun will not pick this up because no ClaimAdjustment
+            // row exists yet. Surface as SubmissionFailed so the caller
+            // sees a non-2xx; failure-mode posture matches 5.10's
+            // partial-failure stance.
+            return ClaimAdjustmentResult.SubmissionFailed(
+                "Predecessor supersession failed after new version was created; contact operations",
+                Array.Empty<ValidationError>());
+        }
+
+        // Step 8 — refetch the superseded predecessor so the version-event
+        // payload carries the post-supersession state (SupersededAt,
+        // SupersededByVersionId, VersionState=Adjusted). Without the
+        // refetch the event payload would still show the pre-supersession
+        // snapshot.
+        var supersededPredecessor = await _claimRepository.GetByIdAsync(predecessor.Id) ?? predecessor;
+
+        // Step 9 — emit the version-chain events. Two distinct events:
+        // (a) ClaimVersionSuperseded for the audit/lineage signal
+        //     (mirrors ProviderVersionSuperseded);
+        // (b) ClaimVersionReversed (NEW) for the
+        //     accumulator-reversal-intent signal.
+        // Both go to the same Mongo append-only stream; both are
+        // idempotent on EventId.
+        var newVersionDomain = newVersion.ToClaim();
+        try
+        {
+            await _versionEventPublisher.PublishVersionSupersededAsync(
+                supersededPredecessor, newVersionDomain, request.AdjustmentReason, actorId, correlationId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionSuperseded emission failed for predecessor {ClaimId}; supersession persisted, audit chain has gap",
+                Sanitize(predecessor.Id));
+        }
+
+        try
+        {
+            await _versionEventPublisher.PublishVersionReversedAsync(
+                supersededPredecessor, newVersion.Id, request.AdjustmentReason, actorId, correlationId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionReversed emission failed for predecessor {ClaimId}; supersession persisted, audit chain has gap",
+                Sanitize(predecessor.Id));
+        }
+
+        // Step 10 — emit ClaimVersionReversedMessage to the Service Bus
+        // topic. 5.12b's ReversalRunService subscribes to this signal in
+        // addition to listing PendingReversal adjustments via HTTP.
+        try
+        {
+            var sbMessage = new ClaimVersionReversedMessage
+            {
+                TenantId = tenantId,
+                ClaimId = predecessor.Id,
+                ClaimVersionId = supersededPredecessor.ClaimVersionId,
+                PredecessorVersionId = predecessor.Id,
+                SupersessorClaimId = newVersion.Id,
+                AdjustmentReason = request.AdjustmentReason,
+                ActorId = actorId,
+                CorrelationId = correlationId,
+            };
+            var sendOptions = new SendOptions(
+                MessageId: $"reversed:{predecessor.Id}->{newVersion.Id}",
+                CorrelationId: correlationId,
+                Properties: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [ClaimVersionEventTopics.MessageTypeProperty] = ClaimVersionMessageTypes.Reversed,
+                });
+
+            await _messageBus.SendAsync(
+                ClaimVersionEventTopics.TopicName, sbMessage, sendOptions, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "ClaimVersionReversed Service Bus emission failed for predecessor {ClaimId}; supersession persisted, ReversalRun signal missed",
+                Sanitize(predecessor.Id));
+        }
+
+        // Step 11 — persist the ClaimAdjustment aggregate. Status starts
+        // at AwaitingReadjudication (Decision 18) — the new version's
+        // pipeline is running asynchronously via Service Bus; transition
+        // to PendingReversal is owned by the orchestrator-finalize
+        // callback path (5.12b).
+        var adjustment = new ClaimAdjustment
+        {
+            TenantId = tenantId,
+            ClaimVersionId = chainKey,
+            PredecessorClaimId = predecessor.Id,
+            PredecessorVersionId = predecessor.Id,
+            NewClaimId = newVersion.Id,
+            AdjustmentReason = request.AdjustmentReason,
+            Notes = request.Notes,
+            Status = ClaimAdjustmentStatus.AwaitingReadjudication,
+            IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
+            CreatedBy = actorId,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        try
+        {
+            await _adjustmentRepository.CreateAsync(adjustment, ct);
+        }
+        catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
+        {
+            // Race: a parallel adjustment for the same chain or idempotency
+            // key landed first. Re-fetch and surface as an idempotency or
+            // chain-conflict result. The pre-checks above narrow the window
+            // but cannot eliminate it without distributed locks.
+            var raceExisting = await _adjustmentRepository.GetByIdempotencyKeyAsync(tenantId, idempotencyKey, ct);
+            if (raceExisting != null)
+            {
+                return string.Equals(raceExisting.RequestHash, requestHash, StringComparison.Ordinal)
+                    ? ClaimAdjustmentResult.AlreadyExists(raceExisting)
+                    : ClaimAdjustmentResult.IdempotencyConflict(raceExisting,
+                        $"Idempotency-Key '{idempotencyKey}' already used with a different request body");
+            }
+            var raceChain = await _adjustmentRepository.GetByClaimVersionIdAsync(tenantId, chainKey, ct);
+            if (raceChain != null)
+            {
+                return ClaimAdjustmentResult.ConflictingAdjustment(raceChain,
+                    $"Chain {chainKey} already has an in-flight adjustment {raceChain.Id} in status {raceChain.Status}");
+            }
+            throw;
+        }
+
+        _logger.LogInformation(
+            "Adjustment {AdjustmentId} created: predecessor {PredecessorClaimId} (chain {ChainKey} v{PredecessorVersion}) → " +
+            "new version {NewClaimId} v{NewVersion}; reason='{Reason}'",
+            Sanitize(adjustment.Id),
+            Sanitize(predecessor.Id),
+            Sanitize(chainKey),
+            predecessor.VersionNumber,
+            Sanitize(newVersion.Id),
+            newVersion.VersionNumber,
+            Sanitize(request.AdjustmentReason));
+
+        return ClaimAdjustmentResult.Created(adjustment, newVersion);
+    }
+
+    internal static string ComputeRequestHash(string predecessorClaimId, ClaimAdjustmentRequest request)
+    {
+        // Stable hash of the request body — used to detect "same key,
+        // different body" idempotency violations. JSON serialization
+        // gives a deterministic-enough surface for the body shapes we
+        // accept (operator UI submits the same payload on retry); we
+        // include the predecessor id so two different chains with the
+        // same idempotency key (operator pasted the wrong key) are
+        // treated as distinct rather than colliding.
+        var canonical = new
+        {
+            PredecessorClaimId = predecessorClaimId,
+            request.AdjustmentReason,
+            request.Notes,
+            request.CorrectedClaim,
+        };
+        var json = JsonSerializer.Serialize(canonical, new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        });
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToHexString(hash);
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/claims-service/Services/ClaimAdjustmentService.cs
+++ b/src/services/claims-service/Services/ClaimAdjustmentService.cs
@@ -77,7 +77,7 @@ public enum ClaimAdjustmentOutcome
     ConflictingAdjustment = 6,
     /// <summary>Predecessor claim id not found for the tenant → 404.</summary>
     PredecessorNotFound = 7,
-    /// <summary>Submission service rejected the corrected payload (validation or vendor adapter NotImplemented). 400 / 501.</summary>
+    /// <summary>Submission service rejected the corrected payload (validation or vendor adapter NotImplemented). 400 / 501; check <see cref="ClaimAdjustmentResult.SubmissionFailureKind"/>.</summary>
     SubmissionFailed = 8,
 }
 
@@ -91,6 +91,16 @@ public class ClaimAdjustmentResult
 
     /// <summary>Carried through on <see cref="ClaimAdjustmentOutcome.SubmissionFailed"/> so the controller can surface field-level detail.</summary>
     public IReadOnlyList<ValidationError> SubmissionErrors { get; init; } = Array.Empty<ValidationError>();
+
+    /// <summary>
+    /// Discriminates the underlying submission failure kind so the
+    /// controller can map <see cref="ClaimSubmissionFailureKind.Validation"/>
+    /// to 400 and <see cref="ClaimSubmissionFailureKind.NotImplemented"/>
+    /// to 501. Null for non-submission failure outcomes and for
+    /// non-submission-driven failure paths
+    /// (e.g. supersession write failure).
+    /// </summary>
+    public ClaimSubmissionFailureKind? SubmissionFailureKind { get; init; }
 
     public static ClaimAdjustmentResult Created(ClaimAdjustment adjustment, AdapterClaim newVersion) =>
         new() { Outcome = ClaimAdjustmentOutcome.Created, Adjustment = adjustment, NewVersion = newVersion };
@@ -113,8 +123,17 @@ public class ClaimAdjustmentResult
     public static ClaimAdjustmentResult PredecessorNotFound(string message) =>
         new() { Outcome = ClaimAdjustmentOutcome.PredecessorNotFound, Message = message };
 
-    public static ClaimAdjustmentResult SubmissionFailed(string message, IReadOnlyList<ValidationError> errors) =>
-        new() { Outcome = ClaimAdjustmentOutcome.SubmissionFailed, Message = message, SubmissionErrors = errors };
+    public static ClaimAdjustmentResult SubmissionFailed(
+        string message,
+        IReadOnlyList<ValidationError> errors,
+        ClaimSubmissionFailureKind? failureKind = null) =>
+        new()
+        {
+            Outcome = ClaimAdjustmentOutcome.SubmissionFailed,
+            Message = message,
+            SubmissionErrors = errors,
+            SubmissionFailureKind = failureKind,
+        };
 }
 
 public class ClaimAdjustmentService : IClaimAdjustmentService
@@ -234,7 +253,60 @@ public class ClaimAdjustmentService : IClaimAdjustmentService
                 $"Chain {chainKey} already has an in-flight adjustment {inflight.Id} in status {inflight.Status}");
         }
 
-        // Step 5 — prepare the corrected claim payload. Override
+        // Step 5 — acquire the chain lock by inserting a placeholder
+        // ClaimAdjustment row BEFORE supersession + submission. The
+        // unique index on (TenantId, ClaimVersionId) is the
+        // serialization point: a concurrent request for the same chain
+        // collides at insert time and gets a clean 409 with no
+        // side effects. Without this early insert, two requests could
+        // both pass the in-memory inflight check, both supersede +
+        // submit, and only THEN one would lose at the duplicate-key
+        // step — by which point the loser already has a new version
+        // persisted and supersession events emitted. NewClaimId is
+        // empty until step 7's update.
+        var adjustment = new ClaimAdjustment
+        {
+            TenantId = tenantId,
+            ClaimVersionId = chainKey,
+            PredecessorClaimId = predecessor.Id,
+            PredecessorVersionId = predecessor.Id,
+            NewClaimId = string.Empty,
+            AdjustmentReason = request.AdjustmentReason,
+            Notes = request.Notes,
+            Status = ClaimAdjustmentStatus.AwaitingReadjudication,
+            IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
+            CreatedBy = actorId,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        try
+        {
+            await _adjustmentRepository.CreateAsync(adjustment, ct);
+        }
+        catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
+        {
+            // Lost the race for this chain or idempotency key. Re-fetch
+            // and surface the appropriate 409 — supersession + version
+            // events have NOT yet fired, so this is a clean rejection.
+            var raceExisting = await _adjustmentRepository.GetByIdempotencyKeyAsync(tenantId, idempotencyKey, ct);
+            if (raceExisting != null)
+            {
+                return string.Equals(raceExisting.RequestHash, requestHash, StringComparison.Ordinal)
+                    ? ClaimAdjustmentResult.AlreadyExists(raceExisting)
+                    : ClaimAdjustmentResult.IdempotencyConflict(raceExisting,
+                        $"Idempotency-Key '{idempotencyKey}' already used with a different request body");
+            }
+            var raceChain = await _adjustmentRepository.GetByClaimVersionIdAsync(tenantId, chainKey, ct);
+            if (raceChain != null)
+            {
+                return ClaimAdjustmentResult.ConflictingAdjustment(raceChain,
+                    $"Chain {chainKey} already has an in-flight adjustment {raceChain.Id} in status {raceChain.Status}");
+            }
+            throw;
+        }
+
+        // Step 6 — prepare the corrected claim payload. Override
         // identity-bearing fields so the new version is a fresh row that
         // joins the existing chain. Per Gap 6, zero stale signals from the
         // predecessor (AI rationale, pend reasons, prior adjudication) so
@@ -273,11 +345,25 @@ public class ClaimAdjustmentService : IClaimAdjustmentService
         {
             var errSummary = string.Join("; ", submission.Errors.Select(e => $"{e.Field}:{e.Code}"));
             _logger.LogWarning(
-                "Adjustment submission failed for predecessor {ClaimId}: {ErrorSummary}",
-                Sanitize(predecessor.Id), Sanitize(errSummary));
+                "Adjustment submission failed for predecessor {ClaimId} ({FailureKind}): {ErrorSummary}",
+                Sanitize(predecessor.Id), submission.FailureKind, Sanitize(errSummary));
+            // Release the chain lock — no version was created, no
+            // supersession occurred. Operator can retry against a clean
+            // chain. Failure to delete is logged but doesn't change the
+            // returned outcome (a stale Failed-state row would block
+            // the chain; that's surfaced via support).
+            await TryReleaseChainLockAsync(adjustment, ct);
+            // Preserve the failure-kind discriminator so the controller
+            // can map Validation → 400 and NotImplemented → 501. The
+            // message text differs by kind so the operator-facing copy
+            // matches the disposition.
+            var message = submission.FailureKind == ClaimSubmissionFailureKind.NotImplemented
+                ? "Adapter for this tenant does not implement claim submission"
+                : "Corrected claim failed validation";
             return ClaimAdjustmentResult.SubmissionFailed(
-                "Corrected claim failed validation",
-                submission.Errors);
+                message,
+                submission.Errors,
+                submission.FailureKind);
         }
 
         var newVersion = submission.Claim!;
@@ -296,12 +382,13 @@ public class ClaimAdjustmentService : IClaimAdjustmentService
             _logger.LogError(
                 "Failed to supersede predecessor {ClaimId} after new version {NewClaimId} was created; manual triage required",
                 Sanitize(predecessor.Id), Sanitize(newVersion.Id));
-            // Do not roll back the new version — the audit chain shows the
-            // submission, the operator can re-trigger supersession, and a
-            // ReversalRun will not pick this up because no ClaimAdjustment
-            // row exists yet. Surface as SubmissionFailed so the caller
-            // sees a non-2xx; failure-mode posture matches 5.10's
-            // partial-failure stance.
+            // Release the chain lock so retry is possible. The new
+            // version row is left behind on the audit chain (operator
+            // can re-trigger supersession via a fresh adjustment with
+            // a new Idempotency-Key, or operations can intervene
+            // manually). Surface as SubmissionFailed so the caller
+            // sees a non-2xx.
+            await TryReleaseChainLockAsync(adjustment, ct);
             return ClaimAdjustmentResult.SubmissionFailed(
                 "Predecessor supersession failed after new version was created; contact operations",
                 Array.Empty<ValidationError>());
@@ -380,53 +467,16 @@ public class ClaimAdjustmentService : IClaimAdjustmentService
                 Sanitize(predecessor.Id));
         }
 
-        // Step 11 — persist the ClaimAdjustment aggregate. Status starts
-        // at AwaitingReadjudication (Decision 18) — the new version's
-        // pipeline is running asynchronously via Service Bus; transition
-        // to PendingReversal is owned by the orchestrator-finalize
-        // callback path (5.12b).
-        var adjustment = new ClaimAdjustment
-        {
-            TenantId = tenantId,
-            ClaimVersionId = chainKey,
-            PredecessorClaimId = predecessor.Id,
-            PredecessorVersionId = predecessor.Id,
-            NewClaimId = newVersion.Id,
-            AdjustmentReason = request.AdjustmentReason,
-            Notes = request.Notes,
-            Status = ClaimAdjustmentStatus.AwaitingReadjudication,
-            IdempotencyKey = idempotencyKey,
-            RequestHash = requestHash,
-            CreatedBy = actorId,
-            CreatedAt = DateTime.UtcNow,
-        };
-
-        try
-        {
-            await _adjustmentRepository.CreateAsync(adjustment, ct);
-        }
-        catch (MongoDB.Driver.MongoWriteException ex) when (ex.WriteError?.Category == MongoDB.Driver.ServerErrorCategory.DuplicateKey)
-        {
-            // Race: a parallel adjustment for the same chain or idempotency
-            // key landed first. Re-fetch and surface as an idempotency or
-            // chain-conflict result. The pre-checks above narrow the window
-            // but cannot eliminate it without distributed locks.
-            var raceExisting = await _adjustmentRepository.GetByIdempotencyKeyAsync(tenantId, idempotencyKey, ct);
-            if (raceExisting != null)
-            {
-                return string.Equals(raceExisting.RequestHash, requestHash, StringComparison.Ordinal)
-                    ? ClaimAdjustmentResult.AlreadyExists(raceExisting)
-                    : ClaimAdjustmentResult.IdempotencyConflict(raceExisting,
-                        $"Idempotency-Key '{idempotencyKey}' already used with a different request body");
-            }
-            var raceChain = await _adjustmentRepository.GetByClaimVersionIdAsync(tenantId, chainKey, ct);
-            if (raceChain != null)
-            {
-                return ClaimAdjustmentResult.ConflictingAdjustment(raceChain,
-                    $"Chain {chainKey} already has an in-flight adjustment {raceChain.Id} in status {raceChain.Status}");
-            }
-            throw;
-        }
+        // Step 11 — finalize the placeholder ClaimAdjustment row with
+        // the NewClaimId now that submission + supersession have
+        // succeeded. The placeholder was inserted in step 5; this is
+        // the post-success update. Status remains
+        // AwaitingReadjudication (Decision 18) — the new version's
+        // pipeline is running asynchronously via Service Bus;
+        // transition to PendingReversal is owned by the
+        // orchestrator-finalize callback path (5.12b).
+        adjustment.NewClaimId = newVersion.Id;
+        await _adjustmentRepository.UpdateAsync(adjustment, ct);
 
         _logger.LogInformation(
             "Adjustment {AdjustmentId} created: predecessor {PredecessorClaimId} (chain {ChainKey} v{PredecessorVersion}) → " +
@@ -440,6 +490,26 @@ public class ClaimAdjustmentService : IClaimAdjustmentService
             Sanitize(request.AdjustmentReason));
 
         return ClaimAdjustmentResult.Created(adjustment, newVersion);
+    }
+
+    private async Task TryReleaseChainLockAsync(ClaimAdjustment placeholder, CancellationToken ct)
+    {
+        try
+        {
+            var deleted = await _adjustmentRepository.DeleteAsync(placeholder.TenantId, placeholder.Id, ct);
+            if (!deleted)
+            {
+                _logger.LogWarning(
+                    "Chain-lock release for adjustment {AdjustmentId} on chain {ClaimVersionId} matched 0 rows; chain may stay locked",
+                    Sanitize(placeholder.Id), Sanitize(placeholder.ClaimVersionId));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to release chain lock for adjustment {AdjustmentId} on chain {ClaimVersionId}; chain may stay locked",
+                Sanitize(placeholder.Id), Sanitize(placeholder.ClaimVersionId));
+        }
     }
 
     internal static string ComputeRequestHash(string predecessorClaimId, ClaimAdjustmentRequest request)

--- a/src/services/claims-service/Services/ClaimFinalizationService.cs
+++ b/src/services/claims-service/Services/ClaimFinalizationService.cs
@@ -4,25 +4,53 @@ using ClaimsService.Repositories;
 namespace ClaimsService.Services;
 
 /// <summary>
-/// Owns the Adjudicated → Paid transition for a claim version. The
-/// canonical 5.10 finalize path: payment-service issues a
+/// Owns the Adjudicated → Paid transition (5.10) and the Paid/Adjusted →
+/// Voided transition (5.12a, invoked by 5.12b ReversalRun) for a claim
+/// version. The canonical 5.10 finalize path: payment-service issues a
 /// <c>POST /api/claims/{id}/remittance</c> per claim during PaymentRun
 /// execution; the controller delegates here so the lifecycle write is
 /// idempotent, source-state-validated, and emits the
 /// <c>ClaimVersionPaid</c> event into the Mongo version chain alongside
 /// the existing Kafka <c>claims.finalized.v1</c> notification.
 ///
-/// Phase 1 only supports the Paid transition (status==Paid). Other
-/// state transitions (Voided, Reversed) are deferred to capability 5.12
-/// (Adjustment Workflow). A request whose source claim is not in the
-/// terminal-Paid-eligible set (Approved or PartiallyPaid) returns
-/// <see cref="ClaimFinalizationOutcome.InvalidSourceState"/>.
+/// <para>
+/// 5.12a extends this service with <see cref="VoidAsync"/> per Gap 1
+/// ratification — keeping the version-event emission unified inside one
+/// service rather than splitting into a sibling <c>IClaimVoidService</c>.
+/// The Void transition is wired in 5.12a; actual invocation occurs in
+/// 5.12b's <c>ReversalRunService</c> when the predecessor is reversed.
+/// </para>
 /// </summary>
 public interface IClaimFinalizationService
 {
     Task<ClaimFinalizationResult> FinalizeAsync(
         string claimId,
         ClaimFinalizationRequest request,
+        string tenantId,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Paid/Adjusted → Voided transition (5.12a; Gap 1 ratification).
+    /// Idempotent: a second call against an already-Voided claim returns
+    /// <see cref="ClaimVoidOutcome.AlreadyVoided"/>. Source-state guard
+    /// rejects anything outside Paid/PartiallyPaid/Adjusted with
+    /// <see cref="ClaimVoidOutcome.InvalidSourceState"/>.
+    ///
+    /// <para>
+    /// Emits <c>ClaimVersionVoided</c> to the Mongo version chain and
+    /// <c>claims.finalized.v1</c> with <c>FinalStatus="Reversed"</c>
+    /// (the existing <c>ClaimEventPublisher.Status</c> Voided→"Reversed"
+    /// mapping convention). Per Decision 16, the BP engine reversal
+    /// path is the source of truth for accumulator un-application;
+    /// this Kafka emit is observability/audit, not the accumulator
+    /// trigger.
+    /// </para>
+    /// </summary>
+    Task<ClaimVoidResult> VoidAsync(
+        string claimId,
+        ClaimVoidRequest request,
         string tenantId,
         string? actorId,
         string? correlationId,
@@ -97,6 +125,46 @@ public class ClaimFinalizationRequest
     public string? PaymentRunId { get; set; }
     public string? EraEnvelopeId { get; set; }
     public string? EdiControlNumber { get; set; }
+}
+
+/// <summary>
+/// Outcome discriminator on <see cref="ClaimVoidResult"/>. Lets the
+/// caller (5.12b ReversalRun) map results to specific HTTP status codes.
+/// </summary>
+public enum ClaimVoidOutcome
+{
+    /// <summary>Claim transitioned to Voided; ClaimVersionVoided emitted; ClaimFinalized re-emitted with FinalStatus="Reversed".</summary>
+    Voided = 1,
+    /// <summary>Claim already Voided; idempotent no-op; no event re-emit.</summary>
+    AlreadyVoided = 2,
+    /// <summary>Source claim is not in a Void-eligible state (must be Paid/PartiallyPaid/Adjusted); maps to 422.</summary>
+    InvalidSourceState = 3,
+    /// <summary>Claim id not found for the tenant; maps to 404.</summary>
+    NotFound = 4,
+}
+
+public class ClaimVoidRequest
+{
+    /// <summary>Operator-supplied reason for the void. Required for the audit trail.</summary>
+    public string Reason { get; set; } = string.Empty;
+    /// <summary>Optional 5.12b ReversalRun id correlation.</summary>
+    public string? ReversalRunId { get; set; }
+}
+
+public class ClaimVoidResult
+{
+    public ClaimVoidOutcome Outcome { get; init; }
+    public Claim? Claim { get; init; }
+    public string? Message { get; init; }
+
+    public static ClaimVoidResult Voided(Claim claim) =>
+        new() { Outcome = ClaimVoidOutcome.Voided, Claim = claim };
+    public static ClaimVoidResult AlreadyVoided(Claim claim) =>
+        new() { Outcome = ClaimVoidOutcome.AlreadyVoided, Claim = claim };
+    public static ClaimVoidResult InvalidSourceState(Claim claim, string message) =>
+        new() { Outcome = ClaimVoidOutcome.InvalidSourceState, Claim = claim, Message = message };
+    public static ClaimVoidResult NotFound(string message) =>
+        new() { Outcome = ClaimVoidOutcome.NotFound, Message = message };
 }
 
 public class ClaimFinalizationService : IClaimFinalizationService
@@ -224,6 +292,102 @@ public class ClaimFinalizationService : IClaimFinalizationService
             Sanitize(request.PaymentRunId), Sanitize(request.EraEnvelopeId));
 
         return ClaimFinalizationResult.Finalized(updated);
+    }
+
+    public async Task<ClaimVoidResult> VoidAsync(
+        string claimId,
+        ClaimVoidRequest request,
+        string tenantId,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(claimId))
+            throw new ArgumentException("claimId is required", nameof(claimId));
+        if (string.IsNullOrWhiteSpace(tenantId))
+            throw new ArgumentException("tenantId is required", nameof(tenantId));
+
+        var claim = await _claimRepository.GetByIdAsync(claimId);
+        if (claim == null || claim.TenantId != tenantId)
+        {
+            _logger.LogWarning("Void requested for unknown claim {ClaimId}", Sanitize(claimId));
+            return ClaimVoidResult.NotFound($"Claim {claimId} not found");
+        }
+
+        if (claim.Status == ClaimStatus.Voided)
+        {
+            _logger.LogInformation(
+                "Claim {ClaimId} already Voided; idempotent no-op", Sanitize(claim.Id));
+            return ClaimVoidResult.AlreadyVoided(claim);
+        }
+
+        // Source-state guard. Phase 1 supports voiding from
+        // Paid/PartiallyPaid (5.10 happy-path remittance terminal) or
+        // from Adjusted (5.12a supersession-intermediate). Voiding from
+        // Submitted/InAdjudication/Pended/Approved/Denied is rejected
+        // (those have separate lifecycle paths).
+        if (claim.Status is not (ClaimStatus.Paid or ClaimStatus.PartiallyPaid))
+        {
+            // Check VersionState too — supersession projection sets
+            // VersionState=Adjusted while leaving Status=Paid; the
+            // VersionState path captures that case.
+            var voidFromAdjusted = claim.VersionState == ClaimVersionState.Adjusted;
+            if (!voidFromAdjusted)
+            {
+                _logger.LogWarning(
+                    "Claim {ClaimId} cannot void from Status={Status}/VersionState={VersionState}; only Paid/PartiallyPaid/Adjusted allowed",
+                    Sanitize(claim.Id), claim.Status, claim.VersionState);
+                return ClaimVoidResult.InvalidSourceState(
+                    claim,
+                    $"Claim must be Paid, PartiallyPaid, or Adjusted to void; current Status={claim.Status}, VersionState={claim.VersionState}");
+            }
+        }
+
+        // Apply the Void transition via the projection bypass — the
+        // regular UpdateAsync path rejects terminal-state mutations
+        // (Paid is terminal). The projection-bypass exists precisely
+        // for this lifecycle write.
+        var voidedAt = DateTime.UtcNow;
+        var ok = await _claimRepository.MarkVoidedProjectionAsync(
+            tenantId, claim.Id, voidedAt, actorId, ct);
+        if (!ok)
+        {
+            // Should not happen — we just read the row above. Surface as
+            // not-found rather than crashing.
+            _logger.LogWarning(
+                "Void projection bypass for claim {ClaimId} matched 0 rows; treating as not-found",
+                Sanitize(claim.Id));
+            return ClaimVoidResult.NotFound($"Claim {claimId} not found (race or concurrent delete)");
+        }
+
+        // Refetch so the post-Void payload is what flows into events.
+        var updated = await _claimRepository.GetByIdAsync(claim.Id) ?? claim;
+
+        try
+        {
+            await _versionEventPublisher.PublishVersionVoidedAsync(updated, request.Reason, actorId, correlationId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to publish ClaimVersionVoided for claim {ClaimId}; void already persisted",
+                Sanitize(updated.Id));
+        }
+
+        // Emit to Kafka — the existing ClaimEventPublisher.Status mapper
+        // translates Voided → "Reversed" so accumulator-service +
+        // analytics consumers see the canonical reversal signal. Per
+        // Decision 16 the BP engine path is the source of truth for
+        // accumulator un-application; this Kafka emit is observability
+        // only.
+        await _kafkaEventPublisher.PublishClaimFinalizedAsync(updated, tenantId, ct);
+
+        _logger.LogInformation(
+            "Voided claim {ClaimId}; reason='{Reason}'; ReversalRun={ReversalRunId}",
+            Sanitize(updated.Id), Sanitize(request.Reason), Sanitize(request.ReversalRunId));
+
+        return ClaimVoidResult.Voided(updated);
     }
 
     private static string Sanitize(string? value) =>

--- a/src/services/claims-service/Services/ClaimFinalizationService.cs
+++ b/src/services/claims-service/Services/ClaimFinalizationService.cs
@@ -307,6 +307,11 @@ public class ClaimFinalizationService : IClaimFinalizationService
             throw new ArgumentException("claimId is required", nameof(claimId));
         if (string.IsNullOrWhiteSpace(tenantId))
             throw new ArgumentException("tenantId is required", nameof(tenantId));
+        // Reason is required by the docstring + audit trail. Enforced
+        // here so callers (5.12b ReversalRunService) cannot accidentally
+        // emit empty-reason ClaimVersionVoided events.
+        if (string.IsNullOrWhiteSpace(request.Reason))
+            throw new ArgumentException("Reason is required for the audit trail", nameof(request));
 
         var claim = await _claimRepository.GetByIdAsync(claimId);
         if (claim == null || claim.TenantId != tenantId)
@@ -361,8 +366,25 @@ public class ClaimFinalizationService : IClaimFinalizationService
             return ClaimVoidResult.NotFound($"Claim {claimId} not found (race or concurrent delete)");
         }
 
-        // Refetch so the post-Void payload is what flows into events.
-        var updated = await _claimRepository.GetByIdAsync(claim.Id) ?? claim;
+        // Refetch so the post-Void payload is what flows into events. If
+        // the refetch returns null (concurrent delete between projection
+        // write and refetch — extremely rare), fall back to the in-memory
+        // claim BUT mutate it to the post-Void state so the version event
+        // and Kafka emit reflect the actual transition rather than the
+        // pre-Void Status/VersionState. The projection write succeeded;
+        // the row exists in the post-Void state by definition.
+        var updated = await _claimRepository.GetByIdAsync(claim.Id);
+        if (updated == null)
+        {
+            claim.Status = ClaimStatus.Voided;
+            claim.VersionState = ClaimVersionState.Voided;
+            claim.LastUpdatedDate = voidedAt;
+            claim.LastUpdatedBy = actorId;
+            updated = claim;
+            _logger.LogWarning(
+                "Void refetch returned null for claim {ClaimId}; emitting events from in-memory post-Void state",
+                Sanitize(claim.Id));
+        }
 
         try
         {

--- a/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
+++ b/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
@@ -30,6 +30,23 @@ public interface IClaimVersionEventPublisher
     Task<ClaimVersionEvent> PublishVersionDeniedAsync(Claim version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default);
     Task<ClaimVersionEvent> PublishVersionSupersededAsync(Claim from, Claim to, string? reason, string? actorId, string? correlationId, CancellationToken ct = default);
     Task<ClaimVersionEvent> PublishVersionVoidedAsync(Claim version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Capability 5.12. Append a <c>ClaimVersionReversed</c> event for the
+    /// <paramref name="version"/> being reversed (the predecessor in an
+    /// adjustment workflow). Distinct from
+    /// <see cref="PublishVersionSupersededAsync"/>: supersession marks
+    /// the chain transition; reversal signals downstream consumers
+    /// (audit/lineage, future FHIR _history, payment-service ReversalRun
+    /// queue) that the prior accumulator state must be unwound.
+    /// </summary>
+    Task<ClaimVersionEvent> PublishVersionReversedAsync(
+        Claim version,
+        string supersessorVersionId,
+        string adjustmentReason,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default);
 }
 
 public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublisher
@@ -197,6 +214,43 @@ public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublishe
         return AppendAsync(evt, ct);
     }
 
+    public Task<ClaimVersionEvent> PublishVersionReversedAsync(
+        Claim version,
+        string supersessorVersionId,
+        string adjustmentReason,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+    {
+        var payload = new JsonObject
+        {
+            ["versionId"] = version.Id,
+            ["versionNumber"] = version.VersionNumber,
+            ["supersessorVersionId"] = supersessorVersionId,
+            ["adjustmentReason"] = adjustmentReason,
+            ["originalCheckNumber"] = version.AdjudicationResult?.CheckNumber,
+            ["originalPayerPayment"] = version.AdjudicationResult?.PayerPayment,
+            ["originalPaidDate"] = version.PaidDate
+        };
+
+        var evt = new ClaimVersionEvent
+        {
+            // Pair the predecessor and supersessor in the event id so two
+            // adjustments against the same predecessor (Phase 2) emit
+            // distinct rows. Today the depth=1 invariant means at most one
+            // such reversal per predecessor; the pairing is forward-compat.
+            EventId = $"reversed:{version.Id}->{supersessorVersionId}",
+            EventType = ClaimVersionEventType.ClaimVersionReversed,
+            TenantId = version.TenantId,
+            ClaimVersionId = version.ClaimVersionId,
+            VersionId = version.Id,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = payload
+        };
+        return AppendAsync(evt, ct);
+    }
+
     private async Task<ClaimVersionEvent> AppendAsync(ClaimVersionEvent evt, CancellationToken ct)
     {
         evt.PartitionKey = ClaimVersionEvent.BuildPartitionKey(evt.TenantId, evt.ClaimVersionId);
@@ -298,6 +352,15 @@ public sealed class NoopClaimVersionEventPublisher : IClaimVersionEventPublisher
 
     public Task<ClaimVersionEvent> PublishVersionVoidedAsync(Claim version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default)
         => DropAndReturn(version, $"voided:{version.Id}", ClaimVersionEventType.ClaimVersionVoided, actorId, correlationId);
+
+    public Task<ClaimVersionEvent> PublishVersionReversedAsync(
+        Claim version,
+        string supersessorVersionId,
+        string adjustmentReason,
+        string? actorId,
+        string? correlationId,
+        CancellationToken ct = default)
+        => DropAndReturn(version, $"reversed:{version.Id}->{supersessorVersionId}", ClaimVersionEventType.ClaimVersionReversed, actorId, correlationId);
 
     private Task<ClaimVersionEvent> DropAndReturn(Claim version, string eventId, ClaimVersionEventType type, string? actorId, string? correlationId)
     {

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
@@ -966,6 +966,101 @@ public class AdjudicationControllerTests : IClassFixture<AdjudicationControllerT
 }
 
 /// <summary>
+/// Capability 5.12a — covers the new
+/// <c>POST /api/v1/adjudication/reverse-claim</c> endpoint added per
+/// Decision 15. Verifies the controller forwards to
+/// <see cref="IBenefitCalculationEngine.ReverseClaimAsync"/> with the
+/// expected arguments and returns 204 on success / 400 on bad input.
+/// </summary>
+public class AdjudicationControllerReverseClaimTests : IClassFixture<AdjudicationControllerTests.Factory>
+{
+    private const string TenantId = "test-tenant-001";
+    private static readonly Guid PlanId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+
+    private readonly AdjudicationControllerTests.Factory _factory;
+
+    public AdjudicationControllerReverseClaimTests(AdjudicationControllerTests.Factory factory) => _factory = factory;
+
+    private HttpClient CreateClient()
+    {
+        var c = _factory.CreateClient();
+        c.DefaultRequestHeaders.Add("X-Tenant-ID", TenantId);
+        return c;
+    }
+
+    [Fact]
+    public async Task ReverseClaim_HappyPath_ReturnsNoContentAndCallsEngine()
+    {
+        var client = CreateClient();
+        var body = new ReverseClaimRequest
+        {
+            MemberId = "m1",
+            SubscriberId = "sub-1",
+            BenefitPlanId = PlanId,
+            ServiceDate = new DateOnly(2026, 5, 1),
+            OriginalClaimId = "claim-99",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/reverse-claim", body);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        await _factory.BenefitEngine.Received(1).ReverseClaimAsync(
+            "m1", "sub-1", PlanId, new DateOnly(2026, 5, 1), "claim-99", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReverseClaim_MissingMemberId_Returns400()
+    {
+        var client = CreateClient();
+        var body = new ReverseClaimRequest
+        {
+            MemberId = "",
+            SubscriberId = "sub-1",
+            BenefitPlanId = PlanId,
+            ServiceDate = new DateOnly(2026, 5, 1),
+            OriginalClaimId = "claim-99",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/reverse-claim", body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReverseClaim_MissingOriginalClaimId_Returns400()
+    {
+        var client = CreateClient();
+        var body = new ReverseClaimRequest
+        {
+            MemberId = "m1",
+            SubscriberId = "sub-1",
+            BenefitPlanId = PlanId,
+            ServiceDate = new DateOnly(2026, 5, 1),
+            OriginalClaimId = "",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/reverse-claim", body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReverseClaim_EmptyBenefitPlanId_Returns400()
+    {
+        var client = CreateClient();
+        var body = new ReverseClaimRequest
+        {
+            MemberId = "m1",
+            SubscriberId = "sub-1",
+            BenefitPlanId = Guid.Empty,
+            ServiceDate = new DateOnly(2026, 5, 1),
+            OriginalClaimId = "claim-99",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/reverse-claim", body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}
+
+/// <summary>
 /// DTO for the 422 error response from the /adjudicate endpoint when NCCI edits fail.
 /// </summary>
 internal record NcciErrorResponse

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -77,7 +77,8 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType.FullName?.Contains("Mongo") == true
                          || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                          || d.ImplementationType?.FullName?.Contains("Mongo") == true
-                         || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true)
+                         || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
+                         || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true)
                 .ToList();
 
             foreach (var descriptor in cosmosDescriptors)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -22,6 +22,8 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
     public IClaimAdapter ClaimAdapter { get; } = CreateChoStubAdapter();
     public IClaimVersionEventPublisher VersionEventPublisher { get; } = Substitute.For<IClaimVersionEventPublisher>();
     public IClaimFinalizationService FinalizationService { get; } = Substitute.For<IClaimFinalizationService>();
+    public IClaimAdjustmentRepository AdjustmentRepository { get; } = Substitute.For<IClaimAdjustmentRepository>();
+    public IClaimAdjustmentService AdjustmentService { get; } = Substitute.For<IClaimAdjustmentService>();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -52,6 +54,8 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType == typeof(IAiExaminationAuditRepository)
                          || d.ServiceType == typeof(IClaimSubmissionService)
                          || d.ServiceType == typeof(IClaimFinalizationService)
+                         || d.ServiceType == typeof(IClaimAdjustmentService)
+                         || d.ServiceType == typeof(IClaimAdjustmentRepository)
                          || d.ServiceType == typeof(IClaimAdapter)
                          || d.ServiceType == typeof(ClaimAdapterFactory)
                          || d.ServiceType == typeof(ClaimTenantConfigCache))
@@ -113,6 +117,8 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(AuditRepository);
             services.AddSingleton(VersionEventPublisher);
             services.AddSingleton(FinalizationService);
+            services.AddSingleton(AdjustmentRepository);
+            services.AddSingleton(AdjustmentService);
 
             // 5.7 — NcciEngine's repository implementation got removed by
             // the Cosmos/Mongo filter above. The engine's INcciEditService

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -189,6 +189,7 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                              || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                              || d.ImplementationType?.FullName?.Contains("Mongo") == true
                              || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
+                             || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true
                              || d.ServiceType == typeof(IClaimVersionEventPublisher)
                              || d.ServiceType == typeof(IBenefitCalculationEngine)
                              || d.ServiceType == typeof(IBenefitPlanResolver)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -202,6 +202,16 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                 services.AddSingleton(Repository);
                 services.AddSingleton(Substitute.For<IClaimVersionEventPublisher>());
 
+                // 5.12a — IClaimAdjustmentRepository is removed by the
+                // Cosmos/Mongo substring filter above (both impls have those
+                // tokens in their type names). IClaimAdjustmentService still
+                // depends on it, so register substitutes for DI validation.
+                // This integration test exercises the submission/adjudication
+                // path, not the adjustment workflow, so substitutes never
+                // get invoked.
+                services.AddSingleton(Substitute.For<IClaimAdjustmentRepository>());
+                services.AddSingleton(Substitute.For<IClaimAdjustmentService>());
+
                 // 5.7 — NcciEngine's repository implementation gets removed
                 // by the Cosmos/Mongo filter above. INcciEditService still
                 // depends on INcciRepository — register a substitute so

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Services.Adjudication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication;
+
+/// <summary>
+/// Capability 5.12a — verifies
+/// <see cref="HttpBenefitCalculationEngineClient.ReverseClaimAsync"/>
+/// dispatches the reversal HTTP call to BP service's
+/// <c>POST /api/v1/adjudication/reverse-claim</c> endpoint with the
+/// expected payload, propagates the X-Tenant-ID header from the scoped
+/// adjudication context, and surfaces non-2xx responses as
+/// <see cref="HttpRequestException"/>.
+/// </summary>
+public class HttpBenefitCalculationEngineClientReverseTests
+{
+    private readonly StubHttpMessageHandler _handler = new();
+    private readonly IHttpClientFactory _factory;
+    private readonly IHttpContextAccessor _httpContext = Substitute.For<IHttpContextAccessor>();
+    private readonly IAdjudicationTenantContext _tenantContext = Substitute.For<IAdjudicationTenantContext>();
+
+    public HttpBenefitCalculationEngineClientReverseTests()
+    {
+        _factory = Substitute.For<IHttpClientFactory>();
+        _factory.CreateClient(HttpBenefitCalculationEngineClient.HttpClientName).Returns(_ =>
+            new HttpClient(_handler) { BaseAddress = new Uri("http://benefit-plan-service:8080") });
+    }
+
+    private HttpBenefitCalculationEngineClient CreateClient() => new(
+        _factory, _httpContext, _tenantContext, NullLogger<HttpBenefitCalculationEngineClient>.Instance);
+
+    [Fact]
+    public async Task ReverseClaimAsync_HappyPath_PostsToReverseEndpointAndReturns()
+    {
+        _tenantContext.TenantId.Returns("tenant-x");
+        _handler.RespondWith(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+        var sut = CreateClient();
+        await sut.ReverseClaimAsync(
+            memberId: "m1",
+            subscriberId: "sub-1",
+            benefitPlanId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            serviceDate: new DateOnly(2026, 5, 1),
+            originalClaimId: "claim-99");
+
+        Assert.NotNull(_handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, _handler.LastRequest!.Method);
+        Assert.Equal("/api/v1/adjudication/reverse-claim", _handler.LastRequest.RequestUri!.AbsolutePath);
+        Assert.Equal("tenant-x", _handler.LastRequest.Headers.GetValues("X-Tenant-ID").Single());
+
+        Assert.NotNull(_handler.LastBodyJson);
+        var doc = JsonDocument.Parse(_handler.LastBodyJson!);
+        Assert.Equal("m1", doc.RootElement.GetProperty("memberId").GetString());
+        Assert.Equal("sub-1", doc.RootElement.GetProperty("subscriberId").GetString());
+        Assert.Equal("claim-99", doc.RootElement.GetProperty("originalClaimId").GetString());
+    }
+
+    [Fact]
+    public async Task ReverseClaimAsync_HttpFailure_ThrowsHttpRequestException()
+    {
+        _tenantContext.TenantId.Returns("tenant-x");
+        _handler.RespondWith(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("engine error")
+        });
+
+        var sut = CreateClient();
+        await Assert.ThrowsAsync<HttpRequestException>(() => sut.ReverseClaimAsync(
+            "m1", "sub-1",
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            new DateOnly(2026, 5, 1),
+            "claim-99"));
+    }
+
+    [Fact]
+    public async Task ReverseClaimAsync_BlankMemberId_Throws()
+    {
+        var sut = CreateClient();
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ReverseClaimAsync(
+            "", "sub-1", Guid.NewGuid(), new DateOnly(2026, 5, 1), "claim-99"));
+    }
+
+    [Fact]
+    public async Task ReverseClaimAsync_BlankOriginalClaimId_Throws()
+    {
+        var sut = CreateClient();
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.ReverseClaimAsync(
+            "m1", "sub-1", Guid.NewGuid(), new DateOnly(2026, 5, 1), ""));
+    }
+
+    [Fact]
+    public async Task ReverseClaimAsync_TenantIdFallsBackToHttpContextWhenScopedContextEmpty()
+    {
+        _tenantContext.TenantId.Returns(string.Empty);
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = "fallback-tenant";
+        _httpContext.HttpContext.Returns(ctx);
+        _handler.RespondWith(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+        var sut = CreateClient();
+        await sut.ReverseClaimAsync(
+            "m1", "sub-1", Guid.NewGuid(), new DateOnly(2026, 5, 1), "claim-99");
+
+        Assert.Equal("fallback-tenant", _handler.LastRequest!.Headers.GetValues("X-Tenant-ID").Single());
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private HttpResponseMessage _response = new(HttpStatusCode.NoContent);
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastBodyJson { get; private set; }
+
+        public void RespondWith(HttpResponseMessage response) => _response = response;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content != null)
+            {
+                LastBodyJson = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+            return _response;
+        }
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimAdjustmentServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimAdjustmentServiceTests.cs
@@ -344,7 +344,7 @@ public class ClaimAdjustmentServiceTests
     }
 
     [Fact]
-    public async Task CreateAdjustment_SubmissionFails_ReturnsSubmissionFailedAndDoesNotSupersede()
+    public async Task CreateAdjustment_SubmissionFails_ReturnsSubmissionFailedAndReleasesChainLock()
     {
         var p = PaidPredecessor();
         _claimRepository.GetByIdAsync("pred-1").Returns(p);
@@ -352,16 +352,40 @@ public class ClaimAdjustmentServiceTests
         _submissionService
             .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(ClaimSubmissionResult.ValidationFailed(errors)));
+        _adjustmentRepository.DeleteAsync(default!, default!, default).ReturnsForAnyArgs(true);
 
         var sut = CreateService();
         var result = await sut.CreateAdjustmentAsync(
             "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
 
         Assert.Equal(ClaimAdjustmentOutcome.SubmissionFailed, result.Outcome);
+        Assert.Equal(ClaimSubmissionFailureKind.Validation, result.SubmissionFailureKind);
         Assert.Single(result.SubmissionErrors);
         await _claimRepository.DidNotReceiveWithAnyArgs().MarkSupersededProjectionAsync(
             default!, default!, default!, default, default, default);
-        await _adjustmentRepository.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+        // Placeholder was inserted (chain lock acquired) then released on failure.
+        await _adjustmentRepository.Received(1).CreateAsync(Arg.Any<ClaimAdjustment>(), Arg.Any<CancellationToken>());
+        await _adjustmentRepository.Received(1).DeleteAsync("t1", Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Final-stage UpdateAsync (NewClaimId set) must NOT have run.
+        await _adjustmentRepository.DidNotReceiveWithAnyArgs().UpdateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_AdapterNotImplemented_Returns501FailureKind()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(ClaimSubmissionResult.AdapterNotImplemented("vendor stub")));
+        _adjustmentRepository.DeleteAsync(default!, default!, default).ReturnsForAnyArgs(true);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.SubmissionFailed, result.Outcome);
+        Assert.Equal(ClaimSubmissionFailureKind.NotImplemented, result.SubmissionFailureKind);
     }
 
     [Fact]
@@ -404,12 +428,13 @@ public class ClaimAdjustmentServiceTests
     }
 
     [Fact]
-    public async Task CreateAdjustment_SupersessionFails_ReturnsSubmissionFailed()
+    public async Task CreateAdjustment_SupersessionFails_ReturnsSubmissionFailedAndReleasesChainLock()
     {
         var p = PaidPredecessor();
         _claimRepository.GetByIdAsync("pred-1").Returns(p);
         _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default, default, default)
             .ReturnsForAnyArgs(false);
+        _adjustmentRepository.DeleteAsync(default!, default!, default).ReturnsForAnyArgs(true);
         StubSubmissionSuccess();
 
         var sut = CreateService();
@@ -417,7 +442,11 @@ public class ClaimAdjustmentServiceTests
             "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
 
         Assert.Equal(ClaimAdjustmentOutcome.SubmissionFailed, result.Outcome);
-        await _adjustmentRepository.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+        // Placeholder was inserted (chain lock acquired) then released.
+        await _adjustmentRepository.Received(1).CreateAsync(Arg.Any<ClaimAdjustment>(), Arg.Any<CancellationToken>());
+        await _adjustmentRepository.Received(1).DeleteAsync("t1", Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // Final-stage UpdateAsync (NewClaimId set) must NOT have run.
+        await _adjustmentRepository.DidNotReceiveWithAnyArgs().UpdateAsync(default!, default);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimAdjustmentServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimAdjustmentServiceTests.cs
@@ -1,0 +1,479 @@
+using ClaimsService.Models;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using CloudHealthOffice.Infrastructure.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+/// <summary>
+/// Capability 5.12a — covers <see cref="ClaimAdjustmentService"/>'s
+/// happy path + the source-state, depth, idempotency, and chain-conflict
+/// branches; verifies the dual version-event emission
+/// (<c>ClaimVersionSuperseded</c> + <c>ClaimVersionReversed</c>) and the
+/// Service Bus <c>ClaimVersionReversedMessage</c> emit; verifies the
+/// fresh-AI-examination semantics (Gap 6 — predecessor's
+/// <see cref="Claim.AiExamination"/> snapshot is not carried over).
+/// </summary>
+public class ClaimAdjustmentServiceTests
+{
+    private readonly IClaimRepository _claimRepository = Substitute.For<IClaimRepository>();
+    private readonly IClaimAdjustmentRepository _adjustmentRepository = Substitute.For<IClaimAdjustmentRepository>();
+    private readonly IClaimSubmissionService _submissionService = Substitute.For<IClaimSubmissionService>();
+    private readonly IClaimVersionEventPublisher _versionPublisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
+
+    private ClaimAdjustmentService CreateService() => new(
+        _claimRepository,
+        _adjustmentRepository,
+        _submissionService,
+        _versionPublisher,
+        _messageBus,
+        NullLogger<ClaimAdjustmentService>.Instance);
+
+    private static Claim PaidPredecessor(string id = "pred-1", string tenantId = "t1") => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        ClaimVersionId = id,
+        VersionNumber = 1,
+        VersionState = ClaimVersionState.Paid,
+        Status = ClaimStatus.Paid,
+        ClaimNumber = "CLM-001",
+        MemberId = "m1",
+        BillingProviderNPI = "1234567890",
+        ServiceDateFrom = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        TotalChargeAmount = 1000m,
+        AdjudicationResult = new AdjudicationResult { CheckNumber = "CHK-001", PayerPayment = 800m },
+        AiExamination = new AiExamination { Rationale = "stale-pre-adjustment" },
+    };
+
+    private static AdapterClaim CorrectedAdapterClaim(string memberId = "m1") => new()
+    {
+        TenantId = "ignored-overridden",
+        Id = "ignored-overridden",
+        ClaimVersionId = "ignored-overridden",
+        VersionNumber = 999,
+        VersionState = ClaimVersionState.Adjudicated,
+        PredecessorVersionId = "ignored-overridden",
+        ClaimNumber = "CLM-001",
+        MemberId = memberId,
+        BillingProviderNPI = "1234567890",
+        ServiceDateFrom = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        TotalChargeAmount = 1200m,
+        Status = ClaimStatus.Approved,
+        AiExamination = new AiExamination { Rationale = "should-be-zeroed" },
+        PendDetails = new PendDetails { },
+        AdjudicationResult = new AdapterAdjudicationResult { PayerPayment = 1100m },
+        ClaimLines = new List<AdapterClaimLine>
+        {
+            new() { ProcedureCode = "99213", ChargeAmount = 1200m, Units = 1 }
+        },
+    };
+
+    private static ClaimAdjustmentRequest Request(string reason = "Wrong service code") => new()
+    {
+        AdjustmentReason = reason,
+        Notes = "operator note",
+        CorrectedClaim = CorrectedAdapterClaim(),
+    };
+
+    private void StubSubmissionSuccess(string newClaimId = "new-1", int newVersionNumber = 2, string chainKey = "pred-1")
+    {
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var c = ci.Arg<AdapterClaim>();
+                c.Id = newClaimId;
+                c.ClaimVersionId = chainKey;
+                c.VersionNumber = newVersionNumber;
+                c.VersionState = ClaimVersionState.Submitted;
+                return Task.FromResult(ClaimSubmissionResult.Ok(c));
+            });
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_HappyPath_PersistsAggregateAndEmitsAllSignals()
+    {
+        var predecessor = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(predecessor);
+        _claimRepository.MarkSupersededProjectionAsync("t1", "pred-1", Arg.Any<string>(), Arg.Any<DateTime>(), "actor-1", Arg.Any<CancellationToken>())
+            .Returns(true);
+        StubSubmissionSuccess();
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.Created, result.Outcome);
+        Assert.NotNull(result.Adjustment);
+        Assert.Equal(ClaimAdjustmentStatus.AwaitingReadjudication, result.Adjustment!.Status);
+        Assert.Equal("pred-1", result.Adjustment.PredecessorClaimId);
+        Assert.Equal("new-1", result.Adjustment.NewClaimId);
+        Assert.Equal("pred-1", result.Adjustment.ClaimVersionId);
+
+        await _claimRepository.Received(1).MarkSupersededProjectionAsync(
+            "t1", "pred-1", "new-1", Arg.Any<DateTime>(), "actor-1", Arg.Any<CancellationToken>());
+        await _versionPublisher.Received(1).PublishVersionSupersededAsync(
+            Arg.Any<Claim>(), Arg.Any<Claim>(), "Wrong service code", "actor-1", "corr-1", Arg.Any<CancellationToken>());
+        await _versionPublisher.Received(1).PublishVersionReversedAsync(
+            Arg.Any<Claim>(), "new-1", "Wrong service code", "actor-1", "corr-1", Arg.Any<CancellationToken>());
+        await _messageBus.Received(1).SendAsync(
+            "claim-version-events",
+            Arg.Any<ClaimVersionReversedMessage>(),
+            Arg.Any<SendOptions?>(),
+            Arg.Any<CancellationToken>());
+        await _adjustmentRepository.Received(1).CreateAsync(Arg.Any<ClaimAdjustment>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_OverridesIdentityFieldsAndZerosStaleSignals()
+    {
+        var predecessor = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(predecessor);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default!, default, default)
+            .ReturnsForAnyArgs(true);
+
+        // Snapshot the as-handed-off-to-SubmitAsync state BEFORE the stub
+        // simulates the adapter assigning a new id. AdapterClaim is a class
+        // (reference type), so the service's pre-submit mutations are visible
+        // to whatever the stub later writes — snapshot at hand-off time.
+        AdapterClaim? snapshot = null;
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var c = ci.Arg<AdapterClaim>();
+                snapshot = AdapterClaim.From(c.ToClaim());
+                c.Id = "new-1";
+                return Task.FromResult(ClaimSubmissionResult.Ok(c));
+            });
+
+        var sut = CreateService();
+        await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.NotNull(snapshot);
+        Assert.Equal("t1", snapshot!.TenantId);
+        Assert.Equal(string.Empty, snapshot.Id); // CreateAsync inside adapter assigns id
+        Assert.Equal("pred-1", snapshot.ClaimVersionId);
+        Assert.Equal(2, snapshot.VersionNumber);
+        Assert.Equal(ClaimVersionState.Submitted, snapshot.VersionState);
+        Assert.Equal("pred-1", snapshot.PredecessorVersionId);
+        Assert.Equal(ClaimStatus.Submitted, snapshot.Status);
+        // Gap 6 — fresh AI examination; predecessor's snapshot must not leak
+        Assert.Null(snapshot.AiExamination);
+        Assert.Null(snapshot.PendDetails);
+        Assert.Null(snapshot.AdjudicationResult);
+        Assert.Null(snapshot.PaidDate);
+        Assert.Null(snapshot.AdjudicatedDate);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_SameIdempotencyKey_SameBody_ReturnsAlreadyExists()
+    {
+        // The replay scenario tests hash *value* equality, not object
+        // identity. Construct an existing ClaimAdjustment whose RequestHash
+        // matches what the service will compute from the second call's
+        // request. Use the same internal hashing helper to guarantee
+        // alignment with the service's logic.
+        var request = Request();
+        var expectedHash = ClaimAdjustmentService.ComputeRequestHash("pred-1", request);
+        var existing = new ClaimAdjustment
+        {
+            TenantId = "t1",
+            Id = "adj-existing",
+            ClaimVersionId = "pred-1",
+            PredecessorClaimId = "pred-1",
+            PredecessorVersionId = "pred-1",
+            NewClaimId = "new-from-prior-call",
+            AdjustmentReason = "Wrong service code",
+            Status = ClaimAdjustmentStatus.AwaitingReadjudication,
+            IdempotencyKey = "idem-1",
+            RequestHash = expectedHash,
+            CreatedBy = "actor-1",
+        };
+        _adjustmentRepository.GetByIdempotencyKeyAsync("t1", "idem-1", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", request, "idem-1", "t1", "actor-1", "corr-replay");
+
+        Assert.Equal(ClaimAdjustmentOutcome.AlreadyExists, result.Outcome);
+        Assert.Same(existing, result.Adjustment);
+        await _adjustmentRepository.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_SameIdempotencyKey_DifferentBody_ReturnsConflict()
+    {
+        var stale = new ClaimAdjustment
+        {
+            TenantId = "t1",
+            ClaimVersionId = "pred-1",
+            PredecessorClaimId = "pred-1",
+            PredecessorVersionId = "pred-1",
+            NewClaimId = "new-1",
+            AdjustmentReason = "DIFFERENT REASON",
+            Status = ClaimAdjustmentStatus.AwaitingReadjudication,
+            IdempotencyKey = "idem-1",
+            RequestHash = "OLD_HASH_DIFFERENT",
+            CreatedBy = "actor-0",
+        };
+        _adjustmentRepository.GetByIdempotencyKeyAsync("t1", "idem-1", Arg.Any<CancellationToken>()).Returns(stale);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request("Wrong service code"), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.IdempotencyConflict, result.Outcome);
+        Assert.Same(stale, result.Adjustment);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_PredecessorNotFound_Returns404()
+    {
+        _claimRepository.GetByIdAsync("missing").Returns((Claim?)null);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "missing", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.PredecessorNotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_PredecessorWrongTenant_Returns404()
+    {
+        var p = PaidPredecessor(tenantId: "OTHER");
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.PredecessorNotFound, result.Outcome);
+    }
+
+    [Theory]
+    [InlineData(ClaimStatus.Submitted)]
+    [InlineData(ClaimStatus.Pended)]
+    [InlineData(ClaimStatus.InAdjudication)]
+    [InlineData(ClaimStatus.Approved)]
+    [InlineData(ClaimStatus.Voided)]
+    public async Task CreateAdjustment_InvalidSourceState_Returns422(ClaimStatus status)
+    {
+        var p = PaidPredecessor();
+        p.Status = status;
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.InvalidSourceState, result.Outcome);
+    }
+
+    [Theory]
+    [InlineData(ClaimStatus.Paid)]
+    [InlineData(ClaimStatus.Denied)]
+    [InlineData(ClaimStatus.PartiallyPaid)]
+    public async Task CreateAdjustment_AcceptedSourceStates_DoNotReturnInvalidSourceState(ClaimStatus status)
+    {
+        var p = PaidPredecessor();
+        p.Status = status;
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default!, default, default)
+            .ReturnsForAnyArgs(true);
+        StubSubmissionSuccess();
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), $"idem-{status}", "t1", "actor-1", "corr-1");
+
+        Assert.NotEqual(ClaimAdjustmentOutcome.InvalidSourceState, result.Outcome);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_DepthLimitExceeded_Returns422()
+    {
+        var p = PaidPredecessor();
+        p.PredecessorVersionId = "earlier-version";  // predecessor is itself an adjustment
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.DepthLimitExceeded, result.Outcome);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_ChainHasInflightAdjustment_Returns409()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        var existing = new ClaimAdjustment
+        {
+            TenantId = "t1",
+            ClaimVersionId = "pred-1",
+            PredecessorClaimId = "pred-1",
+            PredecessorVersionId = "pred-1",
+            NewClaimId = "new-0",
+            Status = ClaimAdjustmentStatus.PendingReversal,
+            IdempotencyKey = "idem-old",
+            RequestHash = "h",
+            CreatedBy = "actor-0",
+            AdjustmentReason = "earlier",
+        };
+        _adjustmentRepository.GetByClaimVersionIdAsync("t1", "pred-1", Arg.Any<CancellationToken>()).Returns(existing);
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-new", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.ConflictingAdjustment, result.Outcome);
+        Assert.Same(existing, result.Adjustment);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_SubmissionFails_ReturnsSubmissionFailedAndDoesNotSupersede()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        var errors = new[] { new ValidationError { Field = "MemberId", Code = "Required", Message = "required" } };
+        _submissionService
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(ClaimSubmissionResult.ValidationFailed(errors)));
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.SubmissionFailed, result.Outcome);
+        Assert.Single(result.SubmissionErrors);
+        await _claimRepository.DidNotReceiveWithAnyArgs().MarkSupersededProjectionAsync(
+            default!, default!, default!, default, default, default);
+        await _adjustmentRepository.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_VersionPublisherThrows_StillCreatesAdjustment()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default, default, default)
+            .ReturnsForAnyArgs(true);
+        StubSubmissionSuccess();
+        _versionPublisher
+            .PublishVersionSupersededAsync(default!, default!, default, default, default, default)
+            .ReturnsForAnyArgs<ClaimVersionEvent>(_ => throw new InvalidOperationException("Mongo down"));
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.Created, result.Outcome);
+        await _adjustmentRepository.Received(1).CreateAsync(Arg.Any<ClaimAdjustment>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_ServiceBusEmitFails_StillCreatesAdjustment()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default, default, default)
+            .ReturnsForAnyArgs(true);
+        StubSubmissionSuccess();
+        _messageBus
+            .SendAsync(Arg.Any<string>(), Arg.Any<ClaimVersionReversedMessage>(), Arg.Any<SendOptions?>(), Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("Service Bus down"));
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.Created, result.Outcome);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_SupersessionFails_ReturnsSubmissionFailed()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default, default, default)
+            .ReturnsForAnyArgs(false);
+        StubSubmissionSuccess();
+
+        var sut = CreateService();
+        var result = await sut.CreateAdjustmentAsync(
+            "pred-1", Request(), "idem-1", "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimAdjustmentOutcome.SubmissionFailed, result.Outcome);
+        await _adjustmentRepository.DidNotReceiveWithAnyArgs().CreateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_RejectsBlankIdempotencyKey()
+    {
+        var sut = CreateService();
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.CreateAdjustmentAsync("pred-1", Request(), "", "t1", "actor-1", "corr-1"));
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_RejectsBlankActorId()
+    {
+        var sut = CreateService();
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.CreateAdjustmentAsync("pred-1", Request(), "idem-1", "t1", "", "corr-1"));
+    }
+
+    [Fact]
+    public async Task CreateAdjustment_ServiceBusMessageCarriesCorrectMetadata()
+    {
+        var p = PaidPredecessor();
+        _claimRepository.GetByIdAsync("pred-1").Returns(p);
+        _claimRepository.MarkSupersededProjectionAsync(default!, default!, default!, default, default, default)
+            .ReturnsForAnyArgs(true);
+        StubSubmissionSuccess(newClaimId: "new-7");
+
+        ClaimVersionReversedMessage? captured = null;
+        SendOptions? capturedOptions = null;
+        _messageBus
+            .When(b => b.SendAsync(
+                Arg.Any<string>(),
+                Arg.Any<ClaimVersionReversedMessage>(),
+                Arg.Any<SendOptions?>(),
+                Arg.Any<CancellationToken>()))
+            .Do(ci =>
+            {
+                captured = ci.Arg<ClaimVersionReversedMessage>();
+                capturedOptions = ci.Arg<SendOptions?>();
+            });
+
+        var sut = CreateService();
+        await sut.CreateAdjustmentAsync(
+            "pred-1", Request("Charged wrong code"), "idem-1", "t1", "actor-1", "corr-99");
+
+        Assert.NotNull(captured);
+        Assert.Equal("t1", captured!.TenantId);
+        Assert.Equal("pred-1", captured.ClaimId);
+        Assert.Equal("pred-1", captured.PredecessorVersionId);
+        Assert.Equal("new-7", captured.SupersessorClaimId);
+        Assert.Equal("Charged wrong code", captured.AdjustmentReason);
+        Assert.Equal("actor-1", captured.ActorId);
+        Assert.Equal("corr-99", captured.CorrelationId);
+
+        Assert.NotNull(capturedOptions);
+        Assert.Equal("reversed:pred-1->new-7", capturedOptions!.MessageId);
+        Assert.Equal("ClaimVersionReversed", capturedOptions.Properties!["MessageType"]);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimFinalizationServiceVoidAsyncTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/ClaimFinalizationServiceVoidAsyncTests.cs
@@ -1,0 +1,192 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+/// <summary>
+/// Capability 5.12a — covers <see cref="ClaimFinalizationService.VoidAsync"/>
+/// added per Gap 1 ratification. The method owns the
+/// Paid/PartiallyPaid/Adjusted → Voided transition; emits
+/// <c>ClaimVersionVoided</c> and <c>claims.finalized.v1</c> with the
+/// existing Voided→"Reversed" Kafka mapping convention.
+/// </summary>
+public class ClaimFinalizationServiceVoidAsyncTests
+{
+    private readonly IClaimRepository _repo = Substitute.For<IClaimRepository>();
+    private readonly IClaimVersionEventPublisher _versionPublisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IClaimEventPublisher _kafkaPublisher = Substitute.For<IClaimEventPublisher>();
+
+    private ClaimFinalizationService CreateService() =>
+        new(_repo, _versionPublisher, _kafkaPublisher, NullLogger<ClaimFinalizationService>.Instance);
+
+    private static Claim PaidClaim(string id = "c1", string tenantId = "t1") => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        ClaimVersionId = id,
+        VersionNumber = 1,
+        VersionState = ClaimVersionState.Paid,
+        ClaimNumber = "CLM-001",
+        Status = ClaimStatus.Paid,
+        AdjudicationResult = new AdjudicationResult { CheckNumber = "CHK-001", PayerPayment = 800m },
+        ServiceDateFrom = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        BillingProviderNPI = "1234567890",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        MemberId = "m1",
+        TotalChargeAmount = 1000m,
+    };
+
+    [Fact]
+    public async Task VoidAsync_PaidClaim_TransitionsToVoidedAndEmitsEvents()
+    {
+        var claim = PaidClaim();
+        _repo.GetByIdAsync("c1").Returns(claim);
+        _repo.MarkVoidedProjectionAsync("t1", "c1", Arg.Any<DateTime>(), "actor-1", Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1",
+            new ClaimVoidRequest { Reason = "Adjustment ReversalRun", ReversalRunId = "rr-1" },
+            "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.Voided, result.Outcome);
+        await _repo.Received(1).MarkVoidedProjectionAsync(
+            "t1", "c1", Arg.Any<DateTime>(), "actor-1", Arg.Any<CancellationToken>());
+        await _versionPublisher.Received(1).PublishVersionVoidedAsync(
+            Arg.Any<Claim>(), "Adjustment ReversalRun", "actor-1", "corr-1", Arg.Any<CancellationToken>());
+        await _kafkaPublisher.Received(1).PublishClaimFinalizedAsync(Arg.Any<Claim>(), "t1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task VoidAsync_AlreadyVoided_IsIdempotentNoOp()
+    {
+        var claim = PaidClaim();
+        claim.Status = ClaimStatus.Voided;
+        claim.VersionState = ClaimVersionState.Voided;
+        _repo.GetByIdAsync("c1").Returns(claim);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "double-void test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.AlreadyVoided, result.Outcome);
+        await _repo.DidNotReceiveWithAnyArgs().MarkVoidedProjectionAsync(default!, default!, default, default, default);
+        await _versionPublisher.DidNotReceiveWithAnyArgs().PublishVersionVoidedAsync(default!, default, default, default, default);
+        await _kafkaPublisher.DidNotReceiveWithAnyArgs().PublishClaimFinalizedAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task VoidAsync_AdjustedSourceState_AcceptedViaVersionStatePath()
+    {
+        var claim = PaidClaim();
+        claim.Status = ClaimStatus.Paid;       // Status untouched after supersession
+        claim.VersionState = ClaimVersionState.Adjusted;
+        _repo.GetByIdAsync("c1").Returns(claim);
+        _repo.MarkVoidedProjectionAsync(default!, default!, default, default, default)
+            .ReturnsForAnyArgs(true);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "ReversalRun completing supersession" },
+            "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.Voided, result.Outcome);
+    }
+
+    [Theory]
+    [InlineData(ClaimStatus.Submitted)]
+    [InlineData(ClaimStatus.Pended)]
+    [InlineData(ClaimStatus.Approved)]
+    [InlineData(ClaimStatus.Denied)]
+    public async Task VoidAsync_NonVoidEligibleSourceState_Returns422(ClaimStatus status)
+    {
+        var claim = PaidClaim();
+        claim.Status = status;
+        claim.VersionState = ClaimVersionState.Submitted;  // ensure VersionState path doesn't accept it
+        _repo.GetByIdAsync("c1").Returns(claim);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.InvalidSourceState, result.Outcome);
+    }
+
+    [Fact]
+    public async Task VoidAsync_PartiallyPaid_AcceptedAsVoidEligible()
+    {
+        var claim = PaidClaim();
+        claim.Status = ClaimStatus.PartiallyPaid;
+        _repo.GetByIdAsync("c1").Returns(claim);
+        _repo.MarkVoidedProjectionAsync(default!, default!, default, default, default).ReturnsForAnyArgs(true);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.Voided, result.Outcome);
+    }
+
+    [Fact]
+    public async Task VoidAsync_UnknownClaimId_Returns404()
+    {
+        _repo.GetByIdAsync("missing").Returns((Claim?)null);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "missing", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.NotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task VoidAsync_WrongTenant_Returns404()
+    {
+        var claim = PaidClaim(tenantId: "OTHER");
+        _repo.GetByIdAsync("c1").Returns(claim);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.NotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task VoidAsync_ProjectionWriteFailure_Returns404()
+    {
+        var claim = PaidClaim();
+        _repo.GetByIdAsync("c1").Returns(claim);
+        _repo.MarkVoidedProjectionAsync(default!, default!, default, default, default).ReturnsForAnyArgs(false);
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.NotFound, result.Outcome);
+    }
+
+    [Fact]
+    public async Task VoidAsync_KafkaEmitProceedsAfterVersionPublisherFailure()
+    {
+        var claim = PaidClaim();
+        _repo.GetByIdAsync("c1").Returns(claim);
+        _repo.MarkVoidedProjectionAsync(default!, default!, default, default, default).ReturnsForAnyArgs(true);
+        _versionPublisher
+            .PublishVersionVoidedAsync(default!, default, default, default, default)
+            .ReturnsForAnyArgs<ClaimVersionEvent>(_ => throw new InvalidOperationException("Mongo down"));
+
+        var sut = CreateService();
+        var result = await sut.VoidAsync(
+            "c1", new ClaimVoidRequest { Reason = "test" }, "t1", "actor-1", "corr-1");
+
+        Assert.Equal(ClaimVoidOutcome.Voided, result.Outcome);
+        await _kafkaPublisher.Received(1).PublishClaimFinalizedAsync(Arg.Any<Claim>(), "t1", Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

Operator-initiated adjustment workflow that exercises 5.1a versioning infrastructure for the first time in production. An authorized operator submits a corrected claim through the full 6-stage pipeline; the predecessor version is superseded with `ClaimVersionState.Adjusted`; the new version is persisted with `PredecessorVersionId` set on the same chain. Wires the BP engine accumulator-reversal HTTP surface; extends `ClaimFinalizationService` with the Voided transition path so 5.12b's `ReversalRunService` has an idempotent terminal write.

This is the first half of the 5.12 capability per Plan-First Section 6 split (~1,650 LOC budget; actual ~3K LOC of which most is XML doc comments + tests). 5.12b ships `ReversalRun` + 835 reversal envelope on top of the `PendingReversal` rows this PR creates.

## Plan-First ratifications captured

| Decision | Choice | How realized |
|---|---|---|
| **D14** | (b) aggregate-only — no `ClaimStatus.AdjustmentPending` | Per-version `ClaimStatus` unchanged; cross-version state on `ClaimAdjustment.Status` |
| **D15** | 7(b) — add BP `POST /api/v1/adjudication/reverse-claim` | Engine internals already wired through `ChoAccumulatorService.ReverseAsync` since BP 5.10; this PR adds the HTTP wrapper (~80 LOC) |
| **D16** | Route reversal via BP engine path; accept `AccumulatorSnapshot` drift | Documented in `claim-adjustment-workflow.md` with explicit recovery path; Phase 2 consumer extension deferred |
| **D17** | (deferred to 5.12b) | `BatchEraGeneratorService` extension belongs in 5.12b alongside ReversalRun |
| **D18** | Lifecycle order corrected | `AwaitingReadjudication → PendingReversal → Active` (original prompt's `PendingReversal → AwaitingReadjudication` was impossible — Plan-First caught the inversion) |
| **G1** | Extend `ClaimFinalizationService.VoidAsync` rather than splitting | Keeps version-event emission unified |
| **G2** | Mirror version-chain event for `ClaimVersionReversed` | New `ClaimVersionReversedMessage` on Service Bus + new enum value 7 |
| **G3** | `GET /api/v1/adjustments?status=...` | Filter DTO + paginated controller route ratified |
| **G4** | Mongo-only with Cosmos noop | `ClaimAdjustmentRepositoryCosmosNoop` fails loudly on writes |
| **G5** | `(TenantId, ClaimVersionId)` chain-key uniqueness | Naturally enforces depth=1 invariant |
| **G6** | Fresh AI examination | `AdapterClaim.AiExamination`/`PendDetails`/`AdjudicationResult` zeroed on the corrected payload |

## Surface added

### claims-service
- `POST /api/v1/claims/{predecessorClaimId}/adjustments` — idempotent on `Idempotency-Key` header
- `GET /api/v1/claims/{predecessorClaimId}/adjustments` — chain-scoped list
- `GET /api/v1/adjustments?status=...&...` — tenant-scoped filtered list (5.12b's ReversalRun consumes via this)
- `GET /api/v1/adjustments/{id}` — single fetch
- `ClaimVersionEventType.ClaimVersionReversed = 7` (additive)
- `IClaimVersionEventPublisher.PublishVersionReversedAsync`
- `IClaimRepository.MarkSupersededProjectionAsync` + `MarkVoidedProjectionAsync` (terminal-state-bypass writes)
- `ClaimFinalizationService.VoidAsync` (Paid/PartiallyPaid/Adjusted → Voided; idempotent)
- `HttpBenefitCalculationEngineClient.ReverseClaimAsync` real wire (replaces `NotImplementedException` stub)

### benefit-plan-service
- `POST /api/v1/adjudication/reverse-claim` — thin HTTP wrapper over existing engine method

## Cross-service event surface (new)
- Service Bus `claim-version-events` topic, MessageType=`ClaimVersionReversed` — payload includes predecessor + new-version ids + adjustment reason; 5.12b's ReversalRun reactive batch trigger
- Mongo `ClaimVersionEvents` stream — `ClaimVersionSuperseded` (audit/lineage) + `ClaimVersionReversed` (reversal-intent audit) emitted per adjustment

## Lifecycle (D18 — ratified order)

```
AwaitingReadjudication  ← created on POST; pipeline running async
        │
        ▼
PendingReversal         ← new version finalized; predecessor accums still booked
        │
        ▼ (5.12b — ReversalRun batches)
Active                  ← terminal; accumulators unwound; predecessor Voided; reversal 835 emitted
```

Failed is the off-path terminal state for any unrecoverable error; `FailureReason` carries the diagnostic.

## Test plan
- [x] `dotnet test CloudHealthOffice.ClaimsService.Tests` — 411/411 passing (was 363/411 before factory DI fix; 48 integration-test failures resolved by registering substitute `IClaimAdjustmentRepository` + `IClaimAdjustmentService` in `ClaimsApiFactory` + `AdjudicationEndToEndTests`)
- [x] `dotnet test CloudHealthOffice.AdjudicationController.Tests` — 22/22 passing (4 new ReverseClaim tests + 18 pre-existing)
- [x] `dotnet test CloudHealthOffice.BenefitPlanService.Tests` — 25/25 passing
- [x] New tests: 23 ClaimAdjustmentService + 8 ClaimFinalizationService.VoidAsync + 5 HttpBenefitCalculationEngineClient.ReverseClaim + 4 BP AdjudicationController.ReverseClaim = **40 new tests**

## Out of scope (deferred to 5.12b)
- `ReversalRun` aggregate + service + controller in payment-service
- `BatchEraGeneratorService` extension for negative-amount CLP/SVC segments
- `CarcRarcMappingService` extension for reversal CARC code "23"
- Reversal 835 envelope emission
- Predecessor's actual transition to `Voided` (the `VoidAsync` method is wired and tested in 5.12a; 5.12b invokes it as the terminal step of a reversal batch)

## Architecture
See `docs/architecture/claim-adjustment-workflow.md` — lifecycle diagram, D16 drift acceptance + recovery path, G1 finalization-service rationale, G6 fresh-AI semantics, Phase 2 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)