### PR TITLE
Refresh workflow actions for Node 24 runners

### DIFF
--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -200,7 +200,7 @@ jobs:
     permissions:
       # Read-only checkout of the repository.
       contents: read
-      # OIDC token issuance for azure/login@v3 (only used when push: true,
+      # OIDC token issuance for azure/login@v2 (only used when push: true,
       # but the permission must be granted at the job level regardless).
       id-token: write
 

--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -200,13 +200,13 @@ jobs:
     permissions:
       # Read-only checkout of the repository.
       contents: read
-      # OIDC token issuance for azure/login@v2 (only used when push: true,
+      # OIDC token issuance for azure/login@v3 (only used when push: true,
       # but the permission must be granted at the job level regardless).
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ───────────────────────────────────────────────────────────────────
       # Resolve effective parameters from the input/var/literal fallback
@@ -299,7 +299,7 @@ jobs:
       # ───────────────────────────────────────────────────────────────────
       - name: Azure Login (OIDC) — push mode
         if: env.PUSH_ENABLED == 'true'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           # secrets.X || secrets.Y pattern: in workflow_call mode the lowercase
           # form is the caller-passed secret; in workflow_dispatch mode it's
@@ -346,8 +346,8 @@ jobs:
 
       - name: Log in to ACR for base-image pulls — non-push mode
         id: acr-pr-login
-        if: env.PUSH_ENABLED != 'true' && steps.check-acr-token.outputs.available == 'true'
-        uses: docker/login-action@v3
+        if: env.PUSH_ENABLED != 'true' && inputs.require_acr_read_token && steps.check-acr-token.outputs.available == 'true'
+        uses: docker/login-action@v4
         with:
           registry: ${{ steps.params.outputs.registry }}
           username: ${{ secrets.acr_username || secrets.ACR_USERNAME }}
@@ -378,8 +378,8 @@ jobs:
       - name: Warn when using public MCR base images — non-push mode
         if: env.PUSH_ENABLED != 'true' && !inputs.require_acr_read_token && steps.acr-pr-login.outcome != 'success'
         run: |
-          echo "::warning::ACR read credentials are unavailable for this non-push build."
-          echo "::warning::Falling back to public mcr.microsoft.com base images. This is intended for Dependabot PRs only; normal PRs should keep require_acr_read_token=true."
+          echo "::warning::ACR read credentials are not required for this non-push build."
+          echo "::warning::Falling back to public mcr.microsoft.com base images. This is intended for Dependabot PRs or periods when Azure deployments are paused."
 
       # ───────────────────────────────────────────────────────────────────
       # Buildx + the actual build. Both modes (push:true, push:false) share
@@ -387,10 +387,10 @@ jobs:
       # the cache-to gating.
       # ───────────────────────────────────────────────────────────────────
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and ${{ env.PUSH_ENABLED == 'true' && 'push' || 'check' }} ${{ inputs.service }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ steps.params.outputs.build_context }}
           # The Dockerfile ALWAYS lives at src/services/<service>/Dockerfile,

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -62,14 +62,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -87,7 +87,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push ${{ matrix.container.name }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.container.context }}
           push: ${{ github.event_name != 'pull_request' || github.event.inputs.push_to_registry == 'true' }}
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -192,14 +192,16 @@ jobs:
 
       - name: Post summary
         run: |
