### PR TITLE
Filter Claims Management by MCC run

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/Claims.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Claims.razor
@@ -25,6 +25,13 @@
         <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="() => _serviceError = null">@_serviceError</MudAlert>
     }
 
+    @if (!string.IsNullOrWhiteSpace(RunId))
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-4" Icon="@Icons.Material.Filled.ReceiptLong">
+            Showing persisted claims submitted by MCC run <strong>@ShortId(RunId)</strong>.
+        </MudAlert>
+    }
+
     <!-- Advanced Search Form -->
     <MudPaper Class="pa-4 mb-4" Elevation="2">
         <MudText Typo="Typo.h6" GutterBottom="true">Search Criteria</MudText>
@@ -128,7 +135,7 @@
                         <MudButton Variant="Variant.Filled"
                                   Color="Color.Primary"
                                   FullWidth="true"
-                                  OnClick="PerformSearch"
+                                  OnClick="@(() => PerformSearch())"
                                   Disabled="_loading"
                                   Class="h-100">
                             <MudIcon Icon="@Icons.Material.Filled.Search" Class="mr-2" />
@@ -384,17 +391,27 @@
     private int _currentPage = 1;
     private string? _serviceError;
 
-    protected override void OnInitialized()
+    [SupplyParameterFromQuery(Name = "runId")]
+    public string? RunId { get; set; }
+
+    protected override async Task OnInitializedAsync()
     {
         _searchRequest.PageSize = 25;
+        if (!string.IsNullOrWhiteSpace(RunId))
+        {
+            _searchRequest.RunId = RunId;
+            await PerformSearch(skipValidation: true);
+        }
     }
 
