### PR TITLE
Fix paid summary status repair

### DIFF
--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -436,6 +436,28 @@ public class ClaimRepository : IClaimRepository
     public static readonly IReadOnlyList<ClaimStatus> SynchronousWritebackBlockedStatuses =
         Enum.GetValues<ClaimStatus>().Where(BlocksSynchronousWriteback).ToArray();
 
+    /// <summary>
+    /// True for the narrow repair allowed by benchmark summary writeback: a
+    /// row already says Denied, while the incoming summary is paid and carries
+    /// no denial evidence. This prevents an impossible "Denied + payer payment
+    /// + no denial reason" state from surviving while still protecting pends
+    /// and non-paid summaries.
+    /// </summary>
+    public static bool CanRepairContradictoryDeniedSummary(
+        ClaimStatus preWriteStatus,
+        ClaimStatus desiredStatus,
+        AdjudicationResult incomingAdjudication) =>
+        preWriteStatus == ClaimStatus.Denied
+        && desiredStatus == ClaimStatus.Approved
+        && incomingAdjudication.PayerPayment > 0
+        && !HasDenialEvidence(incomingAdjudication);
+
+    private static bool HasDenialEvidence(AdjudicationResult? adjudication) =>
+        adjudication is not null
+        && (!string.IsNullOrWhiteSpace(adjudication.DenialReasonCode)
+            || !string.IsNullOrWhiteSpace(adjudication.DenialReason)
+            || adjudication.AdjustmentReasons.Any());
+
     private static bool IsTerminal(ClaimVersionState state) => state switch
     {
         ClaimVersionState.Paid or
@@ -1287,7 +1309,7 @@ public class ClaimRepository : IClaimRepository
         CancellationToken ct = default)
     {
         var query = new QueryDefinition(@"
-            SELECT TOP 1 c.id
+            SELECT TOP 1 c.id, c.status, c.adjudicationResult
             FROM c
             WHERE c.tenantId = @tenantId
               AND (c.claimVersionId = @claimVersionId
@@ -1299,17 +1321,17 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@claimVersionId", claimVersionId)
             .WithParameter("@draft", ClaimVersionState.Draft.ToString());
 
-        string? rowId = null;
+        HeadIdResult? head = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
             query,
             requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(ct);
-            rowId = page.FirstOrDefault()?.Id;
+            head = page.FirstOrDefault();
         }
 
-        if (string.IsNullOrEmpty(rowId)) return StatusWriteResult.NotFoundResult;
+        if (head is null || string.IsNullOrEmpty(head.Id)) return StatusWriteResult.NotFoundResult;
 
         // Residual-race fix — financial/audit data (AdjudicationResult, dates)
         // persists by chain/id even if async adjudication already finalized
@@ -1326,7 +1348,7 @@ public class ClaimRepository : IClaimRepository
         try
         {
             await _container.PatchItemAsync<Claim>(
-                rowId,
+                head.Id,
                 new PartitionKey(tenantId),
                 summaryOps,
                 cancellationToken: ct);
@@ -1336,7 +1358,14 @@ public class ClaimRepository : IClaimRepository
             return StatusWriteResult.NotFoundResult;
         }
 
-        return await TryPatchStatusAsync(tenantId, rowId, status, ClaimVersionState.Adjudicated, ct);
+        return await TryPatchStatusAsync(
+            tenantId,
+            head.Id,
+            status,
+            ClaimVersionState.Adjudicated,
+            ct,
+            adjudicationResult,
+            head.Status);
     }
 
     public Task<StatusWriteResult> TryTransitionStatusAsync(
@@ -1364,7 +1393,9 @@ public class ClaimRepository : IClaimRepository
         string rowId,
         ClaimStatus desiredStatus,
         ClaimVersionState desiredVersionState,
-        CancellationToken ct)
+        CancellationToken ct,
+        AdjudicationResult? incomingAdjudication = null,
+        ClaimStatus? preWriteStatus = null)
     {
         var statusOps = new List<PatchOperation>
         {
@@ -1384,6 +1415,31 @@ public class ClaimRepository : IClaimRepository
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
         {
+            if (incomingAdjudication is not null
+                && preWriteStatus is not null
+                && CanRepairContradictoryDeniedSummary(
+                    preWriteStatus.Value,
+                    desiredStatus,
+                    incomingAdjudication))
+            {
+                var repairOptions = new PatchItemRequestOptions { FilterPredicate = ContradictoryDeniedRepairFilterPredicate };
+                try
+                {
+                    await _container.PatchItemAsync<Claim>(rowId, new PartitionKey(tenantId), statusOps, repairOptions, ct);
+                    return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+                }
+                catch (CosmosException repairEx) when (repairEx.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    return StatusWriteResult.NotFoundResult;
+                }
+                catch (CosmosException repairEx) when (repairEx.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                {
+                    // Another writer changed the row after summary writeback.
+                    // Fall through to the normal readback so callers see the
+                    // persisted status that actually won.
+                }
+            }
+
             try
             {
                 var read = await _container.ReadItemAsync<Claim>(rowId, new PartitionKey(tenantId), cancellationToken: ct);
@@ -1401,6 +1457,14 @@ public class ClaimRepository : IClaimRepository
     /// <summary>Cosmos patch FilterPredicate for <see cref="BlocksSynchronousWriteback"/> — built from <see cref="SynchronousWritebackBlockedStatuses"/> so it can't drift from the canonical rule.</summary>
     private static readonly string SynchronousWritebackBlockedFilterPredicate =
         BuildStatusNotInFilterPredicate(SynchronousWritebackBlockedStatuses);
+
+    private const string ContradictoryDeniedRepairFilterPredicate =
+        "FROM c WHERE c.status = 'Denied' " +
+        "AND IS_DEFINED(c.adjudicationResult) " +
+        "AND c.adjudicationResult.payerPayment > 0 " +
+        "AND (NOT IS_DEFINED(c.adjudicationResult.denialReasonCode) " +
+        "OR IS_NULL(c.adjudicationResult.denialReasonCode) " +
+        "OR c.adjudicationResult.denialReasonCode = '')";
 
     /// <summary>Cosmos patch FilterPredicate for <see cref="IsFinalDisposition"/> — built from <see cref="FinalDispositions"/>; Pended is deliberately absent (re-pending is allowed).</summary>
     private static readonly string FinalDispositionFilterPredicate =
@@ -1610,5 +1674,7 @@ public class ClaimRepository : IClaimRepository
     private sealed class HeadIdResult
     {
         public string Id { get; set; } = string.Empty;
+        public ClaimStatus Status { get; set; }
+        public AdjudicationResult? AdjudicationResult { get; set; }
     }
 }

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -436,6 +436,28 @@ public class ClaimRepository : IClaimRepository
     public static readonly IReadOnlyList<ClaimStatus> SynchronousWritebackBlockedStatuses =
         Enum.GetValues<ClaimStatus>().Where(BlocksSynchronousWriteback).ToArray();
 
+    /// <summary>
+    /// True for the narrow repair allowed by benchmark summary writeback: a
+    /// row already says Denied, while the incoming summary is paid and carries
+    /// no denial evidence. This prevents an impossible "Denied + payer payment
+    /// + no denial reason" state from surviving while still protecting pends
+    /// and non-paid summaries.
+    /// </summary>
+    public static bool CanRepairContradictoryDeniedSummary(
+        ClaimStatus preWriteStatus,
+        ClaimStatus desiredStatus,
+        AdjudicationResult incomingAdjudication) =>
+        preWriteStatus == ClaimStatus.Denied
+        && desiredStatus == ClaimStatus.Approved
+        && incomingAdjudication.PayerPayment > 0
+        && !HasDenialEvidence(incomingAdjudication);
+
+    private static bool HasDenialEvidence(AdjudicationResult? adjudication) =>
+        adjudication is not null
+        && (!string.IsNullOrWhiteSpace(adjudication.DenialReasonCode)
+            || !string.IsNullOrWhiteSpace(adjudication.DenialReason)
+            || adjudication.AdjustmentReasons.Any());
+
     private static bool IsTerminal(ClaimVersionState state) => state switch
     {
         ClaimVersionState.Paid or
@@ -1287,7 +1309,7 @@ public class ClaimRepository : IClaimRepository
         CancellationToken ct = default)
     {
         var query = new QueryDefinition(@"
-            SELECT TOP 1 c.id
+            SELECT TOP 1 c.id, c.status
             FROM c
             WHERE c.tenantId = @tenantId
               AND (c.claimVersionId = @claimVersionId
@@ -1299,17 +1321,17 @@ public class ClaimRepository : IClaimRepository
             .WithParameter("@claimVersionId", claimVersionId)
             .WithParameter("@draft", ClaimVersionState.Draft.ToString());
 
-        string? rowId = null;
+        HeadIdResult? head = null;
         var iterator = _container.GetItemQueryIterator<HeadIdResult>(
             query,
             requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(tenantId) });
         if (iterator.HasMoreResults)
         {
             var page = await iterator.ReadNextAsync(ct);
-            rowId = page.FirstOrDefault()?.Id;
+            head = page.FirstOrDefault();
         }
 
-        if (string.IsNullOrEmpty(rowId)) return StatusWriteResult.NotFoundResult;
+        if (head is null || string.IsNullOrEmpty(head.Id)) return StatusWriteResult.NotFoundResult;
 
         // Residual-race fix — financial/audit data (AdjudicationResult, dates)
         // persists by chain/id even if async adjudication already finalized
@@ -1326,7 +1348,7 @@ public class ClaimRepository : IClaimRepository
         try
         {
             await _container.PatchItemAsync<Claim>(
-                rowId,
+                head.Id,
                 new PartitionKey(tenantId),
                 summaryOps,
                 cancellationToken: ct);
@@ -1336,7 +1358,14 @@ public class ClaimRepository : IClaimRepository
             return StatusWriteResult.NotFoundResult;
         }
 
-        return await TryPatchStatusAsync(tenantId, rowId, status, ClaimVersionState.Adjudicated, ct);
+        return await TryPatchStatusAsync(
+            tenantId,
+            head.Id,
+            status,
+            ClaimVersionState.Adjudicated,
+            ct,
+            adjudicationResult,
+            head.Status);
     }
 
     public Task<StatusWriteResult> TryTransitionStatusAsync(
@@ -1364,7 +1393,9 @@ public class ClaimRepository : IClaimRepository
         string rowId,
         ClaimStatus desiredStatus,
         ClaimVersionState desiredVersionState,
-        CancellationToken ct)
+        CancellationToken ct,
+        AdjudicationResult? incomingAdjudication = null,
+        ClaimStatus? preWriteStatus = null)
     {
         var statusOps = new List<PatchOperation>
         {
@@ -1384,6 +1415,31 @@ public class ClaimRepository : IClaimRepository
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
         {
+            if (incomingAdjudication is not null
+                && preWriteStatus is not null
+                && CanRepairContradictoryDeniedSummary(
+                    preWriteStatus.Value,
+                    desiredStatus,
+                    incomingAdjudication))
+            {
+                var repairOptions = new PatchItemRequestOptions { FilterPredicate = ContradictoryDeniedRepairFilterPredicate };
+                try
+                {
+                    await _container.PatchItemAsync<Claim>(rowId, new PartitionKey(tenantId), statusOps, repairOptions, ct);
+                    return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+                }
+                catch (CosmosException repairEx) when (repairEx.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    return StatusWriteResult.NotFoundResult;
+                }
+                catch (CosmosException repairEx) when (repairEx.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+                {
+                    // Another writer changed the row after summary writeback.
+                    // Fall through to the normal readback so callers see the
+                    // persisted status that actually won.
+                }
+            }
+
             try
             {
                 var read = await _container.ReadItemAsync<Claim>(rowId, new PartitionKey(tenantId), cancellationToken: ct);
@@ -1402,12 +1458,22 @@ public class ClaimRepository : IClaimRepository
     private static readonly string SynchronousWritebackBlockedFilterPredicate =
         BuildStatusNotInFilterPredicate(SynchronousWritebackBlockedStatuses);
 
+    private static readonly string ContradictoryDeniedRepairFilterPredicate =
+        $"FROM c WHERE c.status = '{CosmosStatusLiteral(ClaimStatus.Denied)}' " +
+        "AND IS_DEFINED(c.adjudicationResult) " +
+        "AND c.adjudicationResult.payerPayment > 0 " +
+        "AND (NOT IS_DEFINED(c.adjudicationResult.denialReasonCode) " +
+        "OR IS_NULL(c.adjudicationResult.denialReasonCode) " +
+        "OR c.adjudicationResult.denialReasonCode = '')";
+
     /// <summary>Cosmos patch FilterPredicate for <see cref="IsFinalDisposition"/> — built from <see cref="FinalDispositions"/>; Pended is deliberately absent (re-pending is allowed).</summary>
     private static readonly string FinalDispositionFilterPredicate =
         BuildStatusNotInFilterPredicate(FinalDispositions);
 
     private static string BuildStatusNotInFilterPredicate(IReadOnlyList<ClaimStatus> blockedStatuses) =>
-        $"FROM c WHERE NOT (c.status IN ({string.Join(",", blockedStatuses.Select(s => $"'{s}'"))}))";
+        $"FROM c WHERE NOT (c.status IN ({string.Join(",", blockedStatuses.Select(s => $"'{CosmosStatusLiteral(s)}'"))}))";
+
+    private static string CosmosStatusLiteral(ClaimStatus status) => status.ToString();
 
     public async Task<AccumulatorTotalsResponse> GetAccumulatorTotalsAsync(
         string ownerId,
@@ -1610,5 +1676,6 @@ public class ClaimRepository : IClaimRepository
     private sealed class HeadIdResult
     {
         public string Id { get; set; } = string.Empty;
+        public ClaimStatus Status { get; set; }
     }
 }

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Azure.Cosmos;
 using ClaimsService.Exceptions;
 using ClaimsService.Models;
@@ -1473,7 +1474,8 @@ public class ClaimRepository : IClaimRepository
     private static string BuildStatusNotInFilterPredicate(IReadOnlyList<ClaimStatus> blockedStatuses) =>
         $"FROM c WHERE NOT (c.status IN ({string.Join(",", blockedStatuses.Select(s => $"'{CosmosStatusLiteral(s)}'"))}))";
 
-    private static string CosmosStatusLiteral(ClaimStatus status) => status.ToString();
+    private static string CosmosStatusLiteral(ClaimStatus status) =>
+        JsonNamingPolicy.CamelCase.ConvertName(status.ToString());
 
     public async Task<AccumulatorTotalsResponse> GetAccumulatorTotalsAsync(
         string ownerId,

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -648,17 +648,26 @@ public class ClaimRepositoryMongo : IClaimRepository
         var options = new FindOneAndUpdateOptions<Claim>
         {
             Sort = Builders<Claim>.Sort.Descending(c => c.VersionNumber),
-            Projection = Builders<Claim>.Projection.Include(c => c.Id),
-            ReturnDocument = ReturnDocument.After,
+            Projection = Builders<Claim>.Projection
+                .Include(c => c.Id)
+                .Include(c => c.Status),
+            ReturnDocument = ReturnDocument.Before,
         };
 
-        var summaryUpdated = await _collection.FindOneAndUpdateAsync(filter, summaryUpdate, options, ct);
-        if (summaryUpdated is null)
+        var preWriteHead = await _collection.FindOneAndUpdateAsync(filter, summaryUpdate, options, ct);
+        if (preWriteHead is null)
         {
             return StatusWriteResult.NotFoundResult;
         }
 
-        return await TryPatchStatusAsync(tenantId, summaryUpdated.Id, status, ClaimVersionState.Adjudicated, ct);
+        return await TryPatchStatusAsync(
+            tenantId,
+            preWriteHead.Id,
+            status,
+            ClaimVersionState.Adjudicated,
+            ct,
+            adjudicationResult,
+            preWriteHead.Status);
     }
 
     public Task<StatusWriteResult> TryTransitionStatusAsync(
@@ -686,7 +695,9 @@ public class ClaimRepositoryMongo : IClaimRepository
         string rowId,
         ClaimStatus desiredStatus,
         ClaimVersionState desiredVersionState,
-        CancellationToken ct)
+        CancellationToken ct,
+        AdjudicationResult? incomingAdjudication = null,
+        ClaimStatus? preWriteStatus = null)
     {
         var b = Builders<Claim>.Filter;
         var statusFilter = b.And(
@@ -701,6 +712,29 @@ public class ClaimRepositoryMongo : IClaimRepository
         if (result.MatchedCount > 0)
         {
             return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+        }
+
+        if (incomingAdjudication is not null
+            && preWriteStatus is not null
+            && ClaimRepository.CanRepairContradictoryDeniedSummary(
+                preWriteStatus.Value,
+                desiredStatus,
+                incomingAdjudication))
+        {
+            var repairFilter = b.And(
+                b.Eq(c => c.TenantId, tenantId),
+                b.Eq(c => c.Id, rowId),
+                b.Eq(c => c.Status, ClaimStatus.Denied),
+                b.Gt(c => c.AdjudicationResult!.PayerPayment, 0m),
+                b.Or(
+                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, null),
+                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, string.Empty)));
+
+            var repairResult = await _collection.UpdateOneAsync(repairFilter, statusUpdate, cancellationToken: ct);
+            if (repairResult.MatchedCount > 0)
+            {
+                return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+            }
         }
 
         var existing = await _collection

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -648,17 +648,24 @@ public class ClaimRepositoryMongo : IClaimRepository
         var options = new FindOneAndUpdateOptions<Claim>
         {
             Sort = Builders<Claim>.Sort.Descending(c => c.VersionNumber),
-            Projection = Builders<Claim>.Projection.Include(c => c.Id),
-            ReturnDocument = ReturnDocument.After,
+            ReturnDocument = ReturnDocument.Before,
         };
 
-        var summaryUpdated = await _collection.FindOneAndUpdateAsync(filter, summaryUpdate, options, ct);
-        if (summaryUpdated is null)
+        var preWriteHead = await _collection.FindOneAndUpdateAsync(filter, summaryUpdate, options, ct);
+        if (preWriteHead is null)
         {
             return StatusWriteResult.NotFoundResult;
         }
 
-        return await TryPatchStatusAsync(tenantId, summaryUpdated.Id, status, ClaimVersionState.Adjudicated, ct);
+        preWriteHead = Hydrate(preWriteHead);
+        return await TryPatchStatusAsync(
+            tenantId,
+            preWriteHead.Id,
+            status,
+            ClaimVersionState.Adjudicated,
+            ct,
+            adjudicationResult,
+            preWriteHead.Status);
     }
 
     public Task<StatusWriteResult> TryTransitionStatusAsync(
@@ -686,7 +693,9 @@ public class ClaimRepositoryMongo : IClaimRepository
         string rowId,
         ClaimStatus desiredStatus,
         ClaimVersionState desiredVersionState,
-        CancellationToken ct)
+        CancellationToken ct,
+        AdjudicationResult? incomingAdjudication = null,
+        ClaimStatus? preWriteStatus = null)
     {
         var b = Builders<Claim>.Filter;
         var statusFilter = b.And(
@@ -701,6 +710,29 @@ public class ClaimRepositoryMongo : IClaimRepository
         if (result.MatchedCount > 0)
         {
             return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+        }
+
+        if (incomingAdjudication is not null
+            && preWriteStatus is not null
+            && ClaimRepository.CanRepairContradictoryDeniedSummary(
+                preWriteStatus.Value,
+                desiredStatus,
+                incomingAdjudication))
+        {
+            var repairFilter = b.And(
+                b.Eq(c => c.TenantId, tenantId),
+                b.Eq(c => c.Id, rowId),
+                b.Eq(c => c.Status, ClaimStatus.Denied),
+                b.Gt(c => c.AdjudicationResult!.PayerPayment, 0m),
+                b.Or(
+                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, null),
+                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, string.Empty)));
+
+            var repairResult = await _collection.UpdateOneAsync(repairFilter, statusUpdate, cancellationToken: ct);
+            if (repairResult.MatchedCount > 0)
+            {
+                return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
+            }
         }
 
         var existing = await _collection

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryStatusWritebackGuardTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryStatusWritebackGuardTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
 using FluentAssertions;
@@ -101,7 +102,10 @@ public sealed class ClaimRepositoryStatusWritebackGuardTests
         captured.Should().NotBeNull();
         foreach (var blocked in ClaimRepository.SynchronousWritebackBlockedStatuses)
         {
-            captured!.FilterPredicate.Should().Contain($"'{blocked}'");
+            captured!.FilterPredicate.Should()
+                .Contain($"'{JsonNamingPolicy.CamelCase.ConvertName(blocked.ToString())}'");
+            captured.FilterPredicate.Should()
+                .NotContain($"'{blocked}'", "Cosmos persists ClaimStatus enum strings as camelCase");
         }
     }
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -605,6 +605,30 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     }
 
     [Fact]
+    public void CanRepairContradictoryDeniedSummary_only_allows_paid_denial_without_denial_evidence()
+    {
+        var paidSummary = new AdjudicationResult { PayerPayment = 150m };
+
+        ClaimRepository.CanRepairContradictoryDeniedSummary(
+                ClaimStatus.Denied,
+                ClaimStatus.Approved,
+                paidSummary)
+            .Should().BeTrue();
+
+        ClaimRepository.CanRepairContradictoryDeniedSummary(
+                ClaimStatus.Pended,
+                ClaimStatus.Approved,
+                paidSummary)
+            .Should().BeFalse("pends remain protected from synchronous summary writeback");
+
+        ClaimRepository.CanRepairContradictoryDeniedSummary(
+                ClaimStatus.Denied,
+                ClaimStatus.Approved,
+                new AdjudicationResult { PayerPayment = 150m, DenialReasonCode = "96" })
+            .Should().BeFalse("an incoming summary with denial evidence is not a paid contradiction");
+    }
+
+    [Fact]
     public async Task UpdateAdjudicationSummaryAsync_onNonPendedClaim_appliesStatusAndData()
     {
         // Regression: the unguarded, normal case is byte-identical to
@@ -656,10 +680,17 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpdateAdjudicationSummaryAsync_onAlreadyFinalClaim_suppressesStatus_butPersistsFinancialData()
+    public async Task UpdateAdjudicationSummaryAsync_onAlreadyFinalDeniedClaim_repairsPaidSummaryStatus()
     {
         var head = BuildVersion("chain-summary-final", "row-1", n: 1, ClaimVersionState.Denied);
         head.Status = ClaimStatus.Denied;
+        head.AdjudicationResult = new AdjudicationResult
+        {
+            AllowedAmount = 0m,
+            PayerPayment = 0m,
+            DenialReasonCode = "96",
+            DenialReason = "Non-covered charge"
+        };
         await _repo.CreateAsync(head);
         await _repo.CreateAsync(BuildVersion("chain-summary-final", "row-2", n: 2, ClaimVersionState.Draft));
 
@@ -668,17 +699,40 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
             new AdjudicationResult { AllowedAmount = 50m, PayerPayment = 50m },
             ClaimStatus.Approved);
 
-        result.Outcome.Should().Be(StatusWriteOutcome.Suppressed);
-        result.PersistedStatus.Should().Be(ClaimStatus.Denied);
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        result.PersistedStatus.Should().Be(ClaimStatus.Approved);
 
         var reread = await _repo.GetVersionAsync("chain-summary-final", "row-1");
-        reread!.Status.Should().Be(ClaimStatus.Denied, "a completed disposition must never be re-litigated by a stray write-back");
-        reread.VersionState.Should().Be(ClaimVersionState.Denied);
+        reread!.Status.Should().Be(ClaimStatus.Approved, "a paid summary must not leave a denied lifecycle status behind");
+        reread.VersionState.Should().Be(ClaimVersionState.Adjudicated);
         reread.AdjudicationResult!.PayerPayment.Should().Be(50m);
         reread.AdjudicatedDate.Should().NotBeNull();
 
         var draft = await _repo.GetVersionAsync("chain-summary-final", "row-2");
         draft!.AdjudicationResult.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_onDeniedWithoutDenialEvidence_repairsPaidSummaryStatus()
+    {
+        var head = BuildVersion("chain-summary-repair", "row-1", n: 1, ClaimVersionState.Denied);
+        head.Status = ClaimStatus.Denied;
+        head.AdjudicationResult = null;
+        await _repo.CreateAsync(head);
+
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "chain-summary-repair",
+            new AdjudicationResult { AllowedAmount = 180m, PatientResponsibility = 30m, PayerPayment = 150m },
+            ClaimStatus.Approved);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        result.PersistedStatus.Should().Be(ClaimStatus.Approved);
+
+        var reread = await _repo.GetVersionAsync("chain-summary-repair", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Approved);
+        reread.VersionState.Should().Be(ClaimVersionState.Adjudicated);
+        reread.AdjudicationResult!.PayerPayment.Should().Be(150m);
+        reread.AdjudicationResult.DenialReasonCode.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- repair contradictory Denied + paid adjudication-summary writebacks when the incoming summary has payment and no denial evidence
- apply the same repair path in Cosmos and Mongo repositories while preserving the existing pended/final-disposition guard for normal writebacks
- add repository regression coverage for the paid-status repair and guard behavior

## Validation
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~ClaimRepositoryVersioningTests|FullyQualifiedName~ClaimRepositoryStatusWritebackGuardTests" --logger "console;verbosity=minimal" — 67 passed
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-build --logger "console;verbosity=minimal" — 534 passed
- git diff --check

## MCC sanity
- live local repair check converted the stale MCC clean-paid examples from Denied/Adjudicated contradiction to Approved/Adjudicated with the paid summary preserved
- 1K MCC gate passed cleanly after deploying the repair image locally: 1,000 processed, 0 platform failures, 9/9 expected pends observed, 117/130 workflow checks matched, 0 mismatches, 13 unsupported
- attempted a 10K rerun, but the local cluster slowed after seeding; stopped it rather than report an inconclusive gate