### PR TITLE
CRD/adjudication alignment with Prior Auth Rule Engine: LOB propagation, shared rule-decision helper, and classification cache fix

### DIFF
--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Models/PaRuleDecisionExtensions.cs
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/Models/PaRuleDecisionExtensions.cs
@@ -1,0 +1,31 @@
+using CloudHealthOffice.PriorAuthRuleEngine.Domain;
+
+namespace CloudHealthOffice.PriorAuthRuleEngine.Models;
+
+/// <summary>
+/// Extension helpers for interpreting <see cref="PaRuleDecision"/> outcomes.
+/// Shared by FhirService.CrdService and BenefitPlanService.AdjudicationController
+/// to ensure rule-decision interpretation stays in sync.
+/// </summary>
+public static class PaRuleDecisionExtensions
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the decision indicates prior authorization
+    /// is required: a Deny outcome, or a meaningful Pend (i.e. a rule actually fired,
+    /// as opposed to a no-match / no-op / rule-error Pend).
+    /// </summary>
+    public static bool IsPriorAuthRequired(this PaRuleDecision? decision)
+    {
+        if (decision is null)
+            return false;
+
+        if (decision.Outcome is PaDecisionOutcome.Deny)
+            return true;
+
+        if (decision.Outcome is not PaDecisionOutcome.Pend)
+            return false;
+
+        return decision.FiringRuleId is not ("NoRulesConfigured" or "NoRuleMatch" or "NoOp")
+            && !decision.FiringRuleId.StartsWith("RuleError:", StringComparison.Ordinal);
+    }
+}

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -356,7 +356,7 @@ public class AdjudicationController : ControllerBase
 
         // If PA rule engine says auth/review is required and no auth exists,
         // deny the claim unless the provider already has an authorization on file.
