### PR TITLE
Add mass adjudication claim drilldown

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -383,6 +383,62 @@ public class ClaimsServiceTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetMassAdjudicationClaimResultsAsync_WhenApiReturns200_DeserializesClaimResults()
+    {
+        var json = JsonSerializer.Serialize(new[]
+        {
+            new
+            {
+                id = "result-001",
+                runId = "run-001",
+                tenantId = "tenant-a",
+                generatedClaimId = "GEN-001",
+                submittedClaimId = "CLM-001",
+                claimType = 1,
+                outcome = "Paid",
+                adjudicationSuccess = true,
+                actualPlanPayment = 95.25m,
+                expectedPlanPayment = 95.25m,
+                paymentDelta = 0m,
+                elapsedMilliseconds = 250.5,
+                submitMilliseconds = 50.0,
+                adjudicationMilliseconds = 125.0,
+                writebackMilliseconds = 75.5,
+                createdAtUtc = "2026-07-03T00:00:00Z"
+            }
+        }, JsonOpts);
+
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, json)));
+
+        var result = await sut.GetMassAdjudicationClaimResultsAsync("run-001");
+
+        result.Should().ContainSingle();
+        result[0].GeneratedClaimId.Should().Be("GEN-001");
+        result[0].ClaimType.Should().Be("Professional");
+        result[0].Outcome.Should().Be("Paid");
+    }
+
+    [Fact]
+    public async Task GetMassAdjudicationClaimResultsAsync_VerifyUrlContainsEscapedQueryParameters()
+    {
+        var handler = new FakeHandler(HttpStatusCode.OK, "[]");
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.GetMassAdjudicationClaimResultsAsync("run/001", "Business Denial", 5000);
+
+        handler.CapturedUrls.Should().ContainSingle()
+            .Which.Should().Be("http://localhost:5000/mass-adjudication/runs/run%2F001/claims?limit=1000&outcome=Business%20Denial");
+    }
+
+    [Fact]
+    public void FlexibleClaimStatusJsonConverter_WhenApiReturnsNumericValue_DeserializesStatusName()
+    {
+        JsonSerializer.Deserialize<IdCardOrderView>(
+            """{"status":7}""",
+            JsonOpts)!.Status.Should().Be("Paid");
+    }
+
     // ── SubmitClaimAsync ──
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -161,6 +161,88 @@
                 </MudGrid>
             </MudPaper>
 
+            <MudPaper Class="pa-4 mb-3" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+                <div class="d-flex align-center gap-2 mb-3">
+                    <MudIcon Icon="@Icons.Material.Filled.ManageSearch" Color="Color.Primary" />
+                    <MudText Typo="Typo.subtitle2" Style="font-weight: 700;">Claim Results</MudText>
+                    <MudSpacer />
+                    <MudSelect T="string" Value="_claimOutcomeFilter" ValueChanged="OnClaimOutcomeFilterChanged"
+                               Dense="true" Variant="Variant.Outlined" Style="width: 190px;">
+                        <MudSelectItem Value="@("")">All outcomes</MudSelectItem>
+                        <MudSelectItem Value="@("Paid")">Paid</MudSelectItem>
+                        <MudSelectItem Value="@("BusinessDenial")">Business denials</MudSelectItem>
+                        <MudSelectItem Value="@("PlatformFailure")">Platform failures</MudSelectItem>
+                    </MudSelect>
+                </div>
+
+                @if (_claimResultsLoading)
+                {
+                    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-3" />
+                }
+
+                <MudTable Items="_claimResults" Dense="true" Hover="true" T="MassAdjudicationClaimResult" RowsPerPage="10">
+                    <HeaderContent>
+                        <MudTh>Claim</MudTh>
+                        <MudTh>Outcome</MudTh>
+                        <MudTh>Denial / Failure</MudTh>
+                        <MudTh>Latency</MudTh>
+                        <MudTh>Payment</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Claim">
+                            @if (!string.IsNullOrWhiteSpace(context.SubmittedClaimId))
+                            {
+                                <MudLink Href="@ClaimHref(context.SubmittedClaimId!)" Color="Color.Primary" Style="font-family: monospace; font-weight: 700;">
+                                    @ShortId(context.SubmittedClaimId!)
+                                </MudLink>
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.body2" Style="font-family: monospace;">@ShortId(context.GeneratedClaimId)</MudText>
+                            }
+                            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                                @context.ClaimType · @ShortId(context.GeneratedClaimId)
+                            </MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Outcome">
+                            <MudChip T="string" Size="Size.Small" Color="@OutcomeColor(context.Outcome)">
+                                @OutcomeLabel(context.Outcome)
+                            </MudChip>
+                        </MudTd>
+                        <MudTd DataLabel="Denial / Failure">
+                            <MudText Typo="Typo.body2">@(!string.IsNullOrWhiteSpace(context.BusinessDenialCode) ? context.BusinessDenialCode : context.FailureStage ?? "-")</MudText>
+                            @if (!string.IsNullOrWhiteSpace(context.Error))
+                            {
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">@context.Error</MudText>
+                            }
+                        </MudTd>
+                        <MudTd DataLabel="Latency">
+                            <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.ElapsedMilliseconds.ToString("N0") ms</MudText>
+                            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                                s @context.SubmitMilliseconds.ToString("N0") / a @context.AdjudicationMilliseconds.ToString("N0") / w @context.WritebackMilliseconds.ToString("N0")
+                            </MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Payment">
+                            <MudText Typo="Typo.body2" Style="font-family: monospace;">@(context.ActualPlanPayment?.ToString("C") ?? "-")</MudText>
+                            @if (context.PaymentDelta.HasValue)
+                            {
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                                    delta @context.PaymentDelta.Value.ToString("C")
+                                </MudText>
+                            }
+                        </MudTd>
+                    </RowTemplate>
+                    <NoRecordsContent>
+                        <div class="pa-5 text-center">
+                            <MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.55);">No claim-level results were published for this run.</MudText>
+                        </div>
+                    </NoRecordsContent>
+                    <PagerContent>
+                        <MudTablePager PageSizeOptions="new[] { 10, 25, 50 }" />
+                    </PagerContent>
+                </MudTable>
+            </MudPaper>
+
             <MudGrid Spacing="3">
                 <MudItem xs="12" md="6">
                     <MudPaper Class="pa-4" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(255,202,40,0.18); border-radius: 8px;">
