### PR TITLE
Add mass adjudication run dashboard

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -56,6 +56,28 @@ public class ClaimsServiceTests
         ex.ServiceName.Should().Be("Claims Service");
     }
 
+    // ── GetMassAdjudicationRunsAsync ──
+
+    [Fact]
+    public async Task GetMassAdjudicationRunsAsync_WhenApiFails_ThrowsServiceUnavailableException()
+    {
+        var sut = CreateService();
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetMassAdjudicationRunsAsync());
+        ex.ServiceName.Should().Be("Claims Service");
+    }
+
+    // ── GetMassAdjudicationRunAsync ──
+
+    [Fact]
+    public async Task GetMassAdjudicationRunAsync_WhenApiFails_ThrowsServiceUnavailableException()
+    {
+        var sut = CreateService();
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetMassAdjudicationRunAsync("run-001"));
+        ex.ServiceName.Should().Be("Claims Service");
+    }
+
     // ── SubmitClaimAsync ──
 
     [Fact]
@@ -221,6 +243,122 @@ public class ClaimsServiceTests
             new FakeHandler(HttpStatusCode.OK, "null")));
 
         var result = await sut.GetClaimByIdAsync("CLM-NONE");
+
+        result.Should().BeNull();
+    }
+
+    // ── GetMassAdjudicationRunsAsync ──
+
+    [Fact]
+    public async Task GetMassAdjudicationRunsAsync_WhenApiReturns200_DeserializesRunsList()
+    {
+        var json = JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                id = "run-001",
+                run = new
+                {
+                    tenantId = "tenant-a",
+                    requestedClaims = 100,
+                    seed = 42,
+                    parallelism = 8,
+                    claimsUrl = "https://claims",
+                    benefitUrl = "https://benefit",
+                    providerUrl = "https://provider",
+                    seedProviders = true,
+                    skipClaimUpdate = false,
+                    startedAtUtc = "2026-07-01T00:00:00Z",
+                    completedAtUtc = "2026-07-01T00:01:00Z"
+                },
+                totalClaims = 100,
+                processed = 100,
+                paid = 97,
+                businessDenials = 2,
+                platformFailures = 1,
+                throughputClaimsPerSecond = 15.5,
+                createdAtUtc = "2026-07-01T00:01:05Z"
+            }
+        }, JsonOpts);
+
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, json)));
+
+        var result = await sut.GetMassAdjudicationRunsAsync();
+
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be("run-001");
+        result[0].Run.TenantId.Should().Be("tenant-a");
+        result[0].Processed.Should().Be(100);
+        result[0].PlatformFailures.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetMassAdjudicationRunsAsync_WhenApiReturnsNull_ReturnsEmptyList()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, "null")));
+
+        var result = await sut.GetMassAdjudicationRunsAsync();
+
+        result.Should().BeEmpty();
+    }
+
+    // ── GetMassAdjudicationRunAsync ──
+
+    [Fact]
+    public async Task GetMassAdjudicationRunAsync_WhenApiReturns200_DeserializesRun()
+    {
+        var json = JsonSerializer.Serialize(new
+        {
+            id = "run-002",
+            run = new
+            {
+                tenantId = "tenant-b",
+                requestedClaims = 25,
+                seed = 7,
+                parallelism = 4,
+                claimsUrl = "https://claims",
+                benefitUrl = "https://benefit",
+                providerUrl = "https://provider",
+                seedProviders = false,
+                skipClaimUpdate = true,
+                startedAtUtc = "2026-07-02T12:00:00Z",
+                completedAtUtc = "2026-07-02T12:00:10Z"
+            },
+            totalClaims = 25,
+            processed = 24,
+            paid = 24,
+            businessDenials = 0,
+            platformFailures = 0,
+            createdAtUtc = "2026-07-02T12:00:11Z"
+        }, JsonOpts);
+
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, json)));
+
+        var result = await sut.GetMassAdjudicationRunAsync("run-002");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("run-002");
+        result.Run.TenantId.Should().Be("tenant-b");
+        result.Run.SkipClaimUpdate.Should().BeTrue();
+        result.TotalClaims.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task GetMassAdjudicationRunAsync_WhenApiReturnsNull_ReturnsNull()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, "null")));
+
+        var result = await sut.GetMassAdjudicationRunAsync("run-none");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetMassAdjudicationRunAsync_WhenApiReturns404_ReturnsNull()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.NotFound, "{}")));
+
+        var result = await sut.GetMassAdjudicationRunAsync("run-missing");
 
         result.Should().BeNull();
     }

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -302,6 +302,16 @@ public class ClaimsServiceTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetMassAdjudicationRunsAsync_WhenApiReturnsEmptyBody_ReturnsEmptyList()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, string.Empty)));
+
+        var result = await sut.GetMassAdjudicationRunsAsync();
+
+        result.Should().BeEmpty();
+    }
+
     // ── GetMassAdjudicationRunAsync ──
 
     [Fact]
@@ -349,6 +359,16 @@ public class ClaimsServiceTests
         var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, "null")));
 
         var result = await sut.GetMassAdjudicationRunAsync("run-none");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetMassAdjudicationRunAsync_WhenApiReturnsEmptyBody_ReturnsNull()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, string.Empty)));
+
+        var result = await sut.GetMassAdjudicationRunAsync("run-empty");
 
         result.Should().BeNull();
     }

--- a/src/portal/CloudHealthOffice.Portal/App.razor
+++ b/src/portal/CloudHealthOffice.Portal/App.razor
@@ -1,4 +1,5 @@
 @inject NavigationManager Navigation
+@inject IConfiguration Configuration
 
 <CascadingAuthenticationState>
     <Router AppAssembly="@typeof(App).Assembly">
@@ -8,7 +9,10 @@
                     <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
                         <NotAuthorized>
                             @{
-                                Navigation.NavigateTo($"/MicrosoftIdentity/Account/SignIn?redirectUri={Uri.EscapeDataString(Navigation.Uri)}", forceLoad: true);
+                                var signInPath = IsLocalDemoAuth()
+                                    ? "/local-demo/sign-in"
+                                    : "/MicrosoftIdentity/Account/SignIn";
+                                Navigation.NavigateTo($"{signInPath}?redirectUri={Uri.EscapeDataString(Navigation.Uri)}", forceLoad: true);
                             }
                         </NotAuthorized>
                         <Authorizing>
@@ -35,3 +39,11 @@
         </NotFound>
     </Router>
 </CascadingAuthenticationState>
