### PR TITLE
Speed up MCC validation writeback

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+NAMESPACE="${NAMESPACE:-cloudhealthoffice}"
+JOB_NAME="${JOB_NAME:-mcc-validator}"
+IMAGE="${IMAGE:-cloudhealthoffice-mcc-platform-validator:local}"
+CLAIMS="${CLAIMS:-5000}"
+TENANT="${TENANT:-demo}"
+PARALLELISM="${PARALLELISM:-24}"
+PROGRESS_EVERY="${PROGRESS_EVERY:-500}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-docker-desktop}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+
+log() {
+  printf '\033[1;34m==>\033[0m %s\n' "$*"
+}
+
+if [[ "$SKIP_BUILD" != "true" ]]; then
+  log "Building ${IMAGE}"
+  docker build \
+    -t "$IMAGE" \
+    --build-arg REGISTRY=mcr.microsoft.com \
+    -f "$ROOT_DIR/src/tools/mcc-platform-validator/Dockerfile" \
+    "$ROOT_DIR"
+fi
+
+if command -v kind >/dev/null 2>&1 && kind get clusters | grep -qx "$KIND_CLUSTER_NAME"; then
+  log "Loading ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}"
+  kind load docker-image "$IMAGE" --name "$KIND_CLUSTER_NAME"
+fi
+
+log "Running ${CLAIMS} claims in namespace ${NAMESPACE}"
+kubectl delete job -n "$NAMESPACE" "$JOB_NAME" --ignore-not-found >/dev/null
+kubectl apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: mcc-platform-validator
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --claims
+            - "${CLAIMS}"
+            - --tenant
+            - "${TENANT}"
+            - --parallelism
+            - "${PARALLELISM}"
+            - --claims-url
+            - http://claims-service
+            - --benefit-url
+            - http://benefit-plan-service
+            - --provider-url
+            - http://provider-service
+            - --progress-every
+            - "${PROGRESS_EVERY}"
+            - --summary-json
+            - /tmp/mcc-summary.json
+EOF
+
+kubectl wait -n "$NAMESPACE" --for=condition=complete "job/${JOB_NAME}" --timeout=30m
+kubectl logs -n "$NAMESPACE" "job/${JOB_NAME}"

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -444,6 +444,46 @@ public class ClaimsController : ControllerBase
     }
 
     /// <summary>
+    /// Fast claim-level adjudication projection for local benchmark and workflow
+    /// validation paths that do not need line adjudication projection or finalized
+    /// event emission.
+    /// </summary>
+    [HttpPut("{id}/adjudication-summary")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateAdjudicationSummary(
+        string id,
+        [FromBody] AdjudicationResult adjudication,
+        CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "Fast adjudication summary update for claim {Id}: allowed={Allowed}, payer={Payer}, patient={Patient}",
+            SanitizeForLog(id), adjudication.AllowedAmount, adjudication.PayerPayment, adjudication.PatientResponsibility);
+
+        var status = ResolveAdjudicationStatus(adjudication);
+        var updated = await _claimRepository.UpdateAdjudicationSummaryAsync(
+            GetTenantId(),
+            id,
+            adjudication,
+            status,
+            ct);
+
+        return updated ? NoContent() : NotFound($"Claim {id} not found");
+    }
+
+    private static ClaimStatus ResolveAdjudicationStatus(AdjudicationResult adjudication)
+    {
+        if (adjudication.PayerPayment == 0 && !string.IsNullOrEmpty(adjudication.DenialReasonCode))
+        {
+            return ClaimStatus.Denied;
+        }
+
+        return adjudication.PayerPayment > 0
+            ? ClaimStatus.Approved
+            : ClaimStatus.InAdjudication;
+    }
+
+    /// <summary>
     /// Write the AI Claims Examiner's advisory recommendation onto a pended claim.
     ///
     /// Called by claims-examiner-service after it processes a ClaimPendedEvent.

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -125,6 +125,20 @@ public interface IClaimRepository
         PendDetails? pendDetails = null);
 
     /// <summary>
