### PR TITLE
Fix MCC async validation parity

### DIFF
--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationContext.cs
@@ -62,10 +62,24 @@ public class ClaimAdjudicationContext
     public Resolution.NetworkMembership? BillingProviderNetworkMembership { get; set; }
 
     /// <summary>
+    /// Network-membership lookup for the rendering provider when it differs
+    /// from the billing provider. Populated by
+    /// <see cref="Stages.NetworkCredentialingStage"/> so rendering-provider
+    /// exclusions can deny without overwriting billing-provider tier context.
+    /// </summary>
+    public Resolution.NetworkMembership? RenderingProviderNetworkMembership { get; set; }
+
+    /// <summary>
     /// Credentialing-status snapshot for the billing provider as of the
     /// claim's earliest service date. Populated by capability 5.6.
     /// </summary>
     public Resolution.CredentialingStatusSnapshot? BillingProviderCredentialingStatus { get; set; }
+
+    /// <summary>
+    /// Credentialing-status snapshot for the rendering provider when it differs
+    /// from the billing provider. Populated by capability 5.6.
+    /// </summary>
+    public Resolution.CredentialingStatusSnapshot? RenderingProviderCredentialingStatus { get; set; }
 
     /// <summary>
     /// Plan tier the billing provider matched, or <c>null</c> when none

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -178,9 +178,8 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 
     internal static bool RequiresPriorAuthorizationDenial(AdapterClaim claim)
     {
-        var lineOfBusiness = (int)claim.LineOfBusiness;
         return claim.ClaimType is ClaimsService.Models.ClaimType.Institutional
-            && lineOfBusiness is 3 or 4
+            && claim.LineOfBusiness is LineOfBusiness.Medicaid
             && string.Equals(claim.PlaceOfServiceCode, "21", StringComparison.OrdinalIgnoreCase)
             && string.IsNullOrWhiteSpace(claim.PriorAuthorizationNumber);
     }

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -37,6 +37,8 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 {
     public const string StageName = "BenefitCalculation";
     public const string MemberNotEligibleCarc = "27";
+    public const string PriorAuthorizationRequiredCode = "197";
+    public const string PriorAuthorizationRequiredReason = "Prior authorization required but not provided";
 
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
@@ -85,6 +87,16 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             return ClaimAdjudicationStageResult.Deny(
                 StageName,
                 eligibilityReason);
+        }
+
+        if (RequiresPriorAuthorizationDenial(claim))
+        {
+            context.AdjudicationResult.DenialReasonCode = PriorAuthorizationRequiredCode;
+            context.AdjudicationResult.DenialReason = PriorAuthorizationRequiredReason;
+
+            return ClaimAdjudicationStageResult.Deny(
+                StageName,
+                PriorAuthorizationRequiredReason);
         }
 
         var subscriberId = await ResolveSubscriberIdAsync(context, ct).ConfigureAwait(false);
@@ -162,6 +174,15 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 
         reason = "Active coverage";
         return true;
+    }
+
+    internal static bool RequiresPriorAuthorizationDenial(AdapterClaim claim)
+    {
+        var lineOfBusiness = (int)claim.LineOfBusiness;
+        return claim.ClaimType is ClaimsService.Models.ClaimType.Institutional
+            && lineOfBusiness is 3 or 4
+            && string.Equals(claim.PlaceOfServiceCode, "21", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrWhiteSpace(claim.PriorAuthorizationNumber);
     }
 
     private async Task<string> ResolveSubscriberIdAsync(

--- a/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/NetworkCredentialingStage.cs
@@ -90,10 +90,18 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
 
         var serviceDate = ResolveEarliestServiceDate(claim);
 
+        var outcomes = new List<EnforcementOutcome>();
+
         // Membership: walk plan tiers in priority order. First tier whose
         // upstream returns IsActiveMember=true wins.
         var membershipOutcome = await ResolveMembershipAsync(
-            context, billingNpi, serviceDate, ct).ConfigureAwait(false);
+            context,
+            billingNpi,
+            serviceDate,
+            providerRole: "Billing provider",
+            captureBillingContext: true,
+            ct).ConfigureAwait(false);
+        outcomes.Add(membershipOutcome);
         context.EnforcementOutcomes.Add(membershipOutcome);
 
         // Credentialing: only call when we have a providerId from the
@@ -107,17 +115,54 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
             && membershipOutcome.Decision == EnforcementDecision.Allow)
         {
             credentialingOutcome = await ResolveCredentialingAsync(
-                context, matchedProviderId!, serviceDate, ct).ConfigureAwait(false);
+                context,
+                matchedProviderId!,
+                serviceDate,
+                providerRole: "Billing provider",
+                captureBillingContext: true,
+                ct).ConfigureAwait(false);
+            outcomes.Add(credentialingOutcome);
             context.EnforcementOutcomes.Add(credentialingOutcome);
         }
 
