### PR TITLE
Filter MCC claim results by validation status

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -625,10 +625,10 @@ public class ClaimsServiceTests
         var handler = new FakeHandler(HttpStatusCode.OK, "[]");
         var sut = CreateService(new HttpClient(handler));
 
-        await sut.GetMassAdjudicationClaimResultsAsync("run/001", "Business Denial", 5000);
+        await sut.GetMassAdjudicationClaimResultsAsync("run/001", "Business Denial", 5000, "Unsupported");
 
         handler.CapturedUrls.Should().ContainSingle()
-            .Which.Should().Be("http://localhost:5000/mass-adjudication/runs/run%2F001/claims?limit=1000&outcome=Business%20Denial");
+            .Which.Should().Be("http://localhost:5000/mass-adjudication/runs/run%2F001/claims?limit=1000&outcome=Business%20Denial&validationStatus=Unsupported");
     }
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -125,7 +125,7 @@
             <HeaderContent>
                 <MudTh>Run</MudTh>
                 <MudTh>Processed</MudTh>
-                <MudTh>Throughput</MudTh>
+                <MudTh>Claims/sec</MudTh>
                 <MudTh>P95</MudTh>
             </HeaderContent>
             <RowTemplate>
@@ -143,7 +143,7 @@
                                        Color="@(context.PlatformFailures == 0 ? Color.Success : Color.Error)"
                                        Style="width: 90px; height: 6px; border-radius: 3px;" />
                 </MudTd>
-                <MudTd DataLabel="Throughput">
+                <MudTd DataLabel="Claims/sec">
                     <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.ThroughputClaimsPerSecond.ToString("N2")/s</MudText>
                 </MudTd>
                 <MudTd DataLabel="P95">
@@ -187,7 +187,7 @@
                     <MudItem xs="6" md="4">@Metric("Business Denials", $"{_selectedRun.BusinessDenials:N0}", "#ffca28")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Platform Failures", $"{_selectedRun.PlatformFailures:N0}", "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Observation Timeouts", $"{_selectedRun.ObservationTimeouts:N0}", _selectedRun.ObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
-                    <MudItem xs="6" md="4">@Metric("Throughput", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Claims/sec", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
@@ -226,12 +226,14 @@
                     <MudIcon Icon="@Icons.Material.Filled.ManageSearch" Color="Color.Primary" />
                     <MudText Typo="Typo.subtitle2" Style="font-weight: 700;">Claim Results</MudText>
                     <MudSpacer />
-                    <MudSelect T="string" Value="_claimOutcomeFilter" ValueChanged="OnClaimOutcomeFilterChanged"
+                    <MudSelect T="string" Value="_claimResultFilter" ValueChanged="OnClaimResultFilterChanged"
                                Dense="true" Variant="Variant.Outlined" Style="width: 190px;">
-                        <MudSelectItem Value="@("")">All outcomes</MudSelectItem>
+                        <MudSelectItem Value="@("")">All results</MudSelectItem>
                         <MudSelectItem Value="@("Paid")">Paid</MudSelectItem>
                         <MudSelectItem Value="@("Pended")">Pended</MudSelectItem>
                         <MudSelectItem Value="@("BusinessDenial")">Business denials</MudSelectItem>
+                        <MudSelectItem Value="@("validation:Unsupported")">Unsupported</MudSelectItem>
+                        <MudSelectItem Value="@("validation:Mismatched")">Mismatches</MudSelectItem>
                         <MudSelectItem Value="@("ObservationTimeout")">Observation timeouts</MudSelectItem>
                         <MudSelectItem Value="@("PlatformFailure")">Platform failures</MudSelectItem>
                     </MudSelect>
@@ -415,7 +417,7 @@
     private bool _loading;
     private bool _claimResultsLoading;
     private bool _autoRefresh;
-    private string _claimOutcomeFilter = string.Empty;
+    private string _claimResultFilter = string.Empty;
     private string? _error;
     private DateTimeOffset? _lastRefreshedAt;
     private int _newRunsSeen;
@@ -489,13 +491,13 @@
     private async Task SelectRun(MassAdjudicationRunSummary run)
     {
         _selectedRun = run;
-        _claimOutcomeFilter = string.Empty;
+        _claimResultFilter = string.Empty;
         await LoadClaimResults();
     }
 
-    private async Task OnClaimOutcomeFilterChanged(string value)
+    private async Task OnClaimResultFilterChanged(string value)
     {
-        _claimOutcomeFilter = value;
+        _claimResultFilter = value;
         await LoadClaimResults();
     }
 
@@ -516,8 +518,9 @@
         {
             var results = await ClaimsService.GetMassAdjudicationClaimResultsAsync(
                 _selectedRun.Id,
-                string.IsNullOrWhiteSpace(_claimOutcomeFilter) ? null : _claimOutcomeFilter,
-                250);
+                ClaimOutcomeFilter,
+                250,
+                ClaimValidationStatusFilter);
             _claimResults.AddRange(results);
         }
         catch (Exception ex)
@@ -629,6 +632,16 @@
 
     private static string ScenarioCountStyle(int count, string highlightColor)
         => $"font-family: monospace; color: {(count == 0 ? "rgba(255,255,255,0.55)" : highlightColor)};";
