### PR TITLE
Migrate marketing site (src/site) from Azure SWA to Cloudflare Pages

### DIFF
--- a/CLOUDFLARE_MIGRATION.md
+++ b/CLOUDFLARE_MIGRATION.md
@@ -1,0 +1,155 @@
+# Cloudflare Pages Migration — Cloud Health Office marketing site
+
+This document covers migrating the marketing website (`src/site/`) from
+**Azure Static Web Apps (SWA)** to **Cloudflare Pages**, and the steps you must
+perform **manually in the Cloudflare dashboard** (they can't be done from the
+repo).
+
+> **Site location:** the site lives at **`src/site/`** (there is no top-level
+> `site/` folder). Use `src/site` wherever an output/root directory is requested.
+
+---
+
+## What's already in the repo (done for you)
+
+These file-based config files were translated from `staticwebapp.config.json`
+and live next to the site so Cloudflare Pages picks them up automatically:
+
+| File | Purpose |
+|---|---|
+| `src/site/_redirects` | `*.html` → clean-URL 301 redirects + clean-URL → `.html` 200 rewrites |
+| `src/site/_headers` | Global security headers + per-path `Cache-Control` |
+| `src/site/404.html` | Custom 404 page (Cloudflare serves it automatically) |
+
+What was **dropped** in translation and why:
+
+- **`mimeTypes`** — unnecessary on Cloudflare; Content-Type is inferred from the
+  file extension.
+- **`navigationFallback` / `404` rewrite to `/index.html`** — this is a
+  multi-page static site, so a SPA catch-all (`/* /index.html 200`) was
+  deliberately **not** added (it would swallow real pages). A `404.html` is the
+  correct equivalent.
+- **Azure AD auth** (`auth` block, `allowedRoles: authenticated` on `/portal/*`
+  and `/api/*`, `401 → /.auth/login/aad`) — **cannot** be expressed in
+  file-based config. See **"Protect the portal"** below.
+
+---
+
+## Deploy method — recommendation: Cloudflare Git integration
+
+**Recommended: Git integration (no workflow file).**
+
+The site ships as **pre-built static HTML** (the Markdown→HTML output is already
+committed, and the old Azure deploy used `skip_app_build: true`). So there is no
+build to run, which makes Git integration the simplest, lowest-maintenance
+option.
+
+| | Git integration (recommended) | `wrangler pages deploy` GitHub Action |
+|---|---|---|
+| Setup | Connect repo once in dashboard; no YAML | Add workflow + `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` secrets |
+| Maintenance | None in-repo | Maintain a workflow file |
+| Preview deploys | Automatic per PR | Manual to wire up |
+| Control over build | Limited (dashboard settings) | Full (can run `npm run build:site`, metrics injection) |
+| Secrets in GitHub | None needed | API token stored in repo secrets |
+
+Because the deploy is "upload static files," the extra control of a wrangler
+Action buys little here. **No GitHub workflow was added** — that's intentional.
+If you later need the optional `npm run build:site` (regenerates
+`assessment.html`) or `scripts/inject-test-metrics.js` to run on every deploy,
+switch to a wrangler Action or set a Cloudflare build command (see note below).
+
+### Build settings to enter in the dashboard
+
+| Setting | Value |
+|---|---|
+| **Framework preset** | None |
+| **Build command** | *(leave empty)* |
+| **Build output directory** | `src/site` |
+| **Root directory** | `/` (repo root) |
+
+> Optional: if you want the Markdown build to run on Cloudflare, set the build
+> command to `npm install && npm run build:site` — but note the `build:site`
+> script currently points at `site/js/...` and must be fixed to
+> `src/site/js/markdown-converter.js` first. Not required, since the HTML is
+> already committed.
+
+---
+
+## Manual steps in the Cloudflare dashboard
+
+### 1. Create the Pages project
+1. Cloudflare Dashboard → **Workers & Pages** → **Create** → **Pages** →
+   **Connect to Git**.
+2. Authorize and select the `aurelianware/cloudhealthoffice` repository.
+3. Set the **production branch** to `main`.
+4. Enter the build settings from the table above (build command empty, output
+   directory `src/site`).
+5. **Save and Deploy.**
+
+### 2. Set build environment variables
+Project → **Settings** → **Environment variables / Build** (only needed if you
+enable a build command):
+- `NODE_VERSION = 20`
+
+### 3. Add the custom domain (`cloudhealthoffice.com`)
+DNS is already on Cloudflare, so this is a few clicks:
+1. Project → **Custom domains** → **Set up a custom domain**.
+2. Add `cloudhealthoffice.com` (and `www.cloudhealthoffice.com` if you want the
+   `www` host too).
+3. Cloudflare auto-creates the CNAME and provisions the TLS certificate. No
+   ALIAS/ANAME juggling (that was an Azure constraint) — Cloudflare flattens the
+   apex CNAME automatically.
+4. If you add `www`, optionally add a redirect rule (`www` → apex, or vice
+   versa) under **Rules → Redirect Rules**.
+
+### 4. Protect the portal (replaces Azure AD auth) — **important**
+The old config gated `/portal/*` (and `/api/*`) behind Azure AD login. Pages
+file config can't do this. Use **Cloudflare Access (Zero Trust)**:
+1. Zero Trust dashboard → **Access** → **Applications** → **Add an application**
+   → **Self-hosted**.
+2. Application domain: `cloudhealthoffice.com`, path `/portal` (add another for
+   `/portal/*`).
+3. Add an **identity provider** (Azure AD / Entra ID is supported, so you can
+   reuse the existing app registration) under **Settings → Authentication**.
+4. Create an **Access policy** (e.g. allow your org's email domain, or specific
+   users/groups).
+5. Repeat for any `/api/*` paths that must stay authenticated.
+
+> If the portal isn't launched yet / doesn't need gating at go-live, you can
+> skip this and add it later — but the pages will be **publicly reachable** in
+> the meantime.
+
+### 5. Verify, then clean up
+1. Confirm the `*.pages.dev` preview and the custom domain serve the site and
+   that clean URLs, redirects, headers, and the 404 page behave as expected.
+2. Disable/disconnect the Azure Static Web App so it no longer serves or holds
+   the custom domain (do this in the Azure portal).
+3. In the repo, remove the Azure artifacts (handled as **Phase 4** — see below)
+   once you've confirmed Cloudflare is correct.
+
+---
+
+## Phase 4 — repo cleanup (pending your confirmation)
+
+After you confirm the Cloudflare setup works, these will be removed/updated:
+- **Delete** `.github/workflows/deploy-static-site.yml`
+- **Delete** `src/site/staticwebapp.config.json`
+- **Update** docs that reference Azure SWA: `src/site/README.md`,
+  `src/site/DEPLOYMENT.md`, `src/site/IMPLEMENTATION-SUMMARY.md` (and relevant
+  `docs/**` files).
+
+`Dockerfile` / `nginx.conf` in `src/site/` are unrelated to SWA (they're for the
+container/AKS path) and will be left alone unless you say otherwise.
+
+---
+
+## Quick verification checklist
+
+- [ ] `https://<project>.pages.dev/` loads the homepage
+- [ ] `/pricing` serves `pricing.html`; `/pricing.html` 301s to `/pricing`
+- [ ] `/docs` serves the docs index
+- [ ] A bogus URL (e.g. `/nope`) shows the custom **404.html**
+- [ ] Response headers include `X-Frame-Options`, `X-Content-Type-Options`, etc.
+- [ ] `/css/*`, `/js/*`, `/graphics/*` return `Cache-Control: ...immutable`
+- [ ] `cloudhealthoffice.com` resolves to Pages with valid TLS
+- [ ] `/portal` is gated by Cloudflare Access (if required at launch)

