### PR TITLE
Speed up local MCC adjudication runs

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -20,6 +20,7 @@ NAMESPACE="cloudhealthoffice"
 IMAGE_PREFIX="cloudhealthoffice"
 KIND_CLUSTER_NAME=""
 LOCAL_DOTNET_REGISTRY="${LOCAL_DOTNET_REGISTRY:-mcr.microsoft.com}"
+LOCAL_CLAIMS_REPLICAS="${LOCAL_CLAIMS_REPLICAS:-2}"
 LOCAL_BENEFIT_PLAN_REPLICAS="${LOCAL_BENEFIT_PLAN_REPLICAS:-3}"
 
 # Defaults — overridden by .env.local if present
@@ -442,6 +443,7 @@ for dep in attachment-service fhir-service reference-data-service; do
     >/dev/null 2>&1 || true
 done
 kubectl scale deployment --all -n "$NAMESPACE" --replicas=1 >/dev/null 2>&1 || true
+kubectl scale deployment/claims-service -n "$NAMESPACE" --replicas="$LOCAL_CLAIMS_REPLICAS" >/dev/null 2>&1 || true
 kubectl scale deployment/benefit-plan-service -n "$NAMESPACE" --replicas="$LOCAL_BENEFIT_PLAN_REPLICAS" >/dev/null 2>&1 || true
 kubectl delete hpa --all -n "$NAMESPACE" >/dev/null 2>&1 || true
 

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -20,6 +20,7 @@ NAMESPACE="cloudhealthoffice"
 IMAGE_PREFIX="cloudhealthoffice"
 KIND_CLUSTER_NAME=""
 LOCAL_DOTNET_REGISTRY="${LOCAL_DOTNET_REGISTRY:-mcr.microsoft.com}"
+LOCAL_BENEFIT_PLAN_REPLICAS="${LOCAL_BENEFIT_PLAN_REPLICAS:-3}"
 
 # Defaults — overridden by .env.local if present
 MONGO_USER="admin"
@@ -441,6 +442,7 @@ for dep in attachment-service fhir-service reference-data-service; do
     >/dev/null 2>&1 || true
 done
 kubectl scale deployment --all -n "$NAMESPACE" --replicas=1 >/dev/null 2>&1 || true
+kubectl scale deployment/benefit-plan-service -n "$NAMESPACE" --replicas="$LOCAL_BENEFIT_PLAN_REPLICAS" >/dev/null 2>&1 || true
 kubectl delete hpa --all -n "$NAMESPACE" >/dev/null 2>&1 || true
 
 # ── Deploy portal ─────────────────────────────────────────────────────────────

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/ChoBenefitPlanProviderModelMappingTests.cs
@@ -4,7 +4,9 @@ using BenefitPlanService.Repositories;
 using BenefitPlanService.Services;
 using BenefitPlanService.Tests.Fakes;
 using CloudHealthOffice.BenefitEngine.Services;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using BenefitRulePredicate = CloudHealthOffice.BenefitEngine.Domain.BenefitRulePredicate;
 using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
 using ModelFamilyAccumulatorModel = BenefitPlanService.Models.FamilyAccumulatorModel;
@@ -29,6 +31,7 @@ public sealed class ChoBenefitPlanProviderModelMappingTests
             new StubTenantContext("tenant-a"),
             limits,
             new PlanYearResolver(),
+            new MemoryCache(Options.Create(new MemoryCacheOptions())),
             NullLogger<ChoBenefitPlanProvider>.Instance);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpTerminologyCrosswalkClientTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpTerminologyCrosswalkClientTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using BenefitPlanService.Services;
