### PR TITLE
Fix pend-persistence defects in claims-service orchestrator

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -260,71 +260,20 @@ jobs:
       - name: Install site dependencies
         run: |
           echo "Installing dependencies for site build..."
-          npm install
+          cd src/site
+          npm ci
           echo "✓ Dependencies installed"
 
       - name: Validate site build
         run: |
-          echo "Validating site Markdown to HTML conversion..."
+          echo "Validating site build..."
+          cd src/site
 
-          # Check if there are any Markdown files in site/assets
-          if [ -d "site/assets" ] && ls site/assets/*.md >/dev/null 2>&1; then
-            echo "Found Markdown files in site/assets"
+          npm run build
 
-            # Run the build
-            if ! npm run build:site; then
-              echo "::error::Site build failed"
-              exit 1
-            fi
-
-            # Check if assessment.html exists and is in sync
-            if [ -f "site/assessment.html" ]; then
-              # Compare modification times or check git status
-              if git diff --name-only | grep -q "site/assets/cho-assessment.md"; then
-                if ! git diff --name-only | grep -q "site/assessment.html"; then
-                  echo "::error::assessment.html is out of sync with cho-assessment.md"
-                  echo "Please run 'npm run build:site' and commit the generated HTML"
-                  exit 1
-                fi
-              fi
-
-              # Validate HTML structure
-              echo "Validating generated HTML structure..."
-
-              # Check for valid HTML (has <!DOCTYPE>, <html>, <head>, <body>)
-              if ! grep -q "<!DOCTYPE html>" site/assessment.html; then
-                echo "::error file=site/assessment.html::Missing DOCTYPE declaration"
-                exit 1
-              fi
-
-              if ! grep -q "<html" site/assessment.html; then
-                echo "::error file=site/assessment.html::Missing <html> tag"
-                exit 1
-              fi
-
-              # Check for proper heading structure (should have exactly one h1)
-              h1_count=$(grep -o "<h1>" site/assessment.html | wc -l)
-              if [ "$h1_count" -ne 1 ]; then
-                echo "::warning file=site/assessment.html::Found $h1_count <h1> tags (should have exactly 1 for accessibility)"
-              fi
-
-              # Check for list structure (li elements should be in ul/ol)
-              if grep -q "<li>" site/assessment.html; then
-                # Simple check: count <li> and <ul>+<ol>
-                li_count=$(grep -o "<li>" site/assessment.html | wc -l)
-                ul_count=$(grep -o "<ul>" site/assessment.html | wc -l)
-                ol_count=$(grep -o "<ol>" site/assessment.html | wc -l)
-
-                if [ $(("$ul_count" + "$ol_count")) -eq 0 ] && [ "$li_count" -gt 0 ]; then
-                  echo "::error file=site/assessment.html::Found <li> tags without parent <ul> or <ol>"
-                  exit 1
-                fi
-              fi
-
-              echo "✓ Generated HTML has valid structure"
-            fi
-
-            echo "✓ Site build validation complete"
-          else
-            echo "No Markdown files found in site/assets, skipping site build validation"
+          if [ ! -f "dist/index.html" ]; then
+            echo "::error file=src/site/dist/index.html::Site build did not produce dist/index.html"
+            exit 1
           fi
+
+          echo "✓ Site build validation complete"

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -176,11 +176,18 @@ jobs:
 
       - name: Download test results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: dotnet-test-results
           path: ./TestResults
 
+      - name: Skip missing coverage inputs
+        if: ${{ hashFiles('TestResults/**/coverage.cobertura.xml') == '' }}
+        run: |
+          echo "::warning::No .NET coverage reports were produced by the test job; skipping coverage summary."
+
       - name: Merge coverage reports
+        if: ${{ hashFiles('TestResults/**/coverage.cobertura.xml') != '' }}
         run: |
           dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.4.9
           reportgenerator \
@@ -190,6 +197,7 @@ jobs:
             "-filefilters:-*Tests*"
 
       - name: Code Coverage Summary
+        if: ${{ hashFiles('MergedCoverage/Cobertura.xml') != '' }}
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
           filename: 'MergedCoverage/Cobertura.xml'
@@ -203,8 +211,8 @@ jobs:
           thresholds: '60 80'
 
       - name: Add Coverage PR Comment
+        if: ${{ github.event_name == 'pull_request' && hashFiles('code-coverage-results.md') != '' }}
         uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
         with:
           recreate: true
           path: code-coverage-results.md

--- a/docs/architecture/claim-adjudication-pipeline.md
+++ b/docs/architecture/claim-adjudication-pipeline.md
@@ -124,7 +124,10 @@ across tenants. Pattern parity:
 non-persistence stages skip. PersistenceStage **always** runs (forced
 via `IsRequired=true`) so the version chain captures the failure
 outcome. `Pend` is recoverable — pipeline continues so subsequent stages
-can decorate the result before the claim ends up in a human-review queue.
+can decorate the result before the claim ends up in a human-review queue
+(see D9a for how PersistenceStage actually projects `Pend` onto
+`ClaimStatus` so the work queue can find it — that projection was missing
+until the pend-persistence defect fix).
 
 ### D8 — Stage interface
 
@@ -158,6 +161,71 @@ within one message handler so mutability is safe.
 - 5th instance of the projection-bypass pattern across the platform
   (Provider integrity, Provider credentialing, Provider panel-gating, BP
   network tiers, claims adjudication).
+
+#### D9a — Pend → ClaimStatus projection and its precedence rule (pend-persistence defect fix)
+
+Before this fix, `UpdateAdjudicationProjectionAsync`'s patch operation
+list never included `/status` — an orchestrator-computed `Pend` (NCCI/MUE,
+COB) populated `PendDetails` (NCCI) or nothing at all (COB, see
+`claim-cob-pipeline.md` D4) but never moved `ClaimStatus` off whatever it
+was before adjudication ran. Since the examiner work queue filters on
+`ClaimStatus.Pended` (`ClaimsController.GetWorkQueueSummary` /
+`GetWorkQueueItems`), orchestrator-pended claims never reached a human
+examiner. See the dated diagnostics doc
+(`docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md`)
+for the full trace.
+
+Fixed as follows:
+
+1. `PersistenceStage` resolves `isPend` from every stage result recorded
+   **before** Persistence runs (Persistence is always `Order=999`, i.e.
+   last), using the same Reject > Deny > Pend > Pass precedence the
+   orchestrator uses for the emitted event's `Outcome`
+   (`ClaimAdjudicationStageResult.ResolveOutcome` — a single shared
+   static method; the orchestrator's own `ResolveFinalOutcome` now
+   delegates to it, called one stage later so a Persistence-stage
+   `Reject` still wins on the emitted event).
+2. `isPend` and `PendDetails` are passed to
+   `UpdateAdjudicationProjectionAsync`. `isPend=false` is a **pure no-op**
+   on `/status` — Pass/Deny/Reject outcomes never touch it, exactly as
+   before this fix. Status transitions for those outcomes remain owned by
+   other write paths (`UpdateAdjudicationSummaryAsync`, the Argo
+   workflow's `update-claim-step`, or `ClaimsController.PendClaim`), not
+   this bypass method — this fix does not add terminal-status writes here.
+3. **Precedence rule** (documented here — the source of truth, not just
+   the PR that introduced it): when `isPend` is true, the repository ALSO
+   patches `/status` to `ClaimStatus.Pended`, *unless* the claim's current
+   `Status` is already a later-stage disposition — `Approved`, `Denied`,
+   `Paid`, `PartiallyPaid`, or `Voided` (`ClaimRepository.IsFinalDisposition`,
+   shared by both the Cosmos and Mongo repositories). This guards against
+   downgrading a claim that another write path — most plausibly the Argo
+   workflow's synchronous `update-claim-step`, or an examiner's
+   work-queue override — finalized before this async projection landed.
+   `Pended` is deliberately **not** in that list: re-pending an
+   already-`Pended` claim (a re-adjudication run that refreshes
+   `PendDetails`, e.g. a different edit-failure set) is allowed.
+4. `CoordinationOfBenefitsStage` now populates `PendDetails`
+   (`PendCode="COB"`) whenever it detects a secondary/tertiary scenario or
+   a coverage-service outage, mirroring `NcciEditsStage`'s existing
+   precedent of recording the deterministic snapshot regardless of
+   enforcement mode (so a Deny-mode COB claim still carries an audit
+   trail even though it ends up `Denied`, not `Pended` — Deny outweighs
+   Pend in the same precedence rule). No new pend vocabulary: `"COB"` was
+   already a documented `PendDetails.PendCode` value and the work queue
+   already had a `CobRequired` bucket keyed on it; the stage simply never
+   emitted it before.
+
+**Known pre-existing race, out of scope for this fix:** the Argo
+workflow's `update-claim-step` does not check for `ClaimStatus.Pended`
+before calling `PUT /api/claims/{id}/status`. If claims-service's own
+async orchestrator pends a claim (via the write path above) and the Argo
+workflow's synchronous `update-claim-step` runs afterward for the same
+claim, the workflow can still overwrite `Pended` back to `Approved` /
+`Denied` — the precedence rule in this fix only protects the
+orchestrator's own write path against a disposition that already landed;
+it doesn't (and structurally can't, from here) make the Argo workflow
+disposition-aware. Flagged as a finding for the future edit-model ADR, not
+fixed here.
 
 ### D10 — Resolution clients are cached HTTP clients
 
@@ -254,6 +322,8 @@ always enabled regardless.
 | `UpdateAdjudicationProjectionAsync` returns false | PersistenceStage returns `Reject`; orchestrator continues (no further work) and emits the adjudicated event with that outcome. |
 | `UpdateAdjudicationProjectionAsync` throws | PersistenceStage rethrows; Service Bus abandons the message and redelivers. |
 | Re-delivery for already-adjudicated claim | Orchestrator detects via populated `AdjudicationResult` and completes the message without re-running the pipeline. |
+| Orchestrator resolves `Pend`, but claim is already `Approved`/`Denied`/`Paid`/`PartiallyPaid`/`Voided` | `ClaimRepository.IsFinalDisposition` guard (D9a) skips the `/status` patch; `AdjudicationResult`/`PendDetails` still project for audit purposes. |
+| Argo workflow's `update-claim-step` runs after an async-orchestrator pend | Not guarded (pre-existing, out of scope for D9a) — the workflow can overwrite `Pended` back to `Approved`/`Denied`. Flagged as a finding for the future edit-model ADR. |
 
 ## Replacement contract for stub stages
 

--- a/docs/architecture/claim-cob-pipeline.md
+++ b/docs/architecture/claim-cob-pipeline.md
@@ -120,16 +120,40 @@ CHO-secondary persistence (CobReduction, SecondaryPlanPayment,
 PrimaryPayerPayment) is deferred to Phase 2 priorEob work. Phase 1 ships
 CHO-primary adjudication only and CHO-primary scenarios complete their
 full benefit calculation upstream at Order=300 — the existing
-`AdjudicationResult` shape captures CHO-primary fully.
+`AdjudicationResult` shape captures CHO-primary fully. This part is
+unchanged and still correct: no COB *calculation* fields exist yet.
 
-`CobOutcome` lives on the context only; PersistenceStage projection is
-deferred (α posture, consistent with 5.4 ScrubbingResult).
+> **Pend-persistence defect fix (dated diagnostics doc,
+> `docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md`).**
+> The paragraph below originally also deferred *PendDetails* projection —
+> that part was wrong and has been fixed. `CobOutcome` living on the
+> context only (with no PersistenceStage write) meant an examiner never
+> saw *why* a claim pended: `ClaimAdjudicationStageResult.Reason` lives
+> only on `ClaimAdjudicationContext.StageResults` for the duration of one
+> Service Bus message handler — nothing persists it, so the "human-readable
+> pend reason already carried by `ClaimAdjudicationStageResult`" argument
+> below never actually reached any UI. `CoordinationOfBenefitsStage` now
+> populates `PendDetails` (`PendCode="COB"` — already a documented,
+> recognized value, not new vocabulary) whenever it detects a
+> secondary/tertiary scenario or a coverage-service outage, mirroring
+> `NcciEditsStage`'s existing precedent of recording the deterministic
+> snapshot regardless of enforcement mode. `PersistenceStage` in turn now
+> projects the orchestrator's Pend outcome onto `ClaimStatus.Pended`. See
+> `claim-adjudication-pipeline.md` D9 for the full precedence rule.
 
-This is a deliberate non-symmetry with 5.6's `EnforcementOutcome` (which
+~~`CobOutcome` lives on the context only; PersistenceStage projection is
+deferred (α posture, consistent with 5.4 ScrubbingResult).~~ *(superseded —
+see the note above.)*
+
+~~This is a deliberate non-symmetry with 5.6's `EnforcementOutcome` (which
 extends the projection) and 5.7's `PendDetails.EditFailures` (which
 extends the projection-bypass shape): COB Phase 1 has nothing
 calculation-shaped to persist beyond the human-readable pend reason
-already carried by `ClaimAdjudicationStageResult`.
+already carried by `ClaimAdjudicationStageResult`.~~ *(superseded — the
+premise was that the stage-result reason was already visible somewhere
+downstream; it wasn't. `PendDetails.EditFailures` stays NCCI/MUE-specific
+— COB pends persist `PendDetails` with an empty `EditFailures` list, since
+COB has no per-line edit-failure shape to report.)*
 
 ### D5 — `CobOutcome` on `ClaimAdjudicationContext`
 

