### PR TITLE
Fix tenant context for background adjudication repositories

### DIFF
--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Cosmos;
 using ClaimsService.Exceptions;
 using ClaimsService.Models;
+using ClaimsService.Services.Adjudication;
 
 namespace ClaimsService.Repositories;
 
@@ -275,12 +276,14 @@ public class ClaimRepository : IClaimRepository
     private readonly Container _container;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<ClaimRepository> _logger;
+    private readonly IAdjudicationTenantContext? _adjudicationTenantContext;
 
     public ClaimRepository(
         CosmosClient cosmosClient,
         IConfiguration configuration,
         IHttpContextAccessor httpContextAccessor,
-        ILogger<ClaimRepository> logger)
+        ILogger<ClaimRepository> logger,
+        IAdjudicationTenantContext? adjudicationTenantContext = null)
     {
         var databaseName = configuration["CosmosDb:DatabaseName"] ?? "ClaimsDB";
         var containerName = configuration["CosmosDb:ContainerName"] ?? "Claims";
@@ -288,14 +291,16 @@ public class ClaimRepository : IClaimRepository
         _container = cosmosClient.GetContainer(databaseName, containerName);
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
+        _adjudicationTenantContext = adjudicationTenantContext;
     }
 
     private string GetTenantId()
     {
-        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
+        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString()
+            ?? _adjudicationTenantContext?.TenantId;
         if (string.IsNullOrEmpty(tenantId))
         {
-            throw new InvalidOperationException("TenantId not found in request context");
+            throw new InvalidOperationException("TenantId not found in request or adjudication context");
         }
         return tenantId;
     }

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -1,5 +1,6 @@
 using ClaimsService.Exceptions;
 using ClaimsService.Models;
+using ClaimsService.Services.Adjudication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -16,26 +17,27 @@ public class ClaimRepositoryMongo : IClaimRepository
     private readonly IMongoCollection<Claim> _collection;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<ClaimRepositoryMongo> _logger;
+    private readonly IAdjudicationTenantContext? _adjudicationTenantContext;
 
     public ClaimRepositoryMongo(
         IMongoDatabase database,
         IHttpContextAccessor httpContextAccessor,
-        ILogger<ClaimRepositoryMongo> logger)
+        ILogger<ClaimRepositoryMongo> logger,
+        IAdjudicationTenantContext? adjudicationTenantContext = null)
     {
         _collection = database.GetCollection<Claim>("Claims");
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
+        _adjudicationTenantContext = adjudicationTenantContext;
     }
 
     private string GetTenantId()
     {
-        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString();
+        var tenantId = _httpContextAccessor.HttpContext?.Items["TenantId"]?.ToString()
+            ?? _adjudicationTenantContext?.TenantId;
         if (string.IsNullOrEmpty(tenantId))
         {
-            // Fallback for background services or testing if no context.
-            // In a real scenario, we might default to a specific behavior or throw
-            // throw new InvalidOperationException("TenantId not found in request context -- Mongo repo");
-            return "unknown";
+            throw new InvalidOperationException("TenantId not found in request or adjudication context");
         }
         return tenantId;
     }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryPartitionKeyTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryPartitionKeyTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
+using ClaimsService.Services.Adjudication;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Cosmos;
@@ -55,6 +56,37 @@ public sealed class ClaimRepositoryPartitionKeyTests
         StubReadItemReturnsClaim(MakeClaim());
 
         await _sut.GetByIdAsync(ClaimId);
+
+        await _container.Received(1).ReadItemAsync<Claim>(
+            ClaimId,
+            new PartitionKey(TenantId),
+            Arg.Any<ItemRequestOptions>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WithoutHttpContext_UsesAdjudicationTenantPartitionKey()
+    {
+        var cosmos = Substitute.For<CosmosClient>();
+        cosmos.GetContainer(Arg.Any<string>(), Arg.Any<string>()).Returns(_container);
+
+        var config = Substitute.For<IConfiguration>();
+        config["CosmosDb:DatabaseName"].Returns("ClaimsDB");
+        config["CosmosDb:ContainerName"].Returns("Claims");
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns((HttpContext?)null);
+
+        var tenantContext = new AdjudicationTenantContext { TenantId = TenantId };
+        var sut = new ClaimRepository(
+            cosmos,
+            config,
+            httpContextAccessor,
+            NullLogger<ClaimRepository>.Instance,
+            tenantContext);
+        StubReadItemReturnsClaim(MakeClaim());
+
+        await sut.GetByIdAsync(ClaimId);
 
         await _container.Received(1).ReadItemAsync<Claim>(
             ClaimId,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -1,6 +1,7 @@
 using ClaimsService.Exceptions;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
+using ClaimsService.Services.Adjudication;
 using EphemeralMongo;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -234,6 +235,24 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         var mar1 = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
         head = await _repo.GetLatestVersionAsync("chain-multi", mar1);
         head!.Id.Should().Be("row-2");
+    }
+
+    [Fact]
+    public async Task GetLatestVersionAsync_uses_adjudication_tenant_context_without_http_context()
+    {
+        var created = await _repo.CreateAsync(Sample("row-background"));
+        var tenantContext = new AdjudicationTenantContext { TenantId = Tenant };
+        var backgroundRepo = new ClaimRepositoryMongo(
+            _database,
+            new HttpContextAccessor(),
+            NullLogger<ClaimRepositoryMongo>.Instance,
+            tenantContext);
+
+        var latest = await backgroundRepo.GetLatestVersionAsync(created.ClaimVersionId, DateTime.UtcNow);
+
+        latest.Should().NotBeNull();
+        latest!.Id.Should().Be(created.Id);
+        latest.TenantId.Should().Be(Tenant);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Let Cosmos and Mongo claim repositories resolve tenant IDs from adjudication tenant context when no HTTP context exists.
- Remove the Mongo repository fallback to unknown so missing tenant context fails explicitly.
- Add a Mongo repository regression test for background adjudication tenant lookup.

## Verification
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj: 512 passed
- git diff --check

## Follow-up finding
A local MCC pend-observation smoke still does not produce pended claims after this fix. With claims-service rebuilt locally and scaled to one replica, a 1K skip-writeback run observed 16 expected-pend claims, 0 pended, and 16 observation timeouts after 180s. This PR fixes the background repository tenant-resolution bug; the async pend path still needs a separate follow-up before Episode 006 results are publishable.