### PR TITLE
Expand MCC run evidence viewer

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -16,7 +16,8 @@ public class ClaimsServiceTests
         _configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Services:ClaimsService"] = "http://localhost:5000"
+                ["Services:ClaimsService"] = "http://localhost:5000",
+                ["Authentication:LocalDemo:TenantId"] = "demo"
             })
             .Build();
     }
@@ -129,6 +130,16 @@ public class ClaimsServiceTests
         var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
             () => sut.GetAdjudicationDataAsync("CLM-2026-00001"));
         ex.Message.Should().Contain("Claims Service");
+    }
+
+    [Fact]
+    public async Task GetAdjudicationDataAsync_WhenApiReturns404_ReturnsNull()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.NotFound)));
+
+        var result = await sut.GetAdjudicationDataAsync("CLM-NO-DETAIL");
+
+        result.Should().BeNull();
     }
 
     // ════════════════════════════════════════════════════════════════
@@ -265,30 +276,69 @@ public class ClaimsServiceTests
                     parallelism = 8,
                     claimsUrl = "https://claims",
                     benefitUrl = "https://benefit",
+                    memberUrl = "https://member",
+                    coverageUrl = "https://coverage",
                     providerUrl = "https://provider",
+                    seedMembers = true,
                     seedProviders = true,
                     skipClaimUpdate = false,
+                    lineOfBusiness = 3,
                     startedAtUtc = "2026-07-01T00:00:00Z",
                     completedAtUtc = "2026-07-01T00:01:00Z"
                 },
                 totalClaims = 100,
                 processed = 100,
                 paid = 97,
+                pended = 1,
                 businessDenials = 2,
+                observationTimeouts = 0,
                 platformFailures = 1,
+                workflowScenarios = 12,
+                workflowMatches = 10,
+                workflowMismatches = 1,
+                workflowUnsupported = 1,
+                workflowObservationTimeouts = 0,
                 throughputClaimsPerSecond = 15.5,
+                averagePaymentDelta = 59.36m,
+                workflowScenarioBreakdown = new[]
+                {
+                    new
+                    {
+                        scenario = "EdgeCase:CobSecondaryPayer",
+                        total = 10,
+                        matches = 9,
+                        mismatches = 1,
+                        unsupported = 0,
+                        observationTimeouts = 0,
+                        unspecified = 0
+                    }
+                },
                 createdAtUtc = "2026-07-01T00:01:05Z"
             }
         }, JsonOpts);
 
-        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, json)));
+        var handler = new FakeHandler(HttpStatusCode.OK, json);
+        var sut = CreateService(new HttpClient(handler));
 
         var result = await sut.GetMassAdjudicationRunsAsync();
 
+        handler.CapturedRequests.Should().ContainSingle();
+        handler.CapturedRequests[0].Headers.GetValues("X-Tenant-ID").Should().ContainSingle("demo");
         result.Should().ContainSingle();
         result[0].Id.Should().Be("run-001");
         result[0].Run.TenantId.Should().Be("tenant-a");
+        result[0].Run.MemberUrl.Should().Be("https://member");
+        result[0].Run.CoverageUrl.Should().Be("https://coverage");
+        result[0].Run.SeedMembers.Should().BeTrue();
+        result[0].Run.LineOfBusiness.Should().Be(3);
         result[0].Processed.Should().Be(100);
+        result[0].Pended.Should().Be(1);
+        result[0].WorkflowUnsupported.Should().Be(1);
+        result[0].AveragePaymentDelta.Should().Be(59.36m);
+        result[0].WorkflowScenarioBreakdown.Should().ContainSingle(s =>
+            s.Scenario == "EdgeCase:CobSecondaryPayer"
+            && s.Matches == 9
+            && s.Mismatches == 1);
         result[0].PlatformFailures.Should().Be(1);
     }
 

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -12,7 +12,7 @@
     Mass Adjudication Runs
 </MudText>
 <MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.55);" Class="mb-4">
