### PR TITLE
Simplify marketing contact page

### DIFF
--- a/src/site/contact.html
+++ b/src/site/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Contact Cloud Health Office sales for pilot deployments, enterprise pricing, or a platform walkthrough. Email or call our team directly.">
+  <meta name="description" content="Contact Cloud Health Office sales for pilot deployments, enterprise pricing, or a platform walkthrough.">
   <meta name="keywords" content="cloud health office contact sales, payer EDI platform demo, healthcare EDI enterprise pricing">
   <meta name="author" content="Aurelianware">
 
@@ -55,124 +55,10 @@
       line-height: 1.75;
     }
 
-    .contact-section {
-      max-width: 720px;
-      margin: 80px auto;
-      padding: 0 24px 80px;
-    }
-
-    .contact-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 32px;
-      margin-top: 48px;
-    }
-
-    .contact-card {
-      background: rgba(255, 255, 255, 0.03);
-      border: 1px solid rgba(0, 255, 255, 0.15);
-      border-radius: 12px;
-      padding: 36px 32px;
-      text-align: center;
-      transition: border-color 0.2s, background 0.2s;
-    }
-
-    .contact-card:hover {
-      border-color: rgba(0, 255, 255, 0.4);
-      background: rgba(0, 255, 255, 0.04);
-    }
-
-    .contact-card-icon {
-      font-size: 2.4rem;
-      margin-bottom: 16px;
-    }
-
-    .contact-card h2 {
-      font-size: 1.1rem;
-      font-weight: 700;
-      color: #00ffff;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      margin-bottom: 12px;
-    }
-
-    .contact-card p {
-      font-size: 0.95rem;
-      color: rgba(176, 176, 176, 0.75);
-      margin-bottom: 20px;
-      line-height: 1.65;
-    }
-
-    .contact-link {
-      display: inline-block;
-      font-size: 1.05rem;
-      font-weight: 600;
-      color: #fff;
-      text-decoration: none;
-      word-break: break-all;
-      transition: color 0.15s;
-    }
-
-    .contact-link:hover {
-      color: #00ffff;
-    }
-
-    .contact-link.email {
-      color: #00ff88;
-    }
-
-    .contact-link.email:hover {
-      color: #00ffcc;
-    }
-
-    .contact-link.phone {
-      color: #00ffff;
-    }
-
-    .contact-divider {
-      text-align: center;
-      margin: 64px 0 48px;
-      border-top: 1px solid rgba(255, 255, 255, 0.07);
-      padding-top: 48px;
-    }
-
-    .contact-divider h3 {
-      font-size: 1.05rem;
-      color: rgba(128, 128, 128, 0.65);
-      font-weight: 500;
-      margin-bottom: 24px;
-    }
-
-    .topic-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      justify-content: center;
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-
-    .topic-list li {
-      background: rgba(0, 255, 255, 0.06);
-      border: 1px solid rgba(0, 255, 255, 0.18);
-      border-radius: 20px;
-      padding: 6px 16px;
-      font-size: 0.88rem;
-      color: rgba(200, 200, 200, 0.8);
-    }
-
-    .response-note {
-      text-align: center;
-      margin-top: 56px;
-      font-size: 0.9rem;
-      color: rgba(128, 128, 128, 0.55);
-    }
-
     .contact-form-section {
       max-width: 640px;
       margin: 0 auto;
-      padding: 0 24px;
+      padding: 0 24px 100px;
     }
 
     .contact-form-field {
@@ -373,45 +259,6 @@
         </p>
       </div>
     </section>
-
-    <div class="contact-section">
-      <div class="contact-divider" style="margin-top:0;">
-        <h3>Prefer email, phone, or mail?</h3>
-      </div>
-      <div class="contact-grid">
-
-        <div class="contact-card">
-          <div class="contact-card-icon">✉</div>
-          <h2>Email</h2>
-          <p>For pilot deployments, enterprise pricing, or a platform walkthrough.</p>
-          <a href="mailto:sales@cloudhealthoffice.com" class="contact-link email">sales@cloudhealthoffice.com</a>
-        </div>
-
-        <div class="contact-card">
-          <div class="contact-card-icon">☎</div>
-          <h2>Call or Text</h2>
-          <p>Prefer to talk or text? Reach us directly during business hours (CT).</p>
-          <a href="tel:+19289332204" class="contact-link phone">+1 (928) 933-2204</a>
-        </div>
-
-        <div class="contact-card">
-          <div class="contact-card-icon">📍</div>
-          <h2>Office</h2>
-          <p>Aurelianware, Inc.</p>
-          <address style="font-style:normal; font-size:0.95rem; color:rgba(176,176,176,0.75); line-height:1.65;">
-            1111B S Governors Ave<br>
-            STE 42257<br>
-            Dover, DE 19904 US
-          </address>
-        </div>
-
-      </div>
-
-      <p class="response-note">
-        For technical questions, see the <a href="/docs" style="color:rgba(0,255,255,0.7);">documentation</a>
-        or open an issue on <a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer" style="color:rgba(0,255,255,0.7);">GitHub</a>.
-      </p>
-    </div>
 
   </main>
 


### PR DESCRIPTION
## Summary
- remove the office, phone, and direct email contact cards from the marketing contact page
- keep the Formspree sales form as the primary contact path
- remove unused contact-card styles and update the meta description

## Validation
- npm run build in src/site
- git diff --check