--- a/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
+++ b/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
@@ -1,0 +1,222 @@
+# Expected-Pend Diagnostics — Code-Path Trace
+
+**Status: internal engineering finding. Not a published benchmark result, not an
+ADR.** This document is the static-analysis trace that motivated adding
+`--pend-diagnostics` to the MCC platform validator. It answers *why* the 1K
+validation run in PR #841 showed expected-pend scenarios terminating as
+`Paid` or `Denied` instead of `Pended`, using file/line citations against the
+codebase as of this writing. It has not yet been confirmed by an empirical
+diagnostics run — see "How to produce the empirical companion report" below.
+
+## Headline finding
+
+**`ClaimStatus.Pended` is reachable from exactly one code path in the entire
+codebase, and neither the validator nor claims-service's own async
+adjudication pipeline uses it.**
+
+The only place that ever sets `Claim.Status = ClaimStatus.Pended` is
+`ClaimsController.PendClaim` (`PUT /api/claims/{id}/pend`),
+`src/services/claims-service/Controllers/ClaimsController.cs:354-389`. Its own
+doc comment says it plainly:
+
+> "This is the primary entry point used by the Argo adjudication workflow
+> when a deterministic edit (NCCI/MUE today, others later) requires human
+> review." (`ClaimsController.cs:344-345`)
+
+That "Argo adjudication workflow" is the literal Argo Workflow template
+`infrastructure/argo-workflows/claims-adjudication-template.yaml`, not
+claims-service's own message-driven orchestrator, and not the validator. Its
+`update-claim-step` (`claims-adjudication-template.yaml:406-497`) is the only
+caller of `PUT /pend` in the codebase, and it only calls it when the
+synchronous adjudication response carries `editFailures` **and**
+`success == false` (`claims-adjudication-template.yaml:428-457`) — i.e. NCCI/MUE
+only. Every other outcome falls through to:
+
+```python
+elif not adjudication.get('success', True):
+    status = "Denied"
+```
+
+(`claims-adjudication-template.yaml:469-470`) — so even the one workflow that
+*can* reach `Pended` only routes NCCI/MUE there; COB, subrogation,
+retro-eligibility, and dual-eligible/spend-down have no equivalent branch in
+that workflow and would deny if they ever produced `success == false` there.
+
+**The validator does not exercise this workflow at all.** It calls the same
+synchronous endpoint the Argo workflow calls
+(`POST /api/v1/adjudication/adjudicate`,
+`src/tools/mcc-platform-validator/Program.cs:1007`), then writes the result
+back itself via `PUT /api/claims/{id}/adjudication-summary`
+(`Program.cs:1105`, handled by
+`ClaimsController.UpdateAdjudicationSummary`,
+`ClaimsController.cs:451-472`). That handler's status resolver:
+
+```csharp
+private static ClaimStatus ResolveAdjudicationStatus(AdjudicationResult adjudication)
+{
+    if (adjudication.PayerPayment == 0 && !string.IsNullOrEmpty(adjudication.DenialReasonCode))
+        return ClaimStatus.Denied;
+    return adjudication.PayerPayment > 0 ? ClaimStatus.Approved : ClaimStatus.InAdjudication;
+}
+```
+
+(`ClaimsController.cs:474-484`) has exactly three possible outputs —
+`Denied`, `Approved`, `InAdjudication` — and **cannot structurally produce
+`Pended`**, regardless of what the synchronous adjudication response
+contained. This is why the validator's own writeback path can never observe
+a pend, independent of anything the engine does.
+
+## Is there a second, hidden path? (checking claims-service's own pipeline)
+
+The validator's `POST /api/v1/claims` call
+(`Program.cs:951`, hitting `ClaimsV1Controller` →
+`ClaimSubmissionService.SubmitAsync`,
+`src/services/claims-service/Services/ClaimSubmissionService.cs:145-274`)
+*does* publish a `ClaimVersionSubmittedMessage`
+(`ClaimSubmissionService.cs:240-259`), which *does* trigger claims-service's
+own message-driven `ClaimAdjudicationOrchestrator`
+(`src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs:56-136`)
+in the background, racing with the validator's synchronous call chain. This
+pipeline has real `Pend` support:
+
+- `NcciEditsStage` (`Stages/NcciEditsStage.cs:201-222`) — NCCI/MUE failures
+  produce `ClaimAdjudicationStageResult.Pend(...)` by default
+  (`NcciEnforcementMode.PendForReview`), and populate
+  `context.PendDetails` with `PendCode="NCCI"` or `"MUE"`
+  (`NcciEditsStage.cs:154-179`).
+- `CoordinationOfBenefitsStage` (`Stages/CoordinationOfBenefitsStage.cs:382-403`)
+  — CHO-secondary/tertiary detection produces `Pend` by default
+  (`CobEnforcementMode.PendForSecondary`), reason
+  `cob-secondary-not-supported-phase-1`. Coverage-service unavailability also
+  pends (`CoordinationOfBenefitsStage.cs:405-429`), reason
+  `cob-coverage-service-unavailable`.
+
+But this pipeline **still never sets `ClaimStatus.Pended`.**
+`PersistenceStage` (`Stages/PersistenceStage.cs:49-77`) writes the outcome via
+`IClaimRepository.UpdateAdjudicationProjectionAsync`
+(`src/services/claims-service/Repositories/ClaimRepository.cs:805-916`), whose
+patch list is:
+
+```csharp
+var ops = new List<PatchOperation>
+{
+    PatchOperation.Set("/adjudicationResult", adjudicationResult),
+    PatchOperation.Set("/claimLines", head.ClaimLines),
+    PatchOperation.Set("/lastUpdatedDate", DateTime.UtcNow),
+};
+if (pendDetails is not null) ops.Add(PatchOperation.Set("/pendDetails", pendDetails));
+```
+
+(`ClaimRepository.cs:883-900`) — **`/status` is never in that list.** So even
+when NCCI/MUE correctly populates `PendDetails`, the claim's `ClaimStatus`
+field is left untouched by this write path. And the orchestrator's
+`ResolveFinalOutcome` precedence (`ClaimAdjudicationOrchestrator.cs:290-307`,
+Reject > Deny > Pend > Pass) is used **only** to label the
+`ClaimVersionAdjudicatedMessage` Service Bus event
+(`ClaimAdjudicationOrchestrator.cs:232-241`) — it is never used to call
+`PendClaim`/`PUT /pend`, and the orchestrator never calls that endpoint at
+all.
+
+Worse, `CoordinationOfBenefitsStage`'s own doc comment says the quiet part
+explicitly: *"PendDetails is NOT touched — that channel is reserved for
+NCCI's deterministic edit-failure snapshots"*
+(`CoordinationOfBenefitsStage.cs:76-83`). So COB pends don't even get the
+partial credit NCCI gets — they leave zero trace on the persisted claim.
+
+**Confirming this is truly invisible, not just unscored:** the human work
+queue (`ClaimsController.GetWorkQueueSummary` /
+`GetWorkQueueItems`, `ClaimsController.cs:979-1029`) filters
+`_claimRepository.SearchAsync(..., status: ClaimStatus.Pended, ...)`
+(`ClaimsController.cs:983-987`). A claim that NCCI-pended through this
+pipeline has `PendDetails` populated but `Status` untouched — so it **never
+appears in the examiner work queue either.** The work queue's own
+`CobRequired` bucket (`PendCode is "COB"`, `ClaimsController.cs:999`) is
+structurally unreachable today, because `CoordinationOfBenefitsStage` never
+writes `PendCode="COB"` anywhere.
+
+## Net effect
+
+Three independent code paths can touch a claim submitted by the validator,
+and none of them can leave it in `ClaimStatus.Pended`:
+
+| Path | Can detect pendable situations? | Can persist `ClaimStatus.Pended`? |
+|---|---|---|
+| Validator's own writeback (`UpdateAdjudicationSummary`) | No (only sees `AdjudicationResult`, not edit failures) | No — 3 fixed outputs, none is `Pended` |
+| claims-service async orchestrator (triggered by the validator's own `POST /api/v1/claims`) | Yes (NCCI/MUE, COB) | No — `UpdateAdjudicationProjectionAsync` never patches `/status` |
+| Argo Workflow `update-claim-step` | Only NCCI/MUE (`editFailures` check) | Yes, via `PUT /pend` — but the validator never runs this workflow |
+
+This is **not just a routing gap** (validator doesn't take the Argo Workflow
+path). It's also a **coverage gap**: even the one path that can reach
+`Pended` only wires up NCCI/MUE, and the async orchestrator that *does* have
+COB pend-detection logic throws the result away before it reaches the claim
+record. Fixing the routing alone (pointing the validator at the Argo
+Workflow) would only fix NCCI/MUE; COB, subrogation, retro-eligibility, and
+dual-eligible/spend-down would still terminate wrong.
+
+## Per scenario-family trace (Deliverable 3.1)
+
+| Family | Where detected | Where it becomes `Success=false` | Could it pend instead? |
+|---|---|---|---|
+| NCCI/MUE | `AdjudicationController.Adjudicate` step 0b, `src/services/benefit-plan-service/Controllers/AdjudicationController.cs:251-305`; independently re-detected by `NcciEditsStage.cs:119-152` | `AdjudicationController.cs:296-304` (`UnprocessableEntity`, `error="NCCI_MUE_EDIT_FAILURE"`) | Yes — `NcciEditsStage` already computes `Pend`; only the Argo Workflow's `update-claim-step` acts on it (NCCI/MUE branch only) |
+| COB (secondary/tertiary/birthday/gender rule) | Only in claims-service's async orchestrator, `CoordinationOfBenefitsStage.cs:186-201`, via a live call to coverage-service's `/member/{id}/cob` | Nowhere in the synchronous path — the validator never sends `AdjudicationRequest.Cob` (see `Program.cs:970-1005`, no `cob` field in the payload), so `AdjudicationController.Adjudicate` has no COB signal at all and adjudicates the claim as an ordinary claim (likely `Success=true`) | Yes — `CoordinationOfBenefitsStage` already computes `Pend`, but `PendDetails` is explicitly not populated for COB (`CoordinationOfBenefitsStage.cs:76-83`), so even a correct COB pend leaves no trace on the claim |
+| Subrogation (accident/workers-comp/third-party) | **Nowhere.** No stage, engine, or synchronous-adjudication field encodes subrogation. `EdgeCaseClaimGenerator` sets no distinguishing claim/request field for these scenarios beyond place-of-service `"23"` (`src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs:171`) | N/A — nothing detects it, so the claim adjudicates normally and most likely pays | No pend logic exists to redirect; needs new detection before an edit-model can even classify it |
+| Retro-eligibility coverage change | **Nowhere** for this specific scenario. (`RetroEligibilityTermination` is a different scenario and does correctly deny via eligibility checks — not the one the answer key expects to pend.) | N/A — no signal reaches adjudication; the claim adjudicates as ordinary and most likely pays | Same as subrogation — no detection to redirect |
+| Medicaid dual-eligible / spend-down | **Nowhere.** `EdgeCaseClaimGenerator` only adjusts the member's date of birth for these scenarios (`EdgeCaseClaimGenerator.cs:121-124`); no spend-down/dual-eligible signal is transmitted to adjudication | N/A — no signal reaches adjudication; likely pays | Same — no detection to redirect |
+
+**Correction to the original hypothesis:** the task description hypothesized
+that the synchronous path "collapses pendable situations ... into
+`Success=false` business denials." That is precisely true for NCCI/MUE. For
+COB, subrogation, retro-eligibility, and dual-eligible/spend-down, the static
+trace suggests the more likely failure mode is **`Success=true` (Paid)**, not
+a denial — because no code path transmits or detects the distinguishing
+signal for those scenarios in the request the validator actually sends. This
+is a prediction from static analysis; confirming it (Paid vs. Denied vs.
+Pended, and which denial code if any) is exactly what the empirical
+`--pend-diagnostics` per-claim capture is for.
+
+## Denial-code → pendable mapping (Deliverable 3.3, candidate)
+
+| Denial/error code | Emitted by | Pendable? | Scenario families |
+|---|---|---|---|
+| `NCCI_MUE_EDIT_FAILURE` | `AdjudicationController.cs:299` | **Yes** — already pend-capable in `NcciEditsStage`; Argo Workflow already redirects it | NCCI/MUE |
+| `PROVIDER_EXCLUDED` | `AdjudicationController.cs:340` | No — federal exclusion (OIG/LEIE/SAM.gov) is a correct hard denial | Provider integrity |
+| `PRIOR_AUTH_REQUIRED` | `AdjudicationController.cs:403` | Policy-dependent — some payers pend for retro-auth review instead of denying outright; not in scope of this investigation's five families but structurally similar (detected, converted to denial, no pend option wired) | Prior authorization |
+| `SCRUB_VALIDATION_FAILURE` | `AdjudicationController.cs:240` | No — structural/data-quality rejection, needs resubmission, not a clinical/coverage judgment call | Pre-adjudication scrub |
+| `LEGACY_ROUTED` | `AdjudicationController.cs:188-198` | No — routing decision, not a denial | Operating-mode routing |
+| CoB pend reasons (`cob-secondary-not-supported-phase-1`, `cob-coverage-service-unavailable`) | `CoordinationOfBenefitsStage.cs:92,96` | **Yes** — already produces `Pend`, but never persisted (see above) | COB |
+| *(none — no code emits anything for these)* | — | **Yes**, per the Argo/edit-model design intent, but nothing detects them today | Subrogation, retro-eligibility coverage change, Medicaid dual-eligible/spend-down |
+
+## How to produce the empirical companion report
+
+This document is static analysis only — it was written without a live
+Kubernetes/.NET environment available in this session. To confirm or refute
+the "Correction to the original hypothesis" table above with real
+adjudication responses and persisted claim state, run:
+
+```bash
+PEND_DIAGNOSTICS_PATH=/tmp/mcc-pend-diagnostics.json \
+PEND_DIAGNOSTICS_NCCI_SAMPLE=200 \
+CLAIMS=1000 \
+./scripts/run-mcc-local-k8s.sh
+```
+
+or directly:
+
+```bash
+dotnet run --project src/tools/mcc-platform-validator -- \
+  --claims 1000 --parallelism 10 --tenant demo \
+  --pend-diagnostics /tmp/mcc-pend-diagnostics.json \
+  --pend-diagnostics-ncci-sample 200
+```
+
+The run prints an aggregate scenario table to stdout (capture the job logs
+via `kubectl logs job/mcc-validator -n cloudhealthoffice` if run through the
+k8s script) — paste that table into an ADR or episode packet as the primary
+artifact. The full per-claim JSON at `PEND_DIAGNOSTICS_PATH` is the
+supporting evidence; it is not meant to be committed if large (recommended:
+attach it to the episode packet or store it out-of-repo, and commit only the
+aggregate table, dated, as a follow-up to this document).
+
+A diagnostics-on run is **not** a valid throughput benchmark — it performs
+one additional `GET /api/claims/{id}` read per diagnosed claim after the
+timed benchmark window closes (same posture as `--pend-observation`).

--- a/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
+++ b/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
@@ -8,6 +8,57 @@ validation run in PR #841 showed expected-pend scenarios terminating as
 codebase as of this writing. It has not yet been confirmed by an empirical
 diagnostics run — see "How to produce the empirical companion report" below.
 
+> **Defects A/B remediated (this PR — pend-persistence defect fix).** The
+> two structural defects this trace identified inside claims-service's own
+> async orchestrator are now fixed:
+>
+> - **Defect A** — `UpdateAdjudicationProjectionAsync` never patched
+>   `/status`, so an orchestrator-computed `Pend` (NCCI/MUE, COB) never
+>   reached `ClaimStatus`. Fixed: the repository now patches
+>   `ClaimStatus.Pended` when the orchestrator resolved `Pend`, subject to
+>   a precedence rule that never downgrades a claim already at a
+>   later-stage disposition. See
+>   `docs/architecture/claim-adjudication-pipeline.md` D9a.
+> - **Defect B** — `CoordinationOfBenefitsStage` never wrote `PendDetails`
+>   for COB pends. Fixed: it now writes `PendCode="COB"` + a reason string,
+>   mirroring NCCI's existing precedent. See
+>   `docs/architecture/claim-cob-pipeline.md` D4.
+>
+> Orchestrator-computed NCCI/MUE and COB pends are now visible in the
+> examiner work queue (`ClaimsController.GetWorkQueueSummary` /
+> `GetWorkQueueItems`), which they never were before.
+>
+> **This does not change the headline finding below.** The Argo Workflow's
+> `update-claim-step` is still the only caller of
+> `PUT /api/claims/{id}/pend`, and it still only redirects NCCI/MUE to
+> pend — COB, subrogation, retro-eligibility, and dual-eligible/spend-down
+> have no equivalent branch there. The validator's own write-back path
+> (`UpdateAdjudicationSummaryAsync`) still cannot produce `Pended` — that
+> is unchanged. And the coverage gap (no code anywhere detects
+> subrogation, retro-eligibility-coverage-change, or Medicaid
+> dual-eligible/spend-down) is exactly as described below and remains the
+> future edit-model ADR's problem.
+>
+> **New finding surfaced while fixing Defect A, not fixed here (out of
+> scope):** the validator's `POST /api/v1/claims` call triggers the async
+> orchestrator in the background (via `ClaimVersionSubmittedMessage`),
+> which can now legitimately pend a claim. But the validator's own
+> synchronous write-back (`UpdateAdjudicationSummaryAsync`, called
+> moments later in the validator's own request chain) has no precedence
+> guard at all — it unconditionally sets `/status` to
+> `Approved`/`Denied`/`InAdjudication` based on the synchronous
+> adjudication response, with no `IsFinalDisposition`-style check against
+> whatever the async orchestrator already wrote. If the async pend lands
+> first and the synchronous write-back lands second, the write-back will
+> silently overwrite `Pended` back to a terminal status. This fix's
+> precedence rule only protects the orchestrator's own projection write
+> (Defect A's scope); it does not add a guard to
+> `UpdateAdjudicationSummaryAsync`, which is a different method serving a
+> different caller (the validator's direct HTTP path) and was out of
+> scope for this surgical fix.
+>
+> The findings below are preserved unedited as the original record.
+
 ## Headline finding
 
 **`ClaimStatus.Pended` is reachable from exactly one code path in the entire

--- a/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
+++ b/docs/million-claim-challenge/2026-07-07-expected-pend-diagnostics.md
@@ -136,7 +136,7 @@ pipeline has real `Pend` support:
   `context.PendDetails` with `PendCode="NCCI"` or `"MUE"`
   (`NcciEditsStage.cs:154-179`).
 - `CoordinationOfBenefitsStage` (`Stages/CoordinationOfBenefitsStage.cs:382-403`)
-  — CHO-secondary/tertiary detection produces `Pend` by default
+  — Cloud Health Office secondary/tertiary detection produces `Pend` by default
   (`CobEnforcementMode.PendForSecondary`), reason
   `cob-secondary-not-supported-phase-1`. Coverage-service unavailability also
   pends (`CoordinationOfBenefitsStage.cs:405-429`), reason

--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -13,6 +13,11 @@ SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
 PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
 PEND_OBSERVATION_INTERVAL_MS="${PEND_OBSERVATION_INTERVAL_MS:-1000}"
+# Off by default. Set to a path (e.g. /tmp/mcc-pend-diagnostics.json) to capture
+# per-claim pend diagnostics; the aggregate table prints to the job logs regardless
+# of whether the JSON artifact itself is copied out of the pod.
+PEND_DIAGNOSTICS_PATH="${PEND_DIAGNOSTICS_PATH:-}"
+PEND_DIAGNOSTICS_NCCI_SAMPLE="${PEND_DIAGNOSTICS_NCCI_SAMPLE:-200}"
 PARALLELISM="${PARALLELISM:-10}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-500}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-docker-desktop}"
@@ -73,6 +78,7 @@ spec:
             - "${PEND_OBSERVATION_TIMEOUT_SECONDS}"
             - --pend-observation-interval-ms
             - "${PEND_OBSERVATION_INTERVAL_MS}"
+            $(if [[ -n "$PEND_DIAGNOSTICS_PATH" ]]; then printf -- '- --pend-diagnostics\n            - "%s"\n            - --pend-diagnostics-ncci-sample\n            - "%s"\n' "$PEND_DIAGNOSTICS_PATH" "$PEND_DIAGNOSTICS_NCCI_SAMPLE"; fi)
             - --progress-every
             - "${PROGRESS_EVERY}"
             - --summary-json

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -113,6 +113,25 @@ public interface IClaimRepository
     /// read from this field on the head row.
     /// </para>
     ///
+    /// <para>
+    /// <paramref name="isPend"/> (pend-persistence defect fix) — when true,
+    /// this call ALSO patches <c>ClaimStatus</c> to <see cref="ClaimStatus.Pended"/>,
+    /// subject to one precedence rule: a claim already at a later-stage
+    /// disposition (<see cref="ClaimRepository.IsFinalDisposition"/> —
+    /// Approved, Denied, Paid, PartiallyPaid, Voided) is never downgraded
+    /// back to Pended, in case this async projection lands after another
+    /// write path (the Argo workflow's synchronous finalize step, or an
+    /// examiner override) already finalized the claim. Re-pending an
+    /// already-<c>Pended</c> claim (a re-adjudication run refreshing
+    /// <paramref name="pendDetails"/>) is allowed — Pended is not a final
+    /// disposition. <paramref name="isPend"/> false is a pure no-op on
+    /// <c>ClaimStatus</c> — behavior for Pass/Deny/Reject outcomes is
+    /// unchanged from before this parameter existed; those outcomes'
+    /// status transitions are owned by other write paths
+    /// (<c>UpdateAdjudicationSummaryAsync</c>, the Argo workflow, or
+    /// <c>ClaimsController.PendClaim</c>), not this bypass method.
+    /// </para>
+    ///
     /// Returns true on success, false when no head row was found for the
     /// chain.
     /// </summary>
@@ -122,7 +141,8 @@ public interface IClaimRepository
         AdjudicationResult adjudicationResult,
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
-        PendDetails? pendDetails = null);
+        PendDetails? pendDetails = null,
+        bool isPend = false);
 
     /// <summary>
     /// Fast claim-level adjudication projection for direct local workflow
@@ -267,6 +287,26 @@ public class ClaimRepository : IClaimRepository
         ClaimStatus.Denied => ClaimVersionState.Denied,
         ClaimStatus.Voided => ClaimVersionState.Voided,
         _ => ClaimVersionState.Submitted
+    };
+
+    /// <summary>
+    /// Claim dispositions that <see cref="UpdateAdjudicationProjectionAsync"/>'s
+    /// <c>isPend: true</c> path must never downgrade back to
+    /// <see cref="ClaimStatus.Pended"/> — see that method's doc comment for
+    /// the full precedence rule. Public so <see cref="ClaimRepositoryMongo"/>
+    /// shares one canonical rule, mirroring <see cref="MapStatusToVersionState"/>.
+    /// Pended is deliberately excluded: it is not a final disposition, so
+    /// re-pending an already-Pended claim (a re-adjudication run refreshing
+    /// PendDetails) is allowed.
+    /// </summary>
+    public static bool IsFinalDisposition(ClaimStatus status) => status switch
+    {
+        ClaimStatus.Approved or
+        ClaimStatus.Denied or
+        ClaimStatus.Paid or
+        ClaimStatus.PartiallyPaid or
+        ClaimStatus.Voided => true,
+        _ => false
     };
 
     private static bool IsTerminal(ClaimVersionState state) => state switch
@@ -808,7 +848,8 @@ public class ClaimRepository : IClaimRepository
         AdjudicationResult adjudicationResult,
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
-        PendDetails? pendDetails = null)
+        PendDetails? pendDetails = null,
+        bool isPend = false)
     {
         // Resolve the head (non-terminal-but-adjudicatable) row by chain key.
         // PatchItemAsync is keyed on the per-row document Id, so we look up
@@ -897,6 +938,18 @@ public class ClaimRepository : IClaimRepository
         if (pendDetails is not null)
         {
             ops.Add(PatchOperation.Set("/pendDetails", pendDetails));
+        }
+
+        // Defect A fix — project the orchestrator's Pend outcome onto
+        // ClaimStatus. Precedence: never downgrade a claim that already
+        // reached a later-stage disposition (see IsFinalDisposition) — e.g.
+        // because the Argo workflow's synchronous finalize step, or an
+        // examiner override, raced ahead of this async projection.
+        // Re-pending an already-Pended claim is allowed. isPend=false never
+        // touches /status here, same as before this parameter existed.
+        if (isPend && !IsFinalDisposition(head.Status))
+        {
+            ops.Add(PatchOperation.Set("/status", ClaimStatus.Pended));
         }
 
         try

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -423,7 +423,8 @@ public class ClaimRepositoryMongo : IClaimRepository
         AdjudicationResult adjudicationResult,
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
-        PendDetails? pendDetails = null)
+        PendDetails? pendDetails = null,
+        bool isPend = false)
     {
         var b = Builders<Claim>.Filter;
 
@@ -478,6 +479,17 @@ public class ClaimRepositoryMongo : IClaimRepository
         if (pendDetails is not null)
         {
             update = update.Set(c => c.PendDetails, pendDetails);
+        }
+
+        // Defect A fix — project the orchestrator's Pend outcome onto
+        // ClaimStatus. Same precedence rule as the Cosmos sibling: never
+        // downgrade a claim already at a later-stage disposition (see
+        // ClaimRepository.IsFinalDisposition); re-pending an already-Pended
+        // claim is allowed. isPend=false never touches /status here, same
+        // as before this parameter existed.
+        if (isPend && !ClaimRepository.IsFinalDisposition(head.Status))
+        {
+            update = update.Set(c => c.Status, ClaimStatus.Pended);
         }
 
         var rowFilter = b.And(b.Eq(c => c.TenantId, tenantId), b.Eq(c => c.Id, head.Id));

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
@@ -294,16 +294,12 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         // PersistenceStage, whose Reject (e.g.
         // UpdateAdjudicationProjectionAsync returned false) MUST surface
         // on the emitted event so subscribers don't see a Pass for a
-        // claim whose adjudication never persisted.
-        var results = context.StageResults;
-
-        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Reject))
-            return ClaimAdjudicationOutcome.Reject;
-        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Deny))
-            return ClaimAdjudicationOutcome.Deny;
-        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Pend))
-            return ClaimAdjudicationOutcome.Pend;
-        return ClaimAdjudicationOutcome.Pass;
+        // claim whose adjudication never persisted. Called here AFTER
+        // every stage including Persistence has run (see
+        // ClaimAdjudicationStageResult.ResolveOutcome, the shared
+        // precedence rule; PersistenceStage itself calls it one stage
+        // earlier to decide the ClaimStatus.Pended projection).
+        return ClaimAdjudicationStageResult.ResolveOutcome(context.StageResults);
     }
 
     private bool IsEnabled(IClaimAdjudicationStage stage)

