### PR TITLE
Cache fee schedule rate lookups

### DIFF
--- a/src/engines/CloudHealthOffice.FeeScheduleEngine/CloudHealthOffice.FeeScheduleEngine.csproj
+++ b/src/engines/CloudHealthOffice.FeeScheduleEngine/CloudHealthOffice.FeeScheduleEngine.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
   </ItemGroup>

--- a/src/engines/CloudHealthOffice.FeeScheduleEngine/Configuration/FeeScheduleEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.FeeScheduleEngine/Configuration/FeeScheduleEngineRegistration.cs
@@ -1,6 +1,7 @@
 using CloudHealthOffice.FeeScheduleEngine.Persistence;
 using CloudHealthOffice.FeeScheduleEngine.Services;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CloudHealthOffice.FeeScheduleEngine.Configuration;
@@ -30,6 +31,7 @@ public static class FeeScheduleEngineServiceCollectionExtensions
     /// </summary>
     public static FeeScheduleEngineBuilder AddFeeScheduleEngine(this IServiceCollection services)
     {
+        services.AddMemoryCache();
         services.AddScoped<IRateResolutionService, RateResolutionService>();
         return new FeeScheduleEngineBuilder(services);
     }
@@ -50,8 +52,9 @@ public class FeeScheduleEngineBuilder
     /// </summary>
     public FeeScheduleEngineBuilder UseCosmosRepositories()
     {
-        _services.AddScoped<IFeeScheduleRepository, FeeScheduleRepositoryCosmos>();
-        _services.AddScoped<IProviderContractRepository, FeeScheduleRepositoryCosmos>();
+        _services.AddScoped<FeeScheduleRepositoryCosmos>();
+        _services.AddScoped<IFeeScheduleRepository>(CreateFeeScheduleCache<FeeScheduleRepositoryCosmos>);
+        _services.AddScoped<IProviderContractRepository>(CreateFeeScheduleCache<FeeScheduleRepositoryCosmos>);
         return this;
     }
 
@@ -61,8 +64,9 @@ public class FeeScheduleEngineBuilder
     /// </summary>
     public FeeScheduleEngineBuilder UseMongoRepositories()
     {
-        _services.AddScoped<IFeeScheduleRepository, FeeScheduleRepositoryMongo>();
-        _services.AddScoped<IProviderContractRepository, FeeScheduleRepositoryMongo>();
+        _services.AddScoped<FeeScheduleRepositoryMongo>();
+        _services.AddScoped<IFeeScheduleRepository>(CreateFeeScheduleCache<FeeScheduleRepositoryMongo>);
+        _services.AddScoped<IProviderContractRepository>(CreateFeeScheduleCache<FeeScheduleRepositoryMongo>);
         return this;
     }
 
@@ -76,5 +80,15 @@ public class FeeScheduleEngineBuilder
         return !string.IsNullOrEmpty(configuration["MongoDb:ConnectionString"])
             ? UseMongoRepositories()
             : UseCosmosRepositories();
+    }
+
+    private static CachingFeeScheduleRepository CreateFeeScheduleCache<TRepository>(IServiceProvider sp)
+        where TRepository : class, IFeeScheduleRepository, IProviderContractRepository
+    {
+        var inner = sp.GetRequiredService<TRepository>();
+        return new CachingFeeScheduleRepository(
+            inner,
+            inner,
+            sp.GetRequiredService<IMemoryCache>());
     }
 }

