### PR TITLE
Preserve MCC retro eligibility coverage windows

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -92,8 +92,28 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             PayerToPayerReady = true
         };
 
+        ApplyScenarioCoverageWindow(claim, scenario);
         claim.ExpectedOutcome = ComputeExpectedOutcome(claim, scenario, random);
         return claim;
+    }
+
+    private static void ApplyScenarioCoverageWindow(SyntheticClaim claim, EdgeCaseScenario scenario)
+    {
+        if (scenario is not EdgeCaseScenario.RetroEligibilityTermination)
+        {
+            return;
+        }
+
+        var serviceDate = claim.DateOfService.Date;
+        claim.Member.CoverageEffectiveDate = serviceDate.AddYears(-1);
+        claim.Member.CoverageTermDate = serviceDate.AddDays(-30);
+        claim.Member.EnrollmentStatus = "Active";
+
+        foreach (var coverage in claim.Member.Coverages)
+        {
+            coverage.EffectiveDate = claim.Member.CoverageEffectiveDate;
+            coverage.TermDate = claim.Member.CoverageTermDate;
+        }
     }
 
     private SyntheticMember GenerateMemberForScenario(EdgeCaseScenario scenario, Random random)
@@ -112,10 +132,6 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
 
             case EdgeCaseScenario.CobBirthdayRule:
                 member.Relationship = "Child";
-                break;
-
-            case EdgeCaseScenario.RetroEligibilityTermination:
-                member.CoverageTermDate = member.CoverageEffectiveDate.AddMonths(random.Next(3, 12));
                 break;
 
             case EdgeCaseScenario.MedicaidDualEligible:

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -107,12 +107,15 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
         var serviceDate = claim.DateOfService.Date;
         claim.Member.CoverageEffectiveDate = serviceDate.AddYears(-1);
         claim.Member.CoverageTermDate = serviceDate.AddDays(-30);
-        claim.Member.EnrollmentStatus = "Active";
+        claim.Member.EnrollmentStatus = "Terminated";
+        claim.Member.MaintenanceTypeCode = "024";
 
         foreach (var coverage in claim.Member.Coverages)
         {
             coverage.EffectiveDate = claim.Member.CoverageEffectiveDate;
             coverage.TermDate = claim.Member.CoverageTermDate;
+            coverage.Status = "Terminated";
+            coverage.MaintenanceTypeCode = "024";
         }
     }
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1377,6 +1377,7 @@ static void NormalizeClaimDates(List<SyntheticClaim> claims, int seed)
         var dateShift = normalizedServiceDate - originalServiceDate;
 
         claim.DateOfService = claim.DateOfService.Date.Add(dateShift);
+        ShiftMemberCoverageDates(claim.Member, dateShift);
 
         foreach (var line in claim.Lines)
         {
@@ -1392,6 +1393,32 @@ static void NormalizeClaimDates(List<SyntheticClaim> claims, int seed)
             .DefaultIfEmpty(claim.DateOfService)
             .Max();
         claim.DateReceived = latestServiceDate.Date.AddDays(random.Next(1, 15));
+    }
+}
+
+static void ShiftMemberCoverageDates(SyntheticMember member, TimeSpan dateShift)
+{
+    if (member.CoverageEffectiveDate != default)
+    {
+        member.CoverageEffectiveDate = member.CoverageEffectiveDate.Date.Add(dateShift);
+    }
+
+    if (member.CoverageTermDate.HasValue)
+    {
+        member.CoverageTermDate = member.CoverageTermDate.Value.Date.Add(dateShift);
+    }
+
+    foreach (var coverage in member.Coverages)
+    {
+        if (coverage.EffectiveDate != default)
+        {
+            coverage.EffectiveDate = coverage.EffectiveDate.Date.Add(dateShift);
+        }
+
+        if (coverage.TermDate.HasValue)
+        {
+            coverage.TermDate = coverage.TermDate.Value.Date.Add(dateShift);
+        }
     }
 }
 

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -124,6 +124,16 @@ public class EdgeCaseClaimGeneratorTests
     }
 
     [Fact]
+    public void Generate_RetroEligibilityTermination_TerminatesBeforeServiceDate()
+    {
+        var claim = _generator.Generate(1, "RetroEligibilityTermination", new Random(42));
+
+        Assert.NotNull(claim.Member.CoverageTermDate);
+        Assert.True(claim.Member.CoverageEffectiveDate.Date < claim.Member.CoverageTermDate.Value.Date);
+        Assert.True(claim.Member.CoverageTermDate.Value.Date < claim.DateOfService.Date);
+    }
+
+    [Fact]
     public void Generate_AllScenarios_ProduceValidClaims()
     {
         var random = new Random(42);

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -131,6 +131,14 @@ public class EdgeCaseClaimGeneratorTests
         Assert.NotNull(claim.Member.CoverageTermDate);
         Assert.True(claim.Member.CoverageEffectiveDate.Date < claim.Member.CoverageTermDate.Value.Date);
         Assert.True(claim.Member.CoverageTermDate.Value.Date < claim.DateOfService.Date);
+        Assert.Equal("Terminated", claim.Member.EnrollmentStatus);
+        Assert.Equal("024", claim.Member.MaintenanceTypeCode);
+        Assert.All(claim.Member.Coverages, coverage =>
+        {
+            Assert.Equal("Terminated", coverage.Status);
+            Assert.Equal("024", coverage.MaintenanceTypeCode);
+            Assert.Equal(claim.Member.CoverageTermDate, coverage.TermDate);
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make RetroEligibilityTermination fixtures explicitly terminate before the claim service date
- shift member coverage effective/termination dates when the MCC validator normalizes claim service dates into the current benchmark window
- add a generator regression test so expected retro-term denials stay internally consistent

## Validation
- dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj --filter FullyQualifiedName~EdgeCaseClaimGeneratorTests --no-restore /p:UseAppHost=false
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore /p:UseAppHost=false
- git diff --check

## MCC proof runs
- 1K smoke: RetroEligibilityTermination 3/3 matched; platform failures 0; pend observation 9/9 observed
- 5K proof: RetroEligibilityTermination 13/13 matched; platform failures 0; pend observation 46/46 observed
- 5K workflow checks improved from 534/650 matched to 547/650 matched; mismatches dropped from 53 to 40

## Notes
The local 5K proof required rolling benefit-plan-service to a unique local image tag because Kubernetes reused the previous :local image with IfNotPresent. No deployment manifest changes are included in this PR.