### PR TITLE
Reconcile cost-reduction claims to 82% and fix test-metrics automation

### DIFF
--- a/.github/workflows/test-metrics.yml
+++ b/.github/workflows/test-metrics.yml
@@ -457,3 +457,41 @@ jobs:
           flags: combined
           name: combined-coverage
         continue-on-error: true
+
+  # ═══════════════════════════════════════════════════════════════════════
+  # 5. Refresh Test Count Docs (README.md, docs/guides/FEATURES.md)
+  # ═══════════════════════════════════════════════════════════════════════
+  update-docs:
+    name: Update Test Count Docs
+    runs-on: ubuntu-latest
+    needs: publish-metrics
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Download test-metrics.json
+        uses: actions/download-artifact@v8
+        with:
+          name: test-metrics
+          path: .
+
+      - name: Inject metrics into README and FEATURES.md
+        run: node scripts/inject-test-metrics.js test-metrics.json
+
+      - name: Commit updated docs
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- README.md docs/guides/FEATURES.md; then
+            echo "No doc changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md docs/guides/FEATURES.md
+          git commit -m "chore: refresh test count and coverage metrics [skip ci]"
+          git push origin HEAD:main

--- a/docs/guides/FEATURES.md
+++ b/docs/guides/FEATURES.md
@@ -15,7 +15,7 @@ This document provides a comprehensive overview of all features available in Clo
 | **Enhanced Claim Status** | ValueAdds277 (60+ fields) | ✅ Complete | [VALUEADDS277-IMPLEMENTATION-COMPLETE.md](./VALUEADDS277-IMPLEMENTATION-COMPLETE.md) |
 | **Security Hardening** | 6 production controls | ✅ Complete | [SECURITY-HARDENING.md](./SECURITY-HARDENING.md) |
 | **Deployment** | Gated release strategy | ✅ Complete | [DEPLOYMENT-GATES-GUIDE.md](./DEPLOYMENT-GATES-GUIDE.md) |
-| **Testing** | 1,018 automated tests (85.93% coverage) | ✅ Complete | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| **Testing** | 2,800 automated tests across 44 test projects | ✅ Complete | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 | **Multi-Tenant Security** | Cross-tenant isolation | ✅ Complete | [portal/CloudHealthOffice.Portal.Tests/](./portal/CloudHealthOffice.Portal.Tests/) |
 | **Premium Billing** | Monthly premium invoicing, NACHA/ACH EFT drafts, Stripe ACH | ✅ Complete | [src/services/premium-billing-service/](../src/services/premium-billing-service/) |
 

--- a/docs/sales-materials/PITCH-DECK-CONTENT.md
+++ b/docs/sales-materials/PITCH-DECK-CONTENT.md
@@ -257,7 +257,7 @@ npm run generate -- interactive --output my-config.json --generate
 ### Competitive Advantages
 
 1. **18-month head start** on CMS compliance
-2. **85%+ cost reduction** vs. enterprise vendors
+2. **Up to 82% cost reduction** vs. enterprise vendors (results may vary)
 3. **Source-available transparency** eliminates vendor lock-in
 4. **Azure Marketplace** enables instant evaluation
 5. **Community-driven** continuous improvement
@@ -334,7 +334,7 @@ npm run generate -- interactive --output my-config.json --generate
 |---------|-------|-----------------|-------------|
 | **Compliance Champion** | VP Compliance | Regulatory risk | "100% CMS-ready" |
 | **Technology Leader** | CIO/CTO | Implementation risk | "< 5 minute deployment" |
-| **Financial Decision Maker** | CFO | Cost control | "85% cost reduction" |
+| **Financial Decision Maker** | CFO | Cost control | "up to 82% cost reduction" |
 
 ---
 

--- a/docs/sales-materials/SALES-CASE-STUDY-TEMPLATE.md
+++ b/docs/sales-materials/SALES-CASE-STUDY-TEMPLATE.md
@@ -94,7 +94,7 @@ This template is designed to capture pilot customer success stories in a consist
 
 **Example narrative**:
 
-> After evaluating [X] vendors, [Customer Name] selected Cloud Health Office based on three key differentiators: (1) immediate deployment capability that reduced time-to-compliance from 12+ months to under 90 days, (2) source-available transparency that eliminated vendor lock-in concerns, and (3) total cost of ownership 85% lower than enterprise alternatives.
+> After evaluating [X] vendors, [Customer Name] selected Cloud Health Office based on three key differentiators: (1) immediate deployment capability that reduced time-to-compliance from 12+ months to under 90 days, (2) source-available transparency that eliminated vendor lock-in concerns, and (3) total cost of ownership [X]% lower than enterprise alternatives.
 
 ### Implementation Timeline
 

