### PR TITLE
Add MCC adjudication stage timing breakdowns

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -161,6 +161,18 @@
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.AdjudicateTiming)</MudItem>
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.WritebackTiming)</MudItem>
                 </MudGrid>
+
+                @if (_selectedRun.AdjudicationStepTimings.Count > 0)
+                {
+                    <MudDivider Class="my-3" Style="border-color: rgba(0,255,255,0.12);" />
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65); font-weight: 700;">Adjudication Sub-Steps</MudText>
+                    <MudGrid Spacing="2" Class="mt-1">
+                        @foreach (var timing in _selectedRun.AdjudicationStepTimings.Take(6))
+                        {
+                            <MudItem xs="12" sm="6" md="4">@Timing(timing)</MudItem>
+                        }
+                    </MudGrid>
+                }
             </MudPaper>
 
             <MudPaper Class="pa-4 mb-3" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -94,6 +94,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? SubmitTiming { get; set; }
     public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
+    public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
@@ -161,6 +162,7 @@ public class MassAdjudicationClaimResult
     public double SubmitMilliseconds { get; set; }
     public double AdjudicationMilliseconds { get; set; }
     public double WritebackMilliseconds { get; set; }
+    public Dictionary<string, double> AdjudicationStepMilliseconds { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; }
 }
 

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -1119,7 +1119,7 @@ public record AdjudicationResponse
     /// Elapsed milliseconds for adjudication sub-steps. Used by local MCC
     /// benchmarking to identify the next tuning target.
     /// </summary>
-    public IReadOnlyDictionary<string, double> Timings { get; init; } = new Dictionary<string, double>();
+    public IReadOnlyDictionary<string, double>? Timings { get; init; }
 }
 
 public record AdjudicationTotals

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -145,9 +145,26 @@ public class AdjudicationController : ControllerBase
         adjudicationSpan?.SetTag("cho.claim_type", request.ClaimType);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
+        var stageTimings = new Dictionary<string, double>(StringComparer.Ordinal);
+
+        async Task<T> MeasureStageAsync<T>(string stage, Func<Task<T>> action)
+        {
+            var stageWatch = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                return await action();
+            }
+            finally
+            {
+                stageWatch.Stop();
+                stageTimings[stage] = stageWatch.Elapsed.TotalMilliseconds;
+            }
+        }
 
         // ── Routing decision: determine operating mode for this claim type/LOB ──
-        var operatingModeConfig = await _operatingModeProvider.GetConfigurationAsync(TenantId, ct);
+        var operatingModeConfig = await MeasureStageAsync(
+            "routing",
+            () => _operatingModeProvider.GetConfigurationAsync(TenantId, ct));
         var routingDecision = _claimTypeRouter.Route(
             operatingModeConfig, request.ClaimType, request.LineOfBusiness);
 
@@ -176,7 +193,8 @@ public class AdjudicationController : ControllerBase
                 DenialReasonDescription = $"Claim type {request.ClaimType} routed to legacy system per tenant configuration",
                 OperatingMode = "LegacyOnly",
                 RoutingKey = routingDecision.ResolvedKey,
-                IsAuthoritative = false
+                IsAuthoritative = false,
+                Timings = stageTimings
             });
         }
 
@@ -196,8 +214,9 @@ public class AdjudicationController : ControllerBase
             memberId: request.MemberId))
         {
             var scrubClaim = MapToScrubClaim(request);
-            scrubResponse = await _scrubEngine.ScrubAndRouteAsync(
-                new ClaimsScrubRequest { Claim = scrubClaim }, ct);
+            scrubResponse = await MeasureStageAsync(
+                "scrub",
+                () => _scrubEngine.ScrubAndRouteAsync(new ClaimsScrubRequest { Claim = scrubClaim }, ct));
 
             scrubSpan?.SetTag("cho.scrub.passed", scrubResponse.Result.Routing.Destination == "adjudication");
             scrubSpan?.SetTag("cho.scrub.error_count", scrubResponse.Result.ErrorCount);
@@ -225,6 +244,7 @@ public class AdjudicationController : ControllerBase
                 status = scrubResponse.Result.Status,
                 routing = scrubResponse.Result.Routing,
                 validationResults = scrubResponse.Result.Results.Where(r => !r.Passed).ToList(),
+                timings = stageTimings,
             });
         }
 
