### PR TITLE
Tighten MCC paid workflow payment delta reporting

### DIFF
--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -166,6 +166,9 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
         var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
+            ? null
+            : claim.ExpectedOutcome?.ExpectedPaidAmount;
 
         return new ClaimValidationResult(
             claim.ClaimId,
@@ -178,7 +181,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             outcome,
             adjudicated.Success,
             adjudicated.Totals.PlanPayment,
-            claim.ExpectedOutcome?.ExpectedPaidAmount,
+            expectedPlanPayment,
             sw.Elapsed,
             submitElapsed,
             adjudicationElapsed,
@@ -191,6 +194,9 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     {
         sw.Stop();
         var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
+            ? null
+            : claim.ExpectedOutcome?.ExpectedPaidAmount;
         return new ClaimValidationResult(
             claim.ClaimId,
             null,
@@ -202,7 +208,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             ClaimValidationOutcome.PlatformFailure,
             false,
             null,
-            claim.ExpectedOutcome?.ExpectedPaidAmount,
+            expectedPlanPayment,
             sw.Elapsed,
             submitElapsed,
             adjudicationElapsed,
@@ -505,11 +511,11 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
     claim.ExpectedOutcome = new ExpectedOutcome
     {
         Disposition = "Paid",
-        ExpectedAllowedAmount = 117.00m,
-        ExpectedPaidAmount = 68.60m,
-        ExpectedMemberLiability = 48.40m,
-        ExpectedCopay = 25.00m,
-        ExpectedCoinsurance = 23.40m,
+        ExpectedAllowedAmount = 180.00m,
+        ExpectedPaidAmount = 150.00m,
+        ExpectedMemberLiability = 30.00m,
+        ExpectedCopay = 30.00m,
+        ExpectedCoinsurance = 0.00m,
         ExpectedDeductible = 0.00m,
         ExpectedFhirCompliant = true,
         ExpectedPriorAuthDecision = "N/A",
@@ -519,8 +525,8 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
             {
                 LineNumber = 1,
                 Disposition = "Paid",
-                AllowedAmount = 117.00m,
-                PaidAmount = 93.60m
+                AllowedAmount = 180.00m,
+                PaidAmount = 150.00m
             }
         }
     };

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -133,6 +133,10 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     var adjudicationElapsed = TimeSpan.Zero;
     var updateElapsed = TimeSpan.Zero;
     var failureStage = "unknown";
+    var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
+    var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
+        ? null
+        : claim.ExpectedOutcome?.ExpectedPaidAmount;
 
     try
     {
@@ -165,10 +169,6 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         var businessDenialCode = NormalizeBusinessDenialCode(adjudicated.BusinessDenialCode
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
-        var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
-        var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
-            ? null
-            : claim.ExpectedOutcome?.ExpectedPaidAmount;
 
         return new ClaimValidationResult(
             claim.ClaimId,
@@ -193,10 +193,6 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     catch (Exception ex)
     {
         sw.Stop();
-        var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
-        var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
-            ? null
-            : claim.ExpectedOutcome?.ExpectedPaidAmount;
         return new ClaimValidationResult(
             claim.ClaimId,
             null,


### PR DESCRIPTION
## Summary
- align the clean paid workflow expectation with the MCC validation plan math
- only surface expected payment/delta for paid validation workflows
- avoid misleading payment deltas on denial validation rows

## Verification
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore /p:UseAppHost=false`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore /p:UseAppHost=false`
- `git diff --check`
- Live MCC smoke: 25/25 processed, 0 platform failures, 4/4 workflow checks matched, Avg payment delta $0.00
