### PR TITLE
Add MCC benchmark proof to marketing site

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-005/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-005/article.txt
@@ -156,6 +156,37 @@ That is the result that matters most.
 
 Throughput is important. But throughput without correctness is just fast noise.
 
+## Separating setup cost from adjudication throughput
+
+After the true 50,000-claim run, we ran one more important test.
+
+The first successful 50,000-claim validation included provider seeding. That is useful for a first-time local validation because the demo tenant needs synthetic providers before claims can be checked against provider rules.
+
+But once the tenant has already been seeded, provider setup is no longer part of the steady-state adjudication path.
+
+So the local Kubernetes scripts now allow repeat benchmark runs to skip provider seeding:
+
+```bash
+SEED_PROVIDERS=false
+```
+
+That gives a cleaner view of repeat adjudication throughput against an already-prepared tenant.
+
+The difference was meaningful:
+
+- with provider seeding: 157.07 claims/sec, 130 ms P95, 175 ms P99
+- skipping provider seeding: 188.64 claims/sec, 106 ms P95, 151 ms P99
+
+Both runs still completed with zero platform failures and 4,000/4,000 workflow checks matched.
+
+That is an important distinction.
+
+The first run answers, "Can this local environment prepare itself and process the workload correctly?"
+
+The repeat run answers, "Once setup is out of the way, how fast can the adjudication path run while preserving correctness?"
+
+Both questions matter. But they should not be blended together without saying so.
+
 ## Correct denials are not failures
 
 One of the most important ideas in the Million Claim Challenge is that not every unpaid claim is a problem.
@@ -182,7 +213,7 @@ CloudHealthOffice can now run the Million Claim Challenge locally in Kubernetes,
 
 The current local result:
 
-> 50,000 claims processed in Kubernetes, 157.07 claims per second, 130 ms P95 latency, 175 ms P99 latency, zero platform failures, and 4,000/4,000 workflow checks matched.
+> 50,000 claims processed in Kubernetes, 188.64 claims per second on a repeat run with provider seeding skipped, 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 workflow checks matched.
 
 That is a very good place to be.
 

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -238,7 +238,7 @@
             <div class="docs-sidebar-section-title">On This Page</div>
             <ul class="toc-sub">
               <li><a href="#what-is-it">What Is It</a></li>
-              <li><a href="#published-results">Published CHO Results</a></li>
+              <li><a href="#published-results">Published Cloud Health Office Results</a></li>
               <li><a href="#why-we-built-it">Why We Built It</a></li>
               <li><a href="#corpus-anatomy">Corpus Anatomy</a></li>
               <li><a href="#edge-cases">The Edge Cases</a></li>
@@ -337,7 +337,7 @@
         </div>
 
         <!-- Published Results -->
-        <h2 id="published-results">Published CHO Results</h2>
+        <h2 id="published-results">Published Cloud Health Office Results</h2>
 
         <p>
           MCC is not only a generator. We use it as a repeatable validation loop for Cloud Health Office itself.

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -18,7 +18,7 @@
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png" />
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="article:published_time" content="2026-04-05T00:00:00Z" />
-  <meta property="article:modified_time" content="2026-04-16T00:00:00Z" />
+  <meta property="article:modified_time" content="2026-07-06T00:00:00Z" />
   <meta property="article:section" content="Testing &amp; Benchmarks" />
   <meta property="article:tag" content="claims adjudication" />
   <meta property="article:tag" content="benchmarking" />
@@ -49,7 +49,7 @@
       "logo": { "@type": "ImageObject", "url": "https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" }
     },
     "datePublished": "2026-04-05",
