### PR TITLE
Seed coverage for MCC pend validation

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -9,6 +9,11 @@ IMAGE="${IMAGE:-cloudhealthoffice-mcc-platform-validator:local}"
 CLAIMS="${CLAIMS:-5000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
+CLAIMS_URL="${CLAIMS_URL:-http://claims-service}"
+BENEFIT_URL="${BENEFIT_URL:-http://benefit-plan-service}"
+MEMBER_URL="${MEMBER_URL:-http://member-service}"
+COVERAGE_URL="${COVERAGE_URL:-http://coverage-service}"
+PROVIDER_URL="${PROVIDER_URL:-http://provider-service}"
 SEED_MEMBERS="${SEED_MEMBERS:-true}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
@@ -68,13 +73,15 @@ spec:
             - --parallelism
             - "${PARALLELISM}"
             - --claims-url
-            - http://claims-service
+            - "${CLAIMS_URL}"
             - --benefit-url
-            - http://benefit-plan-service
+            - "${BENEFIT_URL}"
             - --member-url
-            - http://member-service
+            - "${MEMBER_URL}"
+            - --coverage-url
+            - "${COVERAGE_URL}"
             - --provider-url
-            - http://provider-service
+            - "${PROVIDER_URL}"
             $(if [[ "$SEED_MEMBERS" != "true" ]]; then printf -- '- --no-seed-members\n'; fi)
             $(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf -- '- --no-seed-providers\n'; fi)
             $(if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then printf -- '- --no-pend-observation\n'; fi)

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -45,7 +45,7 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
                 ProcedureCode = proc.Code,
                 Description = proc.Description,
                 Units = 1,
-                ChargeAmount = proc.BaseCharge + random.Next(-50, 100),
+                ChargeAmount = ChargeWithVariance(proc.BaseCharge, random, -50, 100),
                 ServiceDate = serviceDate,
                 DiagnosisPointers = new List<int> { 1 }
             }
@@ -61,7 +61,7 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
                 ProcedureCode = proc2.Code,
                 Description = proc2.Description,
                 Units = 1,
-                ChargeAmount = proc2.BaseCharge + random.Next(-30, 60),
+                ChargeAmount = ChargeWithVariance(proc2.BaseCharge, random, -30, 60),
                 ServiceDate = serviceDate,
                 DiagnosisPointers = new List<int> { 1 }
             });
@@ -185,6 +185,9 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             EdgeCaseScenario.NewbornMotherClaimLink or
             EdgeCaseScenario.SubrogationAccidentRelated;
     }
+
+    private static decimal ChargeWithVariance(decimal baseCharge, Random random, int minVariance, int maxVariance)
+        => Math.Max(1m, baseCharge + random.Next(minVariance, maxVariance));
 
     private static (string Status, string? Number) GetPriorAuthForScenario(EdgeCaseScenario scenario, Random random)
     {

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -93,6 +93,7 @@ internal static class MccRunSummaryBuilder
                 options.ClaimsUrl,
                 options.BenefitUrl,
                 options.MemberUrl,
+                options.CoverageUrl,
                 options.ProviderUrl,
                 options.SeedMembers,
                 options.SeedProviders,

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -40,6 +40,12 @@ public static class MccWorkflowValidation
             var expectedCode = NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
             var expectedOutcome = OutcomeFromDisposition(claim.ExpectedOutcome.Disposition);
 
+            if (expectedOutcome is ClaimValidationOutcome.Pended
+                && IsUnsupportedPendedEdgeCase(claim.EdgeCase.Value))
+            {
+                return ExpectedValidation.Unsupported(scenario, expectedCode);
+            }
+
             return expectedOutcome is null
                 && claim.ExpectedOutcome.Disposition.Equals("Pended", StringComparison.OrdinalIgnoreCase)
                     ? new ExpectedValidation(scenario, ClaimValidationOutcome.Pended, expectedCode)
@@ -133,6 +139,16 @@ public static class MccWorkflowValidation
             { } value when value.Equals("Pended", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Pended,
             _ => null
         };
+    }
+
+    private static bool IsUnsupportedPendedEdgeCase(EdgeCaseScenario scenario)
+    {
+        return scenario is
+            EdgeCaseScenario.RetroEligibilityCoverageChange or
+            EdgeCaseScenario.SubrogationAccidentRelated or
+            EdgeCaseScenario.SubrogationWorkersComp or
+            EdgeCaseScenario.SubrogationThirdPartyLiability or
+            EdgeCaseScenario.MedicaidSpendDown;
     }
 
     private static string? NormalizeExpectedCode(string? code)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -36,6 +36,7 @@ Console.WriteLine($"  Tenant:      {options.TenantId}");
 Console.WriteLine($"  Claims URL:  {options.ClaimsUrl}");
 Console.WriteLine($"  Benefit URL: {options.BenefitUrl}");
 Console.WriteLine($"  Member URL:  {options.MemberUrl}");
