### PR TITLE
Tune accumulator cache rebuilds

### DIFF
--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
@@ -96,6 +96,7 @@ public class RedisAccumulatorService : IAccumulatorService
     /// plan with 2 months of run-out.
     /// </summary>
     private static readonly TimeSpan DefaultKeyTtl = TimeSpan.FromDays(425);
+    private static readonly RedisValue EmptySnapshotField = "__empty";
 
     public RedisAccumulatorService(
         IConnectionMultiplexer redis,
@@ -306,7 +307,11 @@ public class RedisAccumulatorService : IAccumulatorService
         var computed = await _claimsSource.CalculateAccumulatorsAsync(
             _tenantContext.TenantId, ownerId, scope, benefitPlanId, planYear, ct);
 
-        if (computed.Count == 0) return [];
+        if (computed.Count == 0)
+        {
+            await MarkEmptySnapshotAsync(db, key);
+            return [];
+        }
 
         // Populate Redis
         var hashEntries = computed.Select(s =>
@@ -337,6 +342,8 @@ public class RedisAccumulatorService : IAccumulatorService
         var batch = db.CreateBatch();
         var tasks = new List<Task>();
 
+        tasks.Add(batch.HashDeleteAsync(key, EmptySnapshotField));
+
         foreach (var update in updates)
         {
             var field = MakeField(update);
@@ -348,6 +355,15 @@ public class RedisAccumulatorService : IAccumulatorService
 
         batch.Execute();
         await Task.WhenAll(tasks);
+    }
+
+    private static async Task MarkEmptySnapshotAsync(IDatabase db, RedisKey key)
+    {
+        var batch = db.CreateBatch();
+        var setTask = batch.HashSetAsync(key, EmptySnapshotField, RedisValue.EmptyString);
+        var expireTask = batch.KeyExpireAsync(key, DefaultKeyTtl);
+        batch.Execute();
+        await Task.WhenAll(setTask, expireTask);
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -386,6 +402,8 @@ public class RedisAccumulatorService : IAccumulatorService
         foreach (var entry in entries)
         {
             var field = entry.Name.ToString();
+            if (entry.Name == EmptySnapshotField) continue;
+
             var amount = (decimal)(double)entry.Value;
 
             // Parse "AccumulatorType:NetworkTier" field format

--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/Redisaccumulatorservice.cs
@@ -304,11 +304,21 @@ public class RedisAccumulatorService : IAccumulatorService
         _logger.LogDebug(
             "Cache miss for {Key}. Rebuilding from claim history.", key.ToString());
 
-        var computed = await _claimsSource.CalculateAccumulatorsAsync(
+        var (fetchSuccess, computed) = await _claimsSource.CalculateAccumulatorsAsync(
             _tenantContext.TenantId, ownerId, scope, benefitPlanId, planYear, ct);
+
+        if (!fetchSuccess)
+        {
+            // Source was unavailable — do not cache; the next read will retry.
+            _logger.LogWarning(
+                "Accumulator source unavailable for {Key}. Skipping Redis cache population.",
+                key.ToString());
+            return [];
+        }
 
         if (computed.Count == 0)
         {
+            // Authoritatively empty: owner has no accumulator history.
             await MarkEmptySnapshotAsync(db, key);
             return [];
         }
@@ -460,7 +470,18 @@ public class RedisAccumulatorService : IAccumulatorService
 /// </summary>
 public interface IClaimsAccumulatorSource
 {
-    Task<IReadOnlyList<AccumulatorSnapshot>> CalculateAccumulatorsAsync(
+    /// <summary>
+    /// Calculates accumulator totals from claim history.
+    /// </summary>
+    /// <returns>
+    /// A result where <c>Success</c> is <c>true</c> when the source was
+    /// reachable and the data is authoritative (even if <c>Snapshots</c> is
+    /// empty, meaning the owner has no accumulator history), and <c>false</c>
+    /// when the source was unavailable or returned a non-success response —
+    /// in which case the caller must NOT cache the result as an authoritative
+    /// empty rebuild.
+    /// </returns>
+    Task<(bool Success, IReadOnlyList<AccumulatorSnapshot> Snapshots)> CalculateAccumulatorsAsync(
         string tenantId, string ownerId, AccumulatorScope scope,
         Guid benefitPlanId, string planYear,
         CancellationToken ct = default);

--- a/src/services/benefit-plan-service/Services/ClaimsServiceAccumulatorSource.cs
+++ b/src/services/benefit-plan-service/Services/ClaimsServiceAccumulatorSource.cs
@@ -37,7 +37,7 @@ public class ClaimsServiceAccumulatorSource : IClaimsAccumulatorSource
         _logger = logger;
     }
 
-    public async Task<IReadOnlyList<AccumulatorSnapshot>> CalculateAccumulatorsAsync(
+    public async Task<(bool Success, IReadOnlyList<AccumulatorSnapshot> Snapshots)> CalculateAccumulatorsAsync(
         string tenantId,
         string ownerId,
         AccumulatorScope scope,
@@ -68,7 +68,7 @@ public class ClaimsServiceAccumulatorSource : IClaimsAccumulatorSource
                 "claims-service unavailable during accumulator rebuild for owner {OwnerId}. " +
                 "Returning empty snapshot — Redis cache will remain cold.",
                 SanitizeForLog(ownerId));
-            return Array.Empty<AccumulatorSnapshot>();
+            return (false, Array.Empty<AccumulatorSnapshot>());
         }
 
         if (!response.IsSuccessStatusCode)
@@ -77,18 +77,18 @@ public class ClaimsServiceAccumulatorSource : IClaimsAccumulatorSource
                 "claims-service returned {Status} for accumulator-totals (owner={OwnerId}). " +
                 "Returning empty snapshot.",
                 (int)response.StatusCode, SanitizeForLog(ownerId));
-            return Array.Empty<AccumulatorSnapshot>();
+            return (false, Array.Empty<AccumulatorSnapshot>());
         }
 
         var result = await response.Content.ReadFromJsonAsync<AccumulatorTotalsDto>(JsonOptions, ct);
         if (result?.Totals is null || result.Totals.Count == 0)
-            return Array.Empty<AccumulatorSnapshot>();
+            return (true, Array.Empty<AccumulatorSnapshot>());
 
-        return result.Totals
+        return (true, result.Totals
             .Select(entry => MapToSnapshot(entry, scope))
             .Where(s => s is not null)
             .Cast<AccumulatorSnapshot>()
-            .ToList();
+            .ToList());
     }
 
     private static AccumulatorSnapshot? MapToSnapshot(AccumulatorTotalEntryDto entry, AccumulatorScope scope)

--- a/src/services/claims-service/HostedServices/ClaimIndexInitializer.cs
+++ b/src/services/claims-service/HostedServices/ClaimIndexInitializer.cs
@@ -1,0 +1,66 @@
+using ClaimsService.Models;
+using MongoDB.Driver;
+
+namespace ClaimsService.HostedServices;
+
+/// <summary>
+/// Creates the Mongo indexes used by the <c>Claims</c> collection once at
+/// startup. Moved out of <see cref="Repositories.ClaimRepositoryMongo"/> so
+/// that scoped repository construction stays side-effect free regardless of
+/// how often it is resolved per request.
+///
+/// Includes both the general-purpose claim lookup indexes and the compound
+/// accumulator-rebuild indexes that support Redis cache-miss aggregation by
+/// tenant / plan / owner / service date.
+///
+/// Idempotent: Mongo silently no-ops an index that already exists with the
+/// same spec.
+/// </summary>
+public sealed class ClaimIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _db;
+    private readonly ILogger<ClaimIndexInitializer> _logger;
+
+    public ClaimIndexInitializer(
+        IMongoDatabase db,
+        ILogger<ClaimIndexInitializer> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _db.GetCollection<Claim>("Claims");
+        var keys = Builders<Claim>.IndexKeys;
+
+        var indexes = new[]
+        {
+            new CreateIndexModel<Claim>(keys.Ascending(c => c.TenantId).Ascending(c => c.ClaimNumber)),
+            new CreateIndexModel<Claim>(keys.Ascending(c => c.TenantId).Ascending(c => c.MemberId)),
+            new CreateIndexModel<Claim>(keys.Ascending(c => c.TenantId).Ascending(c => c.SubmittedDate)),
+            // Compound index for search
+            new CreateIndexModel<Claim>(keys.Ascending(c => c.TenantId).Ascending(c => c.ServiceDateFrom)),
+            // Versioning chain key index — supports GetLatestVersion / ListVersions.
+            new CreateIndexModel<Claim>(keys.Ascending(c => c.TenantId).Ascending(c => c.ClaimVersionId).Descending(c => c.VersionNumber)),
+            // Accumulator rebuild indexes — support Redis cache-miss aggregation by owner/plan/year.
+            new CreateIndexModel<Claim>(keys
+                .Ascending(c => c.TenantId)
+                .Ascending(c => c.BenefitPlanId)
+                .Ascending(c => c.MemberId)
+                .Ascending(c => c.ServiceDateFrom)),
+            new CreateIndexModel<Claim>(keys
+                .Ascending(c => c.TenantId)
+                .Ascending(c => c.BenefitPlanId)
+                .Ascending(c => c.SubscriberId)
+                .Ascending(c => c.ServiceDateFrom)),
+        };
+
+        collection.Indexes.CreateMany(indexes, cancellationToken);
+
+        _logger.LogInformation("Claim indexes ensured on collection 'Claims'.");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -36,6 +36,7 @@ var mongoConnectionString = builder.Configuration["MongoDb:ConnectionString"];
 if (!string.IsNullOrEmpty(mongoConnectionString))
 {
     builder.Services.AddScoped<IClaimRepository, ClaimRepositoryMongo>();
+    builder.Services.AddHostedService<ClaimIndexInitializer>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryMongo>();
     builder.Services.AddScoped<IMassAdjudicationRunRepository, MassAdjudicationRunRepositoryMongo>();
     builder.Services.AddHostedService<MassAdjudicationRunIndexInitializer>();

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -36,7 +36,18 @@ public class ClaimRepositoryMongo : IClaimRepository
             // Compound index for search
             new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ServiceDateFrom)),
             // Versioning chain key index — supports GetLatestVersion / ListVersions.
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ClaimVersionId).Descending(c => c.VersionNumber))
+            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ClaimVersionId).Descending(c => c.VersionNumber)),
+            // Accumulator rebuild indexes — support Redis cache miss aggregation by owner/plan/year.
+            new CreateIndexModel<Claim>(indexKeys
+                .Ascending(c => c.TenantId)
+                .Ascending(c => c.BenefitPlanId)
+                .Ascending(c => c.MemberId)
+                .Ascending(c => c.ServiceDateFrom)),
+            new CreateIndexModel<Claim>(indexKeys
+                .Ascending(c => c.TenantId)
+                .Ascending(c => c.BenefitPlanId)
+                .Ascending(c => c.SubscriberId)
+                .Ascending(c => c.ServiceDateFrom))
         };
 
         _collection.Indexes.CreateMany(indexModels);
