### PR TITLE
Fix MCC newborn validation fixtures

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -92,9 +92,34 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             PayerToPayerReady = true
         };
 
+        ApplyScenarioMemberContext(claim, scenario);
         ApplyScenarioCoverageWindow(claim, scenario);
         claim.ExpectedOutcome = ComputeExpectedOutcome(claim, scenario, random);
         return claim;
+    }
+
+    private static void ApplyScenarioMemberContext(SyntheticClaim claim, EdgeCaseScenario scenario)
+    {
+        if (scenario is not (
+            EdgeCaseScenario.NewbornAutoAdjudication or
+            EdgeCaseScenario.NewbornMotherClaimLink or
+            EdgeCaseScenario.NewbornFirstThirtyDays))
+        {
+            return;
+        }
+
+        claim.Member.DateOfBirth = scenario switch
+        {
+            EdgeCaseScenario.NewbornAutoAdjudication => claim.DateOfService.Date.AddDays(-2),
+            EdgeCaseScenario.NewbornMotherClaimLink => claim.DateOfService.Date.AddDays(-5),
+            EdgeCaseScenario.NewbornFirstThirtyDays => claim.DateOfService.Date.AddDays(-29),
+            _ => claim.Member.DateOfBirth
+        };
+        claim.Member.Relationship = "Child";
+        claim.Member.RelationshipCode = "19";
+        claim.Member.IsSubscriber = false;
+        claim.PriorAuthStatus = "OnFile";
+        claim.PriorAuthNumber = $"NB-AUTH-{claim.ClaimId}";
     }
 
     private static void ApplyScenarioCoverageWindow(SyntheticClaim claim, EdgeCaseScenario scenario)
@@ -128,8 +153,9 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             case EdgeCaseScenario.NewbornAutoAdjudication:
             case EdgeCaseScenario.NewbornMotherClaimLink:
             case EdgeCaseScenario.NewbornFirstThirtyDays:
-                member.DateOfBirth = new DateTime(2024, 1, 1).AddDays(random.Next(365));
                 member.Relationship = "Child";
+                member.RelationshipCode = "19";
+                member.IsSubscriber = false;
                 member.Gender = random.Next(2) == 0 ? "M" : "F";
                 break;
 

--- a/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
+++ b/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
@@ -1,0 +1,77 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal static class MccClaimDateNormalizer
+{
+    public static void NormalizeClaimDates(List<SyntheticClaim> claims, int seed)
+    {
+        var random = new Random(seed);
+        var anchorDate = DateTime.UtcNow.Date.AddDays(-45);
+
+        foreach (var claim in claims)
+        {
+            var originalServiceDate = claim.DateOfService.Date;
+            var normalizedServiceDate = anchorDate.AddDays(random.Next(0, 30));
+            var dateShift = normalizedServiceDate - originalServiceDate;
+
+            claim.DateOfService = claim.DateOfService.Date.Add(dateShift);
+            ShiftMemberCoverageDates(claim.Member, dateShift);
+            ShiftNewbornDateOfBirth(claim, dateShift);
+
+            foreach (var line in claim.Lines)
+            {
+                line.ServiceDate = line.ServiceDate.Date.Add(dateShift);
+                if (line.ServiceEndDate.HasValue)
+                {
+                    line.ServiceEndDate = line.ServiceEndDate.Value.Date.Add(dateShift);
+                }
+            }
+
+            var latestServiceDate = claim.Lines
+                .Select(line => line.ServiceEndDate ?? line.ServiceDate)
+                .DefaultIfEmpty(claim.DateOfService)
+                .Max();
+            claim.DateReceived = latestServiceDate.Date.AddDays(random.Next(1, 15));
+        }
+    }
+
+    private static void ShiftNewbornDateOfBirth(SyntheticClaim claim, TimeSpan dateShift)
+    {
+        if (claim.EdgeCase is not (
+            EdgeCaseScenario.NewbornAutoAdjudication or
+            EdgeCaseScenario.NewbornMotherClaimLink or
+            EdgeCaseScenario.NewbornFirstThirtyDays))
+        {
+            return;
+        }
+
+        claim.Member.DateOfBirth = claim.Member.DateOfBirth.Date.Add(dateShift);
+    }
+
+    private static void ShiftMemberCoverageDates(SyntheticMember member, TimeSpan dateShift)
+    {
+        if (member.CoverageEffectiveDate != default)
+        {
+            member.CoverageEffectiveDate = member.CoverageEffectiveDate.Date.Add(dateShift);
+        }
+
+        if (member.CoverageTermDate.HasValue)
+        {
+            member.CoverageTermDate = member.CoverageTermDate.Value.Date.Add(dateShift);
+        }
+
+        foreach (var coverage in member.Coverages)
+        {
+            if (coverage.EffectiveDate != default)
+            {
+                coverage.EffectiveDate = coverage.EffectiveDate.Date.Add(dateShift);
+            }
+
+            if (coverage.TermDate.HasValue)
+            {
+                coverage.TermDate = coverage.TermDate.Value.Date.Add(dateShift);
+            }
+        }
+    }
+}

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -55,6 +55,12 @@ public static class MccWorkflowValidation
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
 