-        if (IsPriorAuthRequired(priorAuthDecision)
+        if (priorAuthDecision.IsPriorAuthRequired()
             && string.IsNullOrEmpty(request.PriorAuthorizationNumber))
         {
             adjudicationSpan?.SetTag("cho.outcome", "pa_denied");
@@ -861,19 +861,6 @@ public class AdjudicationController : ControllerBase
         5 => PaLineOfBusiness.Exchange,
         _ => PaLineOfBusiness.Medicaid   // Default to Medicaid for TX MCO tenants
     };
-
-    private static bool IsPriorAuthRequired(PaRuleDecision decision)
-    {
-        if (decision.Outcome is PaDecisionOutcome.Deny)
-            return true;
-
-        if (decision.Outcome is not PaDecisionOutcome.Pend)
-            return false;
-
-        return decision.FiringRuleId is not
-            ("NoRulesConfigured" or "NoRuleMatch" or "NoOp")
-            && !decision.FiringRuleId.StartsWith("RuleError:", StringComparison.Ordinal);
-    }
 
     private static string? MapToPaProgram(int? lob) => lob switch
     {

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -336,6 +336,7 @@ public class AdjudicationController : ControllerBase
                 TenantId = TenantId,
                 StateCode = request.StateCode ?? "TX",
                 Lob = MapToPaLineOfBusiness(request.LineOfBusiness),
+                Program = MapToPaProgram(request.LineOfBusiness),
                 RequestingProviderNpi = request.ProviderNpi,
                 ServicingProviderNpi = request.ProviderNpi,
                 ServicingProviderTaxonomy = request.ProviderTaxonomy,
@@ -353,9 +354,9 @@ public class AdjudicationController : ControllerBase
             paSpan?.SetTag("cho.pa.rule_id", priorAuthDecision.FiringRuleId);
         }
 
-        // If PA rule engine says Deny (procedure requires auth and none exists),
+        // If PA rule engine says auth/review is required and no auth exists,
         // deny the claim unless the provider already has an authorization on file.
-        if (priorAuthDecision.Outcome == PaDecisionOutcome.Deny
+        if (IsPriorAuthRequired(priorAuthDecision)
             && string.IsNullOrEmpty(request.PriorAuthorizationNumber))
         {
             adjudicationSpan?.SetTag("cho.outcome", "pa_denied");
@@ -859,6 +860,25 @@ public class AdjudicationController : ControllerBase
         4 => PaLineOfBusiness.Medicaid,  // CHIP → Medicaid rules
         5 => PaLineOfBusiness.Exchange,
         _ => PaLineOfBusiness.Medicaid   // Default to Medicaid for TX MCO tenants
+    };
+
+    private static bool IsPriorAuthRequired(PaRuleDecision decision)
+    {
+        if (decision.Outcome is PaDecisionOutcome.Deny)
+            return true;
+
+        if (decision.Outcome is not PaDecisionOutcome.Pend)
+            return false;
+
+        return decision.FiringRuleId is not
+            ("NoRulesConfigured" or "NoRuleMatch" or "NoOp")
+            && !decision.FiringRuleId.StartsWith("RuleError:", StringComparison.Ordinal);
+    }
+
+    private static string? MapToPaProgram(int? lob) => lob switch
+    {
+        3 or 4 => "STAR",
+        _ => null
     };
 
     // ═══════════════════════════════════════════════════════════════════

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -257,6 +257,7 @@ builder.Services.AddHttpClient(UpstreamClientNames.ClaimsService, client =>
 
 // ── Da Vinci CRD / DTR / Bulk ─────────────────────────────────────────────────
 builder.Services.Configure<CrdConfig>(builder.Configuration.GetSection("Cms0057:Crd"));
+builder.Services.AddMemoryCache(options => options.SizeLimit = 1024);
 builder.Services.AddSingleton<ICrdClassificationStore, CrdClassificationStore>();
 builder.Services.AddScoped<ICrdService, CrdService>();
 builder.Services.Configure<DtrConfig>(builder.Configuration.GetSection("Cms0057:Dtr"));

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -257,7 +257,7 @@ builder.Services.AddHttpClient(UpstreamClientNames.ClaimsService, client =>
 
 // ── Da Vinci CRD / DTR / Bulk ─────────────────────────────────────────────────
 builder.Services.Configure<CrdConfig>(builder.Configuration.GetSection("Cms0057:Crd"));
-builder.Services.AddSingleton<ICrdService, CrdService>();
+builder.Services.AddScoped<ICrdService, CrdService>();
 builder.Services.Configure<DtrConfig>(builder.Configuration.GetSection("Cms0057:Dtr"));
 builder.Services.AddSingleton<IDtrService, DtrService>();
 builder.Services.AddSingleton<IBulkExportService, BulkExportService>();

--- a/src/services/fhir-service/Program.cs
+++ b/src/services/fhir-service/Program.cs
@@ -257,6 +257,7 @@ builder.Services.AddHttpClient(UpstreamClientNames.ClaimsService, client =>
 
 // ── Da Vinci CRD / DTR / Bulk ─────────────────────────────────────────────────
 builder.Services.Configure<CrdConfig>(builder.Configuration.GetSection("Cms0057:Crd"));
+builder.Services.AddSingleton<ICrdClassificationStore, CrdClassificationStore>();
 builder.Services.AddScoped<ICrdService, CrdService>();
 builder.Services.Configure<DtrConfig>(builder.Configuration.GetSection("Cms0057:Dtr"));
 builder.Services.AddSingleton<IDtrService, DtrService>();

--- a/src/services/fhir-service/Services/CrdClassificationStore.cs
+++ b/src/services/fhir-service/Services/CrdClassificationStore.cs
@@ -1,5 +1,5 @@
-using System.Collections.Concurrent;
 using FhirService.Models;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace FhirService.Services;
 
@@ -18,20 +18,40 @@ public interface ICrdClassificationStore
 /// <inheritdoc />
 public sealed class CrdClassificationStore : ICrdClassificationStore
 {
-    private readonly ConcurrentDictionary<string, CrdCodeClassification> _cache = new();
+    private static readonly TimeSpan AbsoluteExpiration = TimeSpan.FromHours(6);
+    private static readonly TimeSpan SlidingExpiration = TimeSpan.FromHours(1);
+
+    private readonly IMemoryCache _cache;
+
+    public CrdClassificationStore(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
 
     /// <inheritdoc />
     public bool TryGet(string tenantId, out CrdCodeClassification? classification)
-        => _cache.TryGetValue(tenantId, out classification);
+        => _cache.TryGetValue(CacheKey(tenantId), out classification);
 
     /// <inheritdoc />
     public void Set(string tenantId, CrdCodeClassification classification)
-        => _cache[tenantId] = classification;
+    {
+        _cache.Set(
+            CacheKey(tenantId),
+            classification,
+            new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = AbsoluteExpiration,
+                SlidingExpiration = SlidingExpiration,
+                Size = 1,
+            });
+    }
 
     /// <inheritdoc />
     public CrdCodeClassification? GetOrNull(string tenantId)
     {
-        _cache.TryGetValue(tenantId, out var c);
+        _cache.TryGetValue(CacheKey(tenantId), out CrdCodeClassification? c);
         return c;
     }
+
+    private static string CacheKey(string tenantId) => $"crd-classification:{tenantId}";
 }

--- a/src/services/fhir-service/Services/CrdClassificationStore.cs
+++ b/src/services/fhir-service/Services/CrdClassificationStore.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using FhirService.Models;
+
+namespace FhirService.Services;
+
+/// <summary>
+/// Singleton store for per-tenant CRD code classifications.
+/// Injected into <see cref="CrdService"/> so that the cache lifetime is
+/// explicit and testable, and does not bleed across test cases via static state.
+/// </summary>
+public interface ICrdClassificationStore
+{
+    bool TryGet(string tenantId, out CrdCodeClassification? classification);
+    void Set(string tenantId, CrdCodeClassification classification);
+    CrdCodeClassification? GetOrNull(string tenantId);
+}
+
+/// <inheritdoc />
+public sealed class CrdClassificationStore : ICrdClassificationStore
+{
+    private readonly ConcurrentDictionary<string, CrdCodeClassification> _cache = new();
+
+    /// <inheritdoc />
+    public bool TryGet(string tenantId, out CrdCodeClassification? classification)
+        => _cache.TryGetValue(tenantId, out classification);
+
+    /// <inheritdoc />
+    public void Set(string tenantId, CrdCodeClassification classification)
+        => _cache[tenantId] = classification;
+
+    /// <inheritdoc />
+    public CrdCodeClassification? GetOrNull(string tenantId)
+    {
+        _cache.TryGetValue(tenantId, out var c);
+        return c;
+    }
+}

--- a/src/services/fhir-service/Services/CrdService.cs
+++ b/src/services/fhir-service/Services/CrdService.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http.Json;
+using CloudHealthOffice.PriorAuthRuleEngine.Abstractions;
+using CloudHealthOffice.PriorAuthRuleEngine.Domain;
+using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using FhirService.Models;
 using Microsoft.Extensions.Options;
 
@@ -9,18 +12,20 @@ namespace FhirService.Services;
 public class CrdService : ICrdService
 {
     private readonly HttpClient _terminologyClient;
+    private readonly IPriorAuthRuleEngine _priorAuthRuleEngine;
     private readonly CrdCodeClassification _defaultClassification;
-    private readonly ConcurrentDictionary<string, CrdCodeClassification> _classificationCache = new();
+    private static readonly ConcurrentDictionary<string, CrdCodeClassification> ClassificationCache = new();
     private readonly ILogger<CrdService> _logger;
 
     public CrdService(
         IHttpClientFactory httpClientFactory,
+        IPriorAuthRuleEngine priorAuthRuleEngine,
         IOptions<CrdConfig> config,
         ILogger<CrdService> logger)
     {
         _terminologyClient = httpClientFactory.CreateClient("TerminologyService");
+        _priorAuthRuleEngine = priorAuthRuleEngine;
         _defaultClassification = LoadFromConfig(config.Value);
-        _classificationCache["default"] = _defaultClassification;
         _logger = logger;
     }
 
@@ -42,8 +47,18 @@ public class CrdService : ICrdService
         {
             var effectiveCode = tc.EffectiveCode;
             var display = tc.TranslatedCoding?.Display ?? tc.OriginalCode.Display ?? effectiveCode;
+            var ruleDecision = await EvaluatePriorAuthRuleAsync(
+                request, tenantId, effectiveCode, ct);
 
-            if (classification.AuthRequiredCodes.Contains(effectiveCode))
+            if (IsPriorAuthRequired(ruleDecision))
+            {
+                cards.Add(BuildAuthRequiredCard(display, ruleDecision));
+            }
+            else if (ruleDecision?.Outcome is PaDecisionOutcome.Approve)
+            {
+                cards.Add(BuildAutoApprovedCard(display, ruleDecision));
+            }
+            else if (classification.AuthRequiredCodes.Contains(effectiveCode))
             {
                 cards.Add(BuildAuthRequiredCard(display));
             }
@@ -71,11 +86,75 @@ public class CrdService : ICrdService
         };
     }
 
+    private async Task<PaRuleDecision?> EvaluatePriorAuthRuleAsync(
+        CrdHookRequest request,
+        string tenantId,
+        string procedureCode,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await _priorAuthRuleEngine.EvaluateAsync(new PaRuleContext
+            {
+                TenantId = tenantId,
+                StateCode = "TX",
+                Lob = PaLineOfBusiness.Medicaid,
+                Program = "STAR",
+                RequestingProviderNpi = ExtractPractitionerId(request),
+                ServicingProviderNpi = ExtractPractitionerId(request),
+                MemberId = request.Context?.PatientId ?? string.Empty,
+                ServiceDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                ProcedureCodes = [procedureCode],
+                DiagnosisCodes = [],
+                EstimatedCost = 0m,
+            }, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Prior Auth Rule Engine unavailable for CRD code {Code}; falling back to CRD classification",
+                procedureCode);
+            return null;
+        }
+    }
+
+    private static string ExtractPractitionerId(CrdHookRequest request)
+    {
+        var userId = request.Context?.UserId;
+        if (string.IsNullOrWhiteSpace(userId))
+            return string.Empty;
+
+        var slash = userId.LastIndexOf('/');
+        return slash >= 0 && slash < userId.Length - 1
+            ? userId[(slash + 1)..]
+            : userId;
+    }
+
+    private static bool IsPriorAuthRequired(PaRuleDecision? decision)
+    {
+        if (decision is null)
+            return false;
+
+        if (decision.Outcome is PaDecisionOutcome.Deny)
+            return true;
+
+        if (decision.Outcome is not PaDecisionOutcome.Pend)
+            return false;
+
+        return decision.FiringRuleId is not
+            ("NoRulesConfigured" or "NoRuleMatch" or "NoOp")
+            && !decision.FiringRuleId.StartsWith("RuleError:", StringComparison.Ordinal);
+    }
+
     // ── Classification cache ─────────────────────────────────────────────────
 
     public CrdCodeClassification GetClassification(string tenantId)
     {
-        if (_classificationCache.TryGetValue(tenantId, out var tenantClassification))
+        if (ClassificationCache.TryGetValue(tenantId, out var tenantClassification))
             return tenantClassification;
         return _defaultClassification;
     }
@@ -83,12 +162,12 @@ public class CrdService : ICrdService
     public void SetClassification(string tenantId, CrdCodeClassification classification)
     {
         classification.LoadedAt = DateTimeOffset.UtcNow;
-        _classificationCache[tenantId] = classification;
+        ClassificationCache[tenantId] = classification;
     }
 
     public CrdCodeClassification? GetClassificationOrNull(string tenantId)
     {
-        _classificationCache.TryGetValue(tenantId, out var c);
+        ClassificationCache.TryGetValue(tenantId, out var c);
         return c;
     }
 
@@ -212,11 +291,15 @@ public class CrdService : ICrdService
 
     // ── Card builders ────────────────────────────────────────────────────────
 
-    private static CrdCard BuildAuthRequiredCard(string serviceDisplay) => new()
+    private static CrdCard BuildAuthRequiredCard(
+        string serviceDisplay,
+        PaRuleDecision? decision = null) => new()
     {
         Uuid = Guid.NewGuid().ToString(),
         Summary = $"Prior authorization required for {serviceDisplay}",
-        Detail = "Coverage requires prior authorization. Documentation may be needed.",
+        Detail = decision is null
+            ? "Coverage requires prior authorization. Documentation may be needed."
+            : $"Coverage requires prior authorization. Rule: {decision.FiringRuleName}.",
         Indicator = "warning",
         Source = new CrdCardSource
         {
@@ -264,11 +347,15 @@ public class CrdService : ICrdService
         },
     };
 
-    private static CrdCard BuildAutoApprovedCard(string serviceDisplay) => new()
+    private static CrdCard BuildAutoApprovedCard(
+        string serviceDisplay,
+        PaRuleDecision? decision = null) => new()
     {
         Uuid = Guid.NewGuid().ToString(),
         Summary = $"No prior authorization needed for {serviceDisplay}",
-        Detail = "This service is auto-approved and does not require prior authorization.",
+        Detail = decision is null
+            ? "This service is auto-approved and does not require prior authorization."
+            : $"This service does not require prior authorization. Rule: {decision.FiringRuleName}.",
         Indicator = "info",
         Source = new CrdCardSource
         {

--- a/src/services/fhir-service/Services/CrdService.cs
+++ b/src/services/fhir-service/Services/CrdService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http.Json;
 using CloudHealthOffice.PriorAuthRuleEngine.Abstractions;
@@ -14,18 +13,20 @@ public class CrdService : ICrdService
     private readonly HttpClient _terminologyClient;
     private readonly IPriorAuthRuleEngine _priorAuthRuleEngine;
     private readonly CrdCodeClassification _defaultClassification;
-    private static readonly ConcurrentDictionary<string, CrdCodeClassification> ClassificationCache = new();
+    private readonly ICrdClassificationStore _classificationStore;
     private readonly ILogger<CrdService> _logger;
 
     public CrdService(
         IHttpClientFactory httpClientFactory,
         IPriorAuthRuleEngine priorAuthRuleEngine,
         IOptions<CrdConfig> config,
+        ICrdClassificationStore classificationStore,
         ILogger<CrdService> logger)
     {
         _terminologyClient = httpClientFactory.CreateClient("TerminologyService");
         _priorAuthRuleEngine = priorAuthRuleEngine;
         _defaultClassification = LoadFromConfig(config.Value);
+        _classificationStore = classificationStore;
         _logger = logger;
     }
 
@@ -50,7 +51,7 @@ public class CrdService : ICrdService
             var ruleDecision = await EvaluatePriorAuthRuleAsync(
                 request, tenantId, effectiveCode, ct);
 
-            if (IsPriorAuthRequired(ruleDecision))
+            if (ruleDecision.IsPriorAuthRequired())
             {
                 cards.Add(BuildAuthRequiredCard(display, ruleDecision));
             }
@@ -117,7 +118,7 @@ public class CrdService : ICrdService
         {
             _logger.LogWarning(ex,
                 "Prior Auth Rule Engine unavailable for CRD code {Code}; falling back to CRD classification",
-                procedureCode);
+                SanitizeForLog(procedureCode));
             return null;
         }
     }
@@ -134,27 +135,11 @@ public class CrdService : ICrdService
             : userId;
     }
 
-    private static bool IsPriorAuthRequired(PaRuleDecision? decision)
-    {
-        if (decision is null)
-            return false;
-
-        if (decision.Outcome is PaDecisionOutcome.Deny)
-            return true;
-
-        if (decision.Outcome is not PaDecisionOutcome.Pend)
-            return false;
-
-        return decision.FiringRuleId is not
-            ("NoRulesConfigured" or "NoRuleMatch" or "NoOp")
-            && !decision.FiringRuleId.StartsWith("RuleError:", StringComparison.Ordinal);
-    }
-
     // ── Classification cache ─────────────────────────────────────────────────
 
     public CrdCodeClassification GetClassification(string tenantId)
     {
-        if (ClassificationCache.TryGetValue(tenantId, out var tenantClassification))
+        if (_classificationStore.TryGet(tenantId, out var tenantClassification) && tenantClassification is not null)
             return tenantClassification;
         return _defaultClassification;
     }
@@ -162,14 +147,11 @@ public class CrdService : ICrdService
     public void SetClassification(string tenantId, CrdCodeClassification classification)
     {
         classification.LoadedAt = DateTimeOffset.UtcNow;
-        ClassificationCache[tenantId] = classification;
+        _classificationStore.Set(tenantId, classification);
     }
 
     public CrdCodeClassification? GetClassificationOrNull(string tenantId)
-    {
-        ClassificationCache.TryGetValue(tenantId, out var c);
-        return c;
-    }
+        => _classificationStore.GetOrNull(tenantId);
 
     private static CrdCodeClassification LoadFromConfig(CrdConfig config) => new()
     {
@@ -177,6 +159,18 @@ public class CrdService : ICrdService
         AutoApprovedCodes = new HashSet<string>(config.AutoApprovedCodes, StringComparer.Ordinal),
         DocumentationRequiredCodes = new HashSet<string>(config.DocumentationRequiredCodes, StringComparer.Ordinal),
     };
+
+    private static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var buffer = new System.Text.StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            buffer.Append(char.IsControl(ch) ? '_' : ch);
+        }
+        if (buffer.Length > 256) buffer.Length = 256;
+        return buffer.ToString();
+    }
 
     // ── Code extraction ──────────────────────────────────────────────────────
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -38,6 +38,7 @@ Console.WriteLine($"  Provider URL:{options.ProviderUrl}");
 Console.WriteLine($"  Claims:      {options.Claims:N0}");
 Console.WriteLine($"  Seed:        {options.Seed}");
 Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
+Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine();
 
 await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
@@ -233,7 +234,7 @@ static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions op
         payer = "Cloud Health Office MCC",
         effectiveDate = "2025-01-01T00:00:00Z",
         planType = "PPO",
-        lineOfBusiness = "Commercial",
+        lineOfBusiness = LineOfBusinessName(options.LineOfBusiness),
         isActive = true,
         networkTiers = new[]
         {
@@ -494,7 +495,7 @@ static async Task<SubmittedClaim> SubmitClaimAsync(
         patientFirstName = claim.Member.FirstName,
         patientLastName = claim.Member.LastName,
         patientRelationship = claim.Member.Relationship,
-        lineOfBusiness = 1,
+        lineOfBusiness = options.LineOfBusiness,
         billingProviderNPI = claim.BillingProvider.Npi,
         billingProviderName = claim.BillingProvider.FullName,
         renderingProviderNPI = claim.RenderingProvider.Npi,
@@ -563,7 +564,7 @@ static async Task<AdjudicationResponseDto> AdjudicateClaimAsync(
         serviceDate = DateOnly.FromDateTime(claim.DateOfService),
         providerNpi = claim.RenderingProvider.Npi,
         networkTier,
-        lineOfBusiness = 1,
+        lineOfBusiness = options.LineOfBusiness,
         claimType = NormalizeClaimType(claim),
         stateCode = claim.RenderingProvider.State,
         providerTaxonomy = claim.RenderingProvider.TaxonomyCode,
@@ -646,6 +647,15 @@ static string? NormalizeBusinessDenialCode(string? code)
     var trimmed = code.Trim();
     return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
 }
+
+static string LineOfBusinessName(int lineOfBusiness) => lineOfBusiness switch
+{
+    2 => "Medicare",
+    3 => "Medicaid",
+    4 => "CHIP",
+    5 => "Exchange",
+    _ => "Commercial"
+};
 
 static async Task UpdateClaimAdjudicationAsync(
     HttpClient http,
@@ -923,6 +933,7 @@ static MassAdjudicationRunSummary BuildSummary(
             options.ProviderUrl,
             options.SeedProviders,
             options.SkipClaimUpdate,
+            options.LineOfBusiness,
             runStartedAtUtc,
             runCompletedAtUtc),
         results.Count,
@@ -1068,6 +1079,7 @@ static void PrintUsage()
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 25)
       --parallelism <count>      Number of claims to process concurrently (default: 4)
+      --line-of-business <code>  Adjudication line of business: 1 Commercial, 2 Medicare, 3 Medicaid (default: 3)
       --summary-json <path>      Write machine-readable validation summary JSON
       --no-publish-summary       Do not publish the completed run to claims-service
       --claim-results-limit <n>  Number of per-claim results to publish with the run (default: 1000)
@@ -1107,6 +1119,7 @@ internal sealed record ValidatorOptions(
     int TimeoutSeconds,
     int ProgressEvery,
     int Parallelism,
+    int LineOfBusiness,
     string? SummaryJsonPath,
     bool NoPublishSummary,
     int PublishClaimResultsLimit,
@@ -1155,6 +1168,9 @@ internal sealed record ValidatorOptions(
                 case "--parallelism" or "-p" when i + 1 < args.Length:
                     options.Parallelism = int.Parse(args[++i]);
                     break;
+                case "--line-of-business" when i + 1 < args.Length:
+                    options.LineOfBusiness = int.Parse(args[++i]);
+                    break;
                 case "--summary-json" when i + 1 < args.Length:
                     options.SummaryJsonPath = args[++i];
                     break;
@@ -1196,6 +1212,7 @@ internal sealed record ValidatorOptions(
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
+            Math.Clamp(options.LineOfBusiness, 1, 6),
             options.SummaryJsonPath,
             options.NoPublishSummary,
             Math.Clamp(options.PublishClaimResultsLimit, 0, effectiveClaims),
@@ -1215,6 +1232,7 @@ internal sealed record ValidatorOptions(
         public int TimeoutSeconds { get; set; } = 60;
         public int ProgressEvery { get; set; } = 10;
         public int Parallelism { get; set; } = 4;
+        public int LineOfBusiness { get; set; } = 3;
         public string? SummaryJsonPath { get; set; }
         public bool NoPublishSummary { get; set; }
         public int PublishClaimResultsLimit { get; set; } = 1000;
@@ -1276,6 +1294,7 @@ internal sealed record MassAdjudicationRun(
     string ProviderUrl,
     bool SeedProviders,
     bool SkipClaimUpdate,
+    int LineOfBusiness,
     DateTimeOffset StartedAtUtc,
     DateTimeOffset CompletedAtUtc);
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -650,11 +650,12 @@ static string? NormalizeBusinessDenialCode(string? code)
 
 static string LineOfBusinessName(int lineOfBusiness) => lineOfBusiness switch
 {
+    1 => "Commercial",
     2 => "Medicare",
     3 => "Medicaid",
     4 => "CHIP",
     5 => "Exchange",
-    _ => "Commercial"
+    _ => throw new ArgumentOutOfRangeException(nameof(lineOfBusiness), lineOfBusiness, "Unsupported line-of-business code.")
 };
 
 static async Task UpdateClaimAdjudicationAsync(
@@ -1079,7 +1080,7 @@ static void PrintUsage()
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 25)
       --parallelism <count>      Number of claims to process concurrently (default: 4)
-      --line-of-business <code>  Adjudication line of business: 1 Commercial, 2 Medicare, 3 Medicaid (default: 3)
+      --line-of-business <code>  Adjudication line of business: 1 Commercial, 2 Medicare, 3 Medicaid, 4 CHIP, 5 Exchange (default: 3)
       --summary-json <path>      Write machine-readable validation summary JSON
       --no-publish-summary       Do not publish the completed run to claims-service
       --claim-results-limit <n>  Number of per-claim results to publish with the run (default: 1000)
@@ -1212,7 +1213,7 @@ internal sealed record ValidatorOptions(
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
-            Math.Clamp(options.LineOfBusiness, 1, 6),
+            Math.Clamp(options.LineOfBusiness, 1, 5),
             options.SummaryJsonPath,
             options.NoPublishSummary,
             Math.Clamp(options.PublishClaimResultsLimit, 0, effectiveClaims),

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
@@ -1,3 +1,6 @@
+using CloudHealthOffice.PriorAuthRuleEngine.Abstractions;
+using CloudHealthOffice.PriorAuthRuleEngine.Domain;
+using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using FhirService.Models;
 using FhirService.Services;
 using FluentAssertions;
@@ -26,9 +29,20 @@ public class CrdCodeClassificationTests
         httpClientFactory
             .Setup(f => f.CreateClient("TerminologyService"))
             .Returns(terminologyClient);
+        var priorAuthRuleEngine = new Mock<IPriorAuthRuleEngine>();
+        priorAuthRuleEngine
+            .Setup(e => e.EvaluateAsync(It.IsAny<PaRuleContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaRuleDecision
+            {
+                Outcome = PaDecisionOutcome.Pend,
+                FiringRuleId = "NoRuleMatch",
+                FiringRuleName = "NoRuleMatch",
+                ResolvedRuleSetKey = "platform/TX/Medicaid/any",
+            });
 
         return new CrdService(
             httpClientFactory.Object,
+            priorAuthRuleEngine.Object,
             Options.Create(config),
             new Mock<ILogger<CrdService>>().Object);
     }

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
@@ -4,6 +4,7 @@ using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using FhirService.Models;
 using FhirService.Services;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -44,9 +45,14 @@ public class CrdCodeClassificationTests
             httpClientFactory.Object,
             priorAuthRuleEngine.Object,
             Options.Create(config),
-            new CrdClassificationStore(),
+            new CrdClassificationStore(CreateMemoryCache()),
             new Mock<ILogger<CrdService>>().Object);
     }
+
+    private static MemoryCache CreateMemoryCache() => new(new MemoryCacheOptions
+    {
+        SizeLimit = 1024,
+    });
 
     [Fact]
     public async Task EvaluateAsync_UsesHashSetLookup_AuthRequired()

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdCodeClassificationTests.cs
@@ -44,6 +44,7 @@ public class CrdCodeClassificationTests
             httpClientFactory.Object,
             priorAuthRuleEngine.Object,
             Options.Create(config),
+            new CrdClassificationStore(),
             new Mock<ILogger<CrdService>>().Object);
     }
 

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
@@ -7,6 +7,7 @@ using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using FhirService.Models;
 using FhirService.Services;
 using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -63,9 +64,14 @@ public class CrdServiceTests
             _httpClientFactoryMock.Object,
             _priorAuthRuleEngineMock.Object,
             Options.Create(_config),
-            new CrdClassificationStore(),
+            new CrdClassificationStore(CreateMemoryCache()),
             _loggerMock.Object);
     }
+
+    private static MemoryCache CreateMemoryCache() => new(new MemoryCacheOptions
+    {
+        SizeLimit = 1024,
+    });
 
     // ── SNOMED translation ───────────────────────────────────────────────────
 

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
@@ -63,6 +63,7 @@ public class CrdServiceTests
             _httpClientFactoryMock.Object,
             _priorAuthRuleEngineMock.Object,
             Options.Create(_config),
+            new CrdClassificationStore(),
             _loggerMock.Object);
     }
 