+
+@code {
+    private bool IsLocalDemoAuth()
+        => string.Equals(
+            Configuration["Authentication:Mode"],
+            "LocalDemo",
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -99,7 +99,7 @@
                         @context.Run.StartedAtUtc.LocalDateTime.ToString("MM/dd HH:mm")
                     </MudButton>
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
-                        @ShortId(context.Id) · p@context.Run.Parallelism
+                        @($"{ShortId(context.Id)} · p{context.Run.Parallelism}")
                     </MudText>
                 </MudTd>
                 <MudTd DataLabel="Processed">

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -1,0 +1,289 @@
+@page "/mass-adjudication-runs"
+@attribute [Authorize]
+@using CloudHealthOffice.Portal.Services
+@inject IClaimsService ClaimsService
+@inject ISnackbar Snackbar
+
+<PageTitle>Mass Adjudication Runs — Cloud Health Office</PageTitle>
+
+<PermissionGate Permission="claims:read" RoleName="ClaimsSupervisor">
+<MudText Typo="Typo.h4" Class="mb-1" Style="color: #00ffff; font-weight: 700;">
+    <MudIcon Icon="@Icons.Material.Filled.Assessment" Class="mr-2" Style="vertical-align: middle;" />
+    Mass Adjudication Runs
+</MudText>
+<MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.55);" Class="mb-4">
+    Production mass adjudication runs, outcome mix, timing, and platform failure signal.
+</MudText>
+
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="() => _error = null">
+        @_error
+    </MudAlert>
+}
+
+@if (_loading)
+{
+    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-4" />
+}
+
+<MudGrid Spacing="3" Class="mb-4">
+    <MudItem xs="6" sm="3">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,255,0.05); border: 1px solid rgba(0,255,255,0.2); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Style="color: #00ffff; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #00ffff; font-weight: 700;">@_runs.Count</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Runs</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="6" sm="3">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,136,0.05); border: 1px solid rgba(0,255,136,0.2); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Style="color: #00ff88; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #00ff88; font-weight: 700;">@_runs.Sum(x => x.Processed).ToString("N0")</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Processed Claims</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="6" sm="3">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,202,40,0.06); border: 1px solid rgba(255,202,40,0.25); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.Rule" Style="color: #ffca28; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #ffca28; font-weight: 700;">@_runs.Sum(x => x.BusinessDenials).ToString("N0")</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Business Denials</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="6" sm="3">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,0,85,0.05); border: 1px solid rgba(255,0,85,0.2); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Style="color: #ff0055; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #ff0055; font-weight: 700;">@_runs.Sum(x => x.PlatformFailures).ToString("N0")</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Platform Failures</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
+
+<div class="d-flex align-center gap-3 mb-4">
+    <MudButton Variant="Variant.Outlined"
+               Color="Color.Default"
+               StartIcon="@Icons.Material.Filled.Refresh"
+               OnClick="LoadRuns"
+               Disabled="_loading">
+        Refresh
+    </MudButton>
+    <MudSpacer />
+    @if (_selectedRun is not null)
+    {
+        <MudChip T="string" Color="@(_selectedRun.PlatformFailures == 0 ? Color.Success : Color.Error)" Size="Size.Small">
+            @(_selectedRun.PlatformFailures == 0 ? "Clean Run" : "Platform Failures")
+        </MudChip>
+    }
+</div>
+
+<MudGrid Spacing="3">
+    <MudItem xs="12" lg="5">
+        <MudTable Items="_runs" Dense="true" Hover="true" T="MassAdjudicationRunSummary"
+                  Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+            <HeaderContent>
+                <MudTh>Run</MudTh>
+                <MudTh>Processed</MudTh>
+                <MudTh>Throughput</MudTh>
+                <MudTh>P95</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Run">
+                    <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="@(() => SelectRun(context))" Style="padding-left: 0;">
+                        @context.Run.StartedAtUtc.LocalDateTime.ToString("MM/dd HH:mm")
+                    </MudButton>
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                        @ShortId(context.Id) · p@context.Run.Parallelism
+                    </MudText>
+                </MudTd>
+                <MudTd DataLabel="Processed">
+                    <MudText Typo="Typo.body2">@context.Processed.ToString("N0") / @context.TotalClaims.ToString("N0")</MudText>
+                    <MudProgressLinear Value="@PercentProcessed(context)"
+                                       Color="@(context.PlatformFailures == 0 ? Color.Success : Color.Error)"
+                                       Style="width: 90px; height: 6px; border-radius: 3px;" />
+                </MudTd>
+                <MudTd DataLabel="Throughput">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.ThroughputClaimsPerSecond.ToString("N2")/s</MudText>
+                </MudTd>
+                <MudTd DataLabel="P95">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.P95LatencyMilliseconds.ToString("N0") ms</MudText>
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <div class="pa-8 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.Assessment" Style="font-size: 3rem; color: rgba(0,255,255,0.3);" />
+                    <MudText Typo="Typo.body1" Class="mt-2" Style="color: rgba(255,255,255,0.55);">No mass adjudication runs found</MudText>
+                </div>
+            </NoRecordsContent>
+            <PagerContent>
+                <MudTablePager PageSizeOptions="new[] { 10, 25, 50 }" />
+            </PagerContent>
+        </MudTable>
+    </MudItem>
+
+    <MudItem xs="12" lg="7">
+        @if (_selectedRun is null)
+        {
+            <MudPaper Class="pa-6 text-center" Style="background: rgba(10,10,10,0.75); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+                <MudIcon Icon="@Icons.Material.Filled.TouchApp" Style="font-size: 3rem; color: rgba(0,255,255,0.35);" />
+                <MudText Typo="Typo.body1" Style="color: rgba(255,255,255,0.65);">Select a run to inspect adjudication outcomes.</MudText>
+            </MudPaper>
+        }
+        else
+        {
+            <MudPaper Class="pa-4 mb-3" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+                <div class="d-flex align-center gap-2 mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.Analytics" Color="Color.Primary" />
+                    <MudText Typo="Typo.h6" Style="font-weight: 700;">Run Detail</MudText>
+                    <MudSpacer />
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">@_selectedRun.Id</MudText>
+                </div>
+
+                <MudGrid Spacing="2" Class="mb-3">
+                    <MudItem xs="6" md="4">@Metric("Processed", $"{_selectedRun.Processed:N0}", "#00ffff")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Paid", $"{_selectedRun.Paid:N0}", "#00ff88")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Business Denials", $"{_selectedRun.BusinessDenials:N0}", "#ffca28")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Platform Failures", $"{_selectedRun.PlatformFailures:N0}", "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Throughput", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
+                </MudGrid>
+
+                <MudGrid Spacing="2">
+                    <MudItem xs="12" sm="4">@Timing(_selectedRun.SubmitTiming)</MudItem>
+                    <MudItem xs="12" sm="4">@Timing(_selectedRun.AdjudicateTiming)</MudItem>
+                    <MudItem xs="12" sm="4">@Timing(_selectedRun.WritebackTiming)</MudItem>
+                </MudGrid>
+            </MudPaper>
+
+            <MudGrid Spacing="3">
+                <MudItem xs="12" md="6">
+                    <MudPaper Class="pa-4" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(255,202,40,0.18); border-radius: 8px;">
+                        <MudText Typo="Typo.subtitle2" Class="mb-3" Style="color: #ffca28; font-weight: 700;">Business Denial Breakdown</MudText>
+                        @foreach (var denial in _selectedRun.BusinessDenialBreakdown.Take(8))
+                        {
+                            <div class="mb-2">
+                                <div class="d-flex align-center">
+                                    <MudText Typo="Typo.body2">@denial.Code</MudText>
+                                    <MudSpacer />
+                                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@denial.Count.ToString("N0")</MudText>
+                                </div>
+                                <MudProgressLinear Value="@DenialPercent(denial.Count)" Color="Color.Warning" Style="height: 5px; border-radius: 3px;" />
+                            </div>
+                        }
+                    </MudPaper>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudPaper Class="pa-4" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(255,0,85,0.16); border-radius: 8px;">
+                        <MudText Typo="Typo.subtitle2" Class="mb-3" Style="color: #ff6b9a; font-weight: 700;">Sample Platform Failures</MudText>
+                        @if (_selectedRun.SampleFailures.Count == 0)
+                        {
+                            <MudAlert Severity="Severity.Success" Variant="Variant.Outlined">No platform failures were reported for this run.</MudAlert>
+                        }
+                        else
+                        {
+                            @foreach (var failure in _selectedRun.SampleFailures)
+                            {
+                                <MudText Typo="Typo.body2" Style="font-family: monospace;">@failure.GeneratedClaimId · @failure.Stage</MudText>
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">@failure.Error</MudText>
+                                <MudDivider Class="my-2" />
+                            }
+                        }
+                    </MudPaper>
+                </MudItem>
+            </MudGrid>
+        }
+    </MudItem>
+</MudGrid>
+</PermissionGate>
+
+@code {
+    private readonly List<MassAdjudicationRunSummary> _runs = new();
+    private MassAdjudicationRunSummary? _selectedRun;
+    private bool _loading;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadRuns();
+    }
+
+    private async Task LoadRuns()
+    {
+        _loading = true;
+        _error = null;
+        try
+        {
+            var runs = await ClaimsService.GetMassAdjudicationRunsAsync(50);
+            _runs.Clear();
+            _runs.AddRange(runs);
+            _selectedRun = _runs.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            Snackbar.Add("Unable to load mass adjudication runs", Severity.Error);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private void SelectRun(MassAdjudicationRunSummary run)
+    {
+        _selectedRun = run;
+    }
+
+    private static string ShortId(string id)
+        => string.IsNullOrWhiteSpace(id) ? "run" : id[..Math.Min(8, id.Length)];
+
+    private static double PercentProcessed(MassAdjudicationRunSummary run)
+        => run.TotalClaims <= 0 ? 0 : (double)run.Processed / run.TotalClaims * 100;
+
+    private double DenialPercent(int count)
+        => _selectedRun is null || _selectedRun.BusinessDenials <= 0
+            ? 0
+            : (double)count / _selectedRun.BusinessDenials * 100;
+
+    private RenderFragment Metric(string label, string value, string color) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "style", $"border: 1px solid {color}55; background: {color}12; border-radius: 8px; padding: 12px;");
+        builder.OpenComponent<MudText>(2);
+        builder.AddAttribute(3, "Typo", Typo.caption);
+        builder.AddAttribute(4, "Style", "color: rgba(255,255,255,0.55);");
+        builder.AddAttribute(5, "ChildContent", (RenderFragment)(b => b.AddContent(6, label)));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(7);
+        builder.AddAttribute(8, "Typo", Typo.h6);
+        builder.AddAttribute(9, "Style", $"color: {color}; font-weight: 700; font-family: monospace;");
+        builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.CloseElement();
+    };
+
+    private RenderFragment Timing(MassAdjudicationStageTiming? timing) => builder =>
+    {
+        var label = timing?.Label ?? "Stage";
+        var value = timing is null ? "—" : $"{timing.AverageMilliseconds:N0} / {timing.P95Milliseconds:N0} ms";
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "style", "border: 1px solid rgba(125,211,252,0.25); border-radius: 8px; padding: 10px;");
+        builder.OpenComponent<MudText>(2);
+        builder.AddAttribute(3, "Typo", Typo.caption);
+        builder.AddAttribute(4, "Style", "color: rgba(255,255,255,0.55);");
+        builder.AddAttribute(5, "ChildContent", (RenderFragment)(b => b.AddContent(6, $"{label} avg / p95")));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(7);
+        builder.AddAttribute(8, "Typo", Typo.body2);
+        builder.AddAttribute(9, "Style", "color: #7dd3fc; font-family: monospace;");
+        builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.CloseElement();
+    };
+}

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -12,10 +12,13 @@ using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.HttpOverrides;
 using MongoDB.Driver;
 using MongoDB.Bson.Serialization.Conventions;
 using CloudHealthOffice.Infrastructure.Configuration;