--- a/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/IClaimAdjudicationStage.cs
@@ -107,6 +107,30 @@ public class ClaimAdjudicationStageResult
             Outcome = ClaimAdjudicationOutcome.Deny,
             Reason = reason
         };
+
+    /// <summary>
+    /// Precedence rule for combining every stage's result into one
+    /// adjudication outcome: Reject &gt; Deny &gt; Pend &gt; Pass. Shared by
+    /// two callers that need it at two different points in the pipeline:
+    /// <see cref="Stages.PersistenceStage"/> calls this with
+    /// <c>context.StageResults</c> as they stand BEFORE Persistence's own
+    /// result is appended (Persistence is always <c>Order=999</c>, i.e.
+    /// last) to decide whether the orchestrator computed a Pend and
+    /// therefore whether to persist <c>ClaimStatus.Pended</c>; the
+    /// orchestrator's own final-outcome resolution (used to label the
+    /// emitted Service Bus event) calls this AFTER every stage including
+    /// Persistence has run, so a persistence failure (Reject) still wins.
+    /// </summary>
+    public static ClaimAdjudicationOutcome ResolveOutcome(IReadOnlyList<ClaimAdjudicationStageResult> results)
+    {
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Reject))
+            return ClaimAdjudicationOutcome.Reject;
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Deny))
+            return ClaimAdjudicationOutcome.Deny;
+        if (results.Any(r => r.Outcome == ClaimAdjudicationOutcome.Pend))
+            return ClaimAdjudicationOutcome.Pend;
+        return ClaimAdjudicationOutcome.Pass;
+    }
 }
 
 /// <summary>

--- a/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStage.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using ClaimsService.Models;
 using ClaimsService.Models.Adjudication;
 using ClaimsService.Services.Resolution;
 using CloudHealthOffice.CobEngine.Domain;
@@ -77,9 +78,29 @@ namespace ClaimsService.Services.Adjudication.Stages;
 /// stable machine reason code (<c>cob-secondary-not-supported-phase-1</c>,
 /// <c>cob-coverage-service-unavailable</c>); the
 /// <see cref="ClaimAdjudicationStageResult.Reason"/> is the human-readable
-/// reason that surfaces on the work-queue UI. PendDetails is NOT touched
-/// — that channel is reserved for NCCI's deterministic edit-failure
-/// snapshots (5.7).
+/// reason that surfaces on the work-queue UI.
+/// </para>
+///
+/// <para>
+/// <b>Pend-persistence defect fix.</b> This stage used to leave
+/// <see cref="ClaimAdjudicationContext.PendDetails"/> untouched — the
+/// channel was reserved for NCCI's deterministic edit-failure snapshots
+/// (5.7) on the stated theory that "the work-queue UI uses the stage
+/// result's human-readable reason" for COB. That theory doesn't hold:
+/// <see cref="ClaimAdjudicationStageResult.Reason"/> lives only on the
+/// in-flight <see cref="ClaimAdjudicationContext.StageResults"/> for the
+/// duration of one Service Bus message handler — nothing persists it, so
+/// no work-queue UI or examiner ever actually saw it. <see cref="CobPendCode"/>
+/// (<c>"COB"</c>) was already a documented, expected
+/// <see cref="PendDetails.PendCode"/> value and the work queue already has
+/// a <c>CobRequired</c> bucket keyed on it
+/// (<c>ClaimsController.GetWorkQueueSummary</c>) — this stage simply never
+/// emitted it. Fixed: both Pend-producing paths (<see cref="BuildSecondaryOutcome"/>,
+/// <see cref="BuildDegradedOutcome"/>) now populate <c>PendDetails</c>
+/// unconditionally, mirroring <see cref="NcciEditsStage"/>'s existing
+/// precedent of recording the deterministic snapshot regardless of
+/// enforcement mode (an audit trail even when Deny mode ultimately denies
+/// the claim instead of pending it).
 /// </para>
 /// </summary>
 public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
@@ -94,6 +115,15 @@ public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
     /// <summary>Stable pend-reason code for coverage-service degradation.
     /// Distinguishes ops-triage signal from the structural Phase 2 hook.</summary>
     public const string CoverageServiceUnavailablePendReason = "cob-coverage-service-unavailable";
+
+    /// <summary>
+    /// <see cref="PendDetails.PendCode"/> value for COB pends. Already a
+    /// documented, recognized value (see <see cref="PendDetails.PendCode"/>'s
+    /// own doc comment and the work queue's <c>CobRequired</c> bucket in
+    /// <c>ClaimsController.GetWorkQueueSummary</c>) — no new pend vocabulary
+    /// introduced here.
+    /// </summary>
+    public const string CobPendCode = "COB";
 
     /// <summary>Sentinel <see cref="InsuredInfo.PayerId"/> for CHO when
     /// constructing the engine input. <see cref="ResolvedBenefitPlan"/>
@@ -288,6 +318,22 @@ public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
             AppliedRule = appliedRule,
         };
 
+        // Defect B fix — record the deterministic COB-secondary/tertiary
+        // snapshot on PendDetails regardless of enforcement mode, mirroring
+        // NcciEditsStage.ApplyFailureSnapshots. In Deny mode the claim still
+        // ends up Denied (Deny outweighs Pend in the orchestrator's
+        // precedence), but the audit trail explains why COB fired.
+        context.PendDetails = new PendDetails
+        {
+            PendCode = CobPendCode,
+            PendReason = TruncatePendReason(
+                $"CHO-secondary COB detected ({classification.Scenario}); primary payer " +
+                $"{classification.PrimaryPayerName ?? "unknown"}; secondary claim calculation " +
+                $"deferred to Phase 2. Reason code: {SecondaryNotSupportedPendReason}."),
+            PendedAt = DateTime.UtcNow,
+            EditFailures = new List<NcciEditFailureSnapshot>(),
+        };
+
         return BuildModeDrivenSecondaryResult(activity);
     }
 
