### PR TITLE
Link MCC Part 2 field note from docs

### DIFF
--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -313,9 +313,11 @@
         <div class="callout callout-success">
           <div class="callout-title">From local Kubernetes to workflow proof</div>
           <p>
-            We recently walked through the local Kubernetes path and used generated claims to validate real platform workflows end to end.
-            Read the field note:
-            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>.
+            We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, and stage-level timing.
+            Read the field notes:
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: validating real workflows</a>
+            and
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: from it runs to it measures</a>.
           </p>
         </div>
 

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -315,9 +315,9 @@
           <p>
             We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, and stage-level timing.
             Read the field notes:
-            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: validating real workflows</a>
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>
             and
-            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: from it runs to it measures</a>.
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>.
           </p>
         </div>
 

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -156,7 +156,7 @@
 
         <div class="callout callout-info">
           <div class="callout-title">Field note: local Kubernetes validation</div>
-          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for a practical look at deploying the platform locally, validating claim workflows, and using the Million Claim Challenge as the next proof point.</p>
+          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for the initial local deployment path, then <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a> for the provider verification, tenant context, and MCC timing work that followed.</p>
         </div>
 
         <!-- Prerequisites -->

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -156,7 +156,7 @@
 
         <div class="callout callout-info">
           <div class="callout-title">Field note: local Kubernetes validation</div>
-          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for the initial local deployment path, then <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a> for the provider verification, tenant context, and MCC timing work that followed.</p>
+          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for the initial local deployment path, then <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a> for the provider verification, tenant context, and Million Claim Challenge (MCC) timing work that followed.</p>
         </div>
 
         <!-- Prerequisites -->


### PR DESCRIPTION
## Summary
- link the newly published MCC Part 2 Medium field note from the local Kubernetes Quick Start
- update the Million Claim Challenge docs callout to reference both Part 1 and Part 2

## Validation
- npm run build from src/site
- git diff --check