### PR TITLE
Stabilize CI workflows while Azure deploys are paused

### DIFF
--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -107,6 +107,11 @@ on:
         type: boolean
         required: false
         default: true
+      require_acr_read_token:
+        description: "When push:false, require ACR_USERNAME/ACR_PASSWORD for mirrored .NET base-image pulls. Set false only for actors such as Dependabot that cannot receive repo Actions secrets; those builds fall back to public MCR base images."
+        type: boolean
+        required: false
+        default: true
     secrets:
       # All secrets are declared optional — runtime checks below enforce
       # presence when actually needed (push:true requires Azure OIDC; push:false
@@ -180,6 +185,11 @@ on:
         type: boolean
         required: false
         default: true
+      require_acr_read_token:
+        description: "When push:false, require ACR_USERNAME/ACR_PASSWORD for mirrored .NET base-image pulls. Defaults to true."
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build:
@@ -240,10 +250,12 @@ jobs:
           # hypothetical self-contained services.
           BUILD_CONTEXT="${{ inputs.build_context || format('./src/services/{0}', inputs.service) }}"
 
-          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
-          echo "registry_name=$REGISTRY_NAME" >> "$GITHUB_OUTPUT"
-          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
-          echo "build_context=$BUILD_CONTEXT" >> "$GITHUB_OUTPUT"
+          {
+            echo "registry=$REGISTRY"
+            echo "registry_name=$REGISTRY_NAME"
+            echo "image_name=$IMAGE_NAME"
+            echo "build_context=$BUILD_CONTEXT"
+          } >> "$GITHUB_OUTPUT"
 
           # Build the multi-line tag list that docker/build-push-action expects.
           # Each line becomes one tag the image is published under.
@@ -274,7 +286,9 @@ jobs:
           echo "Resolved image_name:    $IMAGE_NAME"
           echo "Resolved build_context: $BUILD_CONTEXT"
           echo "Resolved tags:"
-          echo "$TAGS" | sed 's/^/  /'
+          while IFS= read -r tag; do
+            printf '  %s\n' "$tag"
+          done <<< "$TAGS"
 
       # ───────────────────────────────────────────────────────────────────
       # PUSH MODE: authenticate to Azure via OIDC and `az acr login`. This
@@ -344,7 +358,7 @@ jobs:
         # login step was skipped, OR (b) the login step ran and failed.
         # Either way, proceeding silently would let the build pull base
         # images from MCR — exactly what 71c9d37 did, undetected for 5 days.
-        if: env.PUSH_ENABLED != 'true' && steps.acr-pr-login.outcome != 'success'
+        if: env.PUSH_ENABLED != 'true' && inputs.require_acr_read_token && steps.acr-pr-login.outcome != 'success'
         env:
           ACR_SHORT_NAME: ${{ steps.params.outputs.registry_name }}
         run: |
@@ -360,6 +374,12 @@ jobs:
           echo "::error::  5. Save password1 value as repo secret ACR_PASSWORD"
           echo "::error::See docs/security/SECRETS-INVENTORY.md for the rationale."
           exit 1
+
+      - name: Warn when using public MCR base images — non-push mode
+        if: env.PUSH_ENABLED != 'true' && !inputs.require_acr_read_token && steps.acr-pr-login.outcome != 'success'
+        run: |
+          echo "::warning::ACR read credentials are unavailable for this non-push build."
+          echo "::warning::Falling back to public mcr.microsoft.com base images. This is intended for Dependabot PRs only; normal PRs should keep require_acr_read_token=true."
 
       # ───────────────────────────────────────────────────────────────────
       # Buildx + the actual build. Both modes (push:true, push:false) share
@@ -388,7 +408,7 @@ jobs:
           # defaults). Setting it here means a future Dockerfile that forgot
           # to default ARG REGISTRY can't silently fall through to MCR.
           build-args: |
-            REGISTRY=${{ steps.params.outputs.registry }}
+            REGISTRY=${{ env.PUSH_ENABLED != 'true' && !inputs.require_acr_read_token && steps.acr-pr-login.outcome != 'success' && 'mcr.microsoft.com' || steps.params.outputs.registry }}
           # cache-from is always read-only — both push and non-push builds
           # benefit from warm cache.
           cache-from: type=gha

