### PR TITLE
Add MCC workflow validation reporting

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -396,6 +396,10 @@ public class ClaimsServiceTests
                 generatedClaimId = "GEN-001",
                 submittedClaimId = "CLM-001",
                 claimType = 1,
+                validationScenario = "TxStarInpatientNoAuth",
+                expectedOutcome = "BusinessDenial",
+                expectedBusinessDenialCode = "PRIOR_AUTH_REQUIRED",
+                validationStatus = "Matched",
                 outcome = "Paid",
                 adjudicationSuccess = true,
                 actualPlanPayment = 95.25m,
@@ -416,6 +420,8 @@ public class ClaimsServiceTests
         result.Should().ContainSingle();
         result[0].GeneratedClaimId.Should().Be("GEN-001");
         result[0].ClaimType.Should().Be("Professional");
+        result[0].ValidationScenario.Should().Be("TxStarInpatientNoAuth");
+        result[0].ValidationStatus.Should().Be("Matched");
         result[0].Outcome.Should().Be("Paid");
     }
 

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -400,7 +400,7 @@ public class ClaimsServiceTests
                 expectedOutcome = "BusinessDenial",
                 expectedBusinessDenialCode = "PRIOR_AUTH_REQUIRED",
                 validationStatus = "Matched",
-                outcome = "Paid",
+                outcome = "BusinessDenial",
                 adjudicationSuccess = true,
                 actualPlanPayment = 95.25m,
                 expectedPlanPayment = 95.25m,
@@ -422,7 +422,7 @@ public class ClaimsServiceTests
         result[0].ClaimType.Should().Be("Professional");
         result[0].ValidationScenario.Should().Be("TxStarInpatientNoAuth");
         result[0].ValidationStatus.Should().Be("Matched");
-        result[0].Outcome.Should().Be("Paid");
+        result[0].Outcome.Should().Be("BusinessDenial");
     }
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/TenantContextServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/TenantContextServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using CloudHealthOffice.Portal.Services;
 
@@ -10,6 +11,7 @@ public class TenantContextServiceTests
     private readonly Mock<AuthenticationStateProvider> _authStateProvider;
     private readonly Mock<ITenantService> _tenantService;
     private readonly Mock<ILogger<TenantContextService>> _logger;
+    private readonly IConfiguration _configuration;
     private readonly TenantContextService _sut;
 
     public TenantContextServiceTests()
@@ -17,7 +19,8 @@ public class TenantContextServiceTests
         _authStateProvider = new Mock<AuthenticationStateProvider>();
         _tenantService = new Mock<ITenantService>();
         _logger = new Mock<ILogger<TenantContextService>>();
-        _sut = new TenantContextService(_authStateProvider.Object, _tenantService.Object, _logger.Object);
+        _configuration = new ConfigurationBuilder().Build();
+        _sut = new TenantContextService(_authStateProvider.Object, _tenantService.Object, _logger.Object, _configuration);
     }
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -152,6 +152,8 @@
                     <MudItem xs="6" md="4">@Metric("Platform Failures", $"{_selectedRun.PlatformFailures:N0}", "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Throughput", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
                 </MudGrid>
 
                 <MudGrid Spacing="2">
@@ -183,6 +185,7 @@
                 <MudTable Items="_claimResults" Dense="true" Hover="true" T="MassAdjudicationClaimResult" RowsPerPage="10">
                     <HeaderContent>
                         <MudTh>Claim</MudTh>
+                        <MudTh>Validation</MudTh>
                         <MudTh>Outcome</MudTh>
                         <MudTh>Denial / Failure</MudTh>
                         <MudTh>Latency</MudTh>
@@ -203,6 +206,21 @@
                             <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
                                 @context.ClaimType · @ShortId(context.GeneratedClaimId)
                             </MudText>
+                        </MudTd>
+                        <MudTd DataLabel="Validation">
+                            @if (!string.IsNullOrWhiteSpace(context.ValidationScenario))
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="@ValidationColor(context.ValidationStatus)">
+                                    @ValidationLabel(context.ValidationStatus)
+                                </MudChip>
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                                    @context.ValidationScenario
+                                </MudText>
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.35);">Unscored</MudText>
+                            }
                         </MudTd>
                         <MudTd DataLabel="Outcome">
                             <MudChip T="string" Size="Size.Small" Color="@OutcomeColor(context.Outcome)">
