### PR TITLE
Link local Kubernetes field note from docs

### DIFF
--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -310,6 +310,15 @@
           </p>
         </div>
 
+        <div class="callout callout-success">
+          <div class="callout-title">From local Kubernetes to workflow proof</div>
+          <p>
+            We recently walked through the local Kubernetes path and used generated claims to validate real platform workflows end to end.
+            Read the field note:
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>.
+          </p>
+        </div>
+
         <!-- Why We Built It -->
         <h2 id="why-we-built-it">Why We Built It</h2>
 

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -154,6 +154,11 @@
           <p>By the end of this guide you'll have the full service suite running in the <code>cloudhealthoffice</code> namespace with MongoDB, Redis, the portal, FHIR, claims, payment, enrollment, provider, and supporting services. You'll also run a claim through adjudication and verify CRD discovery.</p>
         </div>
 
+        <div class="callout callout-info">
+          <div class="callout-title">Field note: local Kubernetes validation</div>
+          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for a practical look at deploying the platform locally, validating claim workflows, and using the Million Claim Challenge as the next proof point.</p>
+        </div>
+
         <!-- Prerequisites -->
         <h2 id="prerequisites">Prerequisites</h2>
 


### PR DESCRIPTION
## Summary
- link the Medium field note from the local Kubernetes Quick Start
- add a workflow-proof callout to the Million Claim Challenge docs

## Validation
- `npm run build` from `src/site`