### PR TITLE
Add local Kubernetes article links to quickstart

### DIFF
--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -156,7 +156,14 @@
 
         <div class="callout callout-info">
           <div class="callout-title">Field note: local Kubernetes validation</div>
-          <p>Want the story behind this walkthrough? Read <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a> for the initial local deployment path, then <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a> for the provider verification, tenant context, and Million Claim Challenge (MCC) timing work that followed.</p>
+          <p>Want the story behind this walkthrough? The full local Kubernetes field-note series follows the path from first deployment to repeatable Million Claim Challenge benchmarking:</p>
+          <ul>
+            <li><a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a></li>
+            <li><a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a></li>
+            <li><a href="https://medium.com/@markus_31/part-3-running-a-healthcare-claims-platform-locally-in-kubernetes-from-it-measures-to-it-f4553a8ef5bc" target="_blank" rel="noopener noreferrer">Part 3: From It Measures to It Explains</a></li>
+            <li><a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-4-from-it-explains-to-it-55f1b14f72b4" target="_blank" rel="noopener noreferrer">Part 4: From It Explains to It Improves</a></li>
+            <li><a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-5-from-faster-to-repeatably-2bb9a65de8de" target="_blank" rel="noopener noreferrer">Part 5: From Faster to Repeatably Faster</a></li>
+          </ul>
         </div>
 
         <div class="callout callout-info">


### PR DESCRIPTION
## Summary
- replace the quickstart field-note paragraph with a five-part Medium series list
- add links for Parts 3, 4, and 5 of the local Kubernetes / Million Claim Challenge series
- keep links opening in a new tab with noopener/noreferrer

## Verification
- npm run build from src/site
- parsed src/site/docs/quickstart.html and generated dist/docs/quickstart.html with Python html.parser
- git diff --check on src/site/docs/quickstart.html