@@ -389,6 +407,20 @@
         "BusinessDenial" => "Business Denial",
         "PlatformFailure" => "Platform Failure",
         _ => outcome
+    };
+
+    private static Color ValidationColor(string status) => status switch
+    {
+        "Matched" => Color.Success,
+        "Mismatched" => Color.Error,
+        _ => Color.Default
+    };
+
+    private static string ValidationLabel(string status) => status switch
+    {
+        "Matched" => "Expected",
+        "Mismatched" => "Mismatch",
+        _ => "Unscored"
     };
 
     private RenderFragment Metric(string label, string value, string color) => builder =>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -84,6 +84,9 @@ public class MassAdjudicationRunSummary
     public int Paid { get; set; }
     public int BusinessDenials { get; set; }
     public int PlatformFailures { get; set; }
+    public int WorkflowScenarios { get; set; }
+    public int WorkflowMatches { get; set; }
+    public int WorkflowMismatches { get; set; }
     public TimeSpan Elapsed { get; set; }
     public double ThroughputClaimsPerSecond { get; set; }
     public double P95LatencyMilliseconds { get; set; }
@@ -140,7 +143,12 @@ public class MassAdjudicationClaimResult
     public string TenantId { get; set; } = string.Empty;
     public string GeneratedClaimId { get; set; } = string.Empty;
     public string? SubmittedClaimId { get; set; }
+    [JsonConverter(typeof(FlexibleClaimTypeJsonConverter))]
     public string ClaimType { get; set; } = string.Empty;
+    public string? ValidationScenario { get; set; }
+    public string? ExpectedOutcome { get; set; }
+    public string? ExpectedBusinessDenialCode { get; set; }
+    public string ValidationStatus { get; set; } = "Unspecified";
     public string Outcome { get; set; } = string.Empty;
     public bool AdjudicationSuccess { get; set; }
     public string? BusinessDenialCode { get; set; }

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -11,6 +11,9 @@ public class MassAdjudicationRunSummary
     public int Paid { get; set; }
     public int BusinessDenials { get; set; }
     public int PlatformFailures { get; set; }
+    public int WorkflowScenarios { get; set; }
+    public int WorkflowMatches { get; set; }
+    public int WorkflowMismatches { get; set; }
     public TimeSpan Elapsed { get; set; }
     public double ThroughputClaimsPerSecond { get; set; }
     public double P95LatencyMilliseconds { get; set; }
@@ -69,6 +72,10 @@ public class MassAdjudicationClaimResult
     public string GeneratedClaimId { get; set; } = string.Empty;
     public string? SubmittedClaimId { get; set; }
     public string ClaimType { get; set; } = string.Empty;
