### PR TITLE
Make MCC pended claims observable

### DIFF
--- a/docs/million-claim-challenge/pend-validation.md
+++ b/docs/million-claim-challenge/pend-validation.md
@@ -1,0 +1,15 @@
+# MCC Pend Validation Note
+
+The MCC edge-case corpus includes expected-pend scenarios such as COB review,
+retro-eligibility coverage change, subrogation review, dual eligible, and
+spend-down cases.
+
+For the next local-k8s run, the platform validator should report these cases as
+first-class `Pended` results when claims-service persists `ClaimStatus.Pended`.
+The validator observes that state after the timed adjudication pass, so
+published throughput, P95, and P99 should continue to be described as excluding
+pend-observation polling.
+
+If expected-pend claims do not reach a pended or terminal claim status within
+the configured window, the validator reports `ObservationTimeout` separately
+from `Mismatched` and `Unsupported`.

--- a/docs/million-claim-challenge/pend-validation.md
+++ b/docs/million-claim-challenge/pend-validation.md
@@ -10,6 +10,20 @@ The validator observes that state after the timed adjudication pass, so
 published throughput, P95, and P99 should continue to be described as excluding
 pend-observation polling.
 
+Run instructions should set pend observation explicitly, even though the scripts
+default it on:
+
+```bash
+PEND_OBSERVATION_ENABLED=true \
+PEND_OBSERVATION_TIMEOUT_SECONDS=45 \
+PEND_OBSERVATION_INTERVAL_MS=1000 \
+./scripts/run-mcc-local-k8s.sh
+```
+
 If expected-pend claims do not reach a pended or terminal claim status within
 the configured window, the validator reports `ObservationTimeout` separately
 from `Mismatched` and `Unsupported`.
+
+Current limitation: the validator polls only scenarios whose answer key expects
+`Pended`. That keeps benchmark overhead bounded, but it does not catch false
+pends for scenarios expected to pay or deny.

--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -10,6 +10,9 @@ CLAIMS="${CLAIMS:-5000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
+PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
+PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
+PEND_OBSERVATION_INTERVAL_MS="${PEND_OBSERVATION_INTERVAL_MS:-1000}"
 PARALLELISM="${PARALLELISM:-10}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-500}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-docker-desktop}"
@@ -65,6 +68,11 @@ spec:
             - --provider-url
             - http://provider-service
             $(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf -- '- --no-seed-providers\n'; fi)
+            $(if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then printf -- '- --no-pend-observation\n'; fi)
+            - --pend-observation-timeout
+            - "${PEND_OBSERVATION_TIMEOUT_SECONDS}"
+            - --pend-observation-interval-ms
+            - "${PEND_OBSERVATION_INTERVAL_MS}"
             - --progress-every
             - "${PROGRESS_EVERY}"
             - --summary-json

--- a/scripts/sweep-mcc-local-k8s.sh
+++ b/scripts/sweep-mcc-local-k8s.sh
@@ -18,6 +18,9 @@ CLAIMS="${CLAIMS:-1000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
+PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
+PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
+PEND_OBSERVATION_INTERVAL_MS="${PEND_OBSERVATION_INTERVAL_MS:-1000}"
 PARALLELISM_VALUES="${PARALLELISM_VALUES:-8 10 11 12}"
 REPEATS="${REPEATS:-2}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-100}"
