### PR TITLE
Avoid duplicate MCC newborn mother line codes

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -242,6 +242,12 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             candidate = _refData.GetProcedureCode(random, procSubType);
         }
 
+        if (candidate.Code == firstProcedureCode)
+        {
+            throw new InvalidOperationException(
+                $"Could not select a distinct procedure code for multi-line {procSubType} edge-case claim.");
+        }
+
         return candidate;
     }
 

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -54,7 +54,7 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
         // Add additional lines for complex scenarios
         if (IsMultiLineScenario(scenario))
         {
-            var proc2 = _refData.GetProcedureCode(random, procSubType);
+            var proc2 = GetDistinctProcedureCode(random, procSubType, proc.Code);
             lines.Add(new ClaimLine
             {
                 LineNumber = 2,
@@ -229,6 +229,20 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
         return scenario is
             EdgeCaseScenario.NewbornMotherClaimLink or
             EdgeCaseScenario.SubrogationAccidentRelated;
+    }
+
+    private (string Code, string Description, decimal BaseCharge) GetDistinctProcedureCode(
+        Random random,
+        string procSubType,
+        string firstProcedureCode)
+    {
+        var candidate = _refData.GetProcedureCode(random, procSubType);
+        for (var attempt = 0; attempt < 100 && candidate.Code == firstProcedureCode; attempt++)
+        {
+            candidate = _refData.GetProcedureCode(random, procSubType);
+        }
+
+        return candidate;
     }
 
     private static decimal ChargeWithVariance(decimal baseCharge, Random random, int minVariance, int maxVariance)

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -105,12 +105,14 @@ public class EdgeCaseClaimGeneratorTests
         Assert.InRange(ageAtServiceDays, 0, 30);
     }
 
-    [Fact]
-    public void Generate_NewbornMotherClaimLink_UsesDistinctLineProcedureCodes()
+    [Theory]
+    [InlineData("NewbornMotherClaimLink")]
+    [InlineData("SubrogationAccidentRelated")]
+    public void Generate_MultiLineScenario_UsesDistinctLineProcedureCodes(string scenario)
     {
         for (var seed = 0; seed < 100; seed++)
         {
-            var claim = _generator.Generate(seed + 1, "NewbornMotherClaimLink", new Random(seed));
+            var claim = _generator.Generate(seed + 1, scenario, new Random(seed));
 
             Assert.Equal(2, claim.Lines.Count);
             Assert.Equal(

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -106,6 +106,20 @@ public class EdgeCaseClaimGeneratorTests
     }
 
     [Fact]
+    public void Generate_NewbornMotherClaimLink_UsesDistinctLineProcedureCodes()
+    {
+        for (var seed = 0; seed < 100; seed++)
+        {
+            var claim = _generator.Generate(seed + 1, "NewbornMotherClaimLink", new Random(seed));
+
+            Assert.Equal(2, claim.Lines.Count);
+            Assert.Equal(
+                claim.Lines.Count,
+                claim.Lines.Select(line => line.ProcedureCode).Distinct(StringComparer.Ordinal).Count());
+        }
+    }
+
+    [Fact]
     public void Generate_CobSecondary_PendsForReview()
     {
         var random = new Random(42);


### PR DESCRIPTION
## Summary
- ensure multi-line MCC newborn mother-link fixtures use distinct procedure codes
- add regression coverage so generated newborn mother-link claims do not duplicate line procedure codes

## Verification
- dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj --no-restore
- CLAIMS=5000 MAX_CLAIMS=5000 PARALLELISM=10 PROGRESS_EVERY=500 PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 scripts/run-mcc-local-k8s.sh

5K smoke result: 5,000/5,000 processed, 0 platform failures, 46/46 expected pends observed, 577/650 matched, 0 mismatched, 73 unsupported; NewbornMotherClaimLink 10/10 matched.