### PR TITLE
Wire claim print and EOB export

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -388,6 +388,20 @@ public class ClaimsServiceTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetExplanationOfBenefitJsonAsync_WhenClaimsServiceBaseUrlMissing_ThrowsServiceUnavailableWithoutRequest()
+    {
+        var handler = new FakeHandler(HttpStatusCode.OK, "{}");
+        var sut = CreateService(new HttpClient(handler), "");
+
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetExplanationOfBenefitJsonAsync("claim-1"));
+
+        ex.ServiceName.Should().Be("Claims Service");
+        ex.InnerException.Should().BeOfType<InvalidOperationException>();
+        handler.CapturedRequests.Should().BeEmpty();
+    }
+
     // ── GetMassAdjudicationRunsAsync ──
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -28,6 +28,19 @@ public class ClaimsServiceTests
         return new ClaimsService(httpClient, _configuration, _logger.Object);
     }
 
+    private ClaimsService CreateService(HttpClient httpClient, string claimsServiceBaseUrl)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Services:ClaimsService"] = claimsServiceBaseUrl,
+                ["Authentication:LocalDemo:TenantId"] = "demo"
+            })
+            .Build();
+
+        return new ClaimsService(httpClient, configuration, _logger.Object);
+    }
+
     // ── GetRecentClaimsAsync ──
 
     [Fact]
@@ -340,6 +353,37 @@ public class ClaimsServiceTests
             new FakeHandler(HttpStatusCode.OK, "null")));
 
         var result = await sut.GetClaimByIdAsync("CLM-NONE");
+
+        result.Should().BeNull();
+    }
+
+    // ── GetExplanationOfBenefitJsonAsync ──
+
+    [Fact]
+    public async Task GetExplanationOfBenefitJsonAsync_StripsApiPrefixAndReturnsRawFhirJson()
+    {
+        const string eobJson = """
+        {"resourceType":"ExplanationOfBenefit","id":"claim-1","status":"active"}
+        """;
+        var handler = new FakeHandler(HttpStatusCode.OK, eobJson);
+        var sut = CreateService(new HttpClient(handler), "http://localhost:5000/api");
+
+        var result = await sut.GetExplanationOfBenefitJsonAsync("claim-1");
+
+        result.Should().Be(eobJson);
+        handler.CapturedRequests.Should().ContainSingle();
+        var request = handler.CapturedRequests.Single();
+        request.RequestUri!.AbsoluteUri.Should()
+            .Be("http://localhost:5000/fhir/ExplanationOfBenefit/claim-1");
+        request.Headers.Accept.Should().Contain(h => h.MediaType == "application/fhir+json");
+    }
+
+    [Fact]
+    public async Task GetExplanationOfBenefitJsonAsync_WhenApiReturns404_ReturnsNull()
+    {
+        var sut = CreateService(new HttpClient(new FakeHandler(HttpStatusCode.NotFound)));
+
+        var result = await sut.GetExplanationOfBenefitJsonAsync("missing-claim");
 
         result.Should().BeNull();
     }

--- a/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
@@ -509,8 +509,19 @@
                 @BackLabel
             </MudButton>
             <MudStack Row="true" Spacing="2">
-                <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Print">Print</MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Download">Export EOB</MudButton>
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Default"
+                           StartIcon="@Icons.Material.Filled.Print"
+                           OnClick="PrintClaimAsync">
+                    Print
+                </MudButton>
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Default"
+                           StartIcon="@Icons.Material.Filled.Download"
+                           Disabled="_exportingEob"
+                           OnClick="ExportEobAsync">
+                    @(_exportingEob ? "Exporting..." : "Export EOB")
+                </MudButton>
             </MudStack>
         </MudPaper>
 
@@ -809,6 +820,7 @@
     private List<BreadcrumbItem> _breadcrumbItems = new();
     private string _noteInput = string.Empty;
     private string? _serviceError;
+    private bool _exportingEob;
     private string BackHref => string.IsNullOrWhiteSpace(FromRun)
         ? "/claims"
         : $"/mass-adjudication-runs?run={Uri.EscapeDataString(FromRun)}";