@@ -204,8 +286,11 @@
 
 @code {
     private readonly List<MassAdjudicationRunSummary> _runs = new();
+    private readonly List<MassAdjudicationClaimResult> _claimResults = new();
     private MassAdjudicationRunSummary? _selectedRun;
     private bool _loading;
+    private bool _claimResultsLoading;
+    private string _claimOutcomeFilter = string.Empty;
     private string? _error;
 
     protected override async Task OnInitializedAsync()
@@ -223,6 +308,7 @@
             _runs.Clear();
             _runs.AddRange(runs);
             _selectedRun = _runs.FirstOrDefault();
+            await LoadClaimResults();
         }
         catch (Exception ex)
         {
@@ -235,10 +321,49 @@
         }
     }
 
-    private void SelectRun(MassAdjudicationRunSummary run)
+    private async Task SelectRun(MassAdjudicationRunSummary run)
     {
         _selectedRun = run;
+        _claimOutcomeFilter = string.Empty;
+        await LoadClaimResults();
     }
+
+    private async Task OnClaimOutcomeFilterChanged(string value)
+    {
+        _claimOutcomeFilter = value;
+        await LoadClaimResults();
+    }
+
+    private async Task LoadClaimResults()
+    {
+        _claimResults.Clear();
+        if (_selectedRun is null)
+        {
+            return;
+        }
+
+        _claimResultsLoading = true;
+        try
+        {
+            var results = await ClaimsService.GetMassAdjudicationClaimResultsAsync(
+                _selectedRun.Id,
+                string.IsNullOrWhiteSpace(_claimOutcomeFilter) ? null : _claimOutcomeFilter,
+                250);
+            _claimResults.AddRange(results);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            Snackbar.Add("Unable to load claim-level results", Severity.Warning);
+        }
+        finally
+        {
+            _claimResultsLoading = false;
+        }
+    }
+
+    private static string ClaimHref(string claimId)
+        => $"/claims/{Uri.EscapeDataString(claimId)}";
 
     private static string ShortId(string id)
         => string.IsNullOrWhiteSpace(id) ? "run" : id[..Math.Min(8, id.Length)];
@@ -250,6 +375,21 @@
         => _selectedRun is null || _selectedRun.BusinessDenials <= 0
             ? 0
             : (double)count / _selectedRun.BusinessDenials * 100;