-    private async Task PerformSearch()
+    private async Task PerformSearch(bool skipValidation = false, bool resetPage = true)
     {
         _showValidationMessage = false;
 
         // Validate at least one search criterion
-        if (string.IsNullOrWhiteSpace(_searchRequest.ClaimNumber)
+        if (!skipValidation
+            && string.IsNullOrWhiteSpace(_searchRequest.RunId)
+            && string.IsNullOrWhiteSpace(_searchRequest.ClaimNumber)
             && _selectedMember == null
             && _selectedProvider == null
             && string.IsNullOrWhiteSpace(_searchRequest.ClaimType)
@@ -407,7 +424,10 @@
 
         _loading = true;
         _hasSearched = true;
-        _currentPage = 1;
+        if (resetPage)
+        {
+            _currentPage = 1;
+        }
 
         try
         {
@@ -449,10 +469,11 @@
         }
     }
 
-    private void ClearSearch()
+    private async Task ClearSearch()
     {
         _searchRequest = new()
         {
+            RunId = RunId,
             PageSize = 25,
             SortBy = "SubmittedDate",
             SortOrder = "Descending"
@@ -464,6 +485,11 @@
         _hasSearched = false;
         _currentPage = 1;
         _showValidationMessage = false;
+
+        if (!string.IsNullOrWhiteSpace(RunId))
+        {
+            await PerformSearch(skipValidation: true);
+        }
     }
 
     private void ToggleAdvancedOptions()
@@ -505,13 +531,24 @@
     {
         _currentPage = page;
         _searchRequest.PageNumber = page;
-        await PerformSearch();
+        await PerformSearch(
+            skipValidation: !string.IsNullOrWhiteSpace(_searchRequest.RunId),
+            resetPage: false);
     }
 
     private void ViewClaimDetails(string claimId)
     {
-        NavigationManager.NavigateTo($"/claims/{claimId}");
+        var href = $"/claims/{Uri.EscapeDataString(claimId)}";
+        if (!string.IsNullOrWhiteSpace(_searchRequest.RunId))
+        {
+            href += $"?fromRun={Uri.EscapeDataString(_searchRequest.RunId)}";
+        }
+
+        NavigationManager.NavigateTo(href);
     }
+
+    private static string ShortId(string value)
+        => string.IsNullOrWhiteSpace(value) ? "run" : value[..Math.Min(8, value.Length)];
 
     private Color GetStatusColor(string status) => status switch
     {

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -106,6 +106,12 @@
     <MudSpacer />
     @if (_selectedRun is not null)
     {
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Info"
+                   StartIcon="@Icons.Material.Filled.ReceiptLong"
+                   Href="@ClaimsSearchHref(_selectedRun.Id)">
+            View Claims
+        </MudButton>
         <MudChip T="string" Color="@(_selectedRun.PlatformFailures == 0 ? Color.Success : Color.Error)" Size="Size.Small">
             @(_selectedRun.PlatformFailures == 0 ? "Clean Run" : "Platform Failures")
         </MudChip>
@@ -586,6 +592,9 @@
             ? href
             : $"{href}?fromRun={Uri.EscapeDataString(runId)}";
     }
+
+    private static string ClaimsSearchHref(string runId)
+        => $"/claims?runId={Uri.EscapeDataString(runId)}";
 
     private static string DisplayClaimId(MassAdjudicationClaimResult result)
         => !string.IsNullOrWhiteSpace(result.GeneratedClaimId)

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -807,6 +807,7 @@ public class ServiceLine
 
 public class ClaimSearchRequest
 {
+    public string? RunId { get; set; }
     public string? ClaimNumber { get; set; }
     public string? MemberId { get; set; }
     public string? MemberName { get; set; }

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -13,6 +13,7 @@ namespace ClaimsService.Controllers;
 public class ClaimsController : ControllerBase
 {
     private readonly IClaimRepository _claimRepository;
+    private readonly IMassAdjudicationRunRepository _massAdjudicationRunRepository;
     private readonly IAiExaminationAuditRepository _auditRepository;
     private readonly IClaimAcknowledgmentService _ackService;
     private readonly IMpipAdjudicationEnhancer _mpipEnhancer;
@@ -24,6 +25,7 @@ public class ClaimsController : ControllerBase
 
     public ClaimsController(
         IClaimRepository claimRepository,
+        IMassAdjudicationRunRepository massAdjudicationRunRepository,
         IAiExaminationAuditRepository auditRepository,
         IClaimAcknowledgmentService ackService,
         IMpipAdjudicationEnhancer mpipEnhancer,
@@ -34,6 +36,7 @@ public class ClaimsController : ControllerBase
         ILogger<ClaimsController> logger)
     {
         _claimRepository = claimRepository;
+        _massAdjudicationRunRepository = massAdjudicationRunRepository;
         _auditRepository = auditRepository;
         _ackService = ackService;
         _mpipEnhancer = mpipEnhancer;
@@ -276,20 +279,46 @@ public class ClaimsController : ControllerBase
     /// <summary>Search claims via POST body (portal search form).</summary>
     [HttpPost("search")]
     [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-    public async Task<IActionResult> SearchClaimsPost([FromBody] ClaimSearchBody body)
+    public async Task<IActionResult> SearchClaimsPost([FromBody] ClaimSearchBody body, CancellationToken ct = default)
     {
         ClaimStatus? status = null;
         if (!string.IsNullOrEmpty(body.Status) && Enum.TryParse<ClaimStatus>(body.Status, true, out var parsed))
             status = parsed;
 
-        var claims = await _claimRepository.SearchAsync(
-            body.MemberId, body.ProviderId,
-            body.ServiceDateFrom, body.ServiceDateTo,
-            status, null,
-            body.PageNumber, body.PageSize);
+        if (!string.IsNullOrWhiteSpace(body.RunId))
+        {
+            var tenantId = GetTenantId();
+            var run = await _massAdjudicationRunRepository.GetAsync(tenantId, body.RunId, ct);
+            if (run is null)
+            {
+                return Ok(new { claims = Array.Empty<Claim>(), totalCount = 0, pageNumber = body.PageNumber, pageSize = body.PageSize });
+            }
 
-        var list = claims.ToList();
-        return Ok(new { claims = list, totalCount = list.Count, page = body.PageNumber, pageSize = body.PageSize });
+            var submittedClaimIds = await _massAdjudicationRunRepository.ListSubmittedClaimIdsAsync(tenantId, body.RunId, ct);
+            var (runPage, runTotalCount) = await _claimRepository.SearchByIdsAsync(
+                submittedClaimIds,
+                body.MemberId,
+                body.ProviderId,
+                body.ServiceDateFrom,
+                body.ServiceDateTo,
+                status,
+                body.PageNumber,
+                body.PageSize);
+
+            return Ok(new { claims = runPage, totalCount = runTotalCount, pageNumber = body.PageNumber, pageSize = body.PageSize });
+        }
+
+        var claims = (await _claimRepository.SearchAsync(
+            body.MemberId,
+            body.ProviderId,
+            body.ServiceDateFrom,
+            body.ServiceDateTo,
+            status,
+            null,
+            body.PageNumber,
+            body.PageSize)).ToList();
+
+        return Ok(new { claims, totalCount = claims.Count, pageNumber = body.PageNumber, pageSize = body.PageSize });
     }
 
     /// <summary>

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -308,7 +308,7 @@ public class ClaimsController : ControllerBase
             return Ok(new { claims = runPage, totalCount = runTotalCount, pageNumber = body.PageNumber, pageSize = body.PageSize });
         }
 
-        var claims = (await _claimRepository.SearchAsync(
+        var (claims, totalCount) = await _claimRepository.SearchWithCountAsync(
             body.MemberId,
             body.ProviderId,
             body.ServiceDateFrom,
@@ -316,9 +316,9 @@ public class ClaimsController : ControllerBase
             status,
             null,
             body.PageNumber,
-            body.PageSize)).ToList();
+            body.PageSize);
 
-        return Ok(new { claims, totalCount = claims.Count, pageNumber = body.PageNumber, pageSize = body.PageSize });
+        return Ok(new { claims, totalCount, pageNumber = body.PageNumber, pageSize = body.PageSize });
     }
 
     /// <summary>

--- a/src/services/claims-service/Models/ClaimDtos.cs
+++ b/src/services/claims-service/Models/ClaimDtos.cs
@@ -77,6 +77,7 @@ public class AccumulatorTotalEntry
 /// </summary>
 public class ClaimSearchBody
 {
+    public string? RunId { get; set; }
     public string? ClaimNumber { get; set; }
     public string? MemberId { get; set; }
     public string? MemberName { get; set; }

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -42,6 +42,16 @@ public interface IClaimRepository
         int page,
         int pageSize);
 
+    Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(
+        IReadOnlyCollection<string> claimIds,
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        int page,
+        int pageSize);
+
     /// <summary>
     /// Member-scoped search with the filters the portal Member Details dialog
     /// exposes: date range, status, provider, claim type, amount range. Always
@@ -555,6 +565,67 @@ public class ClaimRepository : IClaimRepository
         }
 
         return results.Select(Hydrate);
+    }
+
+    public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(
+        IReadOnlyCollection<string> claimIds,
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        int page,
+        int pageSize)
+    {
+        if (claimIds.Count == 0)
+        {
+            return (Array.Empty<Claim>(), 0);
+        }
+
+        var claims = new List<Claim>();
+        foreach (var id in claimIds.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            var claim = await GetByIdAsync(id);
+            if (claim is not null)
+            {
+                claims.Add(claim);
+            }
+        }
+
+        var query = claims.AsEnumerable();
+        if (!string.IsNullOrWhiteSpace(memberId))
+        {
+            query = query.Where(c => string.Equals(c.MemberId, memberId, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrWhiteSpace(providerNPI))
+        {
+            query = query.Where(c =>
+                string.Equals(c.BillingProviderNPI, providerNPI, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(c.RenderingProviderNPI, providerNPI, StringComparison.OrdinalIgnoreCase));
+        }
+        if (serviceDateFrom.HasValue)
+        {
+            query = query.Where(c => c.ServiceDateFrom >= serviceDateFrom.Value);
+        }
+        if (serviceDateTo.HasValue)
+        {
+            query = query.Where(c => c.ServiceDateTo <= serviceDateTo.Value);
+        }
+        if (status.HasValue)
+        {
+            query = query.Where(c => c.Status == status.Value);
+        }
+
+        var filtered = query
+            .OrderByDescending(c => c.SubmittedDate)
+            .ToList();
+
+        return (
+            filtered
+                .Skip((Math.Max(page, 1) - 1) * Math.Clamp(pageSize, 1, 1000))
+                .Take(Math.Clamp(pageSize, 1, 1000))
+                .ToList(),
+            filtered.Count);
     }
 
     public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchForMemberAsync(

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -42,6 +42,16 @@ public interface IClaimRepository
         int page,
         int pageSize);
 
+    Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchWithCountAsync(
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        LineOfBusiness? lineOfBusiness,
+        int page,
+        int pageSize);
+
     Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(
         IReadOnlyCollection<string> claimIds,
         string? memberId,
@@ -499,6 +509,29 @@ public class ClaimRepository : IClaimRepository
         int page,
         int pageSize)
     {
+        var (claims, _) = await SearchWithCountAsync(
+            memberId,
+            providerNPI,
+            serviceDateFrom,
+            serviceDateTo,
+            status,
+            lineOfBusiness,
+            page,
+            pageSize);
+
+        return claims;
+    }
+
+    public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchWithCountAsync(
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        LineOfBusiness? lineOfBusiness,
+        int page,
+        int pageSize)
+    {
         var tenantId = GetTenantId();
 
         // Build dynamic query
@@ -541,11 +574,14 @@ public class ClaimRepository : IClaimRepository
             parameters["@lineOfBusiness"] = lineOfBusiness.Value.ToString();
         }
 
+        var totalCount = await CountClaimsAsync(conditions, parameters, tenantId);
+        var safePage = Math.Max(page, 1);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
         var queryText = $@"
             SELECT * FROM c
             WHERE {string.Join(" AND ", conditions)}
             ORDER BY c.submittedDate DESC
-            OFFSET {(page - 1) * pageSize} LIMIT {pageSize}";
+            OFFSET {(safePage - 1) * safePageSize} LIMIT {safePageSize}";
 
         var queryDef = new QueryDefinition(queryText);
         foreach (var (key, value) in parameters)
@@ -564,7 +600,7 @@ public class ClaimRepository : IClaimRepository
             results.AddRange(response);
         }
 
-        return results.Select(Hydrate);
+        return (results.Select(Hydrate).ToList(), totalCount);
     }
 
     public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(
@@ -582,50 +618,106 @@ public class ClaimRepository : IClaimRepository
             return (Array.Empty<Claim>(), 0);
         }
 
-        var claims = new List<Claim>();
-        foreach (var id in claimIds.Distinct(StringComparer.OrdinalIgnoreCase))
+        var tenantId = GetTenantId();
+        var distinctClaimIds = claimIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (distinctClaimIds.Length == 0)
         {
-            var claim = await GetByIdAsync(id);
-            if (claim is not null)
-            {
-                claims.Add(claim);
-            }
+            return (Array.Empty<Claim>(), 0);
         }
 
-        var query = claims.AsEnumerable();
+        var conditions = new List<string>
+        {
+            "c.tenantId = @tenantId",
+            "ARRAY_CONTAINS(@claimIds, c.id)"
+        };
+        var parameters = new Dictionary<string, object>
+        {
+            ["@tenantId"] = tenantId,
+            ["@claimIds"] = distinctClaimIds
+        };
+
         if (!string.IsNullOrWhiteSpace(memberId))
         {
-            query = query.Where(c => string.Equals(c.MemberId, memberId, StringComparison.OrdinalIgnoreCase));
+            conditions.Add("c.memberId = @memberId");
+            parameters["@memberId"] = memberId;
         }
         if (!string.IsNullOrWhiteSpace(providerNPI))
         {
-            query = query.Where(c =>
-                string.Equals(c.BillingProviderNPI, providerNPI, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(c.RenderingProviderNPI, providerNPI, StringComparison.OrdinalIgnoreCase));
+            conditions.Add("(c.billingProviderNPI = @providerNPI OR c.renderingProviderNPI = @providerNPI)");
+            parameters["@providerNPI"] = providerNPI;
         }
         if (serviceDateFrom.HasValue)
         {
-            query = query.Where(c => c.ServiceDateFrom >= serviceDateFrom.Value);
+            conditions.Add("c.serviceDateFrom >= @serviceDateFrom");
+            parameters["@serviceDateFrom"] = serviceDateFrom.Value;
         }
         if (serviceDateTo.HasValue)
         {
-            query = query.Where(c => c.ServiceDateTo <= serviceDateTo.Value);
+            conditions.Add("c.serviceDateTo <= @serviceDateTo");
+            parameters["@serviceDateTo"] = serviceDateTo.Value;
         }
         if (status.HasValue)
         {
-            query = query.Where(c => c.Status == status.Value);
+            conditions.Add("c.status = @status");
+            parameters["@status"] = status.Value.ToString();
         }
 
-        var filtered = query
-            .OrderByDescending(c => c.SubmittedDate)
-            .ToList();
+        var totalCount = await CountClaimsAsync(conditions, parameters, tenantId);
+        var safePage = Math.Max(page, 1);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
+        var queryText = $@"
+            SELECT * FROM c
+            WHERE {string.Join(" AND ", conditions)}
+            ORDER BY c.submittedDate DESC
+            OFFSET {(safePage - 1) * safePageSize} LIMIT {safePageSize}";
 
-        return (
-            filtered
-                .Skip((Math.Max(page, 1) - 1) * Math.Clamp(pageSize, 1, 1000))
-                .Take(Math.Clamp(pageSize, 1, 1000))
-                .ToList(),
-            filtered.Count);
+        var queryDef = new QueryDefinition(queryText);
+        foreach (var (key, value) in parameters)
+        {
+            queryDef.WithParameter(key, value);
+        }
+
+        var iterator = _container.GetItemQueryIterator<Claim>(
+            queryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+        var results = new List<Claim>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            results.AddRange(response);
+        }
+
+        return (results.Select(Hydrate).ToList(), totalCount);
+    }
+
+    private async Task<int> CountClaimsAsync(
+        IReadOnlyCollection<string> conditions,
+        IReadOnlyDictionary<string, object> parameters,
+        string tenantId)
+    {
+        var queryDef = new QueryDefinition($"SELECT VALUE COUNT(1) FROM c WHERE {string.Join(" AND ", conditions)}");
+        foreach (var (key, value) in parameters)
+        {
+            queryDef.WithParameter(key, value);
+        }
+
+        var iterator = _container.GetItemQueryIterator<int>(
+            queryDef,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
+
+        var count = 0;
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync();
+            count += response.FirstOrDefault();
+        }
+
+        return count;
     }
 
     public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchForMemberAsync(

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -152,6 +152,64 @@ public class ClaimRepositoryMongo : IClaimRepository
         return docs.Select(Hydrate);
     }
 
+    public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(
+        IReadOnlyCollection<string> claimIds,
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        int page,
+        int pageSize)
+    {
+        if (claimIds.Count == 0)
+        {
+            return (Array.Empty<Claim>(), 0);
+        }
+
+        var tenantId = GetTenantId();
+        var builder = Builders<Claim>.Filter;
+        var filter = builder.And(
+            builder.Eq(c => c.TenantId, tenantId),
+            builder.In(c => c.Id, claimIds.Distinct(StringComparer.OrdinalIgnoreCase)));
+
+        if (!string.IsNullOrEmpty(memberId))
+        {
+            filter = builder.And(filter, builder.Eq(c => c.MemberId, memberId));
+        }
+
+        if (!string.IsNullOrEmpty(providerNPI))
+        {
+            filter = builder.And(filter, builder.Or(
+                builder.Eq(c => c.BillingProviderNPI, providerNPI),
+                builder.Eq(c => c.RenderingProviderNPI, providerNPI)));
+        }
+
+        if (serviceDateFrom.HasValue)
+        {
+            filter = builder.And(filter, builder.Gte(c => c.ServiceDateFrom, serviceDateFrom.Value));
+        }
+
+        if (serviceDateTo.HasValue)
+        {
+            filter = builder.And(filter, builder.Lte(c => c.ServiceDateTo, serviceDateTo.Value));
+        }
+
+        if (status.HasValue)
+        {
+            filter = builder.And(filter, builder.Eq(c => c.Status, status.Value));
+        }
+
+        var totalCount = (int)await _collection.CountDocumentsAsync(filter);
+        var docs = await _collection.Find(filter)
+            .SortByDescending(c => c.SubmittedDate)
+            .Skip((Math.Max(page, 1) - 1) * Math.Clamp(pageSize, 1, 1000))
+            .Limit(Math.Clamp(pageSize, 1, 1000))
+            .ToListAsync();
+
+        return (docs.Select(Hydrate).ToList(), totalCount);
+    }
+
     public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchForMemberAsync(
         string memberId,
         DateTime? serviceDateFrom,

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -106,6 +106,29 @@ public class ClaimRepositoryMongo : IClaimRepository
         int page,
         int pageSize)
     {
+        var (claims, _) = await SearchWithCountAsync(
+            memberId,
+            providerNPI,
+            serviceDateFrom,
+            serviceDateTo,
+            status,
+            lineOfBusiness,
+            page,
+            pageSize);
+
+        return claims;
+    }
+
+    public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchWithCountAsync(
+        string? memberId,
+        string? providerNPI,
+        DateTime? serviceDateFrom,
+        DateTime? serviceDateTo,
+        ClaimStatus? status,
+        LineOfBusiness? lineOfBusiness,
+        int page,
+        int pageSize)
+    {
         var tenantId = GetTenantId();
         var builder = Builders<Claim>.Filter;
         var filter = builder.Eq(c => c.TenantId, tenantId);
@@ -144,12 +167,16 @@ public class ClaimRepositoryMongo : IClaimRepository
             filter = builder.And(filter, builder.Eq(c => c.LineOfBusiness, lineOfBusiness.Value));
         }
 
+        var safePage = Math.Max(page, 1);
+        var safePageSize = Math.Clamp(pageSize, 1, 1000);
+        var totalCount = (int)await _collection.CountDocumentsAsync(filter);
         var docs = await _collection.Find(filter)
             .SortByDescending(c => c.SubmittedDate)
-            .Skip((page - 1) * pageSize)
-            .Limit(pageSize)
+            .Skip((safePage - 1) * safePageSize)
+            .Limit(safePageSize)
             .ToListAsync();
-        return docs.Select(Hydrate);
+
+        return (docs.Select(Hydrate).ToList(), totalCount);
     }
 
     public async Task<(IReadOnlyList<Claim> Page, int TotalCount)> SearchByIdsAsync(

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -14,6 +14,11 @@ public interface IMassAdjudicationRunRepository
         string? outcome,
         int limit,
         CancellationToken ct = default);
+
+    Task<IReadOnlyList<string>> ListSubmittedClaimIdsAsync(
+        string tenantId,
+        string runId,
+        CancellationToken ct = default);
 }
 
 public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRepository
@@ -113,6 +118,23 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
             .Limit(Math.Clamp(limit, 1, 1000))
             .ToListAsync(ct);
     }
+
+    public async Task<IReadOnlyList<string>> ListSubmittedClaimIdsAsync(
+        string tenantId,
+        string runId,
+        CancellationToken ct = default)
+    {
+        var filter = Builders<MassAdjudicationClaimResult>.Filter.And(
+            Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, tenantId),
+            Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.RunId, runId),
+            Builders<MassAdjudicationClaimResult>.Filter.Ne(x => x.SubmittedClaimId, null),
+            Builders<MassAdjudicationClaimResult>.Filter.Ne(x => x.SubmittedClaimId, string.Empty));
+
+        return await _claimResults
+            .Find(filter)
+            .Project(x => x.SubmittedClaimId!)
+            .ToListAsync(ct);
+    }
 }
 
 public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRunRepository
@@ -189,6 +211,24 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
                 query
                     .OrderByDescending(x => x.ElapsedMilliseconds)
                     .Take(Math.Clamp(limit, 1, 1000))
+                    .ToList());
+        }
+    }
+
+    public Task<IReadOnlyList<string>> ListSubmittedClaimIdsAsync(
+        string tenantId,
+        string runId,
+        CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            return Task.FromResult<IReadOnlyList<string>>(
+                _claimResults
+                    .Where(x => x.TenantId == tenantId && x.RunId == runId)
+                    .Select(x => x.SubmittedClaimId)
+                    .Where(x => !string.IsNullOrWhiteSpace(x))
+                    .Cast<string>()
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList());
         }
     }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -17,6 +17,7 @@ namespace CloudHealthOffice.ClaimsService.Tests;
 public class ClaimsApiFactory : WebApplicationFactory<Program>
 {
     public IClaimRepository ClaimRepository { get; } = Substitute.For<IClaimRepository>();
+    public IMassAdjudicationRunRepository MassAdjudicationRunRepository { get; } = Substitute.For<IMassAdjudicationRunRepository>();
     public IClaimAcknowledgmentService AcknowledgmentService { get; } = Substitute.For<IClaimAcknowledgmentService>();
     public IAiExaminationAuditRepository AuditRepository { get; } = Substitute.For<IAiExaminationAuditRepository>();
     public IClaimSubmissionService SubmissionService { get; } = Substitute.For<IClaimSubmissionService>();
@@ -49,6 +50,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             // Remove real repository, services, and adapter registrations.
             var descriptorsToRemove = services
                 .Where(d => d.ServiceType == typeof(IClaimRepository)
+                         || d.ServiceType == typeof(IMassAdjudicationRunRepository)
                          || d.ServiceType == typeof(IClaimAcknowledgmentService)
                          || d.ServiceType == typeof(IProviderService)
                          || d.ServiceType == typeof(ITenantComplianceConfigService)
@@ -115,6 +117,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(Substitute.For<IBenefitCalculationEngine>());
 
             services.AddSingleton(ClaimRepository);
+            services.AddSingleton(MassAdjudicationRunRepository);
             services.AddSingleton(AcknowledgmentService);
             services.AddSingleton(Substitute.For<IProviderService>());
             services.AddSingleton(Substitute.For<ITenantComplianceConfigService>());

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -309,6 +309,39 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
             25);
     }
 
