### PR TITLE
Fix DocumentStore restore downgrade

### DIFF
--- a/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
+++ b/src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Align DocumentStore Microsoft.Extensions abstraction package references with the Azure.Storage.Blobs / Azure.Core transitive dependency chain
- Fix attachment-service restore failure caused by DocumentStore downgrade warnings-as-errors

## Validation
- Exact attachment-service restore workflow shape passes
- dotnet restore src/engines/CloudHealthOffice.DocumentStore/CloudHealthOffice.DocumentStore.csproj
- dotnet build src/services/attachment-service/attachment-service.csproj --no-restore --no-incremental -m:1 /nr:false -v:minimal
- git diff --check