@@ -416,6 +462,18 @@ public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
             PendReason = CoverageServiceUnavailablePendReason,
         };
 
+        // Defect B fix — same audit-trail posture as BuildSecondaryOutcome:
+        // record the snapshot regardless of mode.
+        context.PendDetails = new PendDetails
+        {
+            PendCode = CobPendCode,
+            PendReason = TruncatePendReason(
+                $"Coverage-service unavailable; unable to determine payer order for COB. " +
+                $"Reason code: {CoverageServiceUnavailablePendReason}."),
+            PendedAt = DateTime.UtcNow,
+            EditFailures = new List<NcciEditFailureSnapshot>(),
+        };
+
         if (_options.CobMode == CobEnforcementMode.SoftValidation)
         {
             activity?.SetTag("cob.outcome_mode", "softvalidation");
@@ -467,6 +525,14 @@ public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
 
     private static string SanitizeForLog(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+
+    private static string? TruncatePendReason(string? reason)
+    {
+        if (reason is null) return null;
+        // PendDetails.PendReason has [StringLength(500)] — mirrors
+        // NcciEditsStage.TruncatePendReason.
+        return reason.Length <= 500 ? reason : reason.Substring(0, 500);
+    }
 
     /// <summary>Internal classification result threaded through the
     /// stage's outcome builders. Public for the test project via

--- a/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/CoordinationOfBenefitsStage.cs
@@ -327,7 +327,7 @@ public sealed class CoordinationOfBenefitsStage : IClaimAdjudicationStage
         {
             PendCode = CobPendCode,
             PendReason = TruncatePendReason(
-                $"CHO-secondary COB detected ({classification.Scenario}); primary payer " +
+                $"Cloud Health Office is the secondary payer ({classification.Scenario}); primary payer " +
                 $"{classification.PrimaryPayerName ?? "unknown"}; secondary claim calculation " +
                 $"deferred to Phase 2. Reason code: {SecondaryNotSupportedPendReason}."),
             PendedAt = DateTime.UtcNow,

--- a/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
@@ -50,6 +50,19 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
         ClaimAdjudicationContext context,
         CancellationToken ct)
     {
+        // Defect A fix — the orchestrator's Pend decision (NCCI/MUE, COB) was
+        // being computed correctly by upstream stages but never reached
+        // ClaimStatus: this repository call previously had no way to know a
+        // Pend had been decided. Resolve it here from every stage that ran
+        // BEFORE Persistence (Order=999, always last) using the same
+        // Reject>Deny>Pend>Pass precedence the orchestrator uses for the
+        // emitted event's Outcome (ClaimAdjudicationStageResult.ResolveOutcome).
+        // Reject/Deny/Pass outcomes leave isPend=false, so the repository's
+        // status-write behavior for those outcomes is unchanged from before
+        // this fix — this call site only ever adds a status write for Pend.
+        var isPend = ClaimAdjudicationStageResult.ResolveOutcome(context.StageResults)
+            == ClaimAdjudicationOutcome.Pend;
+
         try
         {
             var written = await _repository
@@ -59,7 +72,8 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
                     context.AdjudicationResult,
                     context.LineAdjudicationResults,
                     ct,
-                    pendDetails: context.PendDetails)
+                    pendDetails: context.PendDetails,
+                    isPend: isPend)
                 .ConfigureAwait(false);
 
             if (!written)

--- a/src/tools/mcc-platform-validator/PendDiagnostics.cs
+++ b/src/tools/mcc-platform-validator/PendDiagnostics.cs
@@ -1,0 +1,363 @@
+using System.Text.Json;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+/// <summary>
+/// Diagnostic-only instrumentation for expected-pend MCC scenarios (episode
+/// investigation into PR #841's finding that expected-pend claims never reach
+/// <c>ClaimStatus.Pended</c> through the validator's direct HTTP path).
+///
+/// <para>
+/// Read-only with respect to adjudication: this collector performs additional
+/// <c>GET /api/claims/{id}</c> reads after the timed benchmark window closes
+/// (same posture as <see cref="MccClaimStatusObserver"/> pend observation) and
+/// writes a report artifact. It never calls any write endpoint and never
+/// changes a claim's disposition.
+/// </para>
+///
+/// <para>
+/// Off by default; only runs when <see cref="ValidatorOptions.PendDiagnosticsPath"/>
+/// is set. A diagnostics-on run is not a valid throughput benchmark — see
+/// <see cref="PendDiagnosticsReport.Note"/>.
+/// </para>
+/// </summary>
+internal static class PendDiagnostics
+{
+    /// <summary>
+    /// Business denial code emitted by <c>AdjudicationController.Adjudicate</c>
+    /// (src/services/benefit-plan-service/Controllers/AdjudicationController.cs)
+    /// when the NCCI/MUE engine fails an edit. The Argo workflow's
+    /// <c>update-claim-step</c> is the only code path that redirects this code to
+    /// a pend instead of a denial — see PR description for the full trace.
+    /// </summary>
+    public const string NcciMueDenialCode = "NCCI_MUE_EDIT_FAILURE";
+
+    private const string UnlabeledNcciSampleScenario = "(unlabeled NCCI/MUE sample)";
+
+    /// <summary>
+    /// Every expected-pend claim, plus a bounded sample of claims that failed
+    /// NCCI/MUE edits (denied today) regardless of what the answer key expects —
+    /// the Argo design treats NCCI/MUE as pendable, so their current denial
+    /// codes are evidence for the edit-model severity design (Deliverable 3.3).
+    /// </summary>
+    public static IReadOnlyList<ClaimValidationResult> SelectCandidates(
+        IReadOnlyList<ClaimValidationResult> results,
+        int ncciSampleSize)
+    {
+        var expectedPend = results
+            .Where(r => r.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString())
+            .ToList();
+
+        var ncciSample = results
+            .Where(r => r.ExpectedOutcome != ClaimValidationOutcome.Pended.ToString()
+                && string.Equals(r.BusinessDenialCode, NcciMueDenialCode, StringComparison.Ordinal))
+            .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
+            .Take(Math.Max(0, ncciSampleSize))
+            .ToList();
+
+        return expectedPend.Concat(ncciSample).ToList();
+    }
+
+    public static async Task<PendDiagnosticsReport> CollectAsync(
+        HttpClient http,
+        ValidatorOptions options,
+        IReadOnlyList<ClaimValidationResult> results,
+        CancellationToken ct = default)
+    {
+        var candidates = SelectCandidates(results, options.PendDiagnosticsNcciSampleSize);
+        var rows = new List<PendDiagnosticRow>(candidates.Count);
+
+        foreach (var candidate in candidates)
+        {
+            rows.Add(await BuildRowAsync(http, options, candidate, ct).ConfigureAwait(false));
+        }
+
+        var orderedRows = rows
+            .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
+            .ToList();
+
+        return new PendDiagnosticsReport(
+            DateTimeOffset.UtcNow,
+            options.TenantId,
+            options.Claims,
+            orderedRows.Count,
+            "Diagnostics-on runs are NOT valid throughput benchmarks. This report performs one " +
+            "additional claims-service read per diagnosed claim after the timed benchmark window " +
+            "closes (same posture as --pend-observation); it does not affect P95/P99/throughput.",
+            orderedRows,
+            BuildScenarioSummaries(orderedRows));
+    }
+
+    private static async Task<PendDiagnosticRow> BuildRowAsync(
+        HttpClient http,
+        ValidatorOptions options,
+        ClaimValidationResult result,
+        CancellationToken ct)
+    {
+        ClaimStateSnapshot? state = null;
+        string? fetchError = null;
+
+        if (!string.IsNullOrWhiteSpace(result.SubmittedClaimId))
+        {
+            try
+            {
+                using var response = await http
+                    .GetAsync($"{options.ClaimsUrl}/api/claims/{result.SubmittedClaimId}", ct)
+                    .ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    using var document = JsonDocument.Parse(body);
+                    state = ClaimStateSnapshot.FromClaimJson(document.RootElement);
+                }
+                else
+                {
+                    fetchError = $"claims-service returned {(int)response.StatusCode}";
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                fetchError = $"claim state fetch failed: {ex.Message}";
+            }
+        }
+        else
+        {
+            fetchError = "no submitted claim id (platform failure before submission)";
+        }
+
+        return new PendDiagnosticRow(
+            result.GeneratedClaimId,
+            result.SubmittedClaimId,
+            result.ClaimType,
+            string.IsNullOrWhiteSpace(result.ValidationScenario) ? UnlabeledNcciSampleScenario : result.ValidationScenario,
+            result.ExpectedOutcome,
+            result.ExpectedBusinessDenialCode,
+            result.ValidationStatus,
+            result.Outcome.ToString(),
+            result.AdjudicationSuccess,
+            result.BusinessDenialCode,
+            result.Error,
+            result.SyncAdjudicationSnapshot,
+            state?.Status,
+            state?.PendCode,
+            state?.PendReason,
+            state?.DenialReasonCode,
+            state?.DenialReason,
+            state?.Lines ?? Array.Empty<PendDiagnosticLineOutcome>(),
+            fetchError);
+    }
+
+    public static IReadOnlyList<PendDiagnosticScenarioSummary> BuildScenarioSummaries(
+        IReadOnlyList<PendDiagnosticRow> rows)
+    {
+        return rows
+            .GroupBy(r => r.Scenario, StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g =>
+            {
+                var deniedBreakdown = g
+                    .Where(r => r.Outcome == ClaimValidationOutcome.BusinessDenial.ToString())
+                    .GroupBy(r => r.SynchronousBusinessDenialCode ?? r.PersistedDenialReasonCode ?? "UNKNOWN", StringComparer.Ordinal)
+                    .OrderByDescending(dg => dg.Count())
+                    .ThenBy(dg => dg.Key, StringComparer.Ordinal)
+                    .Select(dg => new PendDiagnosticDenialCount(dg.Key, dg.Count()))
+                    .ToList();
+
+                return new PendDiagnosticScenarioSummary(
+                    g.Key,
+                    g.Count(),
+                    g.Count(r => r.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()),
+                    g.Count(r => r.Outcome == ClaimValidationOutcome.Paid.ToString()),
+                    deniedBreakdown,
+                    g.Count(r => r.Outcome == ClaimValidationOutcome.Pended.ToString()),
+                    g.Count(r => r.Outcome == ClaimValidationOutcome.ObservationTimeout.ToString()));
+            })
+            .ToList();
+    }
+
+    public static async Task WriteReportAsync(string path, PendDiagnosticsReport report, JsonSerializerOptions json)
+    {
+        var directory = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(report, json));
+        Console.WriteLine($"  Pend diagnostics:   {path} ({report.DiagnosedClaimCount:N0} claims)");
+    }
+
+    public static void PrintAggregateTable(PendDiagnosticsReport report)
+    {
+        Console.WriteLine();
+        Console.WriteLine("Pend diagnostics (internal engineering finding — NOT a throughput benchmark)");
+        Console.WriteLine($"  {report.Note}");
+        Console.WriteLine();
+        Console.WriteLine($"  {"Scenario",-34} {"Total",6} {"ExpPend",7} {"Paid",6} {"Pended",6} {"Timeout",7}  Denied (by code)");
+        foreach (var scenario in report.ScenarioSummaries)
+        {
+            var deniedText = scenario.DeniedBreakdown.Count == 0
+                ? "-"
+                : string.Join(", ", scenario.DeniedBreakdown.Select(d => $"{d.Code}={d.Count}"));
+            Console.WriteLine(
+                $"  {scenario.Scenario,-34} {scenario.Total,6:N0} {scenario.ExpectedPendCount,7:N0} {scenario.ObservedPaid,6:N0} {scenario.ObservedPended,6:N0} {scenario.ObservedTimeouts,7:N0}  {deniedText}");
+        }
+        Console.WriteLine();
+    }
+}
+
+/// <summary>Parsed subset of the claims-service <c>GET /api/claims/{id}</c> body relevant to pend diagnostics.</summary>
+internal sealed record ClaimStateSnapshot(
+    string Status,
+    string? PendCode,
+    string? PendReason,
+    string? DenialReasonCode,
+    string? DenialReason,
+    IReadOnlyList<PendDiagnosticLineOutcome> Lines)
+{
+    public static ClaimStateSnapshot FromClaimJson(JsonElement root)
+    {
+        var status = ReadStatus(root);
+
+        string? pendCode = null;
+        string? pendReason = null;
+        if (root.TryGetProperty("pendDetails", out var pendDetails) && pendDetails.ValueKind == JsonValueKind.Object)
+        {
+            pendCode = ReadString(pendDetails, "pendCode");
+            pendReason = ReadString(pendDetails, "pendReason");
+        }
+
+        string? denialCode = null;
+        string? denialReason = null;
+        if (root.TryGetProperty("adjudicationResult", out var adjudicationResult) && adjudicationResult.ValueKind == JsonValueKind.Object)
+        {
+            denialCode = ReadString(adjudicationResult, "denialReasonCode");
+            denialReason = ReadString(adjudicationResult, "denialReason");
+        }
+
+        var lines = new List<PendDiagnosticLineOutcome>();
+        if (root.TryGetProperty("claimLines", out var claimLines) && claimLines.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var line in claimLines.EnumerateArray())
+            {
+                var lineNumber = line.TryGetProperty("lineNumber", out var lineNumberElement)
+                    && lineNumberElement.TryGetInt32(out var parsedLineNumber)
+                        ? parsedLineNumber
+                        : 0;
+                var procedureCode = ReadString(line, "procedureCode");
+
+                decimal? allowed = null;
+                decimal? paid = null;
+                string? lineReasonCodes = null;
+                if (line.TryGetProperty("adjudicationResult", out var lineResult) && lineResult.ValueKind == JsonValueKind.Object)
+                {
+                    allowed = ReadDecimal(lineResult, "allowedAmount");
+                    paid = ReadDecimal(lineResult, "paidAmount");
+                    if (lineResult.TryGetProperty("adjustmentReasons", out var reasons) && reasons.ValueKind == JsonValueKind.Array)
+                    {
+                        var codes = reasons.EnumerateArray()
+                            .Select(r => ReadString(r, "reasonCode"))
+                            .Where(c => !string.IsNullOrWhiteSpace(c))
+                            .ToList();
+                        lineReasonCodes = codes.Count == 0 ? null : string.Join("|", codes);
+                    }
+                }
+
+                lines.Add(new PendDiagnosticLineOutcome(lineNumber, procedureCode, allowed, paid, lineReasonCodes));
+            }
+        }
+
+        return new ClaimStateSnapshot(status, pendCode, pendReason, denialCode, denialReason, lines);
+    }
+
+    private static string ReadStatus(JsonElement root)
+    {
+        if (!root.TryGetProperty("status", out var value))
+        {
+            return "Unknown";
+        }
+
+        var raw = value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.TryGetInt32(out var number) ? number.ToString() : value.GetRawText(),
+            _ => null
+        };
+
+        return raw?.Trim() switch
+        {
+            "1" or "Submitted" => "Submitted",
+            "2" or "Received" => "Received",
+            "3" or "InAdjudication" => "InAdjudication",
+            "4" or "Pended" => "Pended",
+            "5" or "Approved" => "Approved",
+            "6" or "Denied" => "Denied",
+            "7" or "Paid" => "Paid",
+            "8" or "Voided" => "Voided",
+            "9" or "PartiallyPaid" => "PartiallyPaid",
+            null => "Unknown",
+            var other => other
+        };
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static decimal? ReadDecimal(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var value) && value.TryGetDecimal(out var number)
+            ? number
+            : null;
+}
+
+internal sealed record PendDiagnosticLineOutcome(
+    int LineNumber,
+    string? ProcedureCode,
+    decimal? AllowedAmount,
+    decimal? PaidAmount,
+    string? DenialReasonCodes);
+
+/// <summary>One row per diagnosed claim (Deliverable 1 + 2.1).</summary>
+internal sealed record PendDiagnosticRow(
+    string GeneratedClaimId,
+    string? SubmittedClaimId,
+    string ClaimType,
+    string Scenario,
+    string? ExpectedOutcome,
+    string? ExpectedBusinessDenialCode,
+    string ValidationStatus,
+    string Outcome,
+    bool SynchronousAdjudicationSuccess,
+    string? SynchronousBusinessDenialCode,
+    string? Error,
+    JsonElement? SynchronousAdjudicationResponse,
+    string? PersistedClaimStatus,
+    string? PendCode,
+    string? PendReason,
+    string? PersistedDenialReasonCode,
+    string? PersistedDenialReason,
+    IReadOnlyList<PendDiagnosticLineOutcome> LineOutcomes,
+    string? ClaimStateFetchError);
+
+internal sealed record PendDiagnosticDenialCount(string Code, int Count);
+
+/// <summary>Per-scenario aggregate row (Deliverable 2.2) — pasteable into an ADR or episode packet.</summary>
+internal sealed record PendDiagnosticScenarioSummary(
+    string Scenario,
+    int Total,
+    int ExpectedPendCount,
+    int ObservedPaid,
+    IReadOnlyList<PendDiagnosticDenialCount> DeniedBreakdown,
+    int ObservedPended,
+    int ObservedTimeouts);
+
+internal sealed record PendDiagnosticsReport(
+    DateTimeOffset GeneratedAtUtc,
+    string TenantId,
+    int RequestedClaims,
+    int DiagnosedClaimCount,
+    string Note,
+    IReadOnlyList<PendDiagnosticRow> Rows,
+    IReadOnlyList<PendDiagnosticScenarioSummary> ScenarioSummaries);

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -42,6 +42,7 @@ Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
 Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
 Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled ({options.PendObservationTimeoutSeconds}s/{options.PendObservationIntervalMilliseconds}ms)" : " disabled")}");