+using System.Security.Claims;
 
 var builder = WebApplication.CreateBuilder(args);
 // Secret provider (Azure Key Vault / none)
@@ -44,14 +47,35 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownProxies.Clear();
 });
 
-// Azure AD Authentication
-// Do not include downstream API scopes in the initial sign-in request.
-// For multi-tenant apps, custom API scopes must be acquired incrementally
-// (on first API call) to avoid AADSTS1003031 at the authorization endpoint.
-var initialScopes = Array.Empty<string>();
+var authMode = builder.Configuration["Authentication:Mode"] ?? "Entra";
+var useLocalDemoAuth = builder.Environment.IsDevelopment()
+    && string.Equals(authMode, "LocalDemo", StringComparison.OrdinalIgnoreCase);
 
-builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-    .AddMicrosoftIdentityWebApp(options =>
+if (useLocalDemoAuth)
+{
+    builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+        .AddCookie(options =>
+        {
+            options.LoginPath = "/local-demo/sign-in";
+            options.LogoutPath = "/local-demo/sign-out";
+            options.AccessDeniedPath = "/local-demo/sign-in";
+            options.Cookie.Name = ".CloudHealthOffice.LocalDemoAuth";
+            options.Cookie.HttpOnly = true;
+            options.Cookie.IsEssential = true;
+            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        });
+}
+else
+{
+    // Azure AD Authentication
+    // Do not include downstream API scopes in the initial sign-in request.
+    // For multi-tenant apps, custom API scopes must be acquired incrementally
+    // (on first API call) to avoid AADSTS1003031 at the authorization endpoint.
+    var initialScopes = Array.Empty<string>();
+
+    builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+        .AddMicrosoftIdentityWebApp(options =>
     {
         builder.Configuration.Bind("AzureAd", options);
 
@@ -118,6 +142,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     })
     .EnableTokenAcquisitionToCallDownstreamApi(initialScopes)
     .AddDistributedTokenCaches();
+}
 
 // Configure cookies for reverse proxy (HTTPS behind nginx)
 builder.Services.ConfigureApplicationCookie(options =>
@@ -276,13 +301,20 @@ builder.Services.AddSignalR(options =>
     options.EnableDetailedErrors = true;
 });
 
-// Shared distributed cache backed by Redis — required for multi-pod session and MSAL token caches
-var redisConnection = builder.Configuration["Redis:ConnectionString"] ?? "redis-dataprotection.cloudhealthoffice.svc.cluster.local:6379";
-builder.Services.AddStackExchangeRedisCache(options =>
+if (useLocalDemoAuth)
 {
-    options.Configuration = redisConnection;
-    options.InstanceName = "cho:";
-});
+    builder.Services.AddDistributedMemoryCache();
+}
+else
+{
+    // Shared distributed cache backed by Redis — required for multi-pod session and MSAL token caches
+    var redisConnection = builder.Configuration["Redis:ConnectionString"] ?? "redis-dataprotection.cloudhealthoffice.svc.cluster.local:6379";
+    builder.Services.AddStackExchangeRedisCache(options =>
+    {
+        options.Configuration = redisConnection;
+        options.InstanceName = "cho:";
+    });
+}
 
 // Add session state
 builder.Services.AddSession(options =>
@@ -315,9 +347,14 @@ static string BuildAdminConsentErrorUrl(string? tenantId)
     return url;
 }
 
-// Register background tenant seed so it doesn't block startup or health probes
-builder.Services.AddHostedService<TenantSeedService>();
-builder.Services.AddHostedService<TmppmIndexService>();
+// Register background tenant seed so it doesn't block startup or health probes.
+// Local demo auth bypasses tenant subscription lookup and should not require
+// MongoDB just to open the portal.
+if (!useLocalDemoAuth)
+{
+    builder.Services.AddHostedService<TenantSeedService>();
+    builder.Services.AddHostedService<TmppmIndexService>();
+}
 
 var app = builder.Build();
 
@@ -338,6 +375,65 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 app.UseSession();
+
+if (useLocalDemoAuth)
+{
+    app.MapGet("/local-demo/sign-in", async (HttpContext context) =>
+    {
+        var redirectUri = context.Request.Query["redirectUri"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(redirectUri) || !redirectUri.StartsWith("/", StringComparison.Ordinal))
+        {
+            redirectUri = "/";
+        }
+
+        var email = builder.Configuration["Authentication:LocalDemo:Email"]
+            ?? "local-demo@cloudhealthoffice.local";
+        var name = builder.Configuration["Authentication:LocalDemo:DisplayName"]
+            ?? "Local Demo Admin";
+        var tenantId = builder.Configuration["Authentication:LocalDemo:TenantId"]
+            ?? "demo";
+        var azureTenantId = builder.Configuration["Authentication:LocalDemo:AzureTenantId"]
+            ?? "local-demo";
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "local-demo-admin"),
+            new(ClaimTypes.Name, name),
+            new(ClaimTypes.Email, email),
+            new("preferred_username", email),
+            new("oid", "local-demo-admin"),
+            new("tid", azureTenantId),
+            new("extension_TenantId", tenantId),
+            new("cho_local_demo", "true"),
+            new(ClaimTypes.Role, "TenantAdmin"),
+            new(ClaimTypes.Role, "ClaimsSupervisor")
+        };
+
+        var identity = new ClaimsIdentity(
+            claims,
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            ClaimTypes.Name,
+            ClaimTypes.Role);
+        var principal = new ClaimsPrincipal(identity);
+
+        await context.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            principal,
+            new AuthenticationProperties
+            {
+                IsPersistent = true,
+                ExpiresUtc = DateTimeOffset.UtcNow.AddHours(8)
+            });
+
+        return Results.Redirect(redirectUri);
+    }).WithMetadata(new Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute());
+
+    app.MapGet("/local-demo/sign-out", async (HttpContext context) =>
+    {
+        await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Results.Redirect("/");
+    }).WithMetadata(new Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute());
+}
 
 // Health endpoint - anonymous access for Kubernetes probes
 app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }))

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -387,7 +387,7 @@ if (useLocalDemoAuth)
         }
 
         var email = builder.Configuration["Authentication:LocalDemo:Email"]