@@ -254,7 +274,9 @@ public class AdjudicationController : ControllerBase
                 }).ToList(),
             };
 
-            ncciResult = await _ncciEngine.ScrubAsync(ncciRequest, ct);
+            ncciResult = await MeasureStageAsync(
+                "ncci",
+                () => _ncciEngine.ScrubAsync(ncciRequest, ct));
 
             ncciSpan?.SetTag("cho.ncci.passed", ncciResult.Passed);
             ncciSpan?.SetTag("cho.ncci.failure_count", ncciResult.EditFailures.Count);
@@ -278,6 +300,7 @@ public class AdjudicationController : ControllerBase
                 message = $"Claim failed {ncciResult.EditFailures.Count} NCCI/MUE edit(s). " +
                           "Review edit failures and resubmit or override.",
                 editFailures = ncciResult.EditFailures,
+                timings = stageTimings,
             });
         }
 
@@ -290,7 +313,9 @@ public class AdjudicationController : ControllerBase
             claimType: claimTypeCode,
             memberId: request.MemberId))
         {
-            providerIntegrity = await _providerIntegrityGate.CheckAsync(request.ProviderNpi, TenantId, ct: ct);
+            providerIntegrity = await MeasureStageAsync(
+                "providerIntegrity",
+                () => _providerIntegrityGate.CheckAsync(request.ProviderNpi, TenantId, ct: ct));
 
             integritySpan?.SetTag("cho.integrity.passed", providerIntegrity.Passed);
             integritySpan?.SetTag("cho.integrity.score", providerIntegrity.IntegrityScore ?? -1);
@@ -317,6 +342,7 @@ public class AdjudicationController : ControllerBase
                 carc = providerIntegrity.DenialCode,
                 integrityScore = providerIntegrity.IntegrityScore,
                 rating = providerIntegrity.Rating,
+                timings = stageTimings,
             });
         }
 
@@ -348,7 +374,9 @@ public class AdjudicationController : ControllerBase
                 EstimatedCost = request.Lines.Sum(l => l.BilledAmount),
             };
 
-            priorAuthDecision = await _priorAuthEngine.EvaluateAsync(paContext, ct);
+            priorAuthDecision = await MeasureStageAsync(
+                "priorAuth",
+                () => _priorAuthEngine.EvaluateAsync(paContext, ct));
 
             paSpan?.SetTag("cho.pa.outcome", priorAuthDecision.Outcome.ToString());
             paSpan?.SetTag("cho.pa.rule_id", priorAuthDecision.FiringRuleId);
@@ -377,21 +405,24 @@ public class AdjudicationController : ControllerBase
                 carc = priorAuthDecision.DenialCode ?? "197",
                 firingRule = priorAuthDecision.FiringRuleName,
                 ruleSetKey = priorAuthDecision.ResolvedRuleSetKey,
+                timings = stageTimings,
             });
         }
 
         // ── Step 0e: Terminology crosswalk (plan-specific code mappings) ──
         // Resolves plan-specific procedure code overrides before pricing.
         // Essential for TX Medicaid rate accuracy where plan codes differ from standard CPT.
-        var crosswalkResults = await _terminologyClient.TranslateBatchAsync(
-            TenantId,
-            request.Lines.Select(l => new CodeCrosswalkRequest
-            {
-                LineNumber = l.LineNumber,
-                ProcedureCode = l.ProcedureCode,
-                CodeType = l.CodeType ?? "CPT"
-            }).ToList(),
-            ct);
+        var crosswalkResults = await MeasureStageAsync(
+            "terminology",
+            () => _terminologyClient.TranslateBatchAsync(
+                TenantId,
+                request.Lines.Select(l => new CodeCrosswalkRequest
+                {
+                    LineNumber = l.LineNumber,
+                    ProcedureCode = l.ProcedureCode,
+                    CodeType = l.CodeType ?? "CPT"
+                }).ToList(),
+                ct));
 
         var crosswalkMap = crosswalkResults.ToDictionary(r => r.LineNumber, r => r.ResolvedCode);
 
@@ -419,7 +450,9 @@ public class AdjudicationController : ControllerBase
                 LineNumber = line.LineNumber
             }).ToList();
 