-    Production mass adjudication runs, outcome mix, timing, and platform failure signal.
+    Million Claim Challenge and production mass adjudication evidence: outcome mix, workflow scoring, timing, and platform failure signal.
 </MudText>
 
 @if (!string.IsNullOrWhiteSpace(_error))
@@ -28,7 +28,7 @@
 }
 
 <MudGrid Spacing="3" Class="mb-4">
-    <MudItem xs="6" sm="3">
+    <MudItem xs="6" sm="2">
         <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,255,0.05); border: 1px solid rgba(0,255,255,0.2); border-radius: 8px;">
             <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Style="color: #00ffff; font-size: 2rem;" />
             <div>
@@ -37,7 +37,7 @@
             </div>
         </MudPaper>
     </MudItem>
-    <MudItem xs="6" sm="3">
+    <MudItem xs="6" sm="2">
         <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(0,255,136,0.05); border: 1px solid rgba(0,255,136,0.2); border-radius: 8px;">
             <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Style="color: #00ff88; font-size: 2rem;" />
             <div>
@@ -46,7 +46,16 @@
             </div>
         </MudPaper>
     </MudItem>
-    <MudItem xs="6" sm="3">
+    <MudItem xs="6" sm="2">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,202,40,0.06); border: 1px solid rgba(255,202,40,0.25); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.PendingActions" Style="color: #ffca28; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #ffca28; font-weight: 700;">@_runs.Sum(x => x.Pended).ToString("N0")</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Pended</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="6" sm="2">
         <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,202,40,0.06); border: 1px solid rgba(255,202,40,0.25); border-radius: 8px;">
             <MudIcon Icon="@Icons.Material.Filled.Rule" Style="color: #ffca28; font-size: 2rem;" />
             <div>
@@ -55,7 +64,16 @@
             </div>
         </MudPaper>
     </MudItem>
-    <MudItem xs="6" sm="3">
+    <MudItem xs="6" sm="2">
+        <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(148,163,184,0.08); border: 1px solid rgba(148,163,184,0.25); border-radius: 8px;">
+            <MudIcon Icon="@Icons.Material.Filled.VisibilityOff" Style="color: #94a3b8; font-size: 2rem;" />
+            <div>
+                <MudText Typo="Typo.h5" Style="color: #cbd5e1; font-weight: 700;">@_runs.Sum(x => x.WorkflowUnsupported).ToString("N0")</MudText>
+                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">Unsupported</MudText>
+            </div>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="6" sm="2">
         <MudPaper Class="pa-3 d-flex align-center gap-3" Style="background: rgba(255,0,85,0.05); border: 1px solid rgba(255,0,85,0.2); border-radius: 8px;">
             <MudIcon Icon="@Icons.Material.Filled.ErrorOutline" Style="color: #ff0055; font-size: 2rem;" />
             <div>
@@ -148,12 +166,23 @@
                 <MudGrid Spacing="2" Class="mb-3">
                     <MudItem xs="6" md="4">@Metric("Processed", $"{_selectedRun.Processed:N0}", "#00ffff")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Paid", $"{_selectedRun.Paid:N0}", "#00ff88")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Pended", $"{_selectedRun.Pended:N0}", "#ffca28")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Business Denials", $"{_selectedRun.BusinessDenials:N0}", "#ffca28")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Platform Failures", $"{_selectedRun.PlatformFailures:N0}", "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Observation Timeouts", $"{_selectedRun.ObservationTimeouts:N0}", _selectedRun.ObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Throughput", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Unsupported", $"{_selectedRun.WorkflowUnsupported:N0}", "#cbd5e1")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta))</MudItem>