-        return CombineOutcomes(membershipOutcome, credentialingOutcome);
+        var renderingNpi = claim.RenderingProviderNPI;
+        if (!string.IsNullOrWhiteSpace(renderingNpi)
+            && !string.Equals(renderingNpi, billingNpi, StringComparison.OrdinalIgnoreCase))
+        {
+            var renderingMembershipOutcome = await ResolveMembershipAsync(
+                context,
+                renderingNpi,
+                serviceDate,
+                providerRole: "Rendering provider",
+                captureBillingContext: false,
+                ct).ConfigureAwait(false);
+            outcomes.Add(renderingMembershipOutcome);
+            context.EnforcementOutcomes.Add(renderingMembershipOutcome);
+
+            if (!string.IsNullOrWhiteSpace(context.RenderingProviderNetworkMembership?.ProviderId)
+                && renderingMembershipOutcome.Decision == EnforcementDecision.Allow)
+            {
+                var renderingCredentialingOutcome = await ResolveCredentialingAsync(
+                    context,
+                    context.RenderingProviderNetworkMembership.ProviderId,
+                    serviceDate,
+                    providerRole: "Rendering provider",
+                    captureBillingContext: false,
+                    ct).ConfigureAwait(false);
+                outcomes.Add(renderingCredentialingOutcome);
+                context.EnforcementOutcomes.Add(renderingCredentialingOutcome);
+            }
+        }
+
+        return CombineOutcomes(outcomes);
     }
 
     private async Task<EnforcementOutcome> ResolveMembershipAsync(
         ClaimAdjudicationContext context,
         string billingNpi,
         DateTime serviceDate,
+        string providerRole,
+        bool captureBillingContext,
         CancellationToken ct)
     {
         var tiers = context.ResolvedPlan?.NetworkTiers
@@ -137,7 +182,7 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
             return ApplyNetworkMode(
                 context,
                 EnforcementDecision.Deny,
-                reason: "No in-network tier configured for the resolved plan.",
+                reason: $"{providerRole}: no in-network tier configured for the resolved plan.",
                 serviceDate,
                 networkId: null,
                 tier: null);
@@ -149,6 +194,14 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
             var membership = await _membershipClient.GetMembershipAsync(
                 context.TenantId, tier.NetworkId!, billingNpi, serviceDate, forceRefresh: false, ct)
                 .ConfigureAwait(false);
+
+            if (membership is null || !membership.IsActiveMember)
+            {
+                var refreshed = await _membershipClient.GetMembershipAsync(
+                    context.TenantId, tier.NetworkId!, billingNpi, serviceDate, forceRefresh: true, ct)
+                    .ConfigureAwait(false);
+                membership = refreshed ?? membership;
+            }
 
             if (membership is null)
             {
@@ -162,8 +215,16 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
 
             if (membership.IsActiveMember)
             {
-                context.BillingProviderNetworkMembership = membership;
-                context.MatchedNetworkTier = tier;
+                if (captureBillingContext)
+                {
+                    context.BillingProviderNetworkMembership = membership;
+                    context.MatchedNetworkTier = tier;
+                }
+                else
+                {
+                    context.RenderingProviderNetworkMembership = membership;
+                }
+
                 return new EnforcementOutcome(
                     Check: EnforcementCheck.Membership,
                     Decision: EnforcementDecision.Allow,
@@ -181,7 +242,7 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
             return ApplyNetworkMode(
                 context,
                 EnforcementDecision.Deny,
-                reason: "membership-verification-unavailable",
+                reason: $"{providerRole}: membership-verification-unavailable",
                 serviceDate,
                 networkId: null,
                 tier: null);
@@ -192,7 +253,7 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
         return ApplyNetworkMode(
             context,
             EnforcementDecision.Deny,
-            reason: "Billing provider is not an active member of any plan tier on the service date.",
+            reason: $"{providerRole} is not an active member of any plan tier on the service date.",
             serviceDate,
             networkId: null,
             tier: null);
@@ -202,21 +263,38 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
         ClaimAdjudicationContext context,
         string providerId,
         DateTime serviceDate,
+        string providerRole,
+        bool captureBillingContext,
         CancellationToken ct)
     {
         var snapshot = await _credentialingClient.GetStatusAsOfAsync(
             context.TenantId, providerId, serviceDate, forceRefresh: false, ct)
             .ConfigureAwait(false);
 
+        if (snapshot is null || !snapshot.IsApprovedAtAsOf)
+        {
+            var refreshed = await _credentialingClient.GetStatusAsOfAsync(
+                context.TenantId, providerId, serviceDate, forceRefresh: true, ct)
+                .ConfigureAwait(false);
+            snapshot = refreshed ?? snapshot;
+        }
+
         if (snapshot is null)
         {
             return ApplyCredentialingMode(
                 EnforcementDecision.Deny,
-                reason: "credentialing-status-unavailable",
+                reason: $"{providerRole}: credentialing-status-unavailable",
                 serviceDate);
         }
 
-        context.BillingProviderCredentialingStatus = snapshot;
+        if (captureBillingContext)
+        {
+            context.BillingProviderCredentialingStatus = snapshot;
+        }
+        else
+        {
+            context.RenderingProviderCredentialingStatus = snapshot;
+        }
 
         if (snapshot.IsApprovedAtAsOf)
         {
@@ -230,7 +308,7 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
 
         // Pending / Denied / Expired / Suspended / Unknown → not approved
         // for the service date. Drive policy via mode.
-        var reason = $"Provider credentialing status is '{snapshot.Status}' on the service date.";
+        var reason = $"{providerRole} credentialing status is '{snapshot.Status}' on the service date.";
         return ApplyCredentialingMode(EnforcementDecision.Deny, reason, serviceDate);
     }
 
@@ -309,14 +387,9 @@ public sealed class NetworkCredentialingStage : IClaimAdjudicationStage
     }
 
     private static ClaimAdjudicationStageResult CombineOutcomes(
-        EnforcementOutcome membership,
-        EnforcementOutcome? credentialing)
+        IReadOnlyList<EnforcementOutcome> outcomes)
     {
         // Deny dominates Pend; Pend dominates Allow/Observe.
-        var outcomes = credentialing is null
-            ? new[] { membership }
-            : new[] { membership, credentialing };
-
         var deny = outcomes.FirstOrDefault(o => o.Decision == EnforcementDecision.Deny);
         if (deny is not null)
         {

--- a/src/tools/mcc-platform-validator/MccClaimStatusMapping.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusMapping.cs
@@ -1,0 +1,13 @@
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal static class MccClaimStatusMapping
+{
+    public static ClaimValidationOutcome? ToValidationOutcome(int persistedStatus)
+        => persistedStatus switch
+        {
+            4 => ClaimValidationOutcome.Pended,
+            5 or 7 or 9 => ClaimValidationOutcome.Paid,
+            6 or 8 => ClaimValidationOutcome.BusinessDenial,
+            _ => null
+        };
+}

--- a/src/tools/mcc-platform-validator/MccFixtureIsolation.cs
+++ b/src/tools/mcc-platform-validator/MccFixtureIsolation.cs
@@ -4,6 +4,26 @@ namespace CloudHealthOffice.Tools.MccPlatformValidator;
 
 internal static class MccFixtureIsolation
 {
+    public static void IsolateValidationMembers(IEnumerable<SyntheticClaim> claims, int seed, Guid runId)
+    {
+        var ordinal = 0;
+        foreach (var claim in claims.OrderBy(c => c.ClaimId, StringComparer.Ordinal))
+        {
+            var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+            if (expected.ExpectedOutcome is null)
+            {
+                continue;
+            }
+
+            ordinal++;
+            var isolatedId = IsSupportedCobPendScenario(claim)
+                ? BuildCobPendMemberId(claim.ClaimId, seed, ordinal)
+                : BuildValidationMemberId(claim.ClaimId, runId, ordinal);
+
+            RewriteMemberIdentity(claim, isolatedId);
+        }
+    }
+
     public static void IsolateCobPendMembers(IEnumerable<SyntheticClaim> claims, int seed)
     {
         var ordinal = 0;
@@ -11,24 +31,29 @@ internal static class MccFixtureIsolation
         {
             ordinal++;
             var isolatedId = BuildCobPendMemberId(claim.ClaimId, seed, ordinal);
-            claim.Member.MemberId = isolatedId;
-            claim.Member.SubscriberId = isolatedId;
+            RewriteMemberIdentity(claim, isolatedId);
+        }
+    }
 
-            foreach (var coverage in claim.Member.Coverages)
+    private static void RewriteMemberIdentity(SyntheticClaim claim, string isolatedId)
+    {
+        claim.Member.MemberId = isolatedId;
+        claim.Member.SubscriberId = isolatedId;
+
+        foreach (var coverage in claim.Member.Coverages)
+        {
+            coverage.MemberId = isolatedId;
+            coverage.SubscriberId = isolatedId;
+        }
+
+        foreach (var dependent in claim.Member.Dependents)
+        {
+            dependent.SubscriberMemberId = isolatedId;
+            dependent.SubscriberId = isolatedId;
+
+            foreach (var coverage in dependent.Coverages)
             {
-                coverage.MemberId = isolatedId;
                 coverage.SubscriberId = isolatedId;
-            }
-
-            foreach (var dependent in claim.Member.Dependents)
-            {
-                dependent.SubscriberMemberId = isolatedId;
-                dependent.SubscriberId = isolatedId;
-
-                foreach (var coverage in dependent.Coverages)
-                {
-                    coverage.SubscriberId = isolatedId;
-                }
             }
         }
     }
@@ -47,6 +72,14 @@ internal static class MccFixtureIsolation
         var normalizedClaimId = NormalizeClaimIdSuffix(claimId, ordinal);
 
         return $"MCCCB{normalizedSeed}{normalizedClaimId}";
+    }
+
+    private static string BuildValidationMemberId(string claimId, Guid runId, int ordinal)
+    {
+        var runSalt = runId.ToString("N")[..8].ToUpperInvariant();
+        var normalizedClaimId = NormalizeClaimIdSuffix(claimId, ordinal);
+
+        return $"MCCV{runSalt}{normalizedClaimId}";
     }
 
     private static string NormalizeClaimIdSuffix(string claimId, int ordinal)

--- a/src/tools/mcc-platform-validator/MccMemberSeedStatus.cs
+++ b/src/tools/mcc-platform-validator/MccMemberSeedStatus.cs
@@ -1,0 +1,28 @@
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal static class MccMemberSeedStatus
+{
+    public const string Active = "Active";
+    public const string Pending = "Pending";
+    public const string Terminated = "Terminated";
+    public const string Suspended = "Suspended";
+    public const string Cobra = "COBRA";
+
+    public static string ToMemberServiceStatus(string? status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return Active;
+        }
+
+        return status.Trim().ToUpperInvariant() switch
+        {
+            "ACTIVE" => Active,
+            "PENDING" => Pending,
+            "TERMINATED" => Terminated,
+            "SUSPENDED" => Suspended,
+            "COBRA" => Cobra,
+            _ => Active
+        };
+    }
+}

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -961,7 +961,6 @@ static async Task<bool> UpdateMemberSeedStatusAsync(
         $"{options.MemberUrl}/api/v1/members/{Uri.EscapeDataString(member.MemberId)}",
         payload,
         json);
-    var body = await response.Content.ReadAsStringAsync();
 
     if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
     {
@@ -970,6 +969,7 @@ static async Task<bool> UpdateMemberSeedStatusAsync(
 
     if (!response.IsSuccessStatusCode)
     {
+        var body = await response.Content.ReadAsStringAsync();
         throw new InvalidOperationException($"member status alignment failed ({member.MemberId}): {(int)response.StatusCode} {body}");
     }
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -67,8 +67,8 @@ await CreateValidationPlanAsync(http, options, validationPlanId, json);
 
 var claims = await GenerateClaimsAsync(options);
 NormalizePriorAuthEdgeCases(claims, options);
-NormalizeValidationProviderProfiles(claims, options.Seed);
-MccFixtureIsolation.IsolateCobPendMembers(claims, options.Seed);
+NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
+MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
@@ -188,20 +188,24 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
 
         var skipSynchronousWriteback = options.SkipClaimUpdate
             || expectedValidation.ExpectedOutcome is ClaimValidationOutcome.Pended;
+        var outcome = adjudicated.Success
+            ? ClaimValidationOutcome.Paid
+            : ClaimValidationOutcome.BusinessDenial;
 
         if (!skipSynchronousWriteback)
         {
             failureStage = "writeback";
             stage.Restart();
-            await UpdateClaimAdjudicationAsync(http, options, submitted.Id, networkTier, adjudicated, json);
+            var writebackOutcome = await UpdateClaimAdjudicationAsync(http, options, submitted.Id, networkTier, adjudicated, json);
+            if (writebackOutcome is not null)
+            {
+                outcome = writebackOutcome.Value;
+            }
             stage.Stop();
             updateElapsed = stage.Elapsed;
         }
 
         sw.Stop();
-        var outcome = adjudicated.Success
-            ? ClaimValidationOutcome.Paid
-            : ClaimValidationOutcome.BusinessDenial;
         var businessDenialCode = NormalizeBusinessDenialCode(adjudicated.BusinessDenialCode
             ?? adjudicated.DenialReasonCode
             ?? (outcome is ClaimValidationOutcome.BusinessDenial ? "ADJUDICATION_DENIAL" : null));
@@ -405,7 +409,7 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
     return claims;
 }
 
-static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int seed)
+static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int seed, Guid runId)
 {
     var scenarioIndex = 0;
     foreach (var claim in claims.OrderBy(c => c.ClaimId, StringComparer.Ordinal))
@@ -417,7 +421,7 @@ static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int
         }
 
         ForceAdjudicatableProviderProfile(claim.BillingProvider);
-        claim.BillingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, scenarioIndex, role: 0);
+        claim.BillingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 0);
 
         if (!string.Equals(
                 expected.ExpectedBusinessDenialCode,
@@ -425,7 +429,11 @@ static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int
                 StringComparison.OrdinalIgnoreCase))
         {
             ForceAdjudicatableProviderProfile(claim.RenderingProvider);
-            claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, scenarioIndex, role: 1);
+            claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 1);
+        }
+        else
+        {
+            claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 2);
         }
 
         scenarioIndex++;
