### PR TITLE
Add CMS-0057-F pilot diligence package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,10 @@ CloudHealthOffice v3.0.0 — The Open Frontier Release delivers multi-cloud inde
 |----------|-------------|
 | [WHITEPAPER-CMS-0057-F-COMPLIANCE.md](security/WHITEPAPER-CMS-0057-F-COMPLIANCE.md) | Executive whitepaper for CMS-0057-F compliance strategy |
 | [CMS-0057-F-COMPLIANCE.md](features/CMS-0057-F-COMPLIANCE.md) | Technical compliance guide with API specifications |
+| [Compliance README](compliance/README.md) | Compliance document index and CMS-0057-F pilot package workflow |
 | [CMS-0057-F-READINESS-MATRIX.md](compliance/CMS-0057-F-READINESS-MATRIX.md) | Canonical cross-service CMS-0057-F readiness matrix and gap record |
+| [CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md](compliance/CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md) | Buyer-facing CMS-0057-F accelerator brief |
+| [CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md](compliance/CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md) | Pilot diligence checklist for CMS-0057-F implementation planning |
 | [HIPAA-COMPLIANCE-MATRIX.md](features/HIPAA-COMPLIANCE-MATRIX.md) | HIPAA security control mapping |
 | [HIPAA-AUDIT-REPORT.md](features/HIPAA-AUDIT-REPORT.md) | Audit report template |
 | [FL-AHCA-COMPLIANCE.md](compliance/FL-AHCA-COMPLIANCE.md) | Florida AHCA / SMMC 3.0 compliance guide — FMMIS, MPIP, encounter submission |

--- a/docs/compliance/CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md
+++ b/docs/compliance/CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md
@@ -1,0 +1,85 @@
+# CMS-0057-F Compliance Accelerator Brief
+
+**Status as of:** July 2026
+**Audience:** health plan executives, interoperability leaders, compliance
+leaders, implementation partners
+**Canonical readiness source:** [CMS-0057-F-READINESS-MATRIX.md](CMS-0057-F-READINESS-MATRIX.md)
+
+Cloud Health Office provides a CMS-0057-F implementation accelerator for payers
+that need an interoperability layer beside an existing core administration
+platform. The offer packages FHIR R4 APIs, SMART-on-FHIR enforcement,
+Da Vinci prior-authorization workflow support, Bulk FHIR and consent building
+blocks, tenant isolation, audit logging, and pilot evidence into a fixed-scope
+implementation workstream.
+
+This brief describes technical readiness and pilot scope. It is not legal
+advice, regulatory certification, or a payer compliance attestation.
+
+## Buyer Problem
+
+CMS-0057-F creates overlapping technical, operational, and evidence obligations
+for impacted payers. CMS describes impacted payers as Medicare Advantage
+organizations, state Medicaid and CHIP FFS programs, Medicaid managed care
+plans, CHIP managed care entities, and QHP issuers on the FFEs. CMS states that
+some operational provisions generally begin in 2026, while API development and
+enhancement requirements generally begin in 2027, with exact timing varying by
+payer type.
+
+For a payer, the hard part is not only publishing FHIR endpoints. The production
+program also needs source-system data quality, identity and consent workflows,
+provider attribution, utilization-management policy governance, denial reason
+taxonomy, public metrics reporting, security evidence, and operational support.
+
+## Cloud Health Office Offer
+
+The Compliance Accelerator turns Cloud Health Office into the FHIR, SMART/OAuth,
+prior-authorization, audit, and evidence layer for a payer pilot.
+
+| Capability | Pilot position | Production dependency |
+| --- | --- | --- |
+| Patient Access API expansion | FHIR R4 resource surfaces, SMART enforcement, Patient/Coverage/EOB mapping evidence. | Member identity, consent, source-system data breadth, `_history`, search completeness, and payer data-quality validation. |
+| Provider Access API | Provider directory projections/proxies, SMART scope model, consent-service foundation. | Attributed-provider model, patient opt-out process, source-system freshness, and data-minimization policy. |
+| Payer-to-Payer API | Bulk FHIR and consent building blocks. | End-to-end opt-in, historical data scoping, exchange workflow, storage security, and receiving-payer audit. |
+| Prior Authorization API | PAS `$submit`, CRD, DTR, SLA tracking, denial/status response support. | Payer rule configuration, UM policy approval, attachment workflow, manual review operations, and source-system reconciliation. |
+| Public prior-authorization metrics | Metrics template and data collection plan. | Production reporting store, data reconciliation, publication workflow, and payer compliance sign-off. |
+| Security and audit | Tenant isolation patterns, logging, encryption options, HIPAA-oriented controls. | Deployment-specific BAA, retention policy, incident response, backup/DR, pen test, and security review. |
+
+## Six-to-Eight Week Pilot Shape
+
+| Week | Focus | Output |
+| --- | --- | --- |
+| 1 | Intake and scope | Completed diligence checklist, lines of business, covered APIs, data sources, success criteria. |
+| 2 | Environment and security | Tenant environment plan, identity model, logging/audit plan, BAA/security review inputs. |
+| 3 | Source-system mapping | Patient, coverage, claim/EOB, provider, prior-auth, consent, and UM-policy data map. |
+| 4 | FHIR and prior-auth demo | Labeled demo evidence for Patient Access, Provider Directory, PAS `$submit`, CRD/DTR, and Bulk Export. |
+| 5 | Live-adapter pilot path | Integration plan for selected live resources and adapter-mode evidence. |
+| 6 | Metrics and operations | Prior-auth metrics report draft, SLA queue plan, operational runbook outline. |
+| 7-8 | Validation and go/no-go | Evidence packet, open gaps, production backlog, commercial scope, and attestation dependencies. |
+
+## Pilot Success Criteria
+
+- Buyer can see which CMS-0057-F areas are implemented, integration-dependent,
+  Phase 2, or outside platform scope.
+- Demo evidence is explicitly labeled as synthetic/demo or live payer-backed.
+- The payer has an owner and data source for each public prior-authorization
+  metric.
+- The implementation team has a concrete integration plan for identity,
+  source systems, provider attribution, consent, prior-auth rules, denial
+  reasons, and audit evidence.
+- Legal/compliance leaders understand that production attestation remains
+  payer-specific.
+
+## What This Is Not
+
+- Not a CMS certification.
+- Not a legal opinion.
+- Not an out-of-the-box payer attestation.
+- Not a replacement for payer UM policy, coverage criteria, security review,
+  BAA, source-system integration, or operational governance.
+
+## References
+
+- CMS fact sheet:
+  <https://www.cms.gov/newsroom/fact-sheets/cms-interoperability-prior-authorization-final-rule-cms-0057-f>
+- Federal Register final rule:
+  <https://www.federalregister.gov/documents/2024/02/08/2024-00895/medicare-and-medicaid-programs-patient-protection-and-affordable-care-act-advancing-interoperability>