-            ?? "local-demo@cloudhealthoffice.local";
+            ?? "local-demo-user";
         var name = builder.Configuration["Authentication:LocalDemo:DisplayName"]
             ?? "Local Demo Admin";
         var tenantId = builder.Configuration["Authentication:LocalDemo:TenantId"]

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -10,6 +10,8 @@ public interface IClaimsService
     Task<List<ClaimSummary>> GetRecentClaimsAsync(int count);
     Task<ClaimSearchResult> SearchClaimsAsync(ClaimSearchRequest request);
     Task<ClaimDetails?> GetClaimByIdAsync(string claimId);
+    Task<List<MassAdjudicationRunSummary>> GetMassAdjudicationRunsAsync(int limit = 25);
+    Task<MassAdjudicationRunSummary?> GetMassAdjudicationRunAsync(string runId);
     Task<string> SubmitClaimAsync(SubmitClaimRequest request);
     Task UpdateClaimStatusAsync(string claimId, string status, string? notes = null);
     Task<AdjudicationTransparencyData?> GetAdjudicationDataAsync(string claimId);
@@ -67,6 +69,63 @@ public class MemberAccumulators
     public decimal FamilyOopLimit { get; set; }
     public List<ServiceAccumulator> ServiceAccumulators { get; set; } = new();
     public List<AccumulatorActivity> RecentActivity { get; set; } = new();