+Console.WriteLine($"  Pend diag:   {(options.PendDiagnosticsPath is not null ? $"enabled -> {options.PendDiagnosticsPath}" : "disabled")}");
 Console.WriteLine();
 
 await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
@@ -110,6 +111,13 @@ if (options.PendObservationEnabled)
     orderedResults = await ObserveExpectedPendResultsAsync(http, options, orderedResults);
 }
 
+if (!string.IsNullOrWhiteSpace(options.PendDiagnosticsPath))
+{
+    var diagnosticsReport = await PendDiagnostics.CollectAsync(http, options, orderedResults);
+    await PendDiagnostics.WriteReportAsync(options.PendDiagnosticsPath, diagnosticsReport, json);
+    PendDiagnostics.PrintAggregateTable(diagnosticsReport);
+}
+
 var summary = MccRunSummaryBuilder.Build(orderedResults, total.Elapsed, options, runStartedAtUtc, DateTimeOffset.UtcNow);
 WriteSummary(summary);
 
@@ -157,7 +165,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
 
         failureStage = "adjudicate";
         stage.Restart();
-        var adjudicated = await AdjudicateClaimAsync(http, options, claim, submitted.Id, validationPlanId, networkTier, json);
+        var (adjudicated, adjudicationRawBody) = await AdjudicateClaimAsync(http, options, claim, submitted.Id, validationPlanId, networkTier, json);
         stage.Stop();
         adjudicationElapsed = stage.Elapsed;
 
@@ -178,6 +186,18 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
 
