### PR TITLE
Honor in-memory message bus subscription concurrency

### DIFF
--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/InMemoryMessageBusTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/Messaging/InMemoryMessageBusTests.cs
@@ -6,4 +6,60 @@ public class InMemoryMessageBusTests : MessageBusContractTests
 {
     protected override ValueTask<IMessageBus> CreateBusAsync()
         => ValueTask.FromResult<IMessageBus>(new InMemoryMessageBus());
+
+    [Fact]
+    public async Task Subscribe_HonorsMaxConcurrentCalls()
+    {
+        await using var bus = new InMemoryMessageBus();
+        var queue = $"parallel-{Guid.NewGuid():N}";
+        var entered = 0;
+        var maxObserved = 0;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var sub = bus.Subscribe<ParallelPayload>(
+            queue,
+            async (_, _, ct) =>
+            {
+                var current = Interlocked.Increment(ref entered);
+                try
+                {
+                    UpdateMax(ref maxObserved, current);
+                    if (current == 4)
+                    {
+                        allStarted.TrySetResult();
+                    }
+
+                    await release.Task.WaitAsync(ct);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref entered);
+                }
+            },
+            new SubscriptionOptions(MaxConcurrentCalls: 4));
+        await sub.StartAsync(CancellationToken.None);
+
+        for (var i = 0; i < 4; i++)
+        {
+            await bus.SendAsync(queue, new ParallelPayload(i));
+        }
+
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        release.SetResult();
+
+        Assert.Equal(4, maxObserved);
+    }
+
+    private static void UpdateMax(ref int target, int value)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref target);
+            if (value <= current) return;
+            if (Interlocked.CompareExchange(ref target, value, current) == current) return;
+        }
+    }
+
+    private sealed record ParallelPayload(int Value);
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/Messaging/InMemoryMessageBus.cs
@@ -100,6 +100,7 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             queueOrTopic,
             channel,
             env => handler((T)env.Message, env.ToContext(), env.CancellationToken),
+            Math.Max(1, options?.MaxConcurrentCalls ?? 1),
             _logger);
         _subscriptions.Add(new WeakReference<InMemorySubscription>(sub));
         return sub;
@@ -191,10 +192,11 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
         private readonly string _queueOrTopic;
         private readonly Channel<Envelope> _channel;
         private readonly Func<Envelope, Task> _dispatch;
+        private readonly int _maxConcurrentCalls;
         private readonly ILogger _logger;
         private readonly CancellationTokenSource _internalCts = new();
         private CancellationTokenSource? _linkedCts;
-        private Task? _pump;
+        private Task[]? _pumps;
         private int _started;
         private int _disposed;
 
@@ -202,11 +204,13 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             string queueOrTopic,
             Channel<Envelope> channel,
             Func<Envelope, Task> dispatch,
+            int maxConcurrentCalls,
             ILogger logger)
         {
             _queueOrTopic = queueOrTopic;
             _channel = channel;
             _dispatch = dispatch;
+            _maxConcurrentCalls = maxConcurrentCalls;
             _logger = logger;
         }
 
@@ -216,20 +220,22 @@ public sealed class InMemoryMessageBus : IMessageBus, IAsyncDisposable
             if (Interlocked.Exchange(ref _started, 1) == 1) return Task.CompletedTask;
             _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_internalCts.Token, ct);
             var pumpToken = _linkedCts.Token;
-            _pump = Task.Run(() => PumpAsync(pumpToken), pumpToken);
+            _pumps = Enumerable.Range(0, _maxConcurrentCalls)
+                .Select(_ => Task.Run(() => PumpAsync(pumpToken), pumpToken))
+                .ToArray();
             return Task.CompletedTask;
         }
 
         public async Task StopAsync(CancellationToken ct)
         {
-            if (_pump is null) return;
+            if (_pumps is null) return;
             try { _internalCts.Cancel(); }
             catch (ObjectDisposedException) { return; }
             try
             {
                 // Honour the caller's cancellation — don't let a hung handler
                 // block StopAsync past the provided token's lifetime.
-                await _pump.WaitAsync(ct).ConfigureAwait(false);
+                await Task.WhenAll(_pumps).WaitAsync(ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { /* expected on stop or caller cancel */ }
         }


### PR DESCRIPTION
## Summary
- Make InMemoryMessageBus honor SubscriptionOptions.MaxConcurrentCalls by starting a bounded set of subscription pumps.
- Preserve single-consumer behavior when no subscription options are supplied.
- Add an in-memory messaging regression test proving four handlers can run concurrently.

## Why
Local Kubernetes and test runs use the in-memory bus when Azure Service Bus is not configured. The production Service Bus path supports processor concurrency, but the in-memory path processed each subscription serially. That made local MCC async adjudication less representative of production and could leave expected-pend claims queued behind slow downstream resolver calls.

## Verification
- dotnet test src/services/shared/CloudHealthOffice.Infrastructure.Tests/CloudHealthOffice.Infrastructure.Tests.csproj --filter "FullyQualifiedName~Messaging": 19 passed, 6 skipped
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~AdjudicationPendPersistenceEndToEndTests|FullyQualifiedName~AdjudicationWithCobEndToEndTests|FullyQualifiedName~AdjudicationWithNcciEndToEndTests|FullyQualifiedName~ClaimSubmissionServiceMessageBusEmissionTests": 16 passed
- git diff --check

## Follow-up
After merge, rerun the MCC pend-observation smoke with a rebuilt claims-service image to confirm whether expected-pend claims now reach async adjudication before the observation timeout.