### PR TITLE
Seed synthetic MCC providers and preserve tenant context

### DIFF
--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -51,7 +51,7 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     [Fact]
-    public async Task CheckAsync_WithTenantId_ForwardsTenantHeaderToProviderService()
+    public async Task CheckAsync_WithTenantId_ForwardsTenantHeaderToProviderAndVerificationService()
     {
         var providerHandler = new FakeHttpMessageHandler(request =>
         {
@@ -65,13 +65,25 @@ public sealed class HttpProviderIntegrityGateTests
                     "application/json"),
             };
         });
-        var verificationHandler = FakeHttpMessageHandler.Json("{}");
+        var verificationHandler = new FakeHttpMessageHandler(request =>
+        {
+            request.Headers.TryGetValues("X-Tenant-ID", out var values).Should().BeTrue();
+            values.Should().ContainSingle().Which.Should().Be("demo");
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    VerificationJson(compositeScore: 88, rating: "Clear", status: "Verified"),
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            };
+        });
         var gate = BuildGate(providerHandler, verificationHandler);
 
         await gate.CheckAsync(Npi, tenantId: "demo");
+        await gate.CheckAsync(Npi, tenantId: "demo", forceRefresh: true);
 
         providerHandler.RequestCount.Should().Be(1);
-        verificationHandler.RequestCount.Should().Be(0);
+        verificationHandler.RequestCount.Should().Be(1);
     }
 
     [Fact]

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -51,6 +51,30 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     [Fact]
+    public async Task CheckAsync_WithTenantId_ForwardsTenantHeaderToProviderService()
+    {
+        var providerHandler = new FakeHttpMessageHandler(request =>
+        {
+            request.Headers.TryGetValues("X-Tenant-ID", out var values).Should().BeTrue();
+            values.Should().ContainSingle().Which.Should().Be("demo");
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    ProviderJson(score: 92, rating: "Clear", lastVerifiedAt: DateTimeOffset.UtcNow),
+                    System.Text.Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+        var verificationHandler = FakeHttpMessageHandler.Json("{}");
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        await gate.CheckAsync(Npi, tenantId: "demo");
+
+        providerHandler.RequestCount.Should().Be(1);
+        verificationHandler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task CheckAsync_CacheHit_DoesNotIssueAnyHttpCalls()
     {
         var providerHandler = FakeHttpMessageHandler.Json(

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -290,7 +290,7 @@ public class AdjudicationController : ControllerBase
             claimType: claimTypeCode,
             memberId: request.MemberId))
         {
-            providerIntegrity = await _providerIntegrityGate.CheckAsync(request.ProviderNpi, ct: ct);
+            providerIntegrity = await _providerIntegrityGate.CheckAsync(request.ProviderNpi, TenantId, ct: ct);
 
             integritySpan?.SetTag("cho.integrity.passed", providerIntegrity.Passed);
             integritySpan?.SetTag("cho.integrity.score", providerIntegrity.IntegrityScore ?? -1);

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -67,6 +67,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 {
     public const string ProviderServiceClientName = "ProviderService";
     public const string VerificationServiceClientName = "ProviderVerificationService";
+    private const string TenantHeaderName = "X-Tenant-ID";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMemoryCache _cache;
@@ -89,15 +90,17 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 
     public async Task<ProviderIntegrityResult> CheckAsync(
         string npi,
+        string? tenantId = null,
         bool forceRefresh = false,
         CancellationToken ct = default)
     {
         // Cache key separates default vs force-refresh so a force-refresh
         // call's live-only result doesn't pollute the cached-or-live entry,
         // and vice-versa.
+        var cacheTenant = string.IsNullOrWhiteSpace(tenantId) ? "default" : tenantId.Trim();
         var cacheKey = forceRefresh
-            ? $"provider-integrity:force:{npi}"
-            : $"provider-integrity:cached-or-live:{npi}";
+            ? $"provider-integrity:force:{cacheTenant}:{npi}"
+            : $"provider-integrity:cached-or-live:{cacheTenant}:{npi}";
 
         if (_cache.TryGetValue<ProviderIntegrityResult>(cacheKey, out var cached) && cached is not null)
         {
@@ -118,7 +121,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 
         if (forceRefresh)
         {
-            var live = await CallVerificationServiceAsync(npi, ct);
+            var live = await CallVerificationServiceAsync(npi, tenantId, ct);
             isPassthrough = live is null;
             result = live ?? Passthrough();
             RecordDecision(IntegrityGatePath.LiveOnly, result.Rating);
@@ -126,14 +129,14 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         else
         {
             // Default path: try the cached projection first.
-            var projection = await TryReadProjectionAsync(npi, ct);
+            var projection = await TryReadProjectionAsync(npi, tenantId, ct);
 
             if (projection is null)
             {
                 // Provider not found in provider-service or transport
                 // failure — fall back to live verification rather than
                 // failing closed.
-                var live = await CallVerificationServiceAsync(npi, ct);
+                var live = await CallVerificationServiceAsync(npi, tenantId, ct);
                 isPassthrough = live is null;
                 result = live ?? Passthrough();
                 RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
@@ -142,13 +145,13 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             {
                 // Projection row exists but never refreshed — fall back to
                 // live and let the local cache absorb subsequent calls.
-                result = await CallVerificationServiceAsync(npi, ct)
+                result = await CallVerificationServiceAsync(npi, tenantId, ct)
                     ?? BuildResultFromProjection(projection);
                 RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
             }
             else if (IsStale(projection.LastVerifiedAt.Value))
             {
-                result = await CallVerificationServiceAsync(npi, ct)
+                result = await CallVerificationServiceAsync(npi, tenantId, ct)
                     ?? BuildResultFromProjection(projection);
                 RecordDecision(IntegrityGatePath.StaleFallback, result.Rating);
             }
@@ -170,14 +173,17 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         return DateTimeOffset.UtcNow - lastVerifiedAt > threshold;
     }
 
-    private async Task<ProviderProjection?> TryReadProjectionAsync(string npi, CancellationToken ct)
+    private async Task<ProviderProjection?> TryReadProjectionAsync(string npi, string? tenantId, CancellationToken ct)
     {
         try
         {
             var client = _httpClientFactory.CreateClient(ProviderServiceClientName);
             var encodedNpi = Uri.EscapeDataString(npi);
-            var response = await client.GetAsync(
-                $"api/v1/providers/npi/{encodedNpi}", ct);
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"api/v1/providers/npi/{encodedNpi}");
+            AddTenantHeader(request, tenantId);
+            var response = await client.SendAsync(request, ct);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 return null;
@@ -203,14 +209,18 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 
     private async Task<ProviderIntegrityResult?> CallVerificationServiceAsync(
         string npi,
+        string? tenantId,
         CancellationToken ct)
     {
         try
         {
             var client = _httpClientFactory.CreateClient(VerificationServiceClientName);
             var encodedNpi = Uri.EscapeDataString(npi);
-            var response = await client.GetAsync(
-                $"api/v1/providers/{encodedNpi}/integrity-score", ct);
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"api/v1/providers/{encodedNpi}/integrity-score");
+            AddTenantHeader(request, tenantId);
+            var response = await client.SendAsync(request, ct);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -303,6 +313,14 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
 
     private static string? NormalizeStatus(JsonElement value)
         => NormalizeEnumValue(value, ["Pending", "Verified", "VerifiedWithWarnings", "Failed", "Excluded", "Expired", "ManualReviewRequired"]);
+
+    private static void AddTenantHeader(HttpRequestMessage request, string? tenantId)
+    {
+        if (!string.IsNullOrWhiteSpace(tenantId))
+        {
+            request.Headers.TryAddWithoutValidation(TenantHeaderName, tenantId.Trim());
+        }
+    }
 
     private static string? NormalizeEnumValue(JsonElement value, IReadOnlyList<string> names)
     {

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -183,7 +183,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                 HttpMethod.Get,
                 $"api/v1/providers/npi/{encodedNpi}");
             AddTenantHeader(request, tenantId);
-            var response = await client.SendAsync(request, ct);
+            using var response = await client.SendAsync(request, ct);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 return null;
@@ -220,7 +220,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                 HttpMethod.Get,
                 $"api/v1/providers/{encodedNpi}/integrity-score");
             AddTenantHeader(request, tenantId);
-            var response = await client.SendAsync(request, ct);
+            using var response = await client.SendAsync(request, ct);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
@@ -25,8 +25,9 @@ public interface IProviderIntegrityGate
     /// </summary>
     /// <param name="npi">Provider NPI.</param>
     /// <param name="tenantId">
-    /// Tenant id to forward to provider-service when reading cached
-    /// provider integrity projections. Null preserves legacy behavior.
+    /// Tenant id to forward to provider-service and
+    /// provider-verification-service. When null, no tenant header is
+    /// forwarded.
     /// </param>
     /// <param name="forceRefresh">
     /// When <c>true</c> the cached-projection short-circuit is bypassed

--- a/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
@@ -24,6 +24,10 @@ public interface IProviderIntegrityGate
     /// Resolve the integrity result for <paramref name="npi"/>.
     /// </summary>
     /// <param name="npi">Provider NPI.</param>
+    /// <param name="tenantId">
+    /// Tenant id to forward to provider-service when reading cached
+    /// provider integrity projections. Null preserves legacy behavior.
+    /// </param>
     /// <param name="forceRefresh">
     /// When <c>true</c> the cached-projection short-circuit is bypassed
     /// and the gate calls <c>provider-verification-service</c> directly.
@@ -33,6 +37,7 @@ public interface IProviderIntegrityGate
     /// <param name="ct">Cancellation token.</param>
     Task<ProviderIntegrityResult> CheckAsync(
         string npi,
+        string? tenantId = null,
         bool forceRefresh = false,
         CancellationToken ct = default);
 }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -33,6 +33,7 @@ Console.WriteLine("Million Claim Challenge - Platform Validator");
 Console.WriteLine($"  Tenant:      {options.TenantId}");
 Console.WriteLine($"  Claims URL:  {options.ClaimsUrl}");
 Console.WriteLine($"  Benefit URL: {options.BenefitUrl}");
+Console.WriteLine($"  Provider URL:{options.ProviderUrl}");
 Console.WriteLine($"  Claims:      {options.Claims:N0}");
 Console.WriteLine($"  Seed:        {options.Seed}");
 Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
@@ -40,6 +41,10 @@ Console.WriteLine();
 
 await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
 await RequireHealthyAsync(http, $"{options.BenefitUrl}/health", "benefit-plan-service");
+if (options.SeedProviders)
+{
+    await RequireHealthyAsync(http, $"{options.ProviderUrl}/health", "provider-service");
+}
 
 await SeedNcciAsync(http, options, json);
 
@@ -48,6 +53,11 @@ await CreateValidationPlanAsync(http, options, validationPlanId, json);
 
 var claims = await GenerateClaimsAsync(options.Claims, options.Seed);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
+
+if (options.SeedProviders)
+{
+    await SeedProvidersAsync(http, options, claims, validationPlanId, json);
+}
 
 var results = new ConcurrentBag<ClaimValidationResult>();
 var total = Stopwatch.StartNew();
@@ -285,6 +295,134 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(int claimCount, int 
     NormalizeClaimDates(claims, seed);
     return claims;
 }
+
+static async Task SeedProvidersAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    IReadOnlyCollection<SyntheticClaim> claims,
+    Guid validationPlanId,
+    JsonSerializerOptions json)
+{
+    var providers = claims
+        .SelectMany(claim => new[] { claim.RenderingProvider, claim.BillingProvider })
+        .Where(provider => !string.IsNullOrWhiteSpace(provider.Npi))
+        .GroupBy(provider => provider.Npi, StringComparer.Ordinal)
+        .Select(group => group.First())
+        .OrderBy(provider => provider.Npi, StringComparer.Ordinal)
+        .ToList();
+
+    var created = 0;
+    var existing = 0;
+
+    foreach (var provider in providers)
+    {
+        if (await ProviderExistsAsync(http, options, provider.Npi))
+        {
+            existing++;
+            continue;
+        }
+
+        await CreateProviderAsync(http, options, provider, validationPlanId, json);
+        created++;
+    }
+
+    Console.WriteLine($"seeded: {created:N0} synthetic providers ({existing:N0} already present)");
+}
+
+static async Task<bool> ProviderExistsAsync(HttpClient http, ValidatorOptions options, string npi)
+{
+    using var response = await http.GetAsync($"{options.ProviderUrl}/api/v1/providers/npi/{Uri.EscapeDataString(npi)}");
+    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+    {
+        return false;
+    }
+
+    if (response.IsSuccessStatusCode)
+    {
+        return true;
+    }
+
+    var body = await response.Content.ReadAsStringAsync();
+    throw new InvalidOperationException($"provider lookup failed ({npi}): {(int)response.StatusCode} {body}");
+}
+
+static async Task CreateProviderAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    SyntheticProvider provider,
+    Guid validationPlanId,
+    JsonSerializerOptions json)
+{
+    var isOrganization = provider.ProviderType.Equals("Organization", StringComparison.OrdinalIgnoreCase);
+    var effectiveDate = DateTime.SpecifyKind(provider.EffectiveDate == default
+        ? DateTime.UtcNow.Date.AddYears(-2)
+        : provider.EffectiveDate.Date, DateTimeKind.Utc);
+    var now = DateTimeOffset.UtcNow;
+
+    var payload = new
+    {
+        tenantId = options.TenantId,
+        npi = provider.Npi,
+        providerType = isOrganization ? "organization" : "individual",
+        taxId = provider.TaxId,
+        firstName = isOrganization ? null : NullIfWhiteSpace(provider.FirstName) ?? "MCC",
+        lastName = isOrganization ? null : NullIfWhiteSpace(provider.LastName) ?? "Provider",
+        organizationName = isOrganization ? NullIfWhiteSpace(provider.OrganizationName) ?? provider.FullName : null,
+        credentials = isOrganization ? null : NullIfWhiteSpace(provider.Credentials) ?? "MD",
+        primarySpecialty = NullIfWhiteSpace(provider.SpecialtyDescription) ?? provider.TaxonomyCode,
+        taxonomyCode = provider.TaxonomyCode,
+        address = provider.Address,
+        city = provider.City,
+        state = provider.State,
+        zipCode = provider.ZipCode,
+        phone = NullIfWhiteSpace(provider.Phone) ?? "555-0100",
+        email = NullIfWhiteSpace(provider.Email),
+        credentialingStatus = "approved",
+        credentialingDate = effectiveDate,
+        recredentialingDueDate = now.UtcDateTime.AddYears(2),
+        acceptingNewPatients = provider.AcceptingNewPatients,
+        status = "active",
+        integrityScore = 96,
+        integrityRating = "Clear",
+        lastVerifiedAt = now,
+        nextVerificationDue = now.AddDays(30),
+        networkParticipations = new[]
+        {
+            new
+            {
+                planId = validationPlanId.ToString(),
+                networkId = provider.IsParticipating ? "mcc-local-network" : "mcc-local-out-network",
+                lineOfBusiness = "commercial",
+                networkTier = provider.IsParticipating ? "InNetwork" : "OutOfNetwork",
+                effectiveDate,
+                terminationDate = provider.TermDate,
+                acceptingNewPatients = provider.AcceptingNewPatients,
+                panelLimit = 2500,
+                panelAccepted = provider.AcceptingNewPatients,
+                acceptedLobs = new[] { "commercial" },
+                minAcceptedAgeYears = (int?)null,
+                maxAcceptedAgeYears = (int?)null,
+                rates = new
+                {
+                    feeScheduleName = provider.FeeScheduleId ?? "MCC Local Fee Schedule",
+                    percentOfMedicare = provider.IsParticipating ? 1.10m : 0.80m,
+                    pmpm = (decimal?)null,
+                    caseRate = (decimal?)null
+                }
+            }
+        }
+    };
+
+    using var response = await http.PostAsJsonAsync($"{options.ProviderUrl}/api/v1/providers", payload, json);
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException($"provider seed failed ({provider.Npi}): {(int)response.StatusCode} {body}");
+    }
+}
+
+static string? NullIfWhiteSpace(string? value)
+    => string.IsNullOrWhiteSpace(value) ? null : value;
 
 static void NormalizeClaimDates(List<SyntheticClaim> claims, int seed)
 {
@@ -722,6 +860,8 @@ static void PrintUsage()
       --tenant <tenant-id>       Tenant header to use (default: demo)
       --claims-url <url>         Claims service URL (default: http://localhost:5001)
       --benefit-url <url>        Benefit plan service URL (default: http://localhost:5002)
+      --provider-url <url>       Provider service URL (default: http://localhost:5004)
+      --no-seed-providers        Skip synthetic provider seeding
       --skip-claim-update        Do not write adjudication projection back to claims-service
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 25)
@@ -756,6 +896,8 @@ internal sealed record ValidatorOptions(
     string TenantId,
     string ClaimsUrl,
     string BenefitUrl,
+    string ProviderUrl,
+    bool SeedProviders,
     bool SkipClaimUpdate,
     int TimeoutSeconds,
     int ProgressEvery,
@@ -786,6 +928,12 @@ internal sealed record ValidatorOptions(
                     break;
                 case "--benefit-url" when i + 1 < args.Length:
                     options.BenefitUrl = args[++i].TrimEnd('/');
+                    break;
+                case "--provider-url" when i + 1 < args.Length:
+                    options.ProviderUrl = args[++i].TrimEnd('/');
+                    break;
+                case "--no-seed-providers":
+                    options.SeedProviders = false;
                     break;
                 case "--skip-claim-update":
                     options.SkipClaimUpdate = true;
@@ -823,6 +971,8 @@ internal sealed record ValidatorOptions(
             options.TenantId,
             options.ClaimsUrl.TrimEnd('/'),
             options.BenefitUrl.TrimEnd('/'),
+            options.ProviderUrl.TrimEnd('/'),
+            options.SeedProviders,
             options.SkipClaimUpdate,
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
@@ -837,6 +987,8 @@ internal sealed record ValidatorOptions(
         public string TenantId { get; set; } = "demo";
         public string ClaimsUrl { get; set; } = "http://localhost:5001";
         public string BenefitUrl { get; set; } = "http://localhost:5002";
+        public string ProviderUrl { get; set; } = "http://localhost:5004";
+        public bool SeedProviders { get; set; } = true;
         public bool SkipClaimUpdate { get; set; }
         public int TimeoutSeconds { get; set; } = 60;
         public int ProgressEvery { get; set; } = 10;


### PR DESCRIPTION
## Summary
- seed synthetic providers used by the MCC validator into provider-service before claim processing
- add provider-service configuration to the validator with --provider-url and --no-seed-providers
- write clean cached integrity projections for generated providers so MCC validates the provider-integrity workflow deterministically
- pass the resolved tenant id from benefit-plan-service adjudication into the provider integrity gate
- forward X-Tenant-ID from the integrity gate to provider-service/provider-verification-service and scope cache keys by tenant
- add regression coverage for tenant header forwarding

## Validation
- dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests/BenefitPlanService.Tests.csproj --filter HttpProviderIntegrityGateTests — 12 passed
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj — passed
- git diff --check — clean

## Local Kubernetes Runs
- 3 claims, parallelism 2: 0 failures
- 25 claims, parallelism 4: 0 failures, 38.00 claims/sec, p95 200 ms
- 100 claims, parallelism 4: 0 failures, 30.95 claims/sec, p95 295 ms
- 1,000 claims, parallelism 8: 997 processed, 55.74 claims/sec, p95 214 ms; 3 remaining failures were expected NCCI/MUE business-rule denials, not provider-verification or service failures

## Follow-up
Next PR should classify expected business denials separately from platform failures so MCC can distinguish workflow-valid denials from infrastructure defects.