+    /// Fast claim-level adjudication projection for direct local workflow
+    /// validation. Patches only summary adjudication/status fields on a known
+    /// claim row and intentionally skips full-claim hydration, line projection,
+    /// and event emission. Use the full adjudication pipeline when downstream
+    /// finalized events or line adjudications are required.
+    /// </summary>
+    Task<bool> UpdateAdjudicationSummaryAsync(
+        string tenantId,
+        string claimId,
+        AdjudicationResult adjudicationResult,
+        ClaimStatus status,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Supersession projection bypass for capability 5.12. Patches
     /// <c>SupersededAt</c>, <c>SupersededByVersionId</c>, and
     /// <c>VersionState=Adjusted</c> on a single claim row identified by
@@ -897,6 +911,68 @@ public class ClaimRepository : IClaimRepository
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             // Row deleted between lookup and patch.
+            return false;
+        }
+    }
+
+    public async Task<bool> UpdateAdjudicationSummaryAsync(
+        string tenantId,
+        string claimVersionId,
+        AdjudicationResult adjudicationResult,
+        ClaimStatus status,
+        CancellationToken ct = default)
+    {
+        var query = new QueryDefinition(@"
+            SELECT TOP 1 c.id
+            FROM c
+            WHERE c.tenantId = @tenantId
+              AND (c.claimVersionId = @claimVersionId
+                   OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
+                   OR (c.claimVersionId = '' AND c.id = @claimVersionId))
+              AND (NOT IS_DEFINED(c.versionState)
+                   OR c.versionState = @submitted
+                   OR c.versionState = @adjudicated
+                   OR c.versionState = @unknown)
+            ORDER BY c.versionNumber DESC")
+            .WithParameter("@tenantId", tenantId)
+            .WithParameter("@claimVersionId", claimVersionId)
+            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
+            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
+            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
+
+        string? rowId = null;
+        var iterator = _container.GetItemQueryIterator<HeadIdResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        if (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(ct);
+            rowId = page.FirstOrDefault()?.Id;
+        }
+
+        if (string.IsNullOrEmpty(rowId)) return false;
+
+        var now = DateTime.UtcNow;
+        var ops = new List<PatchOperation>
+        {
+            PatchOperation.Set("/adjudicationResult", adjudicationResult),
+            PatchOperation.Set("/adjudicatedDate", now),
+            PatchOperation.Set("/lastUpdatedDate", now),
+            PatchOperation.Set("/status", status),
+            PatchOperation.Set("/versionState", ClaimVersionState.Adjudicated)
+        };
+
+        try
+        {
+            await _container.PatchItemAsync<Claim>(
+                rowId,
+                new PartitionKey(tenantId),
+                ops,
+                cancellationToken: ct);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
             return false;
         }
     }

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -500,6 +500,45 @@ public class ClaimRepositoryMongo : IClaimRepository
         return result.MatchedCount > 0;
     }
 