-          echo "## Container Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Container | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| x12-parser | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| x12-encoder | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| sftp-fetcher | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| metadata-extractor | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "| kafka-publisher | ✅ |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Images pushed to: \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}\`" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Container Build Summary"
+            echo ""
+            echo "| Container | Status |"
+            echo "|-----------|--------|"
+            echo "| x12-parser | ✅ |"
+            echo "| x12-encoder | ✅ |"
+            echo "| sftp-fetcher | ✅ |"
+            echo "| metadata-extractor | ✅ |"
+            echo "| kafka-publisher | ✅ |"
+            echo ""
+            echo "Images pushed to: \`${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cleanup-staging-environments.yml
+++ b/.github/workflows/cleanup-staging-environments.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/debug-oidc.yml
+++ b/.github/workflows/debug-oidc.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Debug JWT Token Content
         run: |
@@ -24,7 +24,7 @@ jobs:
           echo "Repository: $GITHUB_REPOSITORY"
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure login via OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -69,7 +69,7 @@ jobs:
       contents: read
     steps:
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -112,10 +112,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -125,10 +125,10 @@ jobs:
         run: az acr login --name ${{ vars.ACR_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push portal
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./src/portal/CloudHealthOffice.Portal/Dockerfile
@@ -141,7 +141,7 @@ jobs:
           platforms: linux/amd64
 
       - name: Build and push site
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./src/site
           file: ./src/site/Dockerfile
@@ -242,10 +242,10 @@ jobs:
           - x12-834-parser
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -255,7 +255,7 @@ jobs:
         run: az acr login --name ${{ vars.ACR_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Check Dockerfile exists
         id: check
@@ -268,7 +268,7 @@ jobs:
 
       - name: Build and push ${{ matrix.container }}
         if: steps.check.outputs.exists == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./containers/${{ matrix.container }}
           file: ./containers/${{ matrix.container }}/Dockerfile
@@ -292,10 +292,10 @@ jobs:
     environment: PROD
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -361,10 +361,10 @@ jobs:
     environment: PROD
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-dev.yml.disabled
+++ b/.github/workflows/deploy-dev.yml.disabled
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate Required Secrets
         shell: bash
@@ -172,10 +172,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -225,10 +225,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -298,10 +298,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-do.yml.disabled
+++ b/.github/workflows/deploy-do.yml.disabled
@@ -24,7 +24,7 @@ jobs:
       packages: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: src/site
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -43,7 +43,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: src/site/dist
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure login via OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-static-site.yml
+++ b/.github/workflows/deploy-static-site.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -125,7 +125,7 @@ jobs:
 
       - name: Azure Login (OIDC)
         id: azure-login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -454,7 +454,7 @@ jobs:
 
       - name: Upload DNS Instructions
         if: steps.get-swa.outputs.swa_exists == 'true' && steps.custom-domain.outputs.dns_instructions_file != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dns-configuration-instructions
           path: ${{ steps.custom-domain.outputs.dns_instructions_file }}
@@ -510,9 +510,9 @@ jobs:
               exit 0
             fi
 
-            if [ $i -lt $MAX_RETRIES ]; then
+            if [ "$i" -lt "$MAX_RETRIES" ]; then
               echo "   HTTP $HTTP_STATUS - waiting ${RETRY_DELAY}s before retry..."
-              sleep $RETRY_DELAY
+              sleep "$RETRY_DELAY"
             fi
           done
 

--- a/.github/workflows/deploy-uat.yml.disabled
+++ b/.github/workflows/deploy-uat.yml.disabled
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate Required Secrets
         shell: bash
@@ -207,10 +207,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_UAT }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_UAT }}
@@ -260,10 +260,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_UAT }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_UAT }}
@@ -333,10 +333,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_UAT }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_UAT }}
@@ -451,10 +451,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID_UAT }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID_UAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       sp-id: ${{ steps.ensure-sp.outputs.sp-id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set default secrets if not configured
         id: set-defaults
@@ -67,7 +67,7 @@ jobs:
       - name: Azure Login (OIDC) - Optional if secrets exist
         if: env.HAS_AZURE_CREDS == 'true'
         id: azure-login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ env.CLIENT_ID }}
           tenant-id: ${{ env.TENANT_ID }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,14 +46,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Azure Login (OIDC)
         if: github.event_name != 'pull_request'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -63,11 +63,9 @@ jobs:
         if: github.event_name != 'pull_request'
         run: az acr login --name ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
 
-      # PR builds cannot use OIDC (no push), but still need ACR access to pull
-      # mirrored .NET base images. Check first whether the read-only ACR token
-      # (ACR_USERNAME / ACR_PASSWORD secrets) is configured so that fork PRs,
-      # where repository secrets are unavailable, truly skip the login rather
-      # than triggering a noisy failed attempt.
+      # PR builds cannot use OIDC (no push), but should use ACR mirrored .NET
+      # base images only when Azure deploys are active. While Azure is paused,
+      # PR builds intentionally fall back to public MCR base images.
       - name: Check ACR token available
         id: check-acr-token
         if: github.event_name == 'pull_request'
@@ -75,15 +73,15 @@ jobs:
           _ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
         run: |
           if [ -n "$_ACR_USERNAME" ]; then
-            echo "available=true" >> $GITHUB_OUTPUT
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> $GITHUB_OUTPUT
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Log in to ACR for PR base-image pulls
         id: acr-pr-login
-        if: github.event_name == 'pull_request' && steps.check-acr-token.outputs.available == 'true'
-        uses: docker/login-action@v3
+        if: github.event_name == 'pull_request' && vars.AZURE_DEPLOYMENTS_ENABLED == 'true' && steps.check-acr-token.outputs.available == 'true'
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
@@ -96,7 +94,7 @@ jobs:
       # rather than let PR builds and main deploys exercise different
       # registries — PR-green/main-red regressions must be impossible.
       - name: Fail if ACR login didn't succeed on PR
-        if: github.event_name == 'pull_request' && steps.acr-pr-login.outcome != 'success'
+        if: github.event_name == 'pull_request' && vars.AZURE_DEPLOYMENTS_ENABLED == 'true' && steps.acr-pr-login.outcome != 'success'
         env:
           ACR_SHORT_NAME: ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
         run: |
@@ -113,8 +111,13 @@ jobs:
           echo "::error::See docs/security/SECRETS-INVENTORY.md for the rationale."
           exit 1
 
+      - name: Warn when using public MCR base images on PR
+        if: github.event_name == 'pull_request' && vars.AZURE_DEPLOYMENTS_ENABLED != 'true'
+        run: |
+          echo "::warning::Azure deployments are paused; portal PR build will use public mcr.microsoft.com base images."
+
       - name: Set effective base-image registry
-        run: echo "BUILD_REGISTRY=${{ env.REGISTRY }}" >> $GITHUB_ENV
+        run: echo "BUILD_REGISTRY=${{ github.event_name == 'pull_request' && vars.AZURE_DEPLOYMENTS_ENABLED != 'true' && 'mcr.microsoft.com' || env.REGISTRY }}" >> "$GITHUB_ENV"
 
       - name: Extract metadata
         id: meta
@@ -128,7 +131,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./src/portal/CloudHealthOffice.Portal/Dockerfile
@@ -149,14 +152,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Azure Login (OIDC)
         if: github.event_name != 'pull_request'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -178,7 +181,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./src/site
           file: ./src/site/Dockerfile
@@ -200,10 +203,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Azure Login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -332,14 +335,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Azure Login (OIDC)
         if: github.event_name != 'pull_request'
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -364,15 +367,15 @@ jobs:
         id: check
         run: |
           if [ -f "./containers/${{ matrix.container }}/Dockerfile" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ Dockerfile not found for ${{ matrix.container }}"
           fi
 
       - name: Build and push
         if: steps.check.outputs.exists == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./containers/${{ matrix.container }}
           file: ./containers/${{ matrix.container }}/Dockerfile

--- a/.github/workflows/phi-validation.yml
+++ b/.github/workflows/phi-validation.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Label PR based on files changed
         uses: actions/labeler@v6
@@ -54,7 +54,7 @@ jobs:
     if: github.event.action == 'opened'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Auto-assign reviewers
         uses: kentaro-m/auto-assign-action@v2.0.2

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ---------- GitHub Actions workflow lint ----------
       - name: Actionlint (workflows linter)

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -123,7 +123,7 @@ jobs:
       services: ${{ steps.compute.outputs.services }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run path filter
         id: filter
@@ -131,8 +131,8 @@ jobs:
         # v4.0.0/v4.0.1 followed in the same window with a Node 24 runtime
         # upgrade). Pinned to v4.0.1 — the latest minor in the v4 line.
         # All other actions in this repo follow the same "current major"
-        # convention (actions/checkout@v4, docker/setup-buildx-action@v3,
-        # docker/build-push-action@v6, docker/metadata-action@v5).
+        # convention (actions/checkout@v7, docker/setup-buildx-action@v4,
+        # docker/build-push-action@v7, docker/metadata-action@v5).
         uses: dorny/paths-filter@v4.0.1
         with:
           filters: .github/paths-filter.yml
@@ -314,12 +314,10 @@ jobs:
       # PR builds neither pollute :latest nor leak per-PR sha tags.
       tag_latest: false
       tag_sha: true
-      # Dependabot PRs do not receive normal repo Actions secrets, so they
-      # cannot log into the mirrored ACR base-image repositories unless
-      # equivalent Dependabot secrets are configured. Keep strict ACR parity
-      # for human/automation PRs that can access secrets, but let Dependabot
-      # still compile the affected service image against public MCR bases.
-      require_acr_read_token: ${{ github.actor != 'dependabot[bot]' }}
+      # Dependabot PRs do not receive normal repo Actions secrets, and all PR
+      # validation should avoid ACR while Azure deployments are paused. Keep
+      # strict ACR parity only when Azure deploys are explicitly enabled.
+      require_acr_read_token: ${{ github.actor != 'dependabot[bot]' && vars.AZURE_DEPLOYMENTS_ENABLED == 'true' }}
     secrets:
       # PR builds need ACR read access for mirrored .NET base image pulls.
       # AZURE_CLIENT_ID / TENANT / SUBSCRIPTION are deliberately NOT

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -131,7 +131,7 @@ jobs:
         # v4.0.0/v4.0.1 followed in the same window with a Node 24 runtime
         # upgrade). Pinned to v4.0.1 — the latest minor in the v4 line.
         # All other actions in this repo follow the same "current major"
-        # convention (actions/checkout@v7, docker/setup-buildx-action@v4,
+        # convention (actions/checkout@v4, docker/setup-buildx-action@v4,
         # docker/build-push-action@v7, docker/metadata-action@v5).
         uses: dorny/paths-filter@v4.0.1
         with:

--- a/.github/workflows/pre-approval-checks.yml
+++ b/.github/workflows/pre-approval-checks.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       scan-status: ${{ steps.summary.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Security Scan - Secrets Detection
         id: secrets-scan

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -53,7 +53,7 @@ jobs:
       duration_ms: ${{ steps.results.outputs.duration_ms }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -118,13 +118,15 @@ jobs:
             TOTAL=$((TOTAL + t)); PASSED=$((PASSED + p)); FAILED=$((FAILED + f))
           done
 
-          echo "test_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "pass_count=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "fail_count=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "duration_ms=${{ steps.run.outputs.duration_ms }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "test_count=$TOTAL"
+            echo "pass_count=$PASSED"
+            echo "fail_count=$FAILED"
+            echo "duration_ms=${{ steps.run.outputs.duration_ms }}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload smoke results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: smoke-test-results
@@ -142,7 +144,7 @@ jobs:
       pass_count: ${{ steps.results.outputs.pass_count }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Run structural validation
         id: results
@@ -224,7 +226,7 @@ jobs:
       duration_ms: ${{ steps.results.outputs.duration_ms }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -282,10 +284,12 @@ jobs:
             TOTAL=$((TOTAL + t)); PASSED=$((PASSED + p)); FAILED=$((FAILED + f))
           done
 
-          echo "test_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "pass_count=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "fail_count=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "duration_ms=${{ steps.run.outputs.duration_ms }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "test_count=$TOTAL"
+            echo "pass_count=$PASSED"
+            echo "fail_count=$FAILED"
+            echo "duration_ms=${{ steps.run.outputs.duration_ms }}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Capture service logs on failure
         if: failure()
@@ -298,7 +302,7 @@ jobs:
         run: docker compose down -v 2>/dev/null || true
 
       - name: Upload E2E results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: e2e-test-results
@@ -319,7 +323,7 @@ jobs:
       duration_ms: ${{ steps.results.outputs.duration_ms }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -365,7 +369,7 @@ jobs:
         run: docker compose down -v 2>/dev/null || true
 
       - name: Upload load test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: load-test-results
@@ -430,27 +434,33 @@ jobs:
           }
           EOF
 
-          echo "## Quality Gate Report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Category | Total | Passed | Failed | Duration |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|----------|-------|--------|--------|----------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Smoke Tests | $SMOKE_TOTAL | $SMOKE_PASS | $SMOKE_FAIL | ${SMOKE_DURATION}ms |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Sanity Checks | $SANITY_TOTAL | $SANITY_PASS | $((SANITY_TOTAL - SANITY_PASS)) | — |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| E2E Tests | $E2E_TOTAL | $E2E_PASS | $E2E_FAIL | ${E2E_DURATION}ms |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Load Tests | $LOAD_SCENARIOS scenarios | — | — | ${LOAD_DURATION}ms |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Quality Gate Report"
+            echo ""
+            echo "| Category | Total | Passed | Failed | Duration |"
+            echo "|----------|-------|--------|--------|----------|"
+            echo "| Smoke Tests | $SMOKE_TOTAL | $SMOKE_PASS | $SMOKE_FAIL | ${SMOKE_DURATION}ms |"
+            echo "| Sanity Checks | $SANITY_TOTAL | $SANITY_PASS | $((SANITY_TOTAL - SANITY_PASS)) | — |"
+            echo "| E2E Tests | $E2E_TOTAL | $E2E_PASS | $E2E_FAIL | ${E2E_DURATION}ms |"
+            echo "| Load Tests | $LOAD_SCENARIOS scenarios | — | — | ${LOAD_DURATION}ms |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           # Gate: fail if any smoke tests failed
           if [ "$SMOKE_FAIL" -gt 0 ]; then
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "> **Quality Gate FAILED**: $SMOKE_FAIL smoke test(s) failed" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo ""
+              echo "> **Quality Gate FAILED**: $SMOKE_FAIL smoke test(s) failed"
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "> **Quality Gate PASSED**" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "> **Quality Gate PASSED**"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload quality report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: quality-report

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # ---------- Repository structure validation ----------
       - name: Validate repository structure

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run npm audit
         run: |
-          echo "## NPM Security Audit" >> $GITHUB_STEP_SUMMARY
+          echo "## NPM Security Audit" >> "$GITHUB_STEP_SUMMARY"
           # Keep the raw report as an artifact for triage.
           npm audit --omit=dev --audit-level=moderate --json > npm-audit.json || true
           # Gate on production moderate+ advisories via audit-ci so we can
@@ -44,7 +44,7 @@ jobs:
           npx --yes audit-ci@^7 --config .audit-ci.json
 
       - name: Upload audit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: npm-audit-results
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner in fs mode
         uses: aquasecurity/trivy-action@v0.36.0
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -182,17 +182,19 @@ jobs:
     steps:
       - name: Generate Security Summary
         run: |
-          echo "# 🛡️ Security Scan Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Scan Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## Scan Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Scan Type | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Dependency Scan | ${{ needs.dependency-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| .NET Scan | ${{ needs.dotnet-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Docker Scan | ${{ needs.docker-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Secret Scan | ${{ needs.secret-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Action Required:** Review failed scans and remediate vulnerabilities" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# 🛡️ Security Scan Summary"
+            echo ""
+            echo "**Scan Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            echo ""
+            echo "## Scan Results"
+            echo ""
+            echo "| Scan Type | Status |"
+            echo "|-----------|--------|"
+            echo "| Dependency Scan | ${{ needs.dependency-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo "| .NET Scan | ${{ needs.dotnet-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo "| Docker Scan | ${{ needs.docker-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo "| Secret Scan | ${{ needs.secret-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo ""
+            echo "**Action Required:** Review failed scans and remediate vulnerabilities"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/seed-demo-data.yml
+++ b/.github/workflows/seed-demo-data.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Azure login via OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -125,7 +125,7 @@ jobs:
           PY
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: dotnet-test-results
@@ -138,10 +138,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -167,7 +167,7 @@ jobs:
     if: always()
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -175,7 +175,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dotnet-test-results
           path: ./TestResults

--- a/.github/workflows/test-metrics.yml
+++ b/.github/workflows/test-metrics.yml
@@ -44,7 +44,7 @@ jobs:
       coverage_pct: ${{ steps.parse.outputs.coverage_pct }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -92,7 +92,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TOTAL=0; PASSED=0; FAILED=0; SKIPPED=0; DURATION=0
+          TOTAL=0; PASSED=0; FAILED=0; SKIPPED=0
 
           for trx in TestResults/*.trx; do
             [ -f "$trx" ] || continue
@@ -117,15 +117,17 @@ jobs:
             fi
           fi
 
-          echo "test_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "pass_count=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "fail_count=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skip_count=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "duration_ms=${{ steps.run.outputs.duration_ms }}" >> "$GITHUB_OUTPUT"
-          echo "coverage_pct=$COVERAGE" >> "$GITHUB_OUTPUT"
+          {
+            echo "test_count=$TOTAL"
+            echo "pass_count=$PASSED"
+            echo "fail_count=$FAILED"
+            echo "skip_count=$SKIPPED"
+            echo "duration_ms=${{ steps.run.outputs.duration_ms }}"
+            echo "coverage_pct=$COVERAGE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload .NET test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: dotnet-test-results
@@ -149,10 +151,10 @@ jobs:
       coverage_pct: ${{ steps.parse.outputs.coverage_pct }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -193,15 +195,17 @@ jobs:
             COVERAGE=$(python3 -c "import json; d=json.load(open('coverage/coverage-summary.json')); print(d['total']['lines']['pct'])")
           fi
 
-          echo "test_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "pass_count=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "fail_count=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skip_count=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "duration_ms=${{ steps.run.outputs.duration_ms }}" >> "$GITHUB_OUTPUT"
-          echo "coverage_pct=$COVERAGE" >> "$GITHUB_OUTPUT"
+          {
+            echo "test_count=$TOTAL"
+            echo "pass_count=$PASSED"
+            echo "fail_count=$FAILED"
+            echo "skip_count=$SKIPPED"
+            echo "duration_ms=${{ steps.run.outputs.duration_ms }}"
+            echo "coverage_pct=$COVERAGE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload Jest results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: jest-test-results
@@ -225,7 +229,7 @@ jobs:
       coverage_pct: ${{ steps.parse.outputs.coverage_pct }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -286,15 +290,17 @@ jobs:
           " 2>/dev/null || echo "0")
           fi
 
-          echo "test_count=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "pass_count=$PASSED" >> "$GITHUB_OUTPUT"
-          echo "fail_count=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "skip_count=$SKIPPED" >> "$GITHUB_OUTPUT"
-          echo "duration_ms=${{ steps.run.outputs.duration_ms }}" >> "$GITHUB_OUTPUT"
-          echo "coverage_pct=$COVERAGE" >> "$GITHUB_OUTPUT"
+          {
+            echo "test_count=$TOTAL"
+            echo "pass_count=$PASSED"
+            echo "fail_count=$FAILED"
+            echo "skip_count=$SKIPPED"
+            echo "duration_ms=${{ steps.run.outputs.duration_ms }}"
+            echo "coverage_pct=$COVERAGE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload pytest results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-test-results
@@ -313,7 +319,7 @@ jobs:
     if: always()
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Generate test-metrics.json
         run: |
@@ -345,9 +351,14 @@ jobs:
           GRAND_FAIL=$((DOTNET_FAIL + JEST_FAIL + PYTHON_FAIL))
           GRAND_SKIP=$((DOTNET_SKIP + JEST_SKIP + PYTHON_SKIP))
           GRAND_DURATION=$((DOTNET_DURATION + JEST_DURATION + PYTHON_DURATION))
+          if [ "$GRAND_FAIL" -eq 0 ]; then
+            ALL_PASSING=true
+          else
+            ALL_PASSING=false
+          fi
 
           # Weighted average coverage across all suites that report coverage
-          WEIGHTED_COVERAGE=$(python3 -c "
+          WEIGHTED_COVERAGE=$(python3 - <<PY
           suites = [
               ($DOTNET_COVERAGE, $DOTNET_TOTAL),
               ($JEST_COVERAGE, $JEST_TOTAL),
@@ -362,7 +373,8 @@ jobs:
               print(round(weighted / total_tests, 2))
           else:
               print(0)
-          ")
+          PY
+          )
 
           TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           SHA="${GITHUB_SHA:-unknown}"
@@ -380,7 +392,7 @@ jobs:
               "skipped": $GRAND_SKIP,
               "duration_ms": $GRAND_DURATION,
               "coverage_pct": $WEIGHTED_COVERAGE,
-              "all_passing": $([ "$GRAND_FAIL" -eq 0 ] && echo "true" || echo "false")
+              "all_passing": $ALL_PASSING
             },
             "suites": {
               "dotnet": {
@@ -415,21 +427,23 @@ jobs:
           METRICS_EOF
 
           # Pretty-print for the job summary
-          echo "## Test Metrics Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Suite | Total | Passed | Failed | Skipped | Duration | Coverage |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|-------|--------|--------|---------|----------|----------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| .NET (xUnit) | $DOTNET_TOTAL | $DOTNET_PASS | $DOTNET_FAIL | $DOTNET_SKIP | ${DOTNET_DURATION}ms | ${DOTNET_COVERAGE}% |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| TypeScript (Jest) | $JEST_TOTAL | $JEST_PASS | $JEST_FAIL | $JEST_SKIP | ${JEST_DURATION}ms | ${JEST_COVERAGE}% |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Python (pytest) | $PYTHON_TOTAL | $PYTHON_PASS | $PYTHON_FAIL | $PYTHON_SKIP | ${PYTHON_DURATION}ms | ${PYTHON_COVERAGE}% |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Grand Total** | **$GRAND_TOTAL** | **$GRAND_PASS** | **$GRAND_FAIL** | **$GRAND_SKIP** | **${GRAND_DURATION}ms** | **${WEIGHTED_COVERAGE}%** |" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Generated: $TIMESTAMP | Commit: \`${SHA::7}\` | Ref: \`$REF\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Test Metrics Summary"
+            echo ""
+            echo "| Suite | Total | Passed | Failed | Skipped | Duration | Coverage |"
+            echo "|-------|-------|--------|--------|---------|----------|----------|"
+            echo "| .NET (xUnit) | $DOTNET_TOTAL | $DOTNET_PASS | $DOTNET_FAIL | $DOTNET_SKIP | ${DOTNET_DURATION}ms | ${DOTNET_COVERAGE}% |"
+            echo "| TypeScript (Jest) | $JEST_TOTAL | $JEST_PASS | $JEST_FAIL | $JEST_SKIP | ${JEST_DURATION}ms | ${JEST_COVERAGE}% |"
+            echo "| Python (pytest) | $PYTHON_TOTAL | $PYTHON_PASS | $PYTHON_FAIL | $PYTHON_SKIP | ${PYTHON_DURATION}ms | ${PYTHON_COVERAGE}% |"
+            echo "| **Grand Total** | **$GRAND_TOTAL** | **$GRAND_PASS** | **$GRAND_FAIL** | **$GRAND_SKIP** | **${GRAND_DURATION}ms** | **${WEIGHTED_COVERAGE}%** |"
+            echo ""
+            echo "Generated: $TIMESTAMP | Commit: \`${SHA::7}\` | Ref: \`$REF\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           cat test-metrics.json
 
       - name: Upload test-metrics.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-metrics
           path: test-metrics.json

--- a/src/services/consent-service/consent-service.csproj
+++ b/src/services/consent-service/consent-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
   <PackageReference Include="SharpCompress" Version="0.48.0" />


### PR DESCRIPTION
## Summary
- bump first-party GitHub Actions, Docker actions, and Azure login actions to current Node 24-compatible majors
- keep PR service-image validation off ACR while `AZURE_DEPLOYMENTS_ENABLED` is not `true`
- skip ACR login entirely when the reusable image-build workflow is intentionally using public MCR base images
- clean workflow shell snippets so full actionlint passes locally

## Why
Recent logs show Node 20 deprecation warnings across many jobs. Those warnings were not the hard failure in the sampled PR validation run; the hard failure was a 403 from ACR while Azure is paused. This PR addresses both: it removes the old action majors that produce Node runtime warnings and makes PR validation respect the paused-Azure state.

## Verification
- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- workflow YAML parse check
- `yamllint -c /tmp/cho-yamllint.yml .github/workflows`
- `git diff --check`