-            pricingResults = await _rateEngine.ResolveBatchAsync(pricingRequests, ct);
+            pricingResults = await MeasureStageAsync(
+                "rateResolution",
+                () => _rateEngine.ResolveBatchAsync(pricingRequests, ct));
 
             rateSpan?.SetTag("cho.rate.line_count", pricingResults.LineResults.Count);
         }
@@ -476,12 +509,14 @@ public class AdjudicationController : ControllerBase
             };
 
             // Use mode-aware calculation when in Augment mode to capture discrepancies
-            var augmentResult = await _benefitEngine.CalculateWithModeAsync(
-                benefitRequest,
-                routingDecision.OperatingMode,
-                TenantId,
-                legacyResult: null, // Legacy result injected by workflow when available
-                ct);
+            var augmentResult = await MeasureStageAsync(
+                "benefitCalculation",
+                () => _benefitEngine.CalculateWithModeAsync(
+                    benefitRequest,
+                    routingDecision.OperatingMode,
+                    TenantId,
+                    legacyResult: null, // Legacy result injected by workflow when available
+                    ct));
 
             benefitResult = augmentResult.ChoResult;
             augmentDiscrepancies = augmentResult.Discrepancies;
@@ -559,7 +594,8 @@ public class AdjudicationController : ControllerBase
                     AdjustmentReasons = bl.Adjustments
                 };
             }).ToList(),
-            Accumulators = benefitResult.AccumulatorSnapshot
+            Accumulators = benefitResult.AccumulatorSnapshot,
+            Timings = stageTimings
         };
 
         var outcome = benefitResult.Success ? "approved" : "denied";
@@ -1078,6 +1114,12 @@ public record AdjudicationResponse
     /// Null when the verification service was not consulted.
     /// </summary>
     public int? ProviderIntegrityScore { get; init; }
+
+    /// <summary>
+    /// Elapsed milliseconds for adjudication sub-steps. Used by local MCC
+    /// benchmarking to identify the next tuning target.
+    /// </summary>
+    public IReadOnlyDictionary<string, double> Timings { get; init; } = new Dictionary<string, double>();
 }
 
 public record AdjudicationTotals

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -21,6 +21,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? SubmitTiming { get; set; }
     public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
+    public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
@@ -88,5 +89,6 @@ public class MassAdjudicationClaimResult
     public double SubmitMilliseconds { get; set; }
     public double AdjudicationMilliseconds { get; set; }
     public double WritebackMilliseconds { get; set; }
+    public Dictionary<string, double> AdjudicationStepMilliseconds { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -186,6 +186,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             submitElapsed,
             adjudicationElapsed,
             updateElapsed,
+            adjudicated.Timings ?? new Dictionary<string, double>(),
             businessDenialCode,
             null,
             null);
@@ -209,6 +210,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             submitElapsed,
             adjudicationElapsed,
             updateElapsed,
+            new Dictionary<string, double>(),
             null,
             failureStage,
             ex.Message);
@@ -1032,7 +1034,8 @@ static bool TryParseBusinessDenial(
             error.Carc,
             error.Message,
             new AdjudicationTotalsDto(0, 0, 0, 0, 0, 0, 0, 0),
-            error.Error);
+            error.Error,
+            error.Timings);
         return true;
     }
     catch (JsonException)