+    public async Task<bool> UpdateAdjudicationSummaryAsync(
+        string tenantId,
+        string claimVersionId,
+        AdjudicationResult adjudicationResult,
+        ClaimStatus status,
+        CancellationToken ct = default)
+    {
+        var b = Builders<Claim>.Filter;
+
+        var chainFilter = b.Or(
+            b.Eq(c => c.ClaimVersionId, claimVersionId),
+            b.And(
+                b.Or(b.Eq(c => c.ClaimVersionId, string.Empty), b.Eq(c => c.ClaimVersionId, (string?)null)),
+                b.Eq(c => c.Id, claimVersionId)));
+
+        var stateFilter = b.Or(
+            b.Eq(c => c.VersionState, ClaimVersionState.Submitted),
+            b.Eq(c => c.VersionState, ClaimVersionState.Adjudicated),
+            b.Eq(c => c.VersionState, ClaimVersionState.Unknown));
+
+        var filter = b.And(b.Eq(c => c.TenantId, tenantId), chainFilter, stateFilter);
+        var now = DateTime.UtcNow;
+        var update = Builders<Claim>.Update
+            .Set(c => c.AdjudicationResult, adjudicationResult)
+            .Set(c => c.AdjudicatedDate, now)
+            .Set(c => c.LastUpdatedDate, now)
+            .Set(c => c.Status, status)
+            .Set(c => c.VersionState, ClaimVersionState.Adjudicated);
+
+        var options = new FindOneAndUpdateOptions<Claim>
+        {
+            Sort = Builders<Claim>.Sort.Descending(c => c.VersionNumber),
+            Projection = Builders<Claim>.Projection.Include(c => c.Id)
+        };
+
+        var updated = await _collection.FindOneAndUpdateAsync(filter, update, options, ct);
+        return updated is not null;
+    }
+
     public async Task<AccumulatorTotalsResponse> GetAccumulatorTotalsAsync(
         string ownerId,
         string scope,

--- a/src/tools/mcc-platform-validator/Dockerfile
+++ b/src/tools/mcc-platform-validator/Dockerfile
@@ -1,0 +1,26 @@
+ARG REGISTRY=mcr.microsoft.com
+
+FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+
+COPY src/Directory.Build.props src/
+COPY src/tools/mcc-platform-validator/mcc-platform-validator.csproj src/tools/mcc-platform-validator/
+COPY src/CloudHealthOffice.BenchmarkClaimGenerator/CloudHealthOffice.BenchmarkClaimGenerator.csproj src/CloudHealthOffice.BenchmarkClaimGenerator/
+
+RUN dotnet restore src/tools/mcc-platform-validator/mcc-platform-validator.csproj
+
+COPY src/tools/mcc-platform-validator/ src/tools/mcc-platform-validator/
+COPY src/CloudHealthOffice.BenchmarkClaimGenerator/ src/CloudHealthOffice.BenchmarkClaimGenerator/
+
+RUN dotnet publish src/tools/mcc-platform-validator/mcc-platform-validator.csproj \
+    -c Release \
+    -o /app/publish \
+    --no-restore \
+    /p:UseAppHost=false
+
+FROM ${REGISTRY}/dotnet/runtime:8.0 AS runtime
+WORKDIR /app
+
+COPY --from=build /app/publish .
+
+ENTRYPOINT ["dotnet", "mcc-platform-validator.dll"]

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -663,7 +663,7 @@ static async Task UpdateClaimAdjudicationAsync(
         denialReason = adjudication.DenialReasonDescription
     };
 
-    using var response = await http.PutAsJsonAsync($"{options.ClaimsUrl}/api/claims/{submittedClaimId}/adjudication", payload, json);
+    using var response = await http.PutAsJsonAsync($"{options.ClaimsUrl}/api/claims/{submittedClaimId}/adjudication-summary", payload, json);
     if (!response.IsSuccessStatusCode)
     {
         var body = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- add a fast claim-level adjudication summary writeback endpoint for MCC/local workflow validation
- update the MCC platform validator to use the lean writeback path
- containerize the MCC validator and add a local Kubernetes runner script so benchmarks use in-cluster service DNS instead of localhost port-forwards

## Validation
- `dotnet build src/services/claims-service/claims-service.csproj`
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj`
- `git diff --check`
- `SKIP_BUILD=true JOB_NAME=mcc-validator-script-smoke CLAIMS=100 PROGRESS_EVERY=50 scripts/run-mcc-local-k8s.sh`

## Benchmark
In-cluster MCC validation job, 5,000 claims, tenant `demo`, parallelism `24`:
- processed: 5,000 / 5,000
- platform failures: 0
- paid/adjudicated: 3,161
- business denials: 1,839
- throughput: 155.08 claims/sec
- p95 latency: 344 ms
- p99 latency: 501 ms
- writeback avg/p95: 24 ms / 79 ms
