### PR TITLE
Align local quickstart with Kubernetes

### DIFF
--- a/api/quickstarts/local-claims-quickstart.md
+++ b/api/quickstarts/local-claims-quickstart.md
@@ -29,7 +29,7 @@ Run Cloud Health Office locally and take a claim all the way through adjudicatio
 From the repo root:
 
 ```bash
-docker compose up -d
+docker compose --profile core --profile finance up -d
 ```
 
 This starts:
@@ -40,14 +40,14 @@ This starts:
 | Redis | `localhost:6379` |
 | claims-service | `http://localhost:5001` |
 | benefit-plan-service | `http://localhost:5002` |
-| payment-service | `http://localhost:5003` |
+| payment-service | `http://localhost:5006` |
 
 Wait for all services to be healthy (≈ 45 seconds):
 
 ```bash
 curl -s http://localhost:5001/health
 curl -s http://localhost:5002/health
-curl -s http://localhost:5003/health
+curl -s http://localhost:5006/health
 ```
 
 All should return `Healthy`.
@@ -280,7 +280,7 @@ curl -s -X PUT "http://localhost:5001/api/claims/$CLAIM_ID/status" \
 Execute a payment run that picks up all adjudicated claims and generates 835 EDI for each:
 
 ```bash
-PAYRUN=$(curl -s -X POST http://localhost:5003/api/paymentruns/execute \
+PAYRUN=$(curl -s -X POST http://localhost:5006/api/paymentruns/execute \
   -H "X-Tenant-ID: $TENANT" \
   -H "Content-Type: application/json" \
   -d "{
@@ -306,7 +306,7 @@ echo "Payment ID:  $PAYMENT_ID"
 ## 9. Download the 835 ERA
 
 ```bash
-curl -s "http://localhost:5003/api/payments/$PAYMENT_ID/835" \
+curl -s "http://localhost:5006/api/payments/$PAYMENT_ID/835" \
   -H "X-Tenant-ID: $TENANT" \
   -o era-$(date +%Y%m%d).835
 
@@ -325,7 +325,7 @@ Use these checks to verify payment run persistence, payment lifecycle endpoints,
 ### 10.1 Confirm payment run details
 
 ```bash
-curl -s "http://localhost:5003/api/paymentruns/$PAYRUN_ID" \
+curl -s "http://localhost:5006/api/paymentruns/$PAYRUN_ID" \
   -H "X-Tenant-ID: $TENANT" | jq '{id, status, totalClaims, totalPaymentAmount, paymentIds, claimIds}'
 ```
 
@@ -337,7 +337,7 @@ Expected:
 ### 10.2 Confirm payment record
 
 ```bash
-curl -s "http://localhost:5003/api/payments/$PAYMENT_ID" \
+curl -s "http://localhost:5006/api/payments/$PAYMENT_ID" \
   -H "X-Tenant-ID: $TENANT" | jq '{id, checkNumber, status, totalPaymentAmount, claimPayments}'
 ```
 
@@ -349,11 +349,11 @@ Expected:
 
 ```bash
 # Search payments in a date range
-curl -s "http://localhost:5003/api/payments?paymentDateFrom=2025-06-01&paymentDateTo=2025-12-31&page=1&pageSize=50" \
+curl -s "http://localhost:5006/api/payments?paymentDateFrom=2025-06-01&paymentDateTo=2025-12-31&page=1&pageSize=50" \
   -H "X-Tenant-ID: $TENANT" | jq '.[0:3]'
 
 # Payment summary
-curl -s "http://localhost:5003/api/payments/summary?from=2025-06-01&to=2025-12-31" \
+curl -s "http://localhost:5006/api/payments/summary?from=2025-06-01&to=2025-12-31" \
   -H "X-Tenant-ID: $TENANT" | jq .
 ```
 
@@ -365,13 +365,13 @@ Expected:
 
 ```bash
 # Mark as posted
-curl -s -X POST "http://localhost:5003/api/payments/$PAYMENT_ID/post" \
+curl -s -X POST "http://localhost:5006/api/payments/$PAYMENT_ID/post" \
   -H "X-Tenant-ID: $TENANT" \
   -H "Content-Type: application/json" \
   -d '{"postedBy":"local-tester","notes":"Posted during quickstart"}' | jq '{id, status, postedAt, postedBy}'
 
 # Mark as reconciled
-curl -s -X POST "http://localhost:5003/api/payments/$PAYMENT_ID/reconcile" \
+curl -s -X POST "http://localhost:5006/api/payments/$PAYMENT_ID/reconcile" \
   -H "X-Tenant-ID: $TENANT" \
   -H "Content-Type: application/json" \
   -d '{"notes":"Bank reconciliation test"}' | jq '{id, status, reconciledAt}'
@@ -386,7 +386,7 @@ Expected:
 If you want to test manual ERA ingestion without payment-run execution:
 
 ```bash
-curl -s -X POST http://localhost:5003/api/payments \
+curl -s -X POST http://localhost:5006/api/payments \
   -H "X-Tenant-ID: $TENANT" \
   -H "Content-Type: application/json" \
   -d '{
@@ -416,13 +416,13 @@ curl -s -X POST http://localhost:5003/api/payments \
 - `400 TenantId field is required`: ensure you're on latest code where tenant comes from `X-Tenant-ID`; if not, include `"tenantId":"$TENANT"` in payload as temporary fallback.
 - `404` on `/api/payments/{id}/835`: verify `PAYMENT_ID` is non-empty and was created under the same tenant header.
 - `500` during payment run execution: confirm claims-service has adjudicated claims and `PUT /api/claims/{id}/adjudication` completed first.
-- Intermittent failures right after `docker compose up -d`: wait for health checks to pass (`curl http://localhost:5003/health`) before running API calls.
+- Intermittent failures right after `docker compose --profile core --profile finance up -d`: wait for health checks to pass (`curl http://localhost:5006/health`) before running API calls.
 
 ---
 
 ## Automated script
 
