### PR TITLE
Align MCC prior-auth edge scoring

### DIFF
--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -37,11 +37,20 @@ public static class MccWorkflowValidation
         if (claim.EdgeCase is not null && claim.ExpectedOutcome is not null)
         {
             var scenario = $"EdgeCase:{claim.EdgeCase}";
-            var expectedCode = NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
             var expectedOutcome = OutcomeFromDisposition(claim.ExpectedOutcome.Disposition);
+            var expectedCode = expectedOutcome is ClaimValidationOutcome.BusinessDenial
+                && IsPriorAuthEdgeCase(claim.EdgeCase.Value)
+                    ? PriorAuthRequiredCode
+                    : NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
 
             if (expectedOutcome is ClaimValidationOutcome.Pended
                 && IsUnsupportedPendedEdgeCase(claim.EdgeCase.Value))
+            {
+                return ExpectedValidation.Unsupported(scenario, expectedCode);
+            }
+
+            if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
+                && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value))
             {
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
@@ -149,6 +158,24 @@ public static class MccWorkflowValidation
             EdgeCaseScenario.SubrogationWorkersComp or
             EdgeCaseScenario.SubrogationThirdPartyLiability or
             EdgeCaseScenario.MedicaidSpendDown;
+    }
+
+    private static bool IsUnsupportedPriorAuthValidationEdgeCase(EdgeCaseScenario scenario)
+    {
+        return scenario is
+            EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
+            EdgeCaseScenario.PriorAuthRequired_WrongProvider or
+            EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+    }
+
+    private static bool IsPriorAuthEdgeCase(EdgeCaseScenario scenario)
+    {
+        return scenario is
+            EdgeCaseScenario.PriorAuthRequired_AuthOnFile or
+            EdgeCaseScenario.PriorAuthRequired_NoAuth or
+            EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
+            EdgeCaseScenario.PriorAuthRequired_WrongProvider or
+            EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
     }
 
     private static string? NormalizeExpectedCode(string? code)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -66,7 +66,7 @@ var validationPlanId = Guid.NewGuid();
 await CreateValidationPlanAsync(http, options, validationPlanId, json);
 
 var claims = await GenerateClaimsAsync(options);
-NormalizePriorAuthEdgeCases(claims);
+NormalizePriorAuthEdgeCases(claims, options);
 NormalizeValidationProviderProfiles(claims, options.Seed);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 var answerKey = MccAnswerKey.FromClaims(claims);
@@ -547,8 +547,13 @@ static void InjectPriorAuthScenarios(List<SyntheticClaim> claims, ValidatorOptio
     Console.WriteLine($"PA scenarios: injected {injected:N0} TX STAR inpatient claims without auth");
 }
 
-static void NormalizePriorAuthEdgeCases(List<SyntheticClaim> claims)
+static void NormalizePriorAuthEdgeCases(List<SyntheticClaim> claims, ValidatorOptions options)
 {
+    if (!options.PriorAuthScenariosEnabled || options.LineOfBusiness is not (3 or 4))
+    {
+        return;
+    }
+
     foreach (var claim in claims.Where(claim => claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_NoAuth))
     {
         ForceTexasMedicaidInpatientPriorAuthScenario(claim);

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -66,6 +66,7 @@ var validationPlanId = Guid.NewGuid();
 await CreateValidationPlanAsync(http, options, validationPlanId, json);
 
 var claims = await GenerateClaimsAsync(options);
+NormalizePriorAuthEdgeCases(claims);
 NormalizeValidationProviderProfiles(claims, options.Seed);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 var answerKey = MccAnswerKey.FromClaims(claims);
@@ -544,6 +545,14 @@ static void InjectPriorAuthScenarios(List<SyntheticClaim> claims, ValidatorOptio
     }
 
     Console.WriteLine($"PA scenarios: injected {injected:N0} TX STAR inpatient claims without auth");
+}
+
+static void NormalizePriorAuthEdgeCases(List<SyntheticClaim> claims)
+{
+    foreach (var claim in claims.Where(claim => claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_NoAuth))
+    {
+        ForceTexasMedicaidInpatientPriorAuthScenario(claim);
+    }
 }
 
 static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -137,6 +137,35 @@ public class MccWorkflowValidationTests
             priorAuthStatus: "Required",
             priorAuthNumber: null,
             renderingState: "AZ");