+                </MudGrid>
+
+                <MudGrid Spacing="2" Class="mb-3">
+                    <MudItem xs="12" md="4">@RunFact("Seed / Parallelism", $"{_selectedRun.Run.Seed} / p{_selectedRun.Run.Parallelism}")</MudItem>
+                    <MudItem xs="12" md="4">@RunFact("Line of Business", LineOfBusinessLabel(_selectedRun.Run.LineOfBusiness))</MudItem>
+                    <MudItem xs="12" md="4">@RunFact("Seeding", $"members {OnOff(_selectedRun.Run.SeedMembers)} · providers {OnOff(_selectedRun.Run.SeedProviders)}")</MudItem>
                 </MudGrid>
 
                 <MudGrid Spacing="2">
@@ -184,7 +213,9 @@
                                Dense="true" Variant="Variant.Outlined" Style="width: 190px;">
                         <MudSelectItem Value="@("")">All outcomes</MudSelectItem>
                         <MudSelectItem Value="@("Paid")">Paid</MudSelectItem>
+                        <MudSelectItem Value="@("Pended")">Pended</MudSelectItem>
                         <MudSelectItem Value="@("BusinessDenial")">Business denials</MudSelectItem>
+                        <MudSelectItem Value="@("ObservationTimeout")">Observation timeouts</MudSelectItem>
                         <MudSelectItem Value="@("PlatformFailure")">Platform failures</MudSelectItem>
                     </MudSelect>
                 </div>
@@ -272,6 +303,52 @@
                     </PagerContent>
                 </MudTable>
             </MudPaper>
+
+            @if (_selectedRun.WorkflowScenarioBreakdown.Count > 0)
+            {
+                <MudPaper Class="pa-4 mb-3" Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+                    <div class="d-flex align-center gap-2 mb-3">
+                        <MudIcon Icon="@Icons.Material.Filled.FactCheck" Color="Color.Primary" />
+                        <MudText Typo="Typo.subtitle2" Style="font-weight: 700;">Workflow Scenario Breakdown</MudText>
+                        <MudSpacer />
+                        <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45);">
+                            Matched, mismatched, unsupported, and observation-timeout counts by answer-key scenario.
+                        </MudText>
+                    </div>
+
+                    <MudTable Items="@_selectedRun.WorkflowScenarioBreakdown" Dense="true" Hover="true" T="MassAdjudicationWorkflowScenarioSummary" RowsPerPage="10">
+                        <HeaderContent>
+                            <MudTh>Scenario</MudTh>
+                            <MudTh>Matched</MudTh>
+                            <MudTh>Mismatched</MudTh>
+                            <MudTh>Unsupported</MudTh>
+                            <MudTh>Timeouts</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd DataLabel="Scenario">
+                                <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.Scenario</MudText>
+                                <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45);">@context.Total.ToString("N0") total checks</MudText>
+                            </MudTd>
+                            <MudTd DataLabel="Matched">
+                                <MudText Typo="Typo.body2" Style="font-family: monospace; color: #00ff88;">@context.Matches.ToString("N0")</MudText>
+                                <MudProgressLinear Value="@ScenarioPercent(context.Matches, context.Total)" Color="Color.Success" Style="height: 5px; border-radius: 3px;" />
+                            </MudTd>
+                            <MudTd DataLabel="Mismatched">
+                                <MudText Typo="Typo.body2" Style="@ScenarioCountStyle(context.Mismatches, "#ff0055")">@context.Mismatches.ToString("N0")</MudText>
+                            </MudTd>
+                            <MudTd DataLabel="Unsupported">
+                                <MudText Typo="Typo.body2" Style="@ScenarioCountStyle(context.Unsupported, "#cbd5e1")">@context.Unsupported.ToString("N0")</MudText>
+                            </MudTd>
+                            <MudTd DataLabel="Timeouts">
+                                <MudText Typo="Typo.body2" Style="@ScenarioCountStyle(context.ObservationTimeouts, "#ff0055")">@context.ObservationTimeouts.ToString("N0")</MudText>
+                            </MudTd>
+                        </RowTemplate>
+                        <PagerContent>
+                            <MudTablePager PageSizeOptions="new[] { 10, 25, 50 }" />
+                        </PagerContent>
+                    </MudTable>
+                </MudPaper>
+            }
 
             <MudGrid Spacing="3">
                 <MudItem xs="12" md="6">
