### PR TITLE
Fix MCC writeback summary updates for finalized claims

### DIFF
--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -926,9 +926,16 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
+              AND (NOT IS_DEFINED(c.versionState)
+                   OR c.versionState = @submitted
+                   OR c.versionState = @adjudicated
+                   OR c.versionState = @unknown)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId);
+            .WithParameter("@claimVersionId", claimVersionId)
+            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
+            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
+            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
 
         var iterator = _container.GetItemQueryIterator<Claim>(
             query,
@@ -971,16 +978,9 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
-              AND (NOT IS_DEFINED(c.versionState)
-                   OR c.versionState = @submitted
-                   OR c.versionState = @adjudicated
-                   OR c.versionState = @unknown)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId)
-            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
-            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
-            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
+            .WithParameter("@claimVersionId", claimVersionId);
 
         string? rowId = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
@@ -1130,16 +1130,9 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
-              AND (NOT IS_DEFINED(c.versionState)
-                   OR c.versionState = @submitted
-                   OR c.versionState = @adjudicated
-                   OR c.versionState = @unknown)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId)
-            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
-            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
-            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
+            .WithParameter("@claimVersionId", claimVersionId);
 
         string? rowId = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
@@ -1154,11 +1147,9 @@ public class ClaimRepository : IClaimRepository
         if (string.IsNullOrEmpty(rowId)) return StatusWriteResult.NotFoundResult;
 
         // Residual-race fix — financial/audit data (AdjudicationResult, dates)
-        // persists unconditionally: this method's caller (the validator's
-        // synchronous write-back) always has a legitimate adjudication result
-        // to record even when the status transition below gets suppressed.
-        // Only /status + /versionState are guarded, in a separate conditional
-        // patch — see TryPatchStatusAsync.
+        // persists by chain/id even if async adjudication already finalized
+        // the row. Only /status + /versionState are guarded, in a separate
+        // conditional patch — see TryPatchStatusAsync.
         var now = DateTime.UtcNow;
         var summaryOps = new List<PatchOperation>
         {

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -926,16 +926,9 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
-              AND (NOT IS_DEFINED(c.versionState)
-                   OR c.versionState = @submitted
-                   OR c.versionState = @adjudicated
-                   OR c.versionState = @unknown)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId)
-            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
-            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
-            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
+            .WithParameter("@claimVersionId", claimVersionId);
 
         var iterator = _container.GetItemQueryIterator<Claim>(
             query,
@@ -978,9 +971,16 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
+              AND (NOT IS_DEFINED(c.versionState)
+                   OR c.versionState = @submitted
+                   OR c.versionState = @adjudicated
+                   OR c.versionState = @unknown)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId);
+            .WithParameter("@claimVersionId", claimVersionId)
+            .WithParameter("@submitted", ClaimVersionState.Submitted.ToString())
+            .WithParameter("@adjudicated", ClaimVersionState.Adjudicated.ToString())
+            .WithParameter("@unknown", ClaimVersionState.Unknown.ToString());
 
         string? rowId = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
@@ -1130,9 +1130,11 @@ public class ClaimRepository : IClaimRepository
               AND (c.claimVersionId = @claimVersionId
                    OR (NOT IS_DEFINED(c.claimVersionId) AND c.id = @claimVersionId)
                    OR (c.claimVersionId = '' AND c.id = @claimVersionId))
+              AND (NOT IS_DEFINED(c.versionState) OR c.versionState = null OR c.versionState != @draft)
             ORDER BY c.versionNumber DESC")
             .WithParameter("@tenantId", tenantId)
-            .WithParameter("@claimVersionId", claimVersionId);
+            .WithParameter("@claimVersionId", claimVersionId)
+            .WithParameter("@draft", ClaimVersionState.Draft.ToString());
 
         string? rowId = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -545,7 +545,10 @@ public class ClaimRepositoryMongo : IClaimRepository
                 b.Or(b.Eq(c => c.ClaimVersionId, string.Empty), b.Eq(c => c.ClaimVersionId, (string?)null)),
                 b.Eq(c => c.Id, claimVersionId)));
 
