### PR TITLE
Fix async adjudication terminal status projection

### DIFF
--- a/src/engines/CloudHealthOffice.BenefitEngine/Models/BenefitModels.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Models/BenefitModels.cs
@@ -1,5 +1,6 @@
 namespace CloudHealthOffice.BenefitEngine.Models;
 
+using System.Text.Json.Serialization;
 using CloudHealthOffice.BenefitEngine.Domain;
 
 // ═══════════════════════════════════════════════════════════════════
@@ -12,6 +13,7 @@ public record BenefitResolutionRequest
     public string SubscriberId { get; init; } = default!;
     public Guid BenefitPlanId { get; init; }
     public DateOnly ServiceDate { get; init; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public NetworkTier NetworkTier { get; init; }
     public List<ClaimLineInput> Lines { get; init; } = [];
     public Dictionary<int, decimal> AllowedAmounts { get; init; } = [];

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -148,12 +148,11 @@ public interface IClaimRepository
     /// examiner override) already finalized the claim. Re-pending an
     /// already-<c>Pended</c> claim (a re-adjudication run refreshing
     /// <paramref name="pendDetails"/>) is allowed — Pended is not a final
-    /// disposition. <paramref name="isPend"/> false is a pure no-op on
-    /// <c>ClaimStatus</c> — behavior for Pass/Deny/Reject outcomes is
-    /// unchanged from before this parameter existed; those outcomes'
-    /// status transitions are owned by other write paths
-    /// (<c>UpdateAdjudicationSummaryAsync</c>, the Argo workflow, or
-    /// <c>ClaimsController.PendClaim</c>), not this bypass method.
+    /// disposition. When <paramref name="resolvedStatus"/> is supplied, this
+    /// call also projects async Pass/Deny/Reject outcomes through the same
+    /// guarded status transition used by <c>UpdateAdjudicationSummaryAsync</c>,
+    /// so async-only adjudication runs become observable without overwriting
+    /// an already Pended or final claim.
     /// </para>
     ///
     /// Returns true on success, false when no head row was found for the
@@ -166,7 +165,8 @@ public interface IClaimRepository
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
-        bool isPend = false);
+        bool isPend = false,
+        ClaimStatus? resolvedStatus = null);
 
     /// <summary>
     /// Fast claim-level adjudication projection for direct local workflow
@@ -956,7 +956,8 @@ public class ClaimRepository : IClaimRepository
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
-        bool isPend = false)
+        bool isPend = false,
+        ClaimStatus? resolvedStatus = null)
     {
         // Resolve the head (non-terminal-but-adjudicatable) row by chain key.
         // PatchItemAsync is keyed on the per-row document Id, so we look up
@@ -1061,44 +1062,55 @@ public class ClaimRepository : IClaimRepository
             return false;
         }
 