+}
+
+public class MassAdjudicationRunSummary
+{
+    public string Id { get; set; } = string.Empty;
+    public MassAdjudicationRunMetadata Run { get; set; } = new();
+    public int TotalClaims { get; set; }
+    public int Processed { get; set; }
+    public int Paid { get; set; }
+    public int BusinessDenials { get; set; }
+    public int PlatformFailures { get; set; }
+    public TimeSpan Elapsed { get; set; }
+    public double ThroughputClaimsPerSecond { get; set; }
+    public double P95LatencyMilliseconds { get; set; }
+    public double P99LatencyMilliseconds { get; set; }
+    public MassAdjudicationStageTiming? SubmitTiming { get; set; }
+    public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
+    public MassAdjudicationStageTiming? WritebackTiming { get; set; }
+    public decimal? AveragePaymentDelta { get; set; }
+    public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
+    public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
+    public DateTime CreatedAtUtc { get; set; }
+}
+
+public class MassAdjudicationRunMetadata
+{
+    public string TenantId { get; set; } = string.Empty;
+    public int RequestedClaims { get; set; }
+    public int Seed { get; set; }
+    public int Parallelism { get; set; }
+    public string ClaimsUrl { get; set; } = string.Empty;
+    public string BenefitUrl { get; set; } = string.Empty;
+    public string ProviderUrl { get; set; } = string.Empty;
+    public bool SeedProviders { get; set; }
+    public bool SkipClaimUpdate { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationStageTiming
+{
+    public string Label { get; set; } = string.Empty;
+    public double AverageMilliseconds { get; set; }
+    public double P95Milliseconds { get; set; }
+}
+
+public class MassAdjudicationBusinessDenialSummary
+{
+    public string Code { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class MassAdjudicationFailureSummary
+{
+    public string GeneratedClaimId { get; set; } = string.Empty;
+    public string? Stage { get; set; }
+    public string? Error { get; set; }
 }
 
 public class ServiceAccumulator

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -600,9 +600,13 @@ public class AuthorizationService : IAuthorizationService
     private readonly HttpClient _httpClient;
     private readonly IConfiguration _configuration;
     private readonly ILogger<AuthorizationService> _logger;
-    private readonly ITokenAcquisition _tokenAcquisition;
+    private readonly ITokenAcquisition? _tokenAcquisition;
 
-    public AuthorizationService(HttpClient httpClient, IConfiguration configuration, ILogger<AuthorizationService> logger, ITokenAcquisition tokenAcquisition)
+    public AuthorizationService(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<AuthorizationService> logger,
+        ITokenAcquisition? tokenAcquisition = null)
     {
         _httpClient = httpClient;
         _configuration = configuration;
@@ -664,10 +668,22 @@ public class AuthorizationService : IAuthorizationService
 
     private async Task SetBearerTokenAsync()
     {
+        if (_tokenAcquisition is null || IsLocalDemoAuth())
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+            return;
+        }
+
         var scopes = new[] { "api://cfada1ac-f251-48ea-9330-39212aa4c862/Authorization.ReadWrite" };
         var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(scopes);
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
     }
+
+    private bool IsLocalDemoAuth()
+        => string.Equals(
+            _configuration["Authentication:Mode"],
+            "LocalDemo",
+            StringComparison.OrdinalIgnoreCase);
 
     private class SubmitAuthorizationResponse
     {
@@ -1192,9 +1208,13 @@ public class AttachmentService : IAttachmentService
     private readonly HttpClient _httpClient;
     private readonly IConfiguration _configuration;
     private readonly ILogger<AttachmentService> _logger;
-    private readonly ITokenAcquisition _tokenAcquisition;
+    private readonly ITokenAcquisition? _tokenAcquisition;
 
-    public AttachmentService(HttpClient httpClient, IConfiguration configuration, ILogger<AttachmentService> logger, ITokenAcquisition tokenAcquisition)
+    public AttachmentService(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<AttachmentService> logger,
+        ITokenAcquisition? tokenAcquisition = null)
     {
         _httpClient = httpClient;
         _configuration = configuration;
@@ -1277,10 +1297,22 @@ public class AttachmentService : IAttachmentService
 
     private async Task SetBearerTokenAsync()
     {
+        if (_tokenAcquisition is null || IsLocalDemoAuth())
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = null;
+            return;
+        }
+
         var scopes = new[] { "api://cfada1ac-f251-48ea-9330-39212aa4c862/Attachments.ReadWrite" };
         var accessToken = await _tokenAcquisition.GetAccessTokenForUserAsync(scopes);
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
     }
+
+    private bool IsLocalDemoAuth()
+        => string.Equals(
+            _configuration["Authentication:Mode"],
+            "LocalDemo",
+            StringComparison.OrdinalIgnoreCase);
 
     private class UploadAttachmentResponse
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -67,6 +67,43 @@ public class ClaimsService : IClaimsService
         }
     }
 
+    public async Task<List<MassAdjudicationRunSummary>> GetMassAdjudicationRunsAsync(int limit = 25)
+    {
+        var baseUrl = _configuration["Services:ClaimsService"];
+        try
+        {
+            return await _httpClient.GetFromJsonAsync<List<MassAdjudicationRunSummary>>(
+                $"{baseUrl}/mass-adjudication/runs?limit={Math.Clamp(limit, 1, 100)}")
+                ?? new List<MassAdjudicationRunSummary>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+    }
+
+    public async Task<MassAdjudicationRunSummary?> GetMassAdjudicationRunAsync(string runId)
+    {
+        var baseUrl = _configuration["Services:ClaimsService"];
+        try
+        {
+            var response = await _httpClient.GetAsync($"{baseUrl}/mass-adjudication/runs/{Uri.EscapeDataString(runId)}");
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<MassAdjudicationRunSummary>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+    }
+
     public async Task<string> SubmitClaimAsync(SubmitClaimRequest request)
     {
         var baseUrl = _configuration["Services:ClaimsService"];

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -11,6 +11,7 @@ namespace CloudHealthOffice.Portal.Services;
 
 public class ClaimsService : IClaimsService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private readonly HttpClient _httpClient;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ClaimsService> _logger;
@@ -72,8 +73,10 @@ public class ClaimsService : IClaimsService
         var baseUrl = _configuration["Services:ClaimsService"];
         try
         {
-            return await _httpClient.GetFromJsonAsync<List<MassAdjudicationRunSummary>>(
-                $"{baseUrl}/mass-adjudication/runs?limit={Math.Clamp(limit, 1, 100)}")
+            var response = await _httpClient.GetAsync(
+                $"{baseUrl}/mass-adjudication/runs?limit={Math.Clamp(limit, 1, 100)}");
+            response.EnsureSuccessStatusCode();
+            return await ReadOptionalJsonAsync<List<MassAdjudicationRunSummary>>(response)
                 ?? new List<MassAdjudicationRunSummary>();
         }
         catch (HttpRequestException ex)
@@ -95,7 +98,7 @@ public class ClaimsService : IClaimsService
             }
 
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<MassAdjudicationRunSummary>();
+            return await ReadOptionalJsonAsync<MassAdjudicationRunSummary>(response);
         }
         catch (HttpRequestException ex)
         {
@@ -205,6 +208,22 @@ public class ClaimsService : IClaimsService
     private class SubmitClaimResponse
     {
         public string ClaimId { get; set; } = string.Empty;
+    }
+
+    private static async Task<T?> ReadOptionalJsonAsync<T>(HttpResponseMessage response)
+    {
+        if (response.Content is null)
+        {
+            return default;
+        }
+
+        var body = await response.Content.ReadAsStringAsync();
+        if (string.IsNullOrWhiteSpace(body) || string.Equals(body.Trim(), "null", StringComparison.OrdinalIgnoreCase))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize<T>(body, JsonOptions);
     }
 }
 

--- a/src/portal/CloudHealthOffice.Portal/Services/TenantContextService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/TenantContextService.cs
@@ -46,6 +46,7 @@ public class TenantContextService : ITenantContextService
     private readonly AuthenticationStateProvider _authenticationStateProvider;
     private readonly ITenantService _tenantService;
     private readonly ILogger<TenantContextService> _logger;
+    private readonly IConfiguration _configuration;
     private TenantContext? _cachedContext;
     private List<TenantSubscription>? _cachedAvailableTenants;
     private string? _homeTenantId; // Original Azure AD tenant ID from claims — never changes after first resolution
@@ -59,11 +60,13 @@ public class TenantContextService : ITenantContextService
     public TenantContextService(
         AuthenticationStateProvider authenticationStateProvider,
         ITenantService tenantService,
-        ILogger<TenantContextService> logger)
+        ILogger<TenantContextService> logger,
+        IConfiguration configuration)
     {
         _authenticationStateProvider = authenticationStateProvider;
         _tenantService = tenantService;
         _logger = logger;
+        _configuration = configuration;
     }
 
     public async Task<TenantContext?> GetCurrentTenantContextAsync()
@@ -81,6 +84,14 @@ public class TenantContextService : ITenantContextService
         {
             _logger.LogDebug("User not authenticated, no tenant context available");
             return null;
+        }
+
+        if (IsLocalDemoUser(user))
+        {
+            _cachedContext = BuildLocalDemoTenantContext(user);
+            _logger.LogInformation("Tenant context resolved via local demo auth: {TenantName} ({TenantId})",
+                _cachedContext.TenantName, _cachedContext.TenantId);
+            return _cachedContext;
         }
 
         // Extract Azure AD Tenant ID from claims
@@ -197,6 +208,29 @@ public class TenantContextService : ITenantContextService
         if (currentContext == null)
             return new List<TenantSubscription>();
 
+        if (currentContext.IsDemo && string.Equals(
+                _configuration["Authentication:Mode"],
+                "LocalDemo",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            _cachedAvailableTenants = new List<TenantSubscription>
+            {
+                new()
+                {
+                    TenantId = currentContext.TenantId,
+                    AzureTenantId = currentContext.AzureTenantId,
+                    OrganizationName = currentContext.TenantName,
+                    SubscriptionStatus = currentContext.SubscriptionStatus,
+                    Tier = currentContext.SubscriptionTier,
+                    IsDemo = true,
+                    AdminEmails = string.IsNullOrWhiteSpace(currentContext.UserEmail)
+                        ? new List<string>()
+                        : new List<string> { currentContext.UserEmail }
+                }
+            };
+            return _cachedAvailableTenants;
+        }
+
         var userEmail = currentContext.UserEmail;
         if (string.IsNullOrEmpty(userEmail))
             return new List<TenantSubscription>();
@@ -296,6 +330,38 @@ public class TenantContextService : ITenantContextService
             SubscriptionStatus = subscription.SubscriptionStatus ?? "Unknown",
             IsDemo = subscription.IsDemo,
             UserEmail = userEmail
+        };
+    }
+
+    private bool IsLocalDemoUser(ClaimsPrincipal user)
+        => string.Equals(
+                _configuration["Authentication:Mode"],
+                "LocalDemo",
+                StringComparison.OrdinalIgnoreCase)
+            && user.HasClaim("cho_local_demo", "true");
+
+    private TenantContext BuildLocalDemoTenantContext(ClaimsPrincipal user)
+    {
+        var tenantId = _configuration["Authentication:LocalDemo:TenantId"]
+            ?? user.FindFirst("extension_TenantId")?.Value
+            ?? "demo";
+        var azureTenantId = _configuration["Authentication:LocalDemo:AzureTenantId"]
+            ?? user.FindFirst("tid")?.Value
+            ?? "local-demo";
+        var tenantName = _configuration["Authentication:LocalDemo:TenantName"]
+            ?? "Local Demo Tenant";
+        var email = user.FindFirst(ClaimTypes.Email)?.Value
+            ?? user.FindFirst("preferred_username")?.Value;
+
+        return new TenantContext
+        {
+            TenantId = tenantId,
+            TenantName = tenantName,
+            AzureTenantId = azureTenantId,
+            SubscriptionTier = "local-demo",
+            SubscriptionStatus = "Active",
+            IsDemo = true,
+            UserEmail = email
         };
     }
 

--- a/src/portal/CloudHealthOffice.Portal/Services/UserContextService.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/UserContextService.cs
@@ -96,6 +96,37 @@ public class UserContextService : IUserContextService
             return null;
         }
 
+        if (IsLocalDemoUser(principal))
+        {
+            var localDemoDisplayName = principal.FindFirst("name")?.Value
+                              ?? principal.FindFirst(ClaimTypes.Name)?.Value
+                              ?? email;
+            var roles = new List<string>
+            {
+                "TenantAdmin",
+                "ClaimsSupervisor",
+                "MemberServices",
+                "ProviderRelations",
+                "Finance"
+            };
+
+            _cachedContext = new UserContext
+            {
+                UserId = "local-demo-admin",
+                Email = email,
+                DisplayName = localDemoDisplayName,
+                FirstName = localDemoDisplayName.Split(' ').FirstOrDefault() ?? localDemoDisplayName,
+                LastName = localDemoDisplayName.Split(' ').Skip(1).FirstOrDefault() ?? "",
+                TenantId = _configuration["Authentication:LocalDemo:TenantId"] ?? "demo",
+                Roles = roles,
+                Department = "Local Evaluation",
+                Permissions = ExpandPermissions(roles)
+            };
+
+            _loaded = true;
+            return _cachedContext;
+        }
+
         var tenantContext = await _tenantContextService.GetCurrentTenantContextAsync();
         if (tenantContext == null)
         {
@@ -241,6 +272,13 @@ public class UserContextService : IUserContextService
         if (atIndex <= 1) return "***@" + (atIndex >= 0 ? email[(atIndex + 1)..] : "***");
         return email[0] + "***" + email[(atIndex - 1)..];
     }
+
+    private bool IsLocalDemoUser(ClaimsPrincipal principal)
+        => string.Equals(
+                _configuration["Authentication:Mode"],
+                "LocalDemo",
+                StringComparison.OrdinalIgnoreCase)
+            && principal.HasClaim("cho_local_demo", "true");
 
     public bool HasPermission(string permission)
     {

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
@@ -128,6 +128,10 @@
                                     Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
                             Claims
                         </MudNavLink>
+                        <MudNavLink Href="/mass-adjudication-runs" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Assessment"
+                                    Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
+                            Mass Adjudication
+                        </MudNavLink>
                         <MudNavLink Href="/work-queues" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Queue"
                                     Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
                             Work Queues

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
@@ -8,6 +8,7 @@
 @inject HttpClient HttpClient
 @inject ISnackbar Snackbar
 @inject ILogger<MainLayout> Logger
+@inject IConfiguration Configuration
 
 <MudThemeProvider Theme="_theme" />
 <MudDialogProvider />
@@ -412,7 +413,19 @@
     private bool _tenantLoadComplete;
     private List<TenantSubscription> _availableTenants = new();
 
-    private void SignIn() => Navigation.NavigateTo("/MicrosoftIdentity/Account/SignIn", forceLoad: true);
+    private bool IsLocalDemoAuth()
+        => string.Equals(
+            Configuration["Authentication:Mode"],
+            "LocalDemo",
+            StringComparison.OrdinalIgnoreCase);
+
+    private void SignIn()
+    {
+        var signInPath = IsLocalDemoAuth()
+            ? "/local-demo/sign-in"
+            : "/MicrosoftIdentity/Account/SignIn";
+        Navigation.NavigateTo(signInPath, forceLoad: true);
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -539,8 +552,10 @@
 
     private void Logout()
     {
-        // Navigate to Microsoft Identity logout endpoint
-        Navigation.NavigateTo("/MicrosoftIdentity/Account/SignOut", forceLoad: true);
+        var signOutPath = IsLocalDemoAuth()
+            ? "/local-demo/sign-out"
+            : "/MicrosoftIdentity/Account/SignOut";
+        Navigation.NavigateTo(signOutPath, forceLoad: true);
     }
 
     private MudTheme _theme = new()

--- a/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
+++ b/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
@@ -12,7 +12,7 @@
       "TenantId": "demo",
       "AzureTenantId": "local-demo",
       "TenantName": "Local Demo Tenant",
-      "Email": "local-demo@cloudhealthoffice.local",
+      "Email": "local-demo-user",
       "DisplayName": "Local Demo Admin"
     }
   },

--- a/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
+++ b/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
@@ -6,6 +6,16 @@
       "Microsoft.AspNetCore.SignalR": "Debug"
     }
   },