@@ -406,10 +483,33 @@
             ? 0
             : (double)count / _selectedRun.BusinessDenials * 100;
 
+    private static double ScenarioPercent(int count, int total)
+        => total <= 0 ? 0 : (double)count / total * 100;
+
+    private static string OnOff(bool value) => value ? "on" : "off";
+
+    private static string LineOfBusinessLabel(int lineOfBusiness) => lineOfBusiness switch
+    {
+        1 => "Commercial (1)",
+        2 => "Medicare (2)",
+        3 => "Medicaid (3)",
+        4 => "CHIP (4)",
+        5 => "Exchange (5)",
+        _ => lineOfBusiness <= 0 ? "Unspecified" : $"LOB {lineOfBusiness}"
+    };
+
+    private static string ScenarioCountStyle(int count, string highlightColor)
+        => $"font-family: monospace; color: {(count == 0 ? "rgba(255,255,255,0.55)" : highlightColor)};";
+
+    private static string PaymentDeltaColor(decimal? paymentDelta)
+        => paymentDelta is null ? "#cbd5e1" : paymentDelta == 0 ? "#00ff88" : "#ffca28";
+
     private static Color OutcomeColor(string outcome) => outcome switch
     {
         "Paid" => Color.Success,
+        "Pended" => Color.Warning,
         "BusinessDenial" => Color.Warning,
+        "ObservationTimeout" => Color.Error,
         "PlatformFailure" => Color.Error,
         _ => Color.Default
     };
@@ -417,6 +517,7 @@
     private static string OutcomeLabel(string outcome) => outcome switch
     {
         "BusinessDenial" => "Business Denial",
+        "ObservationTimeout" => "Observation Timeout",
         "PlatformFailure" => "Platform Failure",
         _ => outcome
     };
@@ -425,6 +526,8 @@
     {
         "Matched" => Color.Success,
         "Mismatched" => Color.Error,
+        "Unsupported" => Color.Default,
+        "ObservationTimeout" => Color.Error,
         _ => Color.Default
     };
 
@@ -432,6 +535,8 @@
     {
         "Matched" => "Expected",
         "Mismatched" => "Mismatch",
+        "Unsupported" => "Unsupported",
+        "ObservationTimeout" => "Observation Timeout",
         _ => "Unscored"
     };
 
@@ -447,6 +552,23 @@
         builder.OpenComponent<MudText>(7);
         builder.AddAttribute(8, "Typo", Typo.h6);
         builder.AddAttribute(9, "Style", $"color: {color}; font-weight: 700; font-family: monospace;");
+        builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.CloseElement();
+    };
+
+    private RenderFragment RunFact(string label, string value) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "style", "border: 1px solid rgba(0,255,255,0.18); background: rgba(0,255,255,0.05); border-radius: 8px; padding: 10px;");
+        builder.OpenComponent<MudText>(2);
+        builder.AddAttribute(3, "Typo", Typo.caption);
+        builder.AddAttribute(4, "Style", "color: rgba(255,255,255,0.55);");
+        builder.AddAttribute(5, "ChildContent", (RenderFragment)(b => b.AddContent(6, label)));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(7);
+        builder.AddAttribute(8, "Typo", Typo.body2);
+        builder.AddAttribute(9, "Style", "color: #e2e8f0; font-family: monospace;");
         builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
         builder.CloseComponent();
         builder.CloseElement();

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -380,11 +380,9 @@ if (useLocalDemoAuth)
 {
     app.MapGet("/local-demo/sign-in", async (HttpContext context) =>
     {
-        var redirectUri = context.Request.Query["redirectUri"].FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(redirectUri) || !redirectUri.StartsWith("/", StringComparison.Ordinal))
-        {
-            redirectUri = "/";
-        }
+        var redirectUri = NormalizeLocalDemoRedirect(
+            context.Request.Query["redirectUri"].FirstOrDefault(),
+            context.Request);
 
         var email = builder.Configuration["Authentication:LocalDemo:Email"]
             ?? "local-demo-user";
@@ -433,6 +431,31 @@ if (useLocalDemoAuth)
         await context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         return Results.Redirect("/");
     }).WithMetadata(new Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute());
