### PR TITLE
Claims 5.1b — Cosmos partition-key migration to /TenantId

### DIFF
--- a/docs/architecture/claim-versioning.md
+++ b/docs/architecture/claim-versioning.md
@@ -1,7 +1,7 @@
 # Claim Identity & Versioning
 
 Status: 5.1a — initial implementation (versioning fields + event chain).
-Cosmos partition-key migration deferred to 5.1b (infra-coordinated PR).
+5.1b — Cosmos partition-key migration to `/TenantId` (infra-coordinated).
 Service: `src/services/claims-service`
 
 Cross-references:
@@ -243,30 +243,106 @@ versioned entity's identity. Writing to a projection field doesn't
 change what the entity *is*, only what we *know about its operational
 status right now*.
 
-## Cosmos partition key — current state and 5.1b plan
+## Cosmos partition key — `/TenantId` (5.1b)
 
-The Claims Cosmos container partitions by document `Id` (per the
-runtime call sites in `ClaimRepository`). The Bicep template at
+5.1b moved the Claims Cosmos container from the legacy `/memberId`
+Bicep declaration / `/Id` runtime partition to the canonical
+`/TenantId` partition. Pattern parity with Provider, Benefit Plan,
+and AiExaminationAudit. The change eliminates cross-partition
+fan-out on the versioning surface (`GetLatestVersionAsync`,
+`GetVersionAsync`, `ListVersionsAsync`,
+`UpdateAdjudicationProjectionAsync`,
+`MarkSupersededProjectionAsync`, `MarkVoidedProjectionAsync`); each
+becomes an efficient single-partition operation.
+
+### Why a new container, not an in-place repartition
+
+Cosmos containers cannot be renamed and their partition key cannot
+be changed. Both the Bicep declaration and the SDK enforce this —
+the only "rename" Cosmos supports is delete + recreate, which
+destroys data. 5.1b therefore introduced a sibling container,
+`ClaimsV2`, declared at
 [infrastructure/azure/modules/cosmos-db.bicep](../../infrastructure/azure/modules/cosmos-db.bicep)
-declares `/memberId`. This divergence pre-exists 5.1 and is tracked
-outside this PR's scope.
+with `partitionKey: ['/tenantId']`, and an operator-triggered
+migration job that copies documents from the legacy `Claims`
+container into `ClaimsV2`. The legacy container is preserved during
+a 30-day rollback window then removed in a focused follow-up Bicep
+PR.
 
-Provider/BP partition by `/TenantId` (single key). Pattern parity
-argues Claims should match. The migration is:
+### Migration tooling shape
 
-1. Update Bicep to declare `partitionKey: ['/TenantId']`.
-2. Create a new container with the new partition path.
-3. One-shot or admin-callable migration job copies existing claim
-   documents to the new container, computing `ClaimVersionId` (set
-   equal to existing `Id` for legacy single-version rows).
-4. Update service config to point at the new container.
-5. Verify operational, then deprecate the old container.
+`POST /api/v1/admin/claims/cosmos-migration/run` is the
+operator-facing surface, gated by
+`ClaimsCosmosMigration:MigrationsEnabled` (defaults to false; the
+deployment-layer ACL is the load-bearing authorization, the flag is
+a defence-in-depth tripwire). Mirrors the shape of
+`NetworkTierBackfillAdminController` in benefit-plan-service:
+503-when-disabled (not 404 — operators need to know the route
+exists and is intentionally gated), idempotent reruns, status
+endpoint at `GET /api/v1/admin/claims/cosmos-migration/status`.
 
-Per modernization-PR discipline (don't fix platform-wide concerns in
-single-service PRs), this is **deferred to PR 5.1b**, an
-infrastructure-coordinated follow-up. The 5.1a versioning model lives
-within the existing partition strategy; 5.1b switches the call sites
-from `new PartitionKey(claim.Id)` to `new PartitionKey(tenantId)`.
+The migration logic lives in
+[`Services/Migrations/ClaimMigrationService.cs`](../../src/services/claims-service/Services/Migrations/ClaimMigrationService.cs).
+Three properties of the implementation are worth recording for
+future engineers:
+
+1. **Hydrate-on-write** — every document is passed through
+   `ClaimRepository.Hydrate` before writing to `ClaimsV2`. Legacy
+   rows missing `ClaimVersionId` (`""`), `VersionNumber` (`0`), or
+   `VersionState` (`Unknown`) land in the new container fully
+   canonicalized. Downstream readers don't need to re-Hydrate
+   post-migration.
+2. **Batched idempotency check** — for each page of source
+   documents (default 100), a single `ARRAY_CONTAINS(@ids, c.id)`
+   query against `ClaimsV2` partitioned by tenant resolves the
+   subset already migrated. Per-document point-reads would
+   dominate RU spend on rerun.
+3. **Single-flight semantics** — concurrent invocations are
+   rejected with 409 Conflict via an in-process running flag.
+   Two simultaneous runs would double-count outcomes and produce
+   confusing telemetry; operators get an explicit signal instead.
+
+### Cutover protocol
+
+1. Deploy the Bicep change (creates `ClaimsV2` alongside the
+   existing `Claims` container).
+2. Deploy claims-service with the migration capability
+   (`CosmosDb:ContainerName` still points at `Claims`).
+3. Set `ClaimsCosmosMigration:MigrationsEnabled=true` and run the
+   endpoint with `dryRun=true`. Verify counters and surface any
+   hydration anomalies before the apply pass.
+4. Re-run with `dryRun=false`. Idempotent reruns are safe.
+5. Plan a 2–5 minute low-traffic pause window. Drain the Service
+   Bus subscription, do a final delta migration pass, flip
+   `CosmosDb:ContainerName: "ClaimsV2"`, redeploy.
+6. Verify production traffic on `ClaimsV2` for the 30-day
+   retention window.
+7. Open the follow-up Bicep PR removing the legacy `Claims`
+   container declaration.
+
+### Defense-in-depth tenant guard preserved
+
+`GetByIdAsync`, `MarkSupersededProjectionAsync`, and
+`MarkVoidedProjectionAsync` still perform an in-memory
+`response.Resource.TenantId == tenantId` check after the
+partition-keyed read. With `/TenantId` partitioning a cross-tenant
+lookup surfaces as Cosmos 404 already, but the explicit equality
+check is intentionally retained: it makes the tenant-isolation
+contract explicit at the read point and catches any future code
+path that might bypass the partition-keyed read. Cheap, defensive,
+intentionally **NOT** dead code.
+
+### Known follow-up: Payments container
+
+The Payments Cosmos container at
+[infrastructure/azure/modules/cosmos-db.bicep](../../infrastructure/azure/modules/cosmos-db.bicep)
+also declares `/memberId` — out of scope for 5.1b. Worth a focused
+follow-up PR (mirroring the 5.1b shape) when payment-service
+operational pressure justifies it.
+
+### Operator runbook
+
+[`docs/migrations/claims-cosmos-partition-migration.md`](../migrations/claims-cosmos-partition-migration.md).
 
 ## Tests
 
@@ -291,7 +367,8 @@ common `IClaimRepository` interface.
 
 ## Out of scope for 5.1a
 
-- **Cosmos partition-key migration** — 5.1b.
+- **Cosmos partition-key migration** — shipped in 5.1b (see
+  "Cosmos partition key — `/TenantId` (5.1b)" above).
 - **Kafka `claims.versions.v1` broader-stream topic** — Phase 2, when a
   consumer materializes.
 - **`ClaimEventPublisher` Kafka emission refactor** — preserved

--- a/docs/architecture/claim-versioning.md
+++ b/docs/architecture/claim-versioning.md
@@ -1,7 +1,7 @@
 # Claim Identity & Versioning
 
 Status: 5.1a — initial implementation (versioning fields + event chain).
-5.1b — Cosmos partition-key migration to `/TenantId` (infra-coordinated).
+5.1b — Cosmos partition-key migration to `/tenantId` (infra-coordinated).
 Service: `src/services/claims-service`
 
 Cross-references:
@@ -243,11 +243,11 @@ versioned entity's identity. Writing to a projection field doesn't
 change what the entity *is*, only what we *know about its operational
 status right now*.
 
-## Cosmos partition key — `/TenantId` (5.1b)
+## Cosmos partition key — `/tenantId` (5.1b)
 
 5.1b moved the Claims Cosmos container from the legacy `/memberId`
 Bicep declaration / `/Id` runtime partition to the canonical
-`/TenantId` partition. Pattern parity with Provider, Benefit Plan,
+`/tenantId` partition. Pattern parity with Provider, Benefit Plan,
 and AiExaminationAudit. The change eliminates cross-partition
 fan-out on the versioning surface (`GetLatestVersionAsync`,
 `GetVersionAsync`, `ListVersionsAsync`,
@@ -325,7 +325,7 @@ future engineers:
 `GetByIdAsync`, `MarkSupersededProjectionAsync`, and
 `MarkVoidedProjectionAsync` still perform an in-memory
 `response.Resource.TenantId == tenantId` check after the
-partition-keyed read. With `/TenantId` partitioning a cross-tenant
+partition-keyed read. With `/tenantId` partitioning a cross-tenant
 lookup surfaces as Cosmos 404 already, but the explicit equality
 check is intentionally retained: it makes the tenant-isolation
 contract explicit at the read point and catches any future code
@@ -368,7 +368,7 @@ common `IClaimRepository` interface.
 ## Out of scope for 5.1a
 
 - **Cosmos partition-key migration** — shipped in 5.1b (see
-  "Cosmos partition key — `/TenantId` (5.1b)" above).
+  "Cosmos partition key — `/tenantId` (5.1b)" above).
 - **Kafka `claims.versions.v1` broader-stream topic** — Phase 2, when a
   consumer materializes.
 - **`ClaimEventPublisher` Kafka emission refactor** — preserved