+using BenefitPlanService.Tests.Adapters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace BenefitPlanService.Tests.Services;
+
+/// <summary>
+/// Verifies the caching and fallback contract of
+/// <see cref="HttpTerminologyCrosswalkClient"/>:
+/// <list type="bullet">
+///   <item>Cache-hit short-circuiting: a second identical batch issues no HTTP call.</item>
+///   <item>Mixed hit/miss ordering: partial cache hits preserve per-line result shape and order.</item>
+///   <item>Failure fallback: non-2xx and transport failures return original codes unchanged.</item>
+/// </list>
+/// </summary>
+public sealed class HttpTerminologyCrosswalkClientTests
+{
+    private const string TenantId = "demo";
+
+    private static readonly CodeCrosswalkRequest CptLine1 = new()
+    {
+        LineNumber = 1, ProcedureCode = "99213", CodeType = "CPT"
+    };
+
+    private static readonly CodeCrosswalkRequest HcpcsLine2 = new()
+    {
+        LineNumber = 2, ProcedureCode = "G0001", CodeType = "HCPCS"
+    };
+
+    [Fact]
+    public async Task TranslateBatchAsync_AllCacheHits_NoHttpCallsIssued()
+    {
+        var handler = FakeHttpMessageHandler.Json(BatchTranslateJson("G9999", mapVersionId: "v1"));
+        var client = BuildClient(handler);
+
+        // First call — populates the cache
+        await client.TranslateBatchAsync(TenantId, [CptLine1]);
+
+        // Second call — all entries already cached
+        var result = await client.TranslateBatchAsync(TenantId, [CptLine1]);
+
+        handler.RequestCount.Should().Be(1,
+            "second call is a full cache hit and must not issue an HTTP request");
+        result.Should().ContainSingle()
+            .Which.ResolvedCode.Should().Be("G9999");
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_MixedHitMiss_PreservesResultOrder()
+    {
+        var cache = NewCache();
+
+        // Warm cache for line 1
+        var warmHandler = FakeHttpMessageHandler.Json(BatchTranslateJson("G9999", mapVersionId: "v1"));
+        await BuildClient(warmHandler, cache).TranslateBatchAsync(TenantId, [CptLine1]);
+        warmHandler.RequestCount.Should().Be(1);
+
+        // Second call: line 1 is a hit, line 2 is a miss
+        var missHandler = FakeHttpMessageHandler.Json(BatchTranslateJson("G0002", mapVersionId: "v2"));
+        var results = await BuildClient(missHandler, cache)
+            .TranslateBatchAsync(TenantId, [CptLine1, HcpcsLine2]);
+
+        missHandler.RequestCount.Should().Be(1,
+            "only the miss (line 2) should trigger an HTTP call");
+        results.Should().HaveCount(2);
+        results[0].LineNumber.Should().Be(1);
+        results[0].ResolvedCode.Should().Be("G9999", "line 1 served from cache");
+        results[0].WasTranslated.Should().BeTrue();
+        results[1].LineNumber.Should().Be(2);
+        results[1].ResolvedCode.Should().Be("G0002", "line 2 from HTTP response");
+        results[1].WasTranslated.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_NonSuccessResponse_ReturnsOriginalCodes()
+    {
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.ServiceUnavailable);
+        var client = BuildClient(handler);
+
+        var results = await client.TranslateBatchAsync(TenantId, [CptLine1, HcpcsLine2]);
+
+        results.Should().HaveCount(2);
+        results[0].ResolvedCode.Should().Be(CptLine1.ProcedureCode);
+        results[0].WasTranslated.Should().BeFalse();
+        results[1].ResolvedCode.Should().Be(HcpcsLine2.ProcedureCode);
+        results[1].WasTranslated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_TransportFailure_ReturnsOriginalCodes()
+    {
+        var handler = FakeHttpMessageHandler.Throw(new HttpRequestException("connection refused"));
+        var client = BuildClient(handler);
+
+        var results = await client.TranslateBatchAsync(TenantId, [CptLine1, HcpcsLine2]);
+
+        results.Should().HaveCount(2);
+        results[0].ResolvedCode.Should().Be(CptLine1.ProcedureCode);
+        results[0].WasTranslated.Should().BeFalse();
+        results[1].ResolvedCode.Should().Be(HcpcsLine2.ProcedureCode);
+        results[1].WasTranslated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TranslateBatchAsync_FailurePassthrough_LineNumbers_ArePreserved()
+    {
+        // Verifies that the passthrough path preserves per-line metadata so that
+        // adjudication can correlate results back to the original claim lines.
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.InternalServerError);
+        var client = BuildClient(handler);
+
+        var results = await client.TranslateBatchAsync(TenantId, [CptLine1, HcpcsLine2]);
+
+        results[0].LineNumber.Should().Be(CptLine1.LineNumber);
+        results[0].OriginalCode.Should().Be(CptLine1.ProcedureCode);
+        results[1].LineNumber.Should().Be(HcpcsLine2.LineNumber);
+        results[1].OriginalCode.Should().Be(HcpcsLine2.ProcedureCode);
+    }
+
+    private static HttpTerminologyCrosswalkClient BuildClient(
+        HttpMessageHandler handler, IMemoryCache? cache = null)
+    {
+        var httpClient = new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("http://terminology-service/")
+        };
+        return new HttpTerminologyCrosswalkClient(
+            httpClient,
+            cache ?? NewCache(),
+            NullLogger<HttpTerminologyCrosswalkClient>.Instance);
+    }
+
+    private static IMemoryCache NewCache()
+        => new MemoryCache(Options.Create(new MemoryCacheOptions()));
+
+    /// <summary>
+    /// Builds a single-element batch-translate JSON response array with one match.
+    /// </summary>
+    private static string BatchTranslateJson(string code, string mapVersionId)
+        => $"[{{\"result\":true,\"mapVersionId\":\"{mapVersionId}\","
+         + $"\"matches\":[{{\"concept\":{{\"code\":\"{code}\"}}}}]}}]";
+}

--- a/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
+++ b/src/services/benefit-plan-service/Services/ChoBenefitPlanProvider.cs
@@ -7,6 +7,7 @@ using EnginePlanType = CloudHealthOffice.BenefitEngine.Domain.PlanType;
 using ModelPlanType = BenefitPlanService.Models.PlanType;
 using EngineFamilyAccumulatorModel = CloudHealthOffice.BenefitEngine.Domain.FamilyAccumulatorModel;
 using ModelFamilyAccumulatorModel = BenefitPlanService.Models.FamilyAccumulatorModel;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace BenefitPlanService.Services;
 
@@ -16,6 +17,12 @@ namespace BenefitPlanService.Services;
 /// </summary>
 public class ChoBenefitPlanProvider : IBenefitPlanProvider
 {
+    private static readonly MemoryCacheEntryOptions CacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+        SlidingExpiration = TimeSpan.FromMinutes(2)
+    };
+
     /// <summary>
     /// Cutoff that distinguishes legacy plans (hydrate with
     /// <c>IsAcaCapEnforced=false</c>) from post-5.7 publishes (which set
@@ -32,6 +39,7 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
     private readonly IBenefitEngineTenantContext _tenantContext;
     private readonly IAcaLimitsProvider _acaLimits;
     private readonly IPlanYearResolver _planYear;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<ChoBenefitPlanProvider> _logger;
 
     public ChoBenefitPlanProvider(
@@ -39,22 +47,32 @@ public class ChoBenefitPlanProvider : IBenefitPlanProvider
         IBenefitEngineTenantContext tenantContext,
         IAcaLimitsProvider acaLimits,
         IPlanYearResolver planYear,
+        IMemoryCache cache,
         ILogger<ChoBenefitPlanProvider> logger)
     {
         _repo = repo;
         _tenantContext = tenantContext;
         _acaLimits = acaLimits;
         _planYear = planYear;
+        _cache = cache;
         _logger = logger;
     }
 
     public async Task<BenefitPlanConfig?> GetPlanAsync(Guid benefitPlanId, CancellationToken ct = default)
     {
+        var cacheKey = $"benefit-plan-config:{_tenantContext.TenantId}:{benefitPlanId:N}";
+        if (_cache.TryGetValue<BenefitPlanConfig>(cacheKey, out var cached) && cached is not null)
+        {
+            return cached;
+        }
+
         var plan = await _repo.GetByIdAsync(benefitPlanId.ToString(), _tenantContext.TenantId);
         if (plan is null)
             return null;
 
-        return MapToConfig(plan);
+        var config = MapToConfig(plan);
+        _cache.Set(cacheKey, config, CacheOptions);
+        return config;
     }
 
     internal BenefitPlanConfig MapToConfig(BenefitPlan plan)

--- a/src/services/benefit-plan-service/Services/HttpTerminologyCrosswalkClient.cs
+++ b/src/services/benefit-plan-service/Services/HttpTerminologyCrosswalkClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace BenefitPlanService.Services;
 
@@ -13,7 +14,15 @@ namespace BenefitPlanService.Services;
 /// </summary>
 public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
 {
+    private static readonly MemoryCacheEntryOptions CacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
+        SlidingExpiration = TimeSpan.FromMinutes(10),
+        Size = 1
+    };
+
     private readonly HttpClient _httpClient;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<HttpTerminologyCrosswalkClient> _logger;
 
     // Canonical system URIs matching TerminologyController constants
@@ -23,9 +32,11 @@ public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
 
     public HttpTerminologyCrosswalkClient(
         HttpClient httpClient,
+        IMemoryCache cache,
         ILogger<HttpTerminologyCrosswalkClient> logger)
     {
         _httpClient = httpClient;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -37,12 +48,33 @@ public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
         if (requests.Count == 0)
             return [];
 
+        var results = new CodeCrosswalkResult?[requests.Count];
+        var misses = new List<(int Index, CodeCrosswalkRequest Request)>();
+        for (var i = 0; i < requests.Count; i++)
+        {
+            var request = requests[i];
+            if (_cache.TryGetValue<CachedCrosswalkResult>(CacheKey(tenantId, request), out var cached)
+                && cached is not null)
+            {
+                results[i] = ToResult(request, cached);
+            }
+            else
+            {
+                misses.Add((i, request));
+            }
+        }
+
+        if (misses.Count == 0)
+        {
+            return results.Select(r => r!).ToList();
+        }
+
         try
         {
-            var translateRequests = requests.Select(r => new TranslateRequestDto
+            var translateRequests = misses.Select(m => new TranslateRequestDto
             {
-                System = r.CodeType == "CPT" ? CptSystem : HcpcsSystem,
-                Code = r.ProcedureCode,
+                System = m.Request.CodeType == "CPT" ? CptSystem : HcpcsSystem,
+                Code = m.Request.ProcedureCode,
                 TargetSystem = PlanCodeSystem,
                 TenantId = tenantId
             }).ToList();
@@ -54,46 +86,74 @@ public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
             {
                 _logger.LogWarning(
                     "Terminology crosswalk returned {StatusCode} for {Count} codes; using originals",
-                    response.StatusCode, requests.Count);
-                return Passthrough(requests);
+                    response.StatusCode, misses.Count);
+                FillMissesWithPassthrough(tenantId, misses, results);
+                return results.Select(r => r!).ToList();
             }
 
             var translations = await response.Content
                 .ReadFromJsonAsync<List<TranslateResponseDto>>(ct);
 
-            if (translations is null || translations.Count != requests.Count)
-                return Passthrough(requests);
-
-            return requests.Zip(translations, (req, tx) =>
+            if (translations is null || translations.Count != misses.Count)
             {
-                var match = tx.Matches?.FirstOrDefault();
-                return new CodeCrosswalkResult
-                {
-                    LineNumber = req.LineNumber,
-                    OriginalCode = req.ProcedureCode,
-                    ResolvedCode = match?.Concept?.Code ?? req.ProcedureCode,
-                    WasTranslated = tx.Result && match is not null,
-                    MapVersionId = tx.MapVersionId
-                };
-            }).ToList();
+                FillMissesWithPassthrough(tenantId, misses, results);
+                return results.Select(r => r!).ToList();
+            }
+
+            foreach (var (miss, translation) in misses.Zip(translations))
+            {
+                var match = translation.Matches?.FirstOrDefault();
+                var cached = new CachedCrosswalkResult(
+                    match?.Concept?.Code ?? miss.Request.ProcedureCode,
+                    translation.Result && match is not null,
+                    translation.MapVersionId);
+
+                _cache.Set(CacheKey(tenantId, miss.Request), cached, CacheOptions);
+                results[miss.Index] = ToResult(miss.Request, cached);
+            }
+
+            return results.Select(r => r!).ToList();
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             _logger.LogWarning(ex,
                 "Terminology crosswalk service unreachable; using original codes for {Count} lines",
-                requests.Count);
-            return Passthrough(requests);
+                misses.Count);
+            FillMissesWithPassthrough(tenantId, misses, results);
+            return results.Select(r => r!).ToList();
         }
     }
 