+}
+
+static string NormalizeLocalDemoRedirect(string? redirectUri, HttpRequest request)
+{
+    if (string.IsNullOrWhiteSpace(redirectUri))
+    {
+        return "/";
+    }
+
+    if (redirectUri.StartsWith("/", StringComparison.Ordinal)
+        && !redirectUri.StartsWith("//", StringComparison.Ordinal))
+    {
+        return redirectUri;
+    }
+
+    if (Uri.TryCreate(redirectUri, UriKind.Absolute, out var absolute)
+        && string.Equals(absolute.Host, request.Host.Host, StringComparison.OrdinalIgnoreCase)
+        && (!absolute.IsDefaultPort || absolute.Port == request.Host.Port))
+    {
+        return string.IsNullOrEmpty(absolute.PathAndQuery)
+            ? "/"
+            : absolute.PathAndQuery;
+    }
+
+    return "/";
 }
 
 // Health endpoint - anonymous access for Kubernetes probes

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -82,11 +82,15 @@ public class MassAdjudicationRunSummary
     public int TotalClaims { get; set; }
     public int Processed { get; set; }
     public int Paid { get; set; }
+    public int Pended { get; set; }
     public int BusinessDenials { get; set; }
+    public int ObservationTimeouts { get; set; }
     public int PlatformFailures { get; set; }
     public int WorkflowScenarios { get; set; }
     public int WorkflowMatches { get; set; }
     public int WorkflowMismatches { get; set; }
+    public int WorkflowUnsupported { get; set; }
+    public int WorkflowObservationTimeouts { get; set; }
     public TimeSpan Elapsed { get; set; }
     public double ThroughputClaimsPerSecond { get; set; }
     public double P95LatencyMilliseconds { get; set; }
@@ -97,6 +101,7 @@ public class MassAdjudicationRunSummary
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
+    public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
     public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; }
@@ -110,9 +115,13 @@ public class MassAdjudicationRunMetadata
     public int Parallelism { get; set; }
     public string ClaimsUrl { get; set; } = string.Empty;
     public string BenefitUrl { get; set; } = string.Empty;
+    public string MemberUrl { get; set; } = string.Empty;
+    public string CoverageUrl { get; set; } = string.Empty;
     public string ProviderUrl { get; set; } = string.Empty;
+    public bool SeedMembers { get; set; }
     public bool SeedProviders { get; set; }
     public bool SkipClaimUpdate { get; set; }
+    public int LineOfBusiness { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
 }