@@ -785,11 +793,12 @@ static string BuildSyntheticExcludedProviderNpi(int seed, int index)
     }
 }
 
-static string BuildSyntheticValidationProviderNpi(int seed, int index, int role)
+static string BuildSyntheticValidationProviderNpi(int seed, Guid runId, int index, int role)
 {
     unchecked
     {
-        var combined = (uint)(seed * 1_000_003 + index * 17 + role);
+        var runHash = BitConverter.ToUInt32(runId.ToByteArray(), 0);
+        var combined = runHash ^ (uint)(seed * 1_000_003 + index * 17 + role);
         var value = combined % 1_000_000;
         var baseNineDigits = $"91{role}{value:D6}";
         return $"{baseNineDigits}{CalculateNpiCheckDigit(baseNineDigits)}";
@@ -838,12 +847,17 @@ static async Task SeedMembersAsync(
 
     var created = 0;
     var existing = 0;
+    var statusAligned = 0;
 
     foreach (var member in members)
     {
         if (await MemberExistsAsync(http, options, member.MemberId))
         {
             existing++;
+            if (await UpdateMemberSeedStatusAsync(http, options, member, json))
+            {
+                statusAligned++;
+            }
             continue;
         }
 
@@ -856,9 +870,14 @@ static async Task SeedMembersAsync(
         {
             existing++;
         }
+
+        if (await UpdateMemberSeedStatusAsync(http, options, member, json))
+        {
+            statusAligned++;
+        }
     }
 
-    Console.WriteLine($"seeded: {created:N0} synthetic members ({existing:N0} already present)");
+    Console.WriteLine($"seeded: {created:N0} synthetic members ({existing:N0} already present, {statusAligned:N0} status-aligned)");
 }
 
 static async Task<bool> MemberExistsAsync(HttpClient http, ValidatorOptions options, string memberId)
@@ -923,6 +942,35 @@ static async Task<bool> CreateMemberAsync(
     if (!response.IsSuccessStatusCode)
     {
         throw new InvalidOperationException($"member seed failed ({member.MemberId}): {(int)response.StatusCode} {body}");
+    }
+
+    return true;
+}
+
+static async Task<bool> UpdateMemberSeedStatusAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    SyntheticMember member,
+    JsonSerializerOptions json)
+{
+    var payload = new MemberStatusUpdateDto(
+        MccMemberSeedStatus.ToMemberServiceStatus(member.EnrollmentStatus),
+        $"mcc-validator-member-status:{options.Seed}:{member.MemberId}");
+
+    using var response = await http.PutAsJsonAsync(
+        $"{options.MemberUrl}/api/v1/members/{Uri.EscapeDataString(member.MemberId)}",
+        payload,
+        json);
+    var body = await response.Content.ReadAsStringAsync();
+
+    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+    {
+        return false;
+    }
+
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException($"member status alignment failed ({member.MemberId}): {(int)response.StatusCode} {body}");
     }
 
     return true;
@@ -1110,6 +1158,12 @@ static async Task SeedProvidersAsync(
                 providerId,
                 EffectiveDateForProvider(provider),
                 json);
+            await EnsureProviderNetworkParticipationAsync(
+                http,
+                options,
+                providerId,
+                provider,
+                json);
         }
     }
 
