### PR TITLE
Add MCC workflow validation tests

### DIFF
--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -1,0 +1,79 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+public enum MccValidationOutcome
+{
+    Paid,
+    BusinessDenial,
+    PlatformFailure
+}
+
+public sealed record ExpectedValidation(
+    string? Scenario,
+    string? ExpectedOutcome,
+    string? ExpectedBusinessDenialCode)
+{
+    public static ExpectedValidation Unspecified { get; } = new(null, null, null);
+}
+
+public static class MccWorkflowValidation
+{
+    public const string CleanProfessionalPaidScenario = "CleanProfessionalPaid";
+    public const string CleanProfessionalPaidPlanId = "MCC_VALIDATION_CLEAN_PAID";
+    public const string TexasStarInpatientNoAuthScenario = "TxStarInpatientNoAuth";
+    public const string PriorAuthRequiredCode = "PRIOR_AUTH_REQUIRED";
+
+    public static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
+    {
+        if (claim.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.BenefitPlanId, CleanProfessionalPaidPlanId, StringComparison.Ordinal)
+            && string.Equals(claim.PlaceOfService, "11", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.PriorAuthStatus, "NotRequired", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrWhiteSpace(claim.PriorAuthNumber))
+        {
+            return new ExpectedValidation(
+                CleanProfessionalPaidScenario,
+                MccValidationOutcome.Paid.ToString(),
+                null);
+        }
+
+        var isTxStarInpatientNoAuth =
+            claim.ClaimType.Equals("Institutional", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.PlaceOfService, "21", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.PriorAuthStatus, "Required", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrWhiteSpace(claim.PriorAuthNumber)
+            && string.Equals(claim.RenderingProvider.State, "TX", StringComparison.OrdinalIgnoreCase);
+
+        return isTxStarInpatientNoAuth
+            ? new ExpectedValidation(
+                TexasStarInpatientNoAuthScenario,
+                MccValidationOutcome.BusinessDenial.ToString(),
+                PriorAuthRequiredCode)
+            : ExpectedValidation.Unspecified;
+    }
+
+    public static string ValidationStatus(
+        ExpectedValidation expected,
+        string actualOutcome,
+        string? actualBusinessDenialCode)
+    {
+        if (expected.ExpectedOutcome is null)
+        {
+            return "Unspecified";
+        }
+
+        if (!string.Equals(expected.ExpectedOutcome, actualOutcome, StringComparison.Ordinal))
+        {
+            return "Mismatched";
+        }
+
+        if (!string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
+            && !string.Equals(expected.ExpectedBusinessDenialCode, actualBusinessDenialCode, StringComparison.OrdinalIgnoreCase))
+        {
+            return "Mismatched";
+        }
+
+        return "Matched";
+    }
+}

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -2,16 +2,9 @@ using CloudHealthOffice.BenchmarkClaimGenerator.Models;
 
 namespace CloudHealthOffice.Tools.MccPlatformValidator;
 
-public enum MccValidationOutcome
-{
-    Paid,
-    BusinessDenial,
-    PlatformFailure
-}
-
 public sealed record ExpectedValidation(
     string? Scenario,
-    string? ExpectedOutcome,
+    ClaimValidationOutcome? ExpectedOutcome,
     string? ExpectedBusinessDenialCode)
 {
     public static ExpectedValidation Unspecified { get; } = new(null, null, null);
@@ -34,7 +27,7 @@ public static class MccWorkflowValidation
         {
             return new ExpectedValidation(
                 CleanProfessionalPaidScenario,
-                MccValidationOutcome.Paid.ToString(),
+                ClaimValidationOutcome.Paid,
                 null);
         }
 
@@ -48,14 +41,14 @@ public static class MccWorkflowValidation
         return isTxStarInpatientNoAuth
             ? new ExpectedValidation(
                 TexasStarInpatientNoAuthScenario,
-                MccValidationOutcome.BusinessDenial.ToString(),
+                ClaimValidationOutcome.BusinessDenial,
                 PriorAuthRequiredCode)
             : ExpectedValidation.Unspecified;
     }
 
     public static string ValidationStatus(
         ExpectedValidation expected,
-        string actualOutcome,
+        ClaimValidationOutcome actualOutcome,
         string? actualBusinessDenialCode)
     {
         if (expected.ExpectedOutcome is null)
@@ -63,7 +56,7 @@ public static class MccWorkflowValidation
             return "Unspecified";
         }
 
-        if (!string.Equals(expected.ExpectedOutcome, actualOutcome, StringComparison.Ordinal))
+        if (expected.ExpectedOutcome != actualOutcome)
         {
             return "Mismatched";
         }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -8,6 +8,7 @@ using CloudHealthOffice.BenchmarkClaimGenerator.Configuration;
 using CloudHealthOffice.BenchmarkClaimGenerator.Models;
 using CloudHealthOffice.BenchmarkClaimGenerator.Output;
 using CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
+using CloudHealthOffice.Tools.MccPlatformValidator;
 
 var options = ValidatorOptions.Parse(args);
 if (options.ShowHelp)
@@ -164,7 +165,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         var businessDenialCode = NormalizeBusinessDenialCode(adjudicated.BusinessDenialCode
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
-        var expectedValidation = ExpectedValidationFor(claim);
+        var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
 
         return new ClaimValidationResult(
             claim.ClaimId,
@@ -173,7 +174,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             expectedValidation.Scenario,
             expectedValidation.ExpectedOutcome,
             expectedValidation.ExpectedBusinessDenialCode,
-            ValidationStatus(expectedValidation, outcome, businessDenialCode),
+            MccWorkflowValidation.ValidationStatus(expectedValidation, outcome.ToString(), businessDenialCode),
             outcome,
             adjudicated.Success,
             adjudicated.Totals.PlanPayment,
@@ -189,7 +190,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     catch (Exception ex)
     {
         sw.Stop();
-        var expectedValidation = ExpectedValidationFor(claim);
+        var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
         return new ClaimValidationResult(
             claim.ClaimId,
             null,
@@ -197,7 +198,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             expectedValidation.Scenario,
             expectedValidation.ExpectedOutcome,
             expectedValidation.ExpectedBusinessDenialCode,
-            ValidationStatus(expectedValidation, ClaimValidationOutcome.PlatformFailure, null),
+            MccWorkflowValidation.ValidationStatus(expectedValidation, ClaimValidationOutcome.PlatformFailure.ToString(), null),
             ClaimValidationOutcome.PlatformFailure,
             false,
             null,
@@ -344,8 +345,34 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
         .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
         .ToList();
     NormalizeClaimDates(claims, options.Seed);
+    InjectCleanPaidScenarios(claims);
     InjectPriorAuthScenarios(claims, options);
     return claims;
+}
+
+static void InjectCleanPaidScenarios(List<SyntheticClaim> claims)
+{
+    var candidates = claims
+        .Where(c => c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase))
+        .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
+        .ToList();
+
+    if (candidates.Count == 0)
+    {
+        Console.WriteLine("Clean paid scenarios: skipped (no professional claims generated)");
+        return;
+    }
+
+    var requested = Math.Max(1, (int)Math.Round(claims.Count * 0.02, MidpointRounding.AwayFromZero));
+    var injected = 0;
+
+    foreach (var claim in candidates.Take(Math.Min(requested, candidates.Count)))
+    {
+        ForceCleanProfessionalPaidScenario(claim);
+        injected++;
+    }
+
+    Console.WriteLine($"Clean paid scenarios: injected {injected:N0} professional claims expected to pay");
 }
 
 static void InjectPriorAuthScenarios(List<SyntheticClaim> claims, ValidatorOptions options)
@@ -384,6 +411,78 @@ static void InjectPriorAuthScenarios(List<SyntheticClaim> claims, ValidatorOptio
     Console.WriteLine($"PA scenarios: injected {injected:N0} TX STAR inpatient claims without auth");
 }
 
+static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
+{
+    claim.BenefitPlanId = MccWorkflowValidation.CleanProfessionalPaidPlanId;
+    claim.PlaceOfService = "11";
+    claim.FrequencyCode = "1";
+    claim.BillType = null;
+    claim.DrgCode = null;
+    claim.PriorAuthStatus = "NotRequired";
+    claim.PriorAuthNumber = null;
+    claim.PrimaryDiagnosisCode = "Z00.00";
+    claim.SecondaryDiagnosisCodes.Clear();
+
+    ForceParticipatingProvider(claim.RenderingProvider);
+    ForceParticipatingProvider(claim.BillingProvider);
+
+    var serviceDate = claim.DateOfService.Date;
+    claim.Lines = new List<ClaimLine>
+    {
+        new()
+        {
+            LineNumber = 1,
+            ProcedureCode = "99213",
+            Description = "Office/outpatient established patient visit",
+            Modifiers = new List<string>(),
+            RevenueCode = null,
+            DiagnosisPointers = new List<int> { 1 },
+            Units = 1,
+            ChargeAmount = 180.00m,
+            ServiceDate = serviceDate,
+            ServiceEndDate = serviceDate,
+            PlaceOfService = "11"
+        }
+    };
+    claim.TotalCharges = 180.00m;
+    claim.ExpectedOutcome = new ExpectedOutcome
+    {
+        Disposition = "Paid",
+        ExpectedAllowedAmount = 180.00m,
+        ExpectedPaidAmount = 150.00m,
+        ExpectedMemberLiability = 30.00m,
+        ExpectedCopay = 30.00m,
+        ExpectedCoinsurance = 0.00m,
+        ExpectedDeductible = 0.00m,
+        ExpectedFhirCompliant = true,
+        ExpectedPriorAuthDecision = "N/A",
+        LineOutcomes = new List<LineOutcome>
+        {
+            new()
+            {
+                LineNumber = 1,
+                Disposition = "Paid",
+                AllowedAmount = 180.00m,
+                PaidAmount = 150.00m
+            }
+        }
+    };
+}
+
+static void ForceParticipatingProvider(SyntheticProvider provider)
+{
+    provider.IsParticipating = true;
+    provider.NetworkStatus = "InNetwork";
+    provider.CredentialingStatus = "Active";
+    provider.TermDate = null;
+    provider.AcceptingNewPatients = true;
+    provider.State = "AZ";
+    provider.SpecialtyCode = "207Q00000X";
+    provider.SpecialtyDescription = "Family Medicine";
+    provider.TaxonomyCode = "207Q00000X";
+    provider.ContractType = "FeeForService";
+}
+
 static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
 {
     claim.PlaceOfService = "21";
@@ -398,47 +497,6 @@ static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
     {
         line.PlaceOfService = "21";
     }
-}
-
-static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
-{
-    var isTxStarInpatientNoAuth =
-        claim.ClaimType.Equals("Institutional", StringComparison.OrdinalIgnoreCase)
-        && string.Equals(claim.PlaceOfService, "21", StringComparison.OrdinalIgnoreCase)
-        && string.Equals(claim.PriorAuthStatus, "Required", StringComparison.OrdinalIgnoreCase)
-        && string.IsNullOrWhiteSpace(claim.PriorAuthNumber)
-        && string.Equals(claim.RenderingProvider.State, "TX", StringComparison.OrdinalIgnoreCase);
-
-    return isTxStarInpatientNoAuth
-        ? new ExpectedValidation(
-            "TxStarInpatientNoAuth",
-            ClaimValidationOutcome.BusinessDenial.ToString(),
-            "PRIOR_AUTH_REQUIRED")
-        : ExpectedValidation.Unspecified;
-}
-
-static string ValidationStatus(
-    ExpectedValidation expected,
-    ClaimValidationOutcome actualOutcome,
-    string? actualBusinessDenialCode)
-{
-    if (expected.ExpectedOutcome is null)
-    {
-        return "Unspecified";
-    }
-
-    if (!string.Equals(expected.ExpectedOutcome, actualOutcome.ToString(), StringComparison.Ordinal))
-    {
-        return "Mismatched";
-    }
-
-    if (!string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
-        && !string.Equals(expected.ExpectedBusinessDenialCode, actualBusinessDenialCode, StringComparison.OrdinalIgnoreCase))
-    {
-        return "Mismatched";
-    }
-
-    return "Matched";
 }
 
 static async Task SeedProvidersAsync(
@@ -1488,14 +1546,6 @@ internal sealed record MassAdjudicationClaimResult(
     double SubmitMilliseconds,
     double AdjudicationMilliseconds,
     double WritebackMilliseconds);
-
-internal sealed record ExpectedValidation(
-    string? Scenario,
-    string? ExpectedOutcome,
-    string? ExpectedBusinessDenialCode)
-{
-    public static ExpectedValidation Unspecified { get; } = new(null, null, null);
-}
 
 internal sealed record AdjudicationResponseDto(
     string ClaimId,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -172,9 +172,9 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             submitted.Id,
             claim.ClaimType,
             expectedValidation.Scenario,
-            expectedValidation.ExpectedOutcome,
+            expectedValidation.ExpectedOutcome?.ToString(),
             expectedValidation.ExpectedBusinessDenialCode,
-            MccWorkflowValidation.ValidationStatus(expectedValidation, outcome.ToString(), businessDenialCode),
+            MccWorkflowValidation.ValidationStatus(expectedValidation, outcome, businessDenialCode),
             outcome,
             adjudicated.Success,
             adjudicated.Totals.PlanPayment,
@@ -196,9 +196,9 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             null,
             claim.ClaimType,
             expectedValidation.Scenario,
-            expectedValidation.ExpectedOutcome,
+            expectedValidation.ExpectedOutcome?.ToString(),
             expectedValidation.ExpectedBusinessDenialCode,
-            MccWorkflowValidation.ValidationStatus(expectedValidation, ClaimValidationOutcome.PlatformFailure.ToString(), null),
+            MccWorkflowValidation.ValidationStatus(expectedValidation, ClaimValidationOutcome.PlatformFailure, null),
             ClaimValidationOutcome.PlatformFailure,
             false,
             null,
@@ -423,8 +423,8 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
     claim.PrimaryDiagnosisCode = "Z00.00";
     claim.SecondaryDiagnosisCodes.Clear();
 
-    ForceParticipatingProvider(claim.RenderingProvider);
-    ForceParticipatingProvider(claim.BillingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
 
     var serviceDate = claim.DateOfService.Date;
     claim.Lines = new List<ClaimLine>
@@ -448,11 +448,11 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
     claim.ExpectedOutcome = new ExpectedOutcome
     {
         Disposition = "Paid",
-        ExpectedAllowedAmount = 180.00m,
-        ExpectedPaidAmount = 150.00m,
-        ExpectedMemberLiability = 30.00m,
-        ExpectedCopay = 30.00m,
-        ExpectedCoinsurance = 0.00m,
+        ExpectedAllowedAmount = 117.00m,
+        ExpectedPaidAmount = 68.60m,
+        ExpectedMemberLiability = 48.40m,
+        ExpectedCopay = 25.00m,
+        ExpectedCoinsurance = 23.40m,
         ExpectedDeductible = 0.00m,
         ExpectedFhirCompliant = true,
         ExpectedPriorAuthDecision = "N/A",
@@ -462,14 +462,14 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
             {
                 LineNumber = 1,
                 Disposition = "Paid",
-                AllowedAmount = 180.00m,
-                PaidAmount = 150.00m
+                AllowedAmount = 117.00m,
+                PaidAmount = 93.60m
             }
         }
     };
 }
 
-static void ForceParticipatingProvider(SyntheticProvider provider)
+static void ForceCleanProfessionalPaidProviderProfile(SyntheticProvider provider)
 {
     provider.IsParticipating = true;
     provider.NetworkStatus = "InNetwork";
@@ -1449,7 +1449,7 @@ internal sealed record ValidatorOptions(
 
 internal sealed record SubmittedClaim(string Id);
 
-internal enum ClaimValidationOutcome
+public enum ClaimValidationOutcome
 {
     Paid,
     BusinessDenial,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -77,6 +77,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType.FullName?.Contains("Mongo") == true
                          || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                          || d.ImplementationType?.FullName?.Contains("Mongo") == true
+                         || d.ImplementationType?.FullName?.Contains("MassAdjudicationRunIndexInitializer") == true
                          || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
                          || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true)
                 .ToList();

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\tools\mcc-platform-validator\mcc-platform-validator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -19,11 +19,11 @@ public class MccWorkflowValidationTests
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            MccValidationOutcome.Paid.ToString(),
+            ClaimValidationOutcome.Paid,
             actualBusinessDenialCode: null);
 
         Assert.Equal(MccWorkflowValidation.CleanProfessionalPaidScenario, expected.Scenario);
-        Assert.Equal(MccValidationOutcome.Paid.ToString(), expected.ExpectedOutcome);
+        Assert.Equal(ClaimValidationOutcome.Paid, expected.ExpectedOutcome);
         Assert.Null(expected.ExpectedBusinessDenialCode);
         Assert.Equal("Matched", status);
     }
@@ -42,11 +42,11 @@ public class MccWorkflowValidationTests
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            MccValidationOutcome.BusinessDenial.ToString(),
+            ClaimValidationOutcome.BusinessDenial,
             MccWorkflowValidation.PriorAuthRequiredCode);
 
         Assert.Equal(MccWorkflowValidation.TexasStarInpatientNoAuthScenario, expected.Scenario);
-        Assert.Equal(MccValidationOutcome.BusinessDenial.ToString(), expected.ExpectedOutcome);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
         Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
         Assert.Equal("Matched", status);
     }
@@ -65,7 +65,7 @@ public class MccWorkflowValidationTests
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            MccValidationOutcome.BusinessDenial.ToString(),
+            ClaimValidationOutcome.BusinessDenial,
             "CARC_96");
 
         Assert.Equal("Mismatched", status);
@@ -85,7 +85,7 @@ public class MccWorkflowValidationTests
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            MccValidationOutcome.Paid.ToString(),
+            ClaimValidationOutcome.Paid,
             actualBusinessDenialCode: null);
 
         Assert.Null(expected.Scenario);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -1,0 +1,130 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccWorkflowValidationTests
+{
+    [Fact]
+    public void ExpectedValidationFor_CleanProfessionalClaim_ReturnsPaidScenario()
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.CleanProfessionalPaidPlanId,
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            MccValidationOutcome.Paid.ToString(),
+            actualBusinessDenialCode: null);
+
+        Assert.Equal(MccWorkflowValidation.CleanProfessionalPaidScenario, expected.Scenario);
+        Assert.Equal(MccValidationOutcome.Paid.ToString(), expected.ExpectedOutcome);
+        Assert.Null(expected.ExpectedBusinessDenialCode);
+        Assert.Equal("Matched", status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_TexasInpatientWithoutPriorAuth_ReturnsBusinessDenialScenario()
+    {
+        var claim = CreateClaim(
+            claimType: "Institutional",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "Required",
+            priorAuthNumber: null,
+            renderingState: "TX");
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            MccValidationOutcome.BusinessDenial.ToString(),
+            MccWorkflowValidation.PriorAuthRequiredCode);
+
+        Assert.Equal(MccWorkflowValidation.TexasStarInpatientNoAuthScenario, expected.Scenario);
+        Assert.Equal(MccValidationOutcome.BusinessDenial.ToString(), expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.Equal("Matched", status);
+    }
+
+    [Fact]
+    public void ValidationStatus_WhenExpectedPaidClaimIsDenied_ReturnsMismatched()
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.CleanProfessionalPaidPlanId,
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            MccValidationOutcome.BusinessDenial.ToString(),
+            "CARC_96");
+
+        Assert.Equal("Mismatched", status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_UnscoredClaim_ReturnsUnspecified()
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: "OTHER-PLAN",
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            MccValidationOutcome.Paid.ToString(),
+            actualBusinessDenialCode: null);
+
+        Assert.Null(expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Null(expected.ExpectedBusinessDenialCode);
+        Assert.Equal("Unspecified", status);
+    }
+
+    private static SyntheticClaim CreateClaim(
+        string claimType,
+        string benefitPlanId,
+        string placeOfService,
+        string priorAuthStatus,
+        string? priorAuthNumber,
+        string renderingState)
+    {
+        return new SyntheticClaim
+        {
+            ClaimId = "MCC-TEST-0000001",
+            ClaimType = claimType,
+            BenefitPlanId = benefitPlanId,
+            PlaceOfService = placeOfService,
+            PriorAuthStatus = priorAuthStatus,
+            PriorAuthNumber = priorAuthNumber,
+            RenderingProvider = new SyntheticProvider { State = renderingState },
+            BillingProvider = new SyntheticProvider { State = renderingState },
+            Lines = new List<ClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    PlaceOfService = placeOfService,
+                    Units = 1,
+                    ChargeAmount = 180m,
+                    DiagnosisPointers = new List<int> { 1 }
+                }
+            },
+            ExpectedOutcome = new ExpectedOutcome()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- extract MCC expected workflow policy into a testable `MccWorkflowValidation` class
- add a clean professional paid scenario as a positive workflow control
- keep the Texas inpatient no-auth prior authorization denial scenario scored
- add focused unit tests for matched, mismatched, and unscored validation outcomes

## Validation
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
- MCC smoke run: 25 claims, 0 platform failures, workflow checks 2/2 matched
- git diff --check
