### PR TITLE
Improve MCC run viewer and claim drill-through

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -248,6 +248,92 @@ public class ClaimsServiceTests
     }
 
     [Fact]
+    public async Task GetClaimByIdAsync_WhenApiReturnsMassAdjudicationClaimShape_DeserializesSafely()
+    {
+        const string json = """
+        {
+          "id": "4ff4516a-9e97-4038-80c1-3a2cd6e5d952",
+          "claimNumber": "MCC-D-0000004",
+          "memberId": "MBR-7242385",
+          "subscriberId": "SUB-7242385",
+          "subscriberFirstName": "Sandra",
+          "subscriberLastName": "Anderson",
+          "patientFirstName": "Sandra",
+          "patientLastName": "Anderson",
+          "patientRelationship": "Self",
+          "billingProviderNPI": "1141521249",
+          "billingProviderName": "Thomas White",
+          "renderingProviderNPI": "1681064964",
+          "renderingProviderName": "Susan Moore",
+          "placeOfServiceCode": "11",
+          "claimType": 3,
+          "status": 5,
+          "totalChargeAmount": 100,
+          "allowedAmount": null,
+          "paidAmount": null,
+          "serviceDateFrom": "2026-06-15T07:00:00Z",
+          "serviceDateTo": "2026-06-15T07:00:00Z",
+          "submittedDate": "2026-07-09T22:03:53Z",
+          "receivedDate": "2026-07-09T22:03:53Z",
+          "adjudicatedDate": "2026-07-09T22:03:55.045Z",
+          "diagnosisCodes": [
+            {
+              "code": "K05.10",
+              "codeQualifier": "ABK",
+              "pointerNumber": 1
+            }
+          ],
+          "adjudicationResult": {
+            "allowedAmount": 0,
+            "deductibleAmount": 0
+          },
+          "claimLines": [
+            {
+              "lineNumber": 1,
+              "procedureCode": "D0150",
+              "procedureDescription": "Comprehensive oral evaluation — new or established patient",
+              "modifiers": [],
+              "units": 1,
+              "chargeAmount": 100,
+              "allowedAmount": null,
+              "paidAmount": null,
+              "patientResponsibility": null,
+              "serviceDateFrom": "2026-06-15T07:00:00Z",
+              "serviceDateTo": "2026-06-15T07:00:00Z",
+              "placeOfServiceCode": "11",
+              "diagnosisPointers": [1],
+              "adjustments": null,
+              "mpipMultiplierApplied": null,
+              "adjudicationResult": null,
+              "lineStatus": null
+            }
+          ],
+          "auditTrail": null
+        }
+        """;
+
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.OK, json)));
+
+        var result = await sut.GetClaimByIdAsync("4ff4516a-9e97-4038-80c1-3a2cd6e5d952");
+
+        result.Should().NotBeNull();
+        result!.ClaimId.Should().Be("4ff4516a-9e97-4038-80c1-3a2cd6e5d952");
+        result.Status.Should().Be("Approved");
+        result.ClaimType.Should().Be("Dental");
+        result.TotalChargeAmount.Should().Be(100m);
+        result.DiagnosisCodes.Should().ContainSingle()
+            .Which.Code.Should().Be("K05.10");
+        result.AuditTrail.Should().BeEmpty();
+        result.ServiceLines.Should().ContainSingle();
+        result.ServiceLines[0].ProcedureCode.Should().Be("D0150");
+        result.ServiceLines[0].AllowedAmount.Should().Be(0m);
+        result.ServiceLines[0].Modifiers.Should().BeEmpty();
+        result.ServiceLines[0].DiagnosisPointers.Should().ContainSingle()
+            .Which.Should().Be(1);
+        result.ServiceLines[0].Adjustments.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetClaimByIdAsync_WhenApiReturnsNull_ReturnsNull()
     {
         var sut = CreateService(new HttpClient(

--- a/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
@@ -505,8 +505,8 @@
             <MudButton Variant="Variant.Outlined"
                       Color="Color.Default"
                       StartIcon="@Icons.Material.Filled.ArrowBack"
-                      OnClick="@(() => NavigationManager.NavigateTo("/claims"))">
-                Back to Claims
+                      OnClick="@(() => NavigationManager.NavigateTo(BackHref))">
+                @BackLabel
             </MudButton>
             <MudStack Row="true" Spacing="2">
                 <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Print">Print</MudButton>
@@ -529,7 +529,7 @@
             else if (_adjudicationData == null)
             {
                 <MudAlert Severity="Severity.Info">
-                    Adjudication detail is only available for fully adjudicated claims.
+                    No adjudication pipeline trace was captured for this claim. The claim disposition is shown above; detailed step telemetry may be unavailable for mass adjudication run claims.
                 </MudAlert>
             }
             else
@@ -626,7 +626,7 @@
             else if (_adjudicationData == null)
             {
                 <MudAlert Severity="Severity.Info">
-                    Benefit breakdown is only available for fully adjudicated claims.
+                    No benefit breakdown trace was captured for this claim. The financial summary is shown above; detailed calculation telemetry may be unavailable for mass adjudication run claims.
                 </MudAlert>
             }
             else
@@ -788,9 +788,9 @@
         <MudButton Variant="Variant.Outlined" 
                   Color="Color.Default"
                   StartIcon="@Icons.Material.Filled.ArrowBack"
-                  OnClick="@(() => NavigationManager.NavigateTo("/claims"))"
+                  OnClick="@(() => NavigationManager.NavigateTo(BackHref))"
                   Class="mt-4">
-            Back to Claims
+            @BackLabel
         </MudButton>
     }
 </MudContainer>
@@ -799,6 +799,9 @@
     [Parameter]
     public string ClaimId { get; set; } = string.Empty;
 
+    [SupplyParameterFromQuery(Name = "fromRun")]
+    public string? FromRun { get; set; }
+
     private ClaimDetails? _claim;
     private bool _loading = true;
     private bool _loadingAdjudication = false;
@@ -806,19 +809,44 @@
     private List<BreadcrumbItem> _breadcrumbItems = new();
     private string _noteInput = string.Empty;
     private string? _serviceError;
+    private string BackHref => string.IsNullOrWhiteSpace(FromRun)
+        ? "/claims"
+        : $"/mass-adjudication-runs?run={Uri.EscapeDataString(FromRun)}";
+    private string BackLabel => string.IsNullOrWhiteSpace(FromRun)
+        ? "Back to Claims"
+        : "Back to Adjudication Run";
 
     protected override async Task OnInitializedAsync()
     {
-        _breadcrumbItems = new List<BreadcrumbItem>
-        {
-            new BreadcrumbItem("Home", href: "/"),
-            new BreadcrumbItem("Claims", href: "/claims"),
-            new BreadcrumbItem($"Claim {ClaimId}", href: null, disabled: true)
-        };
+        BuildBreadcrumbs();
 
         await LoadClaimDetails();
+        BuildBreadcrumbs();
         // Load adjudication data in background (fire-and-forget, non-blocking)
         _ = LoadAdjudicationDataAsync();
+    }
+
+    private void BuildBreadcrumbs()
+    {
+        var currentClaimLabel = _claim?.ClaimNumber is { Length: > 0 }
+            ? $"Claim {_claim.ClaimNumber}"
+            : $"Claim {ClaimId}";
+
+        _breadcrumbItems = new List<BreadcrumbItem>
+        {
+            new("Home", href: "/")
+        };
+
+        if (!string.IsNullOrWhiteSpace(FromRun))
+        {
+            _breadcrumbItems.Add(new BreadcrumbItem("Mass Adjudication", href: BackHref));
+        }
+        else
+        {
+            _breadcrumbItems.Add(new BreadcrumbItem("Claims", href: "/claims"));
+        }
+
+        _breadcrumbItems.Add(new BreadcrumbItem(currentClaimLabel, href: null, disabled: true));
     }
 
     private async Task LoadAdjudicationDataAsync()

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -1,5 +1,6 @@
 @page "/mass-adjudication-runs"
 @attribute [Authorize]
+@implements IAsyncDisposable
 @using CloudHealthOffice.Portal.Services
 @inject IClaimsService ClaimsService
 @inject ISnackbar Snackbar
@@ -88,10 +89,20 @@
     <MudButton Variant="Variant.Outlined"
                Color="Color.Default"
                StartIcon="@Icons.Material.Filled.Refresh"
-               OnClick="LoadRuns"
+               OnClick="@(() => LoadRuns())"
                Disabled="_loading">
         Refresh
     </MudButton>
+    <MudButton Variant="@(_autoRefresh ? Variant.Filled : Variant.Outlined)"
+               Color="@(_autoRefresh ? Color.Success : Color.Default)"
+               StartIcon="@(_autoRefresh ? Icons.Material.Filled.Visibility : Icons.Material.Filled.VisibilityOff)"
+               OnClick="ToggleAutoRefresh"
+               Disabled="_loading">
+        @(_autoRefresh ? "Watching" : "Watch Runs")
+    </MudButton>
+    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">
+        @RefreshStatus
+    </MudText>
     <MudSpacer />
     @if (_selectedRun is not null)
     {
@@ -235,19 +246,19 @@
                         <MudTh>Payment</MudTh>
                     </HeaderContent>
                     <RowTemplate>
-                        <MudTd DataLabel="Claim">
+                        <MudTd DataLabel="Claim" Style="min-width: 170px;">
                             @if (!string.IsNullOrWhiteSpace(context.SubmittedClaimId))
                             {
-                                <MudLink Href="@ClaimHref(context.SubmittedClaimId!)" Color="Color.Primary" Style="font-family: monospace; font-weight: 700;">
-                                    @ShortId(context.SubmittedClaimId!)
+                                <MudLink Href="@ClaimHref(context.SubmittedClaimId!, _selectedRun?.Id)" Color="Color.Primary" Style="font-family: monospace; font-weight: 700; white-space: nowrap; display: inline-block;">
+                                    @DisplayClaimId(context)
                                 </MudLink>
                             }
                             else
                             {
-                                <MudText Typo="Typo.body2" Style="font-family: monospace;">@ShortId(context.GeneratedClaimId)</MudText>
+                                <MudText Typo="Typo.body2" Style="font-family: monospace; font-weight: 700; white-space: nowrap;">@DisplayClaimId(context)</MudText>
                             }
-                            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
-                                @context.ClaimType · @ShortId(context.GeneratedClaimId)
+                            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace; display: block; white-space: nowrap;">
+                                @context.ClaimType · @ShortId(context.SubmittedClaimId ?? context.Id)
                             </MudText>
                         </MudTd>
                         <MudTd DataLabel="Validation">
@@ -397,34 +408,75 @@
     private MassAdjudicationRunSummary? _selectedRun;
     private bool _loading;
     private bool _claimResultsLoading;
+    private bool _autoRefresh;
     private string _claimOutcomeFilter = string.Empty;
     private string? _error;
+    private DateTimeOffset? _lastRefreshedAt;
+    private int _newRunsSeen;
+    private CancellationTokenSource? _refreshCts;
+    private PeriodicTimer? _refreshTimer;
+
+    [SupplyParameterFromQuery(Name = "run")]
+    public string? RunId { get; set; }
+
+    private string RefreshStatus
+        => _lastRefreshedAt is null
+            ? "Not checked yet"
+            : $"{(_autoRefresh ? "Watching for newly published runs" : "Last checked")} {_lastRefreshedAt.Value.LocalDateTime:HH:mm:ss}"
+              + (_newRunsSeen > 0 ? $" · {_newRunsSeen} new this session" : string.Empty);
 
     protected override async Task OnInitializedAsync()
     {
         await LoadRuns();
     }
 
-    private async Task LoadRuns()
+    private async Task LoadRuns(bool preserveSelection = true, bool silent = false)
     {
-        _loading = true;
+        if (!silent)
+        {
+            _loading = true;
+        }
+
         _error = null;
         try
         {
+            var previousSelectedId = preserveSelection ? _selectedRun?.Id ?? RunId : RunId;
+            var previousRunIds = _runs.Select(x => x.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
             var runs = await ClaimsService.GetMassAdjudicationRunsAsync(50);
+            var newRunCount = previousRunIds.Count == 0
+                ? 0
+                : runs.Count(x => !previousRunIds.Contains(x.Id));
+
             _runs.Clear();
             _runs.AddRange(runs);
-            _selectedRun = _runs.FirstOrDefault();
-            await LoadClaimResults();
+            _selectedRun = previousSelectedId is null
+                ? _runs.FirstOrDefault()
+                : _runs.FirstOrDefault(x => string.Equals(x.Id, previousSelectedId, StringComparison.OrdinalIgnoreCase))
+                  ?? _runs.FirstOrDefault();
+            _lastRefreshedAt = DateTimeOffset.Now;
+
+            if (newRunCount > 0)
+            {
+                _newRunsSeen += newRunCount;
+                Snackbar.Add($"{newRunCount} new mass adjudication run{(newRunCount == 1 ? string.Empty : "s")} published", Severity.Info);
+            }
+
+            await LoadClaimResults(silent);
         }
         catch (Exception ex)
         {
             _error = ex.Message;
-            Snackbar.Add("Unable to load mass adjudication runs", Severity.Error);
+            if (!silent)
+            {
+                Snackbar.Add("Unable to load mass adjudication runs", Severity.Error);
+            }
         }
         finally
         {
-            _loading = false;
+            if (!silent)
+            {
+                _loading = false;
+            }
         }
     }
 
@@ -441,7 +493,7 @@
         await LoadClaimResults();
     }
 
-    private async Task LoadClaimResults()
+    private async Task LoadClaimResults(bool silent = false)
     {
         _claimResults.Clear();
         if (_selectedRun is null)
@@ -449,7 +501,11 @@
             return;
         }
 
-        _claimResultsLoading = true;
+        if (!silent)
+        {
+            _claimResultsLoading = true;
+        }
+
         try
         {
             var results = await ClaimsService.GetMassAdjudicationClaimResultsAsync(
@@ -461,16 +517,80 @@
         catch (Exception ex)
         {
             _error = ex.Message;
-            Snackbar.Add("Unable to load claim-level results", Severity.Warning);
+            if (!silent)
+            {
+                Snackbar.Add("Unable to load claim-level results", Severity.Warning);
+            }
         }
         finally
         {
-            _claimResultsLoading = false;
+            if (!silent)
+            {
+                _claimResultsLoading = false;
+            }
         }
     }
 
-    private static string ClaimHref(string claimId)
-        => $"/claims/{Uri.EscapeDataString(claimId)}";
+    private void ToggleAutoRefresh()
+    {
+        if (_autoRefresh)
+        {
+            StopAutoRefresh();
+            return;
+        }
+
+        _autoRefresh = true;
+        _refreshCts = new CancellationTokenSource();
+        _refreshTimer = new PeriodicTimer(TimeSpan.FromSeconds(10));
+        _ = WatchForRunsAsync(_refreshCts.Token);
+    }
+
+    private async Task WatchForRunsAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (_refreshTimer is not null && await _refreshTimer.WaitForNextTickAsync(ct))
+            {
+                await InvokeAsync(async () =>
+                {
+                    await LoadRuns(silent: true);
+                    StateHasChanged();
+                });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private void StopAutoRefresh()
+    {
+        _autoRefresh = false;
+        _refreshCts?.Cancel();
+        _refreshCts?.Dispose();
+        _refreshCts = null;
+        _refreshTimer?.Dispose();
+        _refreshTimer = null;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        StopAutoRefresh();
+        return ValueTask.CompletedTask;
+    }
+
+    private static string ClaimHref(string claimId, string? runId = null)
+    {
+        var href = $"/claims/{Uri.EscapeDataString(claimId)}";
+        return string.IsNullOrWhiteSpace(runId)
+            ? href
+            : $"{href}?fromRun={Uri.EscapeDataString(runId)}";
+    }
+
+    private static string DisplayClaimId(MassAdjudicationClaimResult result)
+        => !string.IsNullOrWhiteSpace(result.GeneratedClaimId)
+            ? result.GeneratedClaimId
+            : ShortId(result.SubmittedClaimId ?? result.Id);
 
     private static string ShortId(string id)
         => string.IsNullOrWhiteSpace(id) ? "run" : id[..Math.Min(8, id.Length)];

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -623,7 +623,21 @@ public class IdCardHistoryView
 // DTOs
 public class ClaimSummary
 {
-    public string ClaimId { get; set; } = string.Empty;
+    private string _claimId = string.Empty;
+
+    public string ClaimId
+    {
+        get => _claimId;
+        set => _claimId = string.IsNullOrWhiteSpace(value) ? _claimId : value;
+    }
+
+    [JsonPropertyName("id")]
+    public string? Id
+    {
+        get => _claimId;
+        set => _claimId = string.IsNullOrWhiteSpace(value) ? _claimId : value;
+    }
+
     public string ClaimNumber { get; set; } = string.Empty;
     public string MemberName { get; set; } = string.Empty;
     public string MemberId { get; set; } = string.Empty;
@@ -631,9 +645,13 @@ public class ClaimSummary
     public string ProviderId { get; set; } = string.Empty;
     [JsonConverter(typeof(FlexibleClaimTypeJsonConverter))]
     public string ClaimType { get; set; } = string.Empty; // Professional, Institutional, Dental
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal TotalChargeAmount { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal AllowedAmount { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal PaidAmount { get; set; }
+    [JsonConverter(typeof(FlexibleClaimStatusJsonConverter))]
     public string Status { get; set; } = string.Empty;
     public DateTime ServiceDateFrom { get; set; }
     public DateTime ServiceDateTo { get; set; }
@@ -646,6 +664,10 @@ public class ClaimSummary
 
 public class ClaimDetails : ClaimSummary
 {
+    private List<ClaimDiagnosisCode> _diagnosisCodes = new();
+    private List<ClaimServiceLine> _serviceLines = new();
+    private List<ClaimAudit> _auditTrail = new();
+
     public string SubscriberId { get; set; } = string.Empty;
     public string SubscriberName { get; set; } = string.Empty;
     public string PatientName { get; set; } = string.Empty;
@@ -667,14 +689,32 @@ public class ClaimDetails : ClaimSummary
     public DateTime? PaidDate { get; set; }
     public string? CheckNumber { get; set; }
     public string? DenialReason { get; set; }
-    public List<ClaimDiagnosisCode> DiagnosisCodes { get; set; } = new();
-    public List<ClaimServiceLine> ServiceLines { get; set; } = new();
+    public List<ClaimDiagnosisCode> DiagnosisCodes
+    {
+        get => _diagnosisCodes;
+        set => _diagnosisCodes = value ?? new();
+    }
+    public List<ClaimServiceLine> ServiceLines
+    {
+        get => _serviceLines;
+        set => _serviceLines = value ?? new();
+    }
+    [JsonPropertyName("claimLines")]
+    public List<ClaimServiceLine>? ClaimLines
+    {
+        get => _serviceLines;
+        set => _serviceLines = value ?? new();
+    }
     public ClaimAdjustmentInfo? AdjustmentInfo { get; set; }
     public bool IsEditable { get; set; }
     public bool CanApprove { get; set; }
     public bool CanDeny { get; set; }
     public bool CanReverse { get; set; }
-    public List<ClaimAudit> AuditTrail { get; set; } = new();
+    public List<ClaimAudit> AuditTrail
+    {
+        get => _auditTrail;
+        set => _auditTrail = value ?? new();
+    }
 }
 
 public class ClaimDiagnosisCode
@@ -687,20 +727,41 @@ public class ClaimDiagnosisCode
 
 public class ClaimServiceLine
 {
+    private List<string> _modifiers = new();
+    private List<int> _diagnosisPointers = new();
+    private List<ClaimLineAdjustment> _adjustments = new();
+
     public int LineNumber { get; set; }
     public string ProcedureCode { get; set; } = string.Empty;
     public string ProcedureDescription { get; set; } = string.Empty;
-    public List<string> Modifiers { get; set; } = new();
+    public List<string> Modifiers
+    {
+        get => _modifiers;
+        set => _modifiers = value ?? new();
+    }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal Units { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal ChargeAmount { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal AllowedAmount { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal PaidAmount { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal PatientResponsibility { get; set; }
     public DateTime ServiceDateFrom { get; set; }
     public DateTime ServiceDateTo { get; set; }
     public string? RevenueCode { get; set; } // Institutional
-    public List<int> DiagnosisPointers { get; set; } = new();
-    public List<ClaimLineAdjustment> Adjustments { get; set; } = new();
+    public List<int> DiagnosisPointers
+    {
+        get => _diagnosisPointers;
+        set => _diagnosisPointers = value ?? new();
+    }
+    public List<ClaimLineAdjustment> Adjustments
+    {
+        get => _adjustments;
+        set => _adjustments = value ?? new();
+    }
     public string? LineStatus { get; set; }
 }
 
@@ -708,6 +769,7 @@ public class ClaimLineAdjustment
 {
     public string GroupCode { get; set; } = string.Empty;
     public string ReasonCode { get; set; } = string.Empty;
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal Amount { get; set; }
     public string Description { get; set; } = string.Empty;
 }
@@ -717,6 +779,7 @@ public class ClaimAdjustmentInfo
     public string AdjustmentType { get; set; } = string.Empty; // Reversal, Adjustment, Correction
     public string? OriginalClaimId { get; set; }
     public string? RelatedClaimId { get; set; }
+    [JsonConverter(typeof(FlexibleDecimalJsonConverter))]
     public decimal AdjustmentAmount { get; set; }
     public string? Reason { get; set; }
     public DateTime? AdjustmentDate { get; set; }

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -344,6 +344,33 @@ public sealed class FlexibleClaimStatusJsonConverter : JsonConverter<string>
     }
 }
 
+public sealed class FlexibleDecimalJsonConverter : JsonConverter<decimal>
+{
+    public override decimal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Number when reader.TryGetDecimal(out var value) => value,
+            JsonTokenType.Number => Convert.ToDecimal(reader.GetDouble()),
+            JsonTokenType.String when decimal.TryParse(
+                reader.GetString(),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var value) => value,
+            JsonTokenType.String => 0m,
+            JsonTokenType.Null => 0m,
+            JsonTokenType.True => 1m,
+            JsonTokenType.False => 0m,
+            _ => 0m
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue(value);
+    }
+}
+
 public class EligibilityService : IEligibilityService
 {
     private readonly HttpClient _httpClient;

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -205,6 +205,31 @@ public class ClaimsController : ControllerBase
     }
 
     /// <summary>
+    /// Get a persisted adjudication projection for claim detail transparency.
+    /// </summary>
+    [HttpGet("{id}/adjudication-detail")]
+    [ProducesResponseType(typeof(AdjudicationTransparencyData), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AdjudicationTransparencyData>> GetAdjudicationDetail(string id)
+    {
+        _logger.LogInformation("Fetching adjudication detail for claim ID: {Id}", SanitizeForLog(id));
+
+        var claim = await _claimRepository.GetByIdAsync(id);
+        if (claim == null)
+        {
+            return NotFound($"Claim {id} not found");
+        }
+
+        var detail = AdjudicationTransparencyBuilder.Build(claim);
+        if (detail is null)
+        {
+            return NotFound($"Claim {id} has no persisted adjudication detail");
+        }
+
+        return Ok(detail);
+    }
+
+    /// <summary>
     /// Get claim by claim number
     /// </summary>
     [HttpGet("number/{claimNumber}")]

--- a/src/services/claims-service/Models/AdjudicationTransparencyModels.cs
+++ b/src/services/claims-service/Models/AdjudicationTransparencyModels.cs
@@ -1,0 +1,74 @@
+namespace ClaimsService.Models;
+
+public class NcciEditResult
+{
+    public string EditCode { get; set; } = string.Empty;
+    public string EditType { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public bool Passed { get; set; }
+    public string? FailureReason { get; set; }
+    public string? AffectedProcedureCode { get; set; }
+    public string? AffectedModifier { get; set; }
+    public string? ResolutionApplied { get; set; }
+}
+
+public class FeeScheduleResult
+{
+    public string ProcedureCode { get; set; } = string.Empty;
+    public string Modifier { get; set; } = string.Empty;
+    public string FeeScheduleName { get; set; } = string.Empty;
+    public decimal BilledAmount { get; set; }
+    public decimal AllowedAmount { get; set; }
+    public decimal ContractedRate { get; set; }
+    public string RateBasis { get; set; } = string.Empty;
+    public decimal RateMultiplier { get; set; }
+    public string NetworkTier { get; set; } = string.Empty;
+}
+
+public class AccumulatorUpdate
+{
+    public string AccumulatorType { get; set; } = string.Empty;
+    public decimal AmountApplied { get; set; }
+    public decimal NewBalance { get; set; }
+    public decimal Limit { get; set; }
+}
+
+public class BenefitCalculationResult
+{
+    public string ServiceType { get; set; } = string.Empty;
+    public string BenefitRuleApplied { get; set; } = string.Empty;
+    public string NetworkTier { get; set; } = string.Empty;
+    public decimal AllowedAmount { get; set; }
+    public decimal DeductibleApplied { get; set; }
+    public decimal DeductibleRemaining { get; set; }
+    public decimal CopayAmount { get; set; }
+    public decimal CoinsuranceAmount { get; set; }
+    public decimal PlanPayment { get; set; }
+    public decimal MemberResponsibility { get; set; }
+    public bool DeductibleMet { get; set; }
+    public bool OopMaxMet { get; set; }
+    public decimal IndividualDeductibleBalance { get; set; }
+    public decimal IndividualDeductibleLimit { get; set; }
+    public decimal IndividualOopBalance { get; set; }
+    public decimal IndividualOopLimit { get; set; }
+    public List<AccumulatorUpdate> AccumulatorUpdates { get; set; } = new();
+}
+
+public class AdjudicationStep
+{
+    public string StepName { get; set; } = string.Empty;
+    public int StepNumber { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public DateTime? Timestamp { get; set; }
+    public int? DurationMs { get; set; }
+    public string? Summary { get; set; }
+    public string? ErrorDetail { get; set; }
+}
+
+public class AdjudicationTransparencyData
+{
+    public List<AdjudicationStep> Steps { get; set; } = new();
+    public List<NcciEditResult> NcciResults { get; set; } = new();
+    public List<FeeScheduleResult> FeeScheduleResults { get; set; } = new();
+    public BenefitCalculationResult? BenefitCalculation { get; set; }
+}

--- a/src/services/claims-service/Services/AdjudicationTransparencyBuilder.cs
+++ b/src/services/claims-service/Services/AdjudicationTransparencyBuilder.cs
@@ -1,0 +1,176 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Services;
+
+public static class AdjudicationTransparencyBuilder
+{
+    public static AdjudicationTransparencyData? Build(Claim claim)
+    {
+        if (claim.AdjudicationResult is null && claim.PendDetails is null && !claim.ClaimLines.Any(l => l.AdjudicationResult is not null))
+        {
+            return null;
+        }
+
+        var data = new AdjudicationTransparencyData
+        {
+            Steps = BuildSteps(claim),
+            NcciResults = BuildNcciResults(claim),
+            FeeScheduleResults = BuildFeeScheduleResults(claim),
+            BenefitCalculation = BuildBenefitCalculation(claim)
+        };
+
+        return data;
+    }
+
+    private static List<AdjudicationStep> BuildSteps(Claim claim)
+    {
+        var steps = new List<AdjudicationStep>
+        {
+            new()
+            {
+                StepNumber = 100,
+                StepName = "Claim Intake",
+                Status = "Passed",
+                Timestamp = claim.ReceivedDate,
+                Summary = $"Claim {claim.ClaimNumber} accepted for adjudication."
+            },
+            new()
+            {
+                StepNumber = 200,
+                StepName = "Benefit Calculation",
+                Status = claim.AdjudicationResult is null ? "Skipped" : "Passed",
+                Summary = claim.AdjudicationResult is null
+                    ? "No persisted benefit calculation projection is available for this claim."
+                    : $"Allowed {claim.AdjudicationResult.AllowedAmount:C}; payer payment {claim.AdjudicationResult.PayerPayment:C}; member responsibility {claim.AdjudicationResult.PatientResponsibility:C}."
+            }
+        };
+
+        if (claim.PendDetails is { } pendDetails)
+        {
+            steps.Add(new AdjudicationStep
+            {
+                StepNumber = 250,
+                StepName = "Pend Review",
+                Status = "Warning",
+                Timestamp = pendDetails.PendedAt,
+                Summary = $"{pendDetails.PendCode}: {pendDetails.PendReason ?? "Claim pended for review."}"
+            });
+        }
+
+        steps.Add(new AdjudicationStep
+        {
+            StepNumber = 300,
+            StepName = "Disposition",
+            Status = ResolveDispositionStepStatus(claim),
+            Timestamp = claim.AdjudicatedDate ?? claim.LastUpdatedDate,
+            Summary = BuildDispositionSummary(claim),
+            ErrorDetail = claim.AdjudicationResult?.DenialReason
+        });
+
+        steps.Add(new AdjudicationStep
+        {
+            StepNumber = 400,
+            StepName = "Persistence",
+            Status = "Passed",
+            Timestamp = claim.LastUpdatedDate,
+            Summary = $"Persisted claim status {claim.Status}."
+        });
+
+        return steps;
+    }
+
+    private static List<NcciEditResult> BuildNcciResults(Claim claim)
+    {
+        if (claim.PendDetails?.EditFailures is not { Count: > 0 } editFailures)
+        {
+            return new List<NcciEditResult>();
+        }
+
+        return editFailures.Select(edit => new NcciEditResult
+        {
+            EditCode = edit.RuleId,
+            EditType = edit.EditType,
+            Description = edit.Message ?? string.Empty,
+            Passed = false,
+            FailureReason = edit.SuggestedCarc is null ? null : $"Suggested CARC {edit.SuggestedCarc}",
+            AffectedProcedureCode = edit.Column2Code ?? edit.Column1Code,
+            AffectedModifier = edit.ModifierOverridePresent ? "Modifier override present" : null
+        }).ToList();
+    }
+
+    private static List<FeeScheduleResult> BuildFeeScheduleResults(Claim claim)
+    {
+        var networkTier = claim.AdjudicationResult?.NetworkTier ?? "Not captured";
+
+        return claim.ClaimLines
+            .Where(line => line.AdjudicationResult is not null)
+            .OrderBy(line => line.LineNumber)
+            .Select(line => new FeeScheduleResult
+            {
+                ProcedureCode = line.ProcedureCode,
+                Modifier = string.Join(",", line.Modifiers),
+                FeeScheduleName = "Persisted adjudication projection",
+                BilledAmount = line.ChargeAmount,
+                AllowedAmount = line.AdjudicationResult!.AllowedAmount,
+                ContractedRate = line.AdjudicationResult.AllowedAmount,
+                RateBasis = line.MpipMultiplierApplied.HasValue ? "MPIP" : "PersistedProjection",
+                RateMultiplier = line.MpipMultiplierApplied ?? 1m,
+                NetworkTier = networkTier
+            })
+            .ToList();
+    }
+
+    private static BenefitCalculationResult? BuildBenefitCalculation(Claim claim)
+    {
+        var adjudication = claim.AdjudicationResult;
+        if (adjudication is null)
+        {
+            return null;
+        }
+
+        return new BenefitCalculationResult
+        {
+            ServiceType = claim.ClaimType.ToString(),
+            BenefitRuleApplied = adjudication.DenialReasonCode is { Length: > 0 }
+                ? $"CARC {adjudication.DenialReasonCode}"
+                : "Persisted adjudication projection",
+            NetworkTier = adjudication.NetworkTier ?? "Not captured",
+            AllowedAmount = adjudication.AllowedAmount,
+            DeductibleApplied = adjudication.DeductibleAmount,
+            CopayAmount = adjudication.CopayAmount,
+            CoinsuranceAmount = adjudication.CoinsuranceAmount,
+            PlanPayment = adjudication.PayerPayment,
+            MemberResponsibility = adjudication.PatientResponsibility,
+            DeductibleMet = false,
+            OopMaxMet = false
+        };
+    }
+
+    private static string ResolveDispositionStepStatus(Claim claim) =>
+        claim.Status switch
+        {
+            ClaimStatus.Pended => "Warning",
+            ClaimStatus.Approved or ClaimStatus.Paid or ClaimStatus.PartiallyPaid or ClaimStatus.Denied => "Passed",
+            _ => "Warning"
+        };
+
+    private static string BuildDispositionSummary(Claim claim)
+    {
+        if (claim.Status == ClaimStatus.Pended && claim.PendDetails is { } pendDetails)
+        {
+            return $"Pended for {pendDetails.PendCode}: {pendDetails.PendReason ?? "review required"}.";
+        }
+
+        if (claim.Status == ClaimStatus.Denied && claim.AdjudicationResult?.DenialReasonCode is { Length: > 0 } denialCode)
+        {
+            return $"Denied with CARC {denialCode}: {claim.AdjudicationResult.DenialReason ?? "reason not captured"}.";
+        }
+
+        if (claim.AdjudicationResult is { } adjudication)
+        {
+            return $"{claim.Status}: payer payment {adjudication.PayerPayment:C}; member responsibility {adjudication.PatientResponsibility:C}.";
+        }
+
+        return $"{claim.Status}: no persisted adjudication projection is available.";
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -159,6 +159,52 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task GetAdjudicationDetail_AdjudicatedClaim_ReturnsProjection()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-adj-1";
+        claim.Status = ClaimStatus.Approved;
+        claim.AdjudicationResult = new AdjudicationResult
+        {
+            NetworkTier = "InNetwork",
+            AllowedAmount = 100m,
+            DeductibleAmount = 10m,
+            CoinsuranceAmount = 5m,
+            CopayAmount = 20m,
+            PatientResponsibility = 35m,
+            PayerPayment = 65m
+        };
+        claim.ClaimLines[0].AdjudicationResult = new LineAdjudicationResult
+        {
+            AllowedAmount = 100m,
+            PaidAmount = 65m,
+            PatientResponsibility = 35m
+        };
+        _repo.GetByIdAsync("claim-adj-1").Returns(claim);
+
+        var response = await _client.GetAsync("/api/claims/claim-adj-1/adjudication-detail");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var returned = await response.Content.ReadFromJsonAsync<AdjudicationTransparencyData>();
+        Assert.NotNull(returned);
+        Assert.NotEmpty(returned!.Steps);
+        Assert.Single(returned.FeeScheduleResults);
+        Assert.Equal(65m, returned.BenefitCalculation!.PlanPayment);
+    }
+
+    [Fact]
+    public async Task GetAdjudicationDetail_MissingProjection_Returns404()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-unadjudicated";
+        _repo.GetByIdAsync("claim-unadjudicated").Returns(claim);
+
+        var response = await _client.GetAsync("/api/claims/claim-unadjudicated/adjudication-detail");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // GET CLAIM BY NUMBER
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/AdjudicationTransparencyBuilderTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/AdjudicationTransparencyBuilderTests.cs
@@ -1,0 +1,117 @@
+using ClaimsService.Models;
+using ClaimsService.Services;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+public sealed class AdjudicationTransparencyBuilderTests
+{
+    [Fact]
+    public void Build_ForDeniedClaim_ProjectsDispositionBenefitAndLinePricing()
+    {
+        var claim = CreateClaim();
+        claim.Status = ClaimStatus.Denied;
+        claim.AdjudicationResult = new AdjudicationResult
+        {
+            NetworkTier = "InNetwork",
+            AllowedAmount = 0m,
+            DeductibleAmount = 0m,
+            CoinsuranceAmount = 0m,
+            CopayAmount = 0m,
+            PatientResponsibility = 0m,
+            PayerPayment = 0m,
+            DenialReasonCode = "96",
+            DenialReason = "Non-covered charge"
+        };
+        claim.ClaimLines[0].AdjudicationResult = new LineAdjudicationResult
+        {
+            AllowedAmount = 0m,
+            PaidAmount = 0m,
+            PatientResponsibility = 0m
+        };
+
+        var result = AdjudicationTransparencyBuilder.Build(claim);
+
+        Assert.NotNull(result);
+        Assert.Contains(result!.Steps, s => s.StepName == "Disposition" && s.Status == "Passed" && s.Summary!.Contains("CARC 96"));
+        Assert.Single(result.FeeScheduleResults);
+        Assert.Equal("99213", result.FeeScheduleResults[0].ProcedureCode);
+        Assert.NotNull(result.BenefitCalculation);
+        Assert.Equal("CARC 96", result.BenefitCalculation!.BenefitRuleApplied);
+    }
+
+    [Fact]
+    public void Build_ForPendedClaim_ProjectsPendStepAndNcciFailures()
+    {
+        var claim = CreateClaim();
+        claim.Status = ClaimStatus.Pended;
+        claim.PendDetails = new PendDetails
+        {
+            PendCode = "NCCI",
+            PendReason = "NCCI edit requires review",
+            PendedAt = new DateTime(2026, 7, 9, 12, 0, 0, DateTimeKind.Utc),
+            EditFailures = new List<NcciEditFailureSnapshot>
+            {
+                new()
+                {
+                    RuleId = "NE001",
+                    EditType = "NcciPair",
+                    Message = "Mutually exclusive procedures",
+                    Column1Code = "99213",
+                    Column2Code = "99214",
+                    SuggestedCarc = "151"
+                }
+            }
+        };
+
+        var result = AdjudicationTransparencyBuilder.Build(claim);
+
+        Assert.NotNull(result);
+        Assert.Contains(result!.Steps, s => s.StepName == "Pend Review" && s.Status == "Warning");
+        var ncci = Assert.Single(result.NcciResults);
+        Assert.False(ncci.Passed);
+        Assert.Equal("NE001", ncci.EditCode);
+        Assert.Equal("99214", ncci.AffectedProcedureCode);
+    }
+
+    [Fact]
+    public void Build_ForClaimWithoutPersistedProjection_ReturnsNull()
+    {
+        var claim = CreateClaim();
+
+        var result = AdjudicationTransparencyBuilder.Build(claim);
+
+        Assert.Null(result);
+    }
+
+    private static Claim CreateClaim()
+    {
+        var serviceDate = new DateTime(2026, 7, 9, 0, 0, 0, DateTimeKind.Utc);
+        return new Claim
+        {
+            Id = "claim-1",
+            ClaimNumber = "MCC-P-0000001",
+            TenantId = "test-tenant",
+            MemberId = "MEM-001",
+            BillingProviderNPI = "1234567890",
+            ClaimType = ClaimType.Professional,
+            Status = ClaimStatus.Submitted,
+            ReceivedDate = serviceDate,
+            LastUpdatedDate = serviceDate.AddMinutes(1),
+            ServiceDateFrom = serviceDate,
+            ServiceDateTo = serviceDate,
+            ClaimLines = new List<ClaimLine>
+            {
+                new()
+                {
+                    LineNumber = 1,
+                    ProcedureCode = "99213",
+                    ChargeAmount = 150m,
+                    Units = 1,
+                    ServiceDateFrom = serviceDate,
+                    ServiceDateTo = serviceDate
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add watch mode to the mass adjudication runs console and preserve selected run context
- show human-readable MCC claim IDs while linking through durable submitted claim IDs
- carry run context into claim details breadcrumbs and back navigation
- add a claims-service adjudication-detail projection endpoint for persisted claim disposition, benefit, pend, and pricing data
- harden portal claim DTO parsing for mass adjudication claim shapes

## Notes
- The adjudication detail endpoint is a persisted projection, not full historical stage trace persistence. Per-stage timings and unavailable engine-specific traces remain out of scope.

## Tests
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "AdjudicationTransparencyBuilderTests|GetAdjudicationDetail" --no-restore
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter ClaimsServiceTests --no-restore