--- a/src/site/404.html
+++ b/src/site/404.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page Not Found — Cloud Health Office</title>
+  <meta name="robots" content="noindex, follow" />
+  <link rel="icon" href="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" type="image/svg+xml" />
+  <link rel="stylesheet" href="/css/sentinel.css" />
+  <style>
+    /* Self-contained fallback so the 404 renders even if sentinel.css is missing */
+    :root {
+      --absolute-black: #000000;
+      --light-gray: #b0b0b0;
+      --neon-cyan: #00ffff;
+      --neon-green: #00ff88;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--absolute-black, #000);
+      color: var(--light-gray, #b0b0b0);
+      font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+      text-align: center;
+      padding: 24px;
+    }
+    .panel { max-width: 640px; }
+    .code {
+      font-size: clamp(72px, 18vw, 160px);
+      font-weight: 700;
+      line-height: 1;
+      margin: 0;
+      color: var(--neon-cyan, #00ffff);
+      text-shadow: 0 0 24px rgba(0, 255, 255, 0.5);
+    }
+    h1 { font-size: 1.6rem; margin: 16px 0 8px; color: #fff; }
+    p { font-size: 1.05rem; line-height: 1.6; margin: 0 0 32px; }
+    .actions { display: flex; flex-wrap: wrap; gap: 16px; justify-content: center; }
+    .btn {
+      display: inline-block;
+      padding: 12px 24px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-weight: 700;
+      border: 1px solid var(--neon-cyan, #00ffff);
+    }
+    .btn-primary { background: var(--neon-cyan, #00ffff); color: var(--absolute-black, #000); }
+    .btn-secondary { background: transparent; color: var(--neon-cyan, #00ffff); }
+    .links { margin-top: 32px; font-size: 0.95rem; }
+    .links a { color: var(--neon-green, #00ff88); margin: 0 10px; text-decoration: none; }
+    .links a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="panel">
+    <p class="code">404</p>
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist or may have moved.<br />Let's get you back on track.</p>
+    <div class="actions">
+      <a class="btn btn-primary" href="/">Go to homepage</a>
+      <a class="btn btn-secondary" href="/platform">Explore the platform</a>
+    </div>
+    <nav class="links" aria-label="Helpful links">
+      <a href="/pricing">Pricing</a>
+      <a href="/docs">Documentation</a>
+      <a href="/solutions-payers">For payers</a>
+      <a href="/solutions-providers">For providers</a>
+      <a href="/insights">Insights</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/src/site/_headers
+++ b/src/site/_headers
@@ -1,0 +1,36 @@
+# Cloudflare Pages headers
+# Migrated from staticwebapp.config.json "globalHeaders" + per-route headers.
+# Syntax: a path pattern on its own line, followed by indented "Header: value".
+#
+# mimeTypes from the SWA config were intentionally dropped — Cloudflare Pages
+# sets Content-Type automatically from the file extension (.svg -> image/svg+xml,
+# .css -> text/css, .js -> text/javascript, .json -> application/json,
+# .xml -> application/xml, .txt -> text/plain, .html -> text/html).
+
+# Global security headers (from globalHeaders)
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+
+# HTML pages: short cache
+/*.html
+  Cache-Control: public, max-age=3600
+
+# Fingerprint-free static assets: long, immutable cache
+/css/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/js/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/graphics/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Crawl files: short cache (Content-Type is set automatically by extension)
+/sitemap.xml
+  Cache-Control: public, max-age=3600
+
+/robots.txt
+  Cache-Control: public, max-age=3600

--- a/src/site/_headers
+++ b/src/site/_headers
@@ -6,19 +6,26 @@
 # sets Content-Type automatically from the file extension (.svg -> image/svg+xml,
 # .css -> text/css, .js -> text/javascript, .json -> application/json,
 # .xml -> application/xml, .txt -> text/plain, .html -> text/html).
+#
+# IMPORTANT — path matching: Cloudflare Pages matches _headers patterns against
+# the REQUEST path, not the file that is ultimately served. Because pages are
+# served at clean URLs (e.g. /pricing, rewritten to /pricing.html via
+# _redirects), a "/*.html" rule would never match those requests. So the HTML
+# cache policy is set as the default on "/*" instead, and the long-lived asset
+# caches override it on their more specific paths. (When multiple rules match,
+# the more specific path wins for a conflicting header; "/*" is listed first so
+# the behavior is unambiguous under either precedence interpretation.)
 
-# Global security headers (from globalHeaders)
+# Global: security headers + default short cache (covers HTML at clean URLs,
+# /sitemap.xml, /robots.txt, and anything else not overridden below)
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-
-# HTML pages: short cache
-/*.html
   Cache-Control: public, max-age=3600
 
-# Fingerprint-free static assets: long, immutable cache
+# Fingerprint-free static assets: long, immutable cache (overrides the default)
 /css/*
   Cache-Control: public, max-age=31536000, immutable
 
@@ -27,10 +34,3 @@
 
 /graphics/*
   Cache-Control: public, max-age=31536000, immutable
-
-# Crawl files: short cache (Content-Type is set automatically by extension)
-/sitemap.xml
-  Cache-Control: public, max-age=3600
-
-/robots.txt
-  Cache-Control: public, max-age=3600

--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -1,0 +1,65 @@
+# Cloudflare Pages redirects & rewrites
+# Migrated from staticwebapp.config.json "routes".
+# Syntax: <from>  <to>  <status>   (first match wins, top to bottom)
+#   301 = permanent redirect, 302 = temporary, 200 = rewrite/proxy (URL unchanged)
+#
+# NOTE: Cloudflare Pages already serves clean URLs natively (a request for
+# /pricing serves pricing.html, and /pricing.html 308-redirects to /pricing).
+# These explicit rules are kept to preserve the exact 301 canonicalization and
+# rewrite mapping from the original Azure SWA config.
+
+# ---------------------------------------------------------------------------
+# Canonical redirects: *.html  ->  clean URL (301 permanent)
+# ---------------------------------------------------------------------------
+/index.html                                /                                  301
+/solutions-payers.html                     /solutions-payers                  301
+/solutions-providers.html                  /solutions-providers               301
+/pricing.html                              /pricing                           301
+/platform.html                             /platform                          301
+/assessment.html                           /assessment                        301
+/insights.html                             /insights                          301
+/release-notes.html                        /release-notes                     301
+/legal/privacy-policy.html                 /legal/privacy-policy              301
+/login.html                                /login                             301
+/docs/quickstart.html                      /docs/quickstart                   301
+/docs/compliance.html                      /docs/compliance                   301
+/docs/architecture.html                    /docs/architecture                 301
+/docs/api.html                             /docs/api                          301
+/docs/deployment.html                      /docs/deployment                   301
+/docs/finance-guide.html                   /docs/finance-guide                301
+/docs/terminology-guide.html               /docs/terminology-guide            301
+/docs/provider-verification-guide.html     /docs/provider-verification-guide  301
+/docs/commercial-licensing.html            /docs/commercial-licensing         301
+
+# ---------------------------------------------------------------------------
+# Rewrites: clean URL  ->  *.html (200, URL stays clean)
+# ---------------------------------------------------------------------------
+/solutions-payers                          /solutions-payers.html             200
+/solutions-providers                       /solutions-providers.html          200
+/pricing                                   /pricing.html                      200
+/platform                                  /platform.html                     200
+/assessment                                /assessment.html                   200
+/insights                                  /insights.html                     200
+/release-notes                             /release-notes.html                200
+/legal/privacy-policy                      /legal/privacy-policy.html         200
+/login                                     /login.html                        200
+/docs                                      /docs/index.html                   200
+/docs/quickstart                           /docs/quickstart.html              200
+/docs/compliance                           /docs/compliance.html              200
+/docs/architecture                         /docs/architecture.html            200
+/docs/api                                  /docs/api.html                     200
+/docs/deployment                           /docs/deployment.html              200
+/docs/finance-guide                        /docs/finance-guide.html           200
+/docs/terminology-guide                    /docs/terminology-guide.html       200
+/docs/provider-verification-guide          /docs/provider-verification-guide.html  200
+/docs/commercial-licensing                 /docs/commercial-licensing.html    200
+
+# ---------------------------------------------------------------------------
+# NOT migrated here (cannot be done with file-based config):
+#   - /portal/*  and  /api/*  were gated by Azure AD (allowedRoles:
+#     authenticated). Protect these with Cloudflare Access (Zero Trust)
+#     instead. See CLOUDFLARE_MIGRATION.md.
+#   - The 401 -> /.auth/login/aad override is Azure-specific and is dropped.
+#   - navigationFallback / 404 rewrite -> handled by 404.html (multi-page
+#     site: a SPA catch-all is intentionally NOT added).
+# ---------------------------------------------------------------------------

--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -3,10 +3,11 @@
 # Syntax: <from>  <to>  <status>   (first match wins, top to bottom)
 #   301 = permanent redirect, 302 = temporary, 200 = rewrite/proxy (URL unchanged)
 #
-# NOTE: Cloudflare Pages already serves clean URLs natively (a request for
-# /pricing serves pricing.html, and /pricing.html 308-redirects to /pricing).
-# These explicit rules are kept to preserve the exact 301 canonicalization and
-# rewrite mapping from the original Azure SWA config.
+# NOTE: These explicit rules define clean-URL behavior independently of any
+# Cloudflare Pages "Clean URLs" project setting. The 301 rules pin each
+# .html -> clean-URL canonicalization to a 301, and the 200 rules map each
+# clean URL back to its .html file. This mirrors the original Azure SWA route
+# config exactly and does not rely on Pages' default redirect behavior.
 
 # ---------------------------------------------------------------------------
 # Canonical redirects: *.html  ->  clean URL (301 permanent)


### PR DESCRIPTION
## Summary

Migrates the marketing website at **`src/site/`** from **Azure Static Web Apps** to **Cloudflare Pages**. This PR contains the **additive** changes only — the Azure config is intentionally left in place until the Cloudflare setup is verified.

> Note: the site is at `src/site/`, not a top-level `site/` folder. It's a **multi-page static HTML** site (no SPA, no required build — the HTML is pre-committed and Azure deployed with `skip_app_build: true`).

## What's included (Phases 2, 3, 5)

- **`src/site/_redirects`** — translated from `staticwebapp.config.json` routes: `*.html` → clean-URL **301** redirects and clean-URL → `.html` **200** rewrites. No SPA catch-all (would wrongly swallow real pages).
- **`src/site/_headers`** — global security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`) + per-path `Cache-Control`. `mimeTypes` dropped (Cloudflare infers Content-Type by extension).
- **`src/site/404.html`** — branded custom 404, served automatically by Cloudflare.
- **`CLOUDFLARE_MIGRATION.md`** — deploy recommendation + manual dashboard steps.

## Deploy recommendation

**Cloudflare Git integration** (no workflow file) — build command empty, output dir `src/site`. The site is pre-built static HTML, so a `wrangler` Action's extra control isn't worth the maintenance/secret overhead. Rationale and tradeoff table are in the migration doc.

## ⚠️ Not reproducible in file-based config

The Azure config gated `/portal/*` and `/api/*` behind **Azure AD**. That needs **Cloudflare Access (Zero Trust)** — documented in `CLOUDFLARE_MIGRATION.md`. The root `api/` folder is OpenAPI specs, **not** Azure Functions, so there's nothing to port to Pages Functions.

## Deferred — Phase 4 (cleanup), pending confirmation

Once Cloudflare is verified, a follow-up will:
- Delete `.github/workflows/deploy-static-site.yml`
- Delete `src/site/staticwebapp.config.json`
- Update Azure-SWA references in `src/site/{README,DEPLOYMENT,IMPLEMENTATION-SUMMARY}.md` and relevant `docs/**`

https://claude.ai/code/session_01RvRq1H5tB9r3qMFkG4hZGb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvRq1H5tB9r3qMFkG4hZGb)_