### PR TITLE
Reconcile MCC validator pend scoring

### DIFF
--- a/.github/workflows/test-metrics.yml
+++ b/.github/workflows/test-metrics.yml
@@ -136,6 +136,12 @@ jobs:
             TestResults/**/coverage.cobertura.xml
           retention-days: 90
 
+      - name: Fail on .NET test failures
+        if: steps.run.outputs.build_failed != '0' || steps.parse.outputs.fail_count != '0'
+        run: |
+          echo "::error::.NET test metrics detected ${{ steps.run.outputs.build_failed }} project build/test command failure(s) and ${{ steps.parse.outputs.fail_count }} failed test case(s)"
+          exit 1
+
   # ═══════════════════════════════════════════════════════════════════════
   # 2. TypeScript / Jest Tests
   # ═══════════════════════════════════════════════════════════════════════

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -1,0 +1,171 @@
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal static class MccRunSummaryBuilder
+{
+    public static MassAdjudicationRunSummary Build(
+        List<ClaimValidationResult> results,
+        TimeSpan elapsed,
+        ValidatorOptions options,
+        DateTimeOffset runStartedAtUtc,
+        DateTimeOffset runCompletedAtUtc)
+    {
+        var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+        var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
+        var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
+        var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+        var validationScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
+        var validationMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
+        var validationMismatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus);
+        var validationUnsupported = results.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus);
+        var orderedDurations = results.Select(r => r.Elapsed.TotalMilliseconds).Order().ToArray();
+        var p95 = Percentile(orderedDurations, 0.95);
+        var p99 = Percentile(orderedDurations, 0.99);
+        var throughput = results.Count / Math.Max(0.001, elapsed.TotalSeconds);
+        var comparable = results
+            .Where(r => r.Outcome is ClaimValidationOutcome.Paid)
+            .Where(r => r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue)
+            .ToList();
+        var avgDelta = comparable.Count == 0
+            ? (decimal?)null
+            : comparable.Average(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
+        var denialBreakdown = results
+            .Where(r => r.Outcome is ClaimValidationOutcome.BusinessDenial)
+            .GroupBy(r => r.BusinessDenialCode ?? "UNKNOWN")
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => new MassAdjudicationBusinessDenialSummary(g.Key, g.Count()))
+            .ToList();
+        var workflowBreakdown = results
+            .Where(r => !string.IsNullOrWhiteSpace(r.ValidationScenario))
+            .GroupBy(r => r.ValidationScenario!, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => new MassAdjudicationWorkflowScenarioSummary(
+                g.Key,
+                g.Count(),
+                g.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus),
+                g.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus),
+                g.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus),
+                g.Count(r => r.ValidationStatus == MccWorkflowValidation.UnspecifiedStatus)))
+            .ToList();
+        var failures = results
+            .Where(r => r.Outcome is ClaimValidationOutcome.PlatformFailure)
+            .Take(5)
+            .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
+            .ToList();
+        var claimResults = results
+            .OrderByDescending(r => r.Elapsed)
+            .Take(options.PublishClaimResultsLimit)
+            .Select(r => new MassAdjudicationClaimResult(
+                r.GeneratedClaimId,
+                r.SubmittedClaimId,
+                r.ClaimType,
+                r.ValidationScenario,
+                r.ExpectedOutcome,
+                r.ExpectedBusinessDenialCode,
+                r.ValidationStatus,
+                r.Outcome.ToString(),
+                r.AdjudicationSuccess,
+                r.BusinessDenialCode,
+                r.FailureStage,
+                r.Error,
+                r.ActualPlanPayment,
+                r.ExpectedPlanPayment,
+                r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue
+                    ? Math.Abs(r.ActualPlanPayment.Value - r.ExpectedPlanPayment.Value)
+                    : null,
+                r.Elapsed.TotalMilliseconds,
+                r.SubmitElapsed.TotalMilliseconds,
+                r.AdjudicationElapsed.TotalMilliseconds,
+                r.UpdateElapsed.TotalMilliseconds,
+                r.AdjudicationStepTimings))
+            .ToList();
+
+        return new MassAdjudicationRunSummary(
+            new MassAdjudicationRun(
+                options.TenantId,
+                options.Claims,
+                options.Seed,
+                options.Parallelism,
+                options.ClaimsUrl,
+                options.BenefitUrl,
+                options.ProviderUrl,
+                options.SeedProviders,
+                options.SkipClaimUpdate,
+                options.LineOfBusiness,
+                runStartedAtUtc,
+                runCompletedAtUtc),
+            results.Count,
+            processed,
+            adjudicated,
+            businessDenials,
+            platformFailures,
+            validationScenarios,
+            validationMatches,
+            validationMismatches,
+            validationUnsupported,
+            elapsed,
+            throughput,
+            p95,
+            p99,
+            BuildStageTiming("Submit", results.Select(r => r.SubmitElapsed)),
+            BuildStageTiming("Adjudicate", results.Select(r => r.AdjudicationElapsed)),
+            BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
+            BuildAdjudicationStepTimings(results),
+            avgDelta,
+            denialBreakdown,
+            workflowBreakdown,
+            failures,
+            claimResults);
+    }
+
+    private static MassAdjudicationStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> durations)
+    {
+        var values = durations
+            .Select(d => d.TotalMilliseconds)
+            .Where(ms => ms > 0)
+            .Order()
+            .ToArray();
+
+        return values.Length == 0
+            ? null
+            : new MassAdjudicationStageTiming(label, values.Average(), Percentile(values, 0.95));
+    }
+
+    private static IReadOnlyList<MassAdjudicationStageTiming> BuildAdjudicationStepTimings(
+        IReadOnlyCollection<ClaimValidationResult> results)
+    {
+        return results
+            .SelectMany(r => r.AdjudicationStepTimings)
+            .GroupBy(kvp => kvp.Key, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var values = group
+                    .Select(kvp => kvp.Value)
+                    .Where(ms => ms > 0)
+                    .Order()
+                    .ToArray();
+
+                return values.Length == 0
+                    ? null
+                    : new MassAdjudicationStageTiming(
+                        $"Adjudicate.{group.Key}",
+                        values.Average(),
+                        Percentile(values, 0.95));
+            })
+            .Where(timing => timing is not null)
+            .Cast<MassAdjudicationStageTiming>()
+            .OrderByDescending(timing => timing.AverageMilliseconds)
+            .ToList();
+    }
+
+    private static double Percentile(double[] values, double percentile)
+    {
+        if (values.Length == 0)
+        {
+            return 0;
+        }
+
+        var index = (int)Math.Ceiling(percentile * values.Length) - 1;
+        return values[Math.Clamp(index, 0, values.Length - 1)];
+    }
+}

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -5,9 +5,13 @@ namespace CloudHealthOffice.Tools.MccPlatformValidator;
 public sealed record ExpectedValidation(
     string? Scenario,
     ClaimValidationOutcome? ExpectedOutcome,
-    string? ExpectedBusinessDenialCode)
+    string? ExpectedBusinessDenialCode,
+    bool IsUnsupported = false)
 {
     public static ExpectedValidation Unspecified { get; } = new(null, null, null);
+
+    public static ExpectedValidation Unsupported(string scenario, string? expectedBusinessDenialCode)
+        => new(scenario, null, expectedBusinessDenialCode, IsUnsupported: true);
 }
 
 public static class MccWorkflowValidation