--- a/docs/sales-materials/SALES-EMAIL-TEMPLATES.md
+++ b/docs/sales-materials/SALES-EMAIL-TEMPLATES.md
@@ -52,7 +52,7 @@ Cloud Health Office is the industry's first source-available, Azure-native EDI p
 ✓ Complete FHIR R4 Patient Access API (production-ready)
 ✓ Prior Authorization API with automated 72-hour/7-day response tracking
 ✓ Da Vinci IG conformance (PDex, PAS, CRD, DTR)
-✓ 85% lower cost than enterprise alternatives
+✓ Up to 82% lower cost than enterprise alternatives (results may vary)
 
 I'd welcome 20 minutes to show you how [Similar Regional Plan] went from compliance gap to production-ready in 30 days.
 
@@ -103,7 +103,7 @@ Best,
 ---
 
 **Subject Lines (A/B Test)**:
-- A: Reduce EDI Platform Costs by 85%
+- A: Reduce EDI Platform Costs by Up to 82%
 - B: [Company Name]: $[X]M in EDI Savings (Analysis Attached)
 - C: Your EDI vendor is overcharging you. Here's proof.
 
@@ -116,7 +116,7 @@ Hi [First Name],
 
 TPAs managing multi-payer relationships face a unique challenge: enterprise EDI platforms charge per-payer, per-transaction fees that scale with your success. The more you grow, the more they cost.
 
-I'm reaching out because Cloud Health Office can reduce your EDI platform costs by up to 85% while delivering better compliance and faster deployment.
+I'm reaching out because Cloud Health Office can reduce your EDI platform costs by up to 82% (results may vary) while delivering better compliance and faster deployment.
 
 **Here's the math for an organization like [Company Name]:**
 
@@ -156,7 +156,7 @@ P.S. We also offer a free 60-day pilot program where you can validate these savi
 **Follow-Up (Day 4, if no response)**:
 
 ```
-Subject: Re: Reduce EDI Platform Costs by 85%
+Subject: Re: Reduce EDI Platform Costs by Up to 82%
 
 Hi [First Name],
 

--- a/docs/sales-materials/pitch-deck-v4.md
+++ b/docs/sales-materials/pitch-deck-v4.md
@@ -220,7 +220,7 @@ npm run generate -- interactive --output my-config.json --generate
 
 *Cloud Health Office figures are internal modeled ARPU values for mid-market segment Platform Engagement; specific PMPM ranges per layer are pilot-scoped. See [FINANCIAL-MODEL.md](./FINANCIAL-MODEL.md).*
 
-**Savings**: 83-97% cost reduction vs. alternatives at indicative modeled scale.
+**Savings**: 83-97% cost reduction vs. alternatives at indicative modeled scale (results may vary). *This range is derived directly from the Year 1 cost comparisons in the table above and is a separate, table-specific metric from the general "up to 82%" cost-reduction figure used elsewhere in Cloud Health Office marketing materials.*
 
 ---
 
@@ -267,7 +267,7 @@ npm run generate -- interactive --output my-config.json --generate
 ### Competitive Advantages
 
 1. **10-month head start** on CMS compliance (production-ready today)
-2. **85%+ cost reduction** vs. enterprise vendors
+2. **Up to 82% cost reduction** vs. enterprise vendors (results may vary)
 3. **Source-available transparency** eliminates vendor lock-in and security concerns
 4. **Azure Marketplace** enables instant evaluation and procurement
 5. **Community-driven** continuous improvement (GitHub, Slack, Office Hours)


### PR DESCRIPTION
- Reconcile "85%" cost-reduction claims in sales materials to the
  audited "up to 82% (results may vary)" wording, matching
  MARKETING-LANDING-PAGE-COPY.md per CHO-CLAIMS-AUDIT-REPORT.md §2.8.
- Label the 83-97% modeled savings range in pitch-deck-v4.md as a
  separate, table-derived metric distinct from the general claim.
- Convert the hardcoded 85% TCO figure in the case study template's
  example narrative into a [X]% placeholder, consistent with the rest
  of the template's bracketed fields.
- Add the missing update-docs job to test-metrics.yml so the injection
  script actually runs against README.md and FEATURES.md and commits
  the refreshed test count back to main going forward.
- Manually refresh FEATURES.md's stale "1,018 tests" figure to match
  README's current 2,800 tests / 44 test projects.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y4CkEFBvKRtaqzA1Kf93Jz