+
+    private string? ClaimOutcomeFilter
+        => string.IsNullOrWhiteSpace(_claimResultFilter) || _claimResultFilter.StartsWith("validation:", StringComparison.Ordinal)
+            ? null
+            : _claimResultFilter;
+
+    private string? ClaimValidationStatusFilter
+        => _claimResultFilter.StartsWith("validation:", StringComparison.Ordinal)
+            ? _claimResultFilter["validation:".Length..]
+            : null;
 
     private static string PaymentDeltaColor(decimal? paymentDelta)
         => paymentDelta is null ? "#cbd5e1" : paymentDelta == 0 ? "#00ff88" : "#ffca28";

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -16,7 +16,8 @@ public interface IClaimsService
     Task<List<MassAdjudicationClaimResult>> GetMassAdjudicationClaimResultsAsync(
         string runId,
         string? outcome = null,
-        int limit = 250);
+        int limit = 250,
+        string? validationStatus = null);
     Task<string> SubmitClaimAsync(SubmitClaimRequest request);
     Task UpdateClaimStatusAsync(string claimId, string status, string? notes = null);
     Task<AdjudicationTransparencyData?> GetAdjudicationDataAsync(string claimId);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -147,7 +147,8 @@ public class ClaimsService : IClaimsService
     public async Task<List<MassAdjudicationClaimResult>> GetMassAdjudicationClaimResultsAsync(
         string runId,
         string? outcome = null,
-        int limit = 250)
+        int limit = 250,
+        string? validationStatus = null)
     {
         var baseUrl = _configuration["Services:ClaimsService"];
         try
@@ -156,6 +157,11 @@ public class ClaimsService : IClaimsService
             if (!string.IsNullOrWhiteSpace(outcome))
             {
                 query += $"&outcome={Uri.EscapeDataString(outcome)}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(validationStatus))
+            {
+                query += $"&validationStatus={Uri.EscapeDataString(validationStatus)}";
             }
 
             using var request = CreateMassAdjudicationRequest(

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -43,6 +43,7 @@ public sealed class MassAdjudicationRunsController : ControllerBase
     public async Task<ActionResult<IReadOnlyList<MassAdjudicationClaimResult>>> ListClaimResults(
         string id,
         [FromQuery] string? outcome = null,
+        [FromQuery] string? validationStatus = null,
         [FromQuery] int limit = 250,
         CancellationToken ct = default)
     {
@@ -53,7 +54,7 @@ public sealed class MassAdjudicationRunsController : ControllerBase
             return NotFound();
         }
 
-        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, limit, ct);
+        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, validationStatus, limit, ct);
         return Ok(results);
     }
 

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -12,6 +12,7 @@ public interface IMassAdjudicationRunRepository
         string tenantId,
         string runId,
         string? outcome,
+        string? validationStatus,
         int limit,
         CancellationToken ct = default);
 
@@ -98,6 +99,7 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         string tenantId,
         string runId,
         string? outcome,
+        string? validationStatus,
         int limit,
         CancellationToken ct = default)
     {
@@ -110,6 +112,11 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         if (!string.IsNullOrWhiteSpace(outcome))
         {
             filters.Add(Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.Outcome, outcome));
+        }
+
+        if (!string.IsNullOrWhiteSpace(validationStatus))
+        {
+            filters.Add(Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.ValidationStatus, validationStatus));
         }
 
         return await _claimResults
@@ -194,6 +201,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
         string tenantId,
         string runId,
         string? outcome,
+        string? validationStatus,
         int limit,
         CancellationToken ct = default)
     {
@@ -205,6 +213,11 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
             if (!string.IsNullOrWhiteSpace(outcome))
             {
                 query = query.Where(x => string.Equals(x.Outcome, outcome, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (!string.IsNullOrWhiteSpace(validationStatus))
+            {
+                query = query.Where(x => string.Equals(x.ValidationStatus, validationStatus, StringComparison.OrdinalIgnoreCase));
             }
 
             return Task.FromResult<IReadOnlyList<MassAdjudicationClaimResult>>(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -87,6 +87,60 @@ public class MassAdjudicationRunRepositoryTests
     }
 
     [Fact]
+    public async Task ListClaimResultsAsync_filters_by_outcome_and_validation_status()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var summary = CreateSummary();
+        summary.ClaimResults.AddRange(new[]
+        {
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAID-MATCHED",
+                ClaimType = "Professional",
+                Outcome = "Paid",
+                ValidationStatus = "Matched",
+                ElapsedMilliseconds = 10
+            },
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAID-UNSUPPORTED",
+                ClaimType = "Professional",
+                Outcome = "Paid",
+                ValidationStatus = "Unsupported",
+                ElapsedMilliseconds = 30
+            },
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-DENIAL-UNSUPPORTED",
+                ClaimType = "Professional",
+                Outcome = "BusinessDenial",
+                ValidationStatus = "Unsupported",
+                ElapsedMilliseconds = 20
+            }
+        });
+
+        var saved = await repo.SaveAsync(summary);
+
+        var unsupported = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: null,
+            validationStatus: "Unsupported",
+            limit: 10);
+        var unsupportedPaid = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: "Paid",
+            validationStatus: "Unsupported",
+            limit: 10);
+
+        unsupported.Select(x => x.GeneratedClaimId)
+            .Should().Equal("GEN-PAID-UNSUPPORTED", "GEN-DENIAL-UNSUPPORTED");
+        unsupportedPaid.Should().ContainSingle()
+            .Which.GeneratedClaimId.Should().Be("GEN-PAID-UNSUPPORTED");
+    }
+
+    [Fact]
     public async Task SaveAsync_when_claim_result_insert_fails_deletes_inserted_summary()
     {
         var database = Substitute.For<IMongoDatabase>();


### PR DESCRIPTION
## Summary
- add a validationStatus query filter for mass adjudication claim results
- add Unsupported and Mismatches options to the Mass Adjudication claim-results filter
- rename throughput labels to Claims/sec for clearer dashboard language

## Tests
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter "FullyQualifiedName~ClaimsServiceTests"
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~MassAdjudicationRunRepositoryTests"