@@ -1159,6 +1213,82 @@ static async Task<bool> ProviderNetworkExistsAsync(HttpClient http, ValidatorOpt
 
     var body = await response.Content.ReadAsStringAsync();
     throw new InvalidOperationException($"provider network lookup failed ({networkId}): {(int)response.StatusCode} {body}");
+}
+
+static async Task EnsureProviderNetworkParticipationAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    string providerId,
+    SyntheticProvider provider,
+    JsonSerializerOptions json)
+{
+    var effectiveDate = EffectiveDateForProvider(provider);
+    if (await ProviderHasActiveNetworkParticipationAsync(http, options, provider.Npi, "mcc-local-network", effectiveDate))
+    {
+        return;
+    }
+
+    var payload = new
+    {
+        planId = (string?)null,
+        networkId = "mcc-local-network",
+        lineOfBusiness = LineOfBusinessName(options.LineOfBusiness),
+        networkTier = "InNetwork",
+        effectiveDate,
+        terminationDate = (DateTime?)null,
+        acceptingNewPatients = true,
+        panelLimit = 2500,
+        panelAccepted = true,
+        acceptedLobs = new[] { LineOfBusinessName(options.LineOfBusiness) },
+        minAcceptedAgeYears = (int?)null,
+        maxAcceptedAgeYears = (int?)null,
+        rates = new
+        {
+            feeScheduleName = provider.FeeScheduleId ?? "MCC Local Fee Schedule",
+            percentOfMedicare = 1.10m,
+            pmpm = (decimal?)null,
+            caseRate = (decimal?)null
+        }
+    };
+
+    using var response = await http.PostAsJsonAsync(
+        $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}/network-participations",
+        payload,
+        json);
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode && response.StatusCode is not System.Net.HttpStatusCode.Conflict)
+    {
+        throw new InvalidOperationException(
+            $"provider network participation seed failed ({providerId}/{provider.Npi}): {(int)response.StatusCode} {body}");
+    }
+}
+
+static async Task<bool> ProviderHasActiveNetworkParticipationAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    string npi,
+    string networkId,
+    DateTime effectiveDate)
+{
+    var url =
+        $"{options.ProviderUrl}/api/v1/networks/{Uri.EscapeDataString(networkId)}/members/{Uri.EscapeDataString(npi)}" +
+        $"?asOf={Uri.EscapeDataString(effectiveDate.ToString("O"))}";
+    using var response = await http.GetAsync(url);
+    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+    {
+        return false;
+    }
+
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException(
+            $"provider network membership lookup failed ({networkId}/{npi}): {(int)response.StatusCode} {body}");
+    }
+
+    using var document = JsonDocument.Parse(body);
+    return document.RootElement.TryGetProperty("isActiveMember", out var active)
+        && active.ValueKind == JsonValueKind.True;
 }
 
 static async Task CreateProviderNetworkAsync(
@@ -1560,7 +1690,7 @@ static string LineOfBusinessName(int lineOfBusiness) => lineOfBusiness switch
     _ => throw new ArgumentOutOfRangeException(nameof(lineOfBusiness), lineOfBusiness, "Unsupported line-of-business code.")
 };
 