+
+    private static Color OutcomeColor(string outcome) => outcome switch
+    {
+        "Paid" => Color.Success,
+        "BusinessDenial" => Color.Warning,
+        "PlatformFailure" => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string OutcomeLabel(string outcome) => outcome switch
+    {
+        "BusinessDenial" => "Business Denial",
+        "PlatformFailure" => "Platform Failure",
+        _ => outcome
+    };
 
     private RenderFragment Metric(string label, string value, string color) => builder =>
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -12,6 +12,10 @@ public interface IClaimsService
     Task<ClaimDetails?> GetClaimByIdAsync(string claimId);
     Task<List<MassAdjudicationRunSummary>> GetMassAdjudicationRunsAsync(int limit = 25);
     Task<MassAdjudicationRunSummary?> GetMassAdjudicationRunAsync(string runId);
+    Task<List<MassAdjudicationClaimResult>> GetMassAdjudicationClaimResultsAsync(
+        string runId,
+        string? outcome = null,
+        int limit = 250);
     Task<string> SubmitClaimAsync(SubmitClaimRequest request);
     Task UpdateClaimStatusAsync(string claimId, string status, string? notes = null);
     Task<AdjudicationTransparencyData?> GetAdjudicationDataAsync(string claimId);
@@ -90,6 +94,7 @@ public class MassAdjudicationRunSummary
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
+    public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; }
 }
 
@@ -126,6 +131,29 @@ public class MassAdjudicationFailureSummary
     public string GeneratedClaimId { get; set; } = string.Empty;
     public string? Stage { get; set; }
     public string? Error { get; set; }