+Console.WriteLine($"  Coverage URL:{options.CoverageUrl}");
 Console.WriteLine($"  Provider URL:{options.ProviderUrl}");
 Console.WriteLine($"  Claims:      {options.Claims:N0}");
 Console.WriteLine($"  Seed:        {options.Seed}");
@@ -51,6 +52,7 @@ await RequireHealthyAsync(http, $"{options.BenefitUrl}/health", "benefit-plan-se
 if (options.SeedMembers)
 {
     await RequireHealthyAsync(http, $"{options.MemberUrl}/health", "member-service");
+    await RequireHealthyAsync(http, $"{options.CoverageUrl}/health", "coverage-service");
 }
 if (options.SeedProviders)
 {
@@ -71,6 +73,7 @@ var answerKey = MccAnswerKey.FromClaims(claims);
 if (options.SeedMembers)
 {
     await SeedMembersAsync(http, options, claims, json);
+    await SeedCoverageAsync(http, options, claims, validationPlanId, json);
 }
 
 if (options.SeedProviders)
@@ -908,6 +911,133 @@ static async Task<bool> CreateMemberAsync(
     }
 
     return true;
+}
+
+static async Task SeedCoverageAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    IReadOnlyCollection<SyntheticClaim> claims,
+    Guid validationPlanId,
+    JsonSerializerOptions json)
+{
+    var cobClaims = claims
+        .Where(IsCobPendScenario)
+        .GroupBy(claim => claim.Member.MemberId, StringComparer.Ordinal)
+        .Select(group => group.OrderBy(claim => claim.ClaimId, StringComparer.Ordinal).First())
+        .OrderBy(claim => claim.Member.MemberId, StringComparer.Ordinal)
+        .ToList();
+
+    if (cobClaims.Count == 0)
+    {
+        Console.WriteLine("seeded: 0 COB coverage rows (no supported COB-pend scenarios)");
+        return;
+    }
+
+    var created = 0;
+    var existing = 0;
+    foreach (var claim in cobClaims)
+    {
+        if (await CobCoverageExistsAsync(http, options, claim.Member.MemberId))
+        {
+            existing++;
+            continue;
+        }
+
+        await CreateCobCoverageAsync(http, options, claim, validationPlanId, json);
+        created++;
+    }
+
+    Console.WriteLine($"seeded: {created:N0} COB coverage rows ({existing:N0} already present)");
+}
+
+static bool IsCobPendScenario(SyntheticClaim claim)
+{
+    return claim.EdgeCase is
+        EdgeCaseScenario.CobSecondaryPayer or
+        EdgeCaseScenario.CobTertiaryPayer or
+        EdgeCaseScenario.CobBirthdayRule or
+        EdgeCaseScenario.CobGenderRule or
+        EdgeCaseScenario.MedicaidDualEligible;
+}
+
+static async Task<bool> CobCoverageExistsAsync(HttpClient http, ValidatorOptions options, string memberId)
+{
+    using var response = await http.GetAsync(
+        $"{options.CoverageUrl}/api/v1/coverage/member/{Uri.EscapeDataString(memberId)}/cob");
+
+    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+    {
+        return false;
+    }
+
+    if (response.IsSuccessStatusCode)
+    {
+        return true;
+    }
+
+    var body = await response.Content.ReadAsStringAsync();
+    throw new InvalidOperationException($"COB coverage lookup failed ({memberId}): {(int)response.StatusCode} {body}");
+}
+
+static async Task CreateCobCoverageAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    SyntheticClaim claim,
+    Guid validationPlanId,
+    JsonSerializerOptions json)
+{
+    var member = claim.Member;
+    var memberEffectiveDate = member.CoverageEffectiveDate == default
+        ? claim.DateOfService.Date.AddYears(-1)
+        : member.CoverageEffectiveDate.Date;
+    var effectiveDate = DateTime.SpecifyKind(
+        memberEffectiveDate <= claim.DateOfService.Date
+            ? memberEffectiveDate
+            : claim.DateOfService.Date.AddYears(-1),
+        DateTimeKind.Utc);
+
+    var isMedicaidDual = claim.EdgeCase is EdgeCaseScenario.MedicaidDualEligible;
+    var payload = new
+    {
+        memberId = member.MemberId,
+        groupNumber = NullIfWhiteSpace(member.GroupNumber) ?? "MCC-GRP-001",
+        planId = validationPlanId.ToString(),
+        coverageLevel = "EMP",
+        insuranceLineCode = "HLT",
+        effectiveDate,
+        terminationDate = (DateTime?)null,
+        isCOBRA = false,
+        medicareCoverage = isMedicaidDual
+            ? new
+            {
+                medicareBeneficiaryId = $"MCCMED{member.MemberId.Replace("-", "", StringComparison.OrdinalIgnoreCase)}",
+                hasPartA = true,
+                partAEffectiveDate = effectiveDate,
+                hasPartB = true,
+                partBEffectiveDate = effectiveDate,
+                isPrimaryPayer = true
+            }
+            : null,
+        otherInsurance = isMedicaidDual
+            ? null
+            : new
+            {
+                payerName = "MCC Primary Carrier",
+                policyNumber = $"MCC-PRIMARY-{member.MemberId}",
+                groupNumber = "MCC-OTHER-GRP",
+                isPrimaryPayer = true,
+                effectiveDate
+            },
+        maintenanceTypeCode = "021",
+        maintenanceReasonCode = "COB"
+    };
+
+    using var response = await http.PostAsJsonAsync($"{options.CoverageUrl}/api/v1/coverage", payload, json);
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException($"COB coverage seed failed ({member.MemberId}): {(int)response.StatusCode} {body}");
+    }
 }
 
 static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