@@ -1339,7 +1342,8 @@ static MassAdjudicationRunSummary BuildSummary(
             r.Elapsed.TotalMilliseconds,
             r.SubmitElapsed.TotalMilliseconds,
             r.AdjudicationElapsed.TotalMilliseconds,
-            r.UpdateElapsed.TotalMilliseconds))
+            r.UpdateElapsed.TotalMilliseconds,
+            r.AdjudicationStepTimings))
         .ToList();
 
     return new MassAdjudicationRunSummary(
@@ -1371,6 +1375,7 @@ static MassAdjudicationRunSummary BuildSummary(
         BuildStageTiming("Submit", results.Select(r => r.SubmitElapsed)),
         BuildStageTiming("Adjudicate", results.Select(r => r.AdjudicationElapsed)),
         BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
+        BuildAdjudicationStepTimings(results),
         avgDelta,
         denialBreakdown,
         failures,
@@ -1393,6 +1398,10 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     WriteStageTiming(summary.SubmitTiming);
     WriteStageTiming(summary.AdjudicateTiming);
     WriteStageTiming(summary.WritebackTiming);
+    foreach (var timing in summary.AdjudicationStepTimings)
+    {
+        WriteStageTiming(timing);
+    }
 
     if (summary.AveragePaymentDelta.HasValue)
     {
@@ -1424,6 +1433,33 @@ static MassAdjudicationStageTiming? BuildStageTiming(string label, IEnumerable<T
     }
 
     return new MassAdjudicationStageTiming(label, values.Average(), Percentile(values, 0.95));
+}
+
+static IReadOnlyList<MassAdjudicationStageTiming> BuildAdjudicationStepTimings(
+    IReadOnlyCollection<ClaimValidationResult> results)
+{
+    return results
+        .SelectMany(r => r.AdjudicationStepTimings)
+        .GroupBy(kvp => kvp.Key, StringComparer.Ordinal)
+        .Select(group =>
+        {
+            var values = group
+                .Select(kvp => kvp.Value)
+                .Where(ms => ms > 0)
+                .Order()
+                .ToArray();
+
+            return values.Length == 0
+                ? null
+                : new MassAdjudicationStageTiming(
+                    $"Adjudicate.{group.Key}",
+                    values.Average(),
+                    Percentile(values, 0.95));
+        })
+        .Where(timing => timing is not null)
+        .Cast<MassAdjudicationStageTiming>()
+        .OrderByDescending(timing => timing.AverageMilliseconds)
+        .ToList();
 }
 
 static void WriteStageTiming(MassAdjudicationStageTiming? timing)
@@ -1703,6 +1739,7 @@ internal sealed record ClaimValidationResult(
     TimeSpan SubmitElapsed,
     TimeSpan AdjudicationElapsed,
     TimeSpan UpdateElapsed,
+    IReadOnlyDictionary<string, double> AdjudicationStepTimings,
     string? BusinessDenialCode,
     string? FailureStage,
     string? Error);
@@ -1724,6 +1761,7 @@ internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationStageTiming? SubmitTiming,
     MassAdjudicationStageTiming? AdjudicateTiming,
     MassAdjudicationStageTiming? WritebackTiming,
+    IReadOnlyList<MassAdjudicationStageTiming> AdjudicationStepTimings,
     decimal? AveragePaymentDelta,
     IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
     IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures,
@@ -1776,7 +1814,8 @@ internal sealed record MassAdjudicationClaimResult(
     double ElapsedMilliseconds,
     double SubmitMilliseconds,
     double AdjudicationMilliseconds,
-    double WritebackMilliseconds);
+    double WritebackMilliseconds,
+    IReadOnlyDictionary<string, double> AdjudicationStepMilliseconds);
 
 internal sealed record AdjudicationResponseDto(
     string ClaimId,
@@ -1784,7 +1823,8 @@ internal sealed record AdjudicationResponseDto(
     string? DenialReasonCode,
     string? DenialReasonDescription,
     AdjudicationTotalsDto Totals,
-    string? BusinessDenialCode = null);
+    string? BusinessDenialCode = null,
+    IReadOnlyDictionary<string, double>? Timings = null);
 
 internal sealed record AdjudicationTotalsDto(
     decimal BilledAmount,
@@ -1800,4 +1840,5 @@ internal sealed record AdjudicationErrorDto(
     string? ClaimId,
     string? Error,
     string? Message,
-    string? Carc);
+    string? Carc,
+    IReadOnlyDictionary<string, double>? Timings = null);


### PR DESCRIPTION
## Summary
- Add benefit-plan-service adjudication sub-step timings to adjudication responses
- Aggregate adjudication sub-step avg/p95 timings in the MCC validator summary JSON and console output
- Persist and display adjudication sub-step timings in mass adjudication run details

## Validation
- dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj --no-restore /p:UseAppHost=false
- dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore /p:UseAppHost=false
- dotnet build src/services/claims-service/claims-service.csproj --no-restore /p:UseAppHost=false
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore /p:UseAppHost=false
- git diff --check
- Local K8s smoke: 50/50 processed, 0 platform failures, 4/4 workflow checks matched, adjudication sub-step timings emitted

## K8s smoke highlights
- Throughput: 46.35 claims/sec
- P95 latency: 623 ms
- Adjudicate.ncci avg/p95: 31 ms / 152 ms
- Adjudicate.benefitCalculation avg/p95: 28 ms / 114 ms
- Adjudicate.providerIntegrity avg/p95: 12 ms / 61 ms