--- a/src/engines/CloudHealthOffice.FeeScheduleEngine/Persistence/CachingFeeScheduleRepository.cs
+++ b/src/engines/CloudHealthOffice.FeeScheduleEngine/Persistence/CachingFeeScheduleRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using CloudHealthOffice.FeeScheduleEngine.Models;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -9,11 +10,14 @@ namespace CloudHealthOffice.FeeScheduleEngine.Persistence;
 /// </summary>
 public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProviderContractRepository
 {
-    private static readonly TimeSpan ReadTtl = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan ReadHitTtl = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan ReadMissTtl = TimeSpan.FromMinutes(1);
 
     private readonly IFeeScheduleRepository _feeSchedules;
     private readonly IProviderContractRepository _contracts;
     private readonly IMemoryCache _cache;
+    private readonly ConcurrentDictionary<string, byte> _defaultLookupKeys = new();
+    private readonly ConcurrentDictionary<string, byte> _contractLookupKeys = new();
 
     public CachingFeeScheduleRepository(
         IFeeScheduleRepository feeSchedules,
@@ -46,7 +50,8 @@ public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProv
         var key = $"fee-schedule:default:{tenantId}:{planId}:{serviceDate.Date:yyyyMMdd}";
         var cached = await GetOrCreateAsync(
             key,
-            () => _feeSchedules.GetDefaultForPlanAsync(tenantId, planId, serviceDate, ct));
+            () => _feeSchedules.GetDefaultForPlanAsync(tenantId, planId, serviceDate, ct),
+            _defaultLookupKeys);
         return cached.Value;
     }
 
@@ -61,6 +66,7 @@ public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProv
     {
         var saved = await _feeSchedules.UpsertAsync(schedule, ct);
         _cache.Remove($"fee-schedule:id:{schedule.TenantId}:{schedule.Id}");
+        InvalidateByPrefix(_defaultLookupKeys, $"fee-schedule:default:{schedule.TenantId}:");
         return saved;
     }
 
@@ -81,12 +87,17 @@ public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProv
         var key = $"provider-contract:{tenantId}:{providerNpi}:{planId}:{serviceDate.Date:yyyyMMdd}";
         var cached = await GetOrCreateAsync(
             key,
-            () => _contracts.GetContractAsync(tenantId, providerNpi, planId, serviceDate, ct));
+            () => _contracts.GetContractAsync(tenantId, providerNpi, planId, serviceDate, ct),
+            _contractLookupKeys);
         return cached.Value;
     }
 
-    public Task<ProviderContract> UpsertAsync(ProviderContract contract, CancellationToken ct = default)
-        => _contracts.UpsertAsync(contract, ct);
+    public async Task<ProviderContract> UpsertAsync(ProviderContract contract, CancellationToken ct = default)
+    {
+        var saved = await _contracts.UpsertAsync(contract, ct);
+        InvalidateByPrefix(_contractLookupKeys, $"provider-contract:{contract.TenantId}:{contract.ProviderNpi}:{contract.PlanId}:");
+        return saved;
+    }
 
     public Task<IReadOnlyList<ProviderContract>> ListByProviderAsync(
         string tenantId,
@@ -96,16 +107,47 @@ public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProv
 
     private async Task<CachedValue<T>> GetOrCreateAsync<T>(
         string key,
-        Func<Task<T?>> factory)
+        Func<Task<T?>> factory,
+        ConcurrentDictionary<string, byte>? trackedKeys = null)
     {
         var cached = await _cache.GetOrCreateAsync(key, async entry =>
         {
-            entry.AbsoluteExpirationRelativeToNow = ReadTtl;
-            return new CachedValue<T>(await factory());
+            var value = await factory();
+            entry.AbsoluteExpirationRelativeToNow = value is null ? ReadMissTtl : ReadHitTtl;
+            if (trackedKeys is not null)
+            {
+                trackedKeys[key] = 0;
+                entry.RegisterPostEvictionCallback(
+                    static (evictedKey, _, _, state) =>
+                    {
+                        if (evictedKey is string removedKey &&
+                            state is ConcurrentDictionary<string, byte> keys)
+                        {
+                            keys.TryRemove(removedKey, out _);
+                        }
+                    },
+                    trackedKeys);
+            }
+
+            return new CachedValue<T>(value);
         });
 
         return cached ?? new CachedValue<T>(default);
     }
 
     private sealed record CachedValue<T>(T? Value);
+
+    private void InvalidateByPrefix(ConcurrentDictionary<string, byte> trackedKeys, string prefix)
+    {
+        foreach (var key in trackedKeys.Keys)
+        {
+            if (!key.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            _cache.Remove(key);
+            trackedKeys.TryRemove(key, out _);
+        }
+    }
 }