--- a/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
+++ b/tests/CloudHealthOffice.FhirService.Tests/Services/CrdServiceTests.cs
@@ -1,6 +1,9 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using CloudHealthOffice.PriorAuthRuleEngine.Abstractions;
+using CloudHealthOffice.PriorAuthRuleEngine.Domain;
+using CloudHealthOffice.PriorAuthRuleEngine.Models;
 using FhirService.Models;
 using FhirService.Services;
 using FluentAssertions;
@@ -13,6 +16,7 @@ namespace CloudHealthOffice.FhirService.Tests.Services;
 public class CrdServiceTests
 {
     private readonly Mock<IHttpClientFactory> _httpClientFactoryMock;
+    private readonly Mock<IPriorAuthRuleEngine> _priorAuthRuleEngineMock;
     private readonly Mock<ILogger<CrdService>> _loggerMock;
     private readonly CrdConfig _config;
     private MockHttpHandler _terminologyHandler = null!;
@@ -21,6 +25,7 @@ public class CrdServiceTests
     public CrdServiceTests()
     {
         _httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        _priorAuthRuleEngineMock = new Mock<IPriorAuthRuleEngine>();
         _loggerMock = new Mock<ILogger<CrdService>>();
 
         _config = new CrdConfig
@@ -32,6 +37,15 @@ public class CrdServiceTests
         };
 
         _terminologyHandler = new MockHttpHandler();
+        _priorAuthRuleEngineMock
+            .Setup(e => e.EvaluateAsync(It.IsAny<PaRuleContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaRuleDecision
+            {
+                Outcome = PaDecisionOutcome.Pend,
+                FiringRuleId = "NoRuleMatch",
+                FiringRuleName = "NoRuleMatch",
+                ResolvedRuleSetKey = "platform/TX/Medicaid/any",
+            });
         SetupService();
     }
 
@@ -47,6 +61,7 @@ public class CrdServiceTests
 
         _service = new CrdService(
             _httpClientFactoryMock.Object,
+            _priorAuthRuleEngineMock.Object,
             Options.Create(_config),
             _loggerMock.Object);
     }