-        if (!isPend)
+        if (isPend)
         {
+            // Defect A fix, made atomic — project the orchestrator's Pend outcome
+            // onto ClaimStatus in a SEPARATE conditional patch, evaluated against
+            // the row's live state at commit time via FilterPredicate rather than
+            // the `head` snapshot read above. Precedence: never downgrade a claim
+            // that already reached a later-stage disposition (IsFinalDisposition)
+            // — e.g. because the Argo workflow's synchronous finalize step, or an
+            // examiner override, raced ahead of this async projection. A
+            // read-then-decide check (the original form of this guard) only
+            // catches that race when the other write happens to land before this
+            // method's own read; a concurrent write landing in between read and
+            // write would still get clobbered. The conditional patch closes that
+            // window: Cosmos evaluates FilterPredicate against the document as it
+            // exists at the moment this patch actually commits. Re-pending an
+            // already-Pended claim is allowed — Pended is excluded from
+            // FinalDispositions by design. A blocked patch is not an error; the
+            // /adjudicationResult + /claimLines + /pendDetails write above still
+            // succeeded, so this method still returns true either way.
+            try
+            {
+                await _container.PatchItemAsync<Claim>(
+                    rowId,
+                    new PartitionKey(tenantId),
+                    new List<PatchOperation> { PatchOperation.Set("/status", ClaimStatus.Pended) },
+                    new PatchItemRequestOptions { FilterPredicate = FinalDispositionFilterPredicate },
+                    ct);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+            {
+                // Guard correctly blocked the downgrade — not an error.
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // Row deleted between the first patch and this one.
+            }
+
             return true;
         }
 
-        // Defect A fix, made atomic — project the orchestrator's Pend outcome
-        // onto ClaimStatus in a SEPARATE conditional patch, evaluated against
-        // the row's live state at commit time via FilterPredicate rather than
-        // the `head` snapshot read above. Precedence: never downgrade a claim
-        // that already reached a later-stage disposition (IsFinalDisposition)
-        // — e.g. because the Argo workflow's synchronous finalize step, or an
-        // examiner override, raced ahead of this async projection. A
-        // read-then-decide check (the original form of this guard) only
-        // catches that race when the other write happens to land before this
-        // method's own read; a concurrent write landing in between read and
-        // write would still get clobbered. The conditional patch closes that
-        // window: Cosmos evaluates FilterPredicate against the document as it
-        // exists at the moment this patch actually commits. Re-pending an
-        // already-Pended claim is allowed — Pended is excluded from
-        // FinalDispositions by design. A blocked patch is not an error; the
-        // /adjudicationResult + /claimLines + /pendDetails write above still
-        // succeeded, so this method still returns true either way.
-        try
+        if (resolvedStatus is not null)
         {
-            await _container.PatchItemAsync<Claim>(
-                rowId,
-                new PartitionKey(tenantId),
-                new List<PatchOperation> { PatchOperation.Set("/status", ClaimStatus.Pended) },
-                new PatchItemRequestOptions { FilterPredicate = FinalDispositionFilterPredicate },
-                ct);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
-        {
-            // Guard correctly blocked the downgrade — not an error.
-        }
-        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            // Row deleted between the first patch and this one.
+            await TryPatchStatusAsync(
+                    tenantId,
+                    rowId,
+                    resolvedStatus.Value,
+                    MapStatusToVersionState(resolvedStatus.Value),
+                    ct)
+                .ConfigureAwait(false);
         }
 
         return true;

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -426,7 +426,8 @@ public class ClaimRepositoryMongo : IClaimRepository
         IReadOnlyList<LineAdjudicationResult> lineResults,
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
-        bool isPend = false)
+        bool isPend = false,
+        ClaimStatus? resolvedStatus = null)
     {
         var b = Builders<Claim>.Filter;
 
@@ -490,31 +491,41 @@ public class ClaimRepositoryMongo : IClaimRepository
             return false;
         }
 
-        if (!isPend)
+        if (isPend)
         {
+            // Defect A fix, made atomic — project the orchestrator's Pend outcome
+            // onto ClaimStatus in a SEPARATE conditional update, whose FILTER
+            // (not a C# if-check against the `head` snapshot above) carries the
+            // precedence rule: never downgrade a claim already at a later-stage
+            // disposition (see ClaimRepository.IsFinalDisposition). A
+            // read-then-decide check only catches a concurrent write that lands
+            // before this method's own read; MongoDB evaluates this filter
+            // against the row's live state at the moment the update actually
+            // executes, so a competing write landing in between is still caught.
+            // No match on this second update just means the guard correctly
+            // blocked the downgrade — not an error; the AdjudicationResult /
+            // ClaimLines / PendDetails write above already succeeded, so this
+            // method still returns true either way. Re-pending an already-Pended
+            // claim is allowed — Pended is excluded from FinalDispositions.
+            var pendFilter = b.And(
+                b.Eq(c => c.TenantId, tenantId),
+                b.Eq(c => c.Id, head.Id),
+                b.Not(b.In(c => c.Status, ClaimRepository.FinalDispositions)));
+            var pendUpdate = Builders<Claim>.Update.Set(c => c.Status, ClaimStatus.Pended);
+            await _collection.UpdateOneAsync(pendFilter, pendUpdate, cancellationToken: ct);
             return true;
         }
 
