### PR TITLE
fix: route discovery call links to contact page

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -838,7 +838,7 @@
           </button>
 
           <div style="text-align:center;">
-            <a href="[CALENDAR_LINK]" class="schedule-link">Prefer to talk first? Schedule a discovery call &rarr;</a>
+            <a href="/contact" class="schedule-link">Prefer to talk first? Schedule a discovery call &rarr;</a>
           </div>
 
           <p style="text-align:center; margin-top:16px; font-size:0.82rem; color:rgba(128,128,128,0.5);">
@@ -861,7 +861,7 @@
             Thank you &mdash; we&rsquo;ll respond personally within 2 business days. Questions in the meantime? Email clients@cloudhealthoffice.com
           </p>
           <p style="margin-top: 20px; font-size: 0.85rem; color: rgba(128,128,128,0.6);">
-            Prefer to talk first? <a href="[CALENDAR_LINK]" style="color:#00ff88;">Schedule a discovery call &rarr;</a>
+            Prefer to talk first? <a href="/contact" style="color:#00ff88;">Schedule a discovery call &rarr;</a>
           </p>
         </div>
       </div>
@@ -1299,7 +1299,7 @@
         <a href="/cms-0057f-compliance" class="button button-secondary">Read the CMS-0057-F Guide &rarr;</a>
       </div>
       <div>
-        <a href="[CALENDAR_LINK]" class="schedule-link">Prefer to talk first? Schedule a discovery call &rarr;</a>
+        <a href="/contact" class="schedule-link">Prefer to talk first? Schedule a discovery call &rarr;</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- replace homepage `[CALENDAR_LINK]` placeholders with the existing `/contact` route
- fixes 404s from Schedule a discovery call links

## Validation
- ran `npm run build` in `src/site`
- verified no `CALENDAR_LINK` placeholders remain in `src/site`