+    [Fact]
+    public async Task SearchClaimsPost_StandardSearch_ReturnsFullTotalCount()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "page-claim-1";
+        claim.ClaimNumber = "MCC-P-0000001";
+
+        _repo.SearchWithCountAsync(
+                "MEM-001",
+                null,
+                null,
+                null,
+                null,
+                null,
+                2,
+                1)
+            .Returns((new List<Claim> { claim }, 3));
+
+        var response = await _client.PostAsJsonAsync("/api/claims/search", new ClaimSearchBody
+        {
+            MemberId = "MEM-001",
+            PageNumber = 2,
+            PageSize = 1
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(3, doc.RootElement.GetProperty("totalCount").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("pageNumber").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("claims").GetArrayLength());
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // 277CA ACKNOWLEDGMENT
     // ═══════════════════════════════════════════════════════════════════

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using ClaimsService.Services;
@@ -13,6 +14,7 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
     private readonly ClaimsApiFactory _factory;
     private readonly HttpClient _client;
     private readonly IClaimRepository _repo;
+    private readonly IMassAdjudicationRunRepository _massRunRepo;
     private readonly IClaimAcknowledgmentService _ackService;
     private readonly IClaimSubmissionService _submissionService;
 
@@ -20,6 +22,7 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
     {
         _factory = factory;
         _repo = factory.ClaimRepository;
+        _massRunRepo = factory.MassAdjudicationRunRepository;
         _ackService = factory.AcknowledgmentService;
         _submissionService = factory.SubmissionService;
         _client = factory.CreateClient();
@@ -252,6 +255,58 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
         Assert.NotNull(results);
         Assert.Equal(2, results.Count);
         Assert.All(results, c => Assert.Equal("MEM-001", c.MemberId));
+    }
+
+    [Fact]
+    public async Task SearchClaimsPost_ByRunId_ReturnsClaimsFromMassAdjudicationRun()
+    {
+        var runId = $"run-{Guid.NewGuid():N}";
+        var claim = CreateValidClaim();
+        claim.Id = "submitted-claim-1";
+        claim.ClaimNumber = "MCC-P-0000001";
+
+        _massRunRepo.GetAsync("test-tenant", runId, Arg.Any<CancellationToken>())
+            .Returns(new MassAdjudicationRunSummary
+            {
+                Id = runId,
+                Run = new MassAdjudicationRunMetadata { TenantId = "test-tenant" }
+            });
+        _massRunRepo.ListSubmittedClaimIdsAsync("test-tenant", runId, Arg.Any<CancellationToken>())
+            .Returns(new List<string> { "submitted-claim-1", "submitted-claim-2" });
+        _repo.SearchByIdsAsync(
+                Arg.Any<IReadOnlyCollection<string>>(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                1,
+                25)
+            .Returns((new List<Claim> { claim }, 1));
+
+        var response = await _client.PostAsJsonAsync("/api/claims/search", new ClaimSearchBody
+        {
+            RunId = runId,
+            PageNumber = 1,
+            PageSize = 25
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(1, doc.RootElement.GetProperty("totalCount").GetInt32());
+        var claims = doc.RootElement.GetProperty("claims");
+        Assert.Equal("MCC-P-0000001", claims[0].GetProperty("claimNumber").GetString());
+
+        await _repo.Received(1).SearchByIdsAsync(
+            Arg.Is<IReadOnlyCollection<string>>(ids => ids.Contains("submitted-claim-1") && ids.Contains("submitted-claim-2")),
+            null,
+            null,
+            null,
+            null,
+            null,
+            1,
+            25);
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add runId to claim search so Claims Management can show persisted claims submitted by a selected MCC run
- resolve MCC run claim IDs through MassAdjudicationClaimResults without mutating claim documents
- add a View Claims handoff from the Mass Adjudication run page
- preserve run context when drilling from run-scoped Claims Management into claim details
- keep pagination stable for run-scoped claim searches

## Tests
- dotnet build src/services/claims-service/claims-service.csproj --no-restore
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "SearchClaimsPost_ByRunId|MassAdjudicationRunRepositoryTests" --no-restore
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter ClaimsServiceTests --no-restore