--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -16,6 +16,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Automatic Azure deploys are intentionally opt-in. This keeps main green
+  # while the Azure subscription is inactive, without removing the deployment
+  # workflow or the manual recovery path.
+  AZURE_DEPLOYMENTS_ENABLED: ${{ vars.AZURE_DEPLOYMENTS_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
   REGISTRY: ${{ vars.ACR_LOGIN_SERVER }}
   NAMESPACE: cloudhealthoffice
   AKS_NAME: ${{ vars.AKS_NAME || 'cho-aks' }}
@@ -29,6 +33,17 @@ env:
   # Repository secret:   AZURE_SUBSCRIPTION_ID Subscription containing the Key Vault
 
 jobs:
+  deployment-paused:
+    name: Azure deployment paused
+    if: ${{ vars.AZURE_DEPLOYMENTS_ENABLED != 'true' && github.event_name != 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped deployment
+        run: |
+          echo "::notice::Azure deployment is paused because vars.AZURE_DEPLOYMENTS_ENABLED is not 'true'."
+          echo "::notice::This is expected while the Azure subscription is inactive."
+          echo "::notice::Set repository variable AZURE_DEPLOYMENTS_ENABLED=true to restore automatic main-branch deploys."
+
   # ─────────────────────────────────────────────────────────────
   # Preflight: mirror .NET base images from MCR into ACR so the
   # Dockerfile `FROM ${REGISTRY}/dotnet/...` lines resolve. Every
@@ -47,6 +62,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   ensure-base-images:
     name: Ensure .NET Base Images Mirrored to ACR
+    if: ${{ vars.AZURE_DEPLOYMENTS_ENABLED == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -245,9 +261,9 @@ jobs:
         id: check
         run: |
           if [ -f "./containers/${{ matrix.container }}/Dockerfile" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push ${{ matrix.container }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -314,6 +314,12 @@ jobs:
       # PR builds neither pollute :latest nor leak per-PR sha tags.
       tag_latest: false
       tag_sha: true
+      # Dependabot PRs do not receive normal repo Actions secrets, so they
+      # cannot log into the mirrored ACR base-image repositories unless
+      # equivalent Dependabot secrets are configured. Keep strict ACR parity
+      # for human/automation PRs that can access secrets, but let Dependabot
+      # still compile the affected service image against public MCR bases.
+      require_acr_read_token: ${{ github.actor != 'dependabot[bot]' }}
     secrets:
       # PR builds need ACR read access for mirrored .NET base image pulls.
       # AZURE_CLIENT_ID / TENANT / SUBSCRIPTION are deliberately NOT

--- a/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Services/NetworkRosterServiceTests.cs
@@ -420,12 +420,14 @@ public class NetworkRosterServiceTests
         // mismatch even when other fields are preserved — fix #5.
         var repo = new InMemoryProviderRepository { TenantId = TenantA };
         var svc = NewService(repo);
+        var asOf = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
         for (var i = 0; i < 6; i++)
-            await SeedProviderAsync(repo, $"p-{i}", $"Last-{i}", networkId: Network1);
+            await SeedProviderAsync(repo, $"p-{i}", $"Last-{i}", networkId: Network1,
+                effectiveDate: asOf.AddYears(-1));
 
         var query = NewQuery(Network1);
         query.PageSize = 2;
-        query.AsOfDate = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        query.AsOfDate = asOf;
         var page1 = await svc.GetRosterAsync(query);
         page1.NextCursor.Should().NotBeNull();
 


### PR DESCRIPTION
## Summary
- pause automatic Azure AKS/Container Apps deploys unless `AZURE_DEPLOYMENTS_ENABLED=true`, while preserving manual dispatch
- allow Dependabot PR service-image validation to fall back to public MCR base images when ACR read secrets are unavailable
- fix ProviderService roster cursor test data so the seeded providers are active for the asserted `AsOfDate`
- clean workflow shell issues surfaced by actionlint

## Verification
- `dotnet test tests/CloudHealthOffice.ProviderService.Tests/CloudHealthOffice.ProviderService.Tests.csproj --no-restore`
- `actionlint .github/workflows/deploy-azure-aks.yml .github/workflows/_build-service-image.yml .github/workflows/pr-validation.yml`
- workflow YAML parse check
- `git diff --check`
- local Docker build for `authorization-service` with `REGISTRY=mcr.microsoft.com` fallback

## Notes
Azure deploys are intentionally paused while the subscription is inactive. Set repository variable `AZURE_DEPLOYMENTS_ENABLED=true` after reactivating the subscription to restore automatic main-branch deploys.