### PR TITLE
Improve MCC local adjudication diagnostics

### DIFF
--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -99,6 +99,23 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     [Fact]
+    public async Task CheckAsync_VerificationServiceNumericEnums_NormalizesRatingAndStatus()
+    {
+        var providerHandler = FakeHttpMessageHandler.Json(
+            ProviderJson(score: null, rating: null, lastVerifiedAt: null));
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJsonRaw(compositeScore: 88, ratingToken: "1", statusToken: "1"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeTrue();
+        result.IntegrityScore.Should().Be(88);
+        result.Rating.Should().Be("Clear");
+        result.IsExcluded.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task CheckAsync_ProviderNotFound_FallsBackToVerificationService()
     {
         var providerHandler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
@@ -232,10 +249,13 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     private static string VerificationJson(int compositeScore, string rating, string status) =>
+        VerificationJsonRaw(compositeScore, $"\"{rating}\"", $"\"{status}\"");
+
+    private static string VerificationJsonRaw(int compositeScore, string ratingToken, string statusToken) =>
         "{" +
         $"\"CompositeScore\":{compositeScore}," +
-        $"\"Rating\":\"{rating}\"," +
-        $"\"Status\":\"{status}\"," +
+        $"\"Rating\":{ratingToken}," +
+        $"\"Status\":{statusToken}," +
         $"\"VerifiedAt\":\"{DateTimeOffset.UtcNow:O}\"" +
         "}";
 

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -365,7 +365,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var claimsServiceHealthUrl = builder.Configuration["Services:ClaimsServiceUrl"]
-    ?? "http://claims-service:8080";
+    ?? "http://claims-service";
 builder.Services.AddChoHealthChecks(options =>
 {
     options.MongoDbConnectionString  = builder.Configuration["MongoDb:ConnectionString"];

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -280,7 +280,7 @@ builder.Services.AddHttpClient<IOperatingModeProvider, HttpOperatingModeProvider
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:TenantServiceUrl"]
-        ?? "http://tenant-service:8080/");
+        ?? "http://tenant-service/");
     client.Timeout = TimeSpan.FromSeconds(5);
 });
 
@@ -303,14 +303,14 @@ builder.Services.AddHttpClient(HttpProviderIntegrityGate.ProviderServiceClientNa
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:ProviderServiceUrl"]
-        ?? "http://provider-service:8080/");
+        ?? "http://provider-service/");
     client.Timeout = TimeSpan.FromSeconds(5);
 });
 builder.Services.AddHttpClient(HttpProviderIntegrityGate.VerificationServiceClientName, client =>
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:ProviderVerificationServiceUrl"]
-        ?? "http://provider-verification-service:8080/");
+        ?? "http://provider-verification-service/");
     client.Timeout = TimeSpan.FromSeconds(10);
 });
 builder.Services.AddSingleton<IProviderIntegrityGate, HttpProviderIntegrityGate>();
@@ -350,7 +350,7 @@ builder.Services.AddHttpClient<ITerminologyCrosswalkClient, HttpTerminologyCross
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:TerminologyServiceUrl"]
-        ?? "http://terminology-service:8080/");
+        ?? "http://terminology-service/");
     client.Timeout = TimeSpan.FromSeconds(5);
 });
 

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -306,13 +306,18 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 
     private static string? NormalizeEnumValue(JsonElement value, IReadOnlyList<string> names)
     {
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            var s = value.GetString();
+            if (s is not null && names.Contains(s)) return s;
+            if (s is not null && int.TryParse(s, out var idx) && idx >= 0 && idx < names.Count) return names[idx];
+            return null;
+        }
         return value.ValueKind switch
         {
-            JsonValueKind.String => value.GetString(),
             JsonValueKind.Number when value.TryGetInt32(out var index) && index >= 0 && index < names.Count => names[index],
-            JsonValueKind.Number => value.GetRawText(),
             JsonValueKind.Null or JsonValueKind.Undefined => null,
-            _ => value.ToString()
+            _ => null
         };
     }
 

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using BenefitPlanService.Models;
 using CloudHealthOffice.Infrastructure.Observability;
 using Microsoft.Extensions.Caching.Memory;
@@ -222,12 +223,14 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             var record = await response.Content.ReadFromJsonAsync<IntegrityScoreResponse>(ct);
             if (record is null) return null;
 
-            var isExcluded = record.Status is "Excluded";
+            var rating = NormalizeRating(record.Rating) ?? "Unknown";
+            var status = NormalizeStatus(record.Status);
+            var isExcluded = status is "Excluded";
             return new ProviderIntegrityResult
             {
-                Passed = record.Status is not ("Excluded" or "Failed"),
+                Passed = status is not ("Excluded" or "Failed"),
                 IntegrityScore = record.CompositeScore,
-                Rating = record.Rating,
+                Rating = rating,
                 IsExcluded = isExcluded,
                 DenialCode = isExcluded ? "B7" : null,
                 DenialReason = isExcluded
@@ -295,6 +298,24 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
+    private static string? NormalizeRating(JsonElement value)
+        => NormalizeEnumValue(value, ["Unknown", "Clear", "Advisory", "Caution", "Alert", "Blocked"]);
+
+    private static string? NormalizeStatus(JsonElement value)
+        => NormalizeEnumValue(value, ["Pending", "Verified", "VerifiedWithWarnings", "Failed", "Excluded", "Expired", "ManualReviewRequired"]);
+
+    private static string? NormalizeEnumValue(JsonElement value, IReadOnlyList<string> names)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number when value.TryGetInt32(out var index) && index >= 0 && index < names.Count => names[index],
+            JsonValueKind.Number => value.GetRawText(),
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            _ => value.ToString()
+        };
+    }
+
     /// <summary>
     /// Subset of the <c>Provider</c> entity returned by
     /// <c>GET /api/v1/providers/npi/{npi}</c>. Only the integrity-projection