--- a/src/engines/CloudHealthOffice.FeeScheduleEngine/Persistence/CachingFeeScheduleRepository.cs
+++ b/src/engines/CloudHealthOffice.FeeScheduleEngine/Persistence/CachingFeeScheduleRepository.cs
@@ -1,0 +1,111 @@
+using CloudHealthOffice.FeeScheduleEngine.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CloudHealthOffice.FeeScheduleEngine.Persistence;
+
+/// <summary>
+/// Per-process cache for adjudication-time fee schedule and provider contract reads.
+/// Admin writes still go to the inner repository; short TTLs keep policy changes fresh.
+/// </summary>
+public sealed class CachingFeeScheduleRepository : IFeeScheduleRepository, IProviderContractRepository
+{
+    private static readonly TimeSpan ReadTtl = TimeSpan.FromMinutes(10);
+
+    private readonly IFeeScheduleRepository _feeSchedules;
+    private readonly IProviderContractRepository _contracts;
+    private readonly IMemoryCache _cache;
+
+    public CachingFeeScheduleRepository(
+        IFeeScheduleRepository feeSchedules,
+        IProviderContractRepository contracts,
+        IMemoryCache cache)
+    {
+        _feeSchedules = feeSchedules;
+        _contracts = contracts;
+        _cache = cache;
+    }
+
+    public async Task<FeeSchedule?> GetByIdAsync(
+        string tenantId,
+        string id,
+        CancellationToken ct = default)
+    {
+        var key = $"fee-schedule:id:{tenantId}:{id}";
+        var cached = await GetOrCreateAsync(
+            key,
+            () => _feeSchedules.GetByIdAsync(tenantId, id, ct));
+        return cached.Value;
+    }
+
+    public async Task<FeeSchedule?> GetDefaultForPlanAsync(
+        string tenantId,
+        string planId,
+        DateTime serviceDate,
+        CancellationToken ct = default)
+    {
+        var key = $"fee-schedule:default:{tenantId}:{planId}:{serviceDate.Date:yyyyMMdd}";
+        var cached = await GetOrCreateAsync(
+            key,
+            () => _feeSchedules.GetDefaultForPlanAsync(tenantId, planId, serviceDate, ct));
+        return cached.Value;
+    }
+
+    public Task<FeeScheduleLine?> GetLineAsync(
+        string feeScheduleId,
+        string procedureCode,
+        string? modifier,
+        CancellationToken ct = default)
+        => _feeSchedules.GetLineAsync(feeScheduleId, procedureCode, modifier, ct);
+
+    public async Task<FeeSchedule> UpsertAsync(FeeSchedule schedule, CancellationToken ct = default)
+    {
+        var saved = await _feeSchedules.UpsertAsync(schedule, ct);
+        _cache.Remove($"fee-schedule:id:{schedule.TenantId}:{schedule.Id}");
+        return saved;
+    }
+
+    public Task<IReadOnlyList<FeeSchedule>> ListAsync(
+        string tenantId,
+        int page = 1,
+        int pageSize = 50,
+        CancellationToken ct = default)
+        => _feeSchedules.ListAsync(tenantId, page, pageSize, ct);
+
+    public async Task<ProviderContract?> GetContractAsync(
+        string tenantId,
+        string providerNpi,
+        string planId,
+        DateTime serviceDate,
+        CancellationToken ct = default)
+    {
+        var key = $"provider-contract:{tenantId}:{providerNpi}:{planId}:{serviceDate.Date:yyyyMMdd}";
+        var cached = await GetOrCreateAsync(
+            key,
+            () => _contracts.GetContractAsync(tenantId, providerNpi, planId, serviceDate, ct));
+        return cached.Value;
+    }
+
+    public Task<ProviderContract> UpsertAsync(ProviderContract contract, CancellationToken ct = default)
+        => _contracts.UpsertAsync(contract, ct);
+
+    public Task<IReadOnlyList<ProviderContract>> ListByProviderAsync(
+        string tenantId,
+        string providerNpi,
+        CancellationToken ct = default)
+        => _contracts.ListByProviderAsync(tenantId, providerNpi, ct);
+
+    private async Task<CachedValue<T>> GetOrCreateAsync<T>(
+        string key,
+        Func<Task<T?>> factory)
+    {
+        var cached = await _cache.GetOrCreateAsync(key, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = ReadTtl;
+            return new CachedValue<T>(await factory());
+        });
+
+        return cached ?? new CachedValue<T>(default);
+    }
+
+    private sealed record CachedValue<T>(T? Value);
+}