-    "dateModified": "2026-04-16",
+    "dateModified": "2026-07-06",
     "proficiencyLevel": "Intermediate",
     "about": [
       { "@type": "Thing", "name": "Claims Adjudication" },
@@ -238,6 +238,7 @@
             <div class="docs-sidebar-section-title">On This Page</div>
             <ul class="toc-sub">
               <li><a href="#what-is-it">What Is It</a></li>
+              <li><a href="#published-results">Published CHO Results</a></li>
               <li><a href="#why-we-built-it">Why We Built It</a></li>
               <li><a href="#corpus-anatomy">Corpus Anatomy</a></li>
               <li><a href="#edge-cases">The Edge Cases</a></li>
@@ -287,6 +288,20 @@
           One million synthetic claims. Pre-computed expected outcomes. A single question: <em>does your adjudication engine get them all right?</em>
         </p>
 
+        <div class="callout callout-success">
+          <div class="callout-title">Latest local Kubernetes validation</div>
+          <p>
+            Cloud Health Office processed <strong>50,000 synthetic claims</strong> in local Docker Desktop Kubernetes at
+            <strong>188.64 claims/sec</strong> on a repeat adjudication run with provider seeding skipped.
+            The run held <strong>106 ms P95</strong>, <strong>151 ms P99</strong>, <strong>zero platform failures</strong>,
+            and <strong>4,000/4,000 deterministic workflow checks matched</strong>.
+          </p>
+          <p>
+            This is a local validation benchmark, not a production cloud benchmark. Its value is repeatability:
+            throughput, tail latency, platform reliability, and workflow correctness measured together.
+          </p>
+        </div>
+
         <!-- What Is It -->
         <h2 id="what-is-it">What Is It</h2>
 
@@ -313,13 +328,81 @@
         <div class="callout callout-success">
           <div class="callout-title">From local Kubernetes to workflow proof</div>
           <p>
-            We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, and stage-level timing.
+            We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, stage-level timing, repeatable sweep runs, and a max-claims override for larger local validations.
             Read the field notes:
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>
             and
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>.
           </p>
         </div>
+
+        <!-- Published Results -->
+        <h2 id="published-results">Published CHO Results</h2>
+
+        <p>
+          MCC is not only a generator. We use it as a repeatable validation loop for Cloud Health Office itself.
+          The latest published local result comes from Docker Desktop Kubernetes with Docker allocated 18 CPUs
+          and approximately 24 GB of memory.
+        </p>
+
+        <table>
+          <thead>
+            <tr><th>Run</th><th>Claims</th><th>Throughput</th><th>P95</th><th>P99</th><th>Platform Failures</th><th>Workflow Checks</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>1,000-claim sweep winner, p=11</strong></td>
+              <td>1,000</td>
+              <td>247.10 claims/sec</td>
+              <td>100.35 ms</td>
+              <td>128.53 ms</td>
+              <td>0</td>
+              <td>160/160 matched</td>
+            </tr>
+            <tr>
+              <td><strong>10,000-claim balance, p=10</strong></td>
+              <td>10,000</td>
+              <td>209.54 claims/sec</td>
+              <td>103.47 ms</td>
+              <td>149.85 ms</td>
+              <td>0</td>
+              <td>Validated</td>
+            </tr>
+            <tr>
+              <td><strong>50,000 claims with provider seed, p=10</strong></td>
+              <td>50,000</td>
+              <td>157.07 claims/sec</td>
+              <td>130 ms</td>
+              <td>175 ms</td>
+              <td>0</td>
+              <td>4,000/4,000 matched</td>
+            </tr>
+            <tr>
+              <td><strong>50,000 repeat adjudication run, p=10</strong></td>
+              <td>50,000</td>
+              <td>188.64 claims/sec</td>
+              <td>106 ms</td>
+              <td>151 ms</td>
+              <td>0</td>
+              <td>4,000/4,000 matched</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout callout-info">
+          <div class="callout-title">Why the repeat run is listed separately</div>
+          <p>
+            The first 50,000-claim run includes provider seeding, which answers whether a local environment can prepare itself and process the workload correctly.
+            The repeat run skips provider seeding against an already-prepared tenant, which gives a cleaner view of steady-state adjudication throughput.
+            Both are useful; they answer different questions.
+          </p>
+        </div>
+
+        <p>
+          The most important part of the result is not the throughput number by itself.
+          MCC reports speed and correctness together: business denials are valid outcomes when the platform applies rules correctly,
+          while platform failures are unexpected system, infrastructure, or workflow breakdowns.
+        </p>
 
         <!-- Why We Built It -->
         <h2 id="why-we-built-it">Why We Built It</h2>

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -3,27 +3,27 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Healthcare EDI market analysis: how Medicaid MCOs and Medicare Advantage plans are evaluating payer integration platforms for CMS-0057-F compliance. Competitive landscape and source-available vs. legacy vendor comparison.">
-  <meta name="keywords" content="healthcare EDI market analysis, payer integration platform comparison, CMS-0057-F vendor landscape, Medicaid payer modernization, healthcare interoperability competitive analysis, source-available healthcare EDI, FHIR payer platform">
+  <meta name="description" content="Healthcare EDI market analysis and Cloud Health Office engineering insights: payer integration platform landscape, CMS-0057-F compliance, and repeatable claims adjudication benchmarks.">
+  <meta name="keywords" content="healthcare EDI market analysis, payer integration platform comparison, CMS-0057-F vendor landscape, Medicaid payer modernization, healthcare interoperability competitive analysis, source-available healthcare EDI, FHIR payer platform, claims adjudication benchmark, Million Claim Challenge">
   <meta name="author" content="Aurelianware">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Cloud Health Office">
   <meta property="og:url" content="https://cloudhealthoffice.com/insights">
-  <meta property="og:title" content="Healthcare EDI Market Analysis: Payer Integration Platform Landscape — Cloud Health Office">
-  <meta property="og:description" content="How Medicaid MCOs and Medicare Advantage plans are evaluating payer integration platforms for CMS-0057-F compliance. Open-source vs. legacy vendor comparison.">
+  <meta property="og:title" content="Market and Engineering Insights — Cloud Health Office">
+  <meta property="og:description" content="Healthcare EDI market analysis, CMS-0057-F platform strategy, and repeatable claims adjudication benchmark evidence from Cloud Health Office.">
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/MQ_Objective_GartnerBlue.svg">
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://cloudhealthoffice.com/insights">
-  <meta name="twitter:title" content="Healthcare EDI Market Analysis: Payer Integration Platform Landscape — Cloud Health Office">
-  <meta name="twitter:description" content="How Medicaid MCOs and Medicare Advantage plans are evaluating payer integration platforms for CMS-0057-F compliance.">
+  <meta name="twitter:title" content="Market and Engineering Insights — Cloud Health Office">
+  <meta name="twitter:description" content="Healthcare EDI market analysis plus repeatable claims adjudication benchmark evidence.">
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/MQ_Objective_GartnerBlue.svg">
 
   <link rel="canonical" href="https://cloudhealthoffice.com/insights" />
-  <title>Healthcare EDI Market Analysis: Payer Integration Landscape — Cloud Health Office</title>
+  <title>Market and Engineering Insights — Cloud Health Office</title>
   <!-- Privacy-friendly analytics by Plausible -->
   <script async src="https://plausible.io/js/pa-JQNNrBf52mV2BxHPtkLAv.js"></script>
   <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
@@ -166,6 +166,70 @@
       color: #00ffff;
       margin-bottom: 30px;
     }