@@ -319,8 +340,8 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
     private sealed record IntegrityScoreResponse
     {
         public int CompositeScore { get; init; }
-        public string? Rating { get; init; }
-        public string? Status { get; init; }
+        public JsonElement Rating { get; init; }
+        public JsonElement Status { get; init; }
         public DateTimeOffset? VerifiedAt { get; init; }
     }
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -103,15 +103,33 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     JsonSerializerOptions json)
 {
     var sw = Stopwatch.StartNew();
+    var submitElapsed = TimeSpan.Zero;
+    var adjudicationElapsed = TimeSpan.Zero;
+    var updateElapsed = TimeSpan.Zero;
+    var failureStage = "unknown";
+
     try
     {
         var networkTier = NetworkTier(claim);
+        failureStage = "submit";
+        var stage = Stopwatch.StartNew();
         var submitted = await SubmitClaimAsync(http, options, claim, validationPlanId, json);
+        stage.Stop();
+        submitElapsed = stage.Elapsed;
+
+        failureStage = "adjudicate";
+        stage.Restart();
         var adjudicated = await AdjudicateClaimAsync(http, options, claim, submitted.Id, validationPlanId, networkTier, json);
+        stage.Stop();
+        adjudicationElapsed = stage.Elapsed;
 
         if (!options.SkipClaimUpdate)
         {
+            failureStage = "writeback";
+            stage.Restart();
             await UpdateClaimAdjudicationAsync(http, options, submitted.Id, networkTier, adjudicated, json);
+            stage.Stop();
+            updateElapsed = stage.Elapsed;
         }
 
         sw.Stop();
@@ -124,6 +142,10 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             adjudicated.Totals.PlanPayment,
             claim.ExpectedOutcome?.ExpectedPaidAmount,
             sw.Elapsed,
+            submitElapsed,
+            adjudicationElapsed,
+            updateElapsed,
+            null,
             null);
     }
     catch (Exception ex)
@@ -138,6 +160,10 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             null,
             claim.ExpectedOutcome?.ExpectedPaidAmount,
             sw.Elapsed,
+            submitElapsed,
+            adjudicationElapsed,
+            updateElapsed,
+            failureStage,
             ex.Message);
     }
 }
@@ -635,6 +661,9 @@ static void WriteSummary(List<ClaimValidationResult> results, TimeSpan elapsed)
     Console.WriteLine($"  Throughput:         {throughput:N2} claims/sec");
     Console.WriteLine($"  P95 latency:        {p95:N0} ms");
     Console.WriteLine($"  P99 latency:        {p99:N0} ms");
+    WriteStageTiming("Submit", results.Select(r => r.SubmitElapsed));
+    WriteStageTiming("Adjudicate", results.Select(r => r.AdjudicationElapsed));
+    WriteStageTiming("Writeback", results.Select(r => r.UpdateElapsed));
 
     var comparable = results
         .Where(r => r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue)
@@ -648,8 +677,24 @@ static void WriteSummary(List<ClaimValidationResult> results, TimeSpan elapsed)
 
     foreach (var failure in results.Where(r => !r.Success).Take(5))
     {
-        Console.WriteLine($"  Failure: {failure.GeneratedClaimId} {failure.Error}");
+        Console.WriteLine($"  Failure: {failure.GeneratedClaimId} [{failure.FailureStage}] {failure.Error}");
     }
+}
+
+static void WriteStageTiming(string label, IEnumerable<TimeSpan> durations)
+{
+    var values = durations
+        .Select(d => d.TotalMilliseconds)
+        .Where(ms => ms > 0)
+        .Order()
+        .ToArray();
+
+    if (values.Length == 0)
+    {
+        return;
+    }
+
+    Console.WriteLine($"  {label,-12} avg/p95: {values.Average():N0} ms / {Percentile(values, 0.95):N0} ms");
 }
 
 static double Percentile(double[] values, double percentile)
@@ -811,6 +856,10 @@ internal sealed record ClaimValidationResult(
     decimal? ActualPlanPayment,
     decimal? ExpectedPlanPayment,
     TimeSpan Elapsed,
+    TimeSpan SubmitElapsed,
+    TimeSpan AdjudicationElapsed,
+    TimeSpan UpdateElapsed,
+    string? FailureStage,
     string? Error);
 
 internal sealed record AdjudicationResponseDto(


### PR DESCRIPTION
## Summary
- add per-stage timing to the MCC platform validator for submit, adjudicate, and writeback latency
- fix benefit-plan-service local Kubernetes service defaults to use cluster service DNS on port 80 instead of unavailable :8080 endpoints
- tolerate numeric provider-verification rating/status enum values in the benefit-plan provider integrity gate
- add integrity-gate test coverage for numeric enum normalization

## Validation
- dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests/BenefitPlanService.Tests.csproj --filter HttpProviderIntegrityGateTests
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj
- git diff --check

## Notes
This removes the local Kubernetes latency caused by in-cluster service timeouts and makes the next MCC blocker visible: synthetic provider seed data still needs to produce clean provider integrity outcomes for happy-path processing.