+            if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
+                && IsUnsupportedBusinessDenialEdgeCase(claim.EdgeCase.Value))
+            {
+                return ExpectedValidation.Unsupported(scenario, expectedCode);
+            }
+
             return expectedOutcome is null
                 && claim.ExpectedOutcome.Disposition.Equals("Pended", StringComparison.OrdinalIgnoreCase)
                     ? new ExpectedValidation(scenario, ClaimValidationOutcome.Pended, expectedCode)
@@ -166,6 +172,11 @@ public static class MccWorkflowValidation
             EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
             EdgeCaseScenario.PriorAuthRequired_WrongProvider or
             EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+    }
+
+    private static bool IsUnsupportedBusinessDenialEdgeCase(EdgeCaseScenario scenario)
+    {
+        return scenario is EdgeCaseScenario.BehavioralHealthCarveOut;
     }
 
     private static bool IsPriorAuthEdgeCase(EdgeCaseScenario scenario)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -361,7 +361,7 @@ static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions op
             new
             {
                 benefitType = "medical",
-                serviceCategory = "47",
+                serviceCategory = "48",
                 description = "Hospital Inpatient",
                 cptCodes = Array.Empty<string>(),
                 inNetworkCoinsurance = 0.20m,
@@ -396,7 +396,7 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
     var claims = writer.Claims
         .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
         .ToList();
-    NormalizeClaimDates(claims, options.Seed);
+    MccClaimDateNormalizer.NormalizeClaimDates(claims, options.Seed);
     InjectCleanPaidScenarios(claims);
     InjectExcludedProviderScenarios(claims, options.Seed);
     InjectUncoveredServiceScenarios(claims);
@@ -1364,63 +1364,6 @@ static bool IsProviderExcluded(SyntheticProvider provider) =>
 
 static string? NullIfWhiteSpace(string? value)
     => string.IsNullOrWhiteSpace(value) ? null : value;
-
-static void NormalizeClaimDates(List<SyntheticClaim> claims, int seed)
-{
-    var random = new Random(seed);
-    var anchorDate = DateTime.UtcNow.Date.AddDays(-45);
-
-    foreach (var claim in claims)
-    {
-        var originalServiceDate = claim.DateOfService.Date;
-        var normalizedServiceDate = anchorDate.AddDays(random.Next(0, 30));
-        var dateShift = normalizedServiceDate - originalServiceDate;
-
-        claim.DateOfService = claim.DateOfService.Date.Add(dateShift);
-        ShiftMemberCoverageDates(claim.Member, dateShift);
-
-        foreach (var line in claim.Lines)
-        {
-            line.ServiceDate = line.ServiceDate.Date.Add(dateShift);
-            if (line.ServiceEndDate.HasValue)
-            {
-                line.ServiceEndDate = line.ServiceEndDate.Value.Date.Add(dateShift);
-            }
-        }
-
-        var latestServiceDate = claim.Lines
-            .Select(line => line.ServiceEndDate ?? line.ServiceDate)
-            .DefaultIfEmpty(claim.DateOfService)
-            .Max();
-        claim.DateReceived = latestServiceDate.Date.AddDays(random.Next(1, 15));
-    }
-}
-
-static void ShiftMemberCoverageDates(SyntheticMember member, TimeSpan dateShift)
-{
-    if (member.CoverageEffectiveDate != default)
-    {
-        member.CoverageEffectiveDate = member.CoverageEffectiveDate.Date.Add(dateShift);
-    }
-
-    if (member.CoverageTermDate.HasValue)
-    {
-        member.CoverageTermDate = member.CoverageTermDate.Value.Date.Add(dateShift);
-    }
-
-    foreach (var coverage in member.Coverages)
-    {
-        if (coverage.EffectiveDate != default)
-        {
-            coverage.EffectiveDate = coverage.EffectiveDate.Date.Add(dateShift);
-        }
-
-        if (coverage.TermDate.HasValue)
-        {
-            coverage.TermDate = coverage.TermDate.Value.Date.Add(dateShift);
-        }
-    }
-}
 
 static async Task<SubmittedClaim> SubmitClaimAsync(
     HttpClient http,

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -85,6 +85,24 @@ public class EdgeCaseClaimGeneratorTests
         var claim = _generator.Generate(1, "NewbornAutoAdjudication", random);
 
         Assert.Equal("Child", claim.Member.Relationship);
+        Assert.Equal("19", claim.Member.RelationshipCode);
+        Assert.False(claim.Member.IsSubscriber);
+        Assert.Equal("OnFile", claim.PriorAuthStatus);
+        Assert.Equal($"NB-AUTH-{claim.ClaimId}", claim.PriorAuthNumber);
+    }
+
+    [Theory]
+    [InlineData("NewbornAutoAdjudication", 2)]
+    [InlineData("NewbornMotherClaimLink", 5)]
+    [InlineData("NewbornFirstThirtyDays", 29)]
+    public void Generate_Newborn_SetsDateOfBirthRelativeToServiceDate(string scenario, int expectedAgeDays)
+    {
+        var claim = _generator.Generate(1, scenario, new Random(42));
+
+        var ageAtServiceDays = (claim.DateOfService.Date - claim.Member.DateOfBirth.Date).Days;
+
+        Assert.Equal(expectedAgeDays, ageAtServiceDays);
+        Assert.InRange(ageAtServiceDays, 0, 30);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimDateNormalizerTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimDateNormalizerTests.cs
@@ -1,0 +1,38 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Generators;
+using CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccClaimDateNormalizerTests
+{
+    [Theory]
+    [InlineData("NewbornAutoAdjudication")]
+    [InlineData("NewbornMotherClaimLink")]
+    [InlineData("NewbornFirstThirtyDays")]
+    public void NormalizeClaimDates_PreservesNewbornAgeAtServiceDate(string scenario)
+    {
+        var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
+        var claim = generator.Generate(1, scenario, new Random(42));
+        var originalServiceDate = claim.DateOfService.Date;
+        var originalAgeAtServiceDays = (claim.DateOfService.Date - claim.Member.DateOfBirth.Date).Days;
+
+        MccClaimDateNormalizer.NormalizeClaimDates([claim], seed: 42);
+
+        Assert.NotEqual(originalServiceDate, claim.DateOfService.Date);
+        Assert.Equal(originalAgeAtServiceDays, (claim.DateOfService.Date - claim.Member.DateOfBirth.Date).Days);
+        Assert.InRange(originalAgeAtServiceDays, 0, 30);
+    }
+
+    [Fact]
+    public void NormalizeClaimDates_DoesNotShiftDateOfBirthForNonNewbornEdgeCases()
+    {
+        var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
+        var claim = generator.Generate(1, "CobPrimaryPayer", new Random(42));
+        var originalDateOfBirth = claim.Member.DateOfBirth.Date;
+
+        MccClaimDateNormalizer.NormalizeClaimDates([claim], seed: 42);
+
+        Assert.Equal(originalDateOfBirth, claim.Member.DateOfBirth.Date);
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -291,6 +291,36 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
+    public void ExpectedValidationFor_UnsupportedBusinessDenialEdgeCase_ReturnsUnsupported()
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        claim.EdgeCase = EdgeCaseScenario.BehavioralHealthCarveOut;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "296"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.Paid,
+            actualBusinessDenialCode: null);
+
+        Assert.Equal("EdgeCase:BehavioralHealthCarveOut", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal("CARC_296", expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+    }
+
+    [Fact]
     public void AnswerKey_WhenClaimMissing_ReturnsUnspecified()
     {
         var key = MccAnswerKey.FromClaims([


### PR DESCRIPTION
## Summary
- make MCC newborn edge-case fixtures true dependent newborn encounters with auth on file
- move validator date normalization into a tested helper that preserves newborn age at service
- align the local validation plan inpatient category with POS fallback and mark unsupported behavioral carve-out denial honestly

## Verification
- dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj --no-restore
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore
- CLAIMS=1000 MAX_CLAIMS=1000 PARALLELISM=10 PROGRESS_EVERY=250 PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 scripts/run-mcc-local-k8s.sh

1K smoke result: 117/130 matched, 0 mismatched, 13 unsupported, 0 platform failures; newborn scenarios 6/6 matched.