+}
+
+public class MassAdjudicationClaimResult
+{
+    public string Id { get; set; } = string.Empty;
+    public string RunId { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string GeneratedClaimId { get; set; } = string.Empty;
+    public string? SubmittedClaimId { get; set; }
+    public string ClaimType { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public bool AdjudicationSuccess { get; set; }
+    public string? BusinessDenialCode { get; set; }
+    public string? FailureStage { get; set; }
+    public string? Error { get; set; }
+    public decimal? ActualPlanPayment { get; set; }
+    public decimal? ExpectedPlanPayment { get; set; }
+    public decimal? PaymentDelta { get; set; }
+    public double ElapsedMilliseconds { get; set; }
+    public double SubmitMilliseconds { get; set; }
+    public double AdjudicationMilliseconds { get; set; }
+    public double WritebackMilliseconds { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
 }
 
 public class ServiceAccumulator
@@ -535,6 +563,7 @@ public interface IIdCardService
 public class IdCardOrderView
 {
     public string OrderId { get; set; } = string.Empty;
+    [JsonConverter(typeof(FlexibleClaimStatusJsonConverter))]
     public string Status { get; set; } = string.Empty;
     public string? CardId { get; set; }
     public string? DocumentId { get; set; }
@@ -570,7 +599,8 @@ public class ClaimSummary
     public string MemberId { get; set; } = string.Empty;
     public string ProviderName { get; set; } = string.Empty;
     public string ProviderId { get; set; } = string.Empty;
-    public string ClaimType { get; set; } = string.Empty; // Professional, Institutional
+    [JsonConverter(typeof(FlexibleClaimTypeJsonConverter))]
+    public string ClaimType { get; set; } = string.Empty; // Professional, Institutional, Dental
     public decimal TotalChargeAmount { get; set; }
     public decimal AllowedAmount { get; set; }
     public decimal PaidAmount { get; set; }

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Mail;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Identity.Web;
 using MongoDB.Driver;
 using MongoDB.Bson;
@@ -46,13 +47,13 @@ public class ClaimsService : IClaimsService
             // Try by ID first, then fall back to claim number lookup
             var response = await _httpClient.GetAsync($"{baseUrl}/claims/{claimId}");
             if (response.IsSuccessStatusCode)
-                return await response.Content.ReadFromJsonAsync<ClaimDetails>();
+                return await response.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 var fallback = await _httpClient.GetAsync($"{baseUrl}/claims/number/{claimId}");
                 if (fallback.IsSuccessStatusCode)
-                    return await fallback.Content.ReadFromJsonAsync<ClaimDetails>();
+                    return await fallback.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
                 if (fallback.StatusCode == System.Net.HttpStatusCode.NotFound)
                     return null;
                 fallback.EnsureSuccessStatusCode();
@@ -99,6 +100,33 @@ public class ClaimsService : IClaimsService
 
             response.EnsureSuccessStatusCode();
             return await ReadOptionalJsonAsync<MassAdjudicationRunSummary>(response);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+    }
+
+    public async Task<List<MassAdjudicationClaimResult>> GetMassAdjudicationClaimResultsAsync(
+        string runId,
+        string? outcome = null,
+        int limit = 250)
+    {
+        var baseUrl = _configuration["Services:ClaimsService"];
+        try
+        {
+            var query = $"limit={Math.Clamp(limit, 1, 1000)}";
+            if (!string.IsNullOrWhiteSpace(outcome))
+            {
+                query += $"&outcome={Uri.EscapeDataString(outcome)}";
+            }
+
+            var response = await _httpClient.GetAsync(
+                $"{baseUrl}/mass-adjudication/runs/{Uri.EscapeDataString(runId)}/claims?{query}");
+            response.EnsureSuccessStatusCode();
+            return await ReadOptionalJsonAsync<List<MassAdjudicationClaimResult>>(response)
+                ?? new List<MassAdjudicationClaimResult>();
         }
         catch (HttpRequestException ex)
         {
@@ -224,6 +252,68 @@ public class ClaimsService : IClaimsService
         }
 
         return JsonSerializer.Deserialize<T>(body, JsonOptions);
+    }
+}
+
+public sealed class FlexibleClaimTypeJsonConverter : JsonConverter<string>
+{
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString() ?? string.Empty,
+            JsonTokenType.Number when reader.TryGetInt32(out var value) => value switch
+            {
+                0 => "Professional",
+                1 => "Institutional",
+                2 => "Dental",
+                _ => value.ToString()
+            },
+            JsonTokenType.Number => reader.GetDouble().ToString(System.Globalization.CultureInfo.InvariantCulture),
+            JsonTokenType.True => bool.TrueString,
+            JsonTokenType.False => bool.FalseString,
+            JsonTokenType.Null => string.Empty,
+            _ => JsonDocument.ParseValue(ref reader).RootElement.ToString()
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}
+
+public sealed class FlexibleClaimStatusJsonConverter : JsonConverter<string>
+{
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.String => reader.GetString() ?? string.Empty,
+            JsonTokenType.Number when reader.TryGetInt32(out var value) => value switch
+            {
+                1 => "Submitted",
+                2 => "Received",
+                3 => "InAdjudication",
+                4 => "Pended",
+                5 => "Approved",
+                6 => "Denied",
+                7 => "Paid",
+                8 => "Voided",
+                9 => "PartiallyPaid",
+                _ => value.ToString()
+            },
+            JsonTokenType.Number => reader.GetDouble().ToString(System.Globalization.CultureInfo.InvariantCulture),
+            JsonTokenType.True => bool.TrueString,
+            JsonTokenType.False => bool.FalseString,
+            JsonTokenType.Null => string.Empty,
+            _ => JsonDocument.ParseValue(ref reader).RootElement.ToString()
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
     }
 }
 

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -264,9 +264,9 @@ public sealed class FlexibleClaimTypeJsonConverter : JsonConverter<string>
             JsonTokenType.String => reader.GetString() ?? string.Empty,
             JsonTokenType.Number when reader.TryGetInt32(out var value) => value switch
             {
-                0 => "Professional",
-                1 => "Institutional",
-                2 => "Dental",
+                1 => "Professional",
+                2 => "Institutional",
+                3 => "Dental",
                 _ => value.ToString()
             },
             JsonTokenType.Number => reader.GetDouble().ToString(System.Globalization.CultureInfo.InvariantCulture),

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -38,6 +38,25 @@ public sealed class MassAdjudicationRunsController : ControllerBase
         return run is null ? NotFound() : Ok(run);
     }
 