@@ -22,15 +26,29 @@ public static class MccWorkflowValidation
     public const string UncoveredServiceCode = "CARC_96";
     public const string TexasStarInpatientNoAuthScenario = "TxStarInpatientNoAuth";
     public const string PriorAuthRequiredCode = "PRIOR_AUTH_REQUIRED";
+    public const string UnsupportedStatus = "Unsupported";
+    public const string UnspecifiedStatus = "Unspecified";
+    public const string MismatchedStatus = "Mismatched";
+    public const string MatchedStatus = "Matched";
 
     public static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
     {
         if (claim.EdgeCase is not null && claim.ExpectedOutcome is not null)
         {
-            return new ExpectedValidation(
-                $"EdgeCase:{claim.EdgeCase}",
-                OutcomeFromDisposition(claim.ExpectedOutcome.Disposition),
-                NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode));
+            var scenario = $"EdgeCase:{claim.EdgeCase}";
+            var expectedCode = NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
+            var expectedOutcome = OutcomeFromDisposition(claim.ExpectedOutcome.Disposition);
+
+            // TODO(mcc-pended-signal): The MCC corpus contains expected-pend scenarios,
+            // but this validator currently calls benefit-plan-service directly and only
+            // observes Success plus denial/error fields. Claims-service can represent
+            // ClaimStatus.Pended and 277 P:16:85, but this validator does not yet run
+            // the claim workflow or read that status back. Keep pend expectations
+            // explicit as Unsupported until the validator has a real pend signal.
+            return expectedOutcome is null
+                && claim.ExpectedOutcome.Disposition.Equals("Pended", StringComparison.OrdinalIgnoreCase)
+                    ? ExpectedValidation.Unsupported(scenario, expectedCode)
+                    : new ExpectedValidation(scenario, expectedOutcome, expectedCode);
         }
 
         if (claim.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
@@ -88,21 +106,21 @@ public static class MccWorkflowValidation
     {
         if (expected.ExpectedOutcome is null)
         {
-            return "Unspecified";
+            return expected.IsUnsupported ? UnsupportedStatus : UnspecifiedStatus;
         }
 
         if (expected.ExpectedOutcome != actualOutcome)
         {
-            return "Mismatched";
+            return MismatchedStatus;
         }
 
         if (!string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
             && !string.Equals(expected.ExpectedBusinessDenialCode, actualBusinessDenialCode, StringComparison.OrdinalIgnoreCase))
         {
-            return "Mismatched";
+            return MismatchedStatus;
         }
 
-        return "Matched";
+        return MatchedStatus;
     }
 
     private static ClaimValidationOutcome? OutcomeFromDisposition(string? disposition)
@@ -125,4 +143,41 @@ public static class MccWorkflowValidation
         var trimmed = code.Trim();
         return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
     }