-        var filter = b.And(b.Eq(c => c.TenantId, tenantId), chainFilter);
+        var filter = b.And(
+            b.Eq(c => c.TenantId, tenantId),
+            chainFilter,
+            b.Ne(c => c.VersionState, ClaimVersionState.Draft));
         var now = DateTime.UtcNow;
 
         // Residual-race fix — financial/audit data (AdjudicationResult, dates)

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -545,20 +545,13 @@ public class ClaimRepositoryMongo : IClaimRepository
                 b.Or(b.Eq(c => c.ClaimVersionId, string.Empty), b.Eq(c => c.ClaimVersionId, (string?)null)),
                 b.Eq(c => c.Id, claimVersionId)));
 
-        var stateFilter = b.Or(
-            b.Eq(c => c.VersionState, ClaimVersionState.Submitted),
-            b.Eq(c => c.VersionState, ClaimVersionState.Adjudicated),
-            b.Eq(c => c.VersionState, ClaimVersionState.Unknown));
-
-        var filter = b.And(b.Eq(c => c.TenantId, tenantId), chainFilter, stateFilter);
+        var filter = b.And(b.Eq(c => c.TenantId, tenantId), chainFilter);
         var now = DateTime.UtcNow;
 
         // Residual-race fix — financial/audit data (AdjudicationResult, dates)
-        // persists unconditionally: this method's caller (the validator's
-        // synchronous write-back) always has a legitimate adjudication result
-        // to record even when the status transition below gets suppressed.
-        // Only Status + VersionState are guarded, in a separate conditional
-        // update — see TryPatchStatusAsync.
+        // persists by chain/id even if async adjudication already finalized
+        // the row. Only Status + VersionState are guarded, in a separate
+        // conditional update — see TryPatchStatusAsync.
         var summaryUpdate = Builders<Claim>.Update
             .Set(c => c.AdjudicationResult, adjudicationResult)
             .Set(c => c.AdjudicatedDate, now)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -258,8 +258,8 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     [Fact]
     public async Task ListVersionsAsync_returns_newest_first()
     {
-        await _repo.CreateAsync(BuildVersion("chain-list", "row-1", n: 1, ClaimVersionState.Adjudicated));
-        await _repo.CreateAsync(BuildVersion("chain-list", "row-2", n: 2, ClaimVersionState.Submitted));
+        await _repo.CreateAsync(BuildVersion("chain-list", "row-1", n: 1, ClaimVersionState.Denied));
+        await _repo.CreateAsync(BuildVersion("chain-list", "row-2", n: 2, ClaimVersionState.Draft));
         await _repo.CreateAsync(BuildVersion("chain-list", "row-3", n: 3, ClaimVersionState.Submitted));
 
         var (items, _) = await _repo.ListVersionsAsync("chain-list", pageSize: 10, continuationToken: null);
@@ -336,6 +336,33 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
             Array.Empty<LineAdjudicationResult>());
 
         ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_ignores_newer_draft_versions()
+    {
+        var submitted = await _repo.CreateAsync(BuildVersion("chain-draft-head", "row-1", n: 1, ClaimVersionState.Submitted));
+        submitted.ClaimLines.Add(new ClaimLine
+        {
+            LineNumber = 1, ProcedureCode = "99213", Units = 1, ChargeAmount = 100m,
+            ServiceDateFrom = submitted.ServiceDateFrom, ServiceDateTo = submitted.ServiceDateTo
+        });
+        await _repo.UpdateAsync(submitted);
+        await _repo.CreateAsync(BuildVersion("chain-draft-head", "row-2", n: 2, ClaimVersionState.Draft));
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant, "chain-draft-head",
+            new AdjudicationResult { AllowedAmount = 80m, PayerPayment = 64m },
+            new[] { new LineAdjudicationResult { AllowedAmount = 80m, PaidAmount = 64m, PatientResponsibility = 16m } });
+
+        ok.Should().BeTrue();
+
+        var submittedVersion = await _repo.GetVersionAsync("chain-draft-head", "row-1");
+        submittedVersion!.AdjudicationResult!.PayerPayment.Should().Be(64m);
+        submittedVersion.ClaimLines[0].AdjudicationResult!.PaidAmount.Should().Be(64m);
+
+        var draftVersion = await _repo.GetVersionAsync("chain-draft-head", "row-2");
+        draftVersion!.AdjudicationResult.Should().BeNull();
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -634,6 +661,7 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         var head = BuildVersion("chain-summary-final", "row-1", n: 1, ClaimVersionState.Denied);
         head.Status = ClaimStatus.Denied;
         await _repo.CreateAsync(head);
