### PR TITLE
Use Formspree endpoint in source marketing form

### DIFF
--- a/src/site/build.mjs
+++ b/src/site/build.mjs
@@ -102,6 +102,10 @@ function processHtmlFiles(directory) {
       .replaceAll(
         '__FORMSPREE_FOUNDING_PARTNER_ENDPOINT__',
         formspreeFoundingPartnerEndpoint
+      )
+      .replaceAll(
+        defaultFormspreeFoundingPartnerEndpoint,
+        formspreeFoundingPartnerEndpoint
       );
 
     if (analyticsInjection) {

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -643,7 +643,7 @@
           </p>
         </div>
 
-        <form id="fpApplicationForm" action="__FORMSPREE_FOUNDING_PARTNER_ENDPOINT__" method="POST" novalidate style="display: block;" aria-label="Founding partner application form">
+        <form id="fpApplicationForm" action="https://formspree.io/f/xgojygon" method="POST" novalidate style="display: block;" aria-label="Founding partner application form">
 
           <div style="margin-bottom: 22px;">
             <label for="fp-org-name" style="display:block; font-size:0.9rem; color:rgba(0,255,255,0.8); margin-bottom:6px; font-weight:600;">


### PR DESCRIPTION
## Summary
- Put the real Formspree endpoint directly on the source homepage form so local/source previews do not show the not-configured error
- Keep build-time endpoint replacement for environment overrides

## Validation
- npm run build
- git diff --check