@@ -1793,6 +1923,7 @@ static void PrintUsage()
       --claims-url <url>         Claims service URL (default: http://localhost:5001)
       --benefit-url <url>        Benefit plan service URL (default: http://localhost:5002)
       --member-url <url>         Member service URL (default: http://localhost:5003)
+      --coverage-url <url>       Coverage service URL (default: http://localhost:5005)
       --provider-url <url>       Provider service URL (default: http://localhost:5004)
       --no-seed-members          Skip synthetic member seeding
       --no-seed-providers        Skip synthetic provider seeding
@@ -1914,6 +2045,7 @@ internal sealed record MassAdjudicationRun(
     string ClaimsUrl,
     string BenefitUrl,
     string MemberUrl,
+    string CoverageUrl,
     string ProviderUrl,
     bool SeedMembers,
     bool SeedProviders,

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -7,6 +7,7 @@ public sealed record ValidatorOptions(
     string ClaimsUrl,
     string BenefitUrl,
     string MemberUrl,
+    string CoverageUrl,
     string ProviderUrl,
     bool SeedMembers,
     bool SeedProviders,
@@ -54,6 +55,9 @@ public sealed record ValidatorOptions(
                     break;
                 case "--member-url" when i + 1 < args.Length:
                     options.MemberUrl = args[++i].TrimEnd('/');
+                    break;
+                case "--coverage-url" when i + 1 < args.Length:
+                    options.CoverageUrl = args[++i].TrimEnd('/');
                     break;
                 case "--provider-url" when i + 1 < args.Length:
                     options.ProviderUrl = args[++i].TrimEnd('/');
@@ -140,6 +144,7 @@ public sealed record ValidatorOptions(
             options.ClaimsUrl.TrimEnd('/'),
             options.BenefitUrl.TrimEnd('/'),
             options.MemberUrl.TrimEnd('/'),
+            options.CoverageUrl.TrimEnd('/'),
             options.ProviderUrl.TrimEnd('/'),
             options.SeedMembers,
             options.SeedProviders,
@@ -169,6 +174,7 @@ public sealed record ValidatorOptions(
         public string ClaimsUrl { get; set; } = "http://localhost:5001";
         public string BenefitUrl { get; set; } = "http://localhost:5002";
         public string MemberUrl { get; set; } = "http://localhost:5003";
+        public string CoverageUrl { get; set; } = "http://localhost:5005";
         public string ProviderUrl { get; set; } = "http://localhost:5004";
         public bool SeedMembers { get; set; } = true;
         public bool SeedProviders { get; set; } = true;

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -98,6 +98,21 @@ public class EdgeCaseClaimGeneratorTests
     }
 
     [Fact]
+    public void Generate_AllScenarios_ProducePositiveLineCharges()
+    {
+        foreach (var scenario in Enum.GetValues<EdgeCaseScenario>())
+        {
+            for (var seed = 0; seed < 100; seed++)
+            {
+                var claim = _generator.Generate(seed + 1, scenario.ToString(), new Random(seed));
+
+                Assert.All(claim.Lines, line => Assert.True(line.ChargeAmount > 0m));
+                Assert.True(claim.TotalCharges > 0m);
+            }
+        }
+    }
+
+    [Fact]
     public void Generate_DeniedClaims_HaveZeroPaidAmount()
     {
         var random = new Random(42);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -197,6 +197,36 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
+    public void ExpectedValidationFor_UnsupportedPendedEdgeCase_ReturnsUnsupported()
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "23",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        claim.EdgeCase = EdgeCaseScenario.SubrogationWorkersComp;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Pended",
+            DenialReasonCode = "W1"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: "CARC_96");
+
+        Assert.Equal("EdgeCase:SubrogationWorkersComp", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal("W1", expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+    }
+
+    [Fact]
     public void AnswerKey_WhenClaimMissing_ReturnsUnspecified()
     {
         var key = MccAnswerKey.FromClaims([

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -48,6 +48,14 @@ public class ValidatorOptionsTests
     }
 
     [Fact]
+    public void Parse_WhenCoverageUrlProvided_AppliesOverride()
+    {
+        var options = ValidatorOptions.Parse(["--coverage-url", "http://coverage-service/"]);
+
+        Assert.Equal("http://coverage-service", options.CoverageUrl);
+    }
+
+    [Fact]
     public void Parse_WhenPendObservationOptionsProvided_AppliesOverrides()
     {
         var options = ValidatorOptions.Parse([


### PR DESCRIPTION
## Summary
- add `--coverage-url` support to the MCC platform validator and local K8s runner
- seed coverage-service COB records for expected COB/dual-eligible pend scenarios before adjudication
- score currently unsupported conceptual pend scenarios as `Unsupported` instead of mismatches
- prevent edge-case fixtures from emitting non-positive line charges, which caused one COB secondary fixture to deny even though COB pend details were present
- add focused tests for coverage URL parsing, unsupported pended edge-case scoring, and positive edge-case line charges

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --logger "console;verbosity=minimal"`
  - Passed: 36/36
- `dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj --logger "console;verbosity=minimal"`
  - Passed: 123/123
- `git diff --check`

## 5K benchmark smoke
Command:

```bash
CLAIMS=5000 MAX_CLAIMS=5000 PARALLELISM=10 PROGRESS_EVERY=500 \
PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 \
PEND_OBSERVATION_INTERVAL_MS=1000 SEED_MEMBERS=true SEED_PROVIDERS=true \
scripts/run-mcc-local-k8s.sh
```

Observed:
- 5,000/5,000 claims processed
- 0 platform failures
- 0 pend observation timeouts
- 46/46 supported expected-pend claims observed as pended
- workflow checks: 526/650 matched, 85 mismatched, 39 unsupported
- `EdgeCase:CobSecondaryPayer`: 10/10 matched
- all COB scenarios matched: primary, secondary, tertiary, birthday, gender, Medicare secondary, and Medicaid dual-eligible

Root cause of the prior 45/46 result:
- `MCC-E-0000016` was generated with a negative charge (`99211/-3`), so the claim persisted as denied even though COB pend details were recorded.
- Edge-case line charges are now clamped to at least `$1.00`, with regression coverage across all edge scenarios.

Notes:
- Remaining mismatches are outside this PR's COB/pend-observation scope: newborn rules, prior-auth variants, retro termination, and behavioral-health carve-out.
- Unsupported conceptual pends are now reported honestly as unsupported until corresponding adjudication signals exist.