+}
+
+public sealed class MccAnswerKey
+{
+    private readonly IReadOnlyDictionary<string, ExpectedValidation> _entries;
+
+    private MccAnswerKey(IReadOnlyDictionary<string, ExpectedValidation> entries)
+    {
+        _entries = entries;
+    }
+
+    public static MccAnswerKey FromClaims(IEnumerable<SyntheticClaim> claims)
+    {
+        var entries = new Dictionary<string, ExpectedValidation>(StringComparer.Ordinal);
+
+        foreach (var claim in claims)
+        {
+            if (string.IsNullOrWhiteSpace(claim.ClaimId))
+            {
+                continue;
+            }
+
+            if (entries.ContainsKey(claim.ClaimId))
+            {
+                throw new InvalidOperationException($"Duplicate MCC answer-key claim id: {claim.ClaimId}");
+            }
+
+            entries.Add(claim.ClaimId, MccWorkflowValidation.ExpectedValidationFor(claim));
+        }
+
+        return new MccAnswerKey(entries);
+    }
+
+    public ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
+        => !string.IsNullOrWhiteSpace(claim.ClaimId) && _entries.TryGetValue(claim.ClaimId, out var expected)
+            ? expected
+            : ExpectedValidation.Unspecified;
 }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -58,6 +58,7 @@ await CreateValidationPlanAsync(http, options, validationPlanId, json);
 
 var claims = await GenerateClaimsAsync(options);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