-    private static List<CodeCrosswalkResult> Passthrough(List<CodeCrosswalkRequest> requests)
-        => requests.Select(r => new CodeCrosswalkResult
+    private void FillMissesWithPassthrough(
+        string tenantId,
+        List<(int Index, CodeCrosswalkRequest Request)> misses,
+        CodeCrosswalkResult?[] results)
+    {
+        foreach (var (index, request) in misses)
         {
-            LineNumber = r.LineNumber,
-            OriginalCode = r.ProcedureCode,
-            ResolvedCode = r.ProcedureCode,
-            WasTranslated = false
-        }).ToList();
+            var cached = new CachedCrosswalkResult(request.ProcedureCode, false, null);
+            _cache.Set(CacheKey(tenantId, request), cached, CacheOptions);
+            results[index] = ToResult(request, cached);
+        }
+    }
+
+    private static CodeCrosswalkResult ToResult(CodeCrosswalkRequest request, CachedCrosswalkResult cached)
+        => new()
+        {
+            LineNumber = request.LineNumber,
+            OriginalCode = request.ProcedureCode,
+            ResolvedCode = cached.ResolvedCode,
+            WasTranslated = cached.WasTranslated,
+            MapVersionId = cached.MapVersionId
+        };
+
+    private static string CacheKey(string tenantId, CodeCrosswalkRequest request)
+        => $"terminology-crosswalk:{tenantId}:{request.CodeType}:{request.ProcedureCode}";
+
+    private sealed record CachedCrosswalkResult(
+        string ResolvedCode,
+        bool WasTranslated,
+        string? MapVersionId);
 
     /// <summary>
     /// Matches the TranslateRequest DTO expected by