@@ -577,16 +588,19 @@ public class ClaimRepositoryMongo : IClaimRepository
         else
             filter = builder.And(filter, builder.Eq(c => c.MemberId, ownerId));
 
-        var claims = await _collection
-            .Find(filter)
-            .Project(c => new
-            {
-                c.AdjudicationResult!.DeductibleAmount,
-                c.AdjudicationResult.CoinsuranceAmount,
-                c.AdjudicationResult.CopayAmount,
-                c.AdjudicationResult.PatientResponsibility,
-                c.AdjudicationResult.NetworkTier
-            })
+        var rows = await _collection
+            .Aggregate()
+            .Match(filter)
+            .Group(
+                c => c.AdjudicationResult!.NetworkTier,
+                g => new AccumulatorTotalsAggregationRow
+                {
+                    NetworkTier = g.Key,
+                    DeductibleAmount = g.Sum(c => c.AdjudicationResult!.DeductibleAmount),
+                    CoinsuranceAmount = g.Sum(c => c.AdjudicationResult!.CoinsuranceAmount),
+                    CopayAmount = g.Sum(c => c.AdjudicationResult!.CopayAmount),
+                    PatientResponsibility = g.Sum(c => c.AdjudicationResult!.PatientResponsibility)
+                })
             .ToListAsync(ct);
 
         var deductibleType = scope == "Family" ? "FamilyDeductible"     : "IndividualDeductible";