+        claim.EdgeCase = EdgeCaseScenario.RetroEligibilityTermination;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "27"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: "CARC_27");
+
+        Assert.Equal("EdgeCase:RetroEligibilityTermination", expected.Scenario);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
+        Assert.Equal("CARC_27", expected.ExpectedBusinessDenialCode);
+        Assert.Equal("Matched", status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_PriorAuthNoAuthEdgeCase_UsesPlatformBusinessCode()
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "Required",
+            priorAuthNumber: null,
+            renderingState: "TX");
         claim.EdgeCase = EdgeCaseScenario.PriorAuthRequired_NoAuth;
         claim.ExpectedOutcome = new ExpectedOutcome
         {
@@ -148,12 +177,47 @@ public class MccWorkflowValidationTests
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
             ClaimValidationOutcome.BusinessDenial,
-            actualBusinessDenialCode: "CARC_197");
+            actualBusinessDenialCode: MccWorkflowValidation.PriorAuthRequiredCode);
 
         Assert.Equal("EdgeCase:PriorAuthRequired_NoAuth", expected.Scenario);
         Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
-        Assert.Equal("CARC_197", expected.ExpectedBusinessDenialCode);
-        Assert.Equal("Matched", status);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
+    }
+
+    [Theory]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth)]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProvider)]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProcedure)]
+    public void ExpectedValidationFor_UnsupportedPriorAuthValidationEdgeCase_ReturnsUnsupported(
+        EdgeCaseScenario scenario)
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "OnFile",
+            priorAuthNumber: "AUTH-TEST",
+            renderingState: "TX");
+        claim.EdgeCase = scenario;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "197"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.Paid,
+            actualBusinessDenialCode: null);
+
+        Assert.Equal($"EdgeCase:{scenario}", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- shape `PriorAuthRequired_NoAuth` edge-case claims into the real TX STAR inpatient prior-auth rule path
- score no-auth prior-auth edge cases against the platform business code `PRIOR_AUTH_REQUIRED`
- mark expired/wrong-provider/wrong-procedure auth edge cases as `Unsupported` until adjudication validates non-empty auth numbers
- add focused validator tests for supported and unsupported prior-auth edge-case scoring

## Why
The 10K MCC run after COB pend validation showed the prior-auth mismatch group was stable. `AuthOnFile` and the injected `TxStarInpatientNoAuth` scenarios already matched, but the generated edge-case prior-auth scenarios mixed scoreable missing-auth behavior with unimplemented auth-number validation concepts.

This PR separates those honestly:
- missing auth is scoreable and now matches
- invalid auth-number concepts remain visible, but no longer count as false mismatches

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --logger "console;verbosity=minimal" /p:UseAppHost=false`
  - Passed: 40/40

## Smoke Runs
1K smoke:
- 1,000/1,000 processed
- 0 platform failures
- 9/9 expected pends observed
- `EdgeCase:PriorAuthRequired_NoAuth`: 2/2 matched

10K confirmation:
- 10,000/10,000 processed
- 0 platform failures
- 92/92 expected pends observed
- workflow checks: 1,067/1,300 matched
- mismatches dropped from 171 to 107 versus the prior 10K baseline
- unsupported increased from 78 to 126 because unsupported auth-validation concepts are now labeled honestly
- `EdgeCase:PriorAuthRequired_NoAuth`: 16/16 matched
- `ExpiredAuth`, `WrongProvider`, `WrongProcedure`: 48 unsupported

## Follow-up
To turn the 48 unsupported prior-auth cases into matches, adjudication needs an observable authorization validation step for non-empty auth numbers, likely against authorization-service's existing validation endpoint.