--- a/src/services/benefit-plan-service/Services/HttpTerminologyCrosswalkClient.cs
+++ b/src/services/benefit-plan-service/Services/HttpTerminologyCrosswalkClient.cs
@@ -21,6 +21,14 @@ public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
         Size = 1
     };
 
+    // Short TTL for failure passthroughs so transient terminology-service
+    // outages do not lock in untranslated codes for the full 30-minute window.
+    private static readonly MemoryCacheEntryOptions FailureCacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(30),
+        Size = 1
+    };
+
     private readonly HttpClient _httpClient;
     private readonly IMemoryCache _cache;
     private readonly ILogger<HttpTerminologyCrosswalkClient> _logger;
@@ -132,7 +140,7 @@ public class HttpTerminologyCrosswalkClient : ITerminologyCrosswalkClient
         foreach (var (index, request) in misses)
         {
             var cached = new CachedCrosswalkResult(request.ProcedureCode, false, null);
-            _cache.Set(CacheKey(tenantId, request), cached, CacheOptions);
+            _cache.Set(CacheKey(tenantId, request), cached, FailureCacheOptions);
             results[index] = ToResult(request, cached);
         }
     }


### PR DESCRIPTION
## Summary
- cache terminology crosswalk results per tenant/code/type in benefit-plan-service
- preserve per-line crosswalk response shape while avoiding repeated MCC HTTP crosswalk calls
- default local Kubernetes benefit-plan-service to 3 replicas via `LOCAL_BENEFIT_PLAN_REPLICAS`

## Why
The MCC parallelism sweep showed adjudication was the limiting stage. Caching repeated terminology crosswalk lookups and giving the local adjudication path more benefit-plan-service replicas improved local benchmark throughput while keeping platform failures at zero.

## Validation
- `dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj`
- `bash -n scripts/deploy-local.sh`
- `git diff --check`

## Benchmark notes
1,000-claim local Kubernetes MCC runs, tenant `demo`:

- Before: p16, 1 benefit-plan replica
  - throughput: 53.51 claims/sec
  - P95 latency: 685 ms
  - P99 latency: 899 ms
  - adjudication P95: 623 ms
- After: p24, cached crosswalks, 3 benefit-plan replicas
  - throughput: 102.41 claims/sec
  - P95 latency: 403 ms
  - P99 latency: 584 ms
  - adjudication P95: 391 ms
  - platform failures: 0

p32 was tested and overshot the local sweet spot, dropping to 81.21 claims/sec with higher tail latency.