### PR TITLE
Allow repeat MCC benchmarks to skip provider seeding

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -9,6 +9,7 @@ IMAGE="${IMAGE:-cloudhealthoffice-mcc-platform-validator:local}"
 CLAIMS="${CLAIMS:-5000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
+SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 PARALLELISM="${PARALLELISM:-10}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-500}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-docker-desktop}"
@@ -63,6 +64,7 @@ spec:
             - http://benefit-plan-service
             - --provider-url
             - http://provider-service
+$(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf '            - --no-seed-providers\n'; fi)
             - --progress-every
             - "${PROGRESS_EVERY}"
             - --summary-json

--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -64,7 +64,7 @@ spec:
             - http://benefit-plan-service
             - --provider-url
             - http://provider-service
-$(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf '            - --no-seed-providers\n'; fi)
+            $(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf -- '- --no-seed-providers\n'; fi)
             - --progress-every
             - "${PROGRESS_EVERY}"
             - --summary-json

--- a/scripts/sweep-mcc-local-k8s.sh
+++ b/scripts/sweep-mcc-local-k8s.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 #
 # For a quick smoke test with an image already loaded locally:
 #   SKIP_BUILD=true CLAIMS=20 PARALLELISM_VALUES="2" REPEATS=1 ./scripts/sweep-mcc-local-k8s.sh
+#
+# For repeat benchmarks after synthetic providers have already been seeded:
+#   SKIP_BUILD=true SEED_PROVIDERS=false CLAIMS=50000 PARALLELISM_VALUES="10" REPEATS=1 ./scripts/sweep-mcc-local-k8s.sh
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -14,6 +17,7 @@ IMAGE="${IMAGE:-cloudhealthoffice-mcc-platform-validator:local}"
 CLAIMS="${CLAIMS:-1000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
+SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 PARALLELISM_VALUES="${PARALLELISM_VALUES:-8 10 11 12}"
 REPEATS="${REPEATS:-2}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-100}"
@@ -88,7 +92,12 @@ run_case() {
   local job_name="mcc-sweep-p${parallelism}-r${repeat}-$(date +%H%M%S)"
   local log_file="$OUTPUT_DIR/${job_name}.log"
   local json_file="$OUTPUT_DIR/${job_name}.json"
+  local seed_provider_arg=""
   local status="ok"
+
+  if [[ "$SEED_PROVIDERS" != "true" ]]; then
+    seed_provider_arg='                --no-seed-providers \'
+  fi
 
   log "Running MCC sweep case parallelism=${parallelism}, repeat=${repeat}"
   kubectl delete job -n "$NAMESPACE" "$job_name" --ignore-not-found >/dev/null
@@ -124,6 +133,7 @@ spec:
                 --benefit-url http://benefit-plan-service \
                 --provider-url http://provider-service \
                 --progress-every "${PROGRESS_EVERY}" \
+${seed_provider_arg}
                 --summary-json /tmp/mcc-summary.json
               status=\$?
               echo "__MCC_SUMMARY_JSON_BEGIN__"

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -22,4 +22,12 @@ public class ValidatorOptionsTests
 
         Assert.Equal(50_000, options.Claims);
     }
+
+    [Fact]
+    public void Parse_WhenNoSeedProvidersProvided_DisablesProviderSeeding()
+    {
+        var options = ValidatorOptions.Parse(["--no-seed-providers"]);
+
+        Assert.False(options.SeedProviders);
+    }
 }


### PR DESCRIPTION
## Summary
- add `SEED_PROVIDERS=false` support to local MCC Kubernetes scripts
- pass `--no-seed-providers` for repeat benchmark runs against an already-seeded demo tenant
- keep provider seeding enabled by default for first-time local validation
- add parser coverage for `--no-seed-providers`

## Validation
- `bash -n scripts/sweep-mcc-local-k8s.sh && bash -n scripts/run-mcc-local-k8s.sh`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj`
- Smoke: `SEED_PROVIDERS=false CLAIMS=20 PARALLELISM_VALUES="10" REPEATS=1` processed 20 claims with 0 platform failures and 3/3 workflow checks
- True 50k p=10 no-seed run processed 50,000 claims with 0 platform failures and 4000/4000 workflow checks

## 50k Benchmark Comparison
- With provider seeding: 5:18 elapsed, 157.07 claims/sec, P95 130 ms, P99 175 ms
- Skipping provider seeding: 4:25 elapsed, 188.64 claims/sec, P95 106 ms, P99 151 ms

This keeps first-run setup simple while giving repeat benchmarks a cleaner adjudication throughput measurement.