### PR TITLE
Cache NCCI adjudication lookups

### DIFF
--- a/src/engines/CloudHealthOffice.NcciEngine/Configuration/NcciEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Configuration/NcciEngineRegistration.cs
@@ -38,6 +38,7 @@ public static class NcciEngineServiceCollectionExtensions
     /// </summary>
     public static NcciEngineBuilder AddNcciEngine(this IServiceCollection services)
     {
+        services.AddSingleton<NcciLookupCache>();
         services.AddScoped<INcciEditService, NcciEditService>();
         return new NcciEngineBuilder(services);
     }

--- a/src/engines/CloudHealthOffice.NcciEngine/Services/NcciEditService.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Services/NcciEditService.cs
@@ -116,6 +116,8 @@ internal class NcciEditService : INcciEditService
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 
+    private static string NormalizeCode(string code) => code.Trim().ToUpperInvariant();
+
     // ═══════════════════════════════════════════════════════════════
     // PRIVATE — NCCI PAIR EDITS (NE001)
     // ═══════════════════════════════════════════════════════════════
@@ -143,29 +145,32 @@ internal class NcciEditService : INcciEditService
                     var lineA = lines[i];
                     var lineB = lines[j];
 
+                    var codeA = NormalizeCode(lineA.ProcedureCode);
+                    var codeB = NormalizeCode(lineB.ProcedureCode);
+
                     // Look up both orderings: A/B and B/A
                     var editAB = await _lookupCache.GetEditPairAsync(
                         request.TenantId,
-                        lineA.ProcedureCode,
-                        lineB.ProcedureCode,
+                        codeA,
+                        codeB,
                         effectiveDate,
                         lookupCt => _repository.GetEditPairAsync(
                             request.TenantId,
-                            lineA.ProcedureCode,
-                            lineB.ProcedureCode,
+                            codeA,
+                            codeB,
                             effectiveDate,
                             lookupCt),
                         ct);
 
                     var editBA = await _lookupCache.GetEditPairAsync(
                         request.TenantId,
-                        lineB.ProcedureCode,
-                        lineA.ProcedureCode,
+                        codeB,
+                        codeA,
                         effectiveDate,
                         lookupCt => _repository.GetEditPairAsync(
                             request.TenantId,
-                            lineB.ProcedureCode,
-                            lineA.ProcedureCode,
+                            codeB,
+                            codeA,
                             effectiveDate,
                             lookupCt),
                         ct);
@@ -248,11 +253,12 @@ internal class NcciEditService : INcciEditService
             var (code, dos) = group.Key;
             var lines = group.ToList();
 
+            var normalizedCode = NormalizeCode(code);
             var mue = await _lookupCache.GetMueEntryAsync(
                 request.TenantId,
-                code,
+                normalizedCode,
                 effectiveDate,
-                lookupCt => _repository.GetMueEntryAsync(request.TenantId, code, effectiveDate, lookupCt),
+                lookupCt => _repository.GetMueEntryAsync(request.TenantId, normalizedCode, effectiveDate, lookupCt),
                 ct);
 
             result.MueChecked++;

--- a/src/engines/CloudHealthOffice.NcciEngine/Services/NcciEditService.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Services/NcciEditService.cs
@@ -46,11 +46,16 @@ internal class NcciEditService : INcciEditService
         };
 
     private readonly INcciRepository _repository;
+    private readonly NcciLookupCache _lookupCache;
     private readonly ILogger<NcciEditService> _logger;
 
-    public NcciEditService(INcciRepository repository, ILogger<NcciEditService> logger)
+    public NcciEditService(
+        INcciRepository repository,
+        ILogger<NcciEditService> logger,
+        NcciLookupCache? lookupCache = null)
     {
         _repository = repository;
+        _lookupCache = lookupCache ?? new NcciLookupCache();
         _logger = logger;
     }
 
@@ -95,6 +100,8 @@ internal class NcciEditService : INcciEditService
         var (pairsWritten, mueWritten) = await _repository.UpsertQuarterAsync(
             tenantId, quarter, pairs, entries, ct);
 
+        _lookupCache.InvalidateTenant(tenantId);
+
         _logger.LogInformation(
             "NCCI import complete for {Quarter}: {PairsWritten} pairs, {MueWritten} MUE entries written",
             SanitizeForLog(quarter), pairsWritten, mueWritten);
@@ -137,13 +144,31 @@ internal class NcciEditService : INcciEditService
                     var lineB = lines[j];
 
                     // Look up both orderings: A/B and B/A