--- a/tests/CloudHealthOffice.FeeScheduleEngine.Tests/RateResolutionServiceTests.cs
+++ b/tests/CloudHealthOffice.FeeScheduleEngine.Tests/RateResolutionServiceTests.cs
@@ -461,6 +461,58 @@ public class RateResolutionServiceTests
         Assert.Equal(1, inner.GetContractCalls);
     }
 
+    [Fact]
+    public async Task CachingRepository_UpsertSchedule_InvalidatesDefaultPlanCache()
+    {
+        var inner = new CountingFeeScheduleRepo(defaultSchedule: null);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingFeeScheduleRepository(inner, inner, cache);
+
+        var firstDefault = await sut.GetDefaultForPlanAsync(Tenant, PlanId, new DateTime(2026, 3, 8));
+        var secondDefault = await sut.GetDefaultForPlanAsync(Tenant, PlanId, new DateTime(2026, 3, 8));
+        Assert.Null(firstDefault);
+        Assert.Null(secondDefault);
+        Assert.Equal(1, inner.GetDefaultForPlanCalls);
+
+        var newDefault = CreateCommercialSchedule("99213", 120m);
+        await sut.UpsertAsync(newDefault);
+
+        var refreshedDefault = await sut.GetDefaultForPlanAsync(Tenant, PlanId, new DateTime(2026, 3, 8));
+        Assert.NotNull(refreshedDefault);
+        Assert.Equal(2, inner.GetDefaultForPlanCalls);
+    }
+
+    [Fact]
+    public async Task CachingRepository_UpsertContract_InvalidatesContractCache()
+    {
+        var inner = new CountingFeeScheduleRepo(defaultSchedule: null);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingFeeScheduleRepository(inner, inner, cache);
+        var serviceDate = new DateTime(2026, 3, 8);
+
+        var firstContract = await sut.GetContractAsync(Tenant, ProviderNpi, PlanId, serviceDate);
+        var secondContract = await sut.GetContractAsync(Tenant, ProviderNpi, PlanId, serviceDate);
+        Assert.Null(firstContract);
+        Assert.Null(secondContract);
+        Assert.Equal(1, inner.GetContractCalls);
+
+        var updatedContract = new ProviderContract
+        {
+            Id = ProviderContract.MakeId(Tenant, ProviderNpi, PlanId),
+            TenantId = Tenant,
+            ProviderNpi = ProviderNpi,
+            PlanId = PlanId,
+            EffectiveDate = new DateTime(2026, 1, 1),
+            NetworkStatus = NetworkStatus.InNetwork,
+            FeeScheduleId = "comm-test"
+        };
+        await sut.UpsertAsync(updatedContract);
+
+        var refreshedContract = await sut.GetContractAsync(Tenant, ProviderNpi, PlanId, serviceDate);
+        Assert.NotNull(refreshedContract);
+        Assert.Equal(2, inner.GetContractCalls);
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // HELPERS
     // ═══════════════════════════════════════════════════════════════════
@@ -614,7 +666,8 @@ internal class InMemoryProviderContractRepo : IProviderContractRepository
 
 internal class CountingFeeScheduleRepo : IFeeScheduleRepository, IProviderContractRepository
 {
-    private readonly FeeSchedule? _defaultSchedule;
+    private FeeSchedule? _defaultSchedule;
+    private ProviderContract? _contract;
 
     public int GetByIdCalls { get; private set; }
     public int GetDefaultForPlanCalls { get; private set; }
@@ -641,7 +694,10 @@ internal class CountingFeeScheduleRepo : IFeeScheduleRepository, IProviderContra
         => Task.FromResult<FeeScheduleLine?>(null);
 
     public Task<FeeSchedule> UpsertAsync(FeeSchedule schedule, CancellationToken ct)
-        => Task.FromResult(schedule);
+    {
+        _defaultSchedule = schedule;
+        return Task.FromResult(schedule);
+    }
 
     public Task<IReadOnlyList<FeeSchedule>> ListAsync(
         string tenantId, int page, int pageSize, CancellationToken ct)
@@ -651,11 +707,14 @@ internal class CountingFeeScheduleRepo : IFeeScheduleRepository, IProviderContra
         string tenantId, string providerNpi, string planId, DateTime serviceDate, CancellationToken ct)
     {
         GetContractCalls++;
-        return Task.FromResult<ProviderContract?>(null);
+        return Task.FromResult(_contract);
     }
 
     public Task<ProviderContract> UpsertAsync(ProviderContract contract, CancellationToken ct)
-        => Task.FromResult(contract);
+    {
+        _contract = contract;
+        return Task.FromResult(contract);
+    }
 
     public Task<IReadOnlyList<ProviderContract>> ListByProviderAsync(
         string tenantId, string providerNpi, CancellationToken ct)

--- a/tests/CloudHealthOffice.FeeScheduleEngine.Tests/RateResolutionServiceTests.cs
+++ b/tests/CloudHealthOffice.FeeScheduleEngine.Tests/RateResolutionServiceTests.cs
@@ -2,6 +2,7 @@ using CloudHealthOffice.FeeScheduleEngine.Domain;
 using CloudHealthOffice.FeeScheduleEngine.Models;
 using CloudHealthOffice.FeeScheduleEngine.Persistence;
 using CloudHealthOffice.FeeScheduleEngine.Services;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -422,6 +423,45 @@ public class RateResolutionServiceTests
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    // REPOSITORY CACHE
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task CachingRepository_CachesScheduleReads()
+    {
+        var schedule = CreateCommercialSchedule("99213", 85m);
+        var inner = new CountingFeeScheduleRepo(schedule);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingFeeScheduleRepository(inner, inner, cache);
+
+        var first = await sut.GetByIdAsync(Tenant, schedule.Id);
+        var second = await sut.GetByIdAsync(Tenant, schedule.Id);
+
+        Assert.Same(first, second);
+        Assert.Equal(1, inner.GetByIdCalls);
+    }
+
+    [Fact]
+    public async Task CachingRepository_CachesDefaultScheduleAndContractMisses()
+    {
+        var inner = new CountingFeeScheduleRepo(defaultSchedule: null);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingFeeScheduleRepository(inner, inner, cache);
+
+        var firstDefault = await sut.GetDefaultForPlanAsync(Tenant, PlanId, new DateTime(2026, 3, 8));
+        var secondDefault = await sut.GetDefaultForPlanAsync(Tenant, PlanId, new DateTime(2026, 3, 8));
+        var firstContract = await sut.GetContractAsync(Tenant, ProviderNpi, PlanId, new DateTime(2026, 3, 8));
+        var secondContract = await sut.GetContractAsync(Tenant, ProviderNpi, PlanId, new DateTime(2026, 3, 8));
+
+        Assert.Null(firstDefault);
+        Assert.Null(secondDefault);
+        Assert.Null(firstContract);
+        Assert.Null(secondContract);
+        Assert.Equal(1, inner.GetDefaultForPlanCalls);
+        Assert.Equal(1, inner.GetContractCalls);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // HELPERS
     // ═══════════════════════════════════════════════════════════════════
 
@@ -569,5 +609,55 @@ internal class InMemoryProviderContractRepo : IProviderContractRepository
         => Task.FromResult(contract);
 
     public Task<IReadOnlyList<ProviderContract>> ListByProviderAsync(string tenantId, string providerNpi, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<ProviderContract>>([]);
+}
+
+internal class CountingFeeScheduleRepo : IFeeScheduleRepository, IProviderContractRepository
+{
+    private readonly FeeSchedule? _defaultSchedule;
+
+    public int GetByIdCalls { get; private set; }
+    public int GetDefaultForPlanCalls { get; private set; }
+    public int GetContractCalls { get; private set; }
+
+    public CountingFeeScheduleRepo(FeeSchedule? defaultSchedule)
+        => _defaultSchedule = defaultSchedule;
+
+    public Task<FeeSchedule?> GetByIdAsync(string tenantId, string id, CancellationToken ct)
+    {
+        GetByIdCalls++;
+        return Task.FromResult(_defaultSchedule?.Id == id ? _defaultSchedule : null);
+    }
+
+    public Task<FeeSchedule?> GetDefaultForPlanAsync(
+        string tenantId, string planId, DateTime serviceDate, CancellationToken ct)
+    {
+        GetDefaultForPlanCalls++;
+        return Task.FromResult(_defaultSchedule);
+    }
+
+    public Task<FeeScheduleLine?> GetLineAsync(
+        string feeScheduleId, string procedureCode, string? modifier, CancellationToken ct)
+        => Task.FromResult<FeeScheduleLine?>(null);
+
+    public Task<FeeSchedule> UpsertAsync(FeeSchedule schedule, CancellationToken ct)
+        => Task.FromResult(schedule);
+
+    public Task<IReadOnlyList<FeeSchedule>> ListAsync(
+        string tenantId, int page, int pageSize, CancellationToken ct)
+        => Task.FromResult<IReadOnlyList<FeeSchedule>>([]);
+
+    public Task<ProviderContract?> GetContractAsync(
+        string tenantId, string providerNpi, string planId, DateTime serviceDate, CancellationToken ct)
+    {
+        GetContractCalls++;
+        return Task.FromResult<ProviderContract?>(null);
+    }
+
+    public Task<ProviderContract> UpsertAsync(ProviderContract contract, CancellationToken ct)
+        => Task.FromResult(contract);
+
+    public Task<IReadOnlyList<ProviderContract>> ListByProviderAsync(
+        string tenantId, string providerNpi, CancellationToken ct)
         => Task.FromResult<IReadOnlyList<ProviderContract>>([]);
 }


### PR DESCRIPTION
## Summary
- add a per-process fee schedule/provider contract cache decorator for adjudication-time reads
- wire the decorator into FeeScheduleEngine repository registrations for Mongo and Cosmos paths
- cache both positive hits and negative misses for default schedules/contracts with a short TTL
- add focused unit coverage for cached schedule reads and miss caching

## Validation
- dotnet restore tests/CloudHealthOffice.FeeScheduleEngine.Tests/CloudHealthOffice.FeeScheduleEngine.Tests.csproj
- dotnet restore src/services/benefit-plan-service/benefit-plan-service.csproj
- dotnet test tests/CloudHealthOffice.FeeScheduleEngine.Tests/CloudHealthOffice.FeeScheduleEngine.Tests.csproj --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.BenefitPlanService.Tests/CloudHealthOffice.BenefitPlanService.Tests.csproj --no-restore /p:UseAppHost=false
- dotnet build src/services/benefit-plan-service/benefit-plan-service.csproj --no-restore /p:UseAppHost=false
- docker build benefit-plan-service image and rolled out locally to Kubernetes
- git diff --check

## MCC local Kubernetes
Baseline before this slice:
- 1,000/1,000 processed, 0 platform failures, 80/80 workflow checks matched
- throughput 83.12 claims/sec, p95 latency 184 ms
- rateResolution avg/p95 7/55 ms

After cache, first run:
- throughput 88.16 claims/sec, p95 latency 187 ms
- rateResolution avg/p95 2/3 ms

After cache, repeat warm run:
- throughput 120.80 claims/sec, p95 latency 151 ms
- rateResolution avg/p95 1/1 ms
- 1,000/1,000 processed, 0 platform failures, 80/80 workflow checks matched