--- a/docs/migrations/claims-cosmos-partition-migration.md
+++ b/docs/migrations/claims-cosmos-partition-migration.md
@@ -1,0 +1,269 @@
+# Operator runbook — Claims Cosmos partition migration to `/TenantId` (5.1b)
+
+Status: capability 5.1b shipped. This runbook covers the operator
+sequence for moving production claim documents from the legacy
+`Claims` Cosmos container (`/memberId` Bicep declaration, `/Id`
+runtime partition) to the canonical `ClaimsV2` container
+(`/TenantId` partition).
+
+Architecture context: see
+[`docs/architecture/claim-versioning.md`](../architecture/claim-versioning.md)
+section "Cosmos partition key — `/TenantId` (5.1b)" for the why.
+This runbook covers the how.
+
+## Why migrate
+
+- Eliminates cross-partition fan-out on the versioning surface
+  (`GetLatestVersionAsync`, `GetVersionAsync`, `ListVersionsAsync`,
+  `UpdateAdjudicationProjectionAsync`, `Mark*ProjectionAsync`).
+  Meaningful Cosmos RU savings at scale.
+- Pattern parity with Provider, BenefitPlan, and AiExaminationAudit
+  (all already partition by `/TenantId`).
+- Tenant isolation enforced at the storage layer — defense in depth
+  beyond filter-clause isolation.
+
+## Pre-flight checklist
+
+Before kicking off the migration:
+
+- [ ] **Snapshot / backup the legacy `Claims` container.** Cosmos
+  point-in-time-restore window must cover the full migration window
+  plus the 30-day rollback retention window.
+- [ ] **Confirm peak/off-peak traffic windows for claims-service.**
+  Plan the cutover (step 5 below) for a 2–5 minute low-traffic
+  pause window. Claims-service writes are predominantly batch-driven
+  (837 ingestion + adjudication pipeline running off Service Bus
+  subscription); a brief pause window is operationally feasible.
+- [ ] **Identify the on-call DRI for the cutover window.**
+- [ ] **Verify metrics dashboards are live** for
+  `cho.claims.cosmos_migration.runs.total`,
+  `cho.claims.cosmos_migration.documents.total`, and
+  `cho.claims.cosmos_migration.duration` (ChoMetrics).
+- [ ] **Confirm log aggregation captures claims-service** at the
+  Information level — the migration emits structured start /
+  complete log lines tagged with the run id.
+
+## Step 1 — Bicep deploy (creates `ClaimsV2`)
+
+The 5.1b PR added the `claimsV2Container` resource alongside the
+existing `claimsContainer`. Deploy the Bicep module:
+
+```
+az deployment group create \
+    --resource-group <rg> \
+    --template-file infrastructure/azure/modules/cosmos-db.bicep \
+    --parameters @<env>.parameters.json
+```
+
+Verify the new container exists:
+
+```
+az cosmosdb sql container show \
+    --account-name <cosmos-account> \
+    --database-name ClaimsDB \
+    --name ClaimsV2 \
+    --resource-group <rg>
+```
+
+The Bicep change is purely additive — service traffic continues
+against the legacy `Claims` container until cutover. Bicep failure
+at this step does not affect production reads/writes.
+
+## Step 2 — Deploy claims-service with migration capability
+
+Standard claims-service deployment. After deploy, confirm:
+
+```
+GET /api/v1/admin/claims/cosmos-migration/status
+```
+
+Returns 503 — migration is gated by default. Returning 503 (not
+404) confirms the route is registered and intentionally gated.
+
+## Step 3 — Enable the migration
+
+Set `ClaimsCosmosMigration:MigrationsEnabled=true` via the standard
+configuration channel (Azure App Configuration / Key Vault /
+deployment env vars). Reload claims-service or rely on
+`IOptionsMonitor` to pick up the change. Verify:
+
+```
+GET /api/v1/admin/claims/cosmos-migration/status
+```
+
+Returns 200 with `migrationsEnabled: true` and the configured
+source / target container names.
+
+## Step 4 — Dry-run migration
+
+```
+POST /api/v1/admin/claims/cosmos-migration/run
+Content-Type: application/json
+
+{
+  "dryRun": true,
+  "batchSize": 100
+}
+```
+
+Response shape:
+
+```
+{
+  "migrationRunId": "...",
+  "startedAt": "...",
+  "completedAt": "...",
+  "durationSeconds": ...,
+  "dryRun": true,
+  "sourceContainer": "Claims",
+  "targetContainer": "ClaimsV2",
+  "documentsRead": <int>,
+  "documentsWritten": <int>,    // would-have-been-written in dry-run
+  "documentsSkipped": 0,        // first dry-run; ClaimsV2 is empty
+  "documentsErrored": 0,
+  "documentsHydrated": <int>,   // legacy rows requiring hydration
+  "outcome": "success",
+  "issues": []
+}
+```
+
+Verify:
+
+- [ ] `documentsRead` matches the operator's expected source count
+  (e.g., from `SELECT VALUE COUNT(1) FROM c` on the `Claims`
+  container).
+- [ ] `documentsErrored == 0`. If not zero, inspect `issues[]`. The
+  most common cause is documents missing a `TenantId` field —
+  these cannot be partitioned in `ClaimsV2` and must be either
+  back-filled or excluded prior to apply.
+- [ ] `documentsHydrated` aligns with operator expectation of
+  pre-versioning legacy data volume.
+
+## Step 5 — Apply migration
+
+```
+POST /api/v1/admin/claims/cosmos-migration/run
+Content-Type: application/json
+
+{
+  "dryRun": false,
+  "batchSize": 100
+}
+```
+
+Idempotent: if interrupted (network blip, pod restart), re-run
+with the same body. Already-written documents are skipped via the
+batched idempotency check, not rewritten.
+
+Watch:
+
+- `cho.claims.cosmos_migration.documents.total{cho.outcome="written"}`
+  ramps to match `documentsRead`.
+- `cho.claims.cosmos_migration.documents.total{cho.outcome="errored"}`
+  stays flat at zero.
+- Structured logs tagged `runId={MigrationRunId}` show progress
+  (start + complete; per-batch progress is not logged — telemetry
+  is the per-batch surface).
+
+## Step 6 — Cutover
+
+When the apply pass reports `outcome: "success"`:
+
+1. **Pause new claim ingestion.** Stop the 837 ingestion job /
+   pause the upstream encounter-submission pipeline. The
+   adjudication pipeline can keep draining its Service Bus
+   subscription.
+2. **Wait for the Service Bus subscription drain.** Watch the
+   `claim-version-events` subscription's active message count fall
+   to zero (Azure Service Bus metrics).
+3. **Run a final delta migration pass.** Same endpoint, `dryRun:
+   false`. Picks up any rows written during step 1's pause window
+   that weren't in the apply pass. Should typically write a small
+   number of documents.
+4. **Flip the runtime container.** Update
+   `CosmosDb:ContainerName` from `"Claims"` to `"ClaimsV2"` via
+   the configuration channel. Redeploy claims-service (or restart
+   pods to force config reload).
+5. **Resume claim ingestion.**
+6. **Smoke test.** Submit one test claim, fetch it via
+   `GET /api/v1/claims/{id}`, query its versioning chain. All
+   surfaces should respond normally.
+
+## Step 7 — Validation window
+
+For the next 30 days:
+
+- Monitor `cho.claims.processing.duration` for regressions (the
+  versioning surface should now be faster, not slower).
+- Monitor `cho.claims.adjudication.outcome.total` for any
+  unexpected denied / pended ratio shifts.
+- Monitor application logs for any `ClaimVersionStateException` or
+  Cosmos errors at unexpected rates.
+
+If a regression is identified within the validation window:
+
+**Rollback procedure:**
+1. Flip `CosmosDb:ContainerName` back to `"Claims"` via config.
+2. Redeploy claims-service.
+3. Operations may need to migrate post-cutover writes back to the
+   legacy container (rare — most issues are read-side perf
+   regressions, not data correctness). Run the migration endpoint
+   with `sourceContainer: "ClaimsV2"`, `targetContainer:
+   "Claims"` (config flip) — the service tolerates either as the
+   source or target.
+4. File the regression detail and reschedule the cutover.
+
+## Step 8 — Deprecate legacy `Claims` container
+
+After 30 days of green validation:
+
+- [ ] Open a focused Bicep PR removing the `claimsContainer`
+  resource declaration in
+  `infrastructure/azure/modules/cosmos-db.bicep`.
+- [ ] Confirm no service still references `CosmosDb:ContainerName:
+  "Claims"`.
+- [ ] Set `ClaimsCosmosMigration:MigrationsEnabled=false` and
+  remove the configuration value.
+- [ ] Delete the `Claims` container manually via Azure portal /
+  CLI after the PR merges (Bicep delete may not actually delete
+  data depending on `complete` vs `incremental` deployment mode —
+  verify with `az cosmosdb sql container list`).
+
+## Telemetry reference
+
+| Metric | Type | Dimensions |
+|---|---|---|
+| `cho.claims.cosmos_migration.runs.total` | counter | `cho.outcome` (success / partial / failed), `cho.dry_run` |
+| `cho.claims.cosmos_migration.documents.total` | counter | `cho.outcome` (written / would_write / skipped / errored) |
+| `cho.claims.cosmos_migration.duration` | histogram (s) | `cho.outcome`, `cho.dry_run` |
+
+## Endpoint reference
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/v1/admin/claims/cosmos-migration/run` | Run dry-run or apply |
+| `GET` | `/api/v1/admin/claims/cosmos-migration/status` | Last-run summary + running flag |
+
+Both return 503 when `ClaimsCosmosMigration:MigrationsEnabled=false`.
+The deployment-layer ACL (NetworkPolicy / gateway) is the load-bearing
+authorization control; the feature flag is a defence-in-depth
+tripwire.
+
+## Failure modes
+
+| Failure | Detection | Mitigation |
+|---|---|---|
+| Migration writes corrupt data | Smoke test post-cutover | Rollback to legacy container via config flip |
+| Bicep deployment fails | Bicep deploy step | Bicep failure does not affect running service; investigate template / RBAC and retry |
+| Migration runs out of resources mid-run | Run returns `outcome: partial` | Re-run with same body — idempotent; remaining docs migrate next pass |
+| Cross-tenant data leak | Defense-in-depth tenant guard in repository | Storage-layer partition + in-memory `TenantId` equality check both prevent; alert on `cho.claims.cosmos_migration.documents.total{cho.outcome="errored"}` |
+| Documents written during cutover lost | Final delta pass + brief read-only window | Step 6.3 above |
+| Concurrent operator-triggered runs | 409 Conflict from second invocation | In-process running flag rejects second run; first completes |
+
+## Known follow-ups
+
+- **Payments container** at
+  [`infrastructure/azure/modules/cosmos-db.bicep`](../../infrastructure/azure/modules/cosmos-db.bicep)
+  has the same `/memberId` divergence — out of scope for 5.1b.
+  When payment-service operational pressure justifies it, ship a
+  parallel `PaymentsV2` migration mirroring this PR's shape.

--- a/docs/migrations/claims-cosmos-partition-migration.md
+++ b/docs/migrations/claims-cosmos-partition-migration.md
@@ -1,14 +1,14 @@
-# Operator runbook — Claims Cosmos partition migration to `/TenantId` (5.1b)
+# Operator runbook — Claims Cosmos partition migration to `/tenantId` (5.1b)
 
 Status: capability 5.1b shipped. This runbook covers the operator
 sequence for moving production claim documents from the legacy
 `Claims` Cosmos container (`/memberId` Bicep declaration, `/Id`
 runtime partition) to the canonical `ClaimsV2` container
-(`/TenantId` partition).
+(`/tenantId` partition).
 
 Architecture context: see
 [`docs/architecture/claim-versioning.md`](../architecture/claim-versioning.md)
-section "Cosmos partition key — `/TenantId` (5.1b)" for the why.
+section "Cosmos partition key — `/tenantId` (5.1b)" for the why.
 This runbook covers the how.
 
 ## Why migrate
@@ -18,7 +18,7 @@ This runbook covers the how.
   `UpdateAdjudicationProjectionAsync`, `Mark*ProjectionAsync`).
   Meaningful Cosmos RU savings at scale.
 - Pattern parity with Provider, BenefitPlan, and AiExaminationAudit
-  (all already partition by `/TenantId`).
+  (all already partition by `/tenantId`).
 - Tenant isolation enforced at the storage layer — defense in depth
   beyond filter-clause isolation.
 

--- a/infrastructure/azure/modules/cosmos-db.bicep
+++ b/infrastructure/azure/modules/cosmos-db.bicep
@@ -192,7 +192,13 @@ resource membersContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/co
   }
 }
 
-// Claims Container
+// Claims Container — legacy partition key /memberId (Bicep declaration)
+// /Id (runtime ClaimRepository) — both diverged from canonical /TenantId
+// established in Provider/BP/AiExaminationAudit. Capability 5.1b migrates
+// claim documents to the ClaimsV2 container declared below; this old
+// container is preserved during a 30-day rollback window then removed in
+// a focused follow-up Bicep PR. Cosmos containers cannot be renamed —
+// hence the version-suffix ClaimsV2 over an in-place repartition.
 resource claimsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = {
   parent: cosmosDatabase
   name: 'Claims'
@@ -201,6 +207,44 @@ resource claimsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
       id: 'Claims'
       partitionKey: {
         paths: ['/memberId']
+        kind: 'Hash'
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          {
+            path: '/*'
+          }
+        ]
+        excludedPaths: [
+          {
+            path: '/"_etag"/?'
+          }
+        ]
+      }
+      defaultTtl: -1
+    }
+  }
+}
+
+// ClaimsV2 Container — capability 5.1b canonical /TenantId partition.
+// Pattern parity with Provider, BenefitPlan, and AiExaminationAudit;
+// eliminates cross-partition fan-out on the versioning surface
+// (GetLatestVersionAsync / GetVersionAsync / ListVersionsAsync /
+// UpdateAdjudicationProjectionAsync / Mark*ProjectionAsync). The
+// claims-service migration tooling
+// (POST /api/v1/admin/claims/cosmos-migration/run) copies documents
+// from `Claims` here, hydrating any legacy ClaimVersionId="" rows so
+// this container starts fully canonicalized.
+resource claimsV2Container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = {
+  parent: cosmosDatabase
+  name: 'ClaimsV2'
+  properties: {
+    resource: {
+      id: 'ClaimsV2'
+      partitionKey: {
+        paths: ['/tenantId']
         kind: 'Hash'
       }
       indexingPolicy: {

--- a/infrastructure/azure/modules/cosmos-db.bicep
+++ b/infrastructure/azure/modules/cosmos-db.bicep
@@ -193,7 +193,7 @@ resource membersContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/co
 }
 
 // Claims Container — legacy partition key /memberId (Bicep declaration)
-// /Id (runtime ClaimRepository) — both diverged from canonical /TenantId
+// /Id (runtime ClaimRepository) — both diverged from canonical /tenantId
 // established in Provider/BP/AiExaminationAudit. Capability 5.1b migrates
 // claim documents to the ClaimsV2 container declared below; this old
 // container is preserved during a 30-day rollback window then removed in
@@ -228,7 +228,7 @@ resource claimsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
   }
 }
 
-// ClaimsV2 Container — capability 5.1b canonical /TenantId partition.
+// ClaimsV2 Container — capability 5.1b canonical /tenantId partition.
 // Pattern parity with Provider, BenefitPlan, and AiExaminationAudit;
 // eliminates cross-partition fan-out on the versioning surface
 // (GetLatestVersionAsync / GetVersionAsync / ListVersionsAsync /

--- a/src/services/claims-service/Controllers/AdminMigrationController.cs
+++ b/src/services/claims-service/Controllers/AdminMigrationController.cs
@@ -10,7 +10,7 @@ namespace ClaimsService.Controllers;
 /// migration that copies claim documents from the legacy
 /// <c>Claims</c> container (<c>/memberId</c> Bicep / <c>/Id</c>
 /// runtime) to the canonical <c>ClaimsV2</c> container
-/// (<c>/TenantId</c>) — capability 5.1b.
+/// (<c>/tenantId</c>) — capability 5.1b.
 ///
 /// <para>
 /// Authorization is layered: the deployment layer (NetworkPolicy /
@@ -101,7 +101,7 @@ public sealed class AdminMigrationController : ControllerBase
             var result = await _migration.RunAsync(request, ct);
             return Ok(result);
         }
-        catch (InvalidOperationException ex) when (ex.Message.Contains("already in progress", StringComparison.Ordinal))
+        catch (MigrationAlreadyRunningException)
         {
             return Conflict(new
             {

--- a/src/services/claims-service/Controllers/AdminMigrationController.cs
+++ b/src/services/claims-service/Controllers/AdminMigrationController.cs
@@ -1,0 +1,153 @@
+using ClaimsService.Models.Migrations;
+using ClaimsService.Services.Migrations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace ClaimsService.Controllers;
+
+/// <summary>
+/// Admin endpoint for the operator-triggered Cosmos partition-key
+/// migration that copies claim documents from the legacy
+/// <c>Claims</c> container (<c>/memberId</c> Bicep / <c>/Id</c>
+/// runtime) to the canonical <c>ClaimsV2</c> container
+/// (<c>/TenantId</c>) — capability 5.1b.
+///
+/// <para>
+/// Authorization is layered: the deployment layer (NetworkPolicy /
+/// gateway ACL) is the load-bearing control, and the
+/// <see cref="ClaimMigrationOptions.MigrationsEnabled"/> flag is a
+/// defence-in-depth tripwire. When the flag is false the controller
+/// returns 503 Service Unavailable; a misconfigured gateway can't
+/// expose the route just because it's registered.
+/// </para>
+///
+/// <para>
+/// Mirrors the shape established by
+/// <c>NetworkTierBackfillAdminController</c> in benefit-plan-service:
+/// <c>[Route("api/v1/admin/...")]</c>, <see cref="IOptionsMonitor{T}"/>,
+/// 503-when-disabled, idempotent reruns. Status surface is exposed via
+/// <see cref="GetStatus"/> (Decision 15 — GET status IN, chunked
+/// streaming OUT).
+/// </para>
+/// </summary>
+[ApiController]
+[Route("api/v1/admin/claims/cosmos-migration")]
+public sealed class AdminMigrationController : ControllerBase
+{
+    private readonly IClaimMigrationService _migration;
+    private readonly IOptionsMonitor<ClaimMigrationOptions> _options;
+    private readonly ILogger<AdminMigrationController> _logger;
+
+    public AdminMigrationController(
+        IClaimMigrationService migration,
+        IOptionsMonitor<ClaimMigrationOptions> options,
+        ILogger<AdminMigrationController> logger)
+    {
+        _migration = migration;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run the migration. Defaults to dry-run; set
+    /// <see cref="ClaimMigrationRequest.DryRun"/>=false to apply
+    /// writes against the target container. Idempotent: rows already
+    /// present in the target are skipped.
+    /// </summary>
+    [HttpPost("run")]
+    [ProducesResponseType(typeof(ClaimMigrationResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public async Task<ActionResult<ClaimMigrationResult>> Run(
+        [FromBody] ClaimMigrationRequest? request,
+        CancellationToken ct)
+    {
+        if (!_options.CurrentValue.MigrationsEnabled)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new
+                {
+                    error = "claims_migration_disabled",
+                    message =
+                        "Cosmos partition-key migration is gated. Set " +
+                        "ClaimsCosmosMigration:MigrationsEnabled=true to enable, " +
+                        "and ensure the deployment layer (NetworkPolicy / gateway ACL) " +
+                        "restricts access to this route.",
+                });
+        }
+
+        request ??= new ClaimMigrationRequest();
+
+        if (request.BatchSize is < 1)
+        {
+            return BadRequest(new
+            {
+                error = "invalid_batch_size",
+                message = "batchSize must be greater than zero when supplied.",
+            });
+        }
+
+        request.ActorId ??= ResolveActorId();
+        request.CorrelationId ??= HttpContext.TraceIdentifier;
+
+        _logger.LogInformation(
+            "claims cosmos migration triggered dryRun={DryRun} actor={Actor} correlation={Correlation}",
+            request.DryRun, Sanitize(request.ActorId), Sanitize(request.CorrelationId));
+
+        try
+        {
+            var result = await _migration.RunAsync(request, ct);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already in progress", StringComparison.Ordinal))
+        {
+            return Conflict(new
+            {
+                error = "migration_in_progress",
+                message = "A claim migration run is already in progress. Retry after it completes.",
+            });
+        }
+    }
+
+    /// <summary>
+    /// Snapshot of current migration state. Operators poll this while
+    /// a run is active to monitor progress alongside structured logs
+    /// and Prometheus counters.
+    /// </summary>
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(ClaimMigrationStatus), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+    public ActionResult<ClaimMigrationStatus> GetStatus()
+    {
+        if (!_options.CurrentValue.MigrationsEnabled)
+        {
+            return StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                new
+                {
+                    error = "claims_migration_disabled",
+                    message =
+                        "Cosmos partition-key migration is gated. Set " +
+                        "ClaimsCosmosMigration:MigrationsEnabled=true to enable, " +
+                        "and ensure the deployment layer (NetworkPolicy / gateway ACL) " +
+                        "restricts access to this route.",
+                });
+        }
+
+        return Ok(_migration.GetStatus());
+    }
+
+    private string ResolveActorId()
+    {
+        var sub = HttpContext.User?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrEmpty(sub)) return sub;
+        if (HttpContext.Request.Headers.TryGetValue("X-User-Id", out var header) && !string.IsNullOrEmpty(header.ToString()))
+            return header.ToString();
+        return "admin:claims-cosmos-migration";
+    }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/claims-service/Models/Migrations/ClaimMigrationRequest.cs
+++ b/src/services/claims-service/Models/Migrations/ClaimMigrationRequest.cs
@@ -3,7 +3,7 @@ namespace ClaimsService.Models.Migrations;
 /// <summary>
 /// Operator-supplied request body for the
 /// <c>POST /api/v1/admin/claims/cosmos-migration/run</c> endpoint
-/// (capability 5.1b — Cosmos partition-key migration to <c>/TenantId</c>).
+/// (capability 5.1b — Cosmos partition-key migration to <c>/tenantId</c>).
 ///
 /// <para>
 /// The endpoint is idempotent: re-running with the same source/target

--- a/src/services/claims-service/Models/Migrations/ClaimMigrationRequest.cs
+++ b/src/services/claims-service/Models/Migrations/ClaimMigrationRequest.cs
@@ -1,0 +1,47 @@
+namespace ClaimsService.Models.Migrations;
+
+/// <summary>
+/// Operator-supplied request body for the
+/// <c>POST /api/v1/admin/claims/cosmos-migration/run</c> endpoint
+/// (capability 5.1b — Cosmos partition-key migration to <c>/TenantId</c>).
+///
+/// <para>
+/// The endpoint is idempotent: re-running with the same source/target
+/// pair is safe. Documents already present in the target container by
+/// <c>Id</c> are skipped (counted as <c>Skipped</c> in the result).
+/// </para>
+/// </summary>
+public sealed class ClaimMigrationRequest
+{
+    /// <summary>
+    /// When <c>true</c>, the migration runs end-to-end but never writes
+    /// to the target container. Counters reflect what *would* have been
+    /// migrated. Use this as the first step of any cutover to confirm
+    /// row counts and surface any hydration anomalies before the apply
+    /// pass.
+    /// </summary>
+    public bool DryRun { get; set; } = true;
+
+    /// <summary>
+    /// Optional override for the per-page batch size used to read from
+    /// the source container and to query the target container for
+    /// already-migrated IDs (Decision 7 — batched idempotency check
+    /// rather than per-document RU spend). When unset the option's
+    /// configured default is used.
+    /// </summary>
+    public int? BatchSize { get; set; }
+
+    /// <summary>
+    /// Optional actor id for the audit log line emitted when the run
+    /// starts and completes. Resolved at the controller boundary from
+    /// the request principal when not supplied; defaults to a synthetic
+    /// label when no principal is available.
+    /// </summary>
+    public string? ActorId { get; set; }
+
+    /// <summary>
+    /// Optional correlation id surfaced in log lines for cross-service
+    /// audit traceability. Not persisted.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+}

--- a/src/services/claims-service/Models/Migrations/ClaimMigrationResult.cs
+++ b/src/services/claims-service/Models/Migrations/ClaimMigrationResult.cs
@@ -3,7 +3,7 @@ namespace ClaimsService.Models.Migrations;
 /// <summary>
 /// Per-call summary returned to the operator after the migration
 /// endpoint completes (capability 5.1b — Cosmos partition-key
-/// migration to <c>/TenantId</c>).
+/// migration to <c>/tenantId</c>).
 ///
 /// <para>
 /// Counters are intentionally explicit rather than derived (e.g.

--- a/src/services/claims-service/Models/Migrations/ClaimMigrationResult.cs
+++ b/src/services/claims-service/Models/Migrations/ClaimMigrationResult.cs
@@ -1,0 +1,96 @@
+namespace ClaimsService.Models.Migrations;
+
+/// <summary>
+/// Per-call summary returned to the operator after the migration
+/// endpoint completes (capability 5.1b — Cosmos partition-key
+/// migration to <c>/TenantId</c>).
+///
+/// <para>
+/// Counters are intentionally explicit rather than derived (e.g.
+/// <c>DocumentsRead = DocumentsMigrated + DocumentsSkipped + DocumentsErrored</c>)
+/// so a partial run that bailed mid-batch surfaces the discrepancy
+/// directly instead of forcing the operator to reconcile it.
+/// </para>
+/// </summary>
+public sealed class ClaimMigrationResult
+{
+    public string MigrationRunId { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Wall-clock start of the run (UTC).</summary>
+    public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Wall-clock end of the run (UTC). Set on completion.</summary>
+    public DateTime CompletedAt { get; set; }
+
+    public double DurationSeconds { get; set; }
+
+    /// <summary>True when this run did not write to the target container.</summary>
+    public bool DryRun { get; set; }
+
+    public string SourceContainer { get; set; } = string.Empty;
+    public string TargetContainer { get; set; } = string.Empty;
+
+    /// <summary>Documents read from the source container.</summary>
+    public int DocumentsRead { get; set; }
+
+    /// <summary>Documents written (or, in dry-run, would-have-been-written) to the target.</summary>
+    public int DocumentsWritten { get; set; }
+
+    /// <summary>Documents skipped because the target already contains a row with the same <c>Id</c>.</summary>
+    public int DocumentsSkipped { get; set; }
+
+    /// <summary>Documents that failed during write. Each entry is itemized in <see cref="Issues"/>.</summary>
+    public int DocumentsErrored { get; set; }
+
+    /// <summary>
+    /// Documents that required hydration (legacy <c>ClaimVersionId == ""</c>
+    /// rows) before being written. Operator visibility into how much
+    /// pre-versioning data the run canonicalized.
+    /// </summary>
+    public int DocumentsHydrated { get; set; }
+
+    /// <summary>
+    /// Outcome label for the overall run. <c>success</c> when
+    /// <see cref="DocumentsErrored"/> is zero; <c>partial</c> when at
+    /// least one row failed but the run completed; <c>failed</c> when
+    /// the run aborted before completion (e.g. cancellation).
+    /// </summary>
+    public string Outcome { get; set; } = "success";
+
+    public List<ClaimMigrationIssue> Issues { get; set; } = new();
+}
+
+/// <summary>
+/// One per-document issue surfaced during a migration run.
+/// </summary>
+public sealed class ClaimMigrationIssue
+{
+    public string ClaimId { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public string? Detail { get; set; }
+}
+
+/// <summary>
+/// Status snapshot returned by the
+/// <c>GET /api/v1/admin/claims/cosmos-migration/status</c> endpoint.
+/// Decision 15 (ratified): GET status endpoint IN; chunked progress
+/// streaming OUT. This is the operator-facing observability surface
+/// alongside the structured logs and Prometheus counters.
+/// </summary>
+public sealed class ClaimMigrationStatus
+{
+    public bool MigrationsEnabled { get; set; }
+    public string SourceContainer { get; set; } = string.Empty;
+    public string TargetContainer { get; set; } = string.Empty;
+    public int BatchSize { get; set; }
+
+    /// <summary>
+    /// True while a run is currently executing. Consecutive operator
+    /// triggers while this is true return 409 Conflict.
+    /// </summary>
+    public bool IsRunning { get; set; }
+
+    /// <summary>Last completed run summary (any outcome). Null when no run has completed yet.</summary>
+    public ClaimMigrationResult? LastRun { get; set; }
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -71,7 +71,7 @@ else
 
     // 5.1b — Cosmos partition-key migration tooling. Resolves the source
     // (legacy /memberId Bicep / /Id runtime) and target (canonical
-    // /TenantId) containers from the configured database; the migration
+    // /tenantId) containers from the configured database; the migration
     // service is the only consumer that ever sees both containers.
     // Singleton because it owns the running-flag + last-run state shared
     // across requests; the underlying Cosmos containers are thread-safe.

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -12,6 +12,7 @@ using ClaimsService.Repositories;
 using ClaimsService.Services;
 using ClaimsService.Services.Adjudication;
 using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Migrations;
 using ClaimsService.Services.Resolution;
 using CloudHealthOffice.ClaimsScrubEngine.Configuration;
 using CloudHealthOffice.NcciEngine.Configuration;
@@ -67,6 +68,17 @@ else
 
     builder.Services.AddScoped<IClaimRepository, ClaimRepository>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryCosmos>();
+
+    // 5.1b — Cosmos partition-key migration tooling. Resolves the source
+    // (legacy /memberId Bicep / /Id runtime) and target (canonical
+    // /TenantId) containers from the configured database; the migration
+    // service is the only consumer that ever sees both containers.
+    // Singleton because it owns the running-flag + last-run state shared
+    // across requests; the underlying Cosmos containers are thread-safe.
+    builder.Services.Configure<ClaimMigrationOptions>(
+        builder.Configuration.GetSection(ClaimMigrationOptions.SectionName));
+    builder.Services.AddSingleton<IClaimMigrationContainerResolver, CosmosClaimMigrationContainerResolver>();
+    builder.Services.AddSingleton<IClaimMigrationService, ClaimMigrationService>();
 
     // Cosmos-only deployments don't have a provisioned events stream; the
     // Noop publisher logs a warning so ops can spot the missing wiring

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -208,8 +208,14 @@ public class ClaimRepository : IClaimRepository
     /// Hydrates legacy claim documents (predating versioning fields) with
     /// sensible defaults. Idempotent — running on a fully-versioned row
     /// is a no-op. Mirrors <c>ProviderRepository.Hydrate</c>.
+    ///
+    /// Public so the 5.1b Cosmos partition migration can canonicalize
+    /// rows during the copy from the legacy <c>Claims</c> container into
+    /// the canonical <c>ClaimsV2</c> container — the new container then
+    /// starts fully hydrated and downstream readers don't need to
+    /// re-Hydrate post-migration.
     /// </summary>
-    private static Claim Hydrate(Claim claim)
+    public static Claim Hydrate(Claim claim)
     {
         if (string.IsNullOrEmpty(claim.ClaimVersionId))
         {
@@ -263,9 +269,17 @@ public class ClaimRepository : IClaimRepository
         {
             var response = await _container.ReadItemAsync<Claim>(
                 id,
-                new PartitionKey(id));
+                new PartitionKey(tenantId));
 
-            // Verify tenant isolation
+            // 5.1b: with /TenantId partition, a cross-tenant lookup throws
+            // CosmosException 404 (caught below) rather than returning a
+            // foreign-tenant document. The in-memory tenant equality check
+            // is intentionally retained as defense in depth: it makes the
+            // tenant-isolation contract explicit at the read point and
+            // catches any future code path that might bypass the
+            // partition-keyed read (e.g. a cross-partition query that
+            // hydrates this method's return shape). Cheap, defensive,
+            // intentionally NOT dead code.
             if (response.Resource.TenantId != tenantId)
             {
                 return null;
@@ -292,7 +306,9 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@tenantId", tenantId)
             .WithParameter("@claimNumber", claimNumber);
 
-        var iterator = _container.GetItemQueryIterator<Claim>(query);
+        var iterator = _container.GetItemQueryIterator<Claim>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (!iterator.HasMoreResults) return null;
         var page = await iterator.ReadNextAsync();
         var head = page.FirstOrDefault();
@@ -363,7 +379,9 @@ public class ClaimRepository : IClaimRepository
             queryDef.WithParameter(key, value);
         }
 
-        var iterator = _container.GetItemQueryIterator<Claim>(queryDef);
+        var iterator = _container.GetItemQueryIterator<Claim>(
+            queryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         var results = new List<Claim>();
 
         while (iterator.HasMoreResults)
@@ -442,7 +460,8 @@ public class ClaimRepository : IClaimRepository
         foreach (var (k, v) in parameters) countQuery.WithParameter(k, v);
 
         var totalCount = 0;
-        var countIterator = _container.GetItemQueryIterator<int>(countQuery);
+        var partitionRequestOptions = new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) };
+        var countIterator = _container.GetItemQueryIterator<int>(countQuery, requestOptions: partitionRequestOptions);
         while (countIterator.HasMoreResults)
         {
             var response = await countIterator.ReadNextAsync();
@@ -456,7 +475,7 @@ public class ClaimRepository : IClaimRepository
         foreach (var (k, v) in parameters) pageQuery.WithParameter(k, v);
 
         var items = new List<Claim>();
-        var iterator = _container.GetItemQueryIterator<Claim>(pageQuery);
+        var iterator = _container.GetItemQueryIterator<Claim>(pageQuery, requestOptions: partitionRequestOptions);
         while (iterator.HasMoreResults)
         {
             var response = await iterator.ReadNextAsync();
@@ -503,7 +522,9 @@ public class ClaimRepository : IClaimRepository
             queryDef.WithParameter("@lineOfBusiness", lineOfBusiness.Value.ToString());
         }
 
-        var iterator = _container.GetItemQueryIterator<dynamic>(queryDef);
+        var iterator = _container.GetItemQueryIterator<dynamic>(
+            queryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         var summary = new ClaimsSummary();
 
         if (iterator.HasMoreResults)
@@ -552,7 +573,9 @@ public class ClaimRepository : IClaimRepository
             processingQueryDef.WithParameter("@lineOfBusiness", lineOfBusiness.Value.ToString());
         }
 
-        var processingIterator = _container.GetItemQueryIterator<dynamic>(processingQueryDef);
+        var processingIterator = _container.GetItemQueryIterator<dynamic>(
+            processingQueryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (processingIterator.HasMoreResults)
         {
             var response = await processingIterator.ReadNextAsync();
@@ -592,7 +615,7 @@ public class ClaimRepository : IClaimRepository
             claim.VersionState = MapStatusToVersionState(claim.Status);
         }
 
-        var response = await _container.CreateItemAsync(claim, new PartitionKey(claim.Id));
+        var response = await _container.CreateItemAsync(claim, new PartitionKey(tenantId));
         return response.Resource;
     }
 
@@ -607,7 +630,7 @@ public class ClaimRepository : IClaimRepository
         Claim? existing;
         try
         {
-            var read = await _container.ReadItemAsync<Claim>(claim.Id, new PartitionKey(claim.Id));
+            var read = await _container.ReadItemAsync<Claim>(claim.Id, new PartitionKey(tenantId));
             existing = read.Resource.TenantId == tenantId ? Hydrate(read.Resource) : null;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -641,7 +664,7 @@ public class ClaimRepository : IClaimRepository
             var response = await _container.ReplaceItemAsync(
                 claim,
                 claim.Id,
-                new PartitionKey(claim.Id));
+                new PartitionKey(tenantId));
             return response.Resource;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -660,7 +683,7 @@ public class ClaimRepository : IClaimRepository
     public async Task DeleteAsync(string id)
     {
         var tenantId = GetTenantId();
-        await _container.DeleteItemAsync<Claim>(id, new PartitionKey(id));
+        await _container.DeleteItemAsync<Claim>(id, new PartitionKey(tenantId));
     }
 
     // ── Versioning surface (5.1) ─────────────────────────────────────────
@@ -693,7 +716,9 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@draft", ClaimVersionState.Draft.ToString())
             .WithParameter("@asOf", asOf);
 
-        var iterator = _container.GetItemQueryIterator<Claim>(query);
+        var iterator = _container.GetItemQueryIterator<Claim>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (!iterator.HasMoreResults) return null;
         var page = await iterator.ReadNextAsync();
         var head = page.FirstOrDefault();
@@ -716,7 +741,9 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@versionId", versionId)
             .WithParameter("@claimVersionId", claimVersionId);
 
-        var iterator = _container.GetItemQueryIterator<Claim>(query);
+        var iterator = _container.GetItemQueryIterator<Claim>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (!iterator.HasMoreResults) return null;
         var page = await iterator.ReadNextAsync();
         var match = page.FirstOrDefault();
@@ -742,7 +769,11 @@ public class ClaimRepository : IClaimRepository
         var iterator = _container.GetItemQueryIterator<Claim>(
             query,
             continuationToken,
-            new QueryRequestOptions { MaxItemCount = pageSize });
+            new QueryRequestOptions
+            {
+                MaxItemCount = pageSize,
+                PartitionKey = new PartitionKey(tenantId),
+            });
 
         if (!iterator.HasMoreResults)
         {
@@ -786,7 +817,9 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
 
         string? rowId = null;
-        var iterator = _container.GetItemQueryIterator<HeadIdResult>(query);
+        var iterator = _container.GetItemQueryIterator<HeadIdResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(ct);
@@ -802,7 +835,7 @@ public class ClaimRepository : IClaimRepository
         Claim? head;
         try
         {
-            var read = await _container.ReadItemAsync<Claim>(rowId, new PartitionKey(rowId), cancellationToken: ct);
+            var read = await _container.ReadItemAsync<Claim>(rowId, new PartitionKey(tenantId), cancellationToken: ct);
             head = read.Resource;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -853,7 +886,7 @@ public class ClaimRepository : IClaimRepository
         {
             await _container.PatchItemAsync<Claim>(
                 rowId,
-                new PartitionKey(rowId),
+                new PartitionKey(tenantId),
                 ops,
                 cancellationToken: ct);
             return true;
@@ -919,7 +952,9 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@adjudicated",   ClaimVersionState.Adjudicated.ToString())
             .WithParameter("@paid",          ClaimVersionState.Paid.ToString());
 
-        var iterator = _container.GetItemQueryIterator<dynamic>(queryDef);
+        var iterator = _container.GetItemQueryIterator<dynamic>(
+            queryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
 
         // Accumulate by network tier
         var deductible   = new Dictionary<string, decimal>();
@@ -975,13 +1010,16 @@ public class ClaimRepository : IClaimRepository
         string? actorId,
         CancellationToken ct = default)
     {
-        // Pre-read for tenant isolation — Cosmos partition is claim.Id; we
-        // read by id then enforce tenant match before patching. Mirrors the
-        // tenant-isolation pattern in GetByIdAsync.
+        // Pre-read confirms the row exists and (defense in depth) belongs
+        // to the supplied tenant. With the 5.1b /TenantId partition, a
+        // cross-tenant claimId surfaces as Cosmos 404 (caught below); the
+        // explicit TenantId equality check is intentionally retained
+        // alongside the partition-key boundary for the same reasons
+        // documented on GetByIdAsync.
         Claim? existing;
         try
         {
-            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(claimId), cancellationToken: ct);
+            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(tenantId), cancellationToken: ct);
             existing = read.Resource;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -1004,7 +1042,7 @@ public class ClaimRepository : IClaimRepository
         {
             await _container.PatchItemAsync<Claim>(
                 claimId,
-                new PartitionKey(claimId),
+                new PartitionKey(tenantId),
                 ops,
                 cancellationToken: ct);
             return true;
@@ -1025,7 +1063,7 @@ public class ClaimRepository : IClaimRepository
         Claim? existing;
         try
         {
-            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(claimId), cancellationToken: ct);
+            var read = await _container.ReadItemAsync<Claim>(claimId, new PartitionKey(tenantId), cancellationToken: ct);
             existing = read.Resource;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
@@ -1047,7 +1085,7 @@ public class ClaimRepository : IClaimRepository
         {
             await _container.PatchItemAsync<Claim>(
                 claimId,
-                new PartitionKey(claimId),
+                new PartitionKey(tenantId),
                 ops,
                 cancellationToken: ct);
             return true;

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -209,13 +209,16 @@ public class ClaimRepository : IClaimRepository
     /// sensible defaults. Idempotent — running on a fully-versioned row
     /// is a no-op. Mirrors <c>ProviderRepository.Hydrate</c>.
     ///
-    /// Public so the 5.1b Cosmos partition migration can canonicalize
-    /// rows during the copy from the legacy <c>Claims</c> container into
-    /// the canonical <c>ClaimsV2</c> container — the new container then
-    /// starts fully hydrated and downstream readers don't need to
-    /// re-Hydrate post-migration.
+    /// Internal (not public) so the 5.1b Cosmos partition migration can
+    /// canonicalize rows during the copy from the legacy <c>Claims</c>
+    /// container into the canonical <c>ClaimsV2</c> container — the new
+    /// container then starts fully hydrated and downstream readers don't
+    /// need to re-Hydrate post-migration. Same-assembly consumers
+    /// (<c>ClaimMigrationService</c>) call directly; tests reach via the
+    /// existing <c>InternalsVisibleTo</c> attribute on
+    /// <c>claims-service.csproj</c>.
     /// </summary>
-    public static Claim Hydrate(Claim claim)
+    internal static Claim Hydrate(Claim claim)
     {
         if (string.IsNullOrEmpty(claim.ClaimVersionId))
         {
@@ -271,7 +274,7 @@ public class ClaimRepository : IClaimRepository
                 id,
                 new PartitionKey(tenantId));
 
-            // 5.1b: with /TenantId partition, a cross-tenant lookup throws
+            // 5.1b: with /tenantId partition, a cross-tenant lookup throws
             // CosmosException 404 (caught below) rather than returning a
             // foreign-tenant document. The in-memory tenant equality check
             // is intentionally retained as defense in depth: it makes the
@@ -1011,7 +1014,7 @@ public class ClaimRepository : IClaimRepository
         CancellationToken ct = default)
     {
         // Pre-read confirms the row exists and (defense in depth) belongs
-        // to the supplied tenant. With the 5.1b /TenantId partition, a
+        // to the supplied tenant. With the 5.1b /tenantId partition, a
         // cross-tenant claimId surfaces as Cosmos 404 (caught below); the
         // explicit TenantId equality check is intentionally retained
         // alongside the partition-key boundary for the same reasons

--- a/src/services/claims-service/Services/Migrations/ClaimMigrationOptions.cs
+++ b/src/services/claims-service/Services/Migrations/ClaimMigrationOptions.cs
@@ -1,0 +1,56 @@
+namespace ClaimsService.Services.Migrations;
+
+/// <summary>
+/// Configuration for the capability 5.1b Cosmos partition-key migration
+/// (legacy <c>Claims</c> container with <c>/memberId</c> Bicep
+/// declaration / <c>/Id</c> runtime partition → canonical
+/// <c>ClaimsV2</c> container with <c>/TenantId</c> partition).
+///
+/// <para>
+/// Mirrors the configuration shape established by
+/// <c>NetworkTierBackfillOptions</c> in benefit-plan-service: a
+/// default-false admin gate plus per-call sizing knobs. The deployment
+/// layer (NetworkPolicy / gateway ACL) is the load-bearing
+/// authorization — this flag is a defence-in-depth tripwire.
+/// </para>
+/// </summary>
+public sealed class ClaimMigrationOptions
+{
+    public const string SectionName = "ClaimsCosmosMigration";
+
+    /// <summary>
+    /// Defence-in-depth gate for the admin migration endpoint
+    /// (<c>POST /api/v1/admin/claims/cosmos-migration/run</c>).
+    /// Default <c>false</c>: a misconfigured gateway / NetworkPolicy
+    /// can't expose the endpoint just because the route is registered.
+    /// Operators must explicitly opt in by setting
+    /// <c>ClaimsCosmosMigration:MigrationsEnabled=true</c> in
+    /// configuration AND restrict access at the deployment layer
+    /// (NetworkPolicy, gateway ACL). When disabled, the controller
+    /// returns 503 Service Unavailable.
+    /// </summary>
+    public bool MigrationsEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Source container name (legacy <c>/memberId</c> partition).
+    /// Default <c>"Claims"</c>.
+    /// </summary>
+    public string SourceContainerName { get; set; } = "Claims";
+
+    /// <summary>
+    /// Target container name (canonical <c>/TenantId</c> partition,
+    /// declared in Bicep at <c>cosmos-db.bicep</c>). Default
+    /// <c>"ClaimsV2"</c> per Decision 4 (Cosmos containers cannot be
+    /// renamed; version-suffix convention).
+    /// </summary>
+    public string TargetContainerName { get; set; } = "ClaimsV2";
+
+    /// <summary>
+    /// Documents per page when reading from the source container and
+    /// when querying the target container for already-migrated IDs
+    /// (Decision 7 — batched idempotency check rather than per-doc
+    /// reads). Default 100. Operators can override per-call via the
+    /// request body.
+    /// </summary>
+    public int BatchSize { get; set; } = 100;
+}

--- a/src/services/claims-service/Services/Migrations/ClaimMigrationOptions.cs
+++ b/src/services/claims-service/Services/Migrations/ClaimMigrationOptions.cs
@@ -4,7 +4,7 @@ namespace ClaimsService.Services.Migrations;
 /// Configuration for the capability 5.1b Cosmos partition-key migration
 /// (legacy <c>Claims</c> container with <c>/memberId</c> Bicep
 /// declaration / <c>/Id</c> runtime partition → canonical
-/// <c>ClaimsV2</c> container with <c>/TenantId</c> partition).
+/// <c>ClaimsV2</c> container with <c>/tenantId</c> partition).
 ///
 /// <para>
 /// Mirrors the configuration shape established by
@@ -38,7 +38,7 @@ public sealed class ClaimMigrationOptions
     public string SourceContainerName { get; set; } = "Claims";
 
     /// <summary>
-    /// Target container name (canonical <c>/TenantId</c> partition,
+    /// Target container name (canonical <c>/tenantId</c> partition,
     /// declared in Bicep at <c>cosmos-db.bicep</c>). Default
     /// <c>"ClaimsV2"</c> per Decision 4 (Cosmos containers cannot be
     /// renamed; version-suffix convention).

--- a/src/services/claims-service/Services/Migrations/ClaimMigrationService.cs
+++ b/src/services/claims-service/Services/Migrations/ClaimMigrationService.cs
@@ -1,0 +1,380 @@
+using System.Diagnostics;
+using ClaimsService.Models;
+using ClaimsService.Models.Migrations;
+using ClaimsService.Repositories;
+using CloudHealthOffice.Infrastructure.Observability;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
+namespace ClaimsService.Services.Migrations;
+
+/// <summary>
+/// Capability 5.1b — Cosmos partition-key migration service. Mirrors
+/// the operator-driven, idempotent, single-tenant-aware shape of
+/// <c>NetworkTierBackfillService</c> (benefit-plan capability 5.5),
+/// adapted for cross-tenant container-to-container copy:
+/// <list type="bullet">
+///   <item>The legacy <c>Claims</c> container has no canonical
+///   tenant partition, so the migration walks the entire container
+///   cross-partition; the target <c>ClaimsV2</c> container is
+///   partitioned by <c>/TenantId</c>, so writes are partition-keyed
+///   per row.</item>
+///   <item>Hydration runs before each write so legacy rows
+///   (pre-versioning fields) land in <c>ClaimsV2</c> with
+///   <c>ClaimVersionId</c>, <c>VersionNumber</c>, and
+///   <c>VersionState</c> populated by
+///   <see cref="ClaimRepository.Hydrate"/>.</item>
+///   <item>Idempotency is batched: every 100 reads (configurable),
+///   the service queries the target for already-present <c>Id</c>s in
+///   one round trip rather than paying a per-doc point-read RU. This
+///   matters at scale — a million-row container otherwise burns RUs
+///   re-checking already-migrated rows on each rerun.</item>
+/// </list>
+/// </summary>
+public sealed class ClaimMigrationService : IClaimMigrationService
+{
+    private readonly Container _source;
+    private readonly Container _target;
+    private readonly IOptionsMonitor<ClaimMigrationOptions> _options;
+    private readonly ILogger<ClaimMigrationService> _logger;
+
+    private readonly object _stateLock = new();
+    private bool _running;
+    private ClaimMigrationResult? _lastRun;
+
+    public ClaimMigrationService(
+        IClaimMigrationContainerResolver containers,
+        IOptionsMonitor<ClaimMigrationOptions> options,
+        ILogger<ClaimMigrationService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(containers);
+        _source = containers.Source;
+        _target = containers.Target;
+        _options = options;
+        _logger = logger;
+    }
+
+    public ClaimMigrationStatus GetStatus()
+    {
+        var opts = _options.CurrentValue;
+        lock (_stateLock)
+        {
+            return new ClaimMigrationStatus
+            {
+                MigrationsEnabled = opts.MigrationsEnabled,
+                SourceContainer = opts.SourceContainerName,
+                TargetContainer = opts.TargetContainerName,
+                BatchSize = opts.BatchSize,
+                IsRunning = _running,
+                LastRun = _lastRun,
+            };
+        }
+    }
+
+    public async Task<ClaimMigrationResult> RunAsync(ClaimMigrationRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var opts = _options.CurrentValue;
+        var batchSize = request.BatchSize is > 0 ? request.BatchSize.Value : opts.BatchSize;
+
+        // One-at-a-time: a second concurrent run would double-count
+        // outcomes and produce confusing telemetry. Operators get 409
+        // from the controller; the service itself is the source of
+        // truth for the running flag.
+        lock (_stateLock)
+        {
+            if (_running)
+            {
+                throw new InvalidOperationException("A claim migration run is already in progress.");
+            }
+            _running = true;
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = new ClaimMigrationResult
+        {
+            DryRun = request.DryRun,
+            SourceContainer = opts.SourceContainerName,
+            TargetContainer = opts.TargetContainerName,
+        };
+
+        _logger.LogInformation(
+            "claims cosmos migration start runId={RunId} dryRun={DryRun} source={Source} target={Target} batchSize={BatchSize} actor={Actor} correlation={Correlation}",
+            result.MigrationRunId,
+            request.DryRun,
+            SanitizeForLog(opts.SourceContainerName),
+            SanitizeForLog(opts.TargetContainerName),
+            batchSize,
+            SanitizeForLog(request.ActorId),
+            SanitizeForLog(request.CorrelationId));
+
+        try
+        {
+            await CopyAsync(result, batchSize, request.DryRun, ct);
+            result.Outcome = result.DocumentsErrored == 0 ? "success" : "partial";
+        }
+        catch (OperationCanceledException)
+        {
+            result.Outcome = "failed";
+            throw;
+        }
+        catch (Exception ex)
+        {
+            result.Outcome = "failed";
+            _logger.LogError(ex,
+                "claims cosmos migration aborted runId={RunId} read={Read} written={Written} skipped={Skipped} errored={Errored}",
+                result.MigrationRunId,
+                result.DocumentsRead,
+                result.DocumentsWritten,
+                result.DocumentsSkipped,
+                result.DocumentsErrored);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            result.CompletedAt = DateTime.UtcNow;
+            result.DurationSeconds = stopwatch.Elapsed.TotalSeconds;
+
+            lock (_stateLock)
+            {
+                _lastRun = result;
+                _running = false;
+            }
+
+            ChoMetrics.ClaimsCosmosMigrationRuns.Add(
+                1,
+                new KeyValuePair<string, object?>("cho.outcome", result.Outcome),
+                new KeyValuePair<string, object?>("cho.dry_run", request.DryRun ? "true" : "false"));
+            ChoMetrics.ClaimsCosmosMigrationDuration.Record(
+                result.DurationSeconds,
+                new KeyValuePair<string, object?>("cho.outcome", result.Outcome),
+                new KeyValuePair<string, object?>("cho.dry_run", request.DryRun ? "true" : "false"));
+        }
+
+        _logger.LogInformation(
+            "claims cosmos migration complete runId={RunId} outcome={Outcome} read={Read} written={Written} skipped={Skipped} errored={Errored} hydrated={Hydrated} durationSeconds={DurationSeconds}",
+            result.MigrationRunId,
+            result.Outcome,
+            result.DocumentsRead,
+            result.DocumentsWritten,
+            result.DocumentsSkipped,
+            result.DocumentsErrored,
+            result.DocumentsHydrated,
+            result.DurationSeconds);
+
+        return result;
+    }
+
+    private async Task CopyAsync(ClaimMigrationResult result, int batchSize, bool dryRun, CancellationToken ct)
+    {
+        // Cross-partition read: the legacy container's partition key is
+        // /Id (runtime) or /memberId (Bicep declaration); both are
+        // per-document, so a tenant-scoped read isn't an option here.
+        // We accept the cross-partition cost — this is the migration's
+        // one-time RU spend.
+        var query = new QueryDefinition("SELECT * FROM c");
+        var iterator = _source.GetItemQueryIterator<Claim>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxItemCount = batchSize });
+
+        while (iterator.HasMoreResults)
+        {
+            ct.ThrowIfCancellationRequested();
+            var page = await iterator.ReadNextAsync(ct);
+
+            var batch = page.ToList();
+            if (batch.Count == 0) continue;
+
+            result.DocumentsRead += batch.Count;
+
+            // Batched idempotency check (Decision 7) — query the target
+            // for the IDs in this batch in a single round trip per
+            // partition the IDs span, instead of point-reading each.
+            var existingIds = await GetExistingTargetIdsAsync(batch, ct);
+
+            foreach (var claim in batch)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (existingIds.Contains(claim.Id))
+                {
+                    result.DocumentsSkipped++;
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "skipped"));
+                    continue;
+                }
+
+                var hydrated = HydrateForMigration(claim, out var didHydrate);
+                if (didHydrate) result.DocumentsHydrated++;
+
+                if (string.IsNullOrEmpty(hydrated.TenantId))
+                {
+                    // Defensive: a row missing TenantId can't be partitioned
+                    // in the new container. Surface explicitly rather than
+                    // letting Cosmos reject the write with a generic 400.
+                    result.DocumentsErrored++;
+                    result.Issues.Add(new ClaimMigrationIssue
+                    {
+                        ClaimId = hydrated.Id,
+                        TenantId = string.Empty,
+                        Outcome = "errored",
+                        Detail = "Claim is missing TenantId; cannot partition into ClaimsV2.",
+                    });
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "errored"));
+                    continue;
+                }
+
+                if (dryRun)
+                {
+                    result.DocumentsWritten++;
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "would_write"));
+                    continue;
+                }
+
+                try
+                {
+                    await _target.CreateItemAsync(
+                        hydrated,
+                        new PartitionKey(hydrated.TenantId),
+                        cancellationToken: ct);
+                    result.DocumentsWritten++;
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "written"));
+                }
+                catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+                {
+                    // Race: another writer landed this row between the
+                    // batched existence check and our write. Treat as
+                    // skipped — the row exists in the target.
+                    result.DocumentsSkipped++;
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "skipped"));
+                }
+                catch (CosmosException ex)
+                {
+                    result.DocumentsErrored++;
+                    result.Issues.Add(new ClaimMigrationIssue
+                    {
+                        ClaimId = hydrated.Id,
+                        TenantId = hydrated.TenantId,
+                        Outcome = "errored",
+                        Detail = $"{ex.StatusCode}: {ex.Message}",
+                    });
+                    ChoMetrics.ClaimsCosmosMigrationDocuments.Add(
+                        1,
+                        new KeyValuePair<string, object?>("cho.outcome", "errored"));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Query the target container for the subset of <paramref name="batch"/>
+    /// IDs already present. The query groups by <see cref="Claim.TenantId"/>
+    /// because /TenantId is the target partition key — a per-tenant query is
+    /// partition-scoped. A document with a missing TenantId can't be
+    /// migrated regardless, so it is excluded from the existence check.
+    /// </summary>
+    private async Task<HashSet<string>> GetExistingTargetIdsAsync(IReadOnlyList<Claim> batch, CancellationToken ct)
+    {
+        var found = new HashSet<string>(StringComparer.Ordinal);
+
+        var byTenant = batch
+            .Where(c => !string.IsNullOrEmpty(c.TenantId))
+            .GroupBy(c => c.TenantId);
+
+        foreach (var group in byTenant)
+        {
+            ct.ThrowIfCancellationRequested();
+            var ids = group.Select(c => c.Id).ToArray();
+            if (ids.Length == 0) continue;
+
+            var query = new QueryDefinition("SELECT VALUE c.id FROM c WHERE ARRAY_CONTAINS(@ids, c.id)")
+                .WithParameter("@ids", ids);
+
+            var iterator = _target.GetItemQueryIterator<string>(
+                query,
+                requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(group.Key) });
+
+            while (iterator.HasMoreResults)
+            {
+                var page = await iterator.ReadNextAsync(ct);
+                foreach (var id in page)
+                {
+                    if (!string.IsNullOrEmpty(id)) found.Add(id);
+                }
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Hydration mirrors <see cref="ClaimRepository.Hydrate"/> but
+    /// reports whether any field was modified so the migration result
+    /// can attribute legacy rows accurately. Idempotent on
+    /// already-canonicalized rows.
+    /// </summary>
+    private static Claim HydrateForMigration(Claim claim, out bool didHydrate)
+    {
+        var before = (claim.ClaimVersionId, claim.VersionNumber, claim.VersionState);
+        var hydrated = ClaimRepository.Hydrate(claim);
+        didHydrate =
+            before.ClaimVersionId != hydrated.ClaimVersionId
+            || before.VersionNumber != hydrated.VersionNumber
+            || before.VersionState != hydrated.VersionState;
+        return hydrated;
+    }
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+    }
+}
+
+/// <summary>
+/// DI-resolved holder for the source/target Cosmos containers consumed
+/// by <see cref="ClaimMigrationService"/>. Defining a holder rather
+/// than injecting two named <see cref="Container"/>s keeps the runtime
+/// service code (which only ever references the production container
+/// resolved by <c>CosmosDb:ContainerName</c>) decoupled from the
+/// migration tooling — only the migration job sees both containers.
+/// </summary>
+public interface IClaimMigrationContainerResolver
+{
+    Container Source { get; }
+    Container Target { get; }
+}
+
+/// <summary>
+/// Default <see cref="IClaimMigrationContainerResolver"/>: resolves
+/// both containers from the configured database via the supplied
+/// <see cref="CosmosClient"/>.
+/// </summary>
+public sealed class CosmosClaimMigrationContainerResolver : IClaimMigrationContainerResolver
+{
+    public CosmosClaimMigrationContainerResolver(
+        CosmosClient cosmosClient,
+        IConfiguration configuration,
+        IOptionsMonitor<ClaimMigrationOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(cosmosClient);
+        var databaseName = configuration["CosmosDb:DatabaseName"] ?? "ClaimsDB";
+        var opts = options.CurrentValue;
+        Source = cosmosClient.GetContainer(databaseName, opts.SourceContainerName);
+        Target = cosmosClient.GetContainer(databaseName, opts.TargetContainerName);
+    }
+
+    public Container Source { get; }
+    public Container Target { get; }
+}

--- a/src/services/claims-service/Services/Migrations/ClaimMigrationService.cs
+++ b/src/services/claims-service/Services/Migrations/ClaimMigrationService.cs
@@ -17,7 +17,7 @@ namespace ClaimsService.Services.Migrations;
 ///   <item>The legacy <c>Claims</c> container has no canonical
 ///   tenant partition, so the migration walks the entire container
 ///   cross-partition; the target <c>ClaimsV2</c> container is
-///   partitioned by <c>/TenantId</c>, so writes are partition-keyed
+///   partitioned by <c>/tenantId</c>, so writes are partition-keyed
 ///   per row.</item>
 ///   <item>Hydration runs before each write so legacy rows
 ///   (pre-versioning fields) land in <c>ClaimsV2</c> with
@@ -81,12 +81,14 @@ public sealed class ClaimMigrationService : IClaimMigrationService
         // One-at-a-time: a second concurrent run would double-count
         // outcomes and produce confusing telemetry. Operators get 409
         // from the controller; the service itself is the source of
-        // truth for the running flag.
+        // truth for the running flag. Distinct exception type rather
+        // than a plain InvalidOperationException so the controller's
+        // 409 mapping doesn't depend on string-matching a message.
         lock (_stateLock)
         {
             if (_running)
             {
-                throw new InvalidOperationException("A claim migration run is already in progress.");
+                throw new MigrationAlreadyRunningException();
             }
             _running = true;
         }
@@ -280,7 +282,7 @@ public sealed class ClaimMigrationService : IClaimMigrationService
     /// <summary>
     /// Query the target container for the subset of <paramref name="batch"/>
     /// IDs already present. The query groups by <see cref="Claim.TenantId"/>
-    /// because /TenantId is the target partition key — a per-tenant query is
+    /// because /tenantId is the target partition key — a per-tenant query is
     /// partition-scoped. A document with a missing TenantId can't be
     /// migrated regardless, so it is excluded from the existence check.
     /// </summary>

--- a/src/services/claims-service/Services/Migrations/IClaimMigrationService.cs
+++ b/src/services/claims-service/Services/Migrations/IClaimMigrationService.cs
@@ -1,0 +1,46 @@
+using ClaimsService.Models.Migrations;
+
+namespace ClaimsService.Services.Migrations;
+
+/// <summary>
+/// Capability 5.1b — copies claim documents from the legacy
+/// <c>Claims</c> Cosmos container (Bicep <c>/memberId</c> declaration,
+/// <c>/Id</c> runtime partition) to the canonical <c>ClaimsV2</c>
+/// container (<c>/TenantId</c> partition).
+///
+/// <para>
+/// Idempotent: re-running skips rows already present in the target
+/// container by <c>Id</c> (Decision 7 — batched idempotency check).
+/// Hydrates legacy rows missing versioning fields
+/// (<c>ClaimVersionId == ""</c> → <c>Id</c>; <c>VersionNumber == 0</c>
+/// → 1; <c>VersionState == Unknown</c> → mapped from <c>Status</c>) so
+/// the new container starts fully canonicalized day one.
+/// </para>
+///
+/// <para>
+/// Driven by the admin endpoint
+/// <c>POST /api/v1/admin/claims/cosmos-migration/run</c>; the service
+/// has no HttpContext dependency and is callable from any system
+/// actor. The status surface is reported through <see cref="GetStatus"/>
+/// (Decision 15 — GET status IN, chunked streaming OUT).
+/// </para>
+///
+/// <para>
+/// See <c>docs/migrations/claims-cosmos-partition-migration.md</c>
+/// for the operator runbook.
+/// </para>
+/// </summary>
+public interface IClaimMigrationService
+{
+    /// <summary>
+    /// Run the migration end-to-end. Setting <see cref="ClaimMigrationRequest.DryRun"/>
+    /// produces counters without writing to the target container.
+    /// </summary>
+    Task<ClaimMigrationResult> RunAsync(ClaimMigrationRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Snapshot of current migration state (running / last-completed
+    /// summary / configured source-target pair).
+    /// </summary>
+    ClaimMigrationStatus GetStatus();
+}

--- a/src/services/claims-service/Services/Migrations/IClaimMigrationService.cs
+++ b/src/services/claims-service/Services/Migrations/IClaimMigrationService.cs
@@ -3,10 +3,23 @@ using ClaimsService.Models.Migrations;
 namespace ClaimsService.Services.Migrations;
 
 /// <summary>
+/// Thrown by <see cref="IClaimMigrationService.RunAsync"/> when a
+/// migration run is already in flight. Distinct from a generic
+/// <see cref="InvalidOperationException"/> so the controller can map
+/// it to HTTP 409 Conflict without string-matching the exception
+/// message — message wording can drift; the type cannot.
+/// </summary>
+public sealed class MigrationAlreadyRunningException : InvalidOperationException
+{
+    public MigrationAlreadyRunningException()
+        : base("A claim migration run is already in progress.") { }
+}
+
+/// <summary>
 /// Capability 5.1b — copies claim documents from the legacy
 /// <c>Claims</c> Cosmos container (Bicep <c>/memberId</c> declaration,
 /// <c>/Id</c> runtime partition) to the canonical <c>ClaimsV2</c>
-/// container (<c>/TenantId</c> partition).
+/// container (<c>/tenantId</c> partition).
 ///
 /// <para>
 /// Idempotent: re-running skips rows already present in the target

--- a/src/services/claims-service/appsettings.json
+++ b/src/services/claims-service/appsettings.json
@@ -19,5 +19,11 @@
       "CobMode": "PendForSecondary",
       "AiMode": "BestEffort"
     }
+  },
+  "ClaimsCosmosMigration": {
+    "MigrationsEnabled": false,
+    "SourceContainerName": "Claims",
+    "TargetContainerName": "ClaimsV2",
+    "BatchSize": 100
   }
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Observability/ChoMetrics.cs
@@ -261,6 +261,41 @@ public static class ChoMetrics
     /// </summary>
     public static void ResetIntegrityScoreStaleCounts() => IntegrityScoreStaleCounts.Clear();
 
+    /// <summary>
+    /// Counter tracking claims-service Cosmos partition-key migration
+    /// runs (capability 5.1b). One increment per
+    /// <c>POST /api/v1/admin/claims/cosmos-migration/run</c>
+    /// invocation. Dimensions: <c>cho.outcome</c> (success | partial |
+    /// failed), <c>cho.dry_run</c> (true | false).
+    /// </summary>
+    public static readonly Counter<long> ClaimsCosmosMigrationRuns =
+        Meter.CreateCounter<long>(
+            "cho.claims.cosmos_migration.runs.total",
+            unit: "{run}",
+            description: "Cosmos partition-key migration runs by outcome (5.1b)");
+
+    /// <summary>
+    /// Counter tracking individual document outcomes within a Cosmos
+    /// partition-key migration run (capability 5.1b). Dimensions:
+    /// <c>cho.outcome</c> (written | would_write | skipped | errored).
+    /// </summary>
+    public static readonly Counter<long> ClaimsCosmosMigrationDocuments =
+        Meter.CreateCounter<long>(
+            "cho.claims.cosmos_migration.documents.total",
+            unit: "{document}",
+            description: "Documents processed per migration run, by outcome (5.1b)");
+
+    /// <summary>
+    /// Histogram tracking Cosmos partition-key migration duration
+    /// (capability 5.1b). Dimensions: <c>cho.outcome</c>,
+    /// <c>cho.dry_run</c>.
+    /// </summary>
+    public static readonly Histogram<double> ClaimsCosmosMigrationDuration =
+        Meter.CreateHistogram<double>(
+            "cho.claims.cosmos_migration.duration",
+            unit: "s",
+            description: "Cosmos partition-key migration run duration in seconds (5.1b)");
+
     private static string GetAssemblyVersion()
     {
         return typeof(ChoMetrics).Assembly

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/AdminMigrationControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/AdminMigrationControllerTests.cs
@@ -87,8 +87,7 @@ public sealed class AdminMigrationControllerTests
     public async Task Run_Returns_409_When_Service_Reports_Run_In_Progress()
     {
         var (controller, service) = Build(enabled: true);
-        service.NextException = new InvalidOperationException(
-            "A claim migration run is already in progress.");
+        service.NextException = new MigrationAlreadyRunningException();
 
         var response = await controller.Run(new ClaimMigrationRequest(), default);
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/AdminMigrationControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/AdminMigrationControllerTests.cs
@@ -1,0 +1,195 @@
+using ClaimsService.Controllers;
+using ClaimsService.Models.Migrations;
+using ClaimsService.Services.Migrations;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Controllers;
+
+/// <summary>
+/// Capability 5.1b — admin endpoint contract tests. Mirrors the
+/// shape established by NetworkTierBackfillAdminControllerTests:
+/// feature-flag tripwire, request validation, forwarding to the
+/// underlying migration service, status retrieval, and concurrent-run
+/// 409 mapping.
+/// </summary>
+public sealed class AdminMigrationControllerTests
+{
+    [Fact]
+    public async Task Run_Returns_503_When_Feature_Flag_Is_Off()
+    {
+        var (controller, _) = Build(enabled: false);
+
+        var response = await controller.Run(new ClaimMigrationRequest(), default);
+
+        var status = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task Run_Returns_400_When_BatchSize_Is_Zero()
+    {
+        var (controller, _) = Build(enabled: true);
+
+        var response = await controller.Run(new ClaimMigrationRequest { BatchSize = 0 }, default);
+
+        response.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Run_Returns_400_When_BatchSize_Is_Negative()
+    {
+        var (controller, _) = Build(enabled: true);
+
+        var response = await controller.Run(new ClaimMigrationRequest { BatchSize = -1 }, default);
+
+        response.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Run_With_Null_Body_Defaults_To_DryRun_True()
+    {
+        var (controller, service) = Build(enabled: true);
+        service.NextResult = new ClaimMigrationResult { DryRun = true, Outcome = "success" };
+
+        var response = await controller.Run(null, default);
+
+        response.Result.Should().BeOfType<OkObjectResult>();
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.DryRun.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Run_Forwards_Approved_Request_To_Service_And_Returns_Result()
+    {
+        var (controller, service) = Build(enabled: true);
+        service.NextResult = new ClaimMigrationResult
+        {
+            DryRun = false,
+            DocumentsRead = 5,
+            DocumentsWritten = 5,
+            Outcome = "success",
+        };
+
+        var response = await controller.Run(
+            new ClaimMigrationRequest { DryRun = false }, default);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<ClaimMigrationResult>()
+            .Which.DocumentsWritten.Should().Be(5);
+        service.LastRequest!.DryRun.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Run_Returns_409_When_Service_Reports_Run_In_Progress()
+    {
+        var (controller, service) = Build(enabled: true);
+        service.NextException = new InvalidOperationException(
+            "A claim migration run is already in progress.");
+
+        var response = await controller.Run(new ClaimMigrationRequest(), default);
+
+        response.Result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task Run_Resolves_ActorId_From_X_User_Id_Header_When_No_Sub_Claim()
+    {
+        var (controller, service) = Build(enabled: true);
+        controller.HttpContext.Request.Headers["X-User-Id"] = "ops@cho";
+        service.NextResult = new ClaimMigrationResult { Outcome = "success" };
+
+        await controller.Run(new ClaimMigrationRequest(), default);
+
+        service.LastRequest!.ActorId.Should().Be("ops@cho");
+    }
+
+    [Fact]
+    public async Task Run_Falls_Back_To_Synthetic_ActorId_When_No_Principal()
+    {
+        var (controller, service) = Build(enabled: true);
+        service.NextResult = new ClaimMigrationResult { Outcome = "success" };
+
+        await controller.Run(new ClaimMigrationRequest(), default);
+
+        service.LastRequest!.ActorId.Should().Be("admin:claims-cosmos-migration");
+    }
+
+    [Fact]
+    public void GetStatus_Returns_503_When_Feature_Flag_Is_Off()
+    {
+        var (controller, _) = Build(enabled: false);
+
+        var response = controller.GetStatus();
+
+        var status = response.Result.Should().BeOfType<ObjectResult>().Subject;
+        status.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public void GetStatus_Returns_Snapshot_From_Service_When_Enabled()
+    {
+        var (controller, service) = Build(enabled: true);
+        service.NextStatus = new ClaimMigrationStatus
+        {
+            MigrationsEnabled = true,
+            SourceContainer = "Claims",
+            TargetContainer = "ClaimsV2",
+            BatchSize = 100,
+            IsRunning = false,
+        };
+
+        var response = controller.GetStatus();
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeOfType<ClaimMigrationStatus>()
+            .Which.TargetContainer.Should().Be("ClaimsV2");
+    }
+
+    private static (AdminMigrationController controller, RecordingService service) Build(bool enabled)
+    {
+        var service = new RecordingService();
+        var options = new ClaimMigrationOptions
+        {
+            MigrationsEnabled = enabled,
+            SourceContainerName = "Claims",
+            TargetContainerName = "ClaimsV2",
+            BatchSize = 100,
+        };
+        var monitor = new SingleValueOptionsMonitor<ClaimMigrationOptions>(options);
+        var controller = new AdminMigrationController(
+            service, monitor, NullLogger<AdminMigrationController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+        return (controller, service);
+    }
+
+    private sealed class RecordingService : IClaimMigrationService
+    {
+        public ClaimMigrationResult NextResult { get; set; } = new();
+        public ClaimMigrationStatus NextStatus { get; set; } = new();
+        public Exception? NextException { get; set; }
+        public ClaimMigrationRequest? LastRequest { get; private set; }
+
+        public Task<ClaimMigrationResult> RunAsync(ClaimMigrationRequest request, CancellationToken ct = default)
+        {
+            LastRequest = request;
+            if (NextException is not null) throw NextException;
+            return Task.FromResult(NextResult);
+        }
+
+        public ClaimMigrationStatus GetStatus() => NextStatus;
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/PartitionMigrationContractTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/PartitionMigrationContractTests.cs
@@ -1,0 +1,255 @@
+using ClaimsService.Models;
+using ClaimsService.Models.Migrations;
+using ClaimsService.Services.Migrations;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Integration;
+
+/// <summary>
+/// Capability 5.1b — composition-level contract tests reframing the
+/// originally-planned <c>PartitionMigrationEndToEndTests</c> away from
+/// real-Cosmos round-trip (no Cosmos Emulator in the claims-service
+/// test stack) toward mocked <see cref="Container"/> end-to-end:
+/// pre-migration mixed legacy + canonical data → migration runs → all
+/// rows written to the target with hydrated versioning fields → idempotent
+/// rerun produces zero new writes. Real-Cosmos verification is the
+/// operator runbook's pre-cutover dev-environment dry-run step.
+/// </summary>
+public sealed class PartitionMigrationContractTests
+{
+    [Fact]
+    public async Task EndToEnd_MixedLegacyAndCanonicalRows_AllWrittenWithHydratedFields()
+    {
+        var source = Substitute.For<Container>();
+        var target = new InMemoryTargetContainer();
+
+        var canonicalRow = new Claim
+        {
+            Id = "claim-1",
+            TenantId = "tenant-a",
+            ClaimVersionId = "claim-1",
+            VersionNumber = 1,
+            VersionState = ClaimVersionState.Submitted,
+            Status = ClaimStatus.Submitted,
+        };
+        var legacyRow = new Claim
+        {
+            Id = "legacy-1",
+            TenantId = "tenant-a",
+            ClaimVersionId = string.Empty,
+            VersionNumber = 0,
+            VersionState = ClaimVersionState.Unknown,
+            Status = ClaimStatus.Paid,
+        };
+        var differentTenantRow = new Claim
+        {
+            Id = "claim-2",
+            TenantId = "tenant-b",
+            ClaimVersionId = "claim-2",
+            VersionNumber = 1,
+            VersionState = ClaimVersionState.Adjudicated,
+            Status = ClaimStatus.Approved,
+        };
+
+        StubSourceQuery(source, new[] { canonicalRow, legacyRow, differentTenantRow });
+
+        var sut = BuildSut(source, target);
+
+        var firstRun = await sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        firstRun.DocumentsRead.Should().Be(3);
+        firstRun.DocumentsWritten.Should().Be(3);
+        firstRun.DocumentsSkipped.Should().Be(0);
+        firstRun.DocumentsHydrated.Should().Be(1);
+        firstRun.Outcome.Should().Be("success");
+
+        target.Items.Should().HaveCount(3);
+        target.Items["claim-1"].Should().Match<Claim>(c =>
+            c.ClaimVersionId == "claim-1"
+            && c.VersionNumber == 1
+            && c.VersionState == ClaimVersionState.Submitted);
+        target.Items["legacy-1"].Should().Match<Claim>(c =>
+            c.ClaimVersionId == "legacy-1"
+            && c.VersionNumber == 1
+            && c.VersionState == ClaimVersionState.Paid);
+        target.Items["claim-2"].Should().Match<Claim>(c =>
+            c.ClaimVersionId == "claim-2"
+            && c.VersionNumber == 1
+            && c.VersionState == ClaimVersionState.Adjudicated);
+
+        target.PartitionKeysSeen.Should().Contain(new PartitionKey("tenant-a"));
+        target.PartitionKeysSeen.Should().Contain(new PartitionKey("tenant-b"));
+    }
+
+    [Fact]
+    public async Task EndToEnd_IdempotentRerun_ProducesZeroNewWrites()
+    {
+        var source = Substitute.For<Container>();
+        var target = new InMemoryTargetContainer();
+
+        var rows = new[]
+        {
+            new Claim
+            {
+                Id = "claim-1", TenantId = "tenant-a", ClaimVersionId = "claim-1",
+                VersionNumber = 1, VersionState = ClaimVersionState.Paid,
+                Status = ClaimStatus.Paid,
+            },
+            new Claim
+            {
+                Id = "claim-2", TenantId = "tenant-a", ClaimVersionId = "claim-2",
+                VersionNumber = 1, VersionState = ClaimVersionState.Submitted,
+                Status = ClaimStatus.Submitted,
+            },
+        };
+
+        StubSourceQuery(source, rows);
+
+        var sut = BuildSut(source, target);
+
+        var firstRun = await sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+        firstRun.DocumentsWritten.Should().Be(2);
+
+        // Re-stub the source — the iterator stub is single-use because
+        // HasMoreResults sequence is consumed.
+        StubSourceQuery(source, rows);
+
+        var secondRun = await sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        secondRun.DocumentsRead.Should().Be(2);
+        secondRun.DocumentsWritten.Should().Be(0);
+        secondRun.DocumentsSkipped.Should().Be(2);
+        secondRun.Outcome.Should().Be("success");
+        target.Items.Should().HaveCount(2);
+    }
+
+    private static ClaimMigrationService BuildSut(Container source, InMemoryTargetContainer target)
+    {
+        var resolver = new StubResolver(source, target.Container);
+        var options = new SingleValueOptionsMonitor<ClaimMigrationOptions>(new ClaimMigrationOptions
+        {
+            MigrationsEnabled = true,
+            SourceContainerName = "Claims",
+            TargetContainerName = "ClaimsV2",
+            BatchSize = 100,
+        });
+        return new ClaimMigrationService(resolver, options, NullLogger<ClaimMigrationService>.Instance);
+    }
+
+    private static void StubSourceQuery(Container source, IEnumerable<Claim> claims)
+    {
+        var list = claims.ToList();
+        var feedResponse = Substitute.For<FeedResponse<Claim>>();
+        feedResponse.GetEnumerator().Returns(_ => list.GetEnumerator());
+
+        var iterator = Substitute.For<FeedIterator<Claim>>();
+        iterator.HasMoreResults.Returns(true, false);
+        iterator.ReadNextAsync(Arg.Any<CancellationToken>()).Returns(feedResponse);
+
+        source.GetItemQueryIterator<Claim>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryRequestOptions>())
+            .Returns(iterator);
+    }
+
+    /// <summary>
+    /// Records writes against a <see cref="Container"/> mock, exposes
+    /// the in-memory state for assertions, and serves the existence-
+    /// check query the migration uses to decide whether to write.
+    /// </summary>
+    private sealed class InMemoryTargetContainer
+    {
+        public Container Container { get; }
+        public Dictionary<string, Claim> Items { get; } = new(StringComparer.Ordinal);
+        public List<PartitionKey> PartitionKeysSeen { get; } = new();
+
+        public InMemoryTargetContainer()
+        {
+            Container = Substitute.For<Container>();
+
+            Container.CreateItemAsync(
+                Arg.Any<Claim>(),
+                Arg.Any<PartitionKey>(),
+                Arg.Any<ItemRequestOptions>(),
+                Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    var claim = call.Arg<Claim>();
+                    var key = call.Arg<PartitionKey>();
+                    PartitionKeysSeen.Add(key);
+                    Items[claim.Id] = claim;
+                    var response = Substitute.For<ItemResponse<Claim>>();
+                    response.Resource.Returns(claim);
+                    return Task.FromResult(response);
+                });
+
+            Container.GetItemQueryIterator<string>(
+                Arg.Any<QueryDefinition>(),
+                Arg.Any<string>(),
+                Arg.Any<QueryRequestOptions>())
+                .Returns(call =>
+                {
+                    var query = call.Arg<QueryDefinition>();
+                    var requestOptions = call.Arg<QueryRequestOptions>();
+                    var partitionTenantId = ExtractPartitionTenant(requestOptions);
+                    var queriedIds = ExtractIdsParameter(query);
+
+                    var matches = Items.Values
+                        .Where(c => c.TenantId == partitionTenantId)
+                        .Where(c => queriedIds.Contains(c.Id))
+                        .Select(c => c.Id)
+                        .ToList();
+
+                    var feedResponse = Substitute.For<FeedResponse<string>>();
+                    feedResponse.GetEnumerator().Returns(_ => matches.GetEnumerator());
+
+                    var iterator = Substitute.For<FeedIterator<string>>();
+                    iterator.HasMoreResults.Returns(true, false);
+                    iterator.ReadNextAsync(Arg.Any<CancellationToken>()).Returns(feedResponse);
+                    return iterator;
+                });
+        }
+
+        private static string ExtractPartitionTenant(QueryRequestOptions? options)
+            => options?.PartitionKey?.ToString()?.Trim('[', ']', '"') ?? string.Empty;
+
+        private static HashSet<string> ExtractIdsParameter(QueryDefinition query)
+        {
+            // QueryDefinition exposes parameters via an enumerable contract;
+            // pull the @ids array out so the in-memory store can scope to
+            // the IDs the service is asking about.
+            foreach (var param in query.GetQueryParameters())
+            {
+                if (param.Name == "@ids" && param.Value is IEnumerable<string> arr)
+                {
+                    return new HashSet<string>(arr, StringComparer.Ordinal);
+                }
+                if (param.Name == "@ids" && param.Value is string[] strArr)
+                {
+                    return new HashSet<string>(strArr, StringComparer.Ordinal);
+                }
+            }
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    private sealed class StubResolver : IClaimMigrationContainerResolver
+    {
+        public StubResolver(Container source, Container target) { Source = source; Target = target; }
+        public Container Source { get; }
+        public Container Target { get; }
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryPartitionKeyTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryPartitionKeyTests.cs
@@ -1,0 +1,267 @@
+using System.Net;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Repositories;
+
+/// <summary>
+/// Capability 5.1b — captured-call assertions that every Cosmos
+/// PartitionKey site in <see cref="ClaimRepository"/> uses
+/// <c>new PartitionKey(tenantId)</c> rather than the legacy
+/// <c>claim.Id</c> / <c>id</c> / <c>rowId</c> / <c>claimId</c> values.
+///
+/// <para>
+/// Contract-level coverage (no Cosmos Emulator). Each test sets up
+/// the minimum mocked Container interactions to drive a single
+/// repository call path and verifies <c>Received()</c> with
+/// <c>PartitionKey == new PartitionKey(TenantId)</c>.
+/// </para>
+/// </summary>
+public sealed class ClaimRepositoryPartitionKeyTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ClaimId = "claim-1";
+
+    private readonly Container _container = Substitute.For<Container>();
+    private readonly ClaimRepository _sut;
+
+    public ClaimRepositoryPartitionKeyTests()
+    {
+        var cosmos = Substitute.For<CosmosClient>();
+        cosmos.GetContainer(Arg.Any<string>(), Arg.Any<string>()).Returns(_container);
+
+        var config = Substitute.For<IConfiguration>();
+        config["CosmosDb:DatabaseName"].Returns("ClaimsDB");
+        config["CosmosDb:ContainerName"].Returns("Claims");
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["TenantId"] = TenantId;
+        httpContextAccessor.HttpContext.Returns(httpContext);
+
+        _sut = new ClaimRepository(cosmos, config, httpContextAccessor, NullLogger<ClaimRepository>.Instance);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_UsesTenantPartitionKey()
+    {
+        StubReadItemReturnsClaim(MakeClaim());
+
+        await _sut.GetByIdAsync(ClaimId);
+
+        await _container.Received(1).ReadItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WrongTenant_ReturnsNullDespitePartitionScope()
+    {
+        // Defense-in-depth check: even though the partition-keyed read
+        // would normally be scoped, retain the in-memory tenant guard.
+        var foreign = MakeClaim();
+        foreign.TenantId = "tenant-b";
+        StubReadItemReturnsClaim(foreign);
+
+        var result = await _sut.GetByIdAsync(ClaimId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_UsesTenantPartitionKey()
+    {
+        StubCreateItemOk();
+
+        await _sut.CreateAsync(MakeClaim());
+
+        await _container.Received(1).CreateItemAsync(
+            Arg.Any<Claim>(),
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_BothReadAndReplaceUseTenantPartitionKey()
+    {
+        StubReadItemReturnsClaim(MakeClaim());
+        StubReplaceItemOk();
+
+        await _sut.UpdateAsync(MakeClaim());
+
+        await _container.Received(1).ReadItemAsync<Claim>(
+            Arg.Any<string>(),
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+        await _container.Received(1).ReplaceItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<string>(),
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UsesTenantPartitionKey()
+    {
+        var deleteResponse = Substitute.For<ItemResponse<Claim>>();
+        _container.DeleteItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(deleteResponse);
+
+        await _sut.DeleteAsync(ClaimId);
+
+        await _container.Received(1).DeleteItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkSupersededProjectionAsync_BothReadAndPatchUseTenantPartitionKey()
+    {
+        StubReadItemReturnsClaim(MakeClaim());
+        StubPatchItemOk();
+
+        var ok = await _sut.MarkSupersededProjectionAsync(
+            TenantId, ClaimId, "supersessor-id", DateTime.UtcNow, actorId: "actor", default);
+
+        ok.Should().BeTrue();
+        await _container.Received(1).ReadItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+        await _container.Received(1).PatchItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkVoidedProjectionAsync_BothReadAndPatchUseTenantPartitionKey()
+    {
+        StubReadItemReturnsClaim(MakeClaim());
+        StubPatchItemOk();
+
+        var ok = await _sut.MarkVoidedProjectionAsync(
+            TenantId, ClaimId, DateTime.UtcNow, actorId: "actor", default);
+
+        ok.Should().BeTrue();
+        await _container.Received(1).ReadItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+        await _container.Received(1).PatchItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task MarkSupersededProjectionAsync_ForeignTenant_ReturnsFalse()
+    {
+        // Defense-in-depth: even with the partition-keyed read, the
+        // in-memory tenant equality check is intentionally retained.
+        // A row whose stored TenantId disagrees with the supplied
+        // tenantId is rejected here.
+        var foreign = MakeClaim();
+        foreign.TenantId = "tenant-b";
+        StubReadItemReturnsClaim(foreign);
+
+        var ok = await _sut.MarkSupersededProjectionAsync(
+            TenantId, ClaimId, "supersessor-id", DateTime.UtcNow, null, default);
+
+        ok.Should().BeFalse();
+        await _container.DidNotReceive().PatchItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private static Claim MakeClaim() => new()
+    {
+        Id = ClaimId,
+        TenantId = TenantId,
+        ClaimVersionId = ClaimId,
+        VersionNumber = 1,
+        VersionState = ClaimVersionState.Submitted,
+        Status = ClaimStatus.Submitted,
+        MemberId = "member-1",
+        ClaimNumber = "CN-1",
+    };
+
+    private void StubReadItemReturnsClaim(Claim claim)
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(claim);
+        _container.ReadItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private void StubCreateItemOk()
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(MakeClaim());
+        _container.CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private void StubReplaceItemOk()
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(MakeClaim());
+        _container.ReplaceItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private void StubPatchItemOk()
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(MakeClaim());
+        _container.PatchItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Migrations/ClaimMigrationServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Migrations/ClaimMigrationServiceTests.cs
@@ -271,7 +271,7 @@ public class ClaimMigrationServiceTests
 
         var first = _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<MigrationAlreadyRunningException>(
             () => _sut.RunAsync(new ClaimMigrationRequest { DryRun = false }));
 
         // Release the first run.

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Migrations/ClaimMigrationServiceTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Migrations/ClaimMigrationServiceTests.cs
@@ -1,0 +1,406 @@
+using System.Net;
+using ClaimsService.Models;
+using ClaimsService.Models.Migrations;
+using ClaimsService.Services.Migrations;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Migrations;
+
+/// <summary>
+/// Capability 5.1b — Cosmos partition-key migration service tests.
+/// Mocked-Container approach (Decision: contract-level tests, no
+/// Cosmos Emulator); covers the migration lifecycle: empty,
+/// single-tenant, multi-tenant, legacy hydration, idempotency,
+/// dry-run, error paths.
+/// </summary>
+public class ClaimMigrationServiceTests
+{
+    private readonly Container _source = Substitute.For<Container>();
+    private readonly Container _target = Substitute.For<Container>();
+    private readonly ClaimMigrationService _sut;
+
+    public ClaimMigrationServiceTests()
+    {
+        var resolver = new StubResolver(_source, _target);
+        var options = new SingleValueOptionsMonitor<ClaimMigrationOptions>(new ClaimMigrationOptions
+        {
+            MigrationsEnabled = true,
+            SourceContainerName = "Claims",
+            TargetContainerName = "ClaimsV2",
+            BatchSize = 100,
+        });
+        _sut = new ClaimMigrationService(resolver, options, NullLogger<ClaimMigrationService>.Instance);
+    }
+
+    [Fact]
+    public async Task RunAsync_EmptySource_ReturnsZeroCounters()
+    {
+        StubSourceQuery(Array.Empty<Claim>());
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(0);
+        result.DocumentsWritten.Should().Be(0);
+        result.DocumentsSkipped.Should().Be(0);
+        result.DocumentsErrored.Should().Be(0);
+        result.Outcome.Should().Be("success");
+        result.SourceContainer.Should().Be("Claims");
+        result.TargetContainer.Should().Be("ClaimsV2");
+    }
+
+    [Fact]
+    public async Task RunAsync_SingleTenant_WritesEachClaimWithTenantPartitionKey()
+    {
+        var tenantId = "tenant-a";
+        var claims = new[]
+        {
+            MakeClaim("claim-1", tenantId, claimVersionId: "claim-1", versionNumber: 1, state: ClaimVersionState.Submitted),
+            MakeClaim("claim-2", tenantId, claimVersionId: "claim-2", versionNumber: 1, state: ClaimVersionState.Paid),
+        };
+        StubSourceQuery(claims);
+        StubTargetExistenceQuery(new HashSet<string>());
+        StubTargetCreateOk();
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(2);
+        result.DocumentsWritten.Should().Be(2);
+        result.DocumentsSkipped.Should().Be(0);
+        result.DocumentsErrored.Should().Be(0);
+
+        await _target.Received(1).CreateItemAsync(
+            Arg.Is<Claim>(c => c.Id == "claim-1"),
+            Arg.Is<PartitionKey>(p => p == new PartitionKey(tenantId)),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+        await _target.Received(1).CreateItemAsync(
+            Arg.Is<Claim>(c => c.Id == "claim-2"),
+            Arg.Is<PartitionKey>(p => p == new PartitionKey(tenantId)),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_MultiTenant_GroupsExistenceCheckByTenantPartition()
+    {
+        var claims = new[]
+        {
+            MakeClaim("claim-1", "tenant-a"),
+            MakeClaim("claim-2", "tenant-b"),
+            MakeClaim("claim-3", "tenant-a"),
+        };
+        StubSourceQuery(claims);
+        StubTargetExistenceQuery(new HashSet<string>());
+        StubTargetCreateOk();
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(3);
+        result.DocumentsWritten.Should().Be(3);
+
+        // Existence check executes once per tenant the batch spans.
+        _target.Received().GetItemQueryIterator<string>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Is<QueryRequestOptions>(o => o.PartitionKey == new PartitionKey("tenant-a")));
+        _target.Received().GetItemQueryIterator<string>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Is<QueryRequestOptions>(o => o.PartitionKey == new PartitionKey("tenant-b")));
+    }
+
+    [Fact]
+    public async Task RunAsync_LegacyRowMissingClaimVersionId_HydratesBeforeWriting()
+    {
+        var claim = new Claim
+        {
+            Id = "legacy-1",
+            TenantId = "tenant-a",
+            ClaimVersionId = string.Empty,
+            VersionNumber = 0,
+            VersionState = ClaimVersionState.Unknown,
+            Status = ClaimStatus.Paid,
+        };
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string>());
+        StubTargetCreateOk();
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(1);
+        result.DocumentsWritten.Should().Be(1);
+        result.DocumentsHydrated.Should().Be(1);
+
+        await _target.Received(1).CreateItemAsync(
+            Arg.Is<Claim>(c =>
+                c.Id == "legacy-1"
+                && c.ClaimVersionId == "legacy-1"
+                && c.VersionNumber == 1
+                && c.VersionState == ClaimVersionState.Paid),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_AlreadyMigratedRow_IsSkipped()
+    {
+        var claim = MakeClaim("claim-1", "tenant-a");
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string> { "claim-1" });
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(1);
+        result.DocumentsWritten.Should().Be(0);
+        result.DocumentsSkipped.Should().Be(1);
+
+        await _target.DidNotReceive().CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_DryRun_DoesNotInvokeCreateItem()
+    {
+        var claim = MakeClaim("claim-1", "tenant-a");
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = true });
+
+        result.DocumentsRead.Should().Be(1);
+        result.DocumentsWritten.Should().Be(1);
+        result.DryRun.Should().BeTrue();
+        result.Outcome.Should().Be("success");
+
+        await _target.DidNotReceive().CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_TargetWriteFails_RecordsIssueAndReportsPartial()
+    {
+        var claim = MakeClaim("claim-1", "tenant-a");
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        _target.CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new CosmosException("forbidden", HttpStatusCode.Forbidden, 0, "", 0));
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(1);
+        result.DocumentsWritten.Should().Be(0);
+        result.DocumentsErrored.Should().Be(1);
+        result.Outcome.Should().Be("partial");
+        result.Issues.Should().ContainSingle(i =>
+            i.ClaimId == "claim-1" && i.TenantId == "tenant-a" && i.Outcome == "errored");
+    }
+
+    [Fact]
+    public async Task RunAsync_ConflictOnTargetWrite_TreatsAsSkipped()
+    {
+        var claim = MakeClaim("claim-1", "tenant-a");
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        _target.CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new CosmosException("conflict", HttpStatusCode.Conflict, 0, "", 0));
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsRead.Should().Be(1);
+        result.DocumentsSkipped.Should().Be(1);
+        result.DocumentsErrored.Should().Be(0);
+        result.Outcome.Should().Be("success");
+    }
+
+    [Fact]
+    public async Task RunAsync_RowMissingTenantId_RecordsErrorAndDoesNotWrite()
+    {
+        var claim = new Claim
+        {
+            Id = "orphan-1",
+            TenantId = string.Empty,
+        };
+        StubSourceQuery(new[] { claim });
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        var result = await _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        result.DocumentsErrored.Should().Be(1);
+        result.Outcome.Should().Be("partial");
+        result.Issues.Should().ContainSingle(i => i.ClaimId == "orphan-1");
+
+        await _target.DidNotReceive().CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunAsync_DoubleInvocation_ReturnsConflictOnSecondCall()
+    {
+        // First call hangs by stalling the source iterator's ReadNextAsync;
+        // second call must bail with InvalidOperationException so the
+        // controller can map to 409 Conflict.
+        var firstReady = new TaskCompletionSource<FeedResponse<Claim>>();
+        StubSourceQueryDeferred(firstReady.Task);
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        var first = _sut.RunAsync(new ClaimMigrationRequest { DryRun = false });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.RunAsync(new ClaimMigrationRequest { DryRun = false }));
+
+        // Release the first run.
+        firstReady.SetResult(MakeFeedResponse(Array.Empty<Claim>()));
+        await first;
+    }
+
+    [Fact]
+    public void GetStatus_ReflectsConfiguredOptions()
+    {
+        var status = _sut.GetStatus();
+
+        status.MigrationsEnabled.Should().BeTrue();
+        status.SourceContainer.Should().Be("Claims");
+        status.TargetContainer.Should().Be("ClaimsV2");
+        status.BatchSize.Should().Be(100);
+        status.IsRunning.Should().BeFalse();
+        status.LastRun.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetStatus_AfterRun_ContainsLastRunSummary()
+    {
+        StubSourceQuery(Array.Empty<Claim>());
+        StubTargetExistenceQuery(new HashSet<string>());
+
+        await _sut.RunAsync(new ClaimMigrationRequest { DryRun = true });
+
+        var status = _sut.GetStatus();
+        status.LastRun.Should().NotBeNull();
+        status.LastRun!.Outcome.Should().Be("success");
+        status.IsRunning.Should().BeFalse();
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private static Claim MakeClaim(
+        string id,
+        string tenantId,
+        string? claimVersionId = null,
+        int versionNumber = 1,
+        ClaimVersionState state = ClaimVersionState.Submitted) => new()
+    {
+        Id = id,
+        TenantId = tenantId,
+        ClaimVersionId = claimVersionId ?? id,
+        VersionNumber = versionNumber,
+        VersionState = state,
+        Status = ClaimStatus.Submitted,
+        MemberId = "member-1",
+        ClaimNumber = $"CN-{id}",
+    };
+
+    private static FeedResponse<T> MakeFeedResponse<T>(IEnumerable<T> items)
+    {
+        var list = items.ToList();
+        var response = Substitute.For<FeedResponse<T>>();
+        response.GetEnumerator().Returns(_ => list.GetEnumerator());
+        return response;
+    }
+
+    private void StubSourceQuery(IEnumerable<Claim> claims)
+    {
+        var response = MakeFeedResponse(claims);
+        var iterator = Substitute.For<FeedIterator<Claim>>();
+        iterator.HasMoreResults.Returns(true, false);
+        iterator.ReadNextAsync(Arg.Any<CancellationToken>()).Returns(response);
+
+        _source.GetItemQueryIterator<Claim>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryRequestOptions>())
+            .Returns(iterator);
+    }
+
+    private void StubSourceQueryDeferred(Task<FeedResponse<Claim>> first)
+    {
+        var iterator = Substitute.For<FeedIterator<Claim>>();
+        iterator.HasMoreResults.Returns(true, false);
+        iterator.ReadNextAsync(Arg.Any<CancellationToken>()).Returns(_ => first);
+
+        _source.GetItemQueryIterator<Claim>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryRequestOptions>())
+            .Returns(iterator);
+    }
+
+    private void StubTargetExistenceQuery(HashSet<string> existingIds)
+    {
+        var response = MakeFeedResponse<string>(existingIds);
+        var iterator = Substitute.For<FeedIterator<string>>();
+        iterator.HasMoreResults.Returns(true, false);
+        iterator.ReadNextAsync(Arg.Any<CancellationToken>()).Returns(response);
+
+        _target.GetItemQueryIterator<string>(
+            Arg.Any<QueryDefinition>(),
+            Arg.Any<string>(),
+            Arg.Any<QueryRequestOptions>())
+            .Returns(iterator);
+    }
+
+    private void StubTargetCreateOk()
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        _target.CreateItemAsync(
+            Arg.Any<Claim>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private sealed class StubResolver : IClaimMigrationContainerResolver
+    {
+        public StubResolver(Container source, Container target)
+        {
+            Source = source;
+            Target = target;
+        }
+        public Container Source { get; }
+        public Container Target { get; }
+    }
+
+    private sealed class SingleValueOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public SingleValueOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the canonical `/TenantId`-partitioned `ClaimsV2` Cosmos container alongside the existing `Claims` container (Cosmos cannot rename containers; version-suffix convention preserves data during the rollback window). Bicep declaration + operator-triggered migration tooling at `POST /api/v1/admin/claims/cosmos-migration/run` (mirrors `NetworkTierBackfillAdminController` shape: 503-when-disabled, idempotent reruns).
- Updates all 11 `PartitionKey` call sites in `ClaimRepository` from `claim.Id`/`id`/`rowId`/`claimId` → `tenantId`, and tightens 9 query iterators to single-partition `QueryRequestOptions`. Versioning surface (`GetLatestVersionAsync`, `GetVersionAsync`, `ListVersionsAsync`, `UpdateAdjudicationProjectionAsync`, `Mark*ProjectionAsync`) becomes efficient single-partition operations.
- Hydrate-on-write so legacy rows (`ClaimVersionId == ""`, `VersionNumber == 0`, `VersionState == Unknown`) land in `ClaimsV2` fully canonicalized via `ClaimRepository.Hydrate`. Batched idempotency check (per-tenant `ARRAY_CONTAINS` query) rather than per-doc point reads on rerun.

## Architecture decisions ratified at plan-phase

| Decision | Choice | Why |
|---|---|---|
| Container name | `ClaimsV2` | Cosmos cannot rename containers; (c) `Claims_Legacy` rename was infeasible. Caught at plan-phase. |
| Cutover ordering | Single `CosmosDb:ContainerName` config + redeploy-cutover | No codebase precedent for runtime read/write split; saves ~25 LoC repository plumbing. |
| Validation write-path | Write to NEW only | Aligns with simpler config; rollback = redeploy + re-migrate (acceptable). |
| Tests | Contract-level (mocked Container) + manual real-Cosmos in runbook | No Cosmos Emulator in test infra; adding it = ~250 LoC + CI flake risk = disproportionate. |
| Status observability | GET status endpoint IN; chunked-streaming OUT | YAGNI on streaming; structured logs + Prometheus counters are sufficient progress signal. |
| `GetByIdAsync` tenant guard | Keep in-memory `TenantId` equality check | Defense in depth at the read point; documented as intentionally NOT dead code. |
| Hydration | Call `Hydrate(claim)` before each write to `ClaimsV2` | Legacy rows canonicalized at migration time. |
| Payments container | Note as future follow-up | Same `/memberId` divergence; out of scope for 5.1b. |
| Admin shape | Mirror `NetworkTierBackfillAdminController` | Existing pattern parity in the codebase. |

## Diff

| Bucket | Files |
|---|---|
| Bicep | `infrastructure/azure/modules/cosmos-db.bicep` (+46 LoC) — adds `claimsV2Container` |
| Service code | `ClaimRepository.cs` (~25 modified), `Program.cs` (+12), `appsettings.json` (+6), `ChoMetrics.cs` (+35) |
| New service | `Services/Migrations/{IClaimMigrationService,ClaimMigrationService,ClaimMigrationOptions}.cs`, `Models/Migrations/{ClaimMigrationRequest,ClaimMigrationResult}.cs`, `Controllers/AdminMigrationController.cs` |
| Tests | `Services/Migrations/ClaimMigrationServiceTests.cs` (12 tests), `Repositories/ClaimRepositoryPartitionKeyTests.cs` (8), `Controllers/AdminMigrationControllerTests.cs` (11), `Integration/PartitionMigrationContractTests.cs` (2) |
| Docs | `claim-versioning.md` updated, NEW `docs/migrations/claims-cosmos-partition-migration.md` operator runbook |

464/464 claims-service tests passing (33 new, 0 regressions). Solution-wide `dotnet build` 0 errors.

## Test plan

- [ ] Reviewer confirms all 11 PartitionKey sites in `ClaimRepository.cs` use `tenantId` (captured-call assertion test surface in `ClaimRepositoryPartitionKeyTests`).
- [ ] Reviewer confirms `GetByIdAsync` / `MarkSupersededProjectionAsync` / `MarkVoidedProjectionAsync` retain the in-memory tenant guard with the explicit "NOT dead code" comment.
- [ ] Reviewer confirms migration service is `Singleton` (state-bearing running flag + last-run snapshot) and `IClaimMigrationContainerResolver` is the only place where source + target are co-resolved.
- [ ] Reviewer confirms admin endpoint mirrors `NetworkTierBackfillAdminController` shape: 503-when-disabled, `IOptionsMonitor<TOptions>`, idempotent reruns.
- [ ] Operator dry-runs against a dev-environment Cosmos instance per `docs/migrations/claims-cosmos-partition-migration.md` step 4 before any production cutover.
- [ ] Operator confirms metrics surface (`cho.claims.cosmos_migration.runs.total`, `.documents.total`, `.duration`) reaches the dashboard before scheduling cutover.
- [ ] After cutover, operator runs the smoke test (submit one claim, fetch via `GET /api/v1/claims/{id}`, query versioning chain) before stopping the validation watch.

## After this PR

- Claims Phase 1 close distance: **5.13 only** (Adjudication API Stabilization closer).
- Cross-partition queries on Claims container eliminated for the versioning surface — meaningful Cosmos RU savings.
- Tenant isolation enforced at the storage layer.
- Pattern parity with Provider, BP, AiExaminationAudit fully achieved across the claims-service repository surface.
- Follow-up (separate PR, ~30 days post-cutover): remove the legacy `Claims` container declaration from Bicep.
- Follow-up (when justified): parallel migration for the Payments container's same `/memberId` divergence at `cosmos-db.bicep:233`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)