-        // Defect A fix, made atomic — project the orchestrator's Pend outcome
-        // onto ClaimStatus in a SEPARATE conditional update, whose FILTER
-        // (not a C# if-check against the `head` snapshot above) carries the
-        // precedence rule: never downgrade a claim already at a later-stage
-        // disposition (see ClaimRepository.IsFinalDisposition). A
-        // read-then-decide check only catches a concurrent write that lands
-        // before this method's own read; MongoDB evaluates this filter
-        // against the row's live state at the moment the update actually
-        // executes, so a competing write landing in between is still caught.
-        // No match on this second update just means the guard correctly
-        // blocked the downgrade — not an error; the AdjudicationResult /
-        // ClaimLines / PendDetails write above already succeeded, so this
-        // method still returns true either way. Re-pending an already-Pended
-        // claim is allowed — Pended is excluded from FinalDispositions.
-        var pendFilter = b.And(
-            b.Eq(c => c.TenantId, tenantId),
-            b.Eq(c => c.Id, head.Id),
-            b.Not(b.In(c => c.Status, ClaimRepository.FinalDispositions)));
-        var pendUpdate = Builders<Claim>.Update.Set(c => c.Status, ClaimStatus.Pended);
-        await _collection.UpdateOneAsync(pendFilter, pendUpdate, cancellationToken: ct);
+        if (resolvedStatus is not null)
+        {
+            await TryPatchStatusAsync(
+                    tenantId,
+                    head.Id,
+                    resolvedStatus.Value,
+                    ClaimRepository.MapStatusToVersionState(resolvedStatus.Value),
+                    ct)
+                .ConfigureAwait(false);
+        }
 
         return true;
     }

--- a/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
+++ b/src/services/claims-service/Services/Adjudication/HttpBenefitCalculationEngineClient.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using CloudHealthOffice.BenefitEngine.Models;
 using CloudHealthOffice.BenefitEngine.Services;
 using CloudHealthOffice.OperatingMode;
@@ -43,6 +44,7 @@ public sealed class HttpBenefitCalculationEngineClient : IBenefitCalculationEngi
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
     };
 
     private readonly IHttpClientFactory _httpClientFactory;

--- a/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
@@ -57,11 +57,11 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
         // BEFORE Persistence (Order=999, always last) using the same
         // Reject>Deny>Pend>Pass precedence the orchestrator uses for the
         // emitted event's Outcome (ClaimAdjudicationStageResult.ResolveOutcome).
-        // Reject/Deny/Pass outcomes leave isPend=false, so the repository's
-        // status-write behavior for those outcomes is unchanged from before
-        // this fix — this call site only ever adds a status write for Pend.
-        var isPend = ClaimAdjudicationStageResult.ResolveOutcome(context.StageResults)
-            == ClaimAdjudicationOutcome.Pend;
+        // The repository uses a special one-way guard for Pend and the normal
+        // guarded transition path for terminal Pass/Deny/Reject.
+        var resolvedOutcome = ClaimAdjudicationStageResult.ResolveOutcome(context.StageResults);
+        var isPend = resolvedOutcome == ClaimAdjudicationOutcome.Pend;
+        var resolvedStatus = MapOutcomeToStatus(resolvedOutcome);
 
         try
         {
@@ -73,7 +73,8 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
                     context.LineAdjudicationResults,
                     ct,
                     pendDetails: context.PendDetails,
-                    isPend: isPend)
+                    isPend: isPend,
+                    resolvedStatus: resolvedStatus)
                 .ConfigureAwait(false);
 
             if (!written)
