### PR TITLE
Fix restore package downgrade failures

### DIFF
--- a/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
+++ b/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
   </ItemGroup>
 </Project>

--- a/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
+++ b/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/services/attachment-service/attachment-service.csproj
+++ b/src/services/attachment-service/attachment-service.csproj
@@ -12,8 +12,8 @@
     <ProjectReference Include="..\..\engines\CloudHealthOffice.DocumentStore\CloudHealthOffice.DocumentStore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.50.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageReference Include="Azure.Core" Version="1.55.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/benefit-plan-service/benefit-plan-service.csproj
+++ b/src/services/benefit-plan-service/benefit-plan-service.csproj
@@ -59,9 +59,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.BenefitEngine\CloudHealthOffice.BenefitEngine.csproj" />

--- a/tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj
+++ b/tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />

--- a/tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj
+++ b/tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />


### PR DESCRIPTION
## Summary
- Align DocumentStore Microsoft.Extensions abstraction package references with Azure.Storage.Blobs transitive requirements
- Align benefit-plan-service direct package references with BenefitEngine transitive requirements
- Align attachment-service Azure package references with DocumentStore
- Align EDI test logging abstraction reference with the attachment-service/DocumentStore dependency path

## Validation
- dotnet restore src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
- dotnet restore src/services/benefit-plan-service/benefit-plan-service.csproj
- dotnet restore src/services/attachment-service/attachment-service.csproj
- dotnet restore tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj
- Simulated dependency-submission first-20 project restore loop
- Simulated security-scan service restore matrix
- dotnet build src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj --no-restore
- dotnet build src/services/attachment-service/attachment-service.csproj --no-restore --no-incremental -m:1 /nr:false -v:minimal
- dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj --no-restore --no-incremental -m:1 /nr:false -v:minimal
- dotnet build tests/CloudHealthOffice.Edi.Tests/CloudHealthOffice.Edi.Tests.csproj --no-restore --no-incremental -m:1 /nr:false -v:minimal
- git diff --check