@@ -597,7 +611,7 @@ public class ClaimRepositoryMongo : IClaimRepository
         var coinsurance = new Dictionary<string, decimal>();
         var copay       = new Dictionary<string, decimal>();
 
-        foreach (var row in claims)
+        foreach (var row in rows)
         {
             var tier = row.NetworkTier ?? "InNetwork";
             deductible[tier]  = deductible.GetValueOrDefault(tier)  + row.DeductibleAmount;
@@ -617,6 +631,15 @@ public class ClaimRepositoryMongo : IClaimRepository
             if (amount > 0) totals.Add(new AccumulatorTotalEntry { AccumulatorType = "Copay", NetworkTier = tier, AccumulatedAmount = amount });
 
         return new AccumulatorTotalsResponse { Totals = totals };
+    }
+
+    private sealed class AccumulatorTotalsAggregationRow
+    {
+        public string? NetworkTier { get; set; }
+        public decimal DeductibleAmount { get; set; }
+        public decimal CoinsuranceAmount { get; set; }
+        public decimal CopayAmount { get; set; }
+        public decimal PatientResponsibility { get; set; }
     }
 
     public async Task<bool> MarkSupersededProjectionAsync(

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -25,32 +25,6 @@ public class ClaimRepositoryMongo : IClaimRepository
         _collection = database.GetCollection<Claim>("Claims");
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
-
-        // Ensure indexes (best effort on startup)
-        var indexKeys = Builders<Claim>.IndexKeys;
-        var indexModels = new List<CreateIndexModel<Claim>>
-        {
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ClaimNumber)),
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.MemberId)),
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.SubmittedDate)),
-            // Compound index for search
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ServiceDateFrom)),
-            // Versioning chain key index — supports GetLatestVersion / ListVersions.
-            new CreateIndexModel<Claim>(indexKeys.Ascending(c => c.TenantId).Ascending(c => c.ClaimVersionId).Descending(c => c.VersionNumber)),
-            // Accumulator rebuild indexes — support Redis cache miss aggregation by owner/plan/year.
-            new CreateIndexModel<Claim>(indexKeys
-                .Ascending(c => c.TenantId)
-                .Ascending(c => c.BenefitPlanId)
-                .Ascending(c => c.MemberId)
-                .Ascending(c => c.ServiceDateFrom)),
-            new CreateIndexModel<Claim>(indexKeys
-                .Ascending(c => c.TenantId)
-                .Ascending(c => c.BenefitPlanId)
-                .Ascending(c => c.SubscriberId)
-                .Ascending(c => c.ServiceDateFrom))
-        };
-
-        _collection.Indexes.CreateMany(indexModels);
     }
 
     private string GetTenantId()


### PR DESCRIPTION
## Summary
- add Mongo indexes for accumulator rebuild lookups by tenant/plan/member-or-subscriber/service date
- aggregate accumulator totals in Mongo instead of materializing claim rows in app code
- cache empty Redis accumulator rebuilds with a sentinel so zero-history owners do not repeatedly call claims-service

## Validation
- dotnet build src/services/claims-service/claims-service.csproj --no-restore /p:UseAppHost=false
- dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.BenefitEngine.Tests/CloudHealthOffice.BenefitEngine.Tests.csproj --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore /p:UseAppHost=false --filter FullyQualifiedName~ClaimRepositoryVersioningTests
- git diff --check
- MCC local Kubernetes 1k: 1,000/1,000 processed, 0 platform failures, 80/80 workflow checks matched, 103.34 claims/sec, p95 165 ms, accumulatorRead avg/p95 19/67 ms

## Notes
- Full claims-service test suite still has an unrelated DI failure in MassAdjudicationRunIndexInitializer requiring IMongoDatabase; focused repository tests and service builds pass.