@@ -105,4 +106,13 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
 
     private static string SanitizeForLog(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+
+    private static ClaimStatus MapOutcomeToStatus(ClaimAdjudicationOutcome outcome) => outcome switch
+    {
+        ClaimAdjudicationOutcome.Pass => ClaimStatus.Approved,
+        ClaimAdjudicationOutcome.Pend => ClaimStatus.Pended,
+        ClaimAdjudicationOutcome.Deny => ClaimStatus.Denied,
+        ClaimAdjudicationOutcome.Reject => ClaimStatus.Denied,
+        _ => ClaimStatus.Approved,
+    };
 }

--- a/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
@@ -113,6 +113,6 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
         ClaimAdjudicationOutcome.Pend => ClaimStatus.Pended,
         ClaimAdjudicationOutcome.Deny => ClaimStatus.Denied,
         ClaimAdjudicationOutcome.Reject => ClaimStatus.Denied,
-        _ => ClaimStatus.Approved,
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unexpected adjudication outcome."),
     };
 }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -154,7 +154,7 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                     Arg.Any<string>(), Arg.Any<DateTime>())
                 .Returns(_ => _lastCreated);
 
-            // Explicitly matches all 7 parameters (not just the leading 5) —
+            // Explicitly matches all projection parameters (not just the leading 5) —
             // this test's pipeline runs the real CoordinationOfBenefitsStage
             // against the real HttpCoverageClient, which is unreachable in
             // this test host and degrades to a Pend (Decision 7, default
@@ -169,7 +169,8 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                     Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
                     Arg.Any<CancellationToken>(),
                     Arg.Any<PendDetails?>(),