+    [HttpGet("{id}/claims")]
+    [ProducesResponseType(typeof(IReadOnlyList<MassAdjudicationClaimResult>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IReadOnlyList<MassAdjudicationClaimResult>>> ListClaimResults(
+        string id,
+        [FromQuery] string? outcome = null,
+        [FromQuery] int limit = 250,
+        CancellationToken ct = default)
+    {
+        var tenantId = GetTenantId();
+        var run = await _repository.GetAsync(tenantId, id, ct);
+        if (run is null)
+        {
+            return NotFound();
+        }
+
+        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, limit, ct);
+        return Ok(results);
+    }
+
     [HttpPost]
     [ProducesResponseType(typeof(MassAdjudicationRunSummary), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/services/claims-service/HostedServices/MassAdjudicationRunIndexInitializer.cs
+++ b/src/services/claims-service/HostedServices/MassAdjudicationRunIndexInitializer.cs
@@ -35,9 +35,33 @@ public sealed class MassAdjudicationRunIndexInitializer : IHostedService
             },
             cancellationToken);
 
+        var claimResults = _database.GetCollection<MassAdjudicationClaimResult>(
+            MassAdjudicationRunRepositoryMongo.ClaimResultsCollectionName);
+        var claimResultKeys = Builders<MassAdjudicationClaimResult>.IndexKeys;
+
+        claimResults.Indexes.CreateMany(
+            new[]
+            {
+                new CreateIndexModel<MassAdjudicationClaimResult>(
+                    claimResultKeys.Ascending(x => x.TenantId).Ascending(x => x.RunId).Ascending(x => x.Outcome),
+                    new CreateIndexOptions { Name = "tenant_run_outcome" }),
+                new CreateIndexModel<MassAdjudicationClaimResult>(
+                    claimResultKeys.Ascending(x => x.TenantId).Ascending(x => x.RunId).Descending(x => x.ElapsedMilliseconds),
+                    new CreateIndexOptions { Name = "tenant_run_elapsed_desc" }),
+                new CreateIndexModel<MassAdjudicationClaimResult>(
+                    claimResultKeys.Ascending(x => x.TenantId).Ascending(x => x.SubmittedClaimId),
+                    new CreateIndexOptions
+                    {
+                        Name = "tenant_submitted_claim",
+                        Sparse = true
+                    })
+            },
+            cancellationToken);
+
         _logger.LogInformation(
-            "Mass adjudication run indexes ensured on collection '{Collection}'.",
-            MassAdjudicationRunRepositoryMongo.CollectionName);
+            "Mass adjudication run indexes ensured on collections '{RunCollection}' and '{ClaimResultCollection}'.",
+            MassAdjudicationRunRepositoryMongo.CollectionName,
+            MassAdjudicationRunRepositoryMongo.ClaimResultsCollectionName);
         return Task.CompletedTask;
     }
 

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -1,3 +1,5 @@
+using MongoDB.Bson.Serialization.Attributes;
+
 namespace ClaimsService.Models;
 
 public class MassAdjudicationRunSummary
@@ -19,6 +21,8 @@ public class MassAdjudicationRunSummary
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
+    [BsonIgnore]
+    public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 }
 
@@ -55,4 +59,27 @@ public class MassAdjudicationFailureSummary
     public string GeneratedClaimId { get; set; } = string.Empty;
     public string? Stage { get; set; }
     public string? Error { get; set; }
+}
+
+public class MassAdjudicationClaimResult
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string RunId { get; set; } = string.Empty;
+    public string TenantId { get; set; } = string.Empty;
+    public string GeneratedClaimId { get; set; } = string.Empty;
+    public string? SubmittedClaimId { get; set; }
+    public string ClaimType { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public bool AdjudicationSuccess { get; set; }
+    public string? BusinessDenialCode { get; set; }
+    public string? FailureStage { get; set; }
+    public string? Error { get; set; }
+    public decimal? ActualPlanPayment { get; set; }
+    public decimal? ExpectedPlanPayment { get; set; }
+    public decimal? PaymentDelta { get; set; }
+    public double ElapsedMilliseconds { get; set; }
+    public double SubmitMilliseconds { get; set; }
+    public double AdjudicationMilliseconds { get; set; }
+    public double WritebackMilliseconds { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 }

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -8,23 +8,47 @@ public interface IMassAdjudicationRunRepository
     Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default);
     Task<IReadOnlyList<MassAdjudicationRunSummary>> ListAsync(string tenantId, int limit, CancellationToken ct = default);
     Task<MassAdjudicationRunSummary?> GetAsync(string tenantId, string id, CancellationToken ct = default);
+    Task<IReadOnlyList<MassAdjudicationClaimResult>> ListClaimResultsAsync(
+        string tenantId,
+        string runId,
+        string? outcome,
+        int limit,
+        CancellationToken ct = default);
 }
 
 public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRepository
 {
     internal const string CollectionName = "MassAdjudicationRuns";
+    internal const string ClaimResultsCollectionName = "MassAdjudicationClaimResults";
     private readonly IMongoCollection<MassAdjudicationRunSummary> _collection;
+    private readonly IMongoCollection<MassAdjudicationClaimResult> _claimResults;
 
     public MassAdjudicationRunRepositoryMongo(IMongoDatabase database)
     {
         _collection = database.GetCollection<MassAdjudicationRunSummary>(CollectionName);
+        _claimResults = database.GetCollection<MassAdjudicationClaimResult>(ClaimResultsCollectionName);
     }
 
     public async Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
     {
         summary.Id = Guid.NewGuid().ToString("N");
         summary.CreatedAtUtc = DateTime.UtcNow;
+
+        var claimResults = summary.ClaimResults;
+        foreach (var result in claimResults)
+        {
+            result.Id = string.IsNullOrWhiteSpace(result.Id) ? Guid.NewGuid().ToString("N") : result.Id;
+            result.RunId = summary.Id;
+            result.TenantId = summary.Run.TenantId;
+            result.CreatedAtUtc = summary.CreatedAtUtc;
+        }
+
         await _collection.InsertOneAsync(summary, cancellationToken: ct);
+        if (claimResults.Count > 0)
+        {
+            await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
+        }
+
         return summary;
     }
 
@@ -48,11 +72,37 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
         return _collection.Find(filter).FirstOrDefaultAsync(ct)!;
     }