@@ -962,6 +974,57 @@
     private void ViewClaimDetails(string claimId)
     {
         NavigationManager.NavigateTo($"/claims/{claimId}");
+    }
+
+    private async Task PrintClaimAsync()
+    {
+        await JS.InvokeVoidAsync("window.print");
+    }
+
+    private async Task ExportEobAsync()
+    {
+        if (_claim == null || _exportingEob) return;
+
+        _exportingEob = true;
+        try
+        {
+            var eobJson = await ClaimsService.GetExplanationOfBenefitJsonAsync(_claim.ClaimId);
+            if (string.IsNullOrWhiteSpace(eobJson))
+            {
+                Snackbar.Add("No Explanation of Benefit is available for this claim.", Severity.Warning);
+                return;
+            }
+
+            var claimNumber = string.IsNullOrWhiteSpace(_claim.ClaimNumber)
+                ? _claim.ClaimId
+                : _claim.ClaimNumber;
+            var fileName = $"EOB_{SanitizeFileName(claimNumber)}.json";
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(eobJson));
+            await JS.InvokeVoidAsync("downloadBase64File", fileName, "application/fhir+json", base64);
+            Snackbar.Add("EOB exported.", Severity.Success);
+        }
+        catch (ServiceUnavailableException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Error exporting EOB: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _exportingEob = false;
+        }
+    }
+
+    private static string SanitizeFileName(string value)
+    {
+        foreach (var invalid in System.IO.Path.GetInvalidFileNameChars())
+        {
+            value = value.Replace(invalid, '-');
+        }
+
+        return string.IsNullOrWhiteSpace(value) ? "claim" : value;
     }
 
     private async Task ApproveClaimAsync()

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -10,6 +10,7 @@ public interface IClaimsService
     Task<List<ClaimSummary>> GetRecentClaimsAsync(int count);
     Task<ClaimSearchResult> SearchClaimsAsync(ClaimSearchRequest request);
     Task<ClaimDetails?> GetClaimByIdAsync(string claimId);
+    Task<string?> GetExplanationOfBenefitJsonAsync(string claimId);
     Task<List<MassAdjudicationRunSummary>> GetMassAdjudicationRunsAsync(int limit = 25);
     Task<MassAdjudicationRunSummary?> GetMassAdjudicationRunAsync(string runId);
     Task<List<MassAdjudicationClaimResult>> GetMassAdjudicationClaimResultsAsync(

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -69,6 +69,32 @@ public class ClaimsService : IClaimsService
         }
     }
 
+    public async Task<string?> GetExplanationOfBenefitJsonAsync(string claimId)
+    {
+        var baseUrl = GetClaimsServiceRootUrl();
+        try
+        {
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"{baseUrl}/fhir/ExplanationOfBenefit/{Uri.EscapeDataString(claimId)}");
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/fhir+json"));
+
+            var response = await _httpClient.SendAsync(request);
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+    }
+
     public async Task<List<MassAdjudicationRunSummary>> GetMassAdjudicationRunsAsync(int limit = 25)
     {
         var baseUrl = _configuration["Services:ClaimsService"];
@@ -224,6 +250,14 @@ public class ClaimsService : IClaimsService
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
             throw new ServiceUnavailableException("Claims Service", ex);
         }
+    }
+
+    private string GetClaimsServiceRootUrl()
+    {
+        var baseUrl = (_configuration["Services:ClaimsService"] ?? string.Empty).TrimEnd('/');
+        return baseUrl.EndsWith("/api", StringComparison.OrdinalIgnoreCase)
+            ? baseUrl[..^"/api".Length]
+            : baseUrl;
     }
 
     public async Task<EobSearchResponse> SearchClaimsByMemberAsync(string memberId, MemberClaimsFilter filter)

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -71,15 +71,15 @@ public class ClaimsService : IClaimsService
 
     public async Task<string?> GetExplanationOfBenefitJsonAsync(string claimId)
     {
-        var baseUrl = GetClaimsServiceRootUrl();
         try
         {
+            var baseUrl = GetClaimsServiceRootUrl();
             using var request = new HttpRequestMessage(
                 HttpMethod.Get,
                 $"{baseUrl}/fhir/ExplanationOfBenefit/{Uri.EscapeDataString(claimId)}");
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/fhir+json"));
 
-            var response = await _httpClient.SendAsync(request);
+            using var response = await _httpClient.SendAsync(request);
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 return null;
@@ -91,6 +91,11 @@ public class ClaimsService : IClaimsService
         catch (HttpRequestException ex)
         {
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Service configuration invalid: {ServiceName}", "Claims Service");
             throw new ServiceUnavailableException("Claims Service", ex);
         }
     }
@@ -255,6 +260,11 @@ public class ClaimsService : IClaimsService
     private string GetClaimsServiceRootUrl()
     {
         var baseUrl = (_configuration["Services:ClaimsService"] ?? string.Empty).TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new InvalidOperationException("Services:ClaimsService is not configured.");
+        }
+
         return baseUrl.EndsWith("/api", StringComparison.OrdinalIgnoreCase)
             ? baseUrl[..^"/api".Length]
             : baseUrl;


### PR DESCRIPTION
## Summary
- wire the Claim Details Print button to browser print
- add an Export EOB action that downloads the claim FHIR ExplanationOfBenefit JSON
- add portal service coverage for EOB fetch URL normalization and 404 handling

## Verification
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore`
- `dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter "GetExplanationOfBenefitJsonAsync|ClaimsServiceTests" --no-restore`
- `dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --no-restore`