-                    Arg.Any<bool>())
+                    Arg.Any<bool>(),
+                    Arg.Any<ClaimStatus?>())
                 .Returns(ci =>
                 {
                     ProjectionWrites.Add(new ProjectionWrite(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
@@ -115,11 +115,12 @@ public class AdjudicationPendPersistenceEndToEndTests
     }
 
     [Fact]
-    public async Task Ncci_deny_mode_orchestrator_run_does_not_persist_Pended_status()
+    public async Task Ncci_deny_mode_orchestrator_run_persists_Denied_status_not_Pended()
     {
         // Deny outweighs Pend in the resolved outcome even though NCCI still
         // populates PendDetails as an audit-trail snapshot — the claim must
-        // NOT be left in ClaimStatus.Pended.
+        // NOT be left in ClaimStatus.Pended. Async terminal outcomes should
+        // still become observable, so Deny projects to ClaimStatus.Denied.
         SetupAdapterReturningClaim(BuildBundledPairClaim());
 
         var state = new FakeClaimState();
@@ -132,7 +133,7 @@ public class AdjudicationPendPersistenceEndToEndTests
         await orch.AdjudicateAsync(BuildSubmittedMessage("ver-persist-ncci-deny"), BuildMessageContext("ver-persist-ncci-deny"), CancellationToken.None);
 
         Assert.NotEqual(ClaimStatus.Pended, state.Status);
-        Assert.Equal(ClaimStatus.Submitted, state.Status);
+        Assert.Equal(ClaimStatus.Denied, state.Status);
     }
 
     private void SetupAdapterReturningClaim(AdapterClaim claim) =>
@@ -175,11 +176,13 @@ public class AdjudicationPendPersistenceEndToEndTests
                 Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
                 Arg.Any<CancellationToken>(),
                 Arg.Any<PendDetails?>(),
-                Arg.Any<bool>())
+                Arg.Any<bool>(),
+                Arg.Any<ClaimStatus?>())
             .Returns(ci =>
             {
                 var pendDetails = ci.ArgAt<PendDetails?>(5);
                 var isPend = ci.ArgAt<bool>(6);
+                var resolvedStatus = ci.ArgAt<ClaimStatus?>(7);
 
                 if (pendDetails is not null)
                 {
@@ -189,6 +192,10 @@ public class AdjudicationPendPersistenceEndToEndTests
                 if (isPend && !ClaimRepository.IsFinalDisposition(state.Status))
                 {
                     state.Status = ClaimStatus.Pended;
+                }
+                else if (resolvedStatus is not null && !ClaimRepository.BlocksSynchronousWriteback(state.Status))
+                {
+                    state.Status = resolvedStatus.Value;
                 }
 
                 return true;

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -367,14 +367,11 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpdateAdjudicationProjectionAsync_withIsPendFalse_leavesStatusUnchanged()
+    public async Task UpdateAdjudicationProjectionAsync_withoutResolvedStatus_leavesStatusUnchanged()
     {
-        // Regression guard (task requirement 4): this bypass method has
-        // NEVER written /status for non-pend outcomes and must continue not
-        // to — even when the AdjudicationResult looks like an approval
-        // (PayerPayment > 0). Status transitions for Pass/Deny/Reject stay
-        // owned by UpdateAdjudicationSummaryAsync / UpdateAdjudication / the
-        // Argo workflow, not this method.
+        // Backward-compatibility guard: existing callers that only project
+        // financial metadata and omit resolvedStatus must not accidentally
+        // infer a claim status from the AdjudicationResult shape.
         var head = await _repo.CreateAsync(BuildVersion("chain-pass", "row-1", n: 1, ClaimVersionState.Submitted));
         head.Status.Should().Be(ClaimStatus.Submitted);
 
@@ -386,9 +383,29 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
 
         ok.Should().BeTrue();
         var reread = await _repo.GetVersionAsync("chain-pass", "row-1");
-        reread!.Status.Should().Be(ClaimStatus.Submitted, "isPend=false must never touch /status, matching pre-fix behavior");
+        reread!.Status.Should().Be(ClaimStatus.Submitted, "resolvedStatus was not supplied");
         reread.AdjudicationResult.Should().NotBeNull("the non-status projection fields still write as before");
         reread.AdjudicationResult!.PayerPayment.Should().Be(120m);
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withResolvedStatus_setsTerminalStatusAndVersionState()
+    {
+        var head = await _repo.CreateAsync(BuildVersion("chain-deny", "row-1", n: 1, ClaimVersionState.Submitted));
+        head.Status.Should().Be(ClaimStatus.Submitted);
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-deny",
+            new AdjudicationResult { AllowedAmount = 0m, DenialReasonCode = "999" },
+            Array.Empty<LineAdjudicationResult>(),
+            isPend: false,
+            resolvedStatus: ClaimStatus.Denied);
+
+        ok.Should().BeTrue();
+        var reread = await _repo.GetVersionAsync("chain-deny", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Denied);
+        reread.VersionState.Should().Be(ClaimVersionState.Denied);
+        reread.AdjudicationResult.Should().NotBeNull("the financial projection still writes with the terminal status");
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
@@ -1,8 +1,11 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using ClaimsService.Services.Adjudication;
+using CloudHealthOffice.BenefitEngine.Domain;
+using CloudHealthOffice.BenefitEngine.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -35,6 +38,70 @@ public class HttpBenefitCalculationEngineClientReverseTests
 
     private HttpBenefitCalculationEngineClient CreateClient() => new(
         _factory, _httpContext, _tenantContext, NullLogger<HttpBenefitCalculationEngineClient>.Instance);
+
+    [Fact]
+    public async Task CalculateAsync_RoundTripsStringEnumsInRequestAndResponse()
+    {
+        _tenantContext.TenantId.Returns("tenant-x");
+        _handler.RespondWith(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """
+                {
+                  "success": true,
+                  "lines": [],
+                  "totals": {},
+                  "accumulatorSnapshot": [
+                    {
+                      "type": "IndividualDeductible",
+                      "scope": "Individual",
+                      "networkTier": "InNetwork",
+                      "limitAmount": 1500,
+                      "accumulatedAmountBefore": 100,
+                      "amountApplied": 25,
+                      "accumulatedAmountAfter": 125,
+                      "remainingAmount": 1375,
+                      "limitReached": false
+                    }
+                  ],
+                  "timings": {}
+                }
+                """,
+                Encoding.UTF8,
+                "application/json"),
+        });
+
+        var sut = CreateClient();
+        var result = await sut.CalculateAsync(new BenefitResolutionRequest
+        {
+            ClaimId = "claim-1",
+            MemberId = "member-1",
+            SubscriberId = "subscriber-1",
+            BenefitPlanId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            ServiceDate = new DateOnly(2026, 6, 1),
+            NetworkTier = NetworkTier.InNetwork,
+            Lines =
+            [
+                new ClaimLineInput
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    PlaceOfService = "11",
+                    BilledAmount = 100m,
+                },
+            ],
+        });
+
+        Assert.True(result.Success);
+        var snapshot = Assert.Single(result.AccumulatorSnapshot);
+        Assert.Equal(AccumulatorType.IndividualDeductible, snapshot.Type);
+        Assert.Equal(AccumulatorScope.Individual, snapshot.Scope);
+        Assert.Equal(NetworkTier.InNetwork, snapshot.NetworkTier);
+
+        Assert.NotNull(_handler.LastBodyJson);
+        var requestJson = JsonDocument.Parse(_handler.LastBodyJson!);
+        Assert.Equal("InNetwork", requestJson.RootElement.GetProperty("networkTier").GetString());
+    }
 
     [Fact]
     public async Task ReverseClaimAsync_HappyPath_PostsToReverseEndpointAndReturns()

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/HttpBenefitCalculationEngineClientReverseTests.cs
@@ -99,7 +99,7 @@ public class HttpBenefitCalculationEngineClientReverseTests
         Assert.Equal(NetworkTier.InNetwork, snapshot.NetworkTier);
 
         Assert.NotNull(_handler.LastBodyJson);
-        var requestJson = JsonDocument.Parse(_handler.LastBodyJson!);
+        using var requestJson = JsonDocument.Parse(_handler.LastBodyJson!);
         Assert.Equal("InNetwork", requestJson.RootElement.GetProperty("networkTier").GetString());
     }
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/PersistenceStageTests.cs
@@ -36,13 +36,7 @@ public class PersistenceStageTests
         {
             new() { AllowedAmount = 75m, PaidAmount = 50m, PatientResponsibility = 25m },
         };
-        _repository.UpdateAdjudicationProjectionAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<AdjudicationResult>(),
-            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
-            Arg.Any<CancellationToken>())
-            .Returns(true);
+        StubRepositoryReturns(true);
 
         var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
 