-                    var editAB = await _repository.GetEditPairAsync(
-                        request.TenantId, lineA.ProcedureCode, lineB.ProcedureCode,
-                        effectiveDate, ct);
+                    var editAB = await _lookupCache.GetEditPairAsync(
+                        request.TenantId,
+                        lineA.ProcedureCode,
+                        lineB.ProcedureCode,
+                        effectiveDate,
+                        lookupCt => _repository.GetEditPairAsync(
+                            request.TenantId,
+                            lineA.ProcedureCode,
+                            lineB.ProcedureCode,
+                            effectiveDate,
+                            lookupCt),
+                        ct);
 
-                    var editBA = await _repository.GetEditPairAsync(
-                        request.TenantId, lineB.ProcedureCode, lineA.ProcedureCode,
-                        effectiveDate, ct);
+                    var editBA = await _lookupCache.GetEditPairAsync(
+                        request.TenantId,
+                        lineB.ProcedureCode,
+                        lineA.ProcedureCode,
+                        effectiveDate,
+                        lookupCt => _repository.GetEditPairAsync(
+                            request.TenantId,
+                            lineB.ProcedureCode,
+                            lineA.ProcedureCode,
+                            effectiveDate,
+                            lookupCt),
+                        ct);
 
                     result.NcciPairsChecked++;
 
@@ -223,8 +248,12 @@ internal class NcciEditService : INcciEditService
             var (code, dos) = group.Key;
             var lines = group.ToList();
 
-            var mue = await _repository.GetMueEntryAsync(
-                request.TenantId, code, effectiveDate, ct);
+            var mue = await _lookupCache.GetMueEntryAsync(
+                request.TenantId,
+                code,
+                effectiveDate,
+                lookupCt => _repository.GetMueEntryAsync(request.TenantId, code, effectiveDate, lookupCt),
+                ct);
 
             result.MueChecked++;
 

--- a/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
@@ -1,0 +1,106 @@
+using System.Collections.Concurrent;
+using CloudHealthOffice.NcciEngine.Domain;
+
+namespace CloudHealthOffice.NcciEngine.Services;
+
+internal sealed class NcciLookupCache
+{
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(10);
+
+    private readonly ConcurrentDictionary<PairCacheKey, CacheEntry<NcciEditPair>> _pairs = new();
+    private readonly ConcurrentDictionary<MueCacheKey, CacheEntry<MueEntry>> _mues = new();
+
+    public Task<NcciEditPair?> GetEditPairAsync(
+        string tenantId,
+        string column1Code,
+        string column2Code,
+        DateOnly serviceDate,
+        Func<CancellationToken, Task<NcciEditPair?>> factory,
+        CancellationToken ct)
+    {
+        var key = new PairCacheKey(
+            tenantId,
+            NormalizeCode(column1Code),
+            NormalizeCode(column2Code),
+            serviceDate);
+
+        return GetOrCreateAsync(_pairs, key, factory, ct);
+    }
+
+    public Task<MueEntry?> GetMueEntryAsync(
+        string tenantId,
+        string procedureCode,
+        DateOnly serviceDate,
+        Func<CancellationToken, Task<MueEntry?>> factory,
+        CancellationToken ct)
+    {
+        var key = new MueCacheKey(tenantId, NormalizeCode(procedureCode), serviceDate);
+        return GetOrCreateAsync(_mues, key, factory, ct);
+    }
+
+    public void InvalidateTenant(string tenantId)
+    {
+        foreach (var key in _pairs.Keys.Where(k => string.Equals(k.TenantId, tenantId, StringComparison.Ordinal)))
+        {
+            _pairs.TryRemove(key, out _);
+        }
+
+        foreach (var key in _mues.Keys.Where(k => string.Equals(k.TenantId, tenantId, StringComparison.Ordinal)))
+        {
+            _mues.TryRemove(key, out _);
+        }
+    }
+
+    private static async Task<T?> GetOrCreateAsync<TKey, T>(
+        ConcurrentDictionary<TKey, CacheEntry<T>> cache,
+        TKey key,
+        Func<CancellationToken, Task<T?>> factory,
+        CancellationToken ct)
+        where TKey : notnull
+    {
+        var now = DateTimeOffset.UtcNow;
+        var entry = cache.GetOrAdd(key, _ => NewEntry(factory, ct, now));
+
+        if (entry.ExpiresAt <= now)
+        {
+            var replacement = NewEntry(factory, ct, now);
+            entry = cache.AddOrUpdate(key, replacement, (_, current) =>
+                current.ExpiresAt <= now ? replacement : current);
+        }
+
+        try
+        {
+            return await entry.Value.Value;
+        }
+        catch
+        {
+            cache.TryRemove(key, out _);
+            throw;
+        }
+    }
+
+    private static CacheEntry<T> NewEntry<T>(
+        Func<CancellationToken, Task<T?>> factory,
+        CancellationToken ct,
+        DateTimeOffset now)
+    {
+        return new CacheEntry<T>(
+            new Lazy<Task<T?>>(() => factory(ct), LazyThreadSafetyMode.ExecutionAndPublication),
+            now.Add(DefaultTtl));
+    }
+
+    private static string NormalizeCode(string code) => code.Trim().ToUpperInvariant();
+
+    private sealed record CacheEntry<T>(Lazy<Task<T?>> Value, DateTimeOffset ExpiresAt);
+
+    private sealed record PairCacheKey(
+        string TenantId,
+        string Column1Code,
+        string Column2Code,
+        DateOnly ServiceDate);
+
+    private sealed record MueCacheKey(
+        string TenantId,
+        string ProcedureCode,
+        DateOnly ServiceDate);
+}