+  "Authentication": {
+    "Mode": "LocalDemo",
+    "LocalDemo": {
+      "TenantId": "demo",
+      "AzureTenantId": "local-demo",
+      "TenantName": "Local Demo Tenant",
+      "Email": "local-demo@cloudhealthoffice.local",
+      "DisplayName": "Local Demo Admin"
+    }
+  },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "common",

--- a/src/portal/CloudHealthOffice.Portal/appsettings.json
+++ b/src/portal/CloudHealthOffice.Portal/appsettings.json
@@ -10,6 +10,10 @@
   },
   "AllowedHosts": "*",
 
+  "Authentication": {
+    "Mode": "Entra"
+  },
+
   "_comment_azuread": "Override: AzureAd__TenantId, AzureAd__ClientId, AzureAd__ClientSecret",
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -1,0 +1,77 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ClaimsService.Controllers;
+
+[ApiController]
+[Route("api/mass-adjudication/runs")]
+public sealed class MassAdjudicationRunsController : ControllerBase
+{
+    private readonly IMassAdjudicationRunRepository _repository;
+    private readonly ILogger<MassAdjudicationRunsController> _logger;
+
+    public MassAdjudicationRunsController(
+        IMassAdjudicationRunRepository repository,
+        ILogger<MassAdjudicationRunsController> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(IReadOnlyList<MassAdjudicationRunSummary>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<MassAdjudicationRunSummary>>> List(
+        [FromQuery] int limit = 25,
+        CancellationToken ct = default)
+    {
+        var runs = await _repository.ListAsync(GetTenantId(), limit, ct);
+        return Ok(runs);
+    }
+
+    [HttpGet("{id}")]
+    [ProducesResponseType(typeof(MassAdjudicationRunSummary), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<MassAdjudicationRunSummary>> Get(string id, CancellationToken ct = default)
+    {
+        var run = await _repository.GetAsync(GetTenantId(), id, ct);
+        return run is null ? NotFound() : Ok(run);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(MassAdjudicationRunSummary), StatusCodes.Status201Created)]
+    public async Task<ActionResult<MassAdjudicationRunSummary>> Create(
+        [FromBody] MassAdjudicationRunSummary summary,
+        CancellationToken ct = default)
+    {
+        var tenantId = GetTenantId();
+        summary.Run.TenantId = tenantId;
+
+        var saved = await _repository.SaveAsync(summary, ct);
+        _logger.LogInformation(
+            "Saved mass adjudication run {RunId} for tenant {TenantId}: {Processed}/{Total} processed, {Failures} platform failures",
+            saved.Id,
+            SanitizeForLog(tenantId),
+            saved.Processed,
+            saved.TotalClaims,
+            saved.PlatformFailures);
+
+        return CreatedAtAction(nameof(Get), new { id = saved.Id }, saved);
+    }
+
+    private string GetTenantId()
+    {
+        var tenantId = HttpContext?.Items["TenantId"]?.ToString();
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            throw new InvalidOperationException("TenantId not found in HttpContext. Ensure tenant middleware is configured.");
+        }
+
+        return tenantId;
+    }
+
+    private static string SanitizeForLog(string? value)
+        => string.IsNullOrEmpty(value)
+            ? string.Empty
+            : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+}

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -40,10 +40,16 @@ public sealed class MassAdjudicationRunsController : ControllerBase
 
     [HttpPost]
     [ProducesResponseType(typeof(MassAdjudicationRunSummary), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<MassAdjudicationRunSummary>> Create(
-        [FromBody] MassAdjudicationRunSummary summary,
+        [FromBody] MassAdjudicationRunSummary? summary,
         CancellationToken ct = default)
     {
+        if (summary?.Run is null)
+        {
+            return BadRequest(new { error = "Run payload is required" });
+        }
+
         var tenantId = GetTenantId();
         summary.Run.TenantId = tenantId;
 

--- a/src/services/claims-service/HostedServices/MassAdjudicationRunIndexInitializer.cs
+++ b/src/services/claims-service/HostedServices/MassAdjudicationRunIndexInitializer.cs
@@ -1,0 +1,45 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using MongoDB.Driver;
+
+namespace ClaimsService.HostedServices;
+
+public sealed class MassAdjudicationRunIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _database;
+    private readonly ILogger<MassAdjudicationRunIndexInitializer> _logger;
+
+    public MassAdjudicationRunIndexInitializer(
+        IMongoDatabase database,
+        ILogger<MassAdjudicationRunIndexInitializer> logger)
+    {
+        _database = database;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _database.GetCollection<MassAdjudicationRunSummary>(
+            MassAdjudicationRunRepositoryMongo.CollectionName);
+        var keys = Builders<MassAdjudicationRunSummary>.IndexKeys;
+
+        collection.Indexes.CreateMany(
+            new[]
+            {
+                new CreateIndexModel<MassAdjudicationRunSummary>(
+                    keys.Ascending(x => x.Run.TenantId).Descending(x => x.Run.StartedAtUtc),
+                    new CreateIndexOptions { Name = "tenant_started_desc" }),
+                new CreateIndexModel<MassAdjudicationRunSummary>(
+                    keys.Ascending(x => x.Run.TenantId).Ascending(x => x.Id),
+                    new CreateIndexOptions { Name = "tenant_run_id" })
+            },
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Mass adjudication run indexes ensured on collection '{Collection}'.",
+            MassAdjudicationRunRepositoryMongo.CollectionName);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -1,0 +1,58 @@
+namespace ClaimsService.Models;
+
+public class MassAdjudicationRunSummary
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public MassAdjudicationRunMetadata Run { get; set; } = new();
+    public int TotalClaims { get; set; }
+    public int Processed { get; set; }
+    public int Paid { get; set; }
+    public int BusinessDenials { get; set; }
+    public int PlatformFailures { get; set; }
+    public TimeSpan Elapsed { get; set; }
+    public double ThroughputClaimsPerSecond { get; set; }
+    public double P95LatencyMilliseconds { get; set; }
+    public double P99LatencyMilliseconds { get; set; }
+    public MassAdjudicationStageTiming? SubmitTiming { get; set; }
+    public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
+    public MassAdjudicationStageTiming? WritebackTiming { get; set; }
+    public decimal? AveragePaymentDelta { get; set; }
+    public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
+    public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+}
+
+public class MassAdjudicationRunMetadata
+{
+    public string TenantId { get; set; } = string.Empty;
+    public int RequestedClaims { get; set; }
+    public int Seed { get; set; }
+    public int Parallelism { get; set; }
+    public string ClaimsUrl { get; set; } = string.Empty;
+    public string BenefitUrl { get; set; } = string.Empty;
+    public string ProviderUrl { get; set; } = string.Empty;
+    public bool SeedProviders { get; set; }
+    public bool SkipClaimUpdate { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationStageTiming
+{
+    public string Label { get; set; } = string.Empty;
+    public double AverageMilliseconds { get; set; }
+    public double P95Milliseconds { get; set; }
+}
+
+public class MassAdjudicationBusinessDenialSummary
+{
+    public string Code { get; set; } = string.Empty;
+    public int Count { get; set; }
+}
+
+public class MassAdjudicationFailureSummary
+{
+    public string GeneratedClaimId { get; set; } = string.Empty;
+    public string? Stage { get; set; }
+    public string? Error { get; set; }
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -37,6 +37,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
 {
     builder.Services.AddScoped<IClaimRepository, ClaimRepositoryMongo>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryMongo>();
+    builder.Services.AddScoped<IMassAdjudicationRunRepository, MassAdjudicationRunRepositoryMongo>();
 
     // Claim version event publisher (5.1) — Mongo append-only stream is the
     // system-of-record for the version chain. Mirrors
@@ -68,6 +69,7 @@ else
 
     builder.Services.AddScoped<IClaimRepository, ClaimRepository>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryCosmos>();
+    builder.Services.AddSingleton<IMassAdjudicationRunRepository, InMemoryMassAdjudicationRunRepository>();
 
     // 5.1b — Cosmos partition-key migration tooling. Resolves the source
     // (legacy /memberId Bicep / /Id runtime) and target (canonical

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -38,6 +38,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddScoped<IClaimRepository, ClaimRepositoryMongo>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryMongo>();
     builder.Services.AddScoped<IMassAdjudicationRunRepository, MassAdjudicationRunRepositoryMongo>();
+    builder.Services.AddHostedService<MassAdjudicationRunIndexInitializer>();
 
     // Claim version event publisher (5.1) — Mongo append-only stream is the
     // system-of-record for the version chain. Mirrors

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -1,0 +1,113 @@
+using ClaimsService.Models;
+using MongoDB.Driver;
+
+namespace ClaimsService.Repositories;
+
+public interface IMassAdjudicationRunRepository
+{
+    Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default);
+    Task<IReadOnlyList<MassAdjudicationRunSummary>> ListAsync(string tenantId, int limit, CancellationToken ct = default);
+    Task<MassAdjudicationRunSummary?> GetAsync(string tenantId, string id, CancellationToken ct = default);
+}
+
+public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRepository
+{
+    private readonly IMongoCollection<MassAdjudicationRunSummary> _collection;
+
+    public MassAdjudicationRunRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<MassAdjudicationRunSummary>("MassAdjudicationRuns");
+
+        var keys = Builders<MassAdjudicationRunSummary>.IndexKeys;
+        _collection.Indexes.CreateMany(new[]
+        {
+            new CreateIndexModel<MassAdjudicationRunSummary>(
+                keys.Ascending(x => x.Run.TenantId).Descending(x => x.Run.StartedAtUtc),
+                new CreateIndexOptions { Name = "tenant_started_desc" }),
+            new CreateIndexModel<MassAdjudicationRunSummary>(
+                keys.Ascending(x => x.Run.TenantId).Ascending(x => x.Id),
+                new CreateIndexOptions { Name = "tenant_run_id" })
+        });
+    }
+
+    public async Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(summary.Id))
+        {
+            summary.Id = Guid.NewGuid().ToString("N");
+        }
+
+        summary.CreatedAtUtc = DateTime.UtcNow;
+        await _collection.InsertOneAsync(summary, cancellationToken: ct);
+        return summary;
+    }
+
+    public async Task<IReadOnlyList<MassAdjudicationRunSummary>> ListAsync(
+        string tenantId,
+        int limit,
+        CancellationToken ct = default)
+    {
+        var filter = Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Run.TenantId, tenantId);
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.Run.StartedAtUtc)
+            .Limit(Math.Clamp(limit, 1, 100))
+            .ToListAsync(ct);
+    }
+
+    public Task<MassAdjudicationRunSummary?> GetAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        var filter = Builders<MassAdjudicationRunSummary>.Filter.And(
+            Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Run.TenantId, tenantId),
+            Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Id, id));
+
+        return _collection.Find(filter).FirstOrDefaultAsync(ct)!;
+    }
+}
+
+public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRunRepository
+{
+    private readonly List<MassAdjudicationRunSummary> _runs = new();
+    private readonly object _sync = new();
+
+    public Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(summary.Id))
+        {
+            summary.Id = Guid.NewGuid().ToString("N");
+        }
+
+        summary.CreatedAtUtc = DateTime.UtcNow;
+
+        lock (_sync)
+        {
+            _runs.Add(summary);
+        }
+
+        return Task.FromResult(summary);
+    }
+
+    public Task<IReadOnlyList<MassAdjudicationRunSummary>> ListAsync(
+        string tenantId,
+        int limit,
+        CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            return Task.FromResult<IReadOnlyList<MassAdjudicationRunSummary>>(
+                _runs
+                    .Where(x => x.Run.TenantId == tenantId)
+                    .OrderByDescending(x => x.Run.StartedAtUtc)
+                    .Take(Math.Clamp(limit, 1, 100))
+                    .ToList());
+        }
+    }
+
+    public Task<MassAdjudicationRunSummary?> GetAsync(string tenantId, string id, CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            return Task.FromResult(
+                _runs.FirstOrDefault(x => x.Run.TenantId == tenantId && x.Id == id));
+        }
+    }
+}

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -12,31 +12,17 @@ public interface IMassAdjudicationRunRepository
 
 public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRepository
 {
+    internal const string CollectionName = "MassAdjudicationRuns";
     private readonly IMongoCollection<MassAdjudicationRunSummary> _collection;
 
     public MassAdjudicationRunRepositoryMongo(IMongoDatabase database)
     {
-        _collection = database.GetCollection<MassAdjudicationRunSummary>("MassAdjudicationRuns");
-
-        var keys = Builders<MassAdjudicationRunSummary>.IndexKeys;
-        _collection.Indexes.CreateMany(new[]
-        {
-            new CreateIndexModel<MassAdjudicationRunSummary>(
-                keys.Ascending(x => x.Run.TenantId).Descending(x => x.Run.StartedAtUtc),
-                new CreateIndexOptions { Name = "tenant_started_desc" }),
-            new CreateIndexModel<MassAdjudicationRunSummary>(
-                keys.Ascending(x => x.Run.TenantId).Ascending(x => x.Id),
-                new CreateIndexOptions { Name = "tenant_run_id" })
-        });
+        _collection = database.GetCollection<MassAdjudicationRunSummary>(CollectionName);
     }
 
     public async Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(summary.Id))