@@ -52,20 +46,17 @@ public class PersistenceStageTests
             "ver-1",
             Arg.Is<AdjudicationResult>(a => a.AllowedAmount == 75m),
             Arg.Is<IReadOnlyList<LineAdjudicationResult>>(l => l.Count == 1),
-            Arg.Any<CancellationToken>());
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Is<bool>(isPend => !isPend),
+            Arg.Is<ClaimStatus?>(status => status == ClaimStatus.Approved));
     }
 
     [Fact]
     public async Task Execute_BypassReturnsFalse_StageReturnsReject()
     {
         var ctx = BuildContext();
-        _repository.UpdateAdjudicationProjectionAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<AdjudicationResult>(),
-            Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
-            Arg.Any<CancellationToken>())
-            .Returns(false);
+        StubRepositoryReturns(false);
 
         var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
 
@@ -81,7 +72,10 @@ public class PersistenceStageTests
             Arg.Any<string>(),
             Arg.Any<AdjudicationResult>(),
             Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<PendDetails?>(),
+            Arg.Any<bool>(),
+            Arg.Any<ClaimStatus?>())
             .Throws(new InvalidOperationException("cosmos down"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -109,7 +103,8 @@ public class PersistenceStageTests
             Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
             Arg.Any<CancellationToken>(),
             Arg.Is<PendDetails?>(p => p!.PendCode == "NCCI"),
-            Arg.Is<bool>(isPend => isPend));
+            Arg.Is<bool>(isPend => isPend),
+            Arg.Is<ClaimStatus?>(status => status == ClaimStatus.Pended));
     }
 
     [Fact]