+
+    .engineering-proof {
+      background: #0a0a0a;
+      border: 1px solid rgba(0,255,255,0.22);
+      border-left: 4px solid #00ffff;
+      border-radius: 8px;
+      padding: 30px;
+      margin: 40px 0;
+    }
+
+    .engineering-proof h3 {
+      margin-top: 0;
+      color: #00ffff;
+      text-shadow: none;
+    }
+
+    .engineering-proof .proof-meta {
+      color: #00ff88;
+      font-size: 0.82rem;
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+      font-weight: 700;
+    }
+
+    .proof-metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      margin: 24px 0;
+    }
+
+    .proof-metric {
+      background: rgba(0,0,0,0.42);
+      border: 1px solid rgba(0,255,255,0.14);
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .proof-metric strong {
+      display: block;
+      color: #fff;
+      font-size: 1.18rem;
+      line-height: 1.2;
+      margin-bottom: 6px;
+    }
+
+    .proof-metric span {
+      color: rgba(176,176,176,0.72);
+      font-size: 0.82rem;
+      line-height: 1.35;
+    }
+
+    @media (max-width: 900px) {
+      .proof-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 560px) {
+      .proof-metrics {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 </head>
 <body>
@@ -220,6 +284,47 @@
         <p>The competitive analysis on this page reads Cloud Health Office (CHO) against legacy EDI and core admin vendors. The differentiation thesis is structural: incumbents sell one thing; CHO ships four complementary product lines &mdash; <strong>Public Tools</strong>, <strong>Transactional Services</strong>, <strong>Managed Data Services</strong>, and <strong>Platform Engagement</strong> &mdash; off the same platform substrate.</p>
         <p style="margin-top:12px;">Free fee-schedule lookups feed paid APIs; paid APIs validate the calculation engines that anchor per member per month (PMPM) payer relationships; subscription data services run the same ingestion pipelines that Platform Engagement deploys end-to-end. The competitive moat isn't any single capability. It's the portfolio.</p>
         <p style="margin-top:12px; font-size:0.95rem; color:#888;"><a href="/pricing" style="color:#00ffff;">See full pricing &rarr;</a> &middot; <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">Canonical positioning &rarr;</a></p>
+      </section>
+
+      <section class="featured-article-section" aria-labelledby="engineering-insights-heading">
+        <h2 id="engineering-insights-heading">Engineering Proof</h2>
+
+        <article class="engineering-proof">
+          <div class="proof-meta">Million Claim Challenge &middot; Local Kubernetes validation</div>
+          <h3>From Faster to Repeatably Faster</h3>
+          <p>
+            Cloud Health Office moved from one-off fast local runs to repeatable claims adjudication benchmarks:
+            configurable Kubernetes Jobs, parallelism sweeps, repeated runs, hidden-cap detection, and workflow correctness checks reported alongside throughput.
+          </p>
+
+          <div class="proof-metrics" aria-label="Latest Million Claim Challenge local benchmark metrics">
+            <div class="proof-metric">
+              <strong>50,000</strong>
+              <span>synthetic claims processed</span>
+            </div>
+            <div class="proof-metric">
+              <strong>188.64/sec</strong>
+              <span>repeat adjudication throughput</span>
+            </div>
+            <div class="proof-metric">
+              <strong>106 ms / 151 ms</strong>
+              <span>P95 and P99 latency</span>
+            </div>
+            <div class="proof-metric">
+              <strong>4,000/4,000</strong>
+              <span>workflow checks matched</span>
+            </div>
+          </div>
+
+          <p>
+            The benchmark distinguishes valid business denials from platform failures. Correct denials are not errors;
+            they are evidence that benefit rules, provider checks, prior authorization logic, and adjudication outcomes are being applied consistently.
+          </p>
+          <p style="font-size:0.95rem;color:#888;">
+            Local Docker Desktop Kubernetes benchmark, not a production cloud benchmark.
+            <a href="/docs/million-claim-challenge" style="color:#00ffff;">Read the benchmark methodology &rarr;</a>
+          </p>
+        </article>
       </section>
 
       <section class="assessment-section">

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -303,7 +303,7 @@
               <span>synthetic claims processed</span>
             </div>
             <div class="proof-metric">
-              <strong>188.64/sec</strong>
+              <strong>188.64 claims/sec</strong>
               <span>repeat adjudication throughput</span>
             </div>
             <div class="proof-metric">

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -300,7 +300,7 @@
             <span>claims processed in local Kubernetes</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>188.64/sec</strong>
+            <strong>188.64 claims/sec</strong>
             <span>repeat adjudication throughput</span>
           </div>
           <div class="mcc-proof-metric">
@@ -308,7 +308,7 @@
             <span>P95 and P99 latency</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>0 failures</strong>
+            <strong>0 platform failures</strong>
             <span>4,000/4,000 workflow checks matched</span>
           </div>
         </div>

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -146,6 +146,61 @@
       color: #00ff88;
       font-weight: bold;
     }
+
+    .mcc-proof-strip {
+      background: #0a0a0a;
+      border: 1px solid rgba(0,255,255,0.22);
+      border-left: 4px solid #00ff88;
+      border-radius: 8px;
+      padding: 28px;
+      margin: 36px 0 60px;
+    }
+
+    .mcc-proof-strip h2 {
+      margin-top: 0;
+      font-size: 1.7rem;
+      text-shadow: none;
+    }
+
+    .mcc-proof-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+      margin: 22px 0;
+    }
+
+    .mcc-proof-metric {
+      border: 1px solid rgba(0,255,255,0.14);
+      border-radius: 8px;
+      padding: 14px;
+      background: rgba(0,0,0,0.38);
+    }
+
+    .mcc-proof-metric strong {
+      display: block;
+      color: #fff;
+      font-size: 1.15rem;
+      line-height: 1.2;
+      margin-bottom: 6px;
+    }
+
+    .mcc-proof-metric span {
+      color: rgba(176,176,176,0.72);
+      font-size: 0.82rem;
+      line-height: 1.35;
+    }
+
+    @media (max-width: 900px) {
+      .mcc-proof-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 560px) {
+      .mcc-proof-grid {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 </head>
 <body>
@@ -230,6 +285,36 @@
           <a href="/pricing" style="color:#00ffff;">See full pricing across all four product lines &rarr;</a>
           &nbsp;&middot;&nbsp;
           <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">Canonical positioning (POSITIONING.md) &rarr;</a>
+        </p>
+      </section>
+
+      <section class="mcc-proof-strip" aria-labelledby="mcc-proof-heading">
+        <h2 id="mcc-proof-heading">Claims Adjudication Proof, Measured Locally</h2>
+        <p>
+          The Million Claim Challenge validates the platform under pressure by reporting throughput, tail latency,
+          platform reliability, and deterministic healthcare workflow correctness together.
+        </p>
+        <div class="mcc-proof-grid" aria-label="Latest local Million Claim Challenge validation metrics">
+          <div class="mcc-proof-metric">
+            <strong>50,000</strong>
+            <span>claims processed in local Kubernetes</span>
+          </div>
+          <div class="mcc-proof-metric">
+            <strong>188.64/sec</strong>
+            <span>repeat adjudication throughput</span>
+          </div>
+          <div class="mcc-proof-metric">
+            <strong>106 ms / 151 ms</strong>
+            <span>P95 and P99 latency</span>
+          </div>
+          <div class="mcc-proof-metric">
+            <strong>0 failures</strong>
+            <span>4,000/4,000 workflow checks matched</span>
+          </div>
+        </div>
+        <p style="font-size:0.95rem; color:#888;">
+          Local Docker Desktop Kubernetes validation, not a production cloud benchmark.
+          <a href="/docs/million-claim-challenge" style="color:#00ffff;">See the benchmark methodology &rarr;</a>
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- add latest local Kubernetes MCC validation metrics to the canonical Million Claim Challenge docs page
- add an Engineering Proof feature to the Insights page
- add a compact MCC proof strip to the Platform page
- update episode 005 article copy to include the repeat 50,000-claim run with provider seeding skipped

## Verification
- npm run build from src/site
- git diff --check on changed files
- generated HTML parsed successfully with Python html.parser
- local static server returned 200 for generated .html pages

Note: local browser screenshot QA was not available because no in-app browser instance was exposed in this session.