+        // Diagnostics-only capture (Deliverable 1): only retained when --pend-diagnostics
+        // is on, and only for expected-pend claims or the NCCI/MUE denial sample — never
+        // parsed on the hot path otherwise, so benchmark timing is unaffected when off.
+        JsonElement? syncAdjudicationSnapshot = null;
+        if (!string.IsNullOrWhiteSpace(options.PendDiagnosticsPath)
+            && (expectedValidation.ExpectedOutcome is ClaimValidationOutcome.Pended
+                || string.Equals(businessDenialCode, PendDiagnostics.NcciMueDenialCode, StringComparison.Ordinal)))
+        {
+            using var rawDocument = JsonDocument.Parse(adjudicationRawBody);
+            syncAdjudicationSnapshot = rawDocument.RootElement.Clone();
+        }
+
         return new ClaimValidationResult(
             claim.ClaimId,
             submitted.Id,
@@ -197,7 +217,8 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             adjudicated.Timings ?? new Dictionary<string, double>(),
             businessDenialCode,
             null,
-            null);
+            null,
+            syncAdjudicationSnapshot);
     }
     catch (Exception ex)
     {
@@ -967,7 +988,7 @@ static async Task<SubmittedClaim> SubmitClaimAsync(
     return new SubmittedClaim(id);
 }
 
-static async Task<AdjudicationResponseDto> AdjudicateClaimAsync(
+static async Task<(AdjudicationResponseDto Response, string RawBody)> AdjudicateClaimAsync(
     HttpClient http,
     ValidatorOptions options,
     SyntheticClaim claim,
@@ -1011,14 +1032,14 @@ static async Task<AdjudicationResponseDto> AdjudicateClaimAsync(
         if (response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity
             && TryParseBusinessDenial(body, json, out var denial))
         {
-            return denial with { ClaimId = submittedClaimId };
+            return (denial with { ClaimId = submittedClaimId }, body);
         }
 
         throw new InvalidOperationException($"adjudication failed ({claim.ClaimId}): {(int)response.StatusCode} {body}");
     }
 
     var result = JsonSerializer.Deserialize<AdjudicationResponseDto>(body, json);
-    return result ?? throw new InvalidOperationException($"adjudication returned empty response ({claim.ClaimId})");
+    return (result ?? throw new InvalidOperationException($"adjudication returned empty response ({claim.ClaimId})"), body);
 }
 
 static bool TryParseBusinessDenial(
@@ -1443,6 +1464,14 @@ static void PrintUsage()
                                  Max wait for expected-pend claims after benchmark timing stops (default: 45)
       --pend-observation-interval-ms <ms>
                                  Poll interval for expected-pend claim status (default: 1000)
+      --pend-diagnostics <path>  Write a per-claim pend diagnostic report (JSON) for expected-pend
+                                 scenarios and a sample of NCCI/MUE denials; prints an aggregate
+                                 scenario table to the run summary. Off by default; adds one
+                                 claims-service read per diagnosed claim AFTER the timed benchmark
+                                 window closes — a diagnostics-on run is not a throughput benchmark.
+      --pend-diagnostics-ncci-sample <n>
+                                 Max NCCI/MUE-denied claims (outside expected-pend) to include in
+                                 the diagnostic report (default: 200)
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 10)
       -p, --parallelism <count>  Number of claims to process concurrently (default: 10)
@@ -1508,7 +1537,8 @@ internal sealed record ClaimValidationResult(
     IReadOnlyDictionary<string, double> AdjudicationStepTimings,
     string? BusinessDenialCode,
     string? FailureStage,
-    string? Error);
+    string? Error,
+    JsonElement? SyncAdjudicationSnapshot = null);
 
 internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationRun Run,

--- a/src/tools/mcc-platform-validator/README.md
+++ b/src/tools/mcc-platform-validator/README.md
@@ -62,3 +62,36 @@ Expected-pend scenarios score as:
   timeout.
 - `Unsupported` only when a future expected-pend subtype requires a signal the
   validator still cannot distinguish from persisted claim state.
+
+## Pend Diagnostics (`--pend-diagnostics`)
+
+Off by default. When given a path, the validator captures, for every
+expected-pend claim and a bounded sample of NCCI/MUE-denied claims (see
+`--pend-diagnostics-ncci-sample`, default 200):
+
+- The answer-key expectation (scenario, expected disposition).
+- The full synchronous adjudication response from
+  `POST /api/v1/adjudication/adjudicate` (`Success`, every denial/error field
+  present, totals) — captured verbatim, not reshaped.
+- The post-adjudication claim state read back from claims-service
+  (`ClaimStatus`, `PendDetails`, persisted denial code/reason, per-line
+  adjustment reasons when the claim model exposes them).
+- The validator's own scoring result (`Matched` / `Mismatched` /
+  `ObservationTimeout` / `Unsupported`).
+
+This produces two things:
+
+1. A JSON report at the given path — one row per diagnosed claim. Diffable,
+   and easy to aggregate or load into a notebook.
+2. An aggregate table printed to the run summary — per scenario: expected
+   pend count, observed Paid, observed Denied (grouped by denial code),
+   observed Pended, and observation timeouts. This table is meant to be
+   pasted directly into an ADR or episode packet.
+
+**This is diagnostic instrumentation only.** It changes no dispositions, no
+engine logic, no claim state handling. It performs one additional
+`GET /api/claims/{id}` read per diagnosed claim, and that read happens after
+`total.Stop()` — the same posture as `--pend-observation` — so it never
+affects P95/P99/throughput. But a diagnostics-on run reads more claims than a
+diagnostics-off run of the same size, so **do not report a diagnostics-on
+run's timing as a throughput benchmark result.**

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -12,6 +12,8 @@ public sealed record ValidatorOptions(
     bool PendObservationEnabled,
     int PendObservationTimeoutSeconds,
     int PendObservationIntervalMilliseconds,
+    string? PendDiagnosticsPath,
+    int PendDiagnosticsNcciSampleSize,
     int TimeoutSeconds,
     int ProgressEvery,
     int Parallelism,
@@ -65,6 +67,12 @@ public sealed record ValidatorOptions(
                     break;
                 case "--pend-observation-interval-ms" when i + 1 < args.Length:
                     options.PendObservationIntervalMilliseconds = int.Parse(args[++i]);
+                    break;
+                case "--pend-diagnostics" when i + 1 < args.Length:
+                    options.PendDiagnosticsPath = args[++i];
+                    break;
+                case "--pend-diagnostics-ncci-sample" when i + 1 < args.Length:
+                    options.PendDiagnosticsNcciSampleSize = int.Parse(args[++i]);
                     break;
                 case "--timeout" when i + 1 < args.Length:
                     options.TimeoutSeconds = int.Parse(args[++i]);
@@ -129,6 +137,8 @@ public sealed record ValidatorOptions(
             options.PendObservationEnabled,
             Math.Clamp(options.PendObservationTimeoutSeconds, 1, 300),
             Math.Clamp(options.PendObservationIntervalMilliseconds, 100, 30_000),
+            string.IsNullOrWhiteSpace(options.PendDiagnosticsPath) ? null : options.PendDiagnosticsPath,
+            Math.Clamp(options.PendDiagnosticsNcciSampleSize, 0, 100_000),
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
@@ -154,6 +164,8 @@ public sealed record ValidatorOptions(
         public bool PendObservationEnabled { get; set; } = true;
         public int PendObservationTimeoutSeconds { get; set; } = 45;
         public int PendObservationIntervalMilliseconds { get; set; } = 1000;
+        public string? PendDiagnosticsPath { get; set; }
+        public int PendDiagnosticsNcciSampleSize { get; set; } = 200;
         public int TimeoutSeconds { get; set; } = 60;
         public int ProgressEvery { get; set; } = 10;
         public int Parallelism { get; set; } = 10;

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
@@ -75,7 +75,7 @@ public class WorkQueueVisibilityTests : IClassFixture<ClaimsApiFactory>
         PendDetails = new PendDetails
         {
             PendCode = "COB",
-            PendReason = "CHO-secondary COB detected; primary payer Aetna",
+            PendReason = "Cloud Health Office is the secondary payer; primary payer Aetna",
             PendedAt = DateTime.UtcNow.AddDays(-1),
         },
         ClaimLines = new List<ClaimLine>

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
@@ -1,0 +1,164 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Controllers;
+
+/// <summary>
+/// Pend-persistence defect fix — task requirement 3: a claim pended via
+/// the fixed path (<c>ClaimStatus.Pended</c> + populated <c>PendDetails</c>)
+/// must appear in the examiner work queue, which filters on
+/// <c>IClaimRepository.SearchAsync(..., status: ClaimStatus.Pended, ...)</c>
+/// (<c>ClaimsController.GetWorkQueueSummary</c> / <c>GetWorkQueueItems</c>).
+/// Before the fix, no code path ever produced a claim in this shape, so
+/// this query always returned empty for orchestrator-pended claims.
+/// </summary>
+public class WorkQueueVisibilityTests : IClassFixture<ClaimsApiFactory>
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _client;
+    private readonly IClaimRepository _repo;
+
+    public WorkQueueVisibilityTests(ClaimsApiFactory factory)
+    {
+        _repo = factory.ClaimRepository;
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+        _repo.ClearReceivedCalls();
+    }
+
+    private static Claim NcciPendedClaim() => new()
+    {
+        Id = "claim-ncci-pended",
+        TenantId = "test-tenant",
+        ClaimNumber = "CLM-NCCI-PENDED",
+        Status = ClaimStatus.Pended,
+        VersionState = ClaimVersionState.Submitted,
+        BillingProviderNPI = "1234567890",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        MemberId = "MEM-1",
+        TotalChargeAmount = 200m,
+        ServiceDateFrom = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        LastUpdatedDate = DateTime.UtcNow.AddDays(-2),
+        PendDetails = new PendDetails
+        {
+            PendCode = "NCCI",
+            PendReason = "bundled pair NE001",
+            PendedAt = DateTime.UtcNow.AddDays(-2),
+        },
+        ClaimLines = new List<ClaimLine>
+        {
+            new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 100m, Units = 1 },
+            new() { LineNumber = 2, ProcedureCode = "99214", ChargeAmount = 100m, Units = 1 },
+        },
+    };
+
+    private static Claim CobPendedClaim() => new()
+    {
+        Id = "claim-cob-pended",
+        TenantId = "test-tenant",
+        ClaimNumber = "CLM-COB-PENDED",
+        Status = ClaimStatus.Pended,
+        VersionState = ClaimVersionState.Submitted,
+        BillingProviderNPI = "1234567890",
+        LineOfBusiness = LineOfBusiness.Commercial,
+        MemberId = "MEM-2",
+        TotalChargeAmount = 100m,
+        ServiceDateFrom = new DateTime(2026, 5, 2, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2026, 5, 2, 0, 0, 0, DateTimeKind.Utc),
+        LastUpdatedDate = DateTime.UtcNow.AddDays(-1),
+        PendDetails = new PendDetails
+        {
+            PendCode = "COB",
+            PendReason = "CHO-secondary COB detected; primary payer Aetna",
+            PendedAt = DateTime.UtcNow.AddDays(-1),
+        },
+        ClaimLines = new List<ClaimLine>
+        {
+            new() { LineNumber = 1, ProcedureCode = "99213", ChargeAmount = 100m, Units = 1 },
+        },
+    };
+
+    [Fact]
+    public async Task WorkQueueSummary_reflects_Ncci_and_Cob_pended_claims_by_pend_code()
+    {
+        _repo.SearchAsync(
+                memberId: null, providerNPI: null,
+                serviceDateFrom: null, serviceDateTo: null,
+                status: ClaimStatus.Pended, lineOfBusiness: null,
+                page: 1, pageSize: Arg.Any<int>())
+            .Returns(new[] { NcciPendedClaim(), CobPendedClaim() });
+
+        var response = await _client.GetAsync("/api/claims/work-queue/summary");
+        response.EnsureSuccessStatusCode();
+
+        var summary = await response.Content.ReadFromJsonAsync<WorkQueueSummaryDto>(Json);
+        Assert.NotNull(summary);
+        Assert.Equal(1, summary!.NcciEditFailures);
+        Assert.Equal(1, summary.CobRequired);
+        Assert.Equal(0, summary.MedicalReview);
+    }
+
+    [Fact]
+    public async Task WorkQueueItems_surfaces_pended_claim_with_examiner_relevant_fields()
+    {
+        _repo.SearchAsync(
+                memberId: null, providerNPI: null,
+                serviceDateFrom: null, serviceDateTo: null,
+                status: ClaimStatus.Pended, lineOfBusiness: null,
+                page: 1, pageSize: Arg.Any<int>())
+            .Returns(new[] { NcciPendedClaim() });
+
+        var response = await _client.GetAsync("/api/claims/work-queue/items");
+        response.EnsureSuccessStatusCode();
+
+        var items = await response.Content.ReadFromJsonAsync<List<WorkQueueItemDto>>(Json);
+        Assert.NotNull(items);
+        var item = Assert.Single(items!);
+        Assert.Equal("claim-ncci-pended", item.ClaimId);
+        Assert.Equal("NCCI", item.QueueReasonCode);
+        Assert.Equal("NCCI Edit Failure", item.QueueReason);
+        Assert.Equal(2, item.ProcedureCodes.Count);
+    }
+
+    [Fact]
+    public async Task WorkQueueItems_filters_by_queueType_using_pend_code()
+    {
+        _repo.SearchAsync(
+                memberId: null, providerNPI: null,
+                serviceDateFrom: null, serviceDateTo: null,
+                status: ClaimStatus.Pended, lineOfBusiness: null,
+                page: 1, pageSize: Arg.Any<int>())
+            .Returns(new[] { NcciPendedClaim(), CobPendedClaim() });
+
+        var response = await _client.GetAsync("/api/claims/work-queue/items?queueType=COB");
+        response.EnsureSuccessStatusCode();
+
+        var items = await response.Content.ReadFromJsonAsync<List<WorkQueueItemDto>>(Json);
+        Assert.NotNull(items);
+        var item = Assert.Single(items!);
+        Assert.Equal("claim-cob-pended", item.ClaimId);
+    }
+
+    private sealed class WorkQueueSummaryDto
+    {
+        public int NcciEditFailures { get; set; }
+        public int MissingAuth { get; set; }
+        public int ProviderNotContracted { get; set; }
+        public int CobRequired { get; set; }
+        public int MedicalReview { get; set; }
+    }
+
+    private sealed class WorkQueueItemDto
+    {
+        public string ClaimId { get; set; } = string.Empty;
+        public string QueueReason { get; set; } = string.Empty;
+        public string QueueReasonCode { get; set; } = string.Empty;
+        public List<string> ProcedureCodes { get; set; } = new();
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -154,12 +154,22 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                     Arg.Any<string>(), Arg.Any<DateTime>())
                 .Returns(_ => _lastCreated);
 
+            // Explicitly matches all 7 parameters (not just the leading 5) —
+            // this test's pipeline runs the real CoordinationOfBenefitsStage
+            // against the real HttpCoverageClient, which is unreachable in
+            // this test host and degrades to a Pend (Decision 7, default
+            // CobMode=PendForSecondary). PersistenceStage now resolves that
+            // to isPend=true and passes non-null PendDetails, so a stub that
+            // only specified the first 5 args (implicitly matching
+            // pendDetails=null/isPend=false) would silently stop matching.
             Repository.UpdateAdjudicationProjectionAsync(
                     Arg.Any<string>(),
                     Arg.Any<string>(),
                     Arg.Any<AdjudicationResult>(),
                     Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
-                    Arg.Any<CancellationToken>())
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<PendDetails?>(),
+                    Arg.Any<bool>())
                 .Returns(ci =>
                 {
                     ProjectionWrites.Add(new ProjectionWrite(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
@@ -1,0 +1,360 @@
+using ClaimsService.Adapters;
+using ClaimsService.Models;
+using ClaimsService.Models.Adjudication;
+using ClaimsService.Models.Messaging;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.CobEngine.Domain;
+using CloudHealthOffice.CobEngine.Services;
+using CloudHealthOffice.Infrastructure.Messaging;
+using CloudHealthOffice.NcciEngine.Configuration;
+using CloudHealthOffice.NcciEngine.Domain;
+using CloudHealthOffice.NcciEngine.Persistence;
+using CloudHealthOffice.NcciEngine.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Integration;
+
+/// <summary>
+/// Pend-persistence defect fix — end-to-end orchestrator coverage (task
+/// requirement 2). Unlike <see cref="AdjudicationWithNcciEndToEndTests"/> and
+/// <see cref="AdjudicationWithCobEndToEndTests"/> (which stand in a
+/// no-op <c>TestPersistenceStage</c>), these tests wire the REAL
+/// <see cref="PersistenceStage"/> against a repository substitute that
+/// applies the SAME precedence predicate the real Cosmos/Mongo
+/// repositories use (<see cref="ClaimRepository.IsFinalDisposition"/> —
+/// production code, not a re-implementation) to a simple in-memory claim
+/// state. This proves the orchestrator → PersistenceStage → repository
+/// call chain actually reaches <c>ClaimStatus.Pended</c> + <c>PendDetails</c>
+/// for a submitted claim fixture, with no live Cosmos/Mongo/cluster.
+/// </summary>
+public class AdjudicationPendPersistenceEndToEndTests
+{
+    private const string TenantId = "tenant-1";
+    private const string MemberId = "MEM-1";
+
+    private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
+    private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
+    private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
+    private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
+    private readonly ClaimAdapterFactory _factory;
+
+    public AdjudicationPendPersistenceEndToEndTests()
+    {
+        _adapter.Platform.Returns("cho");
+        var cache = new ClaimTenantConfigCache(
+            Substitute.For<IHttpClientFactory>(),
+            Substitute.For<IConfiguration>(),
+            NullLogger<ClaimTenantConfigCache>.Instance);
+        _factory = new ClaimAdapterFactory(new[] { _adapter }, cache, NullLogger<ClaimAdapterFactory>.Instance);
+
+        _memberResolver.GetMemberAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ResolvedMember
+            {
+                MemberId = MemberId,
+                DateOfBirth = new DateTime(1980, 6, 15, 0, 0, 0, DateTimeKind.Utc),
+                EffectiveDate = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            });
+    }
+
+    [Fact]
+    public async Task Ncci_bundled_pair_orchestrator_run_persists_Pended_status_and_PendDetails()
+    {
+        SetupAdapterReturningClaim(BuildBundledPairClaim());
+
+        var state = new FakeClaimState();
+        var ncciStage = new NcciEditsStage(
+            BuildSeededNcciEngine(),
+            Options.Create(new TenantEnforcementPolicyOptions { NcciMode = NcciEnforcementMode.PendForReview }),
+            NullLogger<NcciEditsStage>.Instance);
+        var orch = BuildOrchestrator(new IClaimAdjudicationStage[] { ncciStage }, state);
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage("ver-persist-ncci"), BuildMessageContext("ver-persist-ncci"), CancellationToken.None);
+
+        Assert.Equal(ClaimStatus.Pended, state.Status);
+        Assert.NotNull(state.PendDetails);
+        Assert.Equal("NCCI", state.PendDetails!.PendCode);
+        Assert.Single(state.PendDetails.EditFailures);
+    }
+
+    [Fact]
+    public async Task Cob_secondary_detected_orchestrator_run_persists_Pended_status_and_PendDetails()
+    {
+        SetupAdapterReturningClaim(BuildCobClaim());
+
+        var coverageClient = Substitute.For<ICoverageClient>();
+        coverageClient.GetCobEntriesAsync(TenantId, MemberId, Arg.Any<DateTime>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new CobEntry { PayerName = "Aetna", PayerId = "AET", CoverageSequence = "P" },
+            });
+        var cobStage = new CoordinationOfBenefitsStage(
+            coverageClient,
+            new PayerOrderService(),
+            Options.Create(new TenantEnforcementPolicyOptions { CobMode = CobEnforcementMode.PendForSecondary }),
+            NullLogger<CoordinationOfBenefitsStage>.Instance);
+
+        var state = new FakeClaimState();
+        var orch = BuildOrchestrator(new IClaimAdjudicationStage[] { cobStage }, state);
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage("ver-persist-cob"), BuildMessageContext("ver-persist-cob"), CancellationToken.None);
+
+        Assert.Equal(ClaimStatus.Pended, state.Status);
+        Assert.NotNull(state.PendDetails);
+        Assert.Equal("COB", state.PendDetails!.PendCode);
+        Assert.Contains("Aetna", state.PendDetails.PendReason);
+    }
+
+    [Fact]
+    public async Task Ncci_deny_mode_orchestrator_run_does_not_persist_Pended_status()
+    {
+        // Deny outweighs Pend in the resolved outcome even though NCCI still
+        // populates PendDetails as an audit-trail snapshot — the claim must
+        // NOT be left in ClaimStatus.Pended.
+        SetupAdapterReturningClaim(BuildBundledPairClaim());
+
+        var state = new FakeClaimState();
+        var ncciStage = new NcciEditsStage(
+            BuildSeededNcciEngine(),
+            Options.Create(new TenantEnforcementPolicyOptions { NcciMode = NcciEnforcementMode.Deny }),
+            NullLogger<NcciEditsStage>.Instance);
+        var orch = BuildOrchestrator(new IClaimAdjudicationStage[] { ncciStage }, state);
+
+        await orch.AdjudicateAsync(BuildSubmittedMessage("ver-persist-ncci-deny"), BuildMessageContext("ver-persist-ncci-deny"), CancellationToken.None);
+
+        Assert.NotEqual(ClaimStatus.Pended, state.Status);
+        Assert.Equal(ClaimStatus.Submitted, state.Status);
+    }
+
+    private void SetupAdapterReturningClaim(AdapterClaim claim) =>
+        _adapter.GetClaimAsync(Arg.Any<ClaimAdapterRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ClaimAdapterResponse { Platform = "cho", Claim = claim });
+
+    private ClaimAdjudicationOrchestrator BuildOrchestrator(
+        IReadOnlyList<IClaimAdjudicationStage> detectionStages,
+        FakeClaimState state)
+    {
+        var stages = detectionStages.Append(new PersistenceStage(BuildRepository(state), NullLogger<PersistenceStage>.Instance)).ToArray();
+
+        return new ClaimAdjudicationOrchestrator(
+            _factory,
+            _planResolver,
+            _memberResolver,
+            stages,
+            _eventPublisher,
+            _messageBus,
+            new AdjudicationTenantContext(),
+            Substitute.For<IClaimAdjustmentService>(),
+            Options.Create(new AdjudicationPipelineOptions()),
+            NullLogger<ClaimAdjudicationOrchestrator>.Instance);
+    }
+
+    /// <summary>
+    /// Applies the SAME precedence predicate the real Cosmos/Mongo
+    /// repositories use (<see cref="ClaimRepository.IsFinalDisposition"/>)
+    /// to a simple in-memory claim record — not a re-implementation of the
+    /// repository, just enough state to observe the effect of the
+    /// isPend/pendDetails arguments PersistenceStage passes.
+    /// </summary>
+    private static IClaimRepository BuildRepository(FakeClaimState state)
+    {
+        var repo = Substitute.For<IClaimRepository>();
+        repo.UpdateAdjudicationProjectionAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<AdjudicationResult>(),
+                Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<PendDetails?>(),
+                Arg.Any<bool>())
+            .Returns(ci =>
+            {
+                var pendDetails = ci.ArgAt<PendDetails?>(5);
+                var isPend = ci.ArgAt<bool>(6);
+
+                if (pendDetails is not null)
+                {
+                    state.PendDetails = pendDetails;
+                }
+
+                if (isPend && !ClaimRepository.IsFinalDisposition(state.Status))
+                {
+                    state.Status = ClaimStatus.Pended;
+                }
+
+                return true;
+            });
+        return repo;
+    }
+
+    private static INcciEditService BuildSeededNcciEngine()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<INcciRepository>(BuildSeededNcciRepository());
+        services.AddNcciEngine();
+        return services.BuildServiceProvider().GetRequiredService<INcciEditService>();
+    }
+
+    private static InMemoryNcciRepository BuildSeededNcciRepository()
+    {
+        var effective = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        return new InMemoryNcciRepository(
+            new[]
+            {
+                new NcciEditPair
+                {
+                    Id = $"{TenantId}_99213_99214_20250101",
+                    TenantId = TenantId,
+                    Column1Code = "99213",
+                    Column2Code = "99214",
+                    ModifierIndicator = NcciModifierIndicator.Allowed,
+                    PolicyType = NcciPolicyType.ProcedureToProc,
+                    EffectiveDate = effective,
+                },
+            },
+            Array.Empty<MueEntry>());
+    }
+
+    private static AdapterClaim BuildBundledPairClaim()
+    {
+        var serviceDate = DateTime.UtcNow.AddDays(-3).Date;
+        var claim = BuildClaimShell(serviceDate);
+        claim.ClaimLines = new List<AdapterClaimLine>
+        {
+            NewLine(1, "99213", 1, serviceDate),
+            NewLine(2, "99214", 1, serviceDate),
+        };
+        return claim;
+    }
+
+    private static AdapterClaim BuildCobClaim()
+    {
+        var serviceDate = DateTime.UtcNow.AddDays(-3).Date;
+        var claim = BuildClaimShell(serviceDate);
+        claim.ClaimLines = new List<AdapterClaimLine>
+        {
+            NewLine(1, "99213", 1, serviceDate),
+        };
+        return claim;
+    }
+
+    private static AdapterClaim BuildClaimShell(DateTime serviceDate) => new()
+    {
+        TenantId = TenantId,
+        // The orchestrator takes ClaimAdjudicationContext.ClaimVersionId from
+        // the ClaimVersionSubmittedMessage, not from these claim fields (see
+        // ClaimAdjudicationOrchestrator.AdjudicateAsync), and the repository
+        // substitute below matches on Arg.Any<string>() for both — so these
+        // values are never asserted against; they just need to be non-empty
+        // for the stages that read them (e.g. NCCI/COB logging).
+        Id = "claim-shell-1",
+        ClaimNumber = "CLM-PERSIST-1",
+        ClaimVersionId = "claim-shell-1",
+        VersionNumber = 1,
+        VersionState = ClaimVersionState.Submitted,
+        MemberId = MemberId,
+        BillingProviderNPI = "1234567893",
+        ClaimType = ClaimType.Professional,
+        ClaimFrequencyCode = "1",
+        PlaceOfServiceCode = "11",
+        TotalChargeAmount = 200m,
+        ServiceDateFrom = serviceDate,
+        ServiceDateTo = serviceDate,
+        SubmittedDate = serviceDate,
+    };
+
+    private static AdapterClaimLine NewLine(int n, string code, decimal units, DateTime serviceDate) => new()
+    {
+        LineNumber = n,
+        ProcedureCode = code,
+        Units = units,
+        ChargeAmount = 100m,
+        ServiceDateFrom = serviceDate,
+        ServiceDateTo = serviceDate,
+    };
+
+    private static ClaimVersionSubmittedMessage BuildSubmittedMessage(string claimVersionId) => new()
+    {
+        TenantId = TenantId,
+        ClaimId = claimVersionId,
+        ClaimVersionId = claimVersionId,
+        VersionNumber = 1,
+        ActorId = "actor",
+        CorrelationId = $"corr-{claimVersionId}",
+    };
+
+    private static MessageContext BuildMessageContext(string claimVersionId) => new(
+        MessageId: $"submitted:{claimVersionId}",
+        CorrelationId: $"corr-{claimVersionId}",
+        DeliveryCount: 1,
+        Properties: new Dictionary<string, string> { ["MessageType"] = "ClaimVersionSubmitted" });
+
+    private sealed class FakeClaimState
+    {
+        public ClaimStatus Status { get; set; } = ClaimStatus.Submitted;
+        public PendDetails? PendDetails { get; set; }
+    }
+
+    /// <summary>Mirrors AdjudicationWithNcciEndToEndTests' in-memory NCCI repository.</summary>
+    private sealed class InMemoryNcciRepository : INcciRepository
+    {
+        private readonly IReadOnlyList<NcciEditPair> _pairs;
+        private readonly IReadOnlyList<MueEntry> _mues;
+
+        public InMemoryNcciRepository(IReadOnlyList<NcciEditPair> pairs, IReadOnlyList<MueEntry> mues)
+        {
+            _pairs = pairs;
+            _mues = mues;
+        }
+
+        public Task<NcciEditPair?> GetEditPairAsync(
+            string tenantId, string column1Code, string column2Code,
+            DateOnly serviceDate, CancellationToken ct = default)
+        {
+            var dos = serviceDate.ToDateTime(TimeOnly.MinValue);
+            var hit = _pairs.FirstOrDefault(p =>
+                p.TenantId == tenantId
+                && p.Column1Code == column1Code
+                && p.Column2Code == column2Code
+                && p.EffectiveDate <= dos
+                && (p.TerminationDate is null || p.TerminationDate > dos));
+            return Task.FromResult<NcciEditPair?>(hit);
+        }
+
+        public Task<MueEntry?> GetMueEntryAsync(
+            string tenantId, string procedureCode,
+            DateOnly serviceDate, CancellationToken ct = default)
+        {
+            var dos = serviceDate.ToDateTime(TimeOnly.MinValue);
+            var hit = _mues.FirstOrDefault(m =>
+                m.TenantId == tenantId
+                && m.ProcedureCode == procedureCode
+                && m.EffectiveDate <= dos
+                && (m.TerminationDate is null || m.TerminationDate > dos));
+            return Task.FromResult<MueEntry?>(hit);
+        }
+
+        public Task<(int PairsWritten, int MueWritten)> UpsertQuarterAsync(
+            string tenantId, string quarter,
+            IReadOnlyList<NcciEditPair> pairs, IReadOnlyList<MueEntry> entries,
+            CancellationToken ct = default)
+            => Task.FromResult((0, 0));
+
+        public Task<CloudHealthOffice.NcciEngine.Models.NcciTableVersion?> GetCurrentVersionAsync(
+            string tenantId, CancellationToken ct = default)
+            => Task.FromResult<CloudHealthOffice.NcciEngine.Models.NcciTableVersion?>(null);
+
+        public Task SaveVersionAsync(CloudHealthOffice.NcciEngine.Models.NcciTableVersion version, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -100,6 +100,24 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         ClaimRepository.MapStatusToVersionState(legacy).Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData(ClaimStatus.Submitted, false)]
+    [InlineData(ClaimStatus.Received, false)]
+    [InlineData(ClaimStatus.InAdjudication, false)]
+    [InlineData(ClaimStatus.Pended, false)] // not final — re-pending must be allowed
+    [InlineData(ClaimStatus.Approved, true)]
+    [InlineData(ClaimStatus.Denied, true)]
+    [InlineData(ClaimStatus.Paid, true)]
+    [InlineData(ClaimStatus.PartiallyPaid, true)]
+    [InlineData(ClaimStatus.Voided, true)]
+    public void IsFinalDisposition_truth_table_is_pinned(ClaimStatus status, bool expectedFinal)
+    {
+        // Shared by ClaimRepository (Cosmos) and ClaimRepositoryMongo so both
+        // backends apply the identical Pend-projection precedence rule; pin
+        // it here so the table is reviewed if anyone changes it.
+        ClaimRepository.IsFinalDisposition(status).Should().Be(expectedFinal);
+    }
+
     [Fact]
     public async Task CreateAsync_seeds_chain_on_first_write()
     {
@@ -299,6 +317,111 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
             Array.Empty<LineAdjudicationResult>());
 
         ok.Should().BeFalse();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Pend-persistence defect fix: isPend projects ClaimStatus.Pended
+    // (Defect A). Non-pend behavior and the terminal-disposition
+    // precedence rule are pinned here too.
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withIsPendTrue_setsStatusPendedAndPendDetails()
+    {
+        var head = await _repo.CreateAsync(BuildVersion("chain-pend-ncci", "row-1", n: 1, ClaimVersionState.Submitted));
+        head.Status.Should().Be(ClaimStatus.Submitted, "the fixture starts pre-adjudication");
+
+        var pendDetails = new PendDetails { PendCode = "NCCI", PendReason = "bundled pair NE001" };
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-pend-ncci",
+            new AdjudicationResult { AllowedAmount = 0m },
+            Array.Empty<LineAdjudicationResult>(),
+            pendDetails: pendDetails,
+            isPend: true);
+
+        ok.Should().BeTrue();
+        var reread = await _repo.GetVersionAsync("chain-pend-ncci", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Pended);
+        reread.PendDetails.Should().NotBeNull();
+        reread.PendDetails!.PendCode.Should().Be("NCCI");
+        reread.PendDetails.PendReason.Should().Be("bundled pair NE001");
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withIsPendFalse_leavesStatusUnchanged()
+    {
+        // Regression guard (task requirement 4): this bypass method has
+        // NEVER written /status for non-pend outcomes and must continue not
+        // to — even when the AdjudicationResult looks like an approval
+        // (PayerPayment > 0). Status transitions for Pass/Deny/Reject stay
+        // owned by UpdateAdjudicationSummaryAsync / UpdateAdjudication / the
+        // Argo workflow, not this method.
+        var head = await _repo.CreateAsync(BuildVersion("chain-pass", "row-1", n: 1, ClaimVersionState.Submitted));
+        head.Status.Should().Be(ClaimStatus.Submitted);
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-pass",
+            new AdjudicationResult { AllowedAmount = 150m, PayerPayment = 120m },
+            Array.Empty<LineAdjudicationResult>(),
+            isPend: false);
+
+        ok.Should().BeTrue();
+        var reread = await _repo.GetVersionAsync("chain-pass", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Submitted, "isPend=false must never touch /status, matching pre-fix behavior");
+        reread.AdjudicationResult.Should().NotBeNull("the non-status projection fields still write as before");
+        reread.AdjudicationResult!.PayerPayment.Should().Be(120m);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withIsPendTrue_onAlreadyApprovedClaim_doesNotDowngradeStatus()
+    {
+        // Precedence rule (task requirement A.3): a claim that already
+        // reached a later-stage disposition — e.g. because the Argo
+        // workflow's synchronous finalize step, or an examiner override,
+        // raced ahead of this async projection — must never be downgraded
+        // back to Pended. Approved maps to VersionState.Adjudicated, which
+        // is NOT terminal for VersionState purposes (re-adjudication is
+        // allowed), so this precedence check is the only thing protecting
+        // ClaimStatus here.
+        var head = BuildVersion("chain-already-approved", "row-1", n: 1, ClaimVersionState.Adjudicated);
+        head.Status = ClaimStatus.Approved;
+        await _repo.CreateAsync(head);
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-already-approved",
+            new AdjudicationResult { AllowedAmount = 100m },
+            Array.Empty<LineAdjudicationResult>(),
+            pendDetails: new PendDetails { PendCode = "NCCI", PendReason = "late-arriving pend" },
+            isPend: true);
+
+        ok.Should().BeTrue("the write itself still succeeds — only the /status patch is skipped");
+        var reread = await _repo.GetVersionAsync("chain-already-approved", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Approved, "a later-stage disposition must never be downgraded back to Pended");
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withIsPendTrue_onAlreadyPendedClaim_refreshesPendDetails()
+    {
+        // Pended is NOT a final disposition — a re-adjudication run that
+        // pends again (e.g. a new NCCI edit-failure set) must be allowed to
+        // refresh PendDetails and re-affirm Status=Pended.
+        var head = BuildVersion("chain-repend", "row-1", n: 1, ClaimVersionState.Submitted);
+        head.Status = ClaimStatus.Pended;
+        head.PendDetails = new PendDetails { PendCode = "NCCI", PendReason = "first pend" };
+        await _repo.CreateAsync(head);
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-repend",
+            new AdjudicationResult { AllowedAmount = 0m },
+            Array.Empty<LineAdjudicationResult>(),
+            pendDetails: new PendDetails { PendCode = "MUE", PendReason = "second pend, different edit" },
+            isPend: true);
+
+        ok.Should().BeTrue();
+        var reread = await _repo.GetVersionAsync("chain-repend", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Pended);
+        reread.PendDetails!.PendCode.Should().Be("MUE");
+        reread.PendDetails.PendReason.Should().Be("second pend, different edit");
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/CoordinationOfBenefitsStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/CoordinationOfBenefitsStageTests.cs
@@ -71,6 +71,9 @@ public class CoordinationOfBenefitsStageTests
         Assert.False(ctx.CobResult.IsMedicarePrimary);
         Assert.Null(ctx.CobResult.PendReason);
         Assert.Null(ctx.CobResult.AppliedRule);
+        // No pend condition detected — BuildPrimaryOutcome is unchanged by
+        // the Defect B fix and must not populate PendDetails.
+        Assert.Null(ctx.PendDetails);
     }
 
     [Fact]
@@ -91,6 +94,7 @@ public class CoordinationOfBenefitsStageTests
         Assert.Equal(CobScenario.ChoPrimaryWithSecondary, ctx.CobResult!.Scenario);
         Assert.False(ctx.CobResult.IsMedicarePrimary);
         Assert.Null(ctx.CobResult.PendReason);
+        Assert.Null(ctx.PendDetails);
     }
 
     [Fact]
@@ -120,6 +124,12 @@ public class CoordinationOfBenefitsStageTests
         // labels rule as ExplicitCoverageRecord (the wire signal IS
         // explicit).
         Assert.Equal(PayerOrderRule.ExplicitCoverageRecord, ctx.CobResult.AppliedRule);
+        // Defect B fix — PendDetails must be populated so the projection
+        // (PersistenceStage) has something to persist onto the claim record.
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
+        Assert.Contains("Aetna", ctx.PendDetails.PendReason);
+        Assert.Empty(ctx.PendDetails.EditFailures);
     }
 
     [Fact]
@@ -142,6 +152,8 @@ public class CoordinationOfBenefitsStageTests
         // MedicareSecondaryPayer when MedicareDesignatedPrimary=true on
         // the other coverage (Decision 16a mapping).
         Assert.Equal(PayerOrderRule.MedicareSecondaryPayer, ctx.CobResult.AppliedRule);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]
@@ -198,6 +210,14 @@ public class CoordinationOfBenefitsStageTests
         Assert.False(result.Continue, "Deny short-circuits to PersistenceStage");
         // Outcome still recorded for audit-trail richness.
         Assert.Equal(CobScenario.ChoSecondaryDetected, ctx.CobResult!.Scenario);
+        // PendDetails is populated even in Deny mode — mirrors NcciEditsStage's
+        // precedent (ApplyFailureSnapshots runs regardless of NcciMode). The
+        // claim still ends up Denied (Deny outweighs Pend in the
+        // orchestrator's Reject>Deny>Pend>Pass precedence — see
+        // ClaimAdjudicationStageResult.ResolveOutcome), but the audit trail
+        // explains why COB fired.
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]
@@ -220,6 +240,10 @@ public class CoordinationOfBenefitsStageTests
         Assert.Equal(
             CoordinationOfBenefitsStage.SecondaryNotSupportedPendReason,
             ctx.CobResult.PendReason);
+        // SoftValidation still records the audit-trail snapshot — telemetry
+        // captures the detection even though the stage outcome is Pass.
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]
@@ -237,6 +261,9 @@ public class CoordinationOfBenefitsStageTests
         Assert.Equal(
             CoordinationOfBenefitsStage.CoverageServiceUnavailablePendReason,
             ctx.CobResult.PendReason);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
+        Assert.Contains("Coverage-service unavailable", ctx.PendDetails.PendReason);
     }
 
     [Fact]
@@ -256,6 +283,8 @@ public class CoordinationOfBenefitsStageTests
         Assert.Equal(
             CoordinationOfBenefitsStage.CoverageServiceUnavailablePendReason,
             ctx.CobResult!.PendReason);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]
@@ -273,6 +302,8 @@ public class CoordinationOfBenefitsStageTests
         // Outcome still recorded — telemetry captures the degradation
         // even when soft-validation suppresses the pend.
         Assert.Equal(CobScenario.None, ctx.CobResult!.Scenario);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]
@@ -322,6 +353,8 @@ public class CoordinationOfBenefitsStageTests
         // so audit trail still records why CHO is secondary.
         Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
         Assert.Equal(PayerOrderRule.ExplicitCoverageRecord, ctx.CobResult!.AppliedRule);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal("COB", ctx.PendDetails!.PendCode);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
@@ -88,6 +88,97 @@ public class PersistenceStageTests
             () => _sut.ExecuteAsync(ctx, CancellationToken.None));
     }
 
+    // ═══════════════════════════════════════════════════════════════════
+    // Defect A fix — isPend resolution (Reject > Deny > Pend > Pass over
+    // every stage that ran before Persistence, since Persistence is
+    // always Order=999/last).
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Execute_WhenPriorStageResultIsPend_PassesIsPendTrue()
+    {
+        var ctx = BuildContext();
+        ctx.PendDetails = new PendDetails { PendCode = "NCCI", PendReason = "bundled pair" };
+        ctx.StageResults.Add(ClaimAdjudicationStageResult.Pend("NcciEdits", "pended for NCCI/MUE review"));
+        StubRepositoryReturns(true);
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        await _repository.Received(1).UpdateAdjudicationProjectionAsync(
+            "tenant-1", "ver-1",
+            Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Is<PendDetails?>(p => p!.PendCode == "NCCI"),
+            Arg.Is<bool>(isPend => isPend));
+    }
+
+    [Fact]
+    public async Task Execute_WhenNoPriorStageResults_PassesIsPendFalse()
+    {
+        var ctx = BuildContext();
+        StubRepositoryReturns(true);
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        await _repository.Received(1).UpdateAdjudicationProjectionAsync(
+            "tenant-1", "ver-1",
+            Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Is<bool>(isPend => !isPend));
+    }
+
+    [Fact]
+    public async Task Execute_WhenPriorStageResultIsDeny_PassesIsPendFalse_EvenWithPendDetailsPresent()
+    {
+        // NcciEditsStage records the deterministic edit-failure snapshot on
+        // PendDetails unconditionally, regardless of NcciMode — so a Deny-mode
+        // claim can carry non-null PendDetails while the resolved outcome is
+        // Deny, not Pend. isPend must reflect the resolved outcome (Deny wins
+        // over Pend), not merely "PendDetails is non-null".
+        var ctx = BuildContext();
+        ctx.PendDetails = new PendDetails { PendCode = "NCCI", PendReason = "bundled pair (Deny mode)" };
+        ctx.StageResults.Add(ClaimAdjudicationStageResult.Deny("NcciEdits", "denied for NCCI/MUE failure"));
+        StubRepositoryReturns(true);
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        await _repository.Received(1).UpdateAdjudicationProjectionAsync(
+            "tenant-1", "ver-1",
+            Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Is<bool>(isPend => !isPend));
+    }
+
+    [Fact]
+    public async Task Execute_WhenPriorStageResultIsReject_PassesIsPendFalse()
+    {
+        var ctx = BuildContext();
+        ctx.StageResults.Add(ClaimAdjudicationStageResult.Reject("Scrubbing", "missing NPI"));
+        StubRepositoryReturns(true);
+
+        await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        await _repository.Received(1).UpdateAdjudicationProjectionAsync(
+            "tenant-1", "ver-1",
+            Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Is<bool>(isPend => !isPend));
+    }
+
+    private void StubRepositoryReturns(bool value) =>
+        _repository.UpdateAdjudicationProjectionAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<AdjudicationResult>(),
+            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Any<bool>())
+            .Returns(value);
+
     private static ClaimAdjudicationContext BuildContext() => new()
     {
         TenantId = "tenant-1",

--- a/tests/CloudHealthOffice.IdCardService.Tests/QrCodeServiceTests.cs
+++ b/tests/CloudHealthOffice.IdCardService.Tests/QrCodeServiceTests.cs
@@ -38,7 +38,17 @@ public class QrCodeServiceTests
 
         // flip a byte in the signature segment
         var parts = qr.Split('.');
-        var flipped = parts[1].Substring(0, parts[1].Length - 1) + (parts[1][^1] == 'A' ? 'B' : 'A');
+        var signature = parts[1].Replace('-', '+').Replace('_', '/');
+        var padding = (signature.Length % 4) switch
+        {
+            2 => "==",
+            3 => "=",
+            _ => string.Empty
+        };
+        signature += padding;
+        var signatureBytes = Convert.FromBase64String(signature);
+        signatureBytes[0] ^= 0x01;
+        var flipped = Convert.ToBase64String(signatureBytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
         var bad = parts[0] + "." + flipped;
 
         var (payload, err, _) = await svc.VerifyAsync(bad);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/PendDiagnosticsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/PendDiagnosticsTests.cs
@@ -1,0 +1,152 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class PendDiagnosticsTests
+{
+    [Fact]
+    public void SelectCandidates_IncludesEveryExpectedPendClaim()
+    {
+        var results = new List<ClaimValidationResult>
+        {
+            Result("MCC-1", "EdgeCase:CobSecondaryPayer", ClaimValidationOutcome.Pended, expectedPend: true, businessDenialCode: null),
+            Result("MCC-2", "EdgeCase:SubrogationWorkersComp", ClaimValidationOutcome.BusinessDenial, expectedPend: true, businessDenialCode: "W1"),
+            Result("MCC-3", "CleanProfessionalPaid", ClaimValidationOutcome.Paid, expectedPend: false, businessDenialCode: null),
+        };
+
+        var candidates = PendDiagnostics.SelectCandidates(results, ncciSampleSize: 200);
+
+        Assert.Equal(2, candidates.Count);
+        Assert.Contains(candidates, r => r.GeneratedClaimId == "MCC-1");
+        Assert.Contains(candidates, r => r.GeneratedClaimId == "MCC-2");
+    }
+
+    [Fact]
+    public void SelectCandidates_SamplesNcciMueDenialsRegardlessOfAnswerKey()
+    {
+        var results = new List<ClaimValidationResult>
+        {
+            Result("MCC-1", "ExcludedProviderDenied", ClaimValidationOutcome.BusinessDenial, expectedPend: false, businessDenialCode: "PROVIDER_EXCLUDED"),
+            Result("MCC-2", null, ClaimValidationOutcome.BusinessDenial, expectedPend: false, businessDenialCode: "NCCI_MUE_EDIT_FAILURE"),
+            Result("MCC-3", null, ClaimValidationOutcome.BusinessDenial, expectedPend: false, businessDenialCode: "NCCI_MUE_EDIT_FAILURE"),
+        };
+
+        var candidates = PendDiagnostics.SelectCandidates(results, ncciSampleSize: 200);
+
+        Assert.Equal(2, candidates.Count);
+        Assert.All(candidates, r => Assert.Equal("NCCI_MUE_EDIT_FAILURE", r.BusinessDenialCode));
+    }
+
+    [Fact]
+    public void SelectCandidates_CapsNcciMueSampleAtConfiguredSize()
+    {
+        var results = Enumerable.Range(1, 10)
+            .Select(i => Result($"MCC-{i:D2}", null, ClaimValidationOutcome.BusinessDenial, expectedPend: false, businessDenialCode: "NCCI_MUE_EDIT_FAILURE"))
+            .ToList();
+
+        var candidates = PendDiagnostics.SelectCandidates(results, ncciSampleSize: 3);
+
+        Assert.Equal(3, candidates.Count);
+    }
+
+    [Fact]
+    public void BuildScenarioSummaries_GroupsDeniedRowsByDenialCode()
+    {
+        var rows = new List<PendDiagnosticRow>
+        {
+            Row("MCC-1", "EdgeCase:CobSecondaryPayer", expectedOutcome: "Pended", outcome: "Pended", syncDenialCode: null, persistedDenialCode: null),
+            Row("MCC-2", "EdgeCase:CobSecondaryPayer", expectedOutcome: "Pended", outcome: "Paid", syncDenialCode: null, persistedDenialCode: null),
+            Row("MCC-3", "EdgeCase:CobSecondaryPayer", expectedOutcome: "Pended", outcome: "BusinessDenial", syncDenialCode: "CARC_22", persistedDenialCode: "CARC_22"),
+            Row("MCC-4", "EdgeCase:CobSecondaryPayer", expectedOutcome: "Pended", outcome: "BusinessDenial", syncDenialCode: "CARC_22", persistedDenialCode: "CARC_22"),
+            Row("MCC-5", "EdgeCase:CobSecondaryPayer", expectedOutcome: "Pended", outcome: "ObservationTimeout", syncDenialCode: null, persistedDenialCode: null),
+        };
+
+        var summaries = PendDiagnostics.BuildScenarioSummaries(rows);
+
+        var cob = Assert.Single(summaries);
+        Assert.Equal("EdgeCase:CobSecondaryPayer", cob.Scenario);
+        Assert.Equal(5, cob.Total);
+        Assert.Equal(5, cob.ExpectedPendCount);
+        Assert.Equal(1, cob.ObservedPaid);
+        Assert.Equal(1, cob.ObservedPended);
+        Assert.Equal(1, cob.ObservedTimeouts);
+        var denialCount = Assert.Single(cob.DeniedBreakdown);
+        Assert.Equal("CARC_22", denialCount.Code);
+        Assert.Equal(2, denialCount.Count);
+    }
+
+    [Fact]
+    public void BuildScenarioSummaries_LabelsUnscopedNcciSampleRowsSeparately()
+    {
+        var rows = new List<PendDiagnosticRow>
+        {
+            Row("MCC-1", "(unlabeled NCCI/MUE sample)", expectedOutcome: "BusinessDenial", outcome: "BusinessDenial", syncDenialCode: "NCCI_MUE_EDIT_FAILURE", persistedDenialCode: "NCCI_MUE_EDIT_FAILURE"),
+        };
+
+        var summaries = PendDiagnostics.BuildScenarioSummaries(rows);
+
+        var sample = Assert.Single(summaries);
+        Assert.Equal(0, sample.ExpectedPendCount);
+        var denialCount = Assert.Single(sample.DeniedBreakdown);
+        Assert.Equal("NCCI_MUE_EDIT_FAILURE", denialCount.Code);
+    }
+
+    private static ClaimValidationResult Result(
+        string claimId,
+        string? scenario,
+        ClaimValidationOutcome outcome,
+        bool expectedPend,
+        string? businessDenialCode)
+    {
+        return new ClaimValidationResult(
+            claimId,
+            $"submitted-{claimId}",
+            "EdgeCase",
+            scenario,
+            expectedPend ? ClaimValidationOutcome.Pended.ToString() : outcome.ToString(),
+            null,
+            MccWorkflowValidation.MatchedStatus,
+            outcome,
+            outcome is ClaimValidationOutcome.Paid,
+            null,
+            null,
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(80),
+            TimeSpan.FromMilliseconds(10),
+            new Dictionary<string, double>(),
+            businessDenialCode,
+            null,
+            null);
+    }
+
+    private static PendDiagnosticRow Row(
+        string claimId,
+        string scenario,
+        string expectedOutcome,
+        string outcome,
+        string? syncDenialCode,
+        string? persistedDenialCode)
+    {
+        return new PendDiagnosticRow(
+            claimId,
+            $"submitted-{claimId}",
+            "EdgeCase",
+            scenario,
+            expectedOutcome,
+            null,
+            MccWorkflowValidation.MatchedStatus,
+            outcome,
+            SynchronousAdjudicationSuccess: outcome == "Paid",
+            SynchronousBusinessDenialCode: syncDenialCode,
+            Error: null,
+            SynchronousAdjudicationResponse: null,
+            PersistedClaimStatus: outcome,
+            PendCode: null,
+            PendReason: null,
+            PersistedDenialReasonCode: persistedDenialCode,
+            PersistedDenialReason: null,
+            LineOutcomes: Array.Empty<PendDiagnosticLineOutcome>(),
+            ClaimStateFetchError: null);
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -44,4 +44,25 @@ public class ValidatorOptionsTests
         Assert.Equal(30, options.PendObservationTimeoutSeconds);
         Assert.Equal(500, options.PendObservationIntervalMilliseconds);
     }
+
+    [Fact]
+    public void Parse_WhenPendDiagnosticsNotProvided_DefaultsToDisabled()
+    {
+        var options = ValidatorOptions.Parse([]);
+
+        Assert.Null(options.PendDiagnosticsPath);
+        Assert.Equal(200, options.PendDiagnosticsNcciSampleSize);
+    }
+
+    [Fact]
+    public void Parse_WhenPendDiagnosticsProvided_AppliesOverrides()
+    {
+        var options = ValidatorOptions.Parse([
+            "--pend-diagnostics", "/tmp/mcc-pend-diagnostics.json",
+            "--pend-diagnostics-ncci-sample", "50"
+        ]);
+
+        Assert.Equal("/tmp/mcc-pend-diagnostics.json", options.PendDiagnosticsPath);
+        Assert.Equal(50, options.PendDiagnosticsNcciSampleSize);
+    }
 }


### PR DESCRIPTION
## Summary

This PR fixes two structural defects in claims-service's async adjudication orchestrator that prevented orchestrator-computed pends (NCCI/MUE and COB) from reaching `ClaimStatus.Pended` and the examiner work queue.

**Defect A:** `UpdateAdjudicationProjectionAsync` never patched `/status` when a pend was resolved, so orchestrator-computed pends populated `PendDetails` (NCCI only) but never moved `ClaimStatus` off its pre-adjudication value. The examiner work queue filters on `ClaimStatus.Pended`, so these claims never reached human review.

**Defect B:** `CoordinationOfBenefitsStage` never wrote `PendDetails` for COB pends, leaving no audit trail and no work-queue visibility.

## Key Changes

### Claims Service Fixes

- **PersistenceStage** (`PersistenceStage.cs`): Now resolves `isPend` from all prior stage results and passes it to the repository, enabling the status projection.

- **ClaimRepository** (`ClaimRepository.cs`): 
  - Added `isPend` parameter to `UpdateAdjudicationProjectionAsync` 
  - When `isPend=true`, patches `ClaimStatus` to `Pended` subject to a precedence rule: never downgrades a claim already at a final disposition (Approved, Denied, Paid, PartiallyPaid, Voided)
  - Introduced `IsFinalDisposition()` static method to enforce this precedence consistently across both Cosmos and Mongo backends

- **CoordinationOfBenefitsStage** (`CoordinationOfBenefitsStage.cs`): Now populates `PendDetails` with `PendCode="COB"` and a human-readable reason when a secondary payer is detected, mirroring NCCI's existing pattern.

- **ClaimAdjudicationOrchestrator** (`ClaimAdjudicationOrchestrator.cs`): Refactored outcome resolution to use the shared precedence rule (Reject > Deny > Pend > Pass).

- **IClaimAdjudicationStage** (`IClaimAdjudicationStage.cs`): Added `ResolvePendOutcome()` static helper to compute the final pend decision across all stage results.

- **ClaimRepositoryMongo** (`ClaimRepositoryMongo.cs`): Updated signature to match Cosmos implementation with `isPend` parameter.

### Test Coverage

- **AdjudicationPendPersistenceEndToEndTests** (new): End-to-end orchestrator tests wiring the real `PersistenceStage` against a repository substitute that applies the actual `IsFinalDisposition` precedence rule, proving the call chain reaches `ClaimStatus.Pended` + `PendDetails` for NCCI and COB scenarios.

- **WorkQueueVisibilityTests** (new): Verifies that pended claims (NCCI and COB) appear in the examiner work queue when queried by `ClaimStatus.Pended`.

- **ClaimRepositoryVersioningTests** (modified): Added pinned truth table for `IsFinalDisposition` and tests for the new `isPend` parameter behavior.

- **PersistenceStageTests** (modified): Added tests for `isPend` resolution logic and precedence rule enforcement.

- **CoordinationOfBenefitsStageTests** (modified): Updated to verify `PendDetails` population for COB pends.

### Validator Diagnostics

- **PendDiagnostics** (new): Diagnostic-only instrumentation for investigating expected-pend scenarios. Collects every expected-pend claim plus a bounded sample of NCCI/MUE-denied claims, reads their final state from claims-service post-benchmark, and generates a report artifact. Read-only; never calls write endpoints.

- **PendDiagnosticsTests** (new): Unit tests for candidate selection and scenario summary aggregation.

- **Program.cs** (validator): Integrated pend diagnostics collection and reporting when `--pend-diagnostics` path is

https://claude.ai/code/session_01QPQXFN7Q1XB6BDNNMxq3ib