@@ -125,7 +120,8 @@ public class PersistenceStageTests
             Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<PendDetails?>(),
-            Arg.Is<bool>(isPend => !isPend));
+            Arg.Is<bool>(isPend => !isPend),
+            Arg.Is<ClaimStatus?>(status => status == ClaimStatus.Approved));
     }
 
     [Fact]
@@ -148,7 +144,8 @@ public class PersistenceStageTests
             Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<PendDetails?>(),
-            Arg.Is<bool>(isPend => !isPend));
+            Arg.Is<bool>(isPend => !isPend),
+            Arg.Is<ClaimStatus?>(status => status == ClaimStatus.Denied));
     }
 
     [Fact]
@@ -165,7 +162,8 @@ public class PersistenceStageTests
             Arg.Any<AdjudicationResult>(), Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<PendDetails?>(),
-            Arg.Is<bool>(isPend => !isPend));
+            Arg.Is<bool>(isPend => !isPend),
+            Arg.Is<ClaimStatus?>(status => status == ClaimStatus.Denied));
     }
 
     private void StubRepositoryReturns(bool value) =>
@@ -176,7 +174,8 @@ public class PersistenceStageTests
             Arg.Any<IReadOnlyList<LineAdjudicationResult>>(),
             Arg.Any<CancellationToken>(),
             Arg.Any<PendDetails?>(),
-            Arg.Any<bool>())
+            Arg.Any<bool>(),
+            Arg.Any<ClaimStatus?>())
             .Returns(value);
 
     private static ClaimAdjudicationContext BuildContext() => new()


### PR DESCRIPTION
## Summary
- project async adjudication terminal outcomes into observable claim status (`Approved`/`Denied`) while preserving the guarded `Pended` path
- align benefit calculation HTTP enum handling across request and response DTOs
- add regression coverage for async terminal projection and string-enum benefit response round-trips

## Validation
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter FullyQualifiedName~HttpBenefitCalculationEngineClientReverseTests --logger "console;verbosity=minimal"` — passed, 6/6
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~PersistenceStageTests|FullyQualifiedName~AdjudicationPendPersistenceEndToEndTests|FullyQualifiedName~AdjudicationEndToEndTests" --logger "console;verbosity=minimal"` — passed, 12/12
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter FullyQualifiedName~ClaimRepositoryVersioningTests --logger "console;verbosity=minimal"` — passed, 59/59
- `dotnet test tests/CloudHealthOffice.AdjudicationController.Tests/CloudHealthOffice.AdjudicationController.Tests.csproj --filter FullyQualifiedName~AdjudicationControllerTests --logger "console;verbosity=minimal"` — passed, 17/17
- `git diff --check` — clean

## MCC smoke
Rebuilt and loaded local `claims-service` and `benefit-plan-service` images into `kind-docker-desktop`, then ran:

```bash
SKIP_BUILD=true CLAIMS=250 MAX_CLAIMS=250 PARALLELISM=10 PROGRESS_EVERY=50 \
  PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=120 \
  PEND_OBSERVATION_INTERVAL_MS=1000 SEED_MEMBERS=true SEED_PROVIDERS=true \
  scripts/run-mcc-local-k8s.sh
```

Observed:
- `Pend observation: 0 pended, 0 timed out`
- workflow checks improved to `24/32 matched`
- no `networkTier` BadRequest
- no benefit response `JsonException`
- no benefit-plan Mongo serializer exception in the second smoke window

The smoke still exits nonzero because there are remaining scenario mismatches and separate writeback `404 Claim not found` failures. Those are outside this async terminal-status/HTTP-contract fix.