+        await _repo.CreateAsync(BuildVersion("chain-summary-final", "row-2", n: 2, ClaimVersionState.Draft));
 
         var result = await _repo.UpdateAdjudicationSummaryAsync(
             Tenant, "chain-summary-final",
@@ -648,6 +676,9 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         reread.VersionState.Should().Be(ClaimVersionState.Denied);
         reread.AdjudicationResult!.PayerPayment.Should().Be(50m);
         reread.AdjudicatedDate.Should().NotBeNull();
+
+        var draft = await _repo.GetVersionAsync("chain-summary-final", "row-2");
+        draft!.AdjudicationResult.Should().BeNull();
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -631,27 +631,23 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     [Fact]
     public async Task UpdateAdjudicationSummaryAsync_onAlreadyFinalClaim_suppressesStatus_butPersistsFinancialData()
     {
-        // Approved (not Denied/Paid/Voided) deliberately: those map to
-        // VersionState.Denied/Paid/Voided, which UpdateAdjudicationSummaryAsync's
-        // own query excludes entirely (terminal VersionState — a separate,
-        // pre-existing guard, not what this test targets). Approved maps to
-        // VersionState.Adjudicated, which IS query-eligible, so this row
-        // reaches the BlocksSynchronousWriteback(Approved) check itself.
-        var head = BuildVersion("chain-summary-final", "row-1", n: 1, ClaimVersionState.Adjudicated);
-        head.Status = ClaimStatus.Approved;
+        var head = BuildVersion("chain-summary-final", "row-1", n: 1, ClaimVersionState.Denied);
+        head.Status = ClaimStatus.Denied;
         await _repo.CreateAsync(head);
 
         var result = await _repo.UpdateAdjudicationSummaryAsync(
             Tenant, "chain-summary-final",
             new AdjudicationResult { AllowedAmount = 50m, PayerPayment = 50m },
-            ClaimStatus.Denied);
+            ClaimStatus.Approved);
 
         result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
-        result.PersistedStatus.Should().Be(ClaimStatus.Approved);
+        result.PersistedStatus.Should().Be(ClaimStatus.Denied);
 
         var reread = await _repo.GetVersionAsync("chain-summary-final", "row-1");
-        reread!.Status.Should().Be(ClaimStatus.Approved, "a completed disposition must never be re-litigated by a stray write-back");
+        reread!.Status.Should().Be(ClaimStatus.Denied, "a completed disposition must never be re-litigated by a stray write-back");
+        reread.VersionState.Should().Be(ClaimVersionState.Denied);
         reread.AdjudicationResult!.PayerPayment.Should().Be(50m);
+        reread.AdjudicatedDate.Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow MCC adjudication summary writeback to locate finalized claim versions by tenant + chain/id
- keep status/version-state mutation guarded so terminal outcomes remain preserved
- update the repository regression to cover a denied terminal row receiving summary data while returning Suppressed

## Verification
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter FullyQualifiedName~ClaimRepositoryVersioningTests --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~PersistenceStageTests|FullyQualifiedName~AdjudicationPendPersistenceEndToEndTests|FullyQualifiedName~AdjudicationEndToEndTests" --logger "console;verbosity=minimal"`
- 50-claim MCC local-k8s smoke: 50/50 processed, 0 platform failures, 6/6 workflow checks matched

## Notes
The failing smoke path was a false 404: async adjudication had already finalized the claim row, so the summary writeback lookup excluded it before the guarded status patch could report Suppressed. This PR lets financial/audit summary data persist while keeping the disposition guard intact.