+    public string? ValidationScenario { get; set; }
+    public string? ExpectedOutcome { get; set; }
+    public string? ExpectedBusinessDenialCode { get; set; }
+    public string ValidationStatus { get; set; } = "Unspecified";
     public string Outcome { get; set; } = string.Empty;
     public bool AdjudicationSuccess { get; set; }
     public string? BusinessDenialCode { get; set; }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -164,11 +164,16 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         var businessDenialCode = NormalizeBusinessDenialCode(adjudicated.BusinessDenialCode
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
+        var expectedValidation = ExpectedValidationFor(claim);
 
         return new ClaimValidationResult(
             claim.ClaimId,
             submitted.Id,
             claim.ClaimType,
+            expectedValidation.Scenario,
+            expectedValidation.ExpectedOutcome,
+            expectedValidation.ExpectedBusinessDenialCode,
+            ValidationStatus(expectedValidation, outcome, businessDenialCode),
             outcome,
             adjudicated.Success,
             adjudicated.Totals.PlanPayment,
@@ -184,10 +189,15 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     catch (Exception ex)
     {
         sw.Stop();
+        var expectedValidation = ExpectedValidationFor(claim);
         return new ClaimValidationResult(
             claim.ClaimId,
             null,
             claim.ClaimType,
+            expectedValidation.Scenario,
+            expectedValidation.ExpectedOutcome,
+            expectedValidation.ExpectedBusinessDenialCode,
+            ValidationStatus(expectedValidation, ClaimValidationOutcome.PlatformFailure, null),
             ClaimValidationOutcome.PlatformFailure,
             false,
             null,
@@ -388,6 +398,47 @@ static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
     {
         line.PlaceOfService = "21";
     }
+}
+
+static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
+{
+    var isTxStarInpatientNoAuth =
+        claim.ClaimType.Equals("Institutional", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(claim.PlaceOfService, "21", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(claim.PriorAuthStatus, "Required", StringComparison.OrdinalIgnoreCase)
+        && string.IsNullOrWhiteSpace(claim.PriorAuthNumber)
+        && string.Equals(claim.RenderingProvider.State, "TX", StringComparison.OrdinalIgnoreCase);
+
+    return isTxStarInpatientNoAuth
+        ? new ExpectedValidation(
+            "TxStarInpatientNoAuth",
+            ClaimValidationOutcome.BusinessDenial.ToString(),
+            "PRIOR_AUTH_REQUIRED")
+        : ExpectedValidation.Unspecified;
+}
+
+static string ValidationStatus(
+    ExpectedValidation expected,
+    ClaimValidationOutcome actualOutcome,
+    string? actualBusinessDenialCode)
+{
+    if (expected.ExpectedOutcome is null)
+    {
+        return "Unspecified";
+    }
+
+    if (!string.Equals(expected.ExpectedOutcome, actualOutcome.ToString(), StringComparison.Ordinal))
+    {
+        return "Mismatched";
+    }
+
+    if (!string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
+        && !string.Equals(expected.ExpectedBusinessDenialCode, actualBusinessDenialCode, StringComparison.OrdinalIgnoreCase))
+    {
+        return "Mismatched";
+    }
+
+    return "Matched";
 }
 
 static async Task SeedProvidersAsync(
@@ -949,6 +1000,9 @@ static MassAdjudicationRunSummary BuildSummary(
     var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
     var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+    var validationScenarios = results.Count(r => r.ExpectedOutcome is not null);
+    var validationMatches = results.Count(r => r.ValidationStatus == "Matched");
+    var validationMismatches = results.Count(r => r.ValidationStatus == "Mismatched");
     var orderedDurations = results.Select(r => r.Elapsed.TotalMilliseconds).Order().ToArray();
     var p95 = Percentile(orderedDurations, 0.95);
     var p99 = Percentile(orderedDurations, 0.99);
@@ -979,6 +1033,10 @@ static MassAdjudicationRunSummary BuildSummary(
             r.GeneratedClaimId,
             r.SubmittedClaimId,
             r.ClaimType,
+            r.ValidationScenario,
+            r.ExpectedOutcome,
+            r.ExpectedBusinessDenialCode,
+            r.ValidationStatus,
             r.Outcome.ToString(),
             r.AdjudicationSuccess,
             r.BusinessDenialCode,
@@ -1014,6 +1072,9 @@ static MassAdjudicationRunSummary BuildSummary(
         adjudicated,
         businessDenials,
         platformFailures,
+        validationScenarios,
+        validationMatches,
+        validationMismatches,
         elapsed,
         throughput,
         p95,
@@ -1035,6 +1096,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Paid/adjudicated:   {summary.Paid:N0}");
     Console.WriteLine($"  Business denials:   {summary.BusinessDenials:N0}");
     Console.WriteLine($"  Platform failures:  {summary.PlatformFailures:N0}");
+    Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched)");
     Console.WriteLine($"  Elapsed:            {summary.Elapsed:mm\\:ss\\.fff}");
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");
     Console.WriteLine($"  P95 latency:        {summary.P95LatencyMilliseconds:N0} ms");
@@ -1340,6 +1402,10 @@ internal sealed record ClaimValidationResult(
     string GeneratedClaimId,
     string? SubmittedClaimId,
     string ClaimType,
+    string? ValidationScenario,
+    string? ExpectedOutcome,
+    string? ExpectedBusinessDenialCode,
+    string ValidationStatus,
     ClaimValidationOutcome Outcome,
     bool AdjudicationSuccess,
     decimal? ActualPlanPayment,
@@ -1359,6 +1425,9 @@ internal sealed record MassAdjudicationRunSummary(
     int Paid,
     int BusinessDenials,
     int PlatformFailures,
+    int WorkflowScenarios,
+    int WorkflowMatches,
+    int WorkflowMismatches,
     TimeSpan Elapsed,
     double ThroughputClaimsPerSecond,
     double P95LatencyMilliseconds,
@@ -1403,6 +1472,10 @@ internal sealed record MassAdjudicationClaimResult(
     string GeneratedClaimId,
     string? SubmittedClaimId,
     string ClaimType,
+    string? ValidationScenario,
+    string? ExpectedOutcome,
+    string? ExpectedBusinessDenialCode,
+    string ValidationStatus,
     string Outcome,
     bool AdjudicationSuccess,
     string? BusinessDenialCode,
@@ -1415,6 +1488,14 @@ internal sealed record MassAdjudicationClaimResult(
     double SubmitMilliseconds,
     double AdjudicationMilliseconds,
     double WritebackMilliseconds);
+
+internal sealed record ExpectedValidation(
+    string? Scenario,
+    string? ExpectedOutcome,
+    string? ExpectedBusinessDenialCode)
+{
+    public static ExpectedValidation Unspecified { get; } = new(null, null, null);
+}
 
 internal sealed record AdjudicationResponseDto(
     string ClaimId,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -18,6 +18,10 @@ public class MassAdjudicationRunRepositoryTests
             Id = "client-supplied-id",
             GeneratedClaimId = "GEN-001",
             ClaimType = "Professional",
+            ValidationScenario = "TxStarInpatientNoAuth",
+            ExpectedOutcome = "BusinessDenial",
+            ExpectedBusinessDenialCode = "PRIOR_AUTH_REQUIRED",
+            ValidationStatus = "Matched",
             Outcome = "Paid",
             AdjudicationSuccess = true
         });
@@ -30,6 +34,8 @@ public class MassAdjudicationRunRepositoryTests
         saved.ClaimResults[0].RunId.Should().Be(saved.Id);
         saved.ClaimResults[0].TenantId.Should().Be(saved.Run.TenantId);
         saved.ClaimResults[0].CreatedAtUtc.Should().Be(saved.CreatedAtUtc);
+        saved.ClaimResults[0].ValidationScenario.Should().Be("TxStarInpatientNoAuth");
+        saved.ClaimResults[0].ValidationStatus.Should().Be("Matched");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add expected workflow validation metadata to MCC claim results and run summaries
- surface workflow check counts and per-claim validation status in the Mass Adjudication portal page
- make portal claim result deserialization tolerate numeric claim type payloads from the claims API
- update claims-service and portal tests for the new validation fields

## Validation
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --no-restore --filter FullyQualifiedName~ClaimsServiceTests
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore --filter FullyQualifiedName~MassAdjudicationRunRepositoryTests
- MCC smoke run: 25 claims, 0 platform failures, workflow checks 1/1 matched