@@ -84,6 +99,30 @@ public class CrdServiceTests
         result.Cards.Should().HaveCount(1);
         result.Cards[0].Indicator.Should().Be("warning");
         result.Cards[0].Summary.Should().Contain("Prior authorization required");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PriorAuthRuleRequiresReview_ReturnsAuthRequiredCard()
+    {
+        _priorAuthRuleEngineMock
+            .Setup(e => e.EvaluateAsync(
+                It.Is<PaRuleContext>(c => c.ProcedureCodes.Contains("K0800")),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaRuleDecision
+            {
+                Outcome = PaDecisionOutcome.Pend,
+                FiringRuleId = "TX-STARPLUS-PA-001",
+                FiringRuleName = "DME PA Required Above Threshold - STARPlus",
+                ResolvedRuleSetKey = "platform/TX/Medicaid/STARPlus",
+            });
+
+        var request = CreateHookRequest("http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets", "K0800", "Power wheelchair");
+        var result = await _service.EvaluateCoverageRequirementsAsync(request, "test-tenant");
+
+        result.Cards.Should().HaveCount(1);
+        result.Cards[0].Indicator.Should().Be("warning");
+        result.Cards[0].Summary.Should().Contain("Prior authorization required");
+        result.Cards[0].Detail.Should().Contain("DME PA Required");
     }
 
     // ── Auto approved ────────────────────────────────────────────────────────


### PR DESCRIPTION
Aligns Coverage Requirements Discovery (CRD) and adjudication behavior with the shared Prior Auth Rule Engine, updates the MCC platform validator to carry line-of-business (LOB) through validation runs, and addresses correctness/reliability issues identified in review.

## Changes

### MCC Platform Validator (`src/tools/mcc-platform-validator/Program.cs`)
- Added `--line-of-business` option to propagate LOB into submitted/adjudicated payloads and include it in run metadata/output.
- Updated help text to list all five supported LOB values: `1 Commercial, 2 Medicare, 3 Medicaid, 4 CHIP, 5 Exchange`.
- Clamped the accepted LOB range to `1..5` to match the values defined in `LineOfBusinessName`.
- Added an explicit `1 => "Commercial"` arm to `LineOfBusinessName` and replaced the silent catch-all default with `throw new ArgumentOutOfRangeException`, so unsupported codes fail fast instead of silently producing incorrect metadata.

### Shared Prior Auth Rule Decision Helper (`src/engines/CloudHealthOffice.PriorAuthRuleEngine/Models/PaRuleDecisionExtensions.cs`) *(new)*
- Extracted `PaRuleDecisionExtensions.IsPriorAuthRequired(this PaRuleDecision?)` as a single authoritative extension method in the `PriorAuthRuleEngine` project.
- Removes the previously duplicated interpretation logic that existed independently in both `CrdService` and `AdjudicationController`, preventing future divergence.

### CRD Service (`src/services/fhir-service/Services/CrdService.cs`)
- Routes CRD code evaluation through `IPriorAuthRuleEngine` (with fallback to configured code classifications) and enriches CRD cards with rule context.
- Replaced the static `ConcurrentDictionary` classification cache with an injected `ICrdClassificationStore` singleton, giving explicit DI lifetime, preventing cross-test pollution, and bounding cache growth.
- Sanitizes `procedureCode` via `SanitizeForLog` before logging to eliminate the CodeQL log-injection alert.

### Classification Store (`src/services/fhir-service/Services/CrdClassificationStore.cs`) *(new)*
- `ICrdClassificationStore` / `CrdClassificationStore` singleton registered in DI, replacing the former static cache in `CrdService`.

### Adjudication Controller (`src/services/benefit-plan-service/Controllers/AdjudicationController.cs`)
- Treats "review required" PA rule outcomes as adjudication denials when no prior authorization number is present.
- Adds program metadata mapping for TX Medicaid/CHIP.
- Removed the local `IsPriorAuthRequired` implementation; now delegates to the shared `PaRuleDecisionExtensions` extension method.

### fhir-service DI (`src/services/fhir-service/Program.cs`)
- Changed `CrdService` DI lifetime to scoped to support the scoped rule engine dependency.
- Registers `ICrdClassificationStore` as a singleton.

## Testing

- ✅ All 381 fhir-service tests pass.
- ✅ All 316 benefit-plan-service tests pass.
- ✅ All modified projects build with zero errors.