-static async Task UpdateClaimAdjudicationAsync(
+static async Task<ClaimValidationOutcome?> UpdateClaimAdjudicationAsync(
     HttpClient http,
     ValidatorOptions options,
     string submittedClaimId,
@@ -1587,6 +1717,19 @@ static async Task UpdateClaimAdjudicationAsync(
         var body = await response.Content.ReadAsStringAsync();
         throw new InvalidOperationException($"claim adjudication update failed ({submittedClaimId}): {(int)response.StatusCode} {body}");
     }
+
+    if (response.StatusCode != System.Net.HttpStatusCode.OK)
+    {
+        return null;
+    }
+
+    var writeback = await response.Content.ReadFromJsonAsync<AdjudicationSummaryWriteResponseDto>(json);
+    if (writeback is not { StatusPreserved: true })
+    {
+        return null;
+    }
+
+    return MccClaimStatusMapping.ToValidationOutcome(writeback.PersistedStatus);
 }
 
 static async Task<List<ClaimValidationResult>> ObserveExpectedPendResultsAsync(
@@ -2102,6 +2245,14 @@ internal sealed record AdjudicationResponseDto(
     AdjudicationTotalsDto Totals,
     string? BusinessDenialCode = null,
     IReadOnlyDictionary<string, double>? Timings = null);
+
+internal sealed record AdjudicationSummaryWriteResponseDto(
+    bool StatusPreserved,
+    int PersistedStatus);
+
+internal sealed record MemberStatusUpdateDto(
+    string Status,
+    string EventId);
 
 internal sealed record AdjudicationTotalsDto(
     decimal BilledAmount,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -214,7 +214,7 @@ public class BenefitCalculationStageTests
     }
 
     [Fact]
-    public async Task Execute_TexasMedicaidInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
+    public async Task Execute_MedicaidInstitutionalInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
     {
         var claim = BuildClaim(Guid.NewGuid().ToString());
         claim.LineOfBusiness = LineOfBusiness.Medicaid;
@@ -237,6 +237,32 @@ public class BenefitCalculationStageTests
         Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredCode, ctx.AdjudicationResult.DenialReasonCode);
         Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredReason, ctx.AdjudicationResult.DenialReason);
         await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_ExchangeInstitutionalInpatientWithoutPriorAuth_ContinuesToBenefitEngine()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.LineOfBusiness = LineOfBusiness.Exchange;
+        claim.ClaimType = ClaimType.Institutional;
+        claim.PlaceOfServiceCode = "21";
+        claim.PriorAuthorizationNumber = null;
+
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -214,6 +214,58 @@ public class BenefitCalculationStageTests
     }
 
     [Fact]
