### PR TITLE
Prioritize MCC evidence rows in dashboard samples

### DIFF
--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -179,6 +179,7 @@ internal static class MccRunSummaryBuilder
             .Where(IsEvidencePriority)
             .OrderBy(PublishPriority)
             .ThenByDescending(r => r.Elapsed)
+            .ThenBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
             .Take(limit)
             .ToList();
 
@@ -194,6 +195,7 @@ internal static class MccRunSummaryBuilder
         selected.AddRange(results
             .Where(r => !selectedIds.Contains(r.GeneratedClaimId))
             .OrderByDescending(r => r.Elapsed)
+            .ThenBy(r => r.GeneratedClaimId, StringComparer.Ordinal)
             .Take(limit - selected.Count));
 
         return selected;

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -56,9 +56,7 @@ internal static class MccRunSummaryBuilder
             .Take(5)
             .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
             .ToList();
-        var claimResults = results
-            .OrderByDescending(r => r.Elapsed)
-            .Take(options.PublishClaimResultsLimit)
+        var claimResults = SelectPublishedClaimResults(results, options.PublishClaimResultsLimit)
             .Select(r => new MassAdjudicationClaimResult(
                 r.GeneratedClaimId,
                 r.SubmittedClaimId,
@@ -166,6 +164,63 @@ internal static class MccRunSummaryBuilder
             .Cast<MassAdjudicationStageTiming>()
             .OrderByDescending(timing => timing.AverageMilliseconds)
             .ToList();
+    }
+
+    private static IReadOnlyList<ClaimValidationResult> SelectPublishedClaimResults(
+        IReadOnlyList<ClaimValidationResult> results,
+        int limit)
+    {
+        if (limit <= 0)
+        {
+            return Array.Empty<ClaimValidationResult>();
+        }
+
+        var selected = results
+            .Where(IsEvidencePriority)
+            .OrderBy(PublishPriority)
+            .ThenByDescending(r => r.Elapsed)
+            .Take(limit)
+            .ToList();
+
+        if (selected.Count >= limit)
+        {
+            return selected;
+        }
+
+        var selectedIds = selected
+            .Select(r => r.GeneratedClaimId)
+            .ToHashSet(StringComparer.Ordinal);
+
+        selected.AddRange(results
+            .Where(r => !selectedIds.Contains(r.GeneratedClaimId))
+            .OrderByDescending(r => r.Elapsed)
+            .Take(limit - selected.Count));
+
+        return selected;
+    }
+
+    private static bool IsEvidencePriority(ClaimValidationResult result)
+        => PublishPriority(result) < 100;
+
+    private static int PublishPriority(ClaimValidationResult result)
+    {
+        if (result.Outcome is ClaimValidationOutcome.PlatformFailure or ClaimValidationOutcome.ObservationTimeout
+            || result.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus)
+        {
+            return 0;
+        }
+
+        if (result.ValidationStatus == MccWorkflowValidation.MismatchedStatus)
+        {
+            return 1;
+        }
+
+        if (result.ValidationStatus == MccWorkflowValidation.UnsupportedStatus)
+        {
+            return 2;
+        }
+
+        return 100;
     }
 
     private static double Percentile(double[] values, double percentile)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -54,11 +54,40 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(0, behavioral.Unspecified);
     }
 
+    [Fact]
+    public void Build_PrioritizesNonGreenClaimResultsBeforeSlowSuccessfulSamples()
+    {
+        var options = ValidatorOptions.Parse([
+            "--claims", "5",
+            "--claim-results-limit", "3"
+        ]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("MCC-SLOW-MATCHED", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 5_000),
+            Result("MCC-MISMATCH", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
+            Result("MCC-UNSUPPORTED", "EdgeCase:BehavioralHealthCarveOut", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 20),
+            Result("MCC-TIMEOUT", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.ObservationTimeoutStatus, ClaimValidationOutcome.ObservationTimeout, elapsedMilliseconds: 30),
+            Result("MCC-MEDIUM-MATCHED", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000)
+        };
+
+        var summary = MccRunSummaryBuilder.Build(
+            results,
+            TimeSpan.FromSeconds(10),
+            options,
+            DateTimeOffset.Parse("2026-07-07T00:00:00Z"),
+            DateTimeOffset.Parse("2026-07-07T00:00:10Z"));
+
+        Assert.Equal(
+            ["MCC-TIMEOUT", "MCC-MISMATCH", "MCC-UNSUPPORTED"],
+            summary.ClaimResults.Select(r => r.GeneratedClaimId).ToArray());
+    }
+
     private static ClaimValidationResult Result(
         string claimId,
         string? scenario,
         string validationStatus,
-        ClaimValidationOutcome outcome)
+        ClaimValidationOutcome outcome,
+        double elapsedMilliseconds = 100)
     {
         return new ClaimValidationResult(
             claimId,
@@ -72,7 +101,7 @@ public class MccRunSummaryBuilderTests
             outcome is ClaimValidationOutcome.Paid,
             outcome is ClaimValidationOutcome.Paid ? 100m : null,
             outcome is ClaimValidationOutcome.Paid ? 100m : null,
-            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(elapsedMilliseconds),
             TimeSpan.FromMilliseconds(10),
             TimeSpan.FromMilliseconds(80),
             TimeSpan.FromMilliseconds(10),

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -58,16 +58,18 @@ public class MccRunSummaryBuilderTests
     public void Build_PrioritizesNonGreenClaimResultsBeforeSlowSuccessfulSamples()
     {
         var options = ValidatorOptions.Parse([
-            "--claims", "5",
-            "--claim-results-limit", "3"
+            "--claims", "7",
+            "--claim-results-limit", "5"
         ]);
         var results = new List<ClaimValidationResult>
         {
             Result("MCC-SLOW-MATCHED", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 5_000),
-            Result("MCC-MISMATCH", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
+            Result("MCC-MISMATCH-B", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
+            Result("MCC-MISMATCH-A", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
             Result("MCC-UNSUPPORTED", "EdgeCase:BehavioralHealthCarveOut", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 20),
             Result("MCC-TIMEOUT", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.ObservationTimeoutStatus, ClaimValidationOutcome.ObservationTimeout, elapsedMilliseconds: 30),
-            Result("MCC-MEDIUM-MATCHED", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000)
+            Result("MCC-MEDIUM-MATCHED-B", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000),
+            Result("MCC-MEDIUM-MATCHED-A", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000)
         };
 
         var summary = MccRunSummaryBuilder.Build(
@@ -78,7 +80,7 @@ public class MccRunSummaryBuilderTests
             DateTimeOffset.Parse("2026-07-07T00:00:10Z"));
 
         Assert.Equal(
-            ["MCC-TIMEOUT", "MCC-MISMATCH", "MCC-UNSUPPORTED"],
+            ["MCC-TIMEOUT", "MCC-MISMATCH-A", "MCC-MISMATCH-B", "MCC-UNSUPPORTED", "MCC-SLOW-MATCHED"],
             summary.ClaimResults.Select(r => r.GeneratedClaimId).ToArray());
     }
 


### PR DESCRIPTION
## Summary
- publish MCC claim-result samples with evidence rows first: platform/observation failures, mismatches, then unsupported claims
- fill the remaining sample budget with the slowest claims for latency triage
- add regression coverage so non-green evidence is not crowded out by slow successful claims

## Tests
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj