### PR TITLE
Guard pended claims from synchronous writeback

### DIFF
--- a/docs/architecture/claim-adjudication-pipeline.md
+++ b/docs/architecture/claim-adjudication-pipeline.md
@@ -215,17 +215,43 @@ Fixed as follows:
    already had a `CobRequired` bucket keyed on it; the stage simply never
    emitted it before.
 
-**Known pre-existing race, out of scope for this fix:** the Argo
-workflow's `update-claim-step` does not check for `ClaimStatus.Pended`
-before calling `PUT /api/claims/{id}/status`. If claims-service's own
-async orchestrator pends a claim (via the write path above) and the Argo
-workflow's synchronous `update-claim-step` runs afterward for the same
-claim, the workflow can still overwrite `Pended` back to `Approved` /
-`Denied` — the precedence rule in this fix only protects the
-orchestrator's own write path against a disposition that already landed;
-it doesn't (and structurally can't, from here) make the Argo workflow
-disposition-aware. Flagged as a finding for the future edit-model ADR, not
-fixed here.
+#### D9b — Synchronous write-back preserves existing pend/final statuses
+
+After D9a, a residual race remained: the Argo workflow's synchronous
+`update-claim-step` could call `PUT /api/claims/{id}/adjudication`,
+`PUT /api/claims/{id}/adjudication-summary`, or
+`PUT /api/claims/{id}/status` after the async orchestrator had already
+projected `ClaimStatus.Pended`. That later synchronous write-back only
+knew its locally computed payable/deniable disposition, so it could stomp
+the pended status back to `Approved` / `Denied` while leaving
+`PendDetails` behind.
+
+Fixed as follows:
+
+1. Claims-service status writes now route through
+   `IClaimRepository.TryTransitionStatusAsync` /
+   `UpdateAdjudicationSummaryAsync`, which apply the shared
+   `ClaimRepository.BlocksSynchronousWriteback` guard before status is
+   patched.
+2. The guard suppresses synchronous write-back when the persisted claim is
+   already `Pended` or at a final disposition (`Approved`, `Denied`,
+   `Paid`, `PartiallyPaid`, or `Voided`). It still allows normal
+   `Received` / `Submitted` / `InReview` transitions.
+3. Adjudication totals, timings, denial codes, MPIP fields, and audit data
+   still persist even when the status patch is suppressed. Only `/status`
+   is protected.
+4. Suppressed fast-summary writes return `200 OK` with
+   `AdjudicationSummaryWriteResponse` (`StatusPreserved=true`,
+   `PersistedStatus=<current status>`) instead of `204 No Content` so the
+   MCC validator can score against the authoritative persisted status.
+   Unsuppressed writes retain the previous `204 No Content` behavior.
+5. Suppressed full adjudication/status writes fold the persisted status
+   back into the response payload and skip lifecycle side effects derived
+   from a transition that did not actually apply.
+
+This guard is intentionally not a human pend-resolution path. Explicit
+examiner override remains owned by `POST work-queue/{id}/override` so a
+generic workflow write-back cannot accidentally resolve a pend.
 
 ### D10 — Resolution clients are cached HTTP clients
 
@@ -323,7 +349,7 @@ always enabled regardless.
 | `UpdateAdjudicationProjectionAsync` throws | PersistenceStage rethrows; Service Bus abandons the message and redelivers. |
 | Re-delivery for already-adjudicated claim | Orchestrator detects via populated `AdjudicationResult` and completes the message without re-running the pipeline. |
 | Orchestrator resolves `Pend`, but claim is already `Approved`/`Denied`/`Paid`/`PartiallyPaid`/`Voided` | `ClaimRepository.IsFinalDisposition` guard (D9a) skips the `/status` patch; `AdjudicationResult`/`PendDetails` still project for audit purposes. |
-| Argo workflow's `update-claim-step` runs after an async-orchestrator pend | Not guarded (pre-existing, out of scope for D9a) — the workflow can overwrite `Pended` back to `Approved`/`Denied`. Flagged as a finding for the future edit-model ADR. |
+| Argo workflow's `update-claim-step` runs after an async-orchestrator pend | Guarded by D9b: synchronous write-back preserves the persisted `Pended` status while still saving adjudication summary/audit data. |
 
 ## Replacement contract for stub stages
 

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -268,14 +268,41 @@ public class ClaimsController : ControllerBase
     }
 
     /// <summary>
-    /// Update claim status (277 claim status update)
+    /// Update claim status (277 claim status update). Called by the Argo
+    /// workflow's synchronous finalize step for every non-NCCI/MUE outcome —
+    /// currently the only live caller (the portal's Approve/Deny buttons wire
+    /// to this same client method, but are permanently disabled today: their
+    /// CanApprove/CanDeny gates are never set true anywhere in the codebase).
+    ///
+    /// Residual-race fix: <paramref name="statusUpdate"/>'s Status is applied
+    /// through the same precedence guard as <c>PUT /{id}/adjudication</c>
+    /// (<see cref="ClaimRepository.BlocksSynchronousWriteback"/>, via
+    /// <see cref="IClaimRepository.TryTransitionStatusAsync"/>) — it is
+    /// atomically decided BEFORE the full-document replace below and folded
+    /// back onto <c>claim.Status</c>, so the replace can't reintroduce a
+    /// stale value over a status the guard just protected. When suppressed,
+    /// the lifecycle-date/notes side effects below are skipped too (they're
+    /// derived from a transition that didn't actually happen), and the
+    /// response's <c>Status</c> field reports what's actually persisted
+    /// (e.g. still Pended) — no response-shape change, the field was always
+    /// there. See docs/architecture/claim-adjudication-pipeline.md D9b.
+    ///
+    /// <para>
+    /// If this endpoint's dead human-approval path is ever wired up
+    /// (CanApprove/CanDeny made reachable), it will need to route pend
+    /// resolution through an explicit action — mirroring
+    /// <c>POST work-queue/{id}/override</c> — rather than relying on this
+    /// generic status endpoint to bypass the guard; today it correctly has
+    /// no live caller that needs to resolve a pend through it.
+    /// </para>
     /// </summary>
     [HttpPut("{id}/status")]
     [ProducesResponseType(typeof(Claim), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<Claim>> UpdateClaimStatus(
         string id,
-        [FromBody] ClaimStatusUpdate statusUpdate)
+        [FromBody] ClaimStatusUpdate statusUpdate,
+        CancellationToken ct = default)
     {
         _logger.LogInformation(
             "Updating claim {Id} status to {Status}",
@@ -287,30 +314,45 @@ public class ClaimsController : ControllerBase
             return NotFound($"Claim {id} not found");
         }
 
-        claim.Status = statusUpdate.Status;
-        claim.LastUpdatedDate = DateTime.UtcNow;
-
-        // Set dates based on status
-        switch (statusUpdate.Status)
+        var statusResult = await _claimRepository.TryTransitionStatusAsync(GetTenantId(), id, statusUpdate.Status, ct);
+        if (statusResult.Outcome == StatusWriteOutcome.NotFound)
         {
-            case ClaimStatus.Received:
-                claim.ReceivedDate = DateTime.UtcNow;
-                break;
-            case ClaimStatus.Approved:
-            case ClaimStatus.Denied:
-            case ClaimStatus.PartiallyPaid:
-                claim.AdjudicatedDate = DateTime.UtcNow;
-                break;
-            case ClaimStatus.Paid:
-                claim.PaidDate = DateTime.UtcNow;
-                break;
+            return NotFound($"Claim {id} not found");
         }
 
-        if (!string.IsNullOrEmpty(statusUpdate.Notes))
+        claim.Status = statusResult.PersistedStatus!.Value;
+        claim.LastUpdatedDate = DateTime.UtcNow;
+
+        if (statusResult.Outcome == StatusWriteOutcome.Suppressed)
         {
-            claim.ClaimNotes = string.IsNullOrEmpty(claim.ClaimNotes)
-                ? statusUpdate.Notes
-                : $"{claim.ClaimNotes}\n{DateTime.UtcNow:yyyy-MM-dd HH:mm}: {statusUpdate.Notes}";
+            _logger.LogInformation(
+                "Status transition suppressed for claim {Id}: requested={Requested}, persisted={Persisted}",
+                SanitizeForLog(id), statusUpdate.Status, statusResult.PersistedStatus);
+        }
+        else
+        {
+            // Set dates based on status
+            switch (statusUpdate.Status)
+            {
+                case ClaimStatus.Received:
+                    claim.ReceivedDate = DateTime.UtcNow;
+                    break;
+                case ClaimStatus.Approved:
+                case ClaimStatus.Denied:
+                case ClaimStatus.PartiallyPaid:
+                    claim.AdjudicatedDate = DateTime.UtcNow;
+                    break;
+                case ClaimStatus.Paid:
+                    claim.PaidDate = DateTime.UtcNow;
+                    break;
+            }
+
+            if (!string.IsNullOrEmpty(statusUpdate.Notes))
+            {
+                claim.ClaimNotes = string.IsNullOrEmpty(claim.ClaimNotes)
+                    ? statusUpdate.Notes
+                    : $"{claim.ClaimNotes}\n{DateTime.UtcNow:yyyy-MM-dd HH:mm}: {statusUpdate.Notes}";
+            }
         }
 
         var updated = await _claimRepository.UpdateAsync(claim);
@@ -318,7 +360,7 @@ public class ClaimsController : ControllerBase
         // If a generic status update happens to land on Pended without going through
         // /pend, still publish the event so downstream consumers see the transition.
         // Payload will lack PendDetails — consumers must tolerate that.
-        if (updated.Status == ClaimStatus.Pended)
+        if (statusResult.Outcome == StatusWriteOutcome.Applied && updated.Status == ClaimStatus.Pended)
         {
             await _eventPublisher.PublishClaimPendedAsync(updated, GetTenantId());
         }
@@ -389,14 +431,32 @@ public class ClaimsController : ControllerBase
     }
 
     /// <summary>
-    /// Update claim with adjudication results (from adjudication workflow)
+    /// Update claim with adjudication results (from adjudication workflow).
+    /// Called by the Argo workflow's synchronous finalize step
+    /// (<c>update-claim-step</c>) for every non-NCCI/MUE outcome, immediately
+    /// followed by that same step's call to <c>PUT /{id}/status</c>.
+    ///
+    /// Residual-race fix: AdjudicationResult/dates/MPIP-enhanced fields
+    /// always persist. The status decision is applied through the same
+    /// precedence guard as <c>PUT /{id}/status</c>
+    /// (<see cref="ClaimRepository.BlocksSynchronousWriteback"/>, via
+    /// <see cref="IClaimRepository.TryTransitionStatusAsync"/>), evaluated
+    /// and committed BEFORE the full-document replace below and folded back
+    /// onto <c>claim.Status</c> — so the replace can't reintroduce a stale
+    /// status over one the guard just protected. When PayerPayment/
+    /// DenialReasonCode don't resolve to a decision at all, behavior is
+    /// unchanged from before this fix (claim.Status is left as read). The
+    /// response's <c>Status</c> field is the existing signal for a suppressed
+    /// transition (e.g. still Pended) — no response-shape change. See
+    /// docs/architecture/claim-adjudication-pipeline.md D9b.
     /// </summary>
     [HttpPut("{id}/adjudication")]
     [ProducesResponseType(typeof(Claim), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<Claim>> UpdateAdjudication(
         string id,
-        [FromBody] AdjudicationResult adjudication)
+        [FromBody] AdjudicationResult adjudication,
+        CancellationToken ct = default)
     {
         _logger.LogInformation(
             "Updating claim {Id} with adjudication: allowed={Allowed}, payer={Payer}, patient={Patient}",
@@ -423,19 +483,36 @@ public class ClaimsController : ControllerBase
             }
         }
 
-        // Update status based on adjudication
-        if (adjudication.PayerPayment == 0 && !string.IsNullOrEmpty(adjudication.DenialReasonCode))
+        // Decide + atomically apply the status transition (guarded — see doc
+        // comment above), folding the authoritative result back onto
+        // claim.Status before the replace below.
+        ClaimStatus? desiredStatus = adjudication.PayerPayment == 0 && !string.IsNullOrEmpty(adjudication.DenialReasonCode)
+            ? ClaimStatus.Denied
+            : adjudication.PayerPayment > 0
+                ? ClaimStatus.Approved
+                : null;
+
+        StatusWriteResult? statusResult = null;
+        if (desiredStatus is not null)
         {
-            claim.Status = ClaimStatus.Denied;
-        }
-        else if (adjudication.PayerPayment > 0)
-        {
-            claim.Status = ClaimStatus.Approved;
+            statusResult = await _claimRepository.TryTransitionStatusAsync(GetTenantId(), id, desiredStatus.Value, ct);
+            if (statusResult.Value.Outcome == StatusWriteOutcome.NotFound)
+            {
+                return NotFound($"Claim {id} not found");
+            }
+
+            claim.Status = statusResult.Value.PersistedStatus!.Value;
         }
 
         var updated = await _claimRepository.UpdateAsync(claim);
 
-        if (IsTerminalStatus(updated.Status))
+        if (statusResult is { Outcome: StatusWriteOutcome.Suppressed })
+        {
+            _logger.LogInformation(
+                "Adjudication status transition suppressed for claim {Id}: requested={Requested}, persisted={Persisted}",
+                SanitizeForLog(id), desiredStatus, statusResult.Value.PersistedStatus);
+        }
+        else if (IsTerminalStatus(updated.Status))
         {
             await _eventPublisher.PublishClaimFinalizedAsync(updated, GetTenantId());
         }
@@ -446,10 +523,20 @@ public class ClaimsController : ControllerBase
     /// <summary>
     /// Fast claim-level adjudication projection for local benchmark and workflow
     /// validation paths that do not need line adjudication projection or finalized
-    /// event emission.
+    /// event emission. Residual-race fix: <paramref name="adjudication"/>'s
+    /// totals/dates always persist. The status transition is guarded (see
+    /// <see cref="ClaimRepository.BlocksSynchronousWriteback"/>) — if this
+    /// claim was already pended (typically by the async orchestrator racing
+    /// this call's own request chain — see docs/architecture/
+    /// claim-adjudication-pipeline.md D9b) or already at a final disposition,
+    /// the status write is suppressed and the response says so via
+    /// <see cref="AdjudicationSummaryWriteResponse"/> instead of the normal
+    /// 204. The unsuppressed case is byte-identical to before this fix: 204,
+    /// no body.
     /// </summary>
     [HttpPut("{id}/adjudication-summary")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(AdjudicationSummaryWriteResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> UpdateAdjudicationSummary(
         string id,
@@ -461,14 +548,29 @@ public class ClaimsController : ControllerBase
             SanitizeForLog(id), adjudication.AllowedAmount, adjudication.PayerPayment, adjudication.PatientResponsibility);
 
         var status = ResolveAdjudicationStatus(adjudication);
-        var updated = await _claimRepository.UpdateAdjudicationSummaryAsync(
+        var result = await _claimRepository.UpdateAdjudicationSummaryAsync(
             GetTenantId(),
             id,
             adjudication,
             status,
             ct);
 
-        return updated ? NoContent() : NotFound($"Claim {id} not found");
+        switch (result.Outcome)
+        {
+            case StatusWriteOutcome.NotFound:
+                return NotFound($"Claim {id} not found");
+            case StatusWriteOutcome.Suppressed:
+                _logger.LogInformation(
+                    "Adjudication summary status transition suppressed for claim {Id}: requested={Requested}, persisted={Persisted}",
+                    SanitizeForLog(id), status, result.PersistedStatus);
+                return Ok(new AdjudicationSummaryWriteResponse
+                {
+                    StatusPreserved = true,
+                    PersistedStatus = result.PersistedStatus!.Value,
+                });
+            default:
+                return NoContent();
+        }
     }
 
     private static ClaimStatus ResolveAdjudicationStatus(AdjudicationResult adjudication)
@@ -1173,6 +1275,22 @@ public class AssignClaimRequest
 public class OverrideClaimRequest
 {
     public string OverrideReason { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Returned by <c>PUT /{id}/adjudication-summary</c> only when the status
+/// transition it requested was suppressed by
+/// <see cref="ClaimRepository.BlocksSynchronousWriteback"/> (e.g. the claim
+/// was already Pended by the async orchestrator). The adjudication summary
+/// payload (totals, timings, denial codes) still persisted — only <c>/status</c>
+/// was protected. Callers (the MCC validator) should score against
+/// <see cref="PersistedStatus"/>, not the outcome they originally computed.
+/// The normal, unsuppressed case is unchanged: 204 No Content, no body.
+/// </summary>
+public class AdjudicationSummaryWriteResponse
+{
+    public bool StatusPreserved { get; set; }
+    public ClaimStatus PersistedStatus { get; set; }
 }
 
 public class AiExaminerAgreementRequest

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -4,6 +4,29 @@ using ClaimsService.Models;
 
 namespace ClaimsService.Repositories;
 
+/// <summary>
+/// Result of a repository call that writes <see cref="ClaimStatus"/> through a
+/// precedence guard (<see cref="ClaimRepository.BlocksSynchronousWriteback"/>).
+/// <see cref="Suppressed"/> means the row exists but the guard blocked the
+/// requested transition — <see cref="PersistedStatus"/> reports what the claim's
+/// status actually is now, so the caller can react (e.g. score against Pended
+/// instead of the outcome it asked for) instead of silently believing its write
+/// won.
+/// </summary>
+public enum StatusWriteOutcome
+{
+    NotFound,
+    Applied,
+    Suppressed,
+}
+
+/// <summary>See <see cref="StatusWriteOutcome"/>. <see cref="PersistedStatus"/> is
+/// null only for <see cref="StatusWriteOutcome.NotFound"/>.</summary>
+public readonly record struct StatusWriteResult(StatusWriteOutcome Outcome, ClaimStatus? PersistedStatus)
+{
+    public static readonly StatusWriteResult NotFoundResult = new(StatusWriteOutcome.NotFound, null);
+}
+
 public interface IClaimRepository
 {
     Task<Claim?> GetByIdAsync(string id);
@@ -146,16 +169,55 @@ public interface IClaimRepository
 
     /// <summary>
     /// Fast claim-level adjudication projection for direct local workflow
-    /// validation. Patches only summary adjudication/status fields on a known
-    /// claim row and intentionally skips full-claim hydration, line projection,
-    /// and event emission. Use the full adjudication pipeline when downstream
-    /// finalized events or line adjudications are required.
+    /// validation. Patches summary adjudication fields on a known claim row and
+    /// intentionally skips full-claim hydration, line projection, and event
+    /// emission. Use the full adjudication pipeline when downstream finalized
+    /// events or line adjudications are required.
+    ///
+    /// <para>
+    /// Residual-race fix — <paramref name="status"/> is applied through the
+    /// same precedence guard as <see cref="TryTransitionStatusAsync"/>
+    /// (<see cref="ClaimRepository.BlocksSynchronousWriteback"/>): it is never
+    /// written over a claim already Pended or at a final disposition, because
+    /// this method's only caller (the validator's synchronous write-back) is
+    /// racing the async orchestrator's own Pend projection, not resolving one.
+    /// <see cref="AdjudicationResult"/>/dates persist unconditionally either
+    /// way — only the status transition is guarded — so a suppressed run never
+    /// drops financial/audit data. See docs/architecture/
+    /// claim-adjudication-pipeline.md D9b.
+    /// </para>
     /// </summary>
-    Task<bool> UpdateAdjudicationSummaryAsync(
+    Task<StatusWriteResult> UpdateAdjudicationSummaryAsync(
         string tenantId,
         string claimId,
         AdjudicationResult adjudicationResult,
         ClaimStatus status,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically applies <paramref name="desiredStatus"/> to the single claim
+    /// row identified by <paramref name="claimId"/> (direct row id, not a
+    /// version-chain lookup — mirrors <see cref="GetByIdAsync"/>), subject to
+    /// <see cref="ClaimRepository.BlocksSynchronousWriteback"/>: never
+    /// overwrites a claim that is already Pended or at a final disposition.
+    /// Backing store enforces this with a conditional write evaluated at
+    /// commit time (Cosmos patch <c>FilterPredicate</c> / Mongo filter-based
+    /// compare-and-set) — not a read-then-decide check — so it holds under a
+    /// true concurrent write, not just sequential ordering.
+    ///
+    /// <para>
+    /// Used by the two Argo-invoked synchronous write-back endpoints
+    /// (<c>PUT /{id}/adjudication</c>, <c>PUT /{id}/status</c>) so their
+    /// status decision is race-safe even though the rest of the claim still
+    /// persists through <see cref="UpdateAsync"/>'s full-document replace.
+    /// Also updates <c>VersionState</c> to keep it consistent with the
+    /// applied status (<see cref="ClaimRepository.MapStatusToVersionState"/>).
+    /// </para>
+    /// </summary>
+    Task<StatusWriteResult> TryTransitionStatusAsync(
+        string tenantId,
+        string claimId,
+        ClaimStatus desiredStatus,
         CancellationToken ct = default);
 
     /// <summary>
@@ -308,6 +370,46 @@ public class ClaimRepository : IClaimRepository
         ClaimStatus.Voided => true,
         _ => false
     };
+
+    /// <summary>
+    /// Every status <see cref="IsFinalDisposition"/> returns true for. Derived,
+    /// not hand-duplicated, so the Cosmos <c>FilterPredicate</c> string built
+    /// from it (<see cref="FinalDispositionFilterPredicate"/>) and Mongo's
+    /// equivalent <c>$nin</c> filter can never drift from the canonical rule.
+    /// </summary>
+    public static readonly IReadOnlyList<ClaimStatus> FinalDispositions =
+        Enum.GetValues<ClaimStatus>().Where(IsFinalDisposition).ToArray();
+
+    /// <summary>
+    /// True when <paramref name="status"/> must not be overwritten by a
+    /// synchronous, non-authoritative adjudication write-back —
+    /// <c>UpdateAdjudicationSummaryAsync</c> (the validator's own write-back)
+    /// and <c>TryTransitionStatusAsync</c> (backing the Argo-invoked
+    /// <c>PUT /{id}/adjudication</c> and <c>PUT /{id}/status</c> endpoints).
+    ///
+    /// <para>
+    /// Composes <see cref="IsFinalDisposition"/> (a stray re-adjudication
+    /// write-back must not re-litigate an already-completed disposition) with
+    /// <see cref="ClaimStatus.Pended"/> (a human-review gate — only an
+    /// explicit, deliberate action, <c>POST work-queue/{id}/override</c>,
+    /// resolves it; never a synchronous write-back that doesn't know the pend
+    /// happened). This is deliberately a DIFFERENT set than
+    /// <see cref="IsFinalDisposition"/> alone: that predicate excludes Pended
+    /// on purpose, for the opposite write direction (the async orchestrator's
+    /// own Pend projection in <c>UpdateAdjudicationProjectionAsync</c>, which
+    /// must still be allowed to re-pend an already-Pended claim). Two
+    /// directions of one precedence lattice, both anchored here so no call
+    /// site forks its own copy. See docs/architecture/
+    /// claim-adjudication-pipeline.md D9b for the full writer x precedence
+    /// table.
+    /// </para>
+    /// </summary>
+    public static bool BlocksSynchronousWriteback(ClaimStatus status) =>
+        status == ClaimStatus.Pended || IsFinalDisposition(status);
+
+    /// <summary>Derived set backing <see cref="BlocksSynchronousWriteback"/> — see that method's doc comment.</summary>
+    public static readonly IReadOnlyList<ClaimStatus> SynchronousWritebackBlockedStatuses =
+        Enum.GetValues<ClaimStatus>().Where(BlocksSynchronousWriteback).ToArray();
 
     private static bool IsTerminal(ClaimVersionState state) => state switch
     {
@@ -940,18 +1042,6 @@ public class ClaimRepository : IClaimRepository
             ops.Add(PatchOperation.Set("/pendDetails", pendDetails));
         }
 
-        // Defect A fix — project the orchestrator's Pend outcome onto
-        // ClaimStatus. Precedence: never downgrade a claim that already
-        // reached a later-stage disposition (see IsFinalDisposition) — e.g.
-        // because the Argo workflow's synchronous finalize step, or an
-        // examiner override, raced ahead of this async projection.
-        // Re-pending an already-Pended claim is allowed. isPend=false never
-        // touches /status here, same as before this parameter existed.
-        if (isPend && !IsFinalDisposition(head.Status))
-        {
-            ops.Add(PatchOperation.Set("/status", ClaimStatus.Pended));
-        }
-
         try
         {
             await _container.PatchItemAsync<Claim>(
@@ -959,16 +1049,57 @@ public class ClaimRepository : IClaimRepository
                 new PartitionKey(tenantId),
                 ops,
                 cancellationToken: ct);
-            return true;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             // Row deleted between lookup and patch.
             return false;
         }
+
+        if (!isPend)
+        {
+            return true;
+        }
+
+        // Defect A fix, made atomic — project the orchestrator's Pend outcome
+        // onto ClaimStatus in a SEPARATE conditional patch, evaluated against
+        // the row's live state at commit time via FilterPredicate rather than
+        // the `head` snapshot read above. Precedence: never downgrade a claim
+        // that already reached a later-stage disposition (IsFinalDisposition)
+        // — e.g. because the Argo workflow's synchronous finalize step, or an
+        // examiner override, raced ahead of this async projection. A
+        // read-then-decide check (the original form of this guard) only
+        // catches that race when the other write happens to land before this
+        // method's own read; a concurrent write landing in between read and
+        // write would still get clobbered. The conditional patch closes that
+        // window: Cosmos evaluates FilterPredicate against the document as it
+        // exists at the moment this patch actually commits. Re-pending an
+        // already-Pended claim is allowed — Pended is excluded from
+        // FinalDispositions by design. A blocked patch is not an error; the
+        // /adjudicationResult + /claimLines + /pendDetails write above still
+        // succeeded, so this method still returns true either way.
+        try
+        {
+            await _container.PatchItemAsync<Claim>(
+                rowId,
+                new PartitionKey(tenantId),
+                new List<PatchOperation> { PatchOperation.Set("/status", ClaimStatus.Pended) },
+                new PatchItemRequestOptions { FilterPredicate = FinalDispositionFilterPredicate },
+                ct);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+        {
+            // Guard correctly blocked the downgrade — not an error.
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Row deleted between the first patch and this one.
+        }
+
+        return true;
     }
 
-    public async Task<bool> UpdateAdjudicationSummaryAsync(
+    public async Task<StatusWriteResult> UpdateAdjudicationSummaryAsync(
         string tenantId,
         string claimVersionId,
         AdjudicationResult adjudicationResult,
@@ -1003,16 +1134,20 @@ public class ClaimRepository : IClaimRepository
             rowId = page.FirstOrDefault()?.Id;
         }
 
-        if (string.IsNullOrEmpty(rowId)) return false;
+        if (string.IsNullOrEmpty(rowId)) return StatusWriteResult.NotFoundResult;
 
+        // Residual-race fix — financial/audit data (AdjudicationResult, dates)
+        // persists unconditionally: this method's caller (the validator's
+        // synchronous write-back) always has a legitimate adjudication result
+        // to record even when the status transition below gets suppressed.
+        // Only /status + /versionState are guarded, in a separate conditional
+        // patch — see TryPatchStatusAsync.
         var now = DateTime.UtcNow;
-        var ops = new List<PatchOperation>
+        var summaryOps = new List<PatchOperation>
         {
             PatchOperation.Set("/adjudicationResult", adjudicationResult),
             PatchOperation.Set("/adjudicatedDate", now),
             PatchOperation.Set("/lastUpdatedDate", now),
-            PatchOperation.Set("/status", status),
-            PatchOperation.Set("/versionState", ClaimVersionState.Adjudicated)
         };
 
         try
@@ -1020,15 +1155,86 @@ public class ClaimRepository : IClaimRepository
             await _container.PatchItemAsync<Claim>(
                 rowId,
                 new PartitionKey(tenantId),
-                ops,
+                summaryOps,
                 cancellationToken: ct);
-            return true;
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            return false;
+            return StatusWriteResult.NotFoundResult;
+        }
+
+        return await TryPatchStatusAsync(tenantId, rowId, status, ClaimVersionState.Adjudicated, ct);
+    }
+
+    public Task<StatusWriteResult> TryTransitionStatusAsync(
+        string tenantId,
+        string claimId,
+        ClaimStatus desiredStatus,
+        CancellationToken ct = default) =>
+        TryPatchStatusAsync(tenantId, claimId, desiredStatus, MapStatusToVersionState(desiredStatus), ct);
+
+    /// <summary>
+    /// Shared atomic status write behind <see cref="UpdateAdjudicationSummaryAsync"/>
+    /// and <see cref="TryTransitionStatusAsync"/>. Guarded by
+    /// <see cref="BlocksSynchronousWriteback"/> via a Cosmos patch
+    /// <c>FilterPredicate</c>, evaluated server-side against the row's live
+    /// state at commit time — not a read-then-decide check, so it holds under
+    /// a true concurrent write. On a blocked write, issues one fallback read
+    /// to report the row's actual current status (needed to disambiguate
+    /// "guard blocked it" from "row was deleted" — a rejected conditional
+    /// patch doesn't return the document — and to tell the caller what
+    /// actually persisted); this only happens on the (expected to be rare)
+    /// suppressed path, not the hot path.
+    /// </summary>
+    private async Task<StatusWriteResult> TryPatchStatusAsync(
+        string tenantId,
+        string rowId,
+        ClaimStatus desiredStatus,
+        ClaimVersionState desiredVersionState,
+        CancellationToken ct)
+    {
+        var statusOps = new List<PatchOperation>
+        {
+            PatchOperation.Set("/status", desiredStatus),
+            PatchOperation.Set("/versionState", desiredVersionState),
+        };
+        var options = new PatchItemRequestOptions { FilterPredicate = SynchronousWritebackBlockedFilterPredicate };
+
+        try
+        {
+            await _container.PatchItemAsync<Claim>(rowId, new PartitionKey(tenantId), statusOps, options, ct);
+            return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return StatusWriteResult.NotFoundResult;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+        {
+            try
+            {
+                var read = await _container.ReadItemAsync<Claim>(rowId, new PartitionKey(tenantId), cancellationToken: ct);
+                return new StatusWriteResult(StatusWriteOutcome.Suppressed, read.Resource.Status);
+            }
+            catch (CosmosException readEx) when (readEx.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // Deleted between the blocked patch and this fallback read —
+                // functionally not-found from the caller's perspective.
+                return StatusWriteResult.NotFoundResult;
+            }
         }
     }
+
+    /// <summary>Cosmos patch FilterPredicate for <see cref="BlocksSynchronousWriteback"/> — built from <see cref="SynchronousWritebackBlockedStatuses"/> so it can't drift from the canonical rule.</summary>
+    private static readonly string SynchronousWritebackBlockedFilterPredicate =
+        BuildStatusNotInFilterPredicate(SynchronousWritebackBlockedStatuses);
+
+    /// <summary>Cosmos patch FilterPredicate for <see cref="IsFinalDisposition"/> — built from <see cref="FinalDispositions"/>; Pended is deliberately absent (re-pending is allowed).</summary>
+    private static readonly string FinalDispositionFilterPredicate =
+        BuildStatusNotInFilterPredicate(FinalDispositions);
+
+    private static string BuildStatusNotInFilterPredicate(IReadOnlyList<ClaimStatus> blockedStatuses) =>
+        $"FROM c WHERE NOT (c.status IN ({string.Join(",", blockedStatuses.Select(s => $"'{s}'"))}))";
 
     public async Task<AccumulatorTotalsResponse> GetAccumulatorTotalsAsync(
         string ownerId,

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -481,23 +481,43 @@ public class ClaimRepositoryMongo : IClaimRepository
             update = update.Set(c => c.PendDetails, pendDetails);
         }
 
-        // Defect A fix — project the orchestrator's Pend outcome onto
-        // ClaimStatus. Same precedence rule as the Cosmos sibling: never
-        // downgrade a claim already at a later-stage disposition (see
-        // ClaimRepository.IsFinalDisposition); re-pending an already-Pended
-        // claim is allowed. isPend=false never touches /status here, same
-        // as before this parameter existed.
-        if (isPend && !ClaimRepository.IsFinalDisposition(head.Status))
-        {
-            update = update.Set(c => c.Status, ClaimStatus.Pended);
-        }
-
         var rowFilter = b.And(b.Eq(c => c.TenantId, tenantId), b.Eq(c => c.Id, head.Id));
         var result = await _collection.UpdateOneAsync(rowFilter, update, cancellationToken: ct);
-        return result.MatchedCount > 0;
+        if (result.MatchedCount == 0)
+        {
+            return false;
+        }
+
+        if (!isPend)
+        {
+            return true;
+        }
+
+        // Defect A fix, made atomic — project the orchestrator's Pend outcome
+        // onto ClaimStatus in a SEPARATE conditional update, whose FILTER
+        // (not a C# if-check against the `head` snapshot above) carries the
+        // precedence rule: never downgrade a claim already at a later-stage
+        // disposition (see ClaimRepository.IsFinalDisposition). A
+        // read-then-decide check only catches a concurrent write that lands
+        // before this method's own read; MongoDB evaluates this filter
+        // against the row's live state at the moment the update actually
+        // executes, so a competing write landing in between is still caught.
+        // No match on this second update just means the guard correctly
+        // blocked the downgrade — not an error; the AdjudicationResult /
+        // ClaimLines / PendDetails write above already succeeded, so this
+        // method still returns true either way. Re-pending an already-Pended
+        // claim is allowed — Pended is excluded from FinalDispositions.
+        var pendFilter = b.And(
+            b.Eq(c => c.TenantId, tenantId),
+            b.Eq(c => c.Id, head.Id),
+            b.Not(b.In(c => c.Status, ClaimRepository.FinalDispositions)));
+        var pendUpdate = Builders<Claim>.Update.Set(c => c.Status, ClaimStatus.Pended);
+        await _collection.UpdateOneAsync(pendFilter, pendUpdate, cancellationToken: ct);
+
+        return true;
     }
 
-    public async Task<bool> UpdateAdjudicationSummaryAsync(
+    public async Task<StatusWriteResult> UpdateAdjudicationSummaryAsync(
         string tenantId,
         string claimVersionId,
         AdjudicationResult adjudicationResult,
@@ -519,21 +539,83 @@ public class ClaimRepositoryMongo : IClaimRepository
 
         var filter = b.And(b.Eq(c => c.TenantId, tenantId), chainFilter, stateFilter);
         var now = DateTime.UtcNow;
-        var update = Builders<Claim>.Update
+
+        // Residual-race fix — financial/audit data (AdjudicationResult, dates)
+        // persists unconditionally: this method's caller (the validator's
+        // synchronous write-back) always has a legitimate adjudication result
+        // to record even when the status transition below gets suppressed.
+        // Only Status + VersionState are guarded, in a separate conditional
+        // update — see TryPatchStatusAsync.
+        var summaryUpdate = Builders<Claim>.Update
             .Set(c => c.AdjudicationResult, adjudicationResult)
             .Set(c => c.AdjudicatedDate, now)
-            .Set(c => c.LastUpdatedDate, now)
-            .Set(c => c.Status, status)
-            .Set(c => c.VersionState, ClaimVersionState.Adjudicated);
+            .Set(c => c.LastUpdatedDate, now);
 
         var options = new FindOneAndUpdateOptions<Claim>
         {
             Sort = Builders<Claim>.Sort.Descending(c => c.VersionNumber),
-            Projection = Builders<Claim>.Projection.Include(c => c.Id)
+            Projection = Builders<Claim>.Projection.Include(c => c.Id),
+            ReturnDocument = ReturnDocument.After,
         };
 
-        var updated = await _collection.FindOneAndUpdateAsync(filter, update, options, ct);
-        return updated is not null;
+        var summaryUpdated = await _collection.FindOneAndUpdateAsync(filter, summaryUpdate, options, ct);
+        if (summaryUpdated is null)
+        {
+            return StatusWriteResult.NotFoundResult;
+        }
+
+        return await TryPatchStatusAsync(tenantId, summaryUpdated.Id, status, ClaimVersionState.Adjudicated, ct);
+    }
+
+    public Task<StatusWriteResult> TryTransitionStatusAsync(
+        string tenantId,
+        string claimId,
+        ClaimStatus desiredStatus,
+        CancellationToken ct = default) =>
+        TryPatchStatusAsync(tenantId, claimId, desiredStatus, ClaimRepository.MapStatusToVersionState(desiredStatus), ct);
+
+    /// <summary>
+    /// Shared atomic status write behind <see cref="UpdateAdjudicationSummaryAsync"/>
+    /// and <see cref="TryTransitionStatusAsync"/>. The precedence guard
+    /// (<see cref="ClaimRepository.BlocksSynchronousWriteback"/>) is encoded
+    /// directly in the update filter's <c>$nin</c> clause, so MongoDB
+    /// evaluates it against the document's live state at the moment the
+    /// update actually executes — not a read-then-decide snapshot — meaning
+    /// it holds under a true concurrent write. A <c>MatchedCount == 0</c>
+    /// result is ambiguous (guard blocked it vs. row doesn't exist), so on
+    /// that path we issue one fallback existence+status read to disambiguate
+    /// and to report what's actually persisted; this only runs on the
+    /// (expected to be rare) suppressed/not-found path, not the hot path.
+    /// </summary>
+    private async Task<StatusWriteResult> TryPatchStatusAsync(
+        string tenantId,
+        string rowId,
+        ClaimStatus desiredStatus,
+        ClaimVersionState desiredVersionState,
+        CancellationToken ct)
+    {
+        var b = Builders<Claim>.Filter;
+        var statusFilter = b.And(
+            b.Eq(c => c.TenantId, tenantId),
+            b.Eq(c => c.Id, rowId),
+            b.Not(b.In(c => c.Status, ClaimRepository.SynchronousWritebackBlockedStatuses)));
+        var statusUpdate = Builders<Claim>.Update
+            .Set(c => c.Status, desiredStatus)
+            .Set(c => c.VersionState, desiredVersionState);
+
+        var result = await _collection.UpdateOneAsync(statusFilter, statusUpdate, cancellationToken: ct);
+        if (result.MatchedCount > 0)
+        {
+            return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+        }
+
+        var existing = await _collection
+            .Find(b.And(b.Eq(c => c.TenantId, tenantId), b.Eq(c => c.Id, rowId)))
+            .FirstOrDefaultAsync(ct);
+
+        return existing is null
+            ? StatusWriteResult.NotFoundResult
+            : new StatusWriteResult(StatusWriteOutcome.Suppressed, existing.Status);
     }
 
     public async Task<AccumulatorTotalsResponse> GetAccumulatorTotalsAsync(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryStatusWritebackGuardTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryStatusWritebackGuardTests.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Repositories;
+
+/// <summary>
+/// Residual-race fix — Cosmos-side coverage for the atomic status-write
+/// primitive backing <c>TryTransitionStatusAsync</c> (used by
+/// <c>PUT /{id}/adjudication</c> and <c>PUT /{id}/status</c>) and, via the
+/// same shared private helper, <c>UpdateAdjudicationSummaryAsync</c>'s status
+/// half.
+///
+/// <para>
+/// Contract-level coverage (no Cosmos Emulator — mirrors
+/// <see cref="ClaimRepositoryPartitionKeyTests"/>'s established pattern for
+/// this repository). <c>TryTransitionStatusAsync</c> operates on a single row
+/// by direct id (no version-chain query, unlike <c>UpdateAdjudicationSummaryAsync</c>'s
+/// chain lookup, which resolves through a private nested query-result type
+/// that isn't reachable from a mocked <see cref="Container"/> in this test
+/// project) — so it's the cleanest place to verify the actual Cosmos
+/// conditional-patch wiring: that a blocked status is expressed as a patch
+/// <c>FilterPredicate</c> the server evaluates atomically (not a prior read),
+/// and that a rejected (412) conditional patch is translated into
+/// <see cref="StatusWriteOutcome.Suppressed"/> via a fallback read — not
+/// silently swallowed or misreported as success.
+/// </para>
+/// </summary>
+public sealed class ClaimRepositoryStatusWritebackGuardTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ClaimId = "claim-1";
+
+    private readonly Container _container = Substitute.For<Container>();
+    private readonly ClaimRepository _sut;
+
+    public ClaimRepositoryStatusWritebackGuardTests()
+    {
+        var cosmos = Substitute.For<CosmosClient>();
+        cosmos.GetContainer(Arg.Any<string>(), Arg.Any<string>()).Returns(_container);
+
+        var config = Substitute.For<IConfiguration>();
+        config["CosmosDb:DatabaseName"].Returns("ClaimsDB");
+        config["CosmosDb:ContainerName"].Returns("Claims");
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["TenantId"] = TenantId;
+        httpContextAccessor.HttpContext.Returns(httpContext);
+
+        _sut = new ClaimRepository(cosmos, config, httpContextAccessor, NullLogger<ClaimRepository>.Instance);
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_NotBlocked_PatchesStatusAndVersionState_WithFilterPredicateSet()
+    {
+        StubPatchItemOk();
+
+        var result = await _sut.TryTransitionStatusAsync(TenantId, ClaimId, ClaimStatus.Denied);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        result.PersistedStatus.Should().Be(ClaimStatus.Denied);
+
+        // The guard MUST be expressed server-side via FilterPredicate — a
+        // conditional patch, not a read-then-decide check — so it holds
+        // under a true concurrent write, not just sequential ordering.
+        await _container.Received(1).PatchItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Is<IReadOnlyList<PatchOperation>>(ops => ops.Count == 2),
+            Arg.Is<PatchItemRequestOptions>(o => o != null && !string.IsNullOrEmpty(o.FilterPredicate)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_FilterPredicate_ExcludesPendedAndFinalDispositions()
+    {
+        // Pin the actual predicate content, not just "some predicate was
+        // set" — this is what stands between a synchronous write-back and
+        // silently overwriting a pend. Built from
+        // ClaimRepository.SynchronousWritebackBlockedStatuses so it can't
+        // drift from the canonical BlocksSynchronousWriteback rule.
+        StubPatchItemOk();
+        PatchItemRequestOptions? captured = null;
+        _container.PatchItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Do<PatchItemRequestOptions>(o => captured = o),
+            Arg.Any<CancellationToken>());
+
+        await _sut.TryTransitionStatusAsync(TenantId, ClaimId, ClaimStatus.Approved);
+
+        captured.Should().NotBeNull();
+        foreach (var blocked in ClaimRepository.SynchronousWritebackBlockedStatuses)
+        {
+            captured!.FilterPredicate.Should().Contain($"'{blocked}'");
+        }
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_GuardBlocked_ReturnsSuppressed_WithActualPersistedStatus()
+    {
+        // Server-side FilterPredicate rejection surfaces as 412; the method
+        // must not treat that as a hard failure, and must report what's
+        // actually persisted (fetched via a fallback read — a rejected
+        // conditional patch doesn't return the document).
+        StubPatchItemThrows(new CosmosException("precondition failed", HttpStatusCode.PreconditionFailed, 0, "", 0));
+        StubReadItemReturnsClaim(MakeClaim(ClaimStatus.Pended));
+
+        var result = await _sut.TryTransitionStatusAsync(TenantId, ClaimId, ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
+        result.PersistedStatus.Should().Be(ClaimStatus.Pended);
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_RowMissing_ReturnsNotFound()
+    {
+        StubPatchItemThrows(new CosmosException("not found", HttpStatusCode.NotFound, 0, "", 0));
+
+        var result = await _sut.TryTransitionStatusAsync(TenantId, ClaimId, ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.NotFound);
+        result.PersistedStatus.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_RowDeletedBetweenBlockedPatchAndFallbackRead_ReturnsNotFound()
+    {
+        StubPatchItemThrows(new CosmosException("precondition failed", HttpStatusCode.PreconditionFailed, 0, "", 0));
+        _container.ReadItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new CosmosException("not found", HttpStatusCode.NotFound, 0, "", 0));
+
+        var result = await _sut.TryTransitionStatusAsync(TenantId, ClaimId, ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.NotFound);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private static Claim MakeClaim(ClaimStatus status = ClaimStatus.Submitted) => new()
+    {
+        Id = ClaimId,
+        TenantId = TenantId,
+        ClaimVersionId = ClaimId,
+        VersionNumber = 1,
+        VersionState = ClaimVersionState.Submitted,
+        Status = status,
+        MemberId = "member-1",
+        ClaimNumber = "CN-1",
+    };
+
+    private void StubReadItemReturnsClaim(Claim claim)
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(claim);
+        _container.ReadItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private void StubPatchItemOk()
+    {
+        var response = Substitute.For<ItemResponse<Claim>>();
+        response.Resource.Returns(MakeClaim());
+        _container.PatchItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .Returns(response);
+    }
+
+    private void StubPatchItemThrows(CosmosException ex)
+    {
+        _container.PatchItemAsync<Claim>(
+            Arg.Any<string>(),
+            Arg.Any<PartitionKey>(),
+            Arg.Any<IReadOnlyList<PatchOperation>>(),
+            Arg.Any<PatchItemRequestOptions>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(ex);
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -514,4 +514,218 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         doc.PublishedAt = publishedAt;
         return doc;
     }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Residual-race fix — UpdateAdjudicationSummaryAsync / TryTransitionStatusAsync
+    // never overwrite a persisted Pended (or already-final) status. Financial/
+    // audit data still persists even when the status transition is suppressed.
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(ClaimStatus.Submitted, false)]
+    [InlineData(ClaimStatus.Received, false)]
+    [InlineData(ClaimStatus.InAdjudication, false)]
+    [InlineData(ClaimStatus.Pended, true)] // the residual-race fix's headline addition
+    [InlineData(ClaimStatus.Approved, true)]
+    [InlineData(ClaimStatus.Denied, true)]
+    [InlineData(ClaimStatus.Paid, true)]
+    [InlineData(ClaimStatus.PartiallyPaid, true)]
+    [InlineData(ClaimStatus.Voided, true)]
+    public void BlocksSynchronousWriteback_truth_table_is_pinned(ClaimStatus status, bool expectedBlocked)
+    {
+        // Shared by ClaimRepository (Cosmos) and ClaimRepositoryMongo so both
+        // backends apply the identical synchronous-writeback precedence rule;
+        // pin it here so the table is reviewed if anyone changes it. Note
+        // this is a DIFFERENT set than IsFinalDisposition (Pended is
+        // included here, excluded there) — see that method's doc comment.
+        ClaimRepository.BlocksSynchronousWriteback(status).Should().Be(expectedBlocked);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_onNonPendedClaim_appliesStatusAndData()
+    {
+        // Regression: the unguarded, normal case is byte-identical to
+        // pre-fix behavior.
+        await _repo.CreateAsync(BuildVersion("chain-summary-normal", "row-1", n: 1, ClaimVersionState.Submitted));
+
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "chain-summary-normal",
+            new AdjudicationResult { AllowedAmount = 80m, PayerPayment = 64m },
+            ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        result.PersistedStatus.Should().Be(ClaimStatus.Approved);
+
+        var reread = await _repo.GetVersionAsync("chain-summary-normal", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Approved);
+        reread.VersionState.Should().Be(ClaimVersionState.Adjudicated);
+        reread.AdjudicationResult!.PayerPayment.Should().Be(64m);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_onAlreadyPendedClaim_suppressesStatus_butPersistsFinancialData()
+    {
+        // Headline scenario (docs/architecture/claim-adjudication-pipeline.md
+        // D9b): the async orchestrator pended the claim; this method's
+        // caller (the validator's own synchronous write-back, racing its own
+        // request chain) must not stomp it back to Denied/Approved/
+        // InAdjudication — but the adjudication totals it computed are still
+        // real data and must not be dropped.
+        var head = BuildVersion("chain-summary-pended", "row-1", n: 1, ClaimVersionState.Submitted);
+        head.Status = ClaimStatus.Pended;
+        head.PendDetails = new PendDetails { PendCode = "COB", PendReason = "async orchestrator pend" };
+        await _repo.CreateAsync(head);
+
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "chain-summary-pended",
+            new AdjudicationResult { AllowedAmount = 80m, PayerPayment = 64m, DenialReasonCode = null },
+            ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
+        result.PersistedStatus.Should().Be(ClaimStatus.Pended);
+
+        var reread = await _repo.GetVersionAsync("chain-summary-pended", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Pended, "a synchronous write-back must never overwrite a persisted pend");
+        reread.PendDetails!.PendCode.Should().Be("COB", "the original pend reason survives untouched");
+        reread.AdjudicationResult.Should().NotBeNull("financial/audit data persists even when the status transition is suppressed");
+        reread.AdjudicationResult!.PayerPayment.Should().Be(64m);
+        reread.AdjudicationResult.AllowedAmount.Should().Be(80m);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_onAlreadyFinalClaim_suppressesStatus_butPersistsFinancialData()
+    {
+        // Approved (not Denied/Paid/Voided) deliberately: those map to
+        // VersionState.Denied/Paid/Voided, which UpdateAdjudicationSummaryAsync's
+        // own query excludes entirely (terminal VersionState — a separate,
+        // pre-existing guard, not what this test targets). Approved maps to
+        // VersionState.Adjudicated, which IS query-eligible, so this row
+        // reaches the BlocksSynchronousWriteback(Approved) check itself.
+        var head = BuildVersion("chain-summary-final", "row-1", n: 1, ClaimVersionState.Adjudicated);
+        head.Status = ClaimStatus.Approved;
+        await _repo.CreateAsync(head);
+
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "chain-summary-final",
+            new AdjudicationResult { AllowedAmount = 50m, PayerPayment = 50m },
+            ClaimStatus.Denied);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
+        result.PersistedStatus.Should().Be(ClaimStatus.Approved);
+
+        var reread = await _repo.GetVersionAsync("chain-summary-final", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Approved, "a completed disposition must never be re-litigated by a stray write-back");
+        reread.AdjudicationResult!.PayerPayment.Should().Be(50m);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_forUnknownClaim_returnsNotFound()
+    {
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "no-such-chain", new AdjudicationResult(), ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.NotFound);
+        result.PersistedStatus.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_onNonPendedClaim_appliesStatus()
+    {
+        var doc = await _repo.CreateAsync(Sample("row-status-normal"));
+
+        var result = await _repo.TryTransitionStatusAsync(Tenant, "row-status-normal", ClaimStatus.Denied);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        var reread = await _repo.GetByIdAsync("row-status-normal");
+        reread!.Status.Should().Be(ClaimStatus.Denied);
+        reread.VersionState.Should().Be(ClaimVersionState.Denied);
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_onAlreadyPendedClaim_suppressesTransition()
+    {
+        // Backs both PUT /{id}/adjudication and PUT /{id}/status — both are
+        // called by the Argo workflow's synchronous finalize step, which can
+        // race the async orchestrator's own Pend projection for the same
+        // claim exactly like the validator's write-back does.
+        var doc = Sample("row-status-pended");
+        doc.Status = ClaimStatus.Pended;
+        await _repo.CreateAsync(doc);
+
+        var result = await _repo.TryTransitionStatusAsync(Tenant, "row-status-pended", ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
+        result.PersistedStatus.Should().Be(ClaimStatus.Pended);
+        var reread = await _repo.GetByIdAsync("row-status-pended");
+        reread!.Status.Should().Be(ClaimStatus.Pended);
+    }
+
+    [Fact]
+    public async Task TryTransitionStatusAsync_forUnknownClaim_returnsNotFound()
+    {
+        var result = await _repo.TryTransitionStatusAsync(Tenant, "no-such-row", ClaimStatus.Approved);
+        result.Outcome.Should().Be(StatusWriteOutcome.NotFound);
+    }
+
+    [Fact]
+    public async Task ConcurrentPendProjectionAndSummaryWriteback_trueRace_neverCorrupts_neverLosesFinancialData()
+    {
+        // True-race test (task requirement: "the guard must hold under a
+        // true race, not just sequential ordering"). Fire the async
+        // orchestrator's Pend projection and the validator's synchronous
+        // write-back concurrently via Task.WhenAll — not sequentially — so
+        // whichever backend actually interleaves the two writes exercises
+        // the conditional-update primitive, not a C# if-check against a
+        // stale read.
+        //
+        // What this test does NOT assert: that Pend always wins. With two
+        // independently-conditional writers (each guard evaluated against
+        // "current status" at ITS OWN commit instant, not a shared lock),
+        // genuine concurrency has two legitimate outcomes depending on which
+        // writer's status commit physically lands first:
+        //   - Pended: the projection's status write commits while status is
+        //     still non-final, and the write-back's own guard then sees
+        //     Pended and correctly defers (the headline scenario from
+        //     docs/architecture/claim-adjudication-pipeline.md D9b).
+        //   - Approved: the write-back's status write commits first while
+        //     status is still non-final, and the projection's own guard
+        //     then sees Approved (IsFinalDisposition) and correctly defers
+        //     — this is the SAME precedence the "writeback-then-pend"
+        //     sequential test pins as existing #844 behavior, just reached
+        //     via interleaving instead of full sequencing.
+        // Both are correct, race-consistent outcomes; which one occurs on a
+        // given run depends on OS/runtime task scheduling and is not
+        // something a test should pin (an embedded single-node Mongo
+        // instance tends to serialize the two tasks' operations fairly
+        // consistently in practice, so don't assert on the distribution —
+        // only on per-iteration safety). What would be an actual bug — and
+        // what this test guards against — is a THIRD outcome: a status that
+        // isn't either of the two conditionally-written values (corruption),
+        // or a row with no AdjudicationResult at all (a lost write).
+        for (var i = 0; i < 20; i++)
+        {
+            var chainKey = $"chain-race-{i}";
+            await _repo.CreateAsync(BuildVersion(chainKey, $"row-race-{i}", n: 1, ClaimVersionState.Submitted));
+
+            var pendTask = _repo.UpdateAdjudicationProjectionAsync(
+                Tenant, chainKey,
+                new AdjudicationResult { AllowedAmount = 0m },
+                Array.Empty<LineAdjudicationResult>(),
+                pendDetails: new PendDetails { PendCode = "COB", PendReason = "race pend" },
+                isPend: true);
+
+            var writebackTask = _repo.UpdateAdjudicationSummaryAsync(
+                Tenant, chainKey,
+                new AdjudicationResult { AllowedAmount = 80m, PayerPayment = 64m },
+                ClaimStatus.Approved);
+
+            await Task.WhenAll(pendTask, writebackTask);
+
+            var reread = await _repo.GetVersionAsync(chainKey, $"row-race-{i}");
+            reread!.Status.Should().BeOneOf(
+                new[] { ClaimStatus.Pended, ClaimStatus.Approved },
+                $"iteration {i}: only these two outcomes are valid under a true race — anything else is corruption");
+            reread.AdjudicationResult.Should().NotBeNull($"iteration {i}: financial data must never be lost to the race");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add guarded status-write outcomes so synchronous adjudication/status writebacks preserve persisted Pended and final statuses
- keep adjudication summary/audit fields persistent while suppressing only unsafe status overwrites
- document the D9b residual-race fix and add repository coverage for Cosmos/Mongo guard behavior

## Validation
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
- git diff --check