### PR TITLE
Add MCC uncovered service validation scenario

### DIFF
--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -17,6 +17,9 @@ public static class MccWorkflowValidation
     public const string ExcludedProviderScenario = "ExcludedProviderDenied";
     public const string ExcludedProviderPlanId = "MCC_VALIDATION_EXCLUDED_PROVIDER";
     public const string ProviderExcludedCode = "PROVIDER_EXCLUDED";
+    public const string UncoveredServiceScenario = "UncoveredServiceDenied";
+    public const string UncoveredServicePlanId = "MCC_VALIDATION_UNCOVERED_SERVICE";
+    public const string UncoveredServiceCode = "CARC_96";
     public const string TexasStarInpatientNoAuthScenario = "TxStarInpatientNoAuth";
     public const string PriorAuthRequiredCode = "PRIOR_AUTH_REQUIRED";
 
@@ -43,6 +46,16 @@ public static class MccWorkflowValidation
                 ExcludedProviderScenario,
                 ClaimValidationOutcome.BusinessDenial,
                 ProviderExcludedCode);
+        }
+
+        if (claim.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(claim.BenefitPlanId, UncoveredServicePlanId, StringComparison.Ordinal)
+            && string.Equals(claim.PlaceOfService, "31", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ExpectedValidation(
+                UncoveredServiceScenario,
+                ClaimValidationOutcome.BusinessDenial,
+                UncoveredServiceCode);
         }
 
         var isTxStarInpatientNoAuth =

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -347,6 +347,7 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
     NormalizeClaimDates(claims, options.Seed);
     InjectCleanPaidScenarios(claims);
     InjectExcludedProviderScenarios(claims, options.Seed);
+    InjectUncoveredServiceScenarios(claims);
     InjectPriorAuthScenarios(claims, options);
     return claims;
 }
@@ -401,6 +402,34 @@ static void InjectExcludedProviderScenarios(List<SyntheticClaim> claims, int see
     }
 
     Console.WriteLine($"Excluded provider scenarios: injected {injected:N0} professional claims expected to deny");
+}
+
+static void InjectUncoveredServiceScenarios(List<SyntheticClaim> claims)
+{
+    var candidates = claims
+        .Where(c =>
+            c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(c.BenefitPlanId, MccWorkflowValidation.CleanProfessionalPaidPlanId, StringComparison.Ordinal)
+            && !string.Equals(c.BenefitPlanId, MccWorkflowValidation.ExcludedProviderPlanId, StringComparison.Ordinal))
+        .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
+        .ToList();
+
+    if (candidates.Count == 0)
+    {
+        Console.WriteLine("Uncovered service scenarios: skipped (no remaining professional claims generated)");
+        return;
+    }
+
+    var requested = Math.Max(1, (int)Math.Round(claims.Count * 0.02, MidpointRounding.AwayFromZero));
+    var injected = 0;
+
+    foreach (var claim in candidates.Take(Math.Min(requested, candidates.Count)))
+    {
+        ForceUncoveredServiceScenario(claim);
+        injected++;
+    }
+
+    Console.WriteLine($"Uncovered service scenarios: injected {injected:N0} professional claims expected to deny");
 }
 
 static void InjectPriorAuthScenarios(List<SyntheticClaim> claims, ValidatorOptions options)