--- a/docs/compliance/CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md
+++ b/docs/compliance/CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md
@@ -1,0 +1,85 @@
+# CMS-0057-F Demo Mode vs Live Adapters
+
+**Status as of:** July 2026
+**Purpose:** keep CMS-0057-F buyer demos and pilot evidence honest by labeling
+which flows use synthetic/demo data and which flows are backed by live payer
+systems.
+
+This document is an evidence-labeling guide. It does not certify production
+readiness.
+
+## Labeling Rules
+
+Every demo artifact, screenshot, request/response sample, and buyer-facing
+claim should carry one of these labels:
+
+| Label | Meaning | Buyer-safe wording |
+| --- | --- | --- |
+| Demo data | Uses seeded or synthetic data in Cloud Health Office. | "Demonstrates technical behavior with synthetic data." |
+| Hybrid | Uses live configuration with one or more mocked or seeded services. | "Pilot wiring in progress; source labels shown per resource." |
+| Live payer-backed | Uses payer-approved source systems and tenant configuration. | "Backed by payer source-system integration for this pilot scope." |
+| Out of scope | Not demonstrated in the pilot. | "Not in current pilot scope." |
+
+## Current Adapter Evidence
+
+| Capability | Current repo evidence | Demo-mode risk | Live-adapter requirement |
+| --- | --- | --- | --- |
+| Patient, Claim, core FHIR reads | `fhir-service` registers `MockFhirDataAdapter` and `MockPatientAccessDataProvider` for generic FHIR data surfaces. | A demo can look broader than the live integration actually is. | Replace or wrap with payer-backed adapters for pilot resources before calling the flow live. |
+| Appeals FHIR resources | `Appeals:UseMockAdapter` selects mock appeal data by config, defaulting to development mode when no appeals service is present. | Appeal demos can be seeded unless explicitly configured for HTTP adapter. | Set `Appeals:UseMockAdapter=false`, configure `Services:AppealsServiceUrl`, and capture request evidence. |
+| ExplanationOfBenefit | `ExplanationOfBenefitController` proxies to claims-service `/fhir/ExplanationOfBenefit`; claims-service owns the canonical EOB projection. | EOB evidence depends on whether claims-service is seeded, synthetic, or live. | Label claims-service data source and show tenant/header propagation evidence. |
+| Provider Directory | FHIR service exposes provider-directory proxies and provider-service projections. | NPPES or test roster data may be mistaken for payer network data. | Identify source roster, update cadence, network affiliation, and endpoint publication process. |
+| PAS `$submit` | PAS controller validates FHIR, performs provider verification checks, calls auto-adjudication, persists decisions, and records metrics. | Auto-decisions can rely on no-op or demo rule behavior if payer rules are not loaded. | Load payer-approved UM rules, denial taxonomy, attachment workflow, and manual review queue. |
+| CRD/DTR | CRD and DTR services/controllers are registered in `fhir-service`. | Cards/questionnaires can represent generic scenarios rather than payer policy. | Load payer-specific rules, questionnaires, prepopulation sources, and provider/EHR launch context. |
+| Bulk FHIR export | Bulk Export controller/service exists and has test coverage. | A completed job can be a technical scaffold rather than a production export. | Define storage, encryption, manifest retention, recipient access, and audit controls. |
+| Consent service | Consent lifecycle and repository patterns exist. | Demo consent may not match payer opt-in/opt-out policy. | Configure payer-approved consent text, revocation workflow, audit retention, and line-of-business rules. |
+| `/fhir/r4/compliance-status` | Compliance controller returns tenant-level CMS-0057-F posture based on configuration checks. | A positive config report can overstate production attestation if source-system integration is incomplete. | Pair endpoint output with this adapter table and the readiness matrix. |
+
+## Demo Script Requirements
+
+Before any buyer or pilot demo:
+
+1. Name the tenant and data class: synthetic, de-identified, limited PHI, or
+   production PHI.
+2. State whether each shown resource is demo, hybrid, live payer-backed, or out
+   of scope.
+3. Keep screenshots and exported samples in a folder named with the adapter
+   mode and date.
+4. For live payer-backed flows, capture the source system, request id,
+   correlation id, tenant id, timestamp, and reviewer.
+5. For demo/hybrid flows, state the production dependency before discussing
+   compliance impact.
+
+## Evidence Folder Convention
+
+Use this naming pattern for pilot evidence:
+
+```text
+cms-0057-pilot-evidence/
+  YYYY-MM-DD-demo-mode/
+  YYYY-MM-DD-hybrid/
+  YYYY-MM-DD-live-payer-backed/
+```
+
+Each folder should include:
+
+- `README.md` describing scope, tenant, data classification, and source labels.
+- Request/response samples with PHI removed unless the customer-approved
+  secure evidence process permits PHI.
+- Screenshots or logs showing correlation id and tenant id where available.
+- A short list of production dependencies not demonstrated by that evidence.
+
+## Buyer-Safe Phrases
+
+- "This flow demonstrates technical capability with synthetic data."
+- "This flow is live for the selected pilot resource but not yet generalized to
+  all payer source systems."
+- "This endpoint is implementation evidence, not legal attestation."
+- "Production readiness depends on payer source-system integration, operating
+  procedures, and compliance review."
+
+## Phrases to Avoid
+
+- "Certified compliant."
+- "100% compliant out of the box."
+- "Production-ready compliance."
+- "Live" when the data source is seeded, synthetic, or mock-backed.

