### PR TITLE
Reframe MCC proof around local validation scope

### DIFF
--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -242,7 +242,7 @@ EDI coverage via Argo workflows: 270/271/275/276/277/278/834/837.
 - Portal under `src/portal/` for operational workflows across tenants, services, and operating modes.
 - `fhir-service` CapabilityStatement advertising CHO-authored profiles in addition to US Core.
 - Observability stack (OpenTelemetry with PHI-scrubbing SpanProcessor, merged in PR #666) applied across services.
-- Million Claim Challenge local Kubernetes validation: 50,000 synthetic claims processed on a repeat adjudication run at 188.64 claims/sec, 106 ms P95, 151 ms P99, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. This is a local validation benchmark, not a production cloud benchmark.
+- Million Claim Challenge local Kubernetes validation: 50,000 synthetic claims processed on a repeat adjudication run at 188.64 claims/sec, 106 ms P95, 151 ms P99, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. This ran in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, which makes the useful throughput frame roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is a local validation benchmark, not a production cloud benchmark.
 
 #### Who enters here
 
@@ -285,7 +285,9 @@ The Million Claim Challenge is a source-available benchmarking asset (BSL 1.1, s
 
 We generate a stratified synthetic corpus of 1,000,000 healthcare claims — professional CMS-1500, institutional UB-04, dental ADA, and named edge-case scenarios — with pre-computed expected adjudication outcomes. Any claims adjudication engine can be benchmarked against the corpus and scored against the expected outcomes.
 
-Latest CHO proof point: in local Docker Desktop Kubernetes, Cloud Health Office processed 50,000 synthetic claims on a repeat adjudication run at 188.64 claims/sec, with 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, and workflow correctness are measured together.
+Latest CHO proof point: in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, Cloud Health Office processed 50,000 synthetic claims on a repeat adjudication run at 188.64 claims/sec, with 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. That is roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, and workflow correctness are measured together.
+
+The published result should not be overstated. The MCC corpus is designed for 1,000,000 claims and 29 named edge-case scenarios; the latest published CHO validation is a 50,000-claim local run with deterministic workflow checks across four core dispositions: clean paid, excluded provider, uncovered service, and prior authorization. The next proof priority is breadth before volume: publish a run that exercises more of the 29 edge scenarios, then extend volume to 250K, 500K, and the full million.
 
 ### What we offer
 

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -281,13 +281,13 @@ Specific indicative PMPM ranges and ARR projections are documented in `docs/sale
 
 ## Million Claim Challenge
 
-The Million Claim Challenge is a source-available benchmarking asset (BSL 1.1, same as the rest of the CHO codebase) that sits across all four product lines as credibility infrastructure.
+The Million Claim Challenge is a source-available benchmarking asset (BSL 1.1, same as the rest of the Cloud Health Office codebase) that sits across all four product lines as credibility infrastructure.
 
 We generate a stratified synthetic corpus of 1,000,000 healthcare claims — professional CMS-1500, institutional UB-04, dental ADA, and named edge-case scenarios — with pre-computed expected adjudication outcomes. Any claims adjudication engine can be benchmarked against the corpus and scored against the expected outcomes.
 
-Latest CHO proof point: in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, Cloud Health Office processed 50,000 synthetic claims on a repeat adjudication run at 188.64 claims/sec, with 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. That is roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, and workflow correctness are measured together.
+Latest Cloud Health Office proof point: in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, Cloud Health Office processed 50,000 synthetic claims on a repeat adjudication run at 188.64 claims/sec, with 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. That is roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, and workflow correctness are measured together.
 
-The published result should not be overstated. The MCC corpus is designed for 1,000,000 claims and 29 named edge-case scenarios; the latest published CHO validation is a 50,000-claim local run with deterministic workflow checks across four core dispositions: clean paid, excluded provider, uncovered service, and prior authorization. The next proof priority is breadth before volume: publish a run that exercises more of the 29 edge scenarios, then extend volume to 250K, 500K, and the full million.
+The published result should not be overstated. The MCC corpus is designed for 1,000,000 claims and 29 named edge-case scenarios; the latest published Cloud Health Office validation is a 50,000-claim local run with deterministic workflow checks across four core dispositions: clean paid, excluded provider, uncovered service, and prior authorization. The next proof priority is breadth before volume: publish a run that exercises more of the 29 edge scenarios, then extend volume to 250K, 500K, and the full million.
 
 ### What we offer
 

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -297,13 +297,13 @@
             and <strong>4,000/4,000 deterministic workflow checks matched</strong>.
           </p>
           <p>
-            Framed per allocated CPU, that is roughly <strong>10.5 claims/sec/core</strong> for the measured workflow.
+            Framed per allocated CPU, that is roughly <strong>10.5 claims/sec per allocated CPU</strong> for the measured workflow.
             This is a local validation benchmark, not a production cloud benchmark. Its value is repeatability:
             throughput, tail latency, platform reliability, and workflow correctness measured together.
           </p>
           <p>
             Scope matters: the MCC corpus is designed for one million claims and 29 named edge-case scenarios.
-            This published CHO run proves a 50K local slice with deterministic checks across four core dispositions:
+            This published Cloud Health Office run proves a 50K local slice with deterministic checks across four core dispositions:
             clean paid, excluded provider, uncovered service, and prior authorization.
           </p>
         </div>

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -122,7 +122,7 @@
         "name": "What accuracy scores should a claims adjudication engine achieve on the Million Claim Challenge?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "The MCC recommends three scoring tiers: Disposition Accuracy (Paid/Denied/Pended matching) should be 99.5% or higher, Amount Accuracy (paid amount within plus or minus $0.01) should be 98.0% or higher, and Edge Case Accuracy (disposition plus amount correct on the 50,000 edge cases) should be 95.0% or higher. Cloud Health Office publishes its own MCC scores with every release."
+          "text": "The MCC recommends three scoring tiers: Disposition Accuracy (Paid/Denied/Pended matching) should be 99.5% or higher, Amount Accuracy (paid amount within plus or minus $0.01) should be 98.0% or higher, and Edge Case Accuracy (disposition plus amount correct on the 50,000 edge cases) should be 95.0% or higher. Cloud Health Office publishes its own MCC validation results as the benchmark coverage expands."
         }
       },
       {
@@ -291,14 +291,20 @@
         <div class="callout callout-success">
           <div class="callout-title">Latest local Kubernetes validation</div>
           <p>
-            Cloud Health Office processed <strong>50,000 synthetic claims</strong> in local Docker Desktop Kubernetes at
+            Cloud Health Office processed <strong>50,000 synthetic claims</strong> in local Docker Desktop Kubernetes with Docker allocated 18 CPUs at
             <strong>188.64 claims/sec</strong> on a repeat adjudication run with provider seeding skipped.
             The run held <strong>106 ms P95</strong>, <strong>151 ms P99</strong>, <strong>zero platform failures</strong>,
             and <strong>4,000/4,000 deterministic workflow checks matched</strong>.
           </p>
           <p>
+            Framed per allocated CPU, that is roughly <strong>10.5 claims/sec/core</strong> for the measured workflow.
             This is a local validation benchmark, not a production cloud benchmark. Its value is repeatability:
             throughput, tail latency, platform reliability, and workflow correctness measured together.
+          </p>
+          <p>
+            Scope matters: the MCC corpus is designed for one million claims and 29 named edge-case scenarios.
+            This published CHO run proves a 50K local slice with deterministic checks across four core dispositions:
+            clean paid, excluded provider, uncovered service, and prior authorization.
           </p>
         </div>
 
@@ -342,7 +348,8 @@
         <p>
           MCC is not only a generator. We use it as a repeatable validation loop for Cloud Health Office itself.
           The latest published local result comes from Docker Desktop Kubernetes with Docker allocated 18 CPUs
-          and approximately 24 GB of memory.
+          and approximately 24 GB of memory. The raw throughput is less important than the shape of the measurement:
+          about 10.5 claims/sec per allocated CPU, tail latency reported with the run, and correctness checks kept in the same artifact.
         </p>
 
         <table>
@@ -403,6 +410,19 @@
           MCC reports speed and correctness together: business denials are valid outcomes when the platform applies rules correctly,
           while platform failures are unexpected system, infrastructure, or workflow breakdowns.
         </p>
+
+        <div class="callout callout-info">
+          <div class="callout-title">Current proof vs benchmark design</div>
+          <p>
+            The benchmark design is the full million-claim corpus with 29 named edge-case scenarios and target scoring tiers.
+            The latest published Cloud Health Office result is narrower: a 50,000-claim local Kubernetes validation with
+            workflow checks across four deterministic dispositions. That gap is intentional and public.
+          </p>
+          <p>
+            Our next proof milestone is not just a larger run. It is broader accuracy coverage across more of the 29 edge scenarios,
+            followed by 250K, 500K, and full-million adjudication runs so the evidence catches up to the name.
+          </p>
+        </div>
 
         <!-- Why We Built It -->
         <h2 id="why-we-built-it">Why We Built It</h2>

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1209,8 +1209,8 @@
           <span class="stat-label">Repeat Adjudication<br>Throughput</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">4,000/4,000</span>
-          <span class="stat-label">Workflow Checks<br>Matched</span>
+          <span class="stat-number">~10.5/s</span>
+          <span class="stat-label">Claims Per<br>Allocated CPU</span>
         </div>
       </div>
     </section>
@@ -1221,7 +1221,7 @@
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
           <h2 class="section-title">1,000,000 claims. One shared yardstick.</h2>
-          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. Benchmark any claims engine against it, including your own.</p>
+          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published CHO proof is a 50K local Kubernetes validation, with broader edge-case coverage next.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">
@@ -1234,12 +1234,12 @@
             <span class="stat-label">Edge Case<br>Scenarios</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">99.5%</span>
-            <span class="stat-label">Disposition Accuracy<br>Target Tier</span>
+            <span class="stat-number">4</span>
+            <span class="stat-label">Published Core<br>Dispositions</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">&lt;5min</span>
-            <span class="stat-label">Corpus<br>Generation Time</span>
+            <span class="stat-number">250K+</span>
+            <span class="stat-label">Next Volume<br>Milestone</span>
           </div>
         </div>
 

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1221,7 +1221,7 @@
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
           <h2 class="section-title">1,000,000 claims. One shared yardstick.</h2>
-          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published CHO proof is a 50K local Kubernetes validation, with broader edge-case coverage next.</p>
+          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published Cloud Health Office proof is a 50K local Kubernetes validation, with broader edge-case coverage next.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -295,6 +295,7 @@
           <p>
             Cloud Health Office moved from one-off fast local runs to repeatable claims adjudication benchmarks:
             configurable Kubernetes Jobs, parallelism sweeps, repeated runs, hidden-cap detection, and workflow correctness checks reported alongside throughput.
+            The latest published result is a 50K local Kubernetes validation on 18 allocated Docker CPUs, not a production cloud benchmark.
           </p>
 
           <div class="proof-metrics" aria-label="Latest Million Claim Challenge local benchmark metrics">
@@ -304,7 +305,7 @@
             </div>
             <div class="proof-metric">
               <strong>188.64 claims/sec</strong>
-              <span>repeat adjudication throughput</span>
+              <span>repeat throughput, about 10.5 claims/sec per allocated CPU</span>
             </div>
             <div class="proof-metric">
               <strong>106 ms / 151 ms</strong>
@@ -312,13 +313,14 @@
             </div>
             <div class="proof-metric">
               <strong>4,000/4,000</strong>
-              <span>workflow checks matched</span>
+              <span>checks matched across four core dispositions</span>
             </div>
           </div>
 
           <p>
             The benchmark distinguishes valid business denials from platform failures. Correct denials are not errors;
             they are evidence that benefit rules, provider checks, prior authorization logic, and adjudication outcomes are being applied consistently.
+            The next proof milestone is broader coverage across the MCC's 29 edge-case scenarios before pushing toward 250K, 500K, and full-million adjudication runs.
           </p>
           <p style="font-size:0.95rem;color:#888;">
             Local Docker Desktop Kubernetes benchmark, not a production cloud benchmark.

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -292,7 +292,7 @@
         <h2 id="mcc-proof-heading">Claims Adjudication Proof, Measured Locally</h2>
         <p>
           The Million Claim Challenge validates the platform under pressure by reporting throughput, tail latency,
-          platform reliability, and deterministic healthcare workflow correctness together. The latest published CHO run
+          platform reliability, and deterministic healthcare workflow correctness together. The latest published Cloud Health Office run
           is a 50K local Kubernetes validation, not a production cloud benchmark or full-million adjudication run.
         </p>
         <div class="mcc-proof-grid" aria-label="Latest local Million Claim Challenge validation metrics">

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -292,7 +292,8 @@
         <h2 id="mcc-proof-heading">Claims Adjudication Proof, Measured Locally</h2>
         <p>
           The Million Claim Challenge validates the platform under pressure by reporting throughput, tail latency,
-          platform reliability, and deterministic healthcare workflow correctness together.
+          platform reliability, and deterministic healthcare workflow correctness together. The latest published CHO run
+          is a 50K local Kubernetes validation, not a production cloud benchmark or full-million adjudication run.
         </p>
         <div class="mcc-proof-grid" aria-label="Latest local Million Claim Challenge validation metrics">
           <div class="mcc-proof-metric">
@@ -301,7 +302,7 @@
           </div>
           <div class="mcc-proof-metric">
             <strong>188.64 claims/sec</strong>
-            <span>repeat adjudication throughput</span>
+            <span>repeat throughput, about 10.5 claims/sec per allocated CPU</span>
           </div>
           <div class="mcc-proof-metric">
             <strong>106 ms / 151 ms</strong>
@@ -309,11 +310,11 @@
           </div>
           <div class="mcc-proof-metric">
             <strong>0 platform failures</strong>
-            <span>4,000/4,000 workflow checks matched</span>
+            <span>4,000/4,000 checks across four core dispositions</span>
           </div>
         </div>
         <p style="font-size:0.95rem; color:#888;">
-          Local Docker Desktop Kubernetes validation, not a production cloud benchmark.
+          The full MCC design covers one million claims and 29 edge-case scenarios; the next proof milestone is broader scenario coverage, then 250K+ volume.
           <a href="/docs/million-claim-challenge" style="color:#00ffff;">See the benchmark methodology &rarr;</a>
         </p>
       </section>


### PR DESCRIPTION
## Summary
- Reframe the latest MCC result as a 50K local Kubernetes validation on 18 allocated Docker CPUs
- Add per-allocated-CPU throughput framing and clarify the four published core dispositions
- Make the proof ladder explicit: broaden 29-scenario coverage before pushing to 250K, 500K, and full-million adjudication runs

## Verification
- npm run build
- git diff --check
- Parsed edited HTML and MCC JSON-LD before commit