+    public async Task Execute_TexasMedicaidInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.LineOfBusiness = LineOfBusiness.Medicaid;
+        claim.ClaimType = ClaimType.Institutional;
+        claim.PlaceOfServiceCode = "21";
+        claim.PriorAuthorizationNumber = null;
+
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredCode, ctx.AdjudicationResult.DenialReasonCode);
+        Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredReason, ctx.AdjudicationResult.DenialReason);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_InpatientWithPriorAuth_ContinuesToBenefitEngine()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.LineOfBusiness = LineOfBusiness.Medicaid;
+        claim.ClaimType = ClaimType.Institutional;
+        claim.PlaceOfServiceCode = "21";
+        claim.PriorAuthorizationNumber = "AUTH-123";
+
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Execute_NoSubscriberOnClaim_FallsBackThroughResolverAndMemberId()
     {
         var claim = BuildClaim(Guid.NewGuid().ToString());

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/NetworkCredentialingStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/NetworkCredentialingStageTests.cs
@@ -21,7 +21,9 @@ public class NetworkCredentialingStageTests
     private const string Network1 = "net-1";
     private const string Network2 = "net-2";
     private const string Npi = "1234567890";
+    private const string RenderingNpi = "9000000011";
     private const string ProviderId = "p-001";
+    private const string RenderingProviderId = "p-rendering-excluded";
 
     private readonly IProviderMembershipClient _membership = Substitute.For<IProviderMembershipClient>();
     private readonly ICredentialingStatusClient _credentialing = Substitute.For<ICredentialingStatusClient>();
@@ -55,6 +57,115 @@ public class NetworkCredentialingStageTests
         Assert.Equal(Network1, ctx.MatchedNetworkTier!.NetworkId);
         Assert.Equal(2, ctx.EnforcementOutcomes.Count);
         Assert.All(ctx.EnforcementOutcomes, o => Assert.Equal(EnforcementDecision.Allow, o.Decision));
+    }
+
+    [Fact]
+    public async Task StaleInactiveMembership_force_refreshes_before_denying()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = false, AsOfDate = DateTime.UtcNow,
+                ParticipationStatus = "not_a_member",
+            });
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), true, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, AsOfDate = DateTime.UtcNow, Status = "Approved",
+            });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.All(ctx.EnforcementOutcomes, o => Assert.Equal(EnforcementDecision.Allow, o.Decision));
+        await _membership.Received(1).GetMembershipAsync(
+            TenantId, Network1, Npi, Arg.Any<DateTime>(), true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StaleCredentialingStatus_force_refreshes_before_denying()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, AsOfDate = DateTime.UtcNow, Status = "Unknown",
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), true, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, AsOfDate = DateTime.UtcNow, Status = "Approved",
+            });
+
+        var ctx = NewContext(tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.All(ctx.EnforcementOutcomes, o => Assert.Equal(EnforcementDecision.Allow, o.Decision));
+        await _credentialing.Received(1).GetStatusAsOfAsync(
+            TenantId, ProviderId, Arg.Any<DateTime>(), true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RenderingProviderCredentialingDenial_denies_even_when_billing_provider_allows()
+    {
+        _membership.GetMembershipAsync(TenantId, Network1, Npi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = Npi, ProviderId = ProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, ProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = ProviderId, AsOfDate = DateTime.UtcNow, Status = "Approved",
+            });
+        _membership.GetMembershipAsync(TenantId, Network1, RenderingNpi, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new NetworkMembership
+            {
+                NetworkId = Network1, Npi = RenderingNpi, ProviderId = RenderingProviderId,
+                IsActiveMember = true, AsOfDate = DateTime.UtcNow,
+            });
+        _credentialing.GetStatusAsOfAsync(TenantId, RenderingProviderId, Arg.Any<DateTime>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CredentialingStatusSnapshot
+            {
+                ProviderId = RenderingProviderId, AsOfDate = DateTime.UtcNow, Status = "Denied",
+            });
+
+        var claim = NewClaim();
+        claim.RenderingProviderNPI = RenderingNpi;
+        var ctx = NewContext(claim, tiers: new[] { Tier(Network1, "InNetwork", 1) });
+        var sut = NewStage(new TenantEnforcementPolicyOptions());
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Equal(4, ctx.EnforcementOutcomes.Count);
+        Assert.NotNull(ctx.BillingProviderCredentialingStatus);
+        Assert.NotNull(ctx.RenderingProviderCredentialingStatus);
+        Assert.Equal("Denied", ctx.RenderingProviderCredentialingStatus!.Status);
+        Assert.Contains(ctx.EnforcementOutcomes, outcome =>
+            outcome.Check == EnforcementCheck.Credentialing
+            && outcome.Decision == EnforcementDecision.Deny
+            && (outcome.Reason?.Contains("Rendering provider", StringComparison.Ordinal) ?? false));
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusMappingTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusMappingTests.cs
@@ -1,0 +1,30 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccClaimStatusMappingTests
+{
+    [Theory]
+    [InlineData(4, ClaimValidationOutcome.Pended)]
+    [InlineData(5, ClaimValidationOutcome.Paid)]
+    [InlineData(7, ClaimValidationOutcome.Paid)]
+    [InlineData(9, ClaimValidationOutcome.Paid)]
+    [InlineData(6, ClaimValidationOutcome.BusinessDenial)]
+    [InlineData(8, ClaimValidationOutcome.BusinessDenial)]
+    public void ToValidationOutcome_maps_terminal_claim_statuses_to_validator_outcomes(
+        int persistedStatus,
+        ClaimValidationOutcome expected)
+    {
+        Assert.Equal(expected, MccClaimStatusMapping.ToValidationOutcome(persistedStatus));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(999)]
+    public void ToValidationOutcome_returns_null_for_non_terminal_statuses(int persistedStatus)
+    {
+        Assert.Null(MccClaimStatusMapping.ToValidationOutcome(persistedStatus));
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
@@ -98,4 +98,37 @@ public class MccFixtureIsolationTests
         Assert.Equal(originalPrimaryMemberId, primary.Member.MemberId);
         Assert.Equal(originalSubrogationMemberId, subrogation.Member.MemberId);
     }
+
+    [Fact]
+    public void IsolateValidationMembers_GivesScoreableNonCobScenariosRunScopedMemberIds()
+    {
+        var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
+        var retroAdd = generator.Generate(1, nameof(EdgeCaseScenario.RetroEligibilityAdd), new Random(42));
+        retroAdd.ClaimId = "MCC-E-0000013";
+        retroAdd.Member.MemberId = "MBR-SHARED";
+        retroAdd.Member.SubscriberId = "SUB-SHARED";
+
+        var runId = Guid.Parse("906f49d1-18cc-4d19-9c77-69822ad6d88b");
+
+        MccFixtureIsolation.IsolateValidationMembers([retroAdd], seed: 42, runId);
+
+        Assert.Equal("MCCV906F49D10000013", retroAdd.Member.MemberId);
+        Assert.Equal(retroAdd.Member.MemberId, retroAdd.Member.SubscriberId);
+        Assert.DoesNotContain("-", retroAdd.Member.MemberId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IsolateValidationMembers_LeavesUnsupportedScenariosUnchanged()
+    {
+        var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
+        var subrogation = generator.Generate(2, nameof(EdgeCaseScenario.SubrogationWorkersComp), new Random(43));
+        var originalMemberId = subrogation.Member.MemberId;
+
+        MccFixtureIsolation.IsolateValidationMembers(
+            [subrogation],
+            seed: 42,
+            runId: Guid.Parse("906f49d1-18cc-4d19-9c77-69822ad6d88b"));
+
+        Assert.Equal(originalMemberId, subrogation.Member.MemberId);
+    }
 }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccMemberSeedStatusTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccMemberSeedStatusTests.cs
@@ -1,0 +1,23 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccMemberSeedStatusTests
+{
+    [Theory]
+    [InlineData(null, MccMemberSeedStatus.Active)]
+    [InlineData("", MccMemberSeedStatus.Active)]
+    [InlineData("Active", MccMemberSeedStatus.Active)]
+    [InlineData("active", MccMemberSeedStatus.Active)]
+    [InlineData("Pending", MccMemberSeedStatus.Pending)]
+    [InlineData("Terminated", MccMemberSeedStatus.Terminated)]
+    [InlineData("Suspended", MccMemberSeedStatus.Suspended)]
+    [InlineData("COBRA", MccMemberSeedStatus.Cobra)]
+    [InlineData("Unexpected", MccMemberSeedStatus.Active)]
+    public void ToMemberServiceStatus_maps_synthetic_enrollment_status_to_member_service_enum(
+        string? status,
+        string expected)
+    {
+        Assert.Equal(expected, MccMemberSeedStatus.ToMemberServiceStatus(status));
+    }
+}


### PR DESCRIPTION
## Summary
- score validator outcomes from persisted claim status when synchronous writeback is suppressed
- align MCC member/provider fixture seeding with async adjudication, including run-scoped scoreable members and provider NPIs
- add async parity fixes for TX STAR prior-auth, rendering-provider credentialing, and force-refresh provider lookups before deny
- add focused validator and claims-service regression coverage

## Verification
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "NetworkCredentialingStageTests"
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "NetworkCredentialingStageTests|BenefitCalculationStageTests"
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
- 1K MCC Kubernetes validation: 1,000/1,000 processed, 0 platform failures, 9/9 expected pends observed, 117/130 workflow checks matched, 0 mismatches, 13 unsupported