--- a/docs/compliance/CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md
+++ b/docs/compliance/CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md
@@ -1,0 +1,101 @@
+# CMS-0057-F Pilot Diligence Checklist
+
+**Status as of:** July 2026
+**Purpose:** define the intake, evidence, integration, security, and go/no-go
+checks for a CMS-0057-F Compliance Accelerator pilot.
+
+This checklist supports pilot planning. It does not replace payer legal,
+compliance, security, or procurement review.
+
+## Intake Summary
+
+| Field | Value |
+| --- | --- |
+| Payer / organization | |
+| Lines of business in scope | |
+| Pilot population | |
+| Target go-live / demo date | |
+| Payer executive sponsor | |
+| Payer compliance owner | |
+| Payer security owner | |
+| Cloud Health Office delivery owner | |
+| Data classification | Synthetic / de-identified / limited PHI / production PHI |
+| Adapter mode | Demo / hybrid / live |
+
+## Regulatory Scope
+
+| Check | Owner | Evidence | Status |
+| --- | --- | --- | --- |
+| Confirm whether payer is an impacted payer for selected LOBs. | Payer compliance | LOB inventory and counsel review. | Not started |
+| Identify exact compliance dates by payer type and contract/rating/plan year. | Payer compliance | CMS/Federal Register mapping. | Not started |
+| Confirm whether pilot includes drugs or excludes drugs from CMS-0057-F prior-auth scope. | Payer compliance | Benefit and UM policy note. | Not started |
+| Confirm state law or contract requirements that are shorter than federal timeframes. | Payer compliance | State/contract matrix. | Not started |
+| Define attestation owner and final approval process. | Payer compliance | Governance RACI. | Not started |
+
+## Source-System and Data Readiness
+
+| Check | Owner | Evidence | Status |
+| --- | --- | --- | --- |
+| Patient/member source identified. | Payer IT | System name, API/feed, sample schema. | Not started |
+| Coverage/benefit source identified. | Payer IT | Coverage map, benefit plan versioning. | Not started |
+| Claims/EOB source identified. | Payer IT | Claims-service or CAPS integration map. | Not started |
+| Provider directory/network source identified. | Payer IT | Provider roster and freshness process. | Not started |
+| Prior authorization source identified. | Payer UM/IT | Authorization status and decision model. | Not started |
+| UM criteria and rules owner identified. | Payer UM | Rule source, approval workflow. | Not started |
+| Denial reason taxonomy approved. | Payer UM/compliance | Reason-code mapping and letter alignment. | Not started |
+| Historical data scope defined. | Payer compliance/IT | Date range and retained data classes. | Not started |
+
+## API and Workflow Readiness
+
+| Area | Pilot evidence | Production dependency | Status |
+| --- | --- | --- | --- |
+| Patient Access API | `/fhir/r4/compliance-status`, Patient/Coverage/EOB demo, SMART scopes. | Identity, consent, live source adapters, data breadth, search/history completeness. | Not started |
+| Provider Access API | Provider Directory proxy/projection demo and SMART scope evidence. | Attributed-provider logic, patient opt-out, data minimization, provider roster operations. | Not started |
+| Payer-to-Payer API | Bulk FHIR and consent lifecycle demonstration. | Opt-in workflow, historical scope, inbound/outbound exchange, export storage, audit retention. | Not started |
+| Prior Authorization API | PAS `$submit`, CRD, DTR, pended/approved/denied examples. | Payer UM rules, clinical documentation governance, manual review queues, source reconciliation. | Not started |
+| Prior-auth decision timelines | SLA calculation and watchdog evidence. | Operational queue staffing, escalation workflow, paused/resumed SLA policy. | Not started |
+| Public prior-auth metrics | Metrics template populated with sample/synthetic data. | Production metric store, reconciliation, publication workflow, payer sign-off. | Not started |
+
+## Security, Privacy, and Operations
+
+| Check | Owner | Evidence | Status |
+| --- | --- | --- | --- |
+| BAA and contract path identified. | Legal/procurement | Draft agreement or existing vehicle. | Not started |
+| Tenant isolation model reviewed. | Security | Architecture diagram and test evidence. | Not started |
+| PHI handling and de-identification approach approved. | Security/privacy | Data handling memo. | Not started |
+| Authentication and authorization model approved. | Security/IAM | SMART/OAuth issuer, scopes, client registration flow. | Not started |
+| Audit logging and retention plan approved. | Security/compliance | Log schema, retention policy, access review. | Not started |
+| Incident response and support contacts defined. | Operations | Escalation matrix. | Not started |
+| Backup, DR, and availability expectations defined. | Operations | RTO/RPO and monitoring plan. | Not started |
+| Vulnerability/pen-test expectations defined. | Security | Test plan or third-party review plan. | Not started |
+
+## Demo Evidence Checklist
+
+| Demonstration | Required label | Evidence artifact | Status |
+| --- | --- | --- | --- |
+| Patient Access flow | Synthetic/demo or live payer-backed. | Screenshot, request/response sample, source label. | Not started |
+| Provider Directory flow | Synthetic/demo or live roster-backed. | Request/response sample and data freshness note. | Not started |
+| PAS `$submit` approval | Synthetic/demo or live UM-rule-backed. | Request/response bundle and rule source label. | Not started |
+| PAS `$submit` denial | Synthetic/demo or live UM-rule-backed. | Denial reason and correspondence mapping. | Not started |
+| Pended/manual review | Synthetic/demo or live queue-backed. | Queue evidence and SLA status. | Not started |
+| Bulk Export job | Synthetic/demo or live export-backed. | Job status, manifest, storage/security note. | Not started |
+| Compliance status endpoint | Tenant config evidence. | `/fhir/r4/compliance-status` output. | Not started |
+
+## Go/No-Go Questions
+
+- Are all demo-mode resources labeled and separated from live payer-backed
+  evidence?
+- Has payer compliance reviewed the readiness matrix and accepted the wording?
+- Is there a named owner for every production dependency?
+- Are public prior-authorization metrics traceable to source records?
+- Can the payer explain how denial reasons, extensions, and appeals are counted?
+- Are security, privacy, BAA, audit logging, and retention requirements either
+  approved or explicitly listed as blockers?
+- Does the production backlog distinguish implementation gaps from legal or
+  operational attestation work?
+
+## References
+
+- Readiness matrix: [CMS-0057-F-READINESS-MATRIX.md](CMS-0057-F-READINESS-MATRIX.md)
+- Demo-mode guide: [CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md](CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md)
+- Metrics template: [CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md](CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md)

