### PR TITLE
Score MCC retro eligibility termination

### DIFF
--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -346,6 +346,28 @@ public class AdjudicationController : ControllerBase
             });
         }
 
+        if (!IsMemberEligibleForServiceDate(request, out var eligibilityReason))
+        {
+            adjudicationSpan?.SetTag("cho.outcome", "member_not_eligible");
+            adjudicationSpan?.SetStatus(ActivityStatusCode.Error, eligibilityReason);
+
+            RecordLatency(sw, claimTypeCode, "member_not_eligible");
+
+            _logger.LogWarning(
+                "Claim {ClaimId} denied: member {MemberId} not eligible on service date {ServiceDate}: {Reason}",
+                SanitizeForLog(request.ClaimId), SanitizeForLog(request.MemberId),
+                request.ServiceDate, SanitizeForLog(eligibilityReason));
+
+            return UnprocessableEntity(new
+            {
+                claimId = request.ClaimId,
+                error = "CARC_27",
+                message = eligibilityReason,
+                carc = "27",
+                timings = stageTimings,
+            });
+        }
+
         // ── Step 0d: Prior auth rule evaluation ──
         // Evaluates whether the procedures on this claim require prior authorization
         // and whether the provided auth (if any) satisfies the requirement.
@@ -908,6 +930,43 @@ public class AdjudicationController : ControllerBase
         _ => null
     };
 
+    private static bool IsMemberEligibleForServiceDate(
+        AdjudicationRequest request,
+        out string reason)
+    {
+        if (request.MemberEffectiveDate is DateOnly effectiveDate
+            && request.ServiceDate < effectiveDate)
+        {
+            reason = "Service date before member coverage effective date";
+            return false;
+        }
+
+        if (request.MemberTerminationDate is DateOnly terminationDate
+            && request.ServiceDate > terminationDate)
+        {
+            reason = "Service date after member coverage termination date";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.MemberEnrollmentStatus)
+            && !request.MemberEnrollmentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase)
+            && !request.MemberEnrollmentStatus.Equals("Terminated", StringComparison.OrdinalIgnoreCase))
+        {
+            reason = $"Member status is {request.MemberEnrollmentStatus}";
+            return false;
+        }
+
+        if (request.MemberEnrollmentStatus?.Equals("Terminated", StringComparison.OrdinalIgnoreCase) is true
+            && request.MemberTerminationDate is null)
+        {
+            reason = "Member coverage terminated";
+            return false;
+        }
+
+        reason = "Active coverage";
+        return true;
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // Helper: Map AdjudicationRequest → X12837Claim for scrub engine
     // ═══════════════════════════════════════════════════════════════════
@@ -999,6 +1058,9 @@ public record AdjudicationRequest
     public string SubscriberId { get; init; } = default!;
     public Guid BenefitPlanId { get; init; }
     public DateOnly ServiceDate { get; init; }