@@ -93,10 +96,14 @@ run_case() {
   local log_file="$OUTPUT_DIR/${job_name}.log"
   local json_file="$OUTPUT_DIR/${job_name}.json"
   local seed_provider_arg=""
+  local pend_observation_arg=""
   local status="ok"
 
   if [[ "$SEED_PROVIDERS" != "true" ]]; then
     seed_provider_arg='                --no-seed-providers \'
+  fi
+  if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then
+    pend_observation_arg='                --no-pend-observation \'
   fi
 
   log "Running MCC sweep case parallelism=${parallelism}, repeat=${repeat}"
@@ -132,8 +139,11 @@ spec:
                 --claims-url http://claims-service \
                 --benefit-url http://benefit-plan-service \
                 --provider-url http://provider-service \
+                --pend-observation-timeout "${PEND_OBSERVATION_TIMEOUT_SECONDS}" \
+                --pend-observation-interval-ms "${PEND_OBSERVATION_INTERVAL_MS}" \
                 --progress-every "${PROGRESS_EVERY}" \
 ${seed_provider_arg}
+${pend_observation_arg}
                 --summary-json /tmp/mcc-summary.json
               status=\$?
               echo "__MCC_SUMMARY_JSON_BEGIN__"

--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -64,7 +64,22 @@ internal sealed class MccClaimStatusObserver
         var deadline = DateTimeOffset.UtcNow.Add(timeout);
         while (true)
         {
-            var observed = await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
+            ObservedClaimStatus? observed;
+            try
+            {
+                observed = await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return result with
+                {
+                    ValidationStatus = MccWorkflowValidation.ObservationTimeoutStatus,
+                    Outcome = ClaimValidationOutcome.ObservationTimeout,
+                    FailureStage = "pend-observation",
+                    Error = $"Claim status observation failed: {ex.Message}"
+                };
+            }
+
             if (observed is { IsTerminal: true })
             {
                 return result with

--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using System.Text.Json;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal interface IClaimStatusSource
+{
+    Task<ObservedClaimStatus?> GetAsync(string submittedClaimId, CancellationToken cancellationToken);
+}
+
+internal sealed class HttpClaimStatusSource : IClaimStatusSource
+{
+    private readonly HttpClient _http;
+    private readonly string _claimsUrl;
+
+    public HttpClaimStatusSource(HttpClient http, string claimsUrl)
+    {
+        _http = http;
+        _claimsUrl = claimsUrl.TrimEnd('/');
+    }
+
+    public async Task<ObservedClaimStatus?> GetAsync(string submittedClaimId, CancellationToken cancellationToken)
+    {
+        using var response = await _http.GetAsync($"{_claimsUrl}/api/claims/{submittedClaimId}", cancellationToken);
+        if (response.StatusCode is HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"claim status read failed ({submittedClaimId}): {(int)response.StatusCode} {body}");
+        }
+
+        using var document = JsonDocument.Parse(body);
+        return ObservedClaimStatus.FromClaimJson(document.RootElement);
+    }
+}
+
+internal sealed class MccClaimStatusObserver
+{
+    private readonly IClaimStatusSource _source;
+
+    public MccClaimStatusObserver(IClaimStatusSource source)
+    {
+        _source = source;
+    }
+
+    public async Task<ClaimValidationResult> ObserveExpectedPendAsync(
+        ClaimValidationResult result,
+        TimeSpan timeout,
+        TimeSpan interval,
+        CancellationToken cancellationToken = default)
+    {
+        if (result.ExpectedOutcome != ClaimValidationOutcome.Pended.ToString()
+            || string.IsNullOrWhiteSpace(result.SubmittedClaimId)
+            || result.Outcome is ClaimValidationOutcome.PlatformFailure)
+        {
+            return result;
+        }
+
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (true)
+        {
+            var observed = await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
+            if (observed is { IsTerminal: true })
+            {
+                return result with
+                {
+                    ValidationStatus = MccWorkflowValidation.ValidationStatus(
+                        new ExpectedValidation(
+                            result.ValidationScenario,
+                            ClaimValidationOutcome.Pended,
+                            result.ExpectedBusinessDenialCode),
+                        observed.Outcome,
+                        result.BusinessDenialCode),
+                    Outcome = observed.Outcome,
+                    BusinessDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
+                        ? result.BusinessDenialCode
+                        : null
+                };
+            }
+
+            var remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return result with
+                {
+                    ValidationStatus = MccWorkflowValidation.ObservationTimeoutStatus,
+                    Outcome = ClaimValidationOutcome.ObservationTimeout,
+                    FailureStage = "pend-observation",
+                    Error = $"Timed out waiting for claim status to become terminal or pended after {timeout.TotalSeconds:N0}s"
+                };
+            }
+
+            var delay = interval <= TimeSpan.Zero || interval < remaining ? interval : remaining;
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+    }
+}
+
+internal sealed record ObservedClaimStatus(
+    ClaimValidationOutcome Outcome,
+    string RawStatus,
+    string? PendCode,
+    bool IsTerminal)
+{
+    public static ObservedClaimStatus FromClaimJson(JsonElement root)
+    {
+        var rawStatus = TryReadStringOrNumber(root, "status") ?? string.Empty;
+        var pendCode = TryReadPendCode(root);
+        var outcome = rawStatus.Trim() switch
+        {
+            "4" => ClaimValidationOutcome.Pended,
+            "5" or "7" or "9" => ClaimValidationOutcome.Paid,
+            "6" or "8" => ClaimValidationOutcome.BusinessDenial,
+            { } value when value.Equals("Pended", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Pended,
+            { } value when value.Equals("Approved", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Paid,
+            { } value when value.Equals("Paid", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Paid,
+            { } value when value.Equals("PartiallyPaid", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Paid,
+            { } value when value.Equals("Denied", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.BusinessDenial,
+            { } value when value.Equals("Voided", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.BusinessDenial,
+            _ => ClaimValidationOutcome.PlatformFailure
+        };
+
+        return new ObservedClaimStatus(
+            outcome,
+            rawStatus,
+            pendCode,
+            outcome is ClaimValidationOutcome.Pended
+                or ClaimValidationOutcome.Paid
+                or ClaimValidationOutcome.BusinessDenial);
+    }
+
+    private static string? TryReadStringOrNumber(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.TryGetInt32(out var number) ? number.ToString() : value.GetRawText(),
+            _ => null
+        };
+    }
+
+    private static string? TryReadPendCode(JsonElement root)
+    {
+        if (!root.TryGetProperty("pendDetails", out var pendDetails)
+            || pendDetails.ValueKind is not JsonValueKind.Object
+            || !pendDetails.TryGetProperty("pendCode", out var pendCode)
+            || pendCode.ValueKind is not JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return pendCode.GetString();
+    }
+}

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -11,12 +11,15 @@ internal static class MccRunSummaryBuilder
     {
         var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
         var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
+        var pended = results.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
         var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
+        var observationTimeouts = results.Count(r => r.Outcome is ClaimValidationOutcome.ObservationTimeout);
         var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
         var validationScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
         var validationMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
         var validationMismatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus);
         var validationUnsupported = results.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus);
+        var validationObservationTimeouts = results.Count(r => r.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus);
         var orderedDurations = results.Select(r => r.Elapsed.TotalMilliseconds).Order().ToArray();
         var p95 = Percentile(orderedDurations, 0.95);
         var p99 = Percentile(orderedDurations, 0.99);
@@ -45,10 +48,11 @@ internal static class MccRunSummaryBuilder
                 g.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus),
                 g.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus),
                 g.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus),
+                g.Count(r => r.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus),
                 g.Count(r => r.ValidationStatus == MccWorkflowValidation.UnspecifiedStatus)))
             .ToList();
         var failures = results
-            .Where(r => r.Outcome is ClaimValidationOutcome.PlatformFailure)
+            .Where(r => r.Outcome is ClaimValidationOutcome.PlatformFailure or ClaimValidationOutcome.ObservationTimeout)
             .Take(5)
             .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
             .ToList();
@@ -97,12 +101,15 @@ internal static class MccRunSummaryBuilder
             results.Count,
             processed,
             adjudicated,
+            pended,
             businessDenials,
+            observationTimeouts,
             platformFailures,
             validationScenarios,
             validationMatches,
             validationMismatches,
             validationUnsupported,
+            validationObservationTimeouts,
             elapsed,
             throughput,
             p95,

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -30,6 +30,7 @@ public static class MccWorkflowValidation
     public const string UnspecifiedStatus = "Unspecified";
     public const string MismatchedStatus = "Mismatched";
     public const string MatchedStatus = "Matched";
+    public const string ObservationTimeoutStatus = "ObservationTimeout";
 
     public static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
     {
@@ -39,15 +40,9 @@ public static class MccWorkflowValidation
             var expectedCode = NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
             var expectedOutcome = OutcomeFromDisposition(claim.ExpectedOutcome.Disposition);
 
-            // TODO(mcc-pended-signal): The MCC corpus contains expected-pend scenarios,
-            // but this validator currently calls benefit-plan-service directly and only
-            // observes Success plus denial/error fields. Claims-service can represent
-            // ClaimStatus.Pended and 277 P:16:85, but this validator does not yet run
-            // the claim workflow or read that status back. Keep pend expectations
-            // explicit as Unsupported until the validator has a real pend signal.
             return expectedOutcome is null
                 && claim.ExpectedOutcome.Disposition.Equals("Pended", StringComparison.OrdinalIgnoreCase)
-                    ? ExpectedValidation.Unsupported(scenario, expectedCode)
+                    ? new ExpectedValidation(scenario, ClaimValidationOutcome.Pended, expectedCode)
                     : new ExpectedValidation(scenario, expectedOutcome, expectedCode);
         }
 
@@ -104,6 +99,11 @@ public static class MccWorkflowValidation
         ClaimValidationOutcome actualOutcome,
         string? actualBusinessDenialCode)
     {
+        if (actualOutcome is ClaimValidationOutcome.ObservationTimeout)
+        {
+            return ObservationTimeoutStatus;
+        }
+
         if (expected.ExpectedOutcome is null)
         {
             return expected.IsUnsupported ? UnsupportedStatus : UnspecifiedStatus;
@@ -114,7 +114,8 @@ public static class MccWorkflowValidation
             return MismatchedStatus;
         }
 
-        if (!string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
+        if (expected.ExpectedOutcome is not ClaimValidationOutcome.Pended
+            && !string.IsNullOrWhiteSpace(expected.ExpectedBusinessDenialCode)
             && !string.Equals(expected.ExpectedBusinessDenialCode, actualBusinessDenialCode, StringComparison.OrdinalIgnoreCase))
         {
             return MismatchedStatus;
@@ -129,6 +130,7 @@ public static class MccWorkflowValidation
         {
             { } value when value.Equals("Paid", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Paid,
             { } value when value.Equals("Denied", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.BusinessDenial,
+            { } value when value.Equals("Pended", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Pended,
             _ => null
         };
     }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -41,6 +41,7 @@ Console.WriteLine($"  Seed:        {options.Seed}");
 Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
 Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
+Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled ({options.PendObservationTimeoutSeconds}s/{options.PendObservationIntervalMilliseconds}ms)" : " disabled")}");
 Console.WriteLine();
 
 await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
@@ -103,6 +104,11 @@ Console.WriteLine();
 var orderedResults = results
     .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
     .ToList();
+
+if (options.PendObservationEnabled)
+{
+    orderedResults = await ObserveExpectedPendResultsAsync(http, options, orderedResults);
+}
 
 var summary = MccRunSummaryBuilder.Build(orderedResults, total.Elapsed, options, runStartedAtUtc, DateTimeOffset.UtcNow);
 WriteSummary(summary);
@@ -1104,6 +1110,48 @@ static async Task UpdateClaimAdjudicationAsync(
     }
 }
 
+static async Task<List<ClaimValidationResult>> ObserveExpectedPendResultsAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    List<ClaimValidationResult> results)
+{
+    var expectedPendResults = results
+        .Where(r => r.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString())
+        .ToList();
+
+    if (expectedPendResults.Count == 0)
+    {
+        return results;
+    }
+
+    Console.WriteLine(
+        $"Observing {expectedPendResults.Count:N0} expected-pend claims for up to {options.PendObservationTimeoutSeconds:N0}s; benchmark timing excludes this polling window.");
+
+    var observer = new MccClaimStatusObserver(new HttpClaimStatusSource(http, options.ClaimsUrl));
+    var observed = new ConcurrentDictionary<string, ClaimValidationResult>(StringComparer.Ordinal);
+    var timeout = TimeSpan.FromSeconds(options.PendObservationTimeoutSeconds);
+    var interval = TimeSpan.FromMilliseconds(options.PendObservationIntervalMilliseconds);
+
+    await Parallel.ForEachAsync(
+        expectedPendResults,
+        new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
+        async (result, cancellationToken) =>
+        {
+            var updated = await observer.ObserveExpectedPendAsync(result, timeout, interval, cancellationToken);
+            observed[result.GeneratedClaimId] = updated;
+        });
+
+    var pended = observed.Values.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
+    var timeouts = observed.Values.Count(r => r.Outcome is ClaimValidationOutcome.ObservationTimeout);
+    Console.WriteLine($"  Pend observation:  {pended:N0} pended, {timeouts:N0} timed out");
+    Console.WriteLine();
+
+    return results
+        .Select(result => observed.TryGetValue(result.GeneratedClaimId, out var updated) ? updated : result)
+        .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
+        .ToList();
+}
+
 static List<object> BuildDiagnosisCodes(SyntheticClaim claim)
 {
     var codes = new List<string>();
@@ -1289,9 +1337,11 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Total claims:       {summary.TotalClaims:N0}");
     Console.WriteLine($"  Processed:          {summary.Processed:N0}");
     Console.WriteLine($"  Paid/adjudicated:   {summary.Paid:N0}");
+    Console.WriteLine($"  Pended:             {summary.Pended:N0}");
     Console.WriteLine($"  Business denials:   {summary.BusinessDenials:N0}");
     Console.WriteLine($"  Platform failures:  {summary.PlatformFailures:N0}");
-    Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched, {summary.WorkflowUnsupported:N0} unsupported)");
+    Console.WriteLine($"  Observation timeout:{summary.ObservationTimeouts:N0}");
+    Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched, {summary.WorkflowUnsupported:N0} unsupported, {summary.WorkflowObservationTimeouts:N0} observation timeouts)");
     Console.WriteLine($"  Elapsed:            {summary.Elapsed:mm\\:ss\\.fff}");
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");
     Console.WriteLine($"  P95 latency:        {summary.P95LatencyMilliseconds:N0} ms");
@@ -1316,7 +1366,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
 
     foreach (var scenario in summary.WorkflowScenarioBreakdown)
     {
-        Console.WriteLine($"  Scenario: {scenario.Scenario} {scenario.Matches:N0}/{scenario.Total:N0} matched ({scenario.Mismatches:N0} mismatched, {scenario.Unsupported:N0} unsupported, {scenario.Unspecified:N0} unspecified)");
+        Console.WriteLine($"  Scenario: {scenario.Scenario} {scenario.Matches:N0}/{scenario.Total:N0} matched ({scenario.Mismatches:N0} mismatched, {scenario.Unsupported:N0} unsupported, {scenario.ObservationTimeouts:N0} observation timeouts, {scenario.Unspecified:N0} unspecified)");
     }
 
     foreach (var failure in summary.SampleFailures)
@@ -1388,6 +1438,11 @@ static void PrintUsage()
       --provider-url <url>       Provider service URL (default: http://localhost:5004)
       --no-seed-providers        Skip synthetic provider seeding
       --skip-claim-update        Do not write adjudication projection back to claims-service
+      --no-pend-observation      Do not poll claims-service for expected-pend claim status
+      --pend-observation-timeout <seconds>
+                                 Max wait for expected-pend claims after benchmark timing stops (default: 45)
+      --pend-observation-interval-ms <ms>
+                                 Poll interval for expected-pend claim status (default: 1000)
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 10)
       -p, --parallelism <count>  Number of claims to process concurrently (default: 10)
@@ -1429,6 +1484,8 @@ public enum ClaimValidationOutcome
 {
     Paid,
     BusinessDenial,
+    Pended,
+    ObservationTimeout,
     PlatformFailure
 }
 
@@ -1458,12 +1515,15 @@ internal sealed record MassAdjudicationRunSummary(
     int TotalClaims,
     int Processed,
     int Paid,
+    int Pended,
     int BusinessDenials,
+    int ObservationTimeouts,
     int PlatformFailures,
     int WorkflowScenarios,
     int WorkflowMatches,
     int WorkflowMismatches,
     int WorkflowUnsupported,
+    int WorkflowObservationTimeouts,
     TimeSpan Elapsed,
     double ThroughputClaimsPerSecond,
     double P95LatencyMilliseconds,
@@ -1507,6 +1567,7 @@ internal sealed record MassAdjudicationWorkflowScenarioSummary(
     int Matches,
     int Mismatches,
     int Unsupported,
+    int ObservationTimeouts,
     int Unspecified);
 
 internal sealed record MassAdjudicationFailureSummary(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1340,7 +1340,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Pended:             {summary.Pended:N0}");
     Console.WriteLine($"  Business denials:   {summary.BusinessDenials:N0}");
     Console.WriteLine($"  Platform failures:  {summary.PlatformFailures:N0}");
-    Console.WriteLine($"  Observation timeout:{summary.ObservationTimeouts:N0}");
+    Console.WriteLine($"  Observation timeout: {summary.ObservationTimeouts:N0}");
     Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched, {summary.WorkflowUnsupported:N0} unsupported, {summary.WorkflowObservationTimeouts:N0} observation timeouts)");
     Console.WriteLine($"  Elapsed:            {summary.Elapsed:mm\\:ss\\.fff}");
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");

--- a/src/tools/mcc-platform-validator/README.md
+++ b/src/tools/mcc-platform-validator/README.md
@@ -15,6 +15,8 @@ The validator currently scores:
 - `Unspecified` when a generated claim has no validator answer-key entry.
 - `Unsupported` when the MCC answer key expects a disposition the validator
   cannot observe yet.
+- `ObservationTimeout` when an expected-pend claim does not reach a terminal or
+  pended claim status within the bounded observation window.
 
 ## Pended Edge Cases
 
@@ -22,19 +24,31 @@ The MCC edge-case corpus does include expected-pend scenarios, including COB
 review, retro-eligibility coverage change, subrogation review, dual eligible,
 and spend-down cases.
 
-The validator does not currently score those as a first-class `Pended` outcome.
-It calls the benefit-plan adjudication endpoint directly, whose response exposes
-`Success`, denial reason fields, totals, and timings, but not a claim/workflow
-pend status. Claims-service and the Argo adjudication workflow can represent
-`ClaimStatus.Pended` and 277 `P:16:85`; this validator does not yet run through
-that workflow path or read claim status back after adjudication.
+The synchronous benefit-plan adjudication response exposes `Success`, denial
+reason fields, totals, and timings, but not a claim/workflow pend status.
+Claims-service is the authoritative post-adjudication state source for this
+validator: `GET /api/claims/{id}` returns `ClaimStatus.Pended`, and
+`PendDetails.PendCode` provides the reason signal when available.
 
-Until that observable signal is wired into the validator, expected-pend scenarios
-are reported as `Unsupported` rather than silently counted as matched,
-mismatched, or unspecified.
+The validator therefore scores expected-pend scenarios in a post-adjudication
+observation pass. The timed benchmark pass completes first; then the validator
+polls claims-service for expected-pend claims only. `P95`, `P99`, stage timings,
+and claims/sec are computed from submission, adjudication, and writeback timing
+and exclude this polling window.
 
-## TODO
+Defaults:
 
-- Add a validator path that observes real pend state, either by running the full
-  claim workflow and reading `ClaimStatus.Pended` / 277 status, or by extending
-  the adjudication response contract with a first-class pend result.
+- `--pend-observation-timeout 45`
+- `--pend-observation-interval-ms 1000`
+
+Use `--no-pend-observation` to disable the post-adjudication observation pass.
+
+Expected-pend scenarios score as:
+
+- `Matched` when claims-service observes `ClaimStatus.Pended`.
+- `Mismatched` when claims-service observes a different terminal state such as
+  approved/paid or denied.
+- `ObservationTimeout` when the claim remains non-terminal until the configured
+  timeout.
+- `Unsupported` only when a future expected-pend subtype requires a signal the
+  validator still cannot distinguish from persisted claim state.

--- a/src/tools/mcc-platform-validator/README.md
+++ b/src/tools/mcc-platform-validator/README.md
@@ -36,12 +36,22 @@ polls claims-service for expected-pend claims only. `P95`, `P99`, stage timings,
 and claims/sec are computed from submission, adjudication, and writeback timing
 and exclude this polling window.
 
+This observation pass is intentionally one-directional for benchmark cost: it
+polls only claims whose answer-key disposition is `Pended`. It can prove that
+expected-pend scenarios did or did not pend, but it does not detect the inverse
+failure mode where a non-pend scenario unexpectedly lands in `ClaimStatus.Pended`
+after the synchronous adjudication response said paid or denied.
+
 Defaults:
 
+- Pend observation is enabled by default. Pass `--no-pend-observation` to turn it
+  off.
 - `--pend-observation-timeout 45`
 - `--pend-observation-interval-ms 1000`
 
-Use `--no-pend-observation` to disable the post-adjudication observation pass.
+The local-k8s scripts also default `PEND_OBSERVATION_ENABLED=true`. Set
+`PEND_OBSERVATION_ENABLED=false` only when reproducing the pre-observation
+validator behavior intentionally.
 
 Expected-pend scenarios score as:
 

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -9,6 +9,9 @@ public sealed record ValidatorOptions(
     string ProviderUrl,
     bool SeedProviders,
     bool SkipClaimUpdate,
+    bool PendObservationEnabled,
+    int PendObservationTimeoutSeconds,
+    int PendObservationIntervalMilliseconds,
     int TimeoutSeconds,
     int ProgressEvery,
     int Parallelism,
@@ -53,6 +56,15 @@ public sealed record ValidatorOptions(
                     break;
                 case "--skip-claim-update":
                     options.SkipClaimUpdate = true;
+                    break;
+                case "--no-pend-observation":
+                    options.PendObservationEnabled = false;
+                    break;
+                case "--pend-observation-timeout" when i + 1 < args.Length:
+                    options.PendObservationTimeoutSeconds = int.Parse(args[++i]);
+                    break;
+                case "--pend-observation-interval-ms" when i + 1 < args.Length:
+                    options.PendObservationIntervalMilliseconds = int.Parse(args[++i]);
                     break;
                 case "--timeout" when i + 1 < args.Length:
                     options.TimeoutSeconds = int.Parse(args[++i]);
@@ -114,6 +126,9 @@ public sealed record ValidatorOptions(
             options.ProviderUrl.TrimEnd('/'),
             options.SeedProviders,
             options.SkipClaimUpdate,
+            options.PendObservationEnabled,
+            Math.Clamp(options.PendObservationTimeoutSeconds, 1, 300),
+            Math.Clamp(options.PendObservationIntervalMilliseconds, 100, 30_000),
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
@@ -136,6 +151,9 @@ public sealed record ValidatorOptions(
         public string ProviderUrl { get; set; } = "http://localhost:5004";
         public bool SeedProviders { get; set; } = true;
         public bool SkipClaimUpdate { get; set; }
+        public bool PendObservationEnabled { get; set; } = true;
+        public int PendObservationTimeoutSeconds { get; set; } = 45;
+        public int PendObservationIntervalMilliseconds { get; set; } = 1000;
         public int TimeoutSeconds { get; set; } = 60;
         public int ProgressEvery { get; set; } = 10;
         public int Parallelism { get; set; } = 10;

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
@@ -72,6 +72,22 @@ public class MccClaimStatusObserverTests
     }
 
     [Fact]
+    public async Task ObserveExpectedPendAsync_WhenStatusReadFails_ReturnsObservationTimeoutResult()
+    {
+        var observer = new MccClaimStatusObserver(new ThrowingClaimStatusSource());
+
+        var result = await observer.ObserveExpectedPendAsync(
+            Result(ClaimValidationOutcome.BusinessDenial),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(ClaimValidationOutcome.ObservationTimeout, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.ObservationTimeoutStatus, result.ValidationStatus);
+        Assert.Equal("pend-observation", result.FailureStage);
+        Assert.Contains("claim read boom", result.Error);
+    }
+
+    [Fact]
     public void FromClaimJson_ParsesNumericPendedStatusAndPendCode()
     {
         using var document = System.Text.Json.JsonDocument.Parse("""
@@ -126,5 +142,11 @@ public class MccClaimStatusObserverTests
 
         public Task<ObservedClaimStatus?> GetAsync(string submittedClaimId, CancellationToken cancellationToken)
             => Task.FromResult(_statuses.Count == 0 ? null : _statuses.Dequeue());
+    }
+
+    private sealed class ThrowingClaimStatusSource : IClaimStatusSource
+    {
+        public Task<ObservedClaimStatus?> GetAsync(string submittedClaimId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("claim read boom");
     }
 }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
@@ -1,0 +1,130 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccClaimStatusObserverTests
+{
+    [Fact]
+    public async Task ObserveExpectedPendAsync_WhenFirstPollIsPended_ReturnsMatchedPended()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.Pended, "Pended", "COB", IsTerminal: true)
+        ]));
+
+        var result = await observer.ObserveExpectedPendAsync(
+            Result(ClaimValidationOutcome.BusinessDenial),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(ClaimValidationOutcome.Pended, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, result.ValidationStatus);
+    }
+
+    [Fact]
+    public async Task ObserveExpectedPendAsync_WhenPendArrivesAfterIntermediatePolls_ReturnsMatchedPended()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.PlatformFailure, "InAdjudication", null, IsTerminal: false),
+            new ObservedClaimStatus(ClaimValidationOutcome.PlatformFailure, "Received", null, IsTerminal: false),
+            new ObservedClaimStatus(ClaimValidationOutcome.Pended, "Pended", "COB", IsTerminal: true)
+        ]));
+
+        var result = await observer.ObserveExpectedPendAsync(
+            Result(ClaimValidationOutcome.BusinessDenial),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.Zero);
+
+        Assert.Equal(ClaimValidationOutcome.Pended, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, result.ValidationStatus);
+    }
+
+    [Fact]
+    public async Task ObserveExpectedPendAsync_WhenObservedPaid_ReturnsMismatched()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.Paid, "Approved", null, IsTerminal: true)
+        ]));
+
+        var result = await observer.ObserveExpectedPendAsync(
+            Result(ClaimValidationOutcome.BusinessDenial),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(100));
+
+        Assert.Equal(ClaimValidationOutcome.Paid, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.MismatchedStatus, result.ValidationStatus);
+    }
+
+    [Fact]
+    public async Task ObserveExpectedPendAsync_WhenNoTerminalStateBeforeTimeout_ReturnsObservationTimeout()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.PlatformFailure, "InAdjudication", null, IsTerminal: false)
+        ]));
+
+        var result = await observer.ObserveExpectedPendAsync(
+            Result(ClaimValidationOutcome.BusinessDenial),
+            TimeSpan.Zero,
+            TimeSpan.Zero);
+
+        Assert.Equal(ClaimValidationOutcome.ObservationTimeout, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.ObservationTimeoutStatus, result.ValidationStatus);
+        Assert.Equal("pend-observation", result.FailureStage);
+    }
+
+    [Fact]
+    public void FromClaimJson_ParsesNumericPendedStatusAndPendCode()
+    {
+        using var document = System.Text.Json.JsonDocument.Parse("""
+        {
+          "status": 4,
+          "pendDetails": {
+            "pendCode": "COB"
+          }
+        }
+        """);
+
+        var observed = ObservedClaimStatus.FromClaimJson(document.RootElement);
+
+        Assert.Equal(ClaimValidationOutcome.Pended, observed.Outcome);
+        Assert.Equal("4", observed.RawStatus);
+        Assert.Equal("COB", observed.PendCode);
+        Assert.True(observed.IsTerminal);
+    }
+
+    private static ClaimValidationResult Result(ClaimValidationOutcome startingOutcome)
+    {
+        return new ClaimValidationResult(
+            "MCC-PEND-0001",
+            "submitted-MCC-PEND-0001",
+            "EdgeCase",
+            "EdgeCase:CobSecondaryPayer",
+            ClaimValidationOutcome.Pended.ToString(),
+            "CARC_22",
+            MccWorkflowValidation.MismatchedStatus,
+            startingOutcome,
+            AdjudicationSuccess: false,
+            ActualPlanPayment: null,
+            ExpectedPlanPayment: null,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(80),
+            TimeSpan.FromMilliseconds(10),
+            new Dictionary<string, double>(),
+            BusinessDenialCode: null,
+            FailureStage: null,
+            Error: null);
+    }
+
+    private sealed class FakeClaimStatusSource : IClaimStatusSource
+    {
+        private readonly Queue<ObservedClaimStatus?> _statuses;
+
+        public FakeClaimStatusSource(IEnumerable<ObservedClaimStatus?> statuses)
+        {
+            _statuses = new Queue<ObservedClaimStatus?>(statuses);
+        }
+
+        public Task<ObservedClaimStatus?> GetAsync(string submittedClaimId, CancellationToken cancellationToken)
+            => Task.FromResult(_statuses.Count == 0 ? null : _statuses.Dequeue());
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -13,8 +13,8 @@ public class MccRunSummaryBuilderTests
         ]);
         var results = new List<ClaimValidationResult>
         {
-            Result("MCC-1", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid),
-            Result("MCC-2", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.BusinessDenial),
+            Result("MCC-1", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Pended),
+            Result("MCC-2", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.ObservationTimeoutStatus, ClaimValidationOutcome.ObservationTimeout),
             Result("MCC-3", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid),
             Result("MCC-4", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial),
             Result("MCC-5", null, MccWorkflowValidation.UnspecifiedStatus, ClaimValidationOutcome.Paid)
@@ -29,16 +29,20 @@ public class MccRunSummaryBuilderTests
 
         Assert.Equal(5, summary.TotalClaims);
         Assert.Equal(4, summary.WorkflowScenarios);
-        Assert.Equal(1, summary.WorkflowMatches);
+        Assert.Equal(2, summary.WorkflowMatches);
         Assert.Equal(1, summary.WorkflowMismatches);
-        Assert.Equal(2, summary.WorkflowUnsupported);
+        Assert.Equal(0, summary.WorkflowUnsupported);
+        Assert.Equal(1, summary.WorkflowObservationTimeouts);
+        Assert.Equal(1, summary.Pended);
+        Assert.Equal(1, summary.ObservationTimeouts);
         Assert.Equal(2, summary.WorkflowScenarioBreakdown.Count);
 
         var cob = Assert.Single(summary.WorkflowScenarioBreakdown, s => s.Scenario == "EdgeCase:CobSecondaryPayer");
         Assert.Equal(2, cob.Total);
-        Assert.Equal(0, cob.Matches);
+        Assert.Equal(1, cob.Matches);
         Assert.Equal(0, cob.Mismatches);
-        Assert.Equal(2, cob.Unsupported);
+        Assert.Equal(0, cob.Unsupported);
+        Assert.Equal(1, cob.ObservationTimeouts);
         Assert.Equal(0, cob.Unspecified);
 
         var behavioral = Assert.Single(summary.WorkflowScenarioBreakdown, s => s.Scenario == "EdgeCase:BehavioralHealthCarveIn");
@@ -46,6 +50,7 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(1, behavioral.Matches);
         Assert.Equal(1, behavioral.Mismatches);
         Assert.Equal(0, behavioral.Unsupported);
+        Assert.Equal(0, behavioral.ObservationTimeouts);
         Assert.Equal(0, behavioral.Unspecified);
     }
 

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -157,7 +157,7 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
-    public void ExpectedValidationFor_PendedEdgeCase_ResultsInUnsupportedOutcome()
+    public void ExpectedValidationFor_PendedEdgeCase_ReturnsPendedOutcome()
     {
         var claim = CreateClaim(
             claimType: "EdgeCase",
@@ -178,17 +178,22 @@ public class MccWorkflowValidationTests
             expected,
             ClaimValidationOutcome.Paid,
             actualBusinessDenialCode: null);
-        var statusWhenDenied = MccWorkflowValidation.ValidationStatus(
+        var statusWhenPended = MccWorkflowValidation.ValidationStatus(
             expected,
-            ClaimValidationOutcome.BusinessDenial,
-            actualBusinessDenialCode: "CARC_22");
+            ClaimValidationOutcome.Pended,
+            actualBusinessDenialCode: null);
+        var statusWhenTimeout = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.ObservationTimeout,
+            actualBusinessDenialCode: null);
 
         Assert.Equal("EdgeCase:CobSecondaryPayer", expected.Scenario);
-        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(ClaimValidationOutcome.Pended, expected.ExpectedOutcome);
         Assert.Equal("CARC_22", expected.ExpectedBusinessDenialCode);
-        Assert.True(expected.IsUnsupported);
-        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, statusWhenPaid);
-        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, statusWhenDenied);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MismatchedStatus, statusWhenPaid);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, statusWhenPended);
+        Assert.Equal(MccWorkflowValidation.ObservationTimeoutStatus, statusWhenTimeout);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -30,4 +30,18 @@ public class ValidatorOptionsTests
 
         Assert.False(options.SeedProviders);
     }
+
+    [Fact]
+    public void Parse_WhenPendObservationOptionsProvided_AppliesOverrides()
+    {
+        var options = ValidatorOptions.Parse([
+            "--no-pend-observation",
+            "--pend-observation-timeout", "30",
+            "--pend-observation-interval-ms", "500"
+        ]);
+
+        Assert.False(options.PendObservationEnabled);
+        Assert.Equal(30, options.PendObservationTimeoutSeconds);
+        Assert.Equal(500, options.PendObservationIntervalMilliseconds);
+    }
 }


### PR DESCRIPTION
## Phase 1 determination

- The MCC corpus does contain expected `Pended` scenarios.
- The synchronous benefit-plan adjudication endpoint cannot emit an observable pend disposition; it exposes success/denial fields, totals, and timings only.
- Claims-service is the authoritative post-adjudication source for this validator. `GET /api/claims/{id}` exposes `ClaimStatus.Pended`, and `PendDetails.PendCode` carries the reason signal when available. 277 `P:16:85` is corroborating but lower precision; work queue/examiner views are derived or downstream.
- Chosen approach: Option B, post-adjudication observation via bounded concurrent polling. This avoids faking a pend result and keeps benchmark throughput/latency separate from pend observation.

## What changed

- Reintroduced `Pended` as a reachable validation outcome for expected-pend MCC scenarios.
- Added distinct `ObservationTimeout` status for expected-pend claims that do not become terminal or pended inside the configured observation window.
- Added claims-service status observation after the timed adjudication pass, polling only expected-pend claims concurrently.
- Kept claims/sec, P95, P99, and stage timings scoped to submit/adjudicate/writeback timing; pend observation is excluded and documented.
- Added summary and per-scenario counts for `Pended`, `Unsupported`, and `ObservationTimeout`.
- Wired local-k8s run/sweep scripts with `PEND_OBSERVATION_ENABLED`, `PEND_OBSERVATION_TIMEOUT_SECONDS`, and `PEND_OBSERVATION_INTERVAL_MS`.
- Updated validator docs and added an MCC pend-validation note for the next published run.

## Defaults and limitations

- Pend observation defaults ON in the validator and scripts. Disable with `--no-pend-observation` or `PEND_OBSERVATION_ENABLED=false` only when intentionally reproducing pre-observation behavior.
- Default observation settings are `PEND_OBSERVATION_TIMEOUT_SECONDS=45` and `PEND_OBSERVATION_INTERVAL_MS=1000`.
- The observation pass intentionally polls only claims whose answer key expects `Pended`. That keeps benchmark overhead bounded, but it does not detect the inverse failure mode where a claim expected to pay or deny unexpectedly lands in `ClaimStatus.Pended` after the synchronous adjudication response.

## Tests and coverage

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --collect:"XPlat Code Coverage" --results-directory TestResults/mcc-current`
- `bash -n scripts/run-mcc-local-k8s.sh`
- `bash -n scripts/sweep-mcc-local-k8s.sh`

Validator package coverage after this PR is 26.13% line / 34.56% branch.

Baseline note: PR #838 publicly showed ~8% validator coverage before the scoring-test work. PR #840 then added answer-key/options/summary tests and recorded the prior merged state at 22.44% line / 32.51% branch. This PR moves that current baseline from 22.44% to 26.13%; the larger story since the original low-water mark is roughly 8% to 26%.

## Follow-up issue

I attempted to recompute the before coverage from a temporary `origin/main` worktree, but that checkout's validator test project failed to compile due to a pre-existing namespace/reference issue. I filed that separately as #842 so this PR can stay scoped to pend observability.