-        {
-            summary.Id = Guid.NewGuid().ToString("N");
-        }
-
+        summary.Id = Guid.NewGuid().ToString("N");
         summary.CreatedAtUtc = DateTime.UtcNow;
         await _collection.InsertOneAsync(summary, cancellationToken: ct);
         return summary;
@@ -71,11 +57,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
 
     public Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(summary.Id))
-        {
-            summary.Id = Guid.NewGuid().ToString("N");
-        }
-
+        summary.Id = Guid.NewGuid().ToString("N");
         summary.CreatedAtUtc = DateTime.UtcNow;
 
         lock (_sync)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -107,6 +107,11 @@ if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
     await WriteSummaryJsonAsync(options.SummaryJsonPath, summary, json);
 }
 
+if (!options.NoPublishSummary)
+{
+    await PublishSummaryAsync(http, options, summary, json);
+}
+
 if (orderedResults.Any(r => r.Outcome is ClaimValidationOutcome.PlatformFailure))
 {
     Environment.ExitCode = 1;
@@ -850,7 +855,7 @@ static IReadOnlyList<(T Item, int Count)> AllocateCounts<T>(int total, IReadOnly
         .ToList();
 }
 
-static MccValidationSummary BuildSummary(
+static MassAdjudicationRunSummary BuildSummary(
     List<ClaimValidationResult> results,
     TimeSpan elapsed,
     ValidatorOptions options,
@@ -877,16 +882,16 @@ static MccValidationSummary BuildSummary(
         .GroupBy(r => r.BusinessDenialCode ?? "UNKNOWN")
         .OrderByDescending(g => g.Count())
         .ThenBy(g => g.Key, StringComparer.Ordinal)
-        .Select(g => new MccBusinessDenialSummary(g.Key, g.Count()))
+        .Select(g => new MassAdjudicationBusinessDenialSummary(g.Key, g.Count()))
         .ToList();
     var failures = results
         .Where(r => r.Outcome is ClaimValidationOutcome.PlatformFailure)
         .Take(5)
-        .Select(r => new MccFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
+        .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
         .ToList();
 
-    return new MccValidationSummary(
-        new MccValidationRun(
+    return new MassAdjudicationRunSummary(
+        new MassAdjudicationRun(
             options.TenantId,
             options.Claims,
             options.Seed,
@@ -915,7 +920,7 @@ static MccValidationSummary BuildSummary(
         failures);
 }
 
-static void WriteSummary(MccValidationSummary summary)
+static void WriteSummary(MassAdjudicationRunSummary summary)
 {
     Console.WriteLine("Validation summary");
     Console.WriteLine($"  Total claims:       {summary.TotalClaims:N0}");
@@ -947,7 +952,7 @@ static void WriteSummary(MccValidationSummary summary)
     }
 }
 
-static MccStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> durations)
+static MassAdjudicationStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> durations)
 {
     var values = durations
         .Select(d => d.TotalMilliseconds)
@@ -960,10 +965,10 @@ static MccStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> dura
         return null;
     }
 
-    return new MccStageTiming(label, values.Average(), Percentile(values, 0.95));
+    return new MassAdjudicationStageTiming(label, values.Average(), Percentile(values, 0.95));
 }
 
-static void WriteStageTiming(MccStageTiming? timing)
+static void WriteStageTiming(MassAdjudicationStageTiming? timing)
 {
     if (timing is null)
     {
@@ -973,7 +978,7 @@ static void WriteStageTiming(MccStageTiming? timing)
     Console.WriteLine($"  {timing.Label,-12} avg/p95: {timing.AverageMilliseconds:N0} ms / {timing.P95Milliseconds:N0} ms");
 }
 
-static async Task WriteSummaryJsonAsync(string path, MccValidationSummary summary, JsonSerializerOptions json)
+static async Task WriteSummaryJsonAsync(string path, MassAdjudicationRunSummary summary, JsonSerializerOptions json)
 {
     var directory = Path.GetDirectoryName(Path.GetFullPath(path));
     if (!string.IsNullOrWhiteSpace(directory))
@@ -983,6 +988,30 @@ static async Task WriteSummaryJsonAsync(string path, MccValidationSummary summar
 
     await File.WriteAllTextAsync(path, JsonSerializer.Serialize(summary, json));
     Console.WriteLine($"  Summary JSON:       {path}");
+}
+
+static async Task PublishSummaryAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    MassAdjudicationRunSummary summary,
+    JsonSerializerOptions json)
+{
+    try
+    {
+        using var response = await http.PostAsJsonAsync($"{options.ClaimsUrl}/api/mass-adjudication/runs", summary, json);
+        if (response.IsSuccessStatusCode)
+        {
+            Console.WriteLine("  Dashboard summary: published");
+            return;
+        }
+
+        var body = await response.Content.ReadAsStringAsync();
+        Console.WriteLine($"  Dashboard summary: publish skipped ({(int)response.StatusCode} {body})");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"  Dashboard summary: publish skipped ({ex.Message})");
+    }
 }
 
 static double Percentile(double[] values, double percentile)
@@ -1017,6 +1046,7 @@ static void PrintUsage()
       --progress-every <count>   Report progress every N claims (default: 25)
       --parallelism <count>      Number of claims to process concurrently (default: 4)
       --summary-json <path>      Write machine-readable validation summary JSON
+      --no-publish-summary       Do not publish the completed run to claims-service
       -h, --help                 Show help
 
     Example:
@@ -1054,6 +1084,7 @@ internal sealed record ValidatorOptions(
     int ProgressEvery,
     int Parallelism,
     string? SummaryJsonPath,
+    bool NoPublishSummary,
     bool ShowHelp)
 {
     public const int MaxClaims = 10_000;
@@ -1102,6 +1133,9 @@ internal sealed record ValidatorOptions(
                 case "--summary-json" when i + 1 < args.Length:
                     options.SummaryJsonPath = args[++i];
                     break;
+                case "--no-publish-summary":
+                    options.NoPublishSummary = true;
+                    break;
                 case "--help" or "-h":
                     options.ShowHelp = true;
                     break;
@@ -1133,6 +1167,7 @@ internal sealed record ValidatorOptions(
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
             options.SummaryJsonPath,
+            options.NoPublishSummary,
             options.ShowHelp);
     }
 
@@ -1150,6 +1185,7 @@ internal sealed record ValidatorOptions(
         public int ProgressEvery { get; set; } = 10;
         public int Parallelism { get; set; } = 4;
         public string? SummaryJsonPath { get; set; }
+        public bool NoPublishSummary { get; set; }
         public bool ShowHelp { get; set; }
     }
 }
@@ -1179,8 +1215,8 @@ internal sealed record ClaimValidationResult(
     string? FailureStage,
     string? Error);
 
-internal sealed record MccValidationSummary(
-    MccValidationRun Run,
+internal sealed record MassAdjudicationRunSummary(
+    MassAdjudicationRun Run,
     int TotalClaims,
     int Processed,
     int Paid,
@@ -1190,14 +1226,14 @@ internal sealed record MccValidationSummary(
     double ThroughputClaimsPerSecond,
     double P95LatencyMilliseconds,
     double P99LatencyMilliseconds,
-    MccStageTiming? SubmitTiming,
-    MccStageTiming? AdjudicateTiming,
-    MccStageTiming? WritebackTiming,
+    MassAdjudicationStageTiming? SubmitTiming,
+    MassAdjudicationStageTiming? AdjudicateTiming,
+    MassAdjudicationStageTiming? WritebackTiming,
     decimal? AveragePaymentDelta,
-    IReadOnlyList<MccBusinessDenialSummary> BusinessDenialBreakdown,
-    IReadOnlyList<MccFailureSummary> SampleFailures);
+    IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
+    IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures);
 
-internal sealed record MccValidationRun(
+internal sealed record MassAdjudicationRun(
     string TenantId,
     int RequestedClaims,
     int Seed,
@@ -1210,16 +1246,16 @@ internal sealed record MccValidationRun(
     DateTimeOffset StartedAtUtc,
     DateTimeOffset CompletedAtUtc);
 
-internal sealed record MccStageTiming(
+internal sealed record MassAdjudicationStageTiming(
     string Label,
     double AverageMilliseconds,
     double P95Milliseconds);
 
-internal sealed record MccBusinessDenialSummary(
+internal sealed record MassAdjudicationBusinessDenialSummary(
     string Code,
     int Count);
 
-internal sealed record MccFailureSummary(
+internal sealed record MassAdjudicationFailureSummary(
     string GeneratedClaimId,
     string? Stage,
     string? Error);


### PR DESCRIPTION
## Summary
- add production-facing mass adjudication run summary API and Mongo/in-memory repositories
- publish validator summaries to the mass adjudication run endpoint
- add portal navigation and dashboard page for run outcomes, timing, denial breakdowns, and platform failure samples

## Validation
- dotnet build src/services/claims-service/claims-service.csproj
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj
- git diff --check