-Run the entire flow (submit → adjudicate → payment → 835) in one command:
+Run the submit → adjudicate flow in one command:
 
 ```bash
 ./scripts/seed-local.sh --tenant demo
@@ -436,7 +436,7 @@ Explore all endpoints interactively:
 
 - **Claims service:** [http://localhost:5001/swagger](http://localhost:5001/swagger)
 - **Benefit-plan / adjudication:** [http://localhost:5002/swagger](http://localhost:5002/swagger)
-- **Payment / 835 ERA:** [http://localhost:5003/swagger](http://localhost:5003/swagger)
+- **Payment / 835 ERA:** [http://localhost:5006/swagger](http://localhost:5006/swagger)
 
 ---
 

--- a/docs/quickstart-kubernetes-local.md
+++ b/docs/quickstart-kubernetes-local.md
@@ -305,9 +305,9 @@ kubectl run -n cloudhealthoffice dns-test --rm -it --image=busybox -- \
 
 ### Out of memory / Docker Desktop slow
 
-The full platform runs 25+ pods. Allocate at least:
-- **CPU:** 4 cores
-- **Memory:** 8 GB (Settings > Resources)
+The full platform runs 30+ pods. Allocate at least:
+- **CPU:** 6 cores
+- **Memory:** 16 GB minimum, 24 GB recommended (Settings > Resources)
 
 ---
 

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/ClaimCorpusGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/ClaimCorpusGenerator.cs
@@ -152,9 +152,8 @@ public class ClaimCorpusGenerator
             ("labpathology", dist.LabPathologyFraction)
         };
 
-        foreach (var (subType, fraction) in subTypes)
+        foreach (var (subType, count) in AllocateCounts(dist.Count, subTypes))
         {
-            var count = (int)(dist.Count * fraction);
             for (int i = 0; i < count && !ct.IsCancellationRequested; i++)
             {
                 seq++;
@@ -185,9 +184,8 @@ public class ClaimCorpusGenerator
             ("skillednursing", dist.SkilledNursingFraction)
         };
 
-        foreach (var (subType, fraction) in subTypes)
+        foreach (var (subType, count) in AllocateCounts(dist.Count, subTypes))
         {
-            var count = (int)(dist.Count * fraction);
             for (int i = 0; i < count && !ct.IsCancellationRequested; i++)
             {
                 seq++;
@@ -218,9 +216,8 @@ public class ClaimCorpusGenerator
             ("oralsurgery", dist.OralSurgeryFraction)
         };
 
-        foreach (var (subType, fraction) in subTypes)
+        foreach (var (subType, count) in AllocateCounts(dist.Count, subTypes))
         {
-            var count = (int)(dist.Count * fraction);
             for (int i = 0; i < count && !ct.IsCancellationRequested; i++)
             {
                 seq++;
@@ -290,10 +287,9 @@ public class ClaimCorpusGenerator
 
         foreach (var (scenarios, totalCount) in scenarioGroups)
         {
-            var perScenario = totalCount / scenarios.Length;
-            foreach (var scenario in scenarios)
+            foreach (var (scenario, count) in AllocateEvenly(totalCount, scenarios))
             {
-                for (int i = 0; i < perScenario && !ct.IsCancellationRequested; i++)
+                for (int i = 0; i < count && !ct.IsCancellationRequested; i++)
                 {
                     seq++;
                     var claim = generator.Generate(seq, scenario.ToString(), random);
@@ -301,6 +297,63 @@ public class ClaimCorpusGenerator
                 }
             }
         }
+    }
+
+    private static IReadOnlyList<(T Item, int Count)> AllocateCounts<T>(
+        int total,
+        IReadOnlyList<(T Item, double Fraction)> weightedItems)
+    {
+        if (total <= 0 || weightedItems.Count == 0)
+        {
+            return Array.Empty<(T, int)>();
+        }
+
+        var allocations = weightedItems
+            .Select(item =>
+            {
+                var exact = total * Math.Max(0, item.Fraction);
+                var floor = (int)Math.Floor(exact);
+                return new
+                {
+                    item.Item,
+                    Count = floor,
+                    Remainder = exact - floor
+                };
+            })
+            .ToList();
+
+        var assigned = allocations.Sum(x => x.Count);
+        var remaining = total - assigned;
+        var counts = allocations.Select(x => x.Count).ToArray();
+
+        foreach (var index in allocations
+            .Select((value, index) => new { value.Remainder, index })
+            .OrderByDescending(x => x.Remainder)
+            .ThenBy(x => x.index)
+            .Take(Math.Max(0, remaining))
+            .Select(x => x.index))
+        {
+            counts[index]++;
+        }
+
+        return weightedItems
+            .Select((item, index) => (item.Item, counts[index]))
+            .ToList();
+    }
+
+    private static IReadOnlyList<(T Item, int Count)> AllocateEvenly<T>(int total, IReadOnlyList<T> items)
+    {
+        if (total <= 0 || items.Count == 0)
+        {
+            return Array.Empty<(T, int)>();
+        }
+
+        var baseCount = total / items.Count;
+        var remainder = total % items.Count;
+
+        return items
+            .Select((item, index) => (item, baseCount + (index < remainder ? 1 : 0)))
+            .ToList();
     }
 }
 

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/ClaimCorpusGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/ClaimCorpusGenerator.cs
@@ -303,15 +303,33 @@ public class ClaimCorpusGenerator
         int total,
         IReadOnlyList<(T Item, double Fraction)> weightedItems)
     {
-        if (total <= 0 || weightedItems.Count == 0)
+        if (weightedItems.Count == 0)
         {
             return Array.Empty<(T, int)>();
         }
 
+        if (total <= 0)
+        {
+            return weightedItems
+                .Select(item => (item.Item, 0))
+                .ToList();
+        }
+
+        var weights = weightedItems
+            .Select(item => Math.Max(0, item.Fraction))
+            .ToArray();
+        var totalWeight = weights.Sum();
+
+        if (totalWeight <= 0)
+        {
+            Array.Fill(weights, 1.0);
+            totalWeight = weights.Length;
+        }
+
         var allocations = weightedItems
-            .Select(item =>
+            .Select((item, index) =>
             {
-                var exact = total * Math.Max(0, item.Fraction);
+                var exact = total * (weights[index] / totalWeight);
                 var floor = (int)Math.Floor(exact);
                 return new
                 {

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -78,8 +78,8 @@
             <div class="docs-sidebar-section-title">Getting Started</div>
             <ul>
               <li><a href="/docs" class="active">Docs Home</a></li>
-              <li><a href="/docs/quickstart">Quick Start (Docker)</a></li>
-              <li><a href="/docs/quickstart-kubernetes">Quick Start (Kubernetes)</a></li>
+              <li><a href="/docs/quickstart">Quick Start</a></li>
+              <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
             </ul>
           </div>
           <div class="docs-sidebar-section">
@@ -141,15 +141,15 @@
 
           <a href="/docs/quickstart" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x26A1;</span>
-            <h3>Quick Start (Docker) <span class="time-estimate">~15 min</span></h3>
-            <p>Clone the repo, start the Docker stack, submit a claim through the full adjudication pipeline, and generate an 835 ERA — no Azure account needed.</p>
+            <h3>Quick Start <span class="time-estimate">~15 min</span></h3>
+            <p>Clone the repo, deploy the full local Kubernetes platform, validate claims adjudication, and verify CRD discovery — no Azure account needed.</p>
             <span class="card-arrow">Get started &rarr;</span>
           </a>
 
           <a href="/docs/quickstart-kubernetes" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x2638;</span>
-            <h3>Quick Start (Kubernetes) <span class="time-estimate">~15 min</span></h3>
-            <p>Deploy the full 25-service platform on Docker Desktop Kubernetes — identical namespace, DNS, and manifests as production Azure AKS.</p>
+            <h3>Kubernetes Reference <span class="time-estimate">~15 min</span></h3>
+            <p>Deploy the full local Kubernetes platform on Docker Desktop Kubernetes — identical namespace, DNS, and manifests as production Azure AKS.</p>
             <span class="card-arrow">Kubernetes guide &rarr;</span>
           </a>
 
@@ -281,8 +281,8 @@
         <div class="footer-col">
           <h5>Documentation</h5>
           <ul>
-            <li><a href="/docs/quickstart">Quick Start (Docker)</a></li>
-            <li><a href="/docs/quickstart-kubernetes">Quick Start (Kubernetes)</a></li>
+            <li><a href="/docs/quickstart">Quick Start</a></li>
+            <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
             <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
             <li><a href="/docs/architecture">Architecture</a></li>
             <li><a href="/docs/api">API Reference</a></li>

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -223,8 +223,8 @@
             <div class="docs-sidebar-section-title">Getting Started</div>
             <ul>
               <li><a href="/docs">Docs Home</a></li>
-              <li><a href="/docs/quickstart">Quick Start (Docker)</a></li>
-              <li><a href="/docs/quickstart-kubernetes">Quick Start (Kubernetes)</a></li>
+              <li><a href="/docs/quickstart">Quick Start</a></li>
+              <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
             </ul>
           </div>
           <div class="docs-sidebar-section">

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Kubernetes Quick Start — Cloud Health Office Documentation</title>
+  <title>Kubernetes Reference — Cloud Health Office Documentation</title>
   <meta name="description" content="Run the full Cloud Health Office platform on Docker Desktop Kubernetes — the same architecture, namespaces, and manifests used in production on Azure AKS. Under 15 minutes." />
   <meta name="keywords" content="Cloud Health Office Kubernetes, local Kubernetes development, Docker Desktop Kubernetes, healthcare payer platform k8s, microservices local deployment, CMS-0057-F Kubernetes" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
-  <meta property="og:title" content="Kubernetes Quick Start — Cloud Health Office" />
-  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production. production-shaped microservices, MongoDB, Redis — identical to Azure AKS." />
+  <meta property="og:title" content="Kubernetes Reference — Cloud Health Office" />
+  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production: production-shaped microservices, MongoDB, and Redis—identical to Azure AKS." />
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    "headline": "Cloud Health Office Kubernetes Quick Start",
+    "headline": "Cloud Health Office Kubernetes Reference",
     "description": "Step-by-step guide to deploying Cloud Health Office on Docker Desktop Kubernetes — matching the production Azure AKS architecture.",
     "url": "https://cloudhealthoffice.com/docs/quickstart-kubernetes",
     "author": { "@type": "Organization", "name": "Aurelianware, Inc." },
@@ -29,7 +29,7 @@
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://cloudhealthoffice.com" },
         { "@type": "ListItem", "position": 2, "name": "Docs", "item": "https://cloudhealthoffice.com/docs" },
-        { "@type": "ListItem", "position": 3, "name": "Kubernetes Quick Start", "item": "https://cloudhealthoffice.com/docs/quickstart-kubernetes" }
+        { "@type": "ListItem", "position": 3, "name": "Kubernetes Reference", "item": "https://cloudhealthoffice.com/docs/quickstart-kubernetes" }
       ]
     }
   }
@@ -134,10 +134,10 @@
           <span class="sep">&#x25B8;</span>
           <a href="/docs">Docs</a>
           <span class="sep">&#x25B8;</span>
-          <span class="current">Kubernetes Quick Start</span>
+          <span class="current">Kubernetes Reference</span>
         </div>
 
-        <h1>Kubernetes Quick Start</h1>
+        <h1>Kubernetes Reference</h1>
         <p class="docs-subtitle">
           Run the full Cloud Health Office platform on Docker Desktop Kubernetes &mdash; the same architecture, namespaces, services, and manifests used in production on Azure AKS. No Azure account needed.
         </p>

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
   <meta property="og:title" content="Kubernetes Quick Start — Cloud Health Office" />
-  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production. 36 microservices, MongoDB, Redis — identical to Azure AKS." />
+  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production. production-shaped microservices, MongoDB, Redis — identical to Azure AKS." />
 
   <script type="application/ld+json">
   {
@@ -77,8 +77,8 @@
             <div class="docs-sidebar-section-title">Getting Started</div>
             <ul>
               <li><a href="/docs">Docs Home</a></li>
-              <li><a href="/docs/quickstart">Quick Start (Docker)</a></li>
-              <li><a href="/docs/quickstart-kubernetes" class="active">Quick Start (Kubernetes)</a></li>
+              <li><a href="/docs/quickstart">Quick Start</a></li>
+              <li><a href="/docs/quickstart-kubernetes" class="active">Kubernetes Reference</a></li>
             </ul>
           </div>
           <div class="docs-sidebar-section">
@@ -143,8 +143,8 @@
         </p>
 
         <div class="callout callout-info">
-          <div class="callout-title">Docker Compose vs Kubernetes</div>
-          <p>The <a href="/docs/quickstart">Docker Compose Quick Start</a> is faster for API testing and claims adjudication. This guide gives you the <strong>full production-equivalent Kubernetes deployment</strong> &mdash; same namespace layout, DNS, secrets, ConfigMaps, and health probes as Azure AKS.</p>
+          <div class="callout-title">Quick Start vs Reference</div>
+          <p>The <a href="/docs/quickstart">primary Quick Start</a> is the shortest local Kubernetes path. This reference guide adds deeper troubleshooting, teardown, resource guidance, and common kubectl workflows for the same production-equivalent deployment.</p>
         </div>
 
         <!-- What You Get -->
@@ -155,7 +155,7 @@
             <tr><th>Component</th><th>Count</th><th>Notes</th></tr>
           </thead>
           <tbody>
-            <tr><td>Microservices</td><td>25</td><td>Claims, Members, Eligibility, Payments, FHIR, Appeals, Capitation, etc.</td></tr>
+            <tr><td>Microservices</td><td>30+</td><td>Claims, Members, Eligibility, Payments, FHIR, Appeals, Capitation, encounters, provider workflows, and supporting services.</td></tr>
             <tr><td>Portal</td><td>1</td><td>Blazor Server UI &mdash; same as <code>portal.cloudhealthoffice.com</code></td></tr>
             <tr><td>MongoDB</td><td>1</td><td>StatefulSet with persistent storage</td></tr>
             <tr><td>Redis</td><td>1</td><td>Data-protection key store and caching</td></tr>
@@ -184,7 +184,7 @@
 
         <div class="callout callout-warning">
           <div class="callout-title">Resource requirements</div>
-          <p>The full platform runs 25+ pods. Allocate at least <strong>4 CPU cores</strong> and <strong>8 GB memory</strong> in Docker Desktop (Settings &gt; Resources). First build pulls .NET 8 SDK + runtime images &mdash; budget ~8 GB disk for images.</p>
+          <p>The full platform runs 30+ pods. Allocate at least <strong>6 CPU cores</strong> and <strong>16 GB memory</strong>; <strong>24 GB</strong> is recommended in Docker Desktop (Settings &gt; Resources). First build pulls .NET 8 SDK + runtime images &mdash; budget ~8 GB disk for images.</p>
         </div>
 
         <!-- Step 1 -->
@@ -328,7 +328,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error</co
 
         <div class="callout callout-success">
           <div class="callout-title">You're running production-equivalent Kubernetes!</div>
-          <p>You now have the same 25-service microservices architecture running locally that powers <code>portal.cloudhealthoffice.com</code> in production. Same namespace, same DNS, same manifests, same health probes.</p>
+          <p>You now have the same production-shaped microservices architecture running locally that powers <code>portal.cloudhealthoffice.com</code> in production. Same namespace, same DNS, same manifests, same health probes.</p>
         </div>
 
         <!-- Production Comparison -->
@@ -424,8 +424,8 @@ docker volume prune -f</code></pre>
 
         <div class="docs-hub-grid" style="grid-template-columns: 1fr 1fr; margin-top: 20px;">
           <a href="/docs/quickstart" class="docs-hub-card">
-            <h3>Docker Compose Quick Start</h3>
-            <p>Faster alternative for API testing. Step-by-step claim adjudication with curl commands.</p>
+            <h3>Primary Quick Start</h3>
+            <p>Short path for deploying local Kubernetes and validating claims plus CRD discovery.</p>
             <span class="card-arrow">View guide &rarr;</span>
           </a>
           <a href="/docs/deployment" class="docs-hub-card">
@@ -449,7 +449,7 @@ docker volume prune -f</code></pre>
         <div class="docs-pager">
           <a href="/docs/quickstart">
             <div class="pager-label">&larr; Previous</div>
-            <div class="pager-title">Quick Start (Docker)</div>
+            <div class="pager-title">Quick Start</div>
           </a>
           <a href="/docs/deployment" class="next">
             <div class="pager-label">Next &rarr;</div>
@@ -473,8 +473,8 @@ docker volume prune -f</code></pre>
         <div class="footer-col">
           <h5>Documentation</h5>
           <ul>
-            <li><a href="/docs/quickstart">Quick Start (Docker)</a></li>
-            <li><a href="/docs/quickstart-kubernetes">Quick Start (Kubernetes)</a></li>
+            <li><a href="/docs/quickstart">Quick Start</a></li>
+            <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
             <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
             <li><a href="/docs/architecture">Architecture</a></li>
             <li><a href="/docs/fee-schedule-engine">Fee Schedule Engine</a></li>

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -4,21 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Quick Start — Cloud Health Office Documentation</title>
-  <meta name="description" content="Get Cloud Health Office running locally in under 15 minutes. Clone, start the Docker stack, submit a claim through full adjudication, and generate an 835 ERA — no Azure account needed." />
-  <meta name="keywords" content="Cloud Health Office quick start, healthcare payer platform setup, FHIR R4 quick start, X12 EDI local development, claims adjudication tutorial, CMS-0057-F getting started" />
+  <meta name="description" content="Get Cloud Health Office running locally on Kubernetes. Deploy the full platform, validate claims adjudication, and test CRD discovery with no Azure account needed." />
+  <meta name="keywords" content="Cloud Health Office quick start, Kubernetes local development, healthcare payer platform setup, FHIR R4 quick start, X12 EDI local development, claims adjudication tutorial, CMS-0057-F getting started" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/quickstart" />
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/quickstart" />
   <meta property="og:title" content="Quick Start — Cloud Health Office" />
-  <meta property="og:description" content="Get Cloud Health Office running locally in under 15 minutes. Full claims adjudication pipeline with no Azure account needed." />
+  <meta property="og:description" content="Get Cloud Health Office running locally on Kubernetes. Full platform deployment with claims adjudication and CRD discovery validation." />
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "headline": "Cloud Health Office Quick Start Guide",
-    "description": "Step-by-step guide to running Cloud Health Office locally with Docker. Submit a claim, run adjudication, generate an 835 ERA.",
+    "description": "Step-by-step guide to running Cloud Health Office locally on Kubernetes. Deploy the full platform, run adjudication, and verify CRD discovery.",
     "url": "https://cloudhealthoffice.com/docs/quickstart",
     "author": { "@type": "Organization", "name": "Aurelianware, Inc." },
     "publisher": { "@type": "Organization", "name": "Cloud Health Office", "url": "https://cloudhealthoffice.com" },
@@ -77,8 +77,8 @@
             <div class="docs-sidebar-section-title">Getting Started</div>
             <ul>
               <li><a href="/docs">Docs Home</a></li>
-              <li><a href="/docs/quickstart" class="active">Quick Start (Docker)</a></li>
-              <li><a href="/docs/quickstart-kubernetes">Quick Start (Kubernetes)</a></li>
+              <li><a href="/docs/quickstart" class="active">Quick Start</a></li>
+              <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
             </ul>
           </div>
           <div class="docs-sidebar-section">
@@ -92,13 +92,12 @@
             <div class="docs-sidebar-section-title">On This Page</div>
             <ul class="toc-sub">
               <li><a href="#prerequisites">Prerequisites</a></li>
-              <li><a href="#step-1">1. Clone &amp; Install</a></li>
-              <li><a href="#step-2">2. Start the Stack</a></li>
-              <li><a href="#step-3">3. Seed Data</a></li>
-              <li><a href="#step-4">4. Submit a Claim</a></li>
-              <li><a href="#step-5">5. Adjudicate</a></li>
-              <li><a href="#step-6">6. Payment &amp; 835 ERA</a></li>
-              <li><a href="#step-7">7. Verify FHIR APIs</a></li>
+              <li><a href="#step-1">1. Clone</a></li>
+              <li><a href="#step-2">2. Deploy Kubernetes</a></li>
+              <li><a href="#step-3">3. Port Forward</a></li>
+              <li><a href="#step-4">4. Validate Claims</a></li>
+              <li><a href="#step-5">5. Verify CRD</a></li>
+              <li><a href="#step-6">6. Check Health</a></li>
               <li><a href="#next-steps">Next Steps</a></li>
             </ul>
           </div>
@@ -141,7 +140,7 @@
 
         <h1>Quick Start</h1>
         <p class="docs-subtitle">
-          Run Cloud Health Office locally and take a claim all the way through adjudication, payment, and 835 ERA download — no Azure account needed. Total time: under 15 minutes.
+          Run the full Cloud Health Office platform locally on Kubernetes, then validate claims adjudication and Da Vinci CRD discovery — no Azure account needed.
         </p>
 
         <!-- Diagram -->
@@ -152,7 +151,7 @@
         <!-- What This Covers -->
         <div class="callout callout-success">
           <div class="callout-title">What you'll build</div>
-          <p>By the end of this guide you'll have a running local stack with MongoDB, Redis, and three core services — and you'll have submitted a claim through NCCI edit checking, fee schedule lookup, benefit calculation, cost-sharing, payment batching, and 835 ERA generation.</p>
+          <p>By the end of this guide you'll have the full service suite running in the <code>cloudhealthoffice</code> namespace with MongoDB, Redis, the portal, FHIR, claims, payment, enrollment, provider, and supporting services. You'll also run a claim through adjudication and verify CRD discovery.</p>
         </div>
 
         <!-- Prerequisites -->
@@ -163,226 +162,139 @@
             <tr><th>Tool</th><th>Version</th><th>Notes</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>Docker Desktop</code></td><td>4.x+</td><td>Must have Docker Compose v2</td></tr>
-            <tr><td><code>Node.js</code></td><td>18+</td><td>For CLI tooling</td></tr>
+            <tr><td><code>Docker Desktop</code></td><td>4.x+</td><td>Kubernetes enabled; 16 GB memory minimum, 24 GB recommended</td></tr>
+            <tr><td><code>kubectl</code></td><td>current</td><td>Bundled with Docker Desktop</td></tr>
+            <tr><td><code>bash</code></td><td>4+</td><td>macOS: <code>brew install bash</code></td></tr>
             <tr><td><code>curl</code></td><td>any</td><td>For API calls</td></tr>
             <tr><td><code>jq</code></td><td>any</td><td>Optional — for pretty JSON output</td></tr>
           </tbody>
         </table>
 
         <!-- Step 1 -->
-        <h2 id="step-1">1. Clone &amp; Install</h2>
+        <h2 id="step-1">1. Clone the Repository</h2>
 
         <div class="step">
           <span class="step-number">1</span>
           <div class="step-body">
-            <h3>Clone the repository and install dependencies</h3>
+            <h3>Clone the repository</h3>
 <pre><code><span class="code-comment"># Clone</span>
 git clone https://github.com/aurelianware/cloudhealthoffice.git
 cd cloudhealthoffice
 
-<span class="code-comment"># Install Node.js dependencies (for CLI tooling)</span>
-npm install</code></pre>
+<span class="code-comment"># Confirm Docker Desktop Kubernetes is selected</span>
+kubectl config current-context
+kubectl cluster-info</code></pre>
           </div>
         </div>
 
         <!-- Step 2 -->
-        <h2 id="step-2">2. Start the Stack</h2>
+        <h2 id="step-2">2. Deploy to Local Kubernetes</h2>
 
         <div class="step">
           <span class="step-number">2</span>
           <div class="step-body">
-            <h3>Launch all services with Docker Compose</h3>
-<pre><code>docker compose up -d</code></pre>
-            <p>This starts MongoDB (<code>localhost:27017</code>), Redis (<code>localhost:6379</code>), and three core services:</p>
+            <h3>Build images and deploy the platform</h3>
+<pre><code>./scripts/deploy-local.sh</code></pre>
+            <p>The script builds local images, creates the <code>cloudhealthoffice</code> namespace, deploys MongoDB and Redis, creates local secrets, applies service manifests, and waits for the core rollout. First run can take 15-30 minutes depending on Docker cache and CPU.</p>
+            <p>For repeat deploys after images are already built:</p>
+<pre><code>./scripts/deploy-local.sh --skip-build</code></pre>
+            <p>Verify the deployments:</p>
+<pre><code>kubectl get deployments -n cloudhealthoffice
+kubectl get pods -n cloudhealthoffice</code></pre>
+            <p>Every deployment should eventually show <code>1/1</code> ready. The main services used below are:</p>
             <table>
               <thead><tr><th>Service</th><th>URL</th></tr></thead>
               <tbody>
+                <tr><td>portal</td><td><code>http://localhost:8080</code></td></tr>
                 <tr><td>claims-service</td><td><code>http://localhost:5001</code></td></tr>
                 <tr><td>benefit-plan-service</td><td><code>http://localhost:5002</code></td></tr>
-                <tr><td>payment-service</td><td><code>http://localhost:5003</code></td></tr>
+                <tr><td>payment-service</td><td><code>http://localhost:5006</code></td></tr>
+                <tr><td>fhir-service</td><td><code>http://localhost:5080</code></td></tr>
               </tbody>
             </table>
-            <p>Wait about 45 seconds, then verify all services are healthy:</p>
-<pre><code>curl -s http://localhost:5001/health
-curl -s http://localhost:5002/health
-curl -s http://localhost:5003/health</code></pre>
-            <p>All should return <code>Healthy</code>.</p>
           </div>
         </div>
 
         <!-- Step 3 -->
-        <h2 id="step-3">3. Seed Reference Data</h2>
+        <h2 id="step-3">3. Open Local Access</h2>
 
         <div class="step">
           <span class="step-number green">3</span>
           <div class="step-body">
-            <h3>Set tenant ID and seed NCCI/MUE edits</h3>
-            <p>All requests require an <code>X-Tenant-ID</code> header. For local development, use any string:</p>
-<pre><code>TENANT="demo"
-
-<span class="code-comment"># Seed NCCI Q1 2025 baseline edits</span>
-curl -s -X POST http://localhost:5002/api/v1/ncci/seed \
-  -H "X-Tenant-ID: $TENANT" | jq .</code></pre>
-            <p>The response includes an <code>editCount</code> showing the number of NCCI pairs loaded.</p>
+            <h3>Port-forward the services used in the walkthrough</h3>
+            <p>Run these in separate terminals, or append <code>&amp;</code> to background them:</p>
+<pre><code>kubectl port-forward -n cloudhealthoffice svc/portal 8080:80
+kubectl port-forward -n cloudhealthoffice svc/claims-service 5001:80
+kubectl port-forward -n cloudhealthoffice svc/benefit-plan-service 5002:80
+kubectl port-forward -n cloudhealthoffice svc/payment-service 5006:80
+kubectl port-forward -n cloudhealthoffice svc/fhir-service 5080:80</code></pre>
+            <p>Open the portal at <a href="http://localhost:8080" target="_blank" rel="noopener noreferrer">http://localhost:8080</a>. API calls use the local seeded tenant header <code>X-Tenant-ID: demo</code>.</p>
           </div>
         </div>
 
         <!-- Step 4 -->
-        <h2 id="step-4">4. Create a Benefit Plan &amp; Submit a Claim</h2>
+        <h2 id="step-4">4. Validate the Claims Workflow</h2>
 
         <div class="step">
           <span class="step-number green">4</span>
           <div class="step-body">
-            <h3>Create a PPO plan with cost-sharing rules</h3>
-<pre><code>PLAN=$(curl -s -X POST http://localhost:5002/api/benefitplans \
-  -H "X-Tenant-ID: $TENANT" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "planId": "LOCAL-PPO-2025",
-    "planName": "Local Dev PPO 2025",
-    "payer": "Demo Health",
-    "effectiveDate": "2025-01-01T00:00:00Z",
-    "planType": "PPO",
-    "lineOfBusiness": "Commercial",
-    "costSharing": {
-      "individualDeductible": 1500.00,
-      "familyDeductible": 3000.00,
-      "individualOutOfPocketMax": 5000.00,
-      "familyOutOfPocketMax": 10000.00
-    },
-    "benefits": [
-      {
-        "serviceCategory": "98",
-        "description": "Professional Office Visit",
-        "inNetworkCopay": 30.00,
-        "deductibleApplies": false
-      },
-      {
-        "serviceCategory": "73",
-        "description": "Diagnostic Lab",
-        "inNetworkCoinsurance": 0.20,
-        "deductibleApplies": true
-      }
-    ]
-  }')
-
-PLAN_ID=$(echo $PLAN | jq -r '.id')
-echo "Plan ID: $PLAN_ID"</code></pre>
-
-            <h3>Submit an 837P-equivalent claim</h3>
-            <p>An office visit (CPT 99213) at POS 11 with a billed amount of $175:</p>
-<pre><code>CLAIM=$(curl -s -X POST http://localhost:5001/api/claims \
-  -H "X-Tenant-ID: $TENANT" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "claimNumber": "LOCAL-TEST-001",
-    "memberId": "MBR001",
-    "subscriberId": "SUB001",
-    "providerNpi": "1234567890",
-    "serviceDate": "2025-06-15T00:00:00Z",
-    "diagnosisCodes": ["Z00.00"],
-    "serviceLines": [{
-      "procedureCode": "99213",
-      "placeOfServiceCode": "11",
-      "billedAmount": 175.00,
-      "units": 1,
-      "diagnosisCodes": ["Z00.00"]
-    }],
-    "totalBilledAmount": 175.00,
-    "status": "Submitted"
-  }')
-
-CLAIM_ID=$(echo $CLAIM | jq -r '.id')
-echo "Claim ID: $CLAIM_ID"</code></pre>
+            <h3>Seed data, submit a claim, and run adjudication</h3>
+<pre><code>CLAIMS_URL=http://localhost:5001 \
+BENEFIT_URL=http://localhost:5002 \
+./scripts/seed-local.sh --tenant demo</code></pre>
+            <p>The script seeds NCCI edits, creates a local PPO benefit plan, submits a professional claim, runs adjudication, and updates the claim with the adjudication result. The summary prints the claim ID, allowed amount, plan payment, and member responsibility.</p>
           </div>
         </div>
 
         <!-- Step 5 -->
-        <h2 id="step-5">5. Adjudicate the Claim</h2>
+        <h2 id="step-5">5. Verify CRD Discovery</h2>
 
         <div class="step">
           <span class="step-number">5</span>
           <div class="step-body">
-            <h3>Run the full adjudication pipeline</h3>
-            <p>This calls the combined endpoint which runs NCCI/MUE edit check, fee schedule lookup, and benefit calculation in a single pass:</p>
-<pre><code>ADJ=$(curl -s -X POST http://localhost:5002/api/v1/adjudication/adjudicate \
-  -H "X-Tenant-ID: $TENANT" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"claimId\": \"$CLAIM_ID\",
-    \"memberId\": \"MBR001\",
-    \"planId\": \"LOCAL-PPO-2025\"
-  }")
-
-echo $ADJ | jq .</code></pre>
-
+            <h3>Call the Da Vinci CRD CDS Hooks discovery endpoint</h3>
+<pre><code>curl -s -H "X-Tenant-ID: demo" http://localhost:5080/cds-services | jq .</code></pre>
             <div class="callout callout-info">
-              <div class="callout-title">What happens during adjudication</div>
-              <p><strong>NCCI check:</strong> CPT 99213 has no NCCI conflicts — passes. <strong>Fee schedule:</strong> No local schedule seeded, falls back to billed charges ($175). <strong>Benefit calculation:</strong> POS 11 resolves to service type "98" (Professional Visit); $30 copay applies, deductible not consumed. <strong>Result:</strong> Allowed $175, plan pays $145, member owes $30 copay.</p>
+              <div class="callout-title">Expected result</div>
+              <p>The response should list the local CRD services, including <code>cho-order-select</code> and <code>cho-order-sign</code>. Browser testing needs a header extension or proxy that sends <code>X-Tenant-ID: demo</code>.</p>
             </div>
           </div>
         </div>
 
         <!-- Step 6 -->
-        <h2 id="step-6">6. Generate Payment &amp; 835 ERA</h2>
+        <h2 id="step-6">6. Check System Health</h2>
 
         <div class="step">
           <span class="step-number green">6</span>
           <div class="step-body">
-            <h3>Create a payment batch and download the X12 835</h3>
-<pre><code><span class="code-comment"># Create payment batch</span>
-BATCH=$(curl -s -X POST http://localhost:5003/api/v1/payment/batch \
-  -H "X-Tenant-ID: $TENANT" \
-  -H "Content-Type: application/json" \
-  -d '{ "batchDate": "2025-06-20T00:00:00Z" }')
+            <h3>Inspect rollouts and logs</h3>
+<pre><code>kubectl get deployments -n cloudhealthoffice
+kubectl get pods -n cloudhealthoffice
 
-BATCH_ID=$(echo $BATCH | jq -r '.batchId')
+<span class="code-comment"># Recent portal and claims logs</span>
+kubectl logs -n cloudhealthoffice -l app=portal --tail=50
+kubectl logs -n cloudhealthoffice -l app=claims-service --tail=50
 
-<span class="code-comment"># Download the 835 ERA file</span>
-curl -s "http://localhost:5003/api/v1/payment/era/$BATCH_ID" \
-  -H "X-Tenant-ID: $TENANT" -o era-835.edi
-
-cat era-835.edi</code></pre>
-            <p>The output is a valid X12 835 Electronic Remittance Advice file showing the claim payment details.</p>
-          </div>
-        </div>
-
-        <!-- Step 7 -->
-        <h2 id="step-7">7. Verify FHIR R4 APIs</h2>
-
-        <div class="step">
-          <span class="step-number green">7</span>
-          <div class="step-body">
-            <h3>Test the CMS-0057-F FHIR endpoints</h3>
-<pre><code><span class="code-comment"># FHIR CapabilityStatement</span>
-curl -s http://localhost:3000/fhir/r4/metadata | jq .resourceType
-
-<span class="code-comment"># Patient Access API — retrieve claims as FHIR resources</span>
-curl -s -H "Authorization: Bearer test-token" \
-  "http://localhost:3000/fhir/r4/Claim?patient=MBR001" | jq .
-
-<span class="code-comment"># Explanation of Benefits</span>
-curl -s -H "Authorization: Bearer test-token" \
-  "http://localhost:3000/fhir/r4/ExplanationOfBenefit?patient=MBR001" | jq .</code></pre>
+<span class="code-comment"># Find recent errors across services</span>
+kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error || true</code></pre>
           </div>
         </div>
 
         <div class="callout callout-success">
           <div class="callout-title">You're done!</div>
-          <p>You've just run a claim through the complete Cloud Health Office pipeline — NCCI edit checking, benefit calculation, cost-sharing, payment, 835 ERA generation, and FHIR R4 API verification. All locally, with synthetic data, in under 15 minutes.</p>
+          <p>You now have the production-shaped Cloud Health Office platform running locally in Kubernetes, with claims adjudication and CRD discovery validated against the seeded <code>demo</code> tenant.</p>
         </div>
 
         <!-- Next Steps -->
         <h2 id="next-steps">Next Steps</h2>
 
-        <p>Now that you have a running local stack, explore these areas:</p>
+        <p>Now that you have a running local Kubernetes platform, explore these areas:</p>
 
         <div class="docs-hub-grid" style="grid-template-columns: 1fr 1fr; margin-top: 20px;">
           <a href="/docs/quickstart-kubernetes" class="docs-hub-card">
-            <h3>Kubernetes Quick Start</h3>
-            <p>Deploy the full 25-service platform on Docker Desktop Kubernetes &mdash; identical to the production Azure AKS architecture.</p>
-            <span class="card-arrow">Kubernetes guide &rarr;</span>
+            <h3>Kubernetes Reference</h3>
+            <p>Review deeper troubleshooting, resource guidance, common kubectl tasks, and teardown commands.</p>
+            <span class="card-arrow">Reference guide &rarr;</span>
           </a>
           <a href="/docs/compliance" class="docs-hub-card">
             <h3>CMS-0057-F Compliance</h3>

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -194,10 +194,10 @@ kubectl cluster-info</code></pre>
           <span class="step-number">2</span>
           <div class="step-body">
             <h3>Build images and deploy the platform</h3>
-<pre><code>./scripts/deploy-local.sh</code></pre>
+<pre><code>bash ./scripts/deploy-local.sh</code></pre>
             <p>The script builds local images, creates the <code>cloudhealthoffice</code> namespace, deploys MongoDB and Redis, creates local secrets, applies service manifests, and waits for the core rollout. First run can take 15-30 minutes depending on Docker cache and CPU.</p>
             <p>For repeat deploys after images are already built:</p>
-<pre><code>./scripts/deploy-local.sh --skip-build</code></pre>
+<pre><code>bash ./scripts/deploy-local.sh --skip-build</code></pre>
             <p>Verify the deployments:</p>
 <pre><code>kubectl get deployments -n cloudhealthoffice
 kubectl get pods -n cloudhealthoffice</code></pre>

--- a/src/tools/mcc-runner/Program.cs
+++ b/src/tools/mcc-runner/Program.cs
@@ -31,15 +31,34 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
-// Build a scaled profile
-var scale = claimCount / 1_000_000.0;
+// Build a scaled profile. Counts are allocated with remainder handling so
+// smaller smoke-test runs generate exactly the requested claim count.
+var majorCounts = AllocateCounts(claimCount, new[]
+{
+    ("professional", 0.60),
+    ("institutional", 0.25),
+    ("dental", 0.10),
+    ("edge", 0.05)
+}).ToDictionary(x => x.Item, x => x.Count);
+
+var edgeCounts = AllocateCounts(majorCounts["edge"], new[]
+{
+    ("cob", 12.0 / 50.0),
+    ("retroEligibility", 8.0 / 50.0),
+    ("newborn", 6.0 / 50.0),
+    ("priorAuth", 8.0 / 50.0),
+    ("subrogation", 4.0 / 50.0),
+    ("behavioralHealth", 6.0 / 50.0),
+    ("medicaid", 6.0 / 50.0)
+}).ToDictionary(x => x.Item, x => x.Count);
+
 var profile = new CorpusProfile
 {
     TotalClaims = claimCount,
     Seed = seed,
     Professional = new ProfessionalDistribution
     {
-        Count = (int)(600_000 * scale),
+        Count = majorCounts["professional"],
         OfficeVisitFraction = 0.40,
         MultiLineProcedureFraction = 0.20,
         GlobalSurgeryFraction = 0.10,
@@ -50,7 +69,7 @@ var profile = new CorpusProfile
     },
     Institutional = new InstitutionalDistribution
     {
-        Count = (int)(250_000 * scale),
+        Count = majorCounts["institutional"],
         InpatientDrgFraction = 0.40,
         OutpatientPerDiemFraction = 0.25,
         EmergencyFraction = 0.15,
@@ -60,7 +79,7 @@ var profile = new CorpusProfile
     },
     Dental = new DentalDistribution
     {
-        Count = (int)(100_000 * scale),
+        Count = majorCounts["dental"],
         PreventiveFraction = 0.40,
         RestorativeFraction = 0.25,
         EndodonticsFraction = 0.10,
@@ -70,14 +89,14 @@ var profile = new CorpusProfile
     },
     EdgeCases = new EdgeCaseDistribution
     {
-        Count = (int)(50_000 * scale),
-        CobCount = (int)(12_000 * scale),
-        RetroEligibilityCount = (int)(8_000 * scale),
-        NewbornCount = (int)(6_000 * scale),
-        PriorAuthCount = (int)(8_000 * scale),
-        SubrogationCount = (int)(4_000 * scale),
-        BehavioralHealthCount = (int)(6_000 * scale),
-        MedicaidCount = (int)(6_000 * scale)
+        Count = majorCounts["edge"],
+        CobCount = edgeCounts["cob"],
+        RetroEligibilityCount = edgeCounts["retroEligibility"],
+        NewbornCount = edgeCounts["newborn"],
+        PriorAuthCount = edgeCounts["priorAuth"],
+        SubrogationCount = edgeCounts["subrogation"],
+        BehavioralHealthCount = edgeCounts["behavioralHealth"],
+        MedicaidCount = edgeCounts["medicaid"]
     }
 };
 
@@ -138,4 +157,44 @@ static void PrintUsage()
       mcc-runner -n 5000 -f fhir -o ./fhir   # 5K claims as FHIR bundles
       mcc-runner -n 1000 -s 123              # Custom seed
     """);
+}
+
+static IReadOnlyList<(T Item, int Count)> AllocateCounts<T>(int total, IReadOnlyList<(T Item, double Fraction)> weightedItems)
+{
+    if (total <= 0 || weightedItems.Count == 0)
+    {
+        return Array.Empty<(T, int)>();
+    }
+
+    var allocations = weightedItems
+        .Select(item =>
+        {
+            var exact = total * Math.Max(0, item.Fraction);
+            var floor = (int)Math.Floor(exact);
+            return new
+            {
+                item.Item,
+                Count = floor,
+                Remainder = exact - floor
+            };
+        })
+        .ToList();
+
+    var assigned = allocations.Sum(x => x.Count);
+    var remaining = total - assigned;
+    var counts = allocations.Select(x => x.Count).ToArray();
+
+    foreach (var index in allocations
+        .Select((value, index) => new { value.Remainder, index })
+        .OrderByDescending(x => x.Remainder)
+        .ThenBy(x => x.index)
+        .Take(Math.Max(0, remaining))
+        .Select(x => x.index))
+    {
+        counts[index]++;
+    }
+
+    return weightedItems
+        .Select((item, index) => (item.Item, counts[index]))
+        .ToList();
 }

--- a/src/tools/mcc-runner/Program.cs
+++ b/src/tools/mcc-runner/Program.cs
@@ -161,15 +161,33 @@ static void PrintUsage()
 
 static IReadOnlyList<(T Item, int Count)> AllocateCounts<T>(int total, IReadOnlyList<(T Item, double Fraction)> weightedItems)
 {
-    if (total <= 0 || weightedItems.Count == 0)
+    if (weightedItems.Count == 0)
     {
         return Array.Empty<(T, int)>();
     }
 
+    if (total <= 0)
+    {
+        return weightedItems
+            .Select(item => (item.Item, 0))
+            .ToList();
+    }
+
+    var weights = weightedItems
+        .Select(item => Math.Max(0, item.Fraction))
+        .ToArray();
+    var totalWeight = weights.Sum();
+
+    if (totalWeight <= 0)
+    {
+        Array.Fill(weights, 1.0);
+        totalWeight = weights.Length;
+    }
+
     var allocations = weightedItems
-        .Select(item =>
+        .Select((item, index) =>
         {
-            var exact = total * Math.Max(0, item.Fraction);
+            var exact = total * (weights[index] / totalWeight);
             var floor = (int)Math.Floor(exact);
             return new
             {

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/ClaimCorpusGeneratorAllocationTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/ClaimCorpusGeneratorAllocationTests.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
+
+namespace CloudHealthOffice.BenchmarkClaimGenerator.Tests;
+
+public class ClaimCorpusGeneratorAllocationTests
+{
+    [Fact]
+    public void AllocateCounts_WithZeroTotal_ReturnsZeroEntries()
+    {
+        var allocations = InvokeAllocateCounts(0, [("a", 0.6), ("b", 0.4)]);
+
+        Assert.Collection(allocations,
+            item =>
+            {
+                Assert.Equal("a", item.Item);
+                Assert.Equal(0, item.Count);
+            },
+            item =>
+            {
+                Assert.Equal("b", item.Item);
+                Assert.Equal(0, item.Count);
+            });
+    }
+
+    [Fact]
+    public void AllocateCounts_NormalizesWeights_AndPreservesRequestedTotal()
+    {
+        var allocations = InvokeAllocateCounts(5, [("a", 3.0), ("b", 1.0), ("c", 0.0)]);
+
+        Assert.Equal(5, allocations.Sum(item => item.Count));
+        Assert.Collection(allocations,
+            item =>
+            {
+                Assert.Equal("a", item.Item);
+                Assert.Equal(4, item.Count);
+            },
+            item =>
+            {
+                Assert.Equal("b", item.Item);
+                Assert.Equal(1, item.Count);
+            },
+            item =>
+            {
+                Assert.Equal("c", item.Item);
+                Assert.Equal(0, item.Count);
+            });
+    }
+
+    private static IReadOnlyList<(string Item, int Count)> InvokeAllocateCounts(
+        int total,
+        IReadOnlyList<(string Item, double Fraction)> weightedItems)
+    {
+        var method = typeof(ClaimCorpusGenerator)
+            .GetMethod("AllocateCounts", BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeof(string));
+
+        return (IReadOnlyList<(string Item, int Count)>)method.Invoke(
+            null,
+            [total, weightedItems])!;
+    }
+}


### PR DESCRIPTION
## Summary
- make the public quickstart Kubernetes-first for local validation
- update local docs resource guidance and navigation labels
- fix MCC corpus count allocation so small and odd-sized runs generate exactly the requested number of claims

## Validation
- npm run build
- dotnet build src/tools/mcc-runner/mcc-runner.csproj
- git diff --check