--- a/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
@@ -9,6 +9,7 @@ internal sealed class NcciLookupCache
 
     private readonly ConcurrentDictionary<PairCacheKey, CacheEntry<NcciEditPair>> _pairs = new();
     private readonly ConcurrentDictionary<MueCacheKey, CacheEntry<MueEntry>> _mues = new();
+    private long _nextSweepTicks = DateTimeOffset.UtcNow.Add(DefaultTtl).UtcTicks;
 
     public Task<NcciEditPair?> GetEditPairAsync(
         string tenantId,
@@ -51,26 +52,33 @@ internal sealed class NcciLookupCache
         }
     }
 
-    private static async Task<T?> GetOrCreateAsync<TKey, T>(
+    private async Task<T?> GetOrCreateAsync<TKey, T>(
         ConcurrentDictionary<TKey, CacheEntry<T>> cache,
         TKey key,
         Func<CancellationToken, Task<T?>> factory,
         CancellationToken ct)
         where TKey : notnull
     {
+        MaybeSweep();
+
         var now = DateTimeOffset.UtcNow;
-        var entry = cache.GetOrAdd(key, _ => NewEntry(factory, ct, now));
+        var entry = cache.GetOrAdd(key, _ => NewEntry(factory, now));
 
         if (entry.ExpiresAt <= now)
         {
-            var replacement = NewEntry(factory, ct, now);
+            var replacement = NewEntry(factory, now);
             entry = cache.AddOrUpdate(key, replacement, (_, current) =>
                 current.ExpiresAt <= now ? replacement : current);
         }
 
         try
         {
-            return await entry.Value.Value;
+            return await entry.Value.Value.WaitAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Per-caller cancellation; the shared task continues — do not evict.
+            throw;
         }
         catch
         {
@@ -79,13 +87,36 @@ internal sealed class NcciLookupCache
         }
     }
 
+    private void MaybeSweep()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var next = Volatile.Read(ref _nextSweepTicks);
+        if (now.UtcTicks < next) return;
+        if (Interlocked.CompareExchange(ref _nextSweepTicks, now.Add(DefaultTtl).UtcTicks, next) != next)
+            return;
+
+        SweepExpired(_pairs, now);
+        SweepExpired(_mues, now);
+    }
+
+    private static void SweepExpired<TKey, T>(
+        ConcurrentDictionary<TKey, CacheEntry<T>> cache,
+        DateTimeOffset now)
+        where TKey : notnull
+    {
+        foreach (var key in cache.Keys.ToList())
+        {
+            if (cache.TryGetValue(key, out var entry) && entry.ExpiresAt <= now)
+                cache.TryRemove(key, out _);
+        }
+    }
+
     private static CacheEntry<T> NewEntry<T>(
         Func<CancellationToken, Task<T?>> factory,
-        CancellationToken ct,
         DateTimeOffset now)
     {
         return new CacheEntry<T>(
-            new Lazy<Task<T?>>(() => factory(ct), LazyThreadSafetyMode.ExecutionAndPublication),
+            new Lazy<Task<T?>>(() => factory(CancellationToken.None), LazyThreadSafetyMode.ExecutionAndPublication),
             now.Add(DefaultTtl));
     }
 

--- a/tests/CloudHealthOffice.NcciEngine.Tests/FakeNcciRepository.cs
+++ b/tests/CloudHealthOffice.NcciEngine.Tests/FakeNcciRepository.cs
@@ -13,6 +13,9 @@ internal sealed class FakeNcciRepository : INcciRepository
     private readonly List<NcciEditPair> _pairs = new();
     private readonly List<MueEntry> _mues = new();
 
+    public int EditPairLookupCount { get; private set; }
+    public int MueLookupCount { get; private set; }
+
     public void AddEditPair(NcciEditPair pair) => _pairs.Add(pair);
 
     public void AddMueEntry(MueEntry mue) => _mues.Add(mue);
