### PR TITLE
Fix claims test index initializer overrides

### DIFF
--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -1,5 +1,6 @@
 using ClaimsService.Adapters;
 using ClaimsService.EDI.Florida;
+using ClaimsService.HostedServices;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using ClaimsService.Services;
@@ -77,10 +78,10 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType.FullName?.Contains("Mongo") == true
                          || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                          || d.ImplementationType?.FullName?.Contains("Mongo") == true
-                         || d.ImplementationType?.FullName?.Contains("ClaimIndexInitializer") == true
-                         || d.ImplementationType?.FullName?.Contains("MassAdjudicationRunIndexInitializer") == true
-                         || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
-                         || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true)
+                         || d.ImplementationType == typeof(ClaimIndexInitializer)
+                         || d.ImplementationType == typeof(MassAdjudicationRunIndexInitializer)
+                         || d.ImplementationType == typeof(ClaimVersionEventIndexInitializer)
+                         || d.ImplementationType == typeof(ClaimAdjustmentIndexInitializer))
                 .ToList();
 
             foreach (var descriptor in cosmosDescriptors)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -77,6 +77,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType.FullName?.Contains("Mongo") == true
                          || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                          || d.ImplementationType?.FullName?.Contains("Mongo") == true
+                         || d.ImplementationType?.FullName?.Contains("ClaimIndexInitializer") == true
                          || d.ImplementationType?.FullName?.Contains("MassAdjudicationRunIndexInitializer") == true
                          || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
                          || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -188,6 +188,8 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                              || d.ServiceType.FullName?.Contains("Mongo") == true
                              || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                              || d.ImplementationType?.FullName?.Contains("Mongo") == true
+                             || d.ImplementationType?.FullName?.Contains("ClaimIndexInitializer") == true
+                             || d.ImplementationType?.FullName?.Contains("MassAdjudicationRunIndexInitializer") == true
                              || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
                              || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true
                              || d.ServiceType == typeof(IClaimVersionEventPublisher)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using ClaimsService.Adapters;
+using ClaimsService.HostedServices;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using ClaimsService.Services;
@@ -188,10 +189,10 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                              || d.ServiceType.FullName?.Contains("Mongo") == true
                              || d.ImplementationType?.FullName?.Contains("Cosmos") == true
                              || d.ImplementationType?.FullName?.Contains("Mongo") == true
-                             || d.ImplementationType?.FullName?.Contains("ClaimIndexInitializer") == true
-                             || d.ImplementationType?.FullName?.Contains("MassAdjudicationRunIndexInitializer") == true
-                             || d.ImplementationType?.FullName?.Contains("ClaimVersionEventIndexInitializer") == true
-                             || d.ImplementationType?.FullName?.Contains("ClaimAdjustmentIndexInitializer") == true
+                             || d.ImplementationType == typeof(ClaimIndexInitializer)
+                             || d.ImplementationType == typeof(MassAdjudicationRunIndexInitializer)
+                             || d.ImplementationType == typeof(ClaimVersionEventIndexInitializer)
+                             || d.ImplementationType == typeof(ClaimAdjustmentIndexInitializer)
                              || d.ServiceType == typeof(IClaimVersionEventPublisher)
                              || d.ServiceType == typeof(IBenefitCalculationEngine)
                              || d.ServiceType == typeof(IBenefitPlanResolver)


### PR DESCRIPTION
## Summary
- remove ClaimIndexInitializer and MassAdjudicationRunIndexInitializer from claims test hosts when Mongo/Cosmos services are replaced
- restores DI validation for WebApplicationFactory-based claims tests

## Validation
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore /p:UseAppHost=false --filter FullyQualifiedName~AdjudicationEndToEndTests.PostClaim_TriggersAdjudicationPipeline_AndPersistenceBypassRecordsResult
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore /p:UseAppHost=false
- git diff --check

Full claims-service suite: 466/466 passing.