@@ -553,6 +582,66 @@ static void ForceExcludedProviderScenario(SyntheticClaim claim, int seed, int in
                 AllowedAmount = 0.00m,
                 PaidAmount = 0.00m,
                 ReasonCode = MccWorkflowValidation.ProviderExcludedCode
+            }
+        }
+    };
+}
+
+static void ForceUncoveredServiceScenario(SyntheticClaim claim)
+{
+    claim.BenefitPlanId = MccWorkflowValidation.UncoveredServicePlanId;
+    claim.PlaceOfService = "31";
+    claim.FrequencyCode = "1";
+    claim.BillType = null;
+    claim.DrgCode = null;
+    claim.PriorAuthStatus = "NotRequired";
+    claim.PriorAuthNumber = null;
+    claim.PrimaryDiagnosisCode = "Z00.00";
+    claim.SecondaryDiagnosisCodes.Clear();
+
+    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
+
+    var serviceDate = claim.DateOfService.Date;
+    claim.Lines = new List<ClaimLine>
+    {
+        new()
+        {
+            LineNumber = 1,
+            ProcedureCode = "99283",
+            Description = "Emergency department visit, moderate severity",
+            Modifiers = new List<string>(),
+            RevenueCode = null,
+            DiagnosisPointers = new List<int> { 1 },
+            Units = 1,
+            ChargeAmount = 850.00m,
+            ServiceDate = serviceDate,
+            ServiceEndDate = serviceDate,
+            PlaceOfService = "31"
+        }
+    };
+    claim.TotalCharges = 850.00m;
+    claim.ExpectedOutcome = new ExpectedOutcome
+    {
+        Disposition = "Denied",
+        DenialReasonCode = MccWorkflowValidation.UncoveredServiceCode,
+        ExpectedAllowedAmount = 0.00m,
+        ExpectedPaidAmount = 0.00m,
+        ExpectedMemberLiability = 0.00m,
+        ExpectedCopay = 0.00m,
+        ExpectedCoinsurance = 0.00m,
+        ExpectedDeductible = 0.00m,
+        ExpectedFhirCompliant = true,
+        ExpectedPriorAuthDecision = "N/A",
+        LineOutcomes = new List<LineOutcome>
+        {
+            new()
+            {
+                LineNumber = 1,
+                Disposition = "Denied",
+                AllowedAmount = 0.00m,
+                PaidAmount = 0.00m,
+                ReasonCode = MccWorkflowValidation.UncoveredServiceCode
             }
         }
     };
@@ -951,9 +1040,10 @@ static bool TryParseBusinessDenial(
 }
 
 static bool IsKnownBusinessDenialCode(string errorCode)
-    => errorCode is
+    => NormalizeBusinessDenialCode(errorCode) is
         "SCRUB_VALIDATION_FAILURE" or
         "NCCI_MUE_EDIT_FAILURE" or
+        "CARC_96" or
         "PROVIDER_EXCLUDED" or
         "PRIOR_AUTH_REQUIRED";
 

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -76,6 +76,29 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
+    public void ExpectedValidationFor_UncoveredServiceClaim_ReturnsCoverageDenialScenario()
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.UncoveredServicePlanId,
+            placeOfService: "31",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            MccWorkflowValidation.UncoveredServiceCode);
+
+        Assert.Equal(MccWorkflowValidation.UncoveredServiceScenario, expected.Scenario);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.UncoveredServiceCode, expected.ExpectedBusinessDenialCode);
+        Assert.Equal("Matched", status);
+    }
+
+    [Fact]
     public void ValidationStatus_WhenExpectedProviderExclusionPays_ReturnsMismatched()
     {
         var claim = CreateClaim(
@@ -86,6 +109,26 @@ public class MccWorkflowValidationTests
             priorAuthNumber: null,
             renderingState: "AZ");
         claim.RenderingProvider.CredentialingStatus = "Excluded";
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.Paid,
+            actualBusinessDenialCode: null);
+
+        Assert.Equal("Mismatched", status);
+    }
+
+    [Fact]
+    public void ValidationStatus_WhenExpectedUncoveredServicePays_ReturnsMismatched()
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.UncoveredServicePlanId,
+            placeOfService: "31",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
 
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(


### PR DESCRIPTION
## Summary
- add an MCC `UncoveredServiceDenied` workflow scenario that expects `CARC_96`
- inject deterministic uncovered professional service claims into generated MCC runs
- recognize normalized `CARC_96` business denials and add focused workflow validation tests

## Verification
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore /p:UseAppHost=false`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore /p:UseAppHost=false`
- `git diff --check`
- Live MCC smoke: 25/25 processed, 0 platform failures, 4/4 workflow checks matched; `UncoveredServiceDenied` matched `CARC_96` with 0 payment