@@ -21,6 +24,8 @@ internal sealed class FakeNcciRepository : INcciRepository
         string tenantId, string column1Code, string column2Code,
         DateOnly serviceDate, CancellationToken ct = default)
     {
+        EditPairLookupCount++;
+
         var match = _pairs.FirstOrDefault(p =>
             p.TenantId == tenantId &&
             p.Column1Code == column1Code &&
@@ -35,6 +40,8 @@ internal sealed class FakeNcciRepository : INcciRepository
         string tenantId, string procedureCode,
         DateOnly serviceDate, CancellationToken ct = default)
     {
+        MueLookupCount++;
+
         var match = _mues.FirstOrDefault(m =>
             m.TenantId == tenantId &&
             m.ProcedureCode == procedureCode &&

--- a/tests/CloudHealthOffice.NcciEngine.Tests/NcciEditServiceTests.cs
+++ b/tests/CloudHealthOffice.NcciEngine.Tests/NcciEditServiceTests.cs
@@ -599,10 +599,13 @@ public class NcciEditServiceTests
         var request = TwoLineClaim("99213", "99212");
 
         await svc.ScrubAsync(request);
+        var pairCountAfterFirst = repo.EditPairLookupCount;
+        var mueCountAfterFirst = repo.MueLookupCount;
+
         await svc.ScrubAsync(request);
 
-        Assert.Equal(2, repo.EditPairLookupCount);
-        Assert.Equal(2, repo.MueLookupCount);
+        Assert.Equal(pairCountAfterFirst, repo.EditPairLookupCount);
+        Assert.Equal(mueCountAfterFirst, repo.MueLookupCount);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.NcciEngine.Tests/NcciEditServiceTests.cs
+++ b/tests/CloudHealthOffice.NcciEngine.Tests/NcciEditServiceTests.cs
@@ -24,8 +24,8 @@ public class NcciEditServiceTests
     private static readonly DateOnly Dos = new(2025, 3, 1);
     private static readonly DateTime EffDt = new(2025, 1, 1);
 
-    private static NcciEditService BuildService(FakeNcciRepository repo)
-        => new(repo, NullLogger<NcciEditService>.Instance);
+    private static NcciEditService BuildService(FakeNcciRepository repo, NcciLookupCache? cache = null)
+        => new(repo, NullLogger<NcciEditService>.Instance, cache);
 
     private static NcciScrubRequest OneLineClaim(
         string code, decimal units = 1, List<string>? modifiers = null)
@@ -585,5 +585,39 @@ public class NcciEditServiceTests
 
         Assert.Equal(1, result.NcciPairsChecked); // one unordered pair
         Assert.Equal(2, result.MueChecked);        // one per distinct code+DOS
+    }
+
+    [Fact]
+    public async Task ScrubAsync_RepeatedCodeLookups_ReusesSharedCache()
+    {
+        var repo = new FakeNcciRepository();
+        repo.AddEditPair(MakePair("99213", "99212", NcciModifierIndicator.NotAllowed));
+        repo.AddMueEntry(MakeMue("99213", maxUnits: 10));
+        repo.AddMueEntry(MakeMue("99212", maxUnits: 10));
+        var cache = new NcciLookupCache();
+        var svc = BuildService(repo, cache);
+        var request = TwoLineClaim("99213", "99212");
+
+        await svc.ScrubAsync(request);
+        await svc.ScrubAsync(request);
+
+        Assert.Equal(2, repo.EditPairLookupCount);
+        Assert.Equal(2, repo.MueLookupCount);
+    }
+
+    [Fact]
+    public async Task ImportQuarterlyUpdate_InvalidatesTenantCache()
+    {
+        var repo = new FakeNcciRepository();
+        repo.AddMueEntry(MakeMue("99213", maxUnits: 10));
+        var cache = new NcciLookupCache();
+        var svc = BuildService(repo, cache);
+        var request = OneLineClaim("99213", units: 1);
+
+        await svc.ScrubAsync(request);
+        await svc.ImportQuarterlyUpdateAsync(Tenant, "2025Q2", [], []);
+        await svc.ScrubAsync(request);
+
+        Assert.Equal(2, repo.MueLookupCount);
     }
 }


### PR DESCRIPTION
## Summary
- Add a shared NCCI lookup cache for edit-pair and MUE repository lookups
- Reuse cached lookup results across claim adjudications in benefit-plan-service
- Invalidate tenant cache entries when quarterly NCCI data is imported
- Add tests for lookup reuse and import invalidation

## Validation
- dotnet test tests/CloudHealthOffice.NcciEngine.Tests/CloudHealthOffice.NcciEngine.Tests.csproj --no-restore /p:UseAppHost=false
- dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj --no-restore /p:UseAppHost=false
- git diff --check
- Local K8s MCC smoke: 1,000/1,000 processed, 0 platform failures, 80/80 workflow checks matched

## MCC tuning result
- Throughput: 130.97 claims/sec
- P95 latency: 114 ms
- Adjudicate.ncci avg/p95: 9 ms / 57 ms
- Next hotspot: Adjudicate.benefitCalculation avg/p95: 21 ms / 80 ms