+    public DateOnly? MemberEffectiveDate { get; init; }
+    public DateOnly? MemberTerminationDate { get; init; }
+    public string? MemberEnrollmentStatus { get; init; }
     public string ProviderNpi { get; init; } = default!;
 
     [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json.Serialization;
 using CloudHealthOffice.BenefitEngine.Domain;
 using CloudHealthOffice.BenefitEngine.Models;
@@ -353,10 +354,13 @@ public class AdjudicationController : ControllerBase
 
             RecordLatency(sw, claimTypeCode, "member_not_eligible");
 
+            var serviceDateForLog = SanitizeForLog(
+                request.ServiceDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+
             _logger.LogWarning(
                 "Claim {ClaimId} denied: member {MemberId} not eligible on service date {ServiceDate}: {Reason}",
                 SanitizeForLog(request.ClaimId), SanitizeForLog(request.MemberId),
-                request.ServiceDate, SanitizeForLog(eligibilityReason));
+                serviceDateForLog, SanitizeForLog(eligibilityReason));
 
             return UnprocessableEntity(new
             {

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -36,6 +36,7 @@ namespace ClaimsService.Services.Adjudication.Stages;
 public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 {
     public const string StageName = "BenefitCalculation";
+    public const string MemberNotEligibleCode = "CARC_27";
 
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
@@ -76,6 +77,16 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
                 $"BenefitPlanId '{claim.BenefitPlanId}' is not a GUID and benefit-plan-service did not resolve a Guid id.");
         }
 
+        if (!IsMemberEligibleForServiceDate(context.ResolvedMember, claim.ServiceDateFrom, out var eligibilityReason))
+        {
+            context.AdjudicationResult.DenialReasonCode = MemberNotEligibleCode;
+            context.AdjudicationResult.DenialReason = eligibilityReason;
+
+            return ClaimAdjudicationStageResult.Deny(
+                StageName,
+                eligibilityReason);
+        }
+
         var subscriberId = await ResolveSubscriberIdAsync(context, ct).ConfigureAwait(false);
         var request = BuildRequest(context, planGuid.Value, subscriberId);
 
@@ -111,6 +122,46 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
     {
         if (resolved?.PlanGuid is Guid resolvedGuid) return resolvedGuid;
         return Guid.TryParse(benefitPlanId, out var parsed) ? parsed : null;
+    }
+
+    private static bool IsMemberEligibleForServiceDate(
+        ResolvedMember? member,
+        DateTime serviceDate,
+        out string reason)
+    {
+        var serviceDay = serviceDate.Date;
+
+        if (member?.EffectiveDate is DateTime effectiveDate
+            && serviceDay < effectiveDate.Date)
+        {
+            reason = "Service date before member coverage effective date";
+            return false;
+        }
+
+        if (member?.TerminationDate is DateTime terminationDate
+            && serviceDay > terminationDate.Date)
+        {
+            reason = "Service date after member coverage termination date";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(member?.EnrollmentStatus)
+            && !member.EnrollmentStatus.Equals("Active", StringComparison.OrdinalIgnoreCase)
+            && !member.EnrollmentStatus.Equals("Terminated", StringComparison.OrdinalIgnoreCase))
+        {
+            reason = $"Member status is {member.EnrollmentStatus}";
+            return false;
+        }
+
+        if (member?.EnrollmentStatus?.Equals("Terminated", StringComparison.OrdinalIgnoreCase) is true
+            && member.TerminationDate is null)
+        {
+            reason = "Member coverage terminated";
+            return false;
+        }
+
+        reason = "Active coverage";
+        return true;
     }
 
     private async Task<string> ResolveSubscriberIdAsync(

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -36,7 +36,7 @@ namespace ClaimsService.Services.Adjudication.Stages;
 public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 {
     public const string StageName = "BenefitCalculation";
-    public const string MemberNotEligibleCode = "CARC_27";
+    public const string MemberNotEligibleCarc = "27";
 
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
@@ -79,7 +79,7 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 
         if (!IsMemberEligibleForServiceDate(context.ResolvedMember, claim.ServiceDateFrom, out var eligibilityReason))
         {
-            context.AdjudicationResult.DenialReasonCode = MemberNotEligibleCode;
+            context.AdjudicationResult.DenialReasonCode = MemberNotEligibleCarc;
             context.AdjudicationResult.DenialReason = eligibilityReason;
 
             return ClaimAdjudicationStageResult.Deny(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1474,6 +1474,10 @@ static async Task<(AdjudicationResponseDto Response, string RawBody)> Adjudicate
     string networkTier,
     JsonSerializerOptions json)
 {
+    var memberEffectiveDate = claim.Member.CoverageEffectiveDate == default
+        ? claim.DateOfService.Date.AddYears(-1)
+        : claim.Member.CoverageEffectiveDate.Date;
+
     var payload = new
     {
         claimId = submittedClaimId,
@@ -1481,7 +1485,7 @@ static async Task<(AdjudicationResponseDto Response, string RawBody)> Adjudicate
         subscriberId = claim.Member.SubscriberId,
         benefitPlanId = validationPlanId,
         serviceDate = DateOnly.FromDateTime(claim.DateOfService),
-        memberEffectiveDate = DateOnly.FromDateTime(claim.Member.CoverageEffectiveDate),
+        memberEffectiveDate = DateOnly.FromDateTime(memberEffectiveDate),
         memberTerminationDate = claim.Member.CoverageTermDate is DateTime termDate
             ? DateOnly.FromDateTime(termDate)
             : (DateOnly?)null,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1481,6 +1481,11 @@ static async Task<(AdjudicationResponseDto Response, string RawBody)> Adjudicate
         subscriberId = claim.Member.SubscriberId,
         benefitPlanId = validationPlanId,
         serviceDate = DateOnly.FromDateTime(claim.DateOfService),
+        memberEffectiveDate = DateOnly.FromDateTime(claim.Member.CoverageEffectiveDate),
+        memberTerminationDate = claim.Member.CoverageTermDate is DateTime termDate
+            ? DateOnly.FromDateTime(termDate)
+            : (DateOnly?)null,
+        memberEnrollmentStatus = claim.Member.EnrollmentStatus,
         providerNpi = claim.RenderingProvider.Npi,
         networkTier,
         lineOfBusiness = options.LineOfBusiness,
@@ -1554,6 +1559,7 @@ static bool IsKnownBusinessDenialCode(string errorCode)
     => NormalizeBusinessDenialCode(errorCode) is
         "SCRUB_VALIDATION_FAILURE" or
         "NCCI_MUE_EDIT_FAILURE" or
+        "CARC_27" or
         "CARC_96" or
         "PROVIDER_EXCLUDED" or
         "PRIOR_AUTH_REQUIRED";

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
@@ -387,6 +387,34 @@ public class AdjudicationControllerTests : IClassFixture<AdjudicationControllerT
         Assert.NotEmpty(result.Accumulators);
     }
 
+    [Fact]
+    public async Task Adjudicate_ServiceDateAfterMemberTermination_ReturnsCarc27WithoutPricing()
+    {
+        SetupNewPipelineDefaults();
+        SetupScrubPass();
+        SetupNcciPass();
+
+        using var client = CreateClientWithTenant();
+        var request = MakeAdjudicationRequest() with
+        {
+            MemberEffectiveDate = new DateOnly(2025, 1, 1),
+            MemberTerminationDate = new DateOnly(2026, 1, 14),
+            MemberEnrollmentStatus = "Active",
+        };
+
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/adjudicate", request);
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.Equal("CARC_27", root.GetProperty("error").GetString());
+        Assert.Equal("27", root.GetProperty("carc").GetString());
+        Assert.Equal(
+            "Service date after member coverage termination date",
+            root.GetProperty("message").GetString());
+    }
+
     // ═══════════════════════════════════════════════════════════════
     // 2. /adjudicate with NCCI CCI conflict → 422 with edit codes
     // ═══════════════════════════════════════════════════════════════

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -185,6 +185,35 @@ public class BenefitCalculationStageTests
     }
 
     [Fact]
+    public async Task Execute_ServiceDateAfterMemberTermination_DeniesWithCarc27WithoutEngineCall()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember
+            {
+                MemberId = "MEM-1",
+                IsSubscriber = true,
+                EffectiveDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                TerminationDate = new DateTime(2026, 4, 14, 0, 0, 0, DateTimeKind.Utc),
+                EnrollmentStatus = "Active",
+            },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Equal(BenefitCalculationStage.MemberNotEligibleCode, ctx.AdjudicationResult.DenialReasonCode);
+        Assert.Equal("Service date after member coverage termination date", ctx.AdjudicationResult.DenialReason);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateWithModeAsync(default!, default!, default!, default, default);
+    }
+
+    [Fact]
     public async Task Execute_NoSubscriberOnClaim_FallsBackThroughResolverAndMemberId()
     {
         var claim = BuildClaim(Guid.NewGuid().ToString());

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -207,7 +207,7 @@ public class BenefitCalculationStageTests
 
         Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
         Assert.False(result.Continue);
-        Assert.Equal(BenefitCalculationStage.MemberNotEligibleCode, ctx.AdjudicationResult.DenialReasonCode);
+        Assert.Equal(BenefitCalculationStage.MemberNotEligibleCarc, ctx.AdjudicationResult.DenialReasonCode);
         Assert.Equal("Service date after member coverage termination date", ctx.AdjudicationResult.DenialReason);
         await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
         await _engine.DidNotReceiveWithAnyArgs().CalculateWithModeAsync(default!, default!, default!, default, default);


### PR DESCRIPTION
## Summary
- pass member coverage effective/termination/status from the MCC validator into benefit-plan adjudication
- deny out-of-window member coverage with CARC_27 in the direct /adjudicate path
- mirror the same CARC_27 member-eligibility gate in the claims-service async benefit stage

## Validation
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter FullyQualifiedName~BenefitCalculationStageTests --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.AdjudicationController.Tests/CloudHealthOffice.AdjudicationController.Tests.csproj --filter FullyQualifiedName~Adjudicate_ServiceDateAfterMemberTermination --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore /p:UseAppHost=false
- git diff --check

## Notes
A 5K/10K MCC run should be done after the updated benefit-plan-service image is deployed; the local MCC runner only rebuilds the validator image.