@@ -128,6 +137,17 @@ public class MassAdjudicationBusinessDenialSummary
 {
     public string Code { get; set; } = string.Empty;
     public int Count { get; set; }
+}
+
+public class MassAdjudicationWorkflowScenarioSummary
+{
+    public string Scenario { get; set; } = string.Empty;
+    public int Total { get; set; }
+    public int Matches { get; set; }
+    public int Mismatches { get; set; }
+    public int Unsupported { get; set; }
+    public int ObservationTimeouts { get; set; }
+    public int Unspecified { get; set; }
 }
 
 public class MassAdjudicationFailureSummary

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -74,8 +74,10 @@ public class ClaimsService : IClaimsService
         var baseUrl = _configuration["Services:ClaimsService"];
         try
         {
-            var response = await _httpClient.GetAsync(
+            using var request = CreateMassAdjudicationRequest(
+                HttpMethod.Get,
                 $"{baseUrl}/mass-adjudication/runs?limit={Math.Clamp(limit, 1, 100)}");
+            var response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             return await ReadOptionalJsonAsync<List<MassAdjudicationRunSummary>>(response)
                 ?? new List<MassAdjudicationRunSummary>();
@@ -92,7 +94,10 @@ public class ClaimsService : IClaimsService
         var baseUrl = _configuration["Services:ClaimsService"];
         try
         {
-            var response = await _httpClient.GetAsync($"{baseUrl}/mass-adjudication/runs/{Uri.EscapeDataString(runId)}");
+            using var request = CreateMassAdjudicationRequest(
+                HttpMethod.Get,
+                $"{baseUrl}/mass-adjudication/runs/{Uri.EscapeDataString(runId)}");
+            var response = await _httpClient.SendAsync(request);
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 return null;
@@ -122,8 +127,10 @@ public class ClaimsService : IClaimsService
                 query += $"&outcome={Uri.EscapeDataString(outcome)}";
             }
 
-            var response = await _httpClient.GetAsync(
+            using var request = CreateMassAdjudicationRequest(
+                HttpMethod.Get,
                 $"{baseUrl}/mass-adjudication/runs/{Uri.EscapeDataString(runId)}/claims?{query}");
+            var response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             return await ReadOptionalJsonAsync<List<MassAdjudicationClaimResult>>(response)
                 ?? new List<MassAdjudicationClaimResult>();
@@ -133,6 +140,19 @@ public class ClaimsService : IClaimsService
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
             throw new ServiceUnavailableException("Claims Service", ex);
         }
+    }
+
+    private HttpRequestMessage CreateMassAdjudicationRequest(HttpMethod method, string url)
+    {
+        var request = new HttpRequestMessage(method, url);
+        var tenantId = _configuration["Services:ClaimsServiceTenantId"]
+            ?? _configuration["Authentication:LocalDemo:TenantId"];
+        if (!string.IsNullOrWhiteSpace(tenantId))
+        {
+            request.Headers.TryAddWithoutValidation("X-Tenant-ID", tenantId);
+        }
+
+        return request;
     }
 
     public async Task<string> SubmitClaimAsync(SubmitClaimRequest request)
@@ -190,7 +210,14 @@ public class ClaimsService : IClaimsService
         var baseUrl = _configuration["Services:ClaimsService"];
         try
         {
-            return await _httpClient.GetFromJsonAsync<AdjudicationTransparencyData>($"{baseUrl}/claims/{claimId}/adjudication-detail");
+            var response = await _httpClient.GetAsync($"{baseUrl}/claims/{claimId}/adjudication-detail");
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<AdjudicationTransparencyData>(JsonOptions);
         }
         catch (HttpRequestException ex)
         {

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -9,11 +9,15 @@ public class MassAdjudicationRunSummary
     public int TotalClaims { get; set; }
     public int Processed { get; set; }
     public int Paid { get; set; }
+    public int Pended { get; set; }
     public int BusinessDenials { get; set; }
+    public int ObservationTimeouts { get; set; }
     public int PlatformFailures { get; set; }
     public int WorkflowScenarios { get; set; }
     public int WorkflowMatches { get; set; }
     public int WorkflowMismatches { get; set; }
+    public int WorkflowUnsupported { get; set; }
+    public int WorkflowObservationTimeouts { get; set; }
     public TimeSpan Elapsed { get; set; }
     public double ThroughputClaimsPerSecond { get; set; }
     public double P95LatencyMilliseconds { get; set; }
@@ -24,6 +28,7 @@ public class MassAdjudicationRunSummary
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
+    public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
     [BsonIgnore]
     public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
@@ -38,9 +43,13 @@ public class MassAdjudicationRunMetadata
     public int Parallelism { get; set; }
     public string ClaimsUrl { get; set; } = string.Empty;
     public string BenefitUrl { get; set; } = string.Empty;
+    public string MemberUrl { get; set; } = string.Empty;
+    public string CoverageUrl { get; set; } = string.Empty;
     public string ProviderUrl { get; set; } = string.Empty;
+    public bool SeedMembers { get; set; }
     public bool SeedProviders { get; set; }
     public bool SkipClaimUpdate { get; set; }
+    public int LineOfBusiness { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
 }
@@ -56,6 +65,17 @@ public class MassAdjudicationBusinessDenialSummary
 {
     public string Code { get; set; } = string.Empty;
     public int Count { get; set; }
+}
+
+public class MassAdjudicationWorkflowScenarioSummary
+{
+    public string Scenario { get; set; } = string.Empty;
+    public int Total { get; set; }
+    public int Matches { get; set; }
+    public int Mismatches { get; set; }
+    public int Unsupported { get; set; }
+    public int ObservationTimeouts { get; set; }
+    public int Unspecified { get; set; }
 }
 
 public class MassAdjudicationFailureSummary

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -1,6 +1,8 @@
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using NSubstitute;
 
@@ -36,6 +38,52 @@ public class MassAdjudicationRunRepositoryTests
         saved.ClaimResults[0].CreatedAtUtc.Should().Be(saved.CreatedAtUtc);
         saved.ClaimResults[0].ValidationScenario.Should().Be("TxStarInpatientNoAuth");
         saved.ClaimResults[0].ValidationStatus.Should().Be("Matched");
+    }
+
+    [Fact]
+    public async Task SaveAsync_preserves_mcc_evidence_summary_fields()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var summary = CreateSummary();
+        summary.Pended = 46;
+        summary.ObservationTimeouts = 1;
+        summary.WorkflowUnsupported = 73;
+        summary.WorkflowObservationTimeouts = 2;
+        summary.AveragePaymentDelta = 59.36m;
+        summary.Run.MemberUrl = "https://member";
+        summary.Run.CoverageUrl = "https://coverage";
+        summary.Run.SeedMembers = true;
+        summary.Run.LineOfBusiness = 3;
+        summary.WorkflowScenarioBreakdown.Add(new MassAdjudicationWorkflowScenarioSummary
+        {
+            Scenario = "EdgeCase:CobSecondaryPayer",
+            Total = 10,
+            Matches = 9,
+            Mismatches = 0,
+            Unsupported = 0,
+            ObservationTimeouts = 1,
+            Unspecified = 0
+        });
+
+        var saved = await repo.SaveAsync(summary);
+        var persisted = saved.ToBson();
+        var reread = BsonSerializer.Deserialize<MassAdjudicationRunSummary>(persisted);
+
+        reread.Should().NotBeNull();
+        reread.Pended.Should().Be(46);
+        reread.ObservationTimeouts.Should().Be(1);
+        reread.WorkflowUnsupported.Should().Be(73);
+        reread.WorkflowObservationTimeouts.Should().Be(2);
+        reread.AveragePaymentDelta.Should().Be(59.36m);
+        reread.Run.MemberUrl.Should().Be("https://member");
+        reread.Run.CoverageUrl.Should().Be("https://coverage");
+        reread.Run.SeedMembers.Should().BeTrue();
+        reread.Run.LineOfBusiness.Should().Be(3);
+        reread.WorkflowScenarioBreakdown.Should().ContainSingle(s =>
+            s.Scenario == "EdgeCase:CobSecondaryPayer"
+            && s.Total == 10
+            && s.Matches == 9
+            && s.ObservationTimeouts == 1);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- preserve MCC evidence fields on saved mass adjudication run summaries
- render pended, unsupported, observation-timeout, payment-delta, and seeding metadata in the portal run viewer
- add workflow scenario breakdown visibility and regression tests for run summary deserialization/persistence

## Tests
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter MassAdjudicationRunRepositoryTests --no-restore
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter ClaimsServiceTests --no-restore