--- a/docs/compliance/CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md
+++ b/docs/compliance/CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md
@@ -1,0 +1,122 @@
+# CMS-0057-F Prior Authorization Metrics Template
+
+**Status as of:** July 2026
+**Purpose:** provide a payer-ready template for annual public
+prior-authorization metrics and the supporting pilot data collection plan.
+
+This template is not legal advice. Payers should confirm final metric
+definitions, exclusions, aggregation level, publication format, and dates with
+their compliance counsel.
+
+## Regulatory Anchor
+
+CMS states that certain operational/process prior-authorization policies begin
+in 2026. The Federal Register final rule requires impacted payers to publicly
+report prior-authorization metrics by March 31 for the previous calendar year,
+with aggregation level varying by payer type. The final rule excludes drugs from
+these prior-authorization metrics.
+
+The recurring required metrics include:
+
+- List of items and services requiring prior authorization.
+- Percentage of standard requests approved.
+- Percentage of standard requests denied.
+- Percentage of standard requests approved after appeal.
+- Percentage of requests with an extended review timeframe that were approved.
+- Percentage of expedited requests approved.
+- Percentage of expedited requests denied.
+- Average and median elapsed time from submission to determination/decision for
+  standard requests.
+- Average and median elapsed time from submission to decision for expedited
+  requests.
+
+## Publication Header Template
+
+| Field | Value |
+| --- | --- |
+| Payer legal name | |
+| Reporting entity level | MA contract / state / plan / issuer |
+| Line(s) of business | |
+| Calendar year reported | |
+| Publication date | |
+| Data extraction date | |
+| Exclusions | Drugs; other payer-approved exclusions |
+| Source systems | |
+| Compliance reviewer | |
+| Notes | |
+
+## Public Metrics Table
+
+| Metric | Numerator | Denominator | Value | Source field(s) | Reconciled? |
+| --- | --- | --- | --- | --- | --- |
+| Items and services requiring prior authorization | n/a | n/a | Link or attached list | UM policy repository | No |
+| Standard requests approved | Standard requests approved | All standard requests | | Authorization status, level of service | No |
+| Standard requests denied | Standard requests denied | All standard requests | | Authorization status, level of service | No |
+| Standard requests approved after appeal | Standard requests approved after appeal | Standard requests appealed or all standard requests, per payer-approved definition | | Appeal outcome, original auth id | No |
+| Requests with extended timeframe and approved | Requests extended and approved | All prior-auth requests or all extended requests, per payer-approved definition | | Extension flag, status | No |
+| Expedited requests approved | Expedited requests approved | All expedited requests | | Authorization status, level of service | No |
+| Expedited requests denied | Expedited requests denied | All expedited requests | | Authorization status, level of service | No |
+| Standard elapsed time average | Sum elapsed time for standard requests | Standard requests with decision | | Submitted timestamp, decision timestamp | No |
+| Standard elapsed time median | Median elapsed time for standard requests | Standard requests with decision | | Submitted timestamp, decision timestamp | No |
+| Expedited elapsed time average | Sum elapsed time for expedited requests | Expedited requests with decision | | Submitted timestamp, decision timestamp | No |
+| Expedited elapsed time median | Median elapsed time for expedited requests | Expedited requests with decision | | Submitted timestamp, decision timestamp | No |
+
+## Pilot Data Collection Plan
+
+| Data element | Required for | Candidate source | Owner | Status |
+| --- | --- | --- | --- | --- |
+| Authorization id | Traceability, dedupe | authorization-service / payer UM system | | Not started |
+| Tenant / payer id | Multi-tenant separation | tenant middleware / payer config | | Not started |
+| Line of business | Reporting scope | payer config | | Not started |
+| Level of service | Standard vs expedited | X12 278, PAS Claim, UM system | | Not started |
+| Submitted timestamp | Elapsed time | PAS submission, UM intake | | Not started |
+| Decision timestamp | Elapsed time | UM decision event | | Not started |
+| Status | Approved/denied/pended/modified | authorization-service / UM system | | Not started |
+| Denial reason | Denial transparency | denial taxonomy / ClaimResponse | | Not started |
+| Extension flag | Extended timeframe metric | UM workflow event | | Not started |
+| Appeal id / outcome | Approved-after-appeal metric | appeals service / payer appeal system | | Not started |
+| Item/service code | PA-required list and stratification | UM policy repository | | Not started |
+| Drug exclusion flag | CMS-0057-F exclusion handling | benefit/UM classification | | Not started |
+
+## Calculation Notes
+
+- Calculate percentages as numerator divided by denominator, multiplied by 100,
+  rounded according to payer-approved reporting policy.
+- Define "standard" and "expedited" from payer-approved source fields before
+  producing public values.
+- Define whether modified/partial approvals count as approved, denied, or a
+  separate internal category before publishing.
+- Define whether withdrawn, duplicate, incomplete, and no-decision requests are
+  excluded from denominators.
+- Preserve an audit snapshot for every published value: query version,
+  extraction timestamp, source-system identifiers, reviewer, and approval date.
+- Keep internal stratifications by item/service, provider group, channel, and
+  adapter mode for operations, even if public reporting is aggregated.
+
+## Evidence Queries to Build
+
+| Query | Output | Purpose |
+| --- | --- | --- |
+| Prior-auth request inventory | One row per request with status, LOB, level, timestamps, item/service, extension, appeal link. | Metric source table. |
+| PA-required item/service list | Current policy list with effective dates. | Public list and policy reconciliation. |
+| Denial reason audit | Denied requests with reason code, reason text, and correspondence mapping. | Denial transparency. |
+| SLA breach audit | Requests over 72 hours expedited or 7 calendar days standard. | Operational remediation. |
+| Appeal outcome join | Original authorization linked to appeal outcome. | Approved-after-appeal metric. |
+
+## Publication Review Checklist
+
+- [ ] Reporting entity level matches payer type and contract/plan structure.
+- [ ] Calendar year and extraction date are visible.
+- [ ] Drug exclusions and other approved exclusions are documented.
+- [ ] Numerators and denominators are approved by compliance.
+- [ ] Public values reconcile to source-system snapshot.
+- [ ] Reviewer and approval date are recorded.
+- [ ] Published file is accessible from payer website by the required date.
+- [ ] Internal audit package is retained under payer retention policy.
+
+## References
+
+- CMS fact sheet:
+  <https://www.cms.gov/newsroom/fact-sheets/cms-interoperability-prior-authorization-final-rule-cms-0057-f>
+- Federal Register final rule:
+  <https://www.federalregister.gov/documents/2024/02/08/2024-00895/medicare-and-medicaid-programs-patient-protection-and-affordable-care-act-advancing-interoperability>