+var answerKey = MccAnswerKey.FromClaims(claims);
 
 if (options.SeedProviders)
 {
@@ -75,7 +76,7 @@ await Parallel.ForEachAsync(
     new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
     async (claim, _) =>
     {
-        var result = await ProcessClaimAsync(http, options, claim, validationPlanId, json);
+        var result = await ProcessClaimAsync(http, options, claim, validationPlanId, answerKey, json);
         results.Add(result);
 
         var done = Interlocked.Increment(ref completed);
@@ -103,7 +104,7 @@ var orderedResults = results
     .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
     .ToList();
 
-var summary = BuildSummary(orderedResults, total.Elapsed, options, runStartedAtUtc, DateTimeOffset.UtcNow);
+var summary = MccRunSummaryBuilder.Build(orderedResults, total.Elapsed, options, runStartedAtUtc, DateTimeOffset.UtcNow);
 WriteSummary(summary);
 
 if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
@@ -126,6 +127,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     ValidatorOptions options,
     SyntheticClaim claim,
     Guid validationPlanId,
+    MccAnswerKey answerKey,
     JsonSerializerOptions json)
 {
     var sw = Stopwatch.StartNew();
@@ -133,7 +135,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     var adjudicationElapsed = TimeSpan.Zero;
     var updateElapsed = TimeSpan.Zero;
     var failureStage = "unknown";
-    var expectedValidation = MccWorkflowValidation.ExpectedValidationFor(claim);
+    var expectedValidation = answerKey.ExpectedValidationFor(claim);
     var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
         ? null
         : claim.ExpectedOutcome?.ExpectedPaidAmount;
@@ -1281,119 +1283,6 @@ static IReadOnlyList<(T Item, int Count)> AllocateCounts<T>(int total, IReadOnly
         .ToList();
 }
 
-static MassAdjudicationRunSummary BuildSummary(
-    List<ClaimValidationResult> results,
-    TimeSpan elapsed,
-    ValidatorOptions options,
-    DateTimeOffset runStartedAtUtc,
-    DateTimeOffset runCompletedAtUtc)
-{
-    var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
-    var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
-    var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
-    var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
-    var validationScenarios = results.Count(r => r.ExpectedOutcome is not null);
-    var validationMatches = results.Count(r => r.ValidationStatus == "Matched");
-    var validationMismatches = results.Count(r => r.ValidationStatus == "Mismatched");
-    var orderedDurations = results.Select(r => r.Elapsed.TotalMilliseconds).Order().ToArray();
-    var p95 = Percentile(orderedDurations, 0.95);
-    var p99 = Percentile(orderedDurations, 0.99);
-    var throughput = results.Count / Math.Max(0.001, elapsed.TotalSeconds);
-    var comparable = results
-        .Where(r => r.Outcome is ClaimValidationOutcome.Paid)
-        .Where(r => r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue)
-        .ToList();
-    var avgDelta = comparable.Count == 0
-        ? (decimal?)null
-        : comparable.Average(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
-    var denialBreakdown = results
-        .Where(r => r.Outcome is ClaimValidationOutcome.BusinessDenial)
-        .GroupBy(r => r.BusinessDenialCode ?? "UNKNOWN")
-        .OrderByDescending(g => g.Count())
-        .ThenBy(g => g.Key, StringComparer.Ordinal)
-        .Select(g => new MassAdjudicationBusinessDenialSummary(g.Key, g.Count()))
-        .ToList();
-    var workflowBreakdown = results
-        .Where(r => !string.IsNullOrWhiteSpace(r.ValidationScenario))
-        .GroupBy(r => r.ValidationScenario!, StringComparer.Ordinal)
-        .OrderBy(g => g.Key, StringComparer.Ordinal)
-        .Select(g => new MassAdjudicationWorkflowScenarioSummary(
-            g.Key,
-            g.Count(),
-            g.Count(r => r.ValidationStatus == "Matched"),
-            g.Count(r => r.ValidationStatus == "Mismatched"),
-            g.Count(r => r.ValidationStatus == "Unspecified")))
-        .ToList();
-    var failures = results
-        .Where(r => r.Outcome is ClaimValidationOutcome.PlatformFailure)
-        .Take(5)
-        .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
-        .ToList();
-    var claimResults = results
-        .OrderByDescending(r => r.Elapsed)
-        .Take(options.PublishClaimResultsLimit)
-        .Select(r => new MassAdjudicationClaimResult(
-            r.GeneratedClaimId,
-            r.SubmittedClaimId,
-            r.ClaimType,
-            r.ValidationScenario,
-            r.ExpectedOutcome,
-            r.ExpectedBusinessDenialCode,
-            r.ValidationStatus,
-            r.Outcome.ToString(),
-            r.AdjudicationSuccess,
-            r.BusinessDenialCode,
-            r.FailureStage,
-            r.Error,
-            r.ActualPlanPayment,
-            r.ExpectedPlanPayment,
-            r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue
-                ? Math.Abs(r.ActualPlanPayment.Value - r.ExpectedPlanPayment.Value)
-                : null,
-            r.Elapsed.TotalMilliseconds,
-            r.SubmitElapsed.TotalMilliseconds,
-            r.AdjudicationElapsed.TotalMilliseconds,
-            r.UpdateElapsed.TotalMilliseconds,
-            r.AdjudicationStepTimings))
-        .ToList();
-
-    return new MassAdjudicationRunSummary(
-        new MassAdjudicationRun(
-            options.TenantId,
-            options.Claims,
-            options.Seed,
-            options.Parallelism,
-            options.ClaimsUrl,
-            options.BenefitUrl,
-            options.ProviderUrl,
-            options.SeedProviders,
-            options.SkipClaimUpdate,
-            options.LineOfBusiness,
-            runStartedAtUtc,
-            runCompletedAtUtc),
-        results.Count,
-        processed,
-        adjudicated,
-        businessDenials,
-        platformFailures,
-        validationScenarios,
-        validationMatches,
-        validationMismatches,
-        elapsed,
-        throughput,
-        p95,
-        p99,
-        BuildStageTiming("Submit", results.Select(r => r.SubmitElapsed)),
-        BuildStageTiming("Adjudicate", results.Select(r => r.AdjudicationElapsed)),
-        BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
-        BuildAdjudicationStepTimings(results),
-        avgDelta,
-        denialBreakdown,
-        workflowBreakdown,
-        failures,
-        claimResults);
-}
-
 static void WriteSummary(MassAdjudicationRunSummary summary)
 {
     Console.WriteLine("Validation summary");
@@ -1402,7 +1291,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Paid/adjudicated:   {summary.Paid:N0}");
     Console.WriteLine($"  Business denials:   {summary.BusinessDenials:N0}");
     Console.WriteLine($"  Platform failures:  {summary.PlatformFailures:N0}");
-    Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched)");
+    Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched, {summary.WorkflowUnsupported:N0} unsupported)");
     Console.WriteLine($"  Elapsed:            {summary.Elapsed:mm\\:ss\\.fff}");
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");
     Console.WriteLine($"  P95 latency:        {summary.P95LatencyMilliseconds:N0} ms");
@@ -1427,56 +1316,13 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
 
     foreach (var scenario in summary.WorkflowScenarioBreakdown)
     {
-        Console.WriteLine($"  Scenario: {scenario.Scenario} {scenario.Matches:N0}/{scenario.Total:N0} matched ({scenario.Mismatches:N0} mismatched, {scenario.Unspecified:N0} unspecified)");
+        Console.WriteLine($"  Scenario: {scenario.Scenario} {scenario.Matches:N0}/{scenario.Total:N0} matched ({scenario.Mismatches:N0} mismatched, {scenario.Unsupported:N0} unsupported, {scenario.Unspecified:N0} unspecified)");
     }
 
     foreach (var failure in summary.SampleFailures)
     {
         Console.WriteLine($"  Failure: {failure.GeneratedClaimId} [{failure.Stage}] {failure.Error}");
     }
-}
-
-static MassAdjudicationStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> durations)
-{
-    var values = durations
-        .Select(d => d.TotalMilliseconds)
-        .Where(ms => ms > 0)
-        .Order()
-        .ToArray();
-
-    if (values.Length == 0)
-    {
-        return null;
-    }
-
-    return new MassAdjudicationStageTiming(label, values.Average(), Percentile(values, 0.95));
-}
-
-static IReadOnlyList<MassAdjudicationStageTiming> BuildAdjudicationStepTimings(
-    IReadOnlyCollection<ClaimValidationResult> results)
-{
-    return results
-        .SelectMany(r => r.AdjudicationStepTimings)
-        .GroupBy(kvp => kvp.Key, StringComparer.Ordinal)
-        .Select(group =>
-        {
-            var values = group
-                .Select(kvp => kvp.Value)
-                .Where(ms => ms > 0)
-                .Order()
-                .ToArray();
-
-            return values.Length == 0
-                ? null
-                : new MassAdjudicationStageTiming(
-                    $"Adjudicate.{group.Key}",
-                    values.Average(),
-                    Percentile(values, 0.95));
-        })
-        .Where(timing => timing is not null)
-        .Cast<MassAdjudicationStageTiming>()
-        .OrderByDescending(timing => timing.AverageMilliseconds)
-        .ToList();
 }
 
 static void WriteStageTiming(MassAdjudicationStageTiming? timing)
@@ -1523,17 +1369,6 @@ static async Task PublishSummaryAsync(
     {
         Console.WriteLine($"  Dashboard summary: publish skipped ({ex.Message})");
     }
-}
-
-static double Percentile(double[] values, double percentile)
-{
-    if (values.Length == 0)
-    {
-        return 0;
-    }
-
-    var index = (int)Math.Ceiling(percentile * values.Length) - 1;
-    return values[Math.Clamp(index, 0, values.Length - 1)];
 }
 
 static void PrintUsage()
@@ -1628,6 +1463,7 @@ internal sealed record MassAdjudicationRunSummary(
     int WorkflowScenarios,
     int WorkflowMatches,
     int WorkflowMismatches,
+    int WorkflowUnsupported,
     TimeSpan Elapsed,
     double ThroughputClaimsPerSecond,
     double P95LatencyMilliseconds,
@@ -1670,6 +1506,7 @@ internal sealed record MassAdjudicationWorkflowScenarioSummary(
     int Total,
     int Matches,
     int Mismatches,
+    int Unsupported,
     int Unspecified);
 
 internal sealed record MassAdjudicationFailureSummary(

--- a/src/tools/mcc-platform-validator/Properties/AssemblyInfo.cs
+++ b/src/tools/mcc-platform-validator/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CloudHealthOffice.MccPlatformValidator.Tests")]

--- a/src/tools/mcc-platform-validator/README.md
+++ b/src/tools/mcc-platform-validator/README.md
@@ -1,0 +1,40 @@
+# MCC Platform Validator
+
+The MCC platform validator submits generated Million Claim Challenge claims to a
+local Cloud Health Office stack and publishes a run summary with throughput,
+latency, platform failures, and workflow-check scoring.
+
+## Workflow Scoring
+
+The validator currently scores:
+
+- `Matched` when the observed outcome and expected business denial code match the
+  deterministic MCC answer key.
+- `Mismatched` when the claim is scoreable but the observed outcome or business
+  denial code differs.
+- `Unspecified` when a generated claim has no validator answer-key entry.
+- `Unsupported` when the MCC answer key expects a disposition the validator
+  cannot observe yet.
+
+## Pended Edge Cases
+
+The MCC edge-case corpus does include expected-pend scenarios, including COB
+review, retro-eligibility coverage change, subrogation review, dual eligible,
+and spend-down cases.
+
+The validator does not currently score those as a first-class `Pended` outcome.
+It calls the benefit-plan adjudication endpoint directly, whose response exposes
+`Success`, denial reason fields, totals, and timings, but not a claim/workflow
+pend status. Claims-service and the Argo adjudication workflow can represent
+`ClaimStatus.Pended` and 277 `P:16:85`; this validator does not yet run through
+that workflow path or read claim status back after adjudication.
+
+Until that observable signal is wired into the validator, expected-pend scenarios
+are reported as `Unsupported` rather than silently counted as matched,
+mismatched, or unspecified.
+
+## TODO
+
+- Add a validator path that observes real pend state, either by running the full
+  claim workflow and reading `ClaimStatus.Pended` / 277 status, or by extending
+  the adjudication response contract with a first-class pend result.

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -1,0 +1,79 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccRunSummaryBuilderTests
+{
+    [Fact]
+    public void Build_AggregatesWorkflowScenarioBreakdownWithoutDoubleCounting()
+    {
+        var options = ValidatorOptions.Parse([
+            "--claims", "5",
+            "--claim-results-limit", "10"
+        ]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("MCC-1", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid),
+            Result("MCC-2", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.BusinessDenial),
+            Result("MCC-3", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid),
+            Result("MCC-4", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial),
+            Result("MCC-5", null, MccWorkflowValidation.UnspecifiedStatus, ClaimValidationOutcome.Paid)
+        };
+
+        var summary = MccRunSummaryBuilder.Build(
+            results,
+            TimeSpan.FromSeconds(10),
+            options,
+            DateTimeOffset.Parse("2026-07-07T00:00:00Z"),
+            DateTimeOffset.Parse("2026-07-07T00:00:10Z"));
+
+        Assert.Equal(5, summary.TotalClaims);
+        Assert.Equal(4, summary.WorkflowScenarios);
+        Assert.Equal(1, summary.WorkflowMatches);
+        Assert.Equal(1, summary.WorkflowMismatches);
+        Assert.Equal(2, summary.WorkflowUnsupported);
+        Assert.Equal(2, summary.WorkflowScenarioBreakdown.Count);
+
+        var cob = Assert.Single(summary.WorkflowScenarioBreakdown, s => s.Scenario == "EdgeCase:CobSecondaryPayer");
+        Assert.Equal(2, cob.Total);
+        Assert.Equal(0, cob.Matches);
+        Assert.Equal(0, cob.Mismatches);
+        Assert.Equal(2, cob.Unsupported);
+        Assert.Equal(0, cob.Unspecified);
+
+        var behavioral = Assert.Single(summary.WorkflowScenarioBreakdown, s => s.Scenario == "EdgeCase:BehavioralHealthCarveIn");
+        Assert.Equal(2, behavioral.Total);
+        Assert.Equal(1, behavioral.Matches);
+        Assert.Equal(1, behavioral.Mismatches);
+        Assert.Equal(0, behavioral.Unsupported);
+        Assert.Equal(0, behavioral.Unspecified);
+    }
+
+    private static ClaimValidationResult Result(
+        string claimId,
+        string? scenario,
+        string validationStatus,
+        ClaimValidationOutcome outcome)
+    {
+        return new ClaimValidationResult(
+            claimId,
+            $"submitted-{claimId}",
+            "EdgeCase",
+            scenario,
+            scenario is null ? null : outcome.ToString(),
+            null,
+            validationStatus,
+            outcome,
+            outcome is ClaimValidationOutcome.Paid,
+            outcome is ClaimValidationOutcome.Paid ? 100m : null,
+            outcome is ClaimValidationOutcome.Paid ? 100m : null,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(80),
+            TimeSpan.FromMilliseconds(10),
+            new Dictionary<string, double> { ["benefit"] = 25 },
+            outcome is ClaimValidationOutcome.BusinessDenial ? "CARC_96" : null,
+            null,
+            null);
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -157,7 +157,7 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
-    public void ExpectedValidationFor_PendedEdgeCase_ResultsInUnspecifiedOutcome()
+    public void ExpectedValidationFor_PendedEdgeCase_ResultsInUnsupportedOutcome()
     {
         var claim = CreateClaim(
             claimType: "EdgeCase",
@@ -186,8 +186,83 @@ public class MccWorkflowValidationTests
         Assert.Equal("EdgeCase:CobSecondaryPayer", expected.Scenario);
         Assert.Null(expected.ExpectedOutcome);
         Assert.Equal("CARC_22", expected.ExpectedBusinessDenialCode);
-        Assert.Equal("Unspecified", statusWhenPaid);
-        Assert.Equal("Unspecified", statusWhenDenied);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, statusWhenPaid);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, statusWhenDenied);
+    }
+
+    [Fact]
+    public void AnswerKey_WhenClaimMissing_ReturnsUnspecified()
+    {
+        var key = MccAnswerKey.FromClaims([
+            CreateClaim(
+                claimType: "Professional",
+                benefitPlanId: MccWorkflowValidation.CleanProfessionalPaidPlanId,
+                placeOfService: "11",
+                priorAuthStatus: "NotRequired",
+                priorAuthNumber: null,
+                renderingState: "AZ")
+        ]);
+        var missing = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: "OTHER-PLAN",
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        missing.ClaimId = "MCC-MISSING-0000001";
+
+        var expected = key.ExpectedValidationFor(missing);
+
+        Assert.Null(expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.False(expected.IsUnsupported);
+    }
+
+    [Fact]
+    public void AnswerKey_WhenEdgeCaseEntryMissingExpectedOutcome_ReturnsUnspecified()
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        claim.EdgeCase = EdgeCaseScenario.CobSecondaryPayer;
+        claim.ExpectedOutcome = null!;
+
+        var key = MccAnswerKey.FromClaims([claim]);
+        var expected = key.ExpectedValidationFor(claim);
+
+        Assert.Null(expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.UnspecifiedStatus,
+            MccWorkflowValidation.ValidationStatus(expected, ClaimValidationOutcome.Paid, null));
+    }
+
+    [Fact]
+    public void AnswerKey_WhenDuplicateClaimIds_Throws()
+    {
+        var first = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.CleanProfessionalPaidPlanId,
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        var second = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.ExcludedProviderPlanId,
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        second.ClaimId = first.ClaimId;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => MccAnswerKey.FromClaims([first, second]));
+
+        Assert.Contains(first.ClaimId, ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Reconcile PR #839's Pended language with the merged validator behavior
- Classify expected-pend MCC edge cases as Unsupported, not Matched/Mismatched/Unspecified, because this validator cannot currently observe a real pend signal from its direct benefit-plan adjudication call
- Add an explicit MCC answer key wrapper for missing/duplicate key handling
- Extract summary aggregation into a testable helper and add per-scenario unsupported counts
- Document the pend-signal gap in the validator README/TODO
- Fix test-metrics so .NET test/build failures fail the .NET Tests job after metrics/artifacts are produced

## Pended Investigation
- The MCC corpus does contain expected-pend scenarios: COB secondary/tertiary/birthday/gender, retro eligibility coverage change, subrogation cases, Medicaid dual eligible, and Medicaid spend-down.
- The broader platform can represent pend state in claims-service (`ClaimStatus.Pended`) and 277 status (`P:16:85`).
- The validator path added by #839 calls benefit-plan-service directly and observes only `Success`, denial fields, totals, and timings. It does not run the Argo claim workflow or read claim status/277 state back, so Pended is unsupported for this validator until that observable signal is wired.

## PR #839 Check Triage
- GitHub currently reports no failed checks on #839. Most checks passed or skipped.
- Two checks still show as in_progress in the API: `Test .NET Projects / .NET Unit Tests` and `Test Metrics / .NET Tests`; I could not confirm the prompt's seven failed checks from the PR rollup.
- No `marketing-claims` workflow exists in `.github/workflows`.
- `test-metrics.yml` was suspect by inspection: it counted .NET project failures but did not fail the job. This PR fixes that misconfiguration.

## Coverage
- mcc-platform-validator line coverage before: 8.86%
- mcc-platform-validator line coverage after: 22.44%
- mcc-platform-validator branch coverage before: 27.69%
- mcc-platform-validator branch coverage after: 32.51%

## Verification
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj`
- `dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-metrics.yml")'`
- `actionlint .github/workflows/test-metrics.yml`
- `git diff --check`