+
+    public async Task<IReadOnlyList<MassAdjudicationClaimResult>> ListClaimResultsAsync(
+        string tenantId,
+        string runId,
+        string? outcome,
+        int limit,
+        CancellationToken ct = default)
+    {
+        var filters = new List<FilterDefinition<MassAdjudicationClaimResult>>
+        {
+            Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, tenantId),
+            Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.RunId, runId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(outcome))
+        {
+            filters.Add(Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.Outcome, outcome));
+        }
+
+        return await _claimResults
+            .Find(Builders<MassAdjudicationClaimResult>.Filter.And(filters))
+            .SortByDescending(x => x.ElapsedMilliseconds)
+            .Limit(Math.Clamp(limit, 1, 1000))
+            .ToListAsync(ct);
+    }
 }
 
 public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRunRepository
 {
     private readonly List<MassAdjudicationRunSummary> _runs = new();
+    private readonly List<MassAdjudicationClaimResult> _claimResults = new();
     private readonly object _sync = new();
 
     public Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
@@ -62,6 +112,15 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
 
         lock (_sync)
         {
+            foreach (var result in summary.ClaimResults)
+            {
+                result.Id = string.IsNullOrWhiteSpace(result.Id) ? Guid.NewGuid().ToString("N") : result.Id;
+                result.RunId = summary.Id;
+                result.TenantId = summary.Run.TenantId;
+                result.CreatedAtUtc = summary.CreatedAtUtc;
+                _claimResults.Add(result);
+            }
+
             _runs.Add(summary);
         }
 
@@ -90,6 +149,31 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
         {
             return Task.FromResult(
                 _runs.FirstOrDefault(x => x.Run.TenantId == tenantId && x.Id == id));
+        }
+    }
+
+    public Task<IReadOnlyList<MassAdjudicationClaimResult>> ListClaimResultsAsync(
+        string tenantId,
+        string runId,
+        string? outcome,
+        int limit,
+        CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            var query = _claimResults
+                .Where(x => x.TenantId == tenantId && x.RunId == runId);
+
+            if (!string.IsNullOrWhiteSpace(outcome))
+            {
+                query = query.Where(x => string.Equals(x.Outcome, outcome, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return Task.FromResult<IReadOnlyList<MassAdjudicationClaimResult>>(
+                query
+                    .OrderByDescending(x => x.ElapsedMilliseconds)
+                    .Take(Math.Clamp(limit, 1, 1000))
+                    .ToList());
         }
     }
 }

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -37,7 +37,7 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         var claimResults = summary.ClaimResults;
         foreach (var result in claimResults)
         {
-            result.Id = string.IsNullOrWhiteSpace(result.Id) ? Guid.NewGuid().ToString("N") : result.Id;
+            result.Id = Guid.NewGuid().ToString("N");
             result.RunId = summary.Id;
             result.TenantId = summary.Run.TenantId;
             result.CreatedAtUtc = summary.CreatedAtUtc;
@@ -46,7 +46,23 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         await _collection.InsertOneAsync(summary, cancellationToken: ct);
         if (claimResults.Count > 0)
         {
-            await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
+            try
+            {
+                await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
+            }
+            catch
+            {
+                try
+                {
+                    var filter = Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Id, summary.Id);
+                    await _collection.DeleteOneAsync(filter, cancellationToken: ct);
+                }
+                catch
+                {
+                }
+
+                throw;
+            }
         }
 
         return summary;
@@ -114,7 +130,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
         {
             foreach (var result in summary.ClaimResults)
             {
-                result.Id = string.IsNullOrWhiteSpace(result.Id) ? Guid.NewGuid().ToString("N") : result.Id;
+                result.Id = Guid.NewGuid().ToString("N");
                 result.RunId = summary.Id;
                 result.TenantId = summary.Run.TenantId;
                 result.CreatedAtUtc = summary.CreatedAtUtc;

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1182,8 +1182,10 @@ internal sealed record ValidatorOptions(
             options.Parallelism = MaxParallelism;
         }
 
+        var effectiveClaims = Math.Max(1, options.Claims);
+
         return new ValidatorOptions(
-            Math.Max(1, options.Claims),
+            effectiveClaims,
             options.Seed,
             options.TenantId,
             options.ClaimsUrl.TrimEnd('/'),
@@ -1196,7 +1198,7 @@ internal sealed record ValidatorOptions(
             Math.Max(1, options.Parallelism),
             options.SummaryJsonPath,
             options.NoPublishSummary,
-            Math.Clamp(options.PublishClaimResultsLimit, 0, options.Claims),
+            Math.Clamp(options.PublishClaimResultsLimit, 0, effectiveClaims),
             options.ShowHelp);
     }
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -889,6 +889,28 @@ static MassAdjudicationRunSummary BuildSummary(
         .Take(5)
         .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
         .ToList();
+    var claimResults = results
+        .OrderByDescending(r => r.Elapsed)
+        .Take(options.PublishClaimResultsLimit)
+        .Select(r => new MassAdjudicationClaimResult(
+            r.GeneratedClaimId,
+            r.SubmittedClaimId,
+            r.ClaimType,
+            r.Outcome.ToString(),
+            r.AdjudicationSuccess,
+            r.BusinessDenialCode,
+            r.FailureStage,
+            r.Error,
+            r.ActualPlanPayment,
+            r.ExpectedPlanPayment,
+            r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue
+                ? Math.Abs(r.ActualPlanPayment.Value - r.ExpectedPlanPayment.Value)
+                : null,
+            r.Elapsed.TotalMilliseconds,
+            r.SubmitElapsed.TotalMilliseconds,
+            r.AdjudicationElapsed.TotalMilliseconds,
+            r.UpdateElapsed.TotalMilliseconds))
+        .ToList();
 
     return new MassAdjudicationRunSummary(
         new MassAdjudicationRun(
@@ -917,7 +939,8 @@ static MassAdjudicationRunSummary BuildSummary(
         BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
         avgDelta,
         denialBreakdown,
-        failures);
+        failures,
+        claimResults);
 }
 
 static void WriteSummary(MassAdjudicationRunSummary summary)
@@ -1047,6 +1070,7 @@ static void PrintUsage()
       --parallelism <count>      Number of claims to process concurrently (default: 4)
       --summary-json <path>      Write machine-readable validation summary JSON
       --no-publish-summary       Do not publish the completed run to claims-service
+      --claim-results-limit <n>  Number of per-claim results to publish with the run (default: 1000)
       -h, --help                 Show help
 
     Example:
@@ -1085,6 +1109,7 @@ internal sealed record ValidatorOptions(
     int Parallelism,
     string? SummaryJsonPath,
     bool NoPublishSummary,
+    int PublishClaimResultsLimit,
     bool ShowHelp)
 {
     public const int MaxClaims = 10_000;
@@ -1136,6 +1161,9 @@ internal sealed record ValidatorOptions(
                 case "--no-publish-summary":
                     options.NoPublishSummary = true;
                     break;
+                case "--claim-results-limit" when i + 1 < args.Length:
+                    options.PublishClaimResultsLimit = int.Parse(args[++i]);
+                    break;
                 case "--help" or "-h":
                     options.ShowHelp = true;
                     break;
@@ -1168,6 +1196,7 @@ internal sealed record ValidatorOptions(
             Math.Max(1, options.Parallelism),
             options.SummaryJsonPath,
             options.NoPublishSummary,
+            Math.Clamp(options.PublishClaimResultsLimit, 0, options.Claims),
             options.ShowHelp);
     }
 
@@ -1186,6 +1215,7 @@ internal sealed record ValidatorOptions(
         public int Parallelism { get; set; } = 4;
         public string? SummaryJsonPath { get; set; }
         public bool NoPublishSummary { get; set; }
+        public int PublishClaimResultsLimit { get; set; } = 1000;
         public bool ShowHelp { get; set; }
     }
 }
@@ -1231,7 +1261,8 @@ internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationStageTiming? WritebackTiming,
     decimal? AveragePaymentDelta,
     IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
-    IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures);
+    IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures,
+    IReadOnlyList<MassAdjudicationClaimResult> ClaimResults);
 
 internal sealed record MassAdjudicationRun(
     string TenantId,
@@ -1259,6 +1290,23 @@ internal sealed record MassAdjudicationFailureSummary(
     string GeneratedClaimId,
     string? Stage,
     string? Error);
+
+internal sealed record MassAdjudicationClaimResult(
+    string GeneratedClaimId,
+    string? SubmittedClaimId,
+    string ClaimType,
+    string Outcome,
+    bool AdjudicationSuccess,
+    string? BusinessDenialCode,
+    string? FailureStage,
+    string? Error,
+    decimal? ActualPlanPayment,
+    decimal? ExpectedPlanPayment,
+    decimal? PaymentDelta,
+    double ElapsedMilliseconds,
+    double SubmitMilliseconds,
+    double AdjudicationMilliseconds,
+    double WritebackMilliseconds);
 
 internal sealed record AdjudicationResponseDto(
     string ClaimId,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -1,0 +1,94 @@
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using FluentAssertions;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Repositories;
+
+public class MassAdjudicationRunRepositoryTests
+{
+    [Fact]
+    public async Task SaveAsync_generates_server_side_ids_for_claim_results()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var summary = CreateSummary();
+        summary.ClaimResults.Add(new MassAdjudicationClaimResult
+        {
+            Id = "client-supplied-id",
+            GeneratedClaimId = "GEN-001",
+            ClaimType = "Professional",
+            Outcome = "Paid",
+            AdjudicationSuccess = true
+        });
+
+        var saved = await repo.SaveAsync(summary);
+
+        saved.Id.Should().NotBeNullOrWhiteSpace();
+        saved.ClaimResults.Should().ContainSingle();
+        saved.ClaimResults[0].Id.Should().NotBe("client-supplied-id");
+        saved.ClaimResults[0].RunId.Should().Be(saved.Id);
+        saved.ClaimResults[0].TenantId.Should().Be(saved.Run.TenantId);
+        saved.ClaimResults[0].CreatedAtUtc.Should().Be(saved.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task SaveAsync_when_claim_result_insert_fails_deletes_inserted_summary()
+    {
+        var database = Substitute.For<IMongoDatabase>();
+        var runs = Substitute.For<IMongoCollection<MassAdjudicationRunSummary>>();
+        var claimResults = Substitute.For<IMongoCollection<MassAdjudicationClaimResult>>();
+
+        database.GetCollection<MassAdjudicationRunSummary>(
+                MassAdjudicationRunRepositoryMongo.CollectionName,
+                Arg.Any<MongoCollectionSettings?>())
+            .Returns(runs);
+        database.GetCollection<MassAdjudicationClaimResult>(
+                MassAdjudicationRunRepositoryMongo.ClaimResultsCollectionName,
+                Arg.Any<MongoCollectionSettings?>())
+            .Returns(claimResults);
+
+        claimResults
+            .InsertManyAsync(
+                Arg.Any<IEnumerable<MassAdjudicationClaimResult>>(),
+                Arg.Any<InsertManyOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("insert failed")));
+
+        var repo = new MassAdjudicationRunRepositoryMongo(database);
+        var summary = CreateSummary();
+        summary.ClaimResults.Add(new MassAdjudicationClaimResult
+        {
+            GeneratedClaimId = "GEN-002",
+            ClaimType = "Institutional",
+            Outcome = "PlatformFailure"
+        });
+
+        var act = () => repo.SaveAsync(summary);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("insert failed");
+        await runs.Received(1).DeleteOneAsync(
+            Arg.Any<FilterDefinition<MassAdjudicationRunSummary>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static MassAdjudicationRunSummary CreateSummary() => new()
+    {
+        Run = new MassAdjudicationRunMetadata
+        {
+            TenantId = "tenant-a",
+            RequestedClaims = 1,
+            Seed = 42,
+            Parallelism = 1,
+            ClaimsUrl = "https://claims",
+            BenefitUrl = "https://benefit",
+            ProviderUrl = "https://provider",
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow
+        },
+        TotalClaims = 1,
+        Processed = 1,
+        Paid = 1
+    };
+}


### PR DESCRIPTION
## Summary
- publish per-claim MCC validation results with mass adjudication run summaries
- store and index claim-level run results in claims-service
- add a claims-service endpoint for run claim drilldown with outcome filtering
- add portal claim result drilldown table and links to claim detail pages
- tolerate numeric claim type/status values returned by claims-service for claim details

## Validation
- dotnet build src/services/claims-service/claims-service.csproj
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj
- git diff --check
- local Kubernetes smoke run confirmed claim result rows are returned and portal renders the drilldown table