--- a/docs/compliance/CMS-0057-F-READINESS-MATRIX.md
+++ b/docs/compliance/CMS-0057-F-READINESS-MATRIX.md
@@ -36,6 +36,20 @@ implementation still requires payer source-system integration and gap closure
 around patient access breadth, payer-to-payer consent/exchange workflow, public
 prior-authorization metrics, and adapter mode clarity.
 
+## Pilot Diligence Package
+
+Use these companion artifacts to turn the readiness matrix into a buyer or pilot
+workstream:
+
+- [CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md](CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md)
+  for the one-page buyer-facing offer.
+- [CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md](CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md)
+  for intake, evidence, security, integration, and go/no-go tracking.
+- [CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md](CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md)
+  for labeling demo, hybrid, and live payer-backed evidence.
+- [CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md](CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md)
+  for public prior-authorization metrics planning.
+
 ## Primary Requirement Matrix
 
 | CMS-0057-F area | Cloud Health Office status | Repo evidence | Gap / implementation note | Buyer-facing position |

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,45 @@
+# Compliance Documentation
+
+This directory contains regulatory-readiness materials for Cloud Health Office.
+These documents describe technical capability, implementation posture, and
+pilot diligence workflows. They are not legal advice, regulatory certification,
+or payer attestation artifacts.
+
+## CMS-0057-F Package
+
+| Document | Purpose |
+| --- | --- |
+| [CMS-0057-F-READINESS-MATRIX.md](CMS-0057-F-READINESS-MATRIX.md) | Canonical cross-service readiness matrix and gap record. |
+| [CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md](CMS-0057-F-COMPLIANCE-ACCELERATOR-BRIEF.md) | One-page buyer-facing brief for the Compliance Accelerator offer. |
+| [CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md](CMS-0057-F-PILOT-DILIGENCE-CHECKLIST.md) | Pilot intake, evidence, security, integration, and go/no-go checklist. |
+| [CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md](CMS-0057-F-DEMO-MODE-LIVE-ADAPTERS.md) | Demo-mode vs live-adapter labeling guide for buyer and pilot demos. |
+| [CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md](CMS-0057-F-PRIOR-AUTH-METRICS-TEMPLATE.md) | Public prior-authorization metrics template and data collection plan. |
+| [claims-cms-0057-f-readiness.md](claims-cms-0057-f-readiness.md) | Claims-domain CMS-0057-F readiness detail. |
+
+## Package Workflow
+
+1. Start with the readiness matrix to set buyer-safe posture.
+2. Use the buyer brief for executive and procurement conversations.
+3. Use the diligence checklist during discovery and implementation planning.
+4. Use the demo-mode guide before every demo or pilot evidence review.
+5. Use the metrics template to scope the public prior-authorization reporting
+   workstream and define data ownership.
+
+## Wording Guardrails
+
+- Say "technical readiness", "implementation accelerator", and
+  "payer-specific production readiness".
+- Avoid saying "certified", "100% compliant", or "production-ready
+  compliance" unless payer counsel and compliance leadership have approved that
+  exact statement for a specific deployment.
+- Keep demo data, synthetic data, mock adapters, and live payer integrations
+  clearly labeled in every artifact.
+
+## External References
+
+- CMS Interoperability and Prior Authorization Final Rule:
+  <https://www.cms.gov/initiatives/burden-reduction/overview/interoperability/policies-regulations/cms-interoperability-prior-authorization-final-rule-cms-0057-f>
+- CMS fact sheet:
+  <https://www.cms.gov/newsroom/fact-sheets/cms-interoperability-prior-authorization-final-rule-cms-0057-f>
+- Federal Register final rule:
+  <https://www.federalregister.gov/documents/2024/02/08/2024-00895/medicare-and-medicaid-programs-patient-protection-and-affordable-care-act-advancing-interoperability>


### PR DESCRIPTION
## Summary
- Add a CMS-0057-F compliance documentation index
- Add a buyer-facing Compliance Accelerator brief
- Add pilot diligence, demo-mode/live-adapter, and prior-auth metrics templates
- Link the package from the top-level docs index and readiness matrix

## Validation
- git diff --check
- Verified package link targets exist
- Confirmed working tree is clean