### PR TITLE
docs: align MCC proof with Part 7 evidence

### DIFF
--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -240,7 +240,7 @@ EDI coverage via Argo workflows: 270/271/275/276/277/278/834/837.
 - Argo-orchestrated adjudication workflow (`infrastructure/argo-workflows/claims-adjudication-workflow.yaml`) wiring the pipeline end-to-end.
 - Per-tenant multi-tenancy enforced across services, databases (Cosmos DB partitions), secrets (Key Vault namespacing), and Kafka topics.
 - Portal under `src/portal/` for operational workflows across tenants, services, and operating modes.
-- `fhir-service` CapabilityStatement advertising CHO-authored profiles in addition to US Core.
+- `fhir-service` CapabilityStatement advertising Cloud Health Office-authored profiles in addition to US Core.
 - Observability stack (OpenTelemetry with PHI-scrubbing SpanProcessor, merged in PR #666) applied across services.
 - Million Claim Challenge local Kubernetes validation: a clean 50,000-claim breadth run with 50,000 claims processed, zero platform failures, 460/460 expected-pend claims observed as pended, 5,767/6,500 workflow checks matched, zero scoreable workflow mismatches, and 733 unsupported scenarios reported separately. The run completed at 68.86 claims/sec with 298 ms P95 and 369 ms P99 latency in local Docker Desktop Kubernetes with Docker allocated 18 CPUs and roughly 23.4 GiB memory. This is a local validation benchmark, not a production cloud benchmark. Part 7 added the portal Mass Adjudication console so run summaries, unsupported rows, mismatches, payment delta, and claim-level evidence are visible inside the product.
 
@@ -364,11 +364,11 @@ We are not in an active acquisition process. We are building the platform with t
 
 *Last verified: July 2026*
 
-These are the ground-truth numbers for CHO as of the most recent verification. Any artifact citing service counts, engine counts, test counts, or documentation volume should reconcile to this section. When these numbers drift from reality, update this section first; derivative artifacts then reconcile to it.
+These are the ground-truth numbers for Cloud Health Office as of the most recent verification. Any artifact citing service counts, engine counts, test counts, or documentation volume should reconcile to this section. When these numbers drift from reality, update this section first; derivative artifacts then reconcile to it.
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| Service projects | 36 | `src/services/*/`, including the shared contracts project |
+| Service projects | 36 | `src/services/*/`, including shared projects such as contracts, infrastructure, and events |
 | Adjudication/rules engines | 9 | BenefitEngine, FeeScheduleEngine, NcciEngine, CobEngine, RiskAdjustmentEngine, EncounterEngine, ClaimsScrubEngine, PriorAuthRuleEngine, ProviderVerificationEngine |
 | Supporting engine projects | 4 | DocumentStore, OperatingMode, ProviderEnrollmentService, enrollment-wiring |
 | Test projects | 45 | `*.Tests.csproj` files |

--- a/docs/POSITIONING.md
+++ b/docs/POSITIONING.md
@@ -242,7 +242,7 @@ EDI coverage via Argo workflows: 270/271/275/276/277/278/834/837.
 - Portal under `src/portal/` for operational workflows across tenants, services, and operating modes.
 - `fhir-service` CapabilityStatement advertising CHO-authored profiles in addition to US Core.
 - Observability stack (OpenTelemetry with PHI-scrubbing SpanProcessor, merged in PR #666) applied across services.
-- Million Claim Challenge local Kubernetes validation: 50,000 synthetic claims processed on a repeat adjudication run at 188.64 claims/sec, 106 ms P95, 151 ms P99, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. This ran in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, which makes the useful throughput frame roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is a local validation benchmark, not a production cloud benchmark.
+- Million Claim Challenge local Kubernetes validation: a clean 50,000-claim breadth run with 50,000 claims processed, zero platform failures, 460/460 expected-pend claims observed as pended, 5,767/6,500 workflow checks matched, zero scoreable workflow mismatches, and 733 unsupported scenarios reported separately. The run completed at 68.86 claims/sec with 298 ms P95 and 369 ms P99 latency in local Docker Desktop Kubernetes with Docker allocated 18 CPUs and roughly 23.4 GiB memory. This is a local validation benchmark, not a production cloud benchmark. Part 7 added the portal Mass Adjudication console so run summaries, unsupported rows, mismatches, payment delta, and claim-level evidence are visible inside the product.
 
 #### Who enters here
 
@@ -285,14 +285,15 @@ The Million Claim Challenge is a source-available benchmarking asset (BSL 1.1, s
 
 We generate a stratified synthetic corpus of 1,000,000 healthcare claims — professional CMS-1500, institutional UB-04, dental ADA, and named edge-case scenarios — with pre-computed expected adjudication outcomes. Any claims adjudication engine can be benchmarked against the corpus and scored against the expected outcomes.
 
-Latest Cloud Health Office proof point: in local Docker Desktop Kubernetes with Docker allocated 18 CPUs, Cloud Health Office processed 50,000 synthetic claims on a repeat adjudication run at 188.64 claims/sec, with 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 deterministic workflow checks matched. That is roughly 10.5 claims/sec per allocated CPU for the measured workflow. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, and workflow correctness are measured together.
+Latest Cloud Health Office proof point: in local Docker Desktop Kubernetes with Docker allocated 18 CPUs and roughly 23.4 GiB memory, Cloud Health Office processed 50,000 synthetic claims with broader edge-case scoring, zero platform failures, 460/460 expected-pend claims observed as pended, 5,767/6,500 workflow checks matched, zero scoreable workflow mismatches, and 733 unsupported scenarios reported separately. The run completed at 68.86 claims/sec with 298 ms P95 latency and 369 ms P99 latency. This is intentionally framed as local validation, not a production cloud benchmark. Its value is that throughput, tail latency, platform reliability, workflow correctness, pended observation, and unsupported gaps are measured together.
 
-The published result should not be overstated. The MCC corpus is designed for 1,000,000 claims and 29 named edge-case scenarios; the latest published Cloud Health Office validation is a 50,000-claim local run with deterministic workflow checks across four core dispositions: clean paid, excluded provider, uncovered service, and prior authorization. The next proof priority is breadth before volume: publish a run that exercises more of the 29 edge scenarios, then extend volume to 250K, 500K, and the full million.
+The published result should not be overstated. The MCC corpus is designed for 1,000,000 claims and 29 named edge-case scenarios; the latest Cloud Health Office validation proves a 50,000-claim local breadth run, not the full million. Payment delta is visible but remains diagnostic, not a formal amount-level pass/fail scoring gate. Expected-pend observation proves expected-pend claims persisted as pended, but a future false-pend sweep is still needed to catch claims expected to pay or deny that later persist as pended. The next proof priority is stricter scoring before a larger headline: rerun 50K with the Part 7 evidence-first console path, add false-pend and payment-amount gates, then make 100K its own focused milestone.
 
 ### What we offer
 
 - `src/CloudHealthOffice.BenchmarkClaimGenerator/` — full .NET 8 library for parallel corpus generation.
 - `/docs/million-claim-challenge` — public landing page at cloudhealthoffice.com describing the benchmark.
+- Portal Mass Adjudication console — operator-facing run evidence with claim-level drilldown, validation-status filtering, human-readable MCC claim IDs, and evidence-first sampling for failures, observation failures, mismatches, unsupported rows, and slow claims.
 - `docs/million-claim-challenge/podcast/` — repeatable podcast packet workflow for turning Medium articles, pull requests, benchmark results, screenshots, and project context into Adobe Podcast / Acrobat Generate Podcast source material.
 - Reference data coverage across procedure codes, diagnosis codes, dental codes, taxonomy codes, modifier sets, revenue codes, network tiers, and benefit plan templates.
 - Dedicated Cosmos DB seeder scaffold (`CosmosDbSeeder`) for running the corpus against production-shape infrastructure — provides document-shape and adapter wiring; actual Cosmos DB persistence requires a concrete implementation or separate package (the base `WriteDocumentsAsync` is a no-op stub by design).
@@ -361,19 +362,19 @@ We are not in an active acquisition process. We are building the platform with t
 
 ## Canonical Facts
 
-*Last verified: April 2026*
+*Last verified: July 2026*
 
 These are the ground-truth numbers for CHO as of the most recent verification. Any artifact citing service counts, engine counts, test counts, or documentation volume should reconcile to this section. When these numbers drift from reality, update this section first; derivative artifacts then reconcile to it.
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| Services | 36 | `src/services/*/` excluding `shared/` |
+| Service projects | 36 | `src/services/*/`, including the shared contracts project |
 | Adjudication/rules engines | 9 | BenefitEngine, FeeScheduleEngine, NcciEngine, CobEngine, RiskAdjustmentEngine, EncounterEngine, ClaimsScrubEngine, PriorAuthRuleEngine, ProviderVerificationEngine |
 | Supporting engine projects | 4 | DocumentStore, OperatingMode, ProviderEnrollmentService, enrollment-wiring |
-| Test projects | 44 | `*.Tests.csproj` files |
-| Test methods | ~2,800 | xUnit Facts + Theories |
-| Production C# lines | ~136,000 | Excluding tests, bin, obj |
-| Documentation lines | ~94,000 | Markdown under `docs/` |
+| Test projects | 45 | `*.Tests.csproj` files |
+| Test methods | ~4,100 | xUnit Facts + Theories |
+| Production C# lines | ~190,000 | Excluding tests, bin, obj, and migrations |
+| Documentation lines | ~108,000 | Markdown and text under `docs/` |
 | Pricing framework | PMPM-based, pilot-specific | See FINANCIAL-MODEL.md for indicative ranges |
 
 Verification procedure documented at `scripts/verify-canonical-facts.sh` (to be created in a follow-up PR). Numbers should be re-verified at each major release and when the Canonical Facts section is cited by another artifact.

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -18,7 +18,7 @@
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png" />
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="article:published_time" content="2026-04-05T00:00:00Z" />
-  <meta property="article:modified_time" content="2026-07-06T00:00:00Z" />
+  <meta property="article:modified_time" content="2026-07-11T00:00:00Z" />
   <meta property="article:section" content="Testing &amp; Benchmarks" />
   <meta property="article:tag" content="claims adjudication" />
   <meta property="article:tag" content="benchmarking" />
@@ -49,7 +49,7 @@
       "logo": { "@type": "ImageObject", "url": "https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" }
     },
     "datePublished": "2026-04-05",
-    "dateModified": "2026-07-06",
+    "dateModified": "2026-07-11",
     "proficiencyLevel": "Intermediate",
     "about": [
       { "@type": "Thing", "name": "Claims Adjudication" },
@@ -291,20 +291,20 @@
         <div class="callout callout-success">
           <div class="callout-title">Latest local Kubernetes validation</div>
           <p>
-            Cloud Health Office processed <strong>50,000 synthetic claims</strong> in local Docker Desktop Kubernetes with Docker allocated 18 CPUs at
-            <strong>188.64 claims/sec</strong> on a repeat adjudication run with provider seeding skipped.
-            The run held <strong>106 ms P95</strong>, <strong>151 ms P99</strong>, <strong>zero platform failures</strong>,
-            and <strong>4,000/4,000 deterministic workflow checks matched</strong>.
+            Cloud Health Office processed <strong>50,000 synthetic claims</strong> in local Docker Desktop Kubernetes with Docker allocated 18 CPUs and roughly 23.4 GiB memory.
+            The clean breadth run completed at <strong>68.86 claims/sec</strong> with <strong>298 ms P95</strong>, <strong>369 ms P99</strong>,
+            <strong>zero platform failures</strong>, <strong>460/460 expected-pend claims observed as pended</strong>,
+            <strong>5,767/6,500 workflow checks matched</strong>, and <strong>zero scoreable workflow mismatches</strong>.
           </p>
           <p>
-            Framed per allocated CPU, that is roughly <strong>10.5 claims/sec per allocated CPU</strong> for the measured workflow.
-            This is a local validation benchmark, not a production cloud benchmark. Its value is repeatability:
-            throughput, tail latency, platform reliability, and workflow correctness measured together.
+            The run also reported <strong>733 unsupported scenarios</strong> separately instead of counting them as wins or failures.
+            This is a local validation benchmark, not a production cloud benchmark. Its value is honesty:
+            throughput, tail latency, platform reliability, pended observation, workflow correctness, unsupported gaps, and payment delta visible together.
           </p>
           <p>
             Scope matters: the MCC corpus is designed for one million claims and 29 named edge-case scenarios.
-            This published Cloud Health Office run proves a 50K local slice with deterministic checks across four core dispositions:
-            clean paid, excluded provider, uncovered service, and prior authorization.
+            This published Cloud Health Office run proves a 50K local breadth slice, not the full million.
+            Payment delta is still diagnostic, and false-pend detection across expected-pay and expected-deny claims remains a future scoring improvement.
           </p>
         </div>
 
@@ -334,11 +334,13 @@
         <div class="callout callout-success">
           <div class="callout-title">From local Kubernetes to workflow proof</div>
           <p>
-            We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, stage-level timing, repeatable sweep runs, and a max-claims override for larger local validations.
+            We recently walked through the local Kubernetes path, used generated claims to validate real platform workflows end to end, then added provider seeding, tenant-aware integrity checks, stage-level timing, repeatable sweep runs, honest edge-case scoring, and an operator-facing Mass Adjudication console.
             Read the field notes:
-            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>,
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>,
+            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">Part 6: From Fast Runs to Honest Edge-Case Scoring</a>,
             and
-            <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>.
+            <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-007/article.txt" target="_blank" rel="noopener noreferrer">Part 7: From Benchmark Logs to an Operator Console</a>.
           </p>
         </div>
 
@@ -347,14 +349,14 @@
 
         <p>
           MCC is not only a generator. We use it as a repeatable validation loop for Cloud Health Office itself.
-          The latest published local result comes from Docker Desktop Kubernetes with Docker allocated 18 CPUs
-          and approximately 24 GB of memory. The raw throughput is less important than the shape of the measurement:
-          about 10.5 claims/sec per allocated CPU, tail latency reported with the run, and correctness checks kept in the same artifact.
+          The latest published scale result comes from Docker Desktop Kubernetes with Docker allocated 18 CPUs
+          and roughly 23.4 GiB of memory. The raw throughput is less important than the shape of the measurement:
+          tail latency, platform failures, expected pends, workflow checks, unsupported scenarios, and payment delta kept in the same artifact.
         </p>
 
         <table>
           <thead>
-            <tr><th>Run</th><th>Claims</th><th>Throughput</th><th>P95</th><th>P99</th><th>Platform Failures</th><th>Workflow Checks</th></tr>
+            <tr><th>Run</th><th>Claims</th><th>Throughput</th><th>P95</th><th>P99</th><th>Platform Failures</th><th>Workflow / Evidence</th></tr>
           </thead>
           <tbody>
             <tr>
@@ -385,13 +387,31 @@
               <td>4,000/4,000 matched</td>
             </tr>
             <tr>
-              <td><strong>50,000 repeat adjudication run, p=10</strong></td>
+              <td><strong>50,000 repeat throughput run, p=10</strong></td>
               <td>50,000</td>
               <td>188.64 claims/sec</td>
               <td>106 ms</td>
               <td>151 ms</td>
               <td>0</td>
-              <td>4,000/4,000 matched</td>
+              <td>4,000/4,000 matched; historical throughput baseline</td>
+            </tr>
+            <tr>
+              <td><strong>50,000 breadth validation, p=10</strong></td>
+              <td>50,000</td>
+              <td>68.86 claims/sec</td>
+              <td>298 ms</td>
+              <td>369 ms</td>
+              <td>0</td>
+              <td>5,767/6,500 matched; 0 mismatches; 733 unsupported; 460/460 expected pends observed</td>
+            </tr>
+            <tr>
+              <td><strong>5,000 console evidence run, p=10</strong></td>
+              <td>5,000</td>
+              <td>37.90 claims/sec</td>
+              <td>384 ms</td>
+              <td>466 ms</td>
+              <td>0</td>
+              <td>577/650 matched; 0 mismatches; 73 unsupported; evidence-first sample visible in portal</td>
             </tr>
           </tbody>
         </table>
@@ -401,7 +421,8 @@
           <p>
             The first 50,000-claim run includes provider seeding, which answers whether a local environment can prepare itself and process the workload correctly.
             The repeat run skips provider seeding against an already-prepared tenant, which gives a cleaner view of steady-state adjudication throughput.
-            Both are useful; they answer different questions.
+            The later breadth run answers a different question: whether more edge-case scenarios can be scored honestly, with unsupported gaps separated from mismatches.
+            All three are useful; they answer different questions.
           </p>
         </div>
 
@@ -415,12 +436,11 @@
           <div class="callout-title">Current proof vs benchmark design</div>
           <p>
             The benchmark design is the full million-claim corpus with 29 named edge-case scenarios and target scoring tiers.
-            The latest published Cloud Health Office result is narrower: a 50,000-claim local Kubernetes validation with
-            workflow checks across four deterministic dispositions. That gap is intentional and public.
+            The latest published Cloud Health Office result is narrower: a 50,000-claim local Kubernetes breadth validation with
+            pended observation, zero scoreable workflow mismatches, unsupported scenarios reported separately, and payment delta visible as a diagnostic. That gap is intentional and public.
           </p>
           <p>
-            Our next proof milestone is not just a larger run. It is broader accuracy coverage across more of the 29 edge scenarios,
-            followed by 250K, 500K, and full-million adjudication runs so the evidence catches up to the name.
+            Our next proof milestone is not just a larger run. It is stricter scoring: a false-pend sweep across expected-pay and expected-deny claims, a formal amount-level payment gate, a fresh 50K evidence-first console run, and then a focused 100K milestone before 250K, 500K, and full-million adjudication runs.
           </p>
         </div>
 

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1202,15 +1202,15 @@
         </div>
         <div class="stat-item">
           <span class="stat-number">50K</span>
-          <span class="stat-label">MCC Claims<br>Validated Locally</span>
+          <span class="stat-label">MCC Breadth<br>Run</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">188.64/s</span>
-          <span class="stat-label">Repeat Adjudication<br>Throughput</span>
+          <span class="stat-number">0</span>
+          <span class="stat-label">Scoreable<br>Mismatches</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">~10.5/s</span>
-          <span class="stat-label">Claims Per<br>Allocated CPU</span>
+          <span class="stat-number">5,767</span>
+          <span class="stat-label">Workflow Checks<br>Matched</span>
         </div>
       </div>
     </section>
@@ -1221,7 +1221,7 @@
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
           <h2 class="section-title">1,000,000 claims. One shared yardstick.</h2>
-          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published Cloud Health Office proof is a 50K local Kubernetes validation, with broader edge-case coverage next.</p>
+          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published Cloud Health Office proof is a 50K local Kubernetes breadth run with zero scoreable mismatches and unsupported gaps reported separately.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">
@@ -1234,12 +1234,12 @@
             <span class="stat-label">Edge Case<br>Scenarios</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">4</span>
-            <span class="stat-label">Published Core<br>Dispositions</span>
+            <span class="stat-number">733</span>
+            <span class="stat-label">Unsupported<br>Separated</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">250K+</span>
-            <span class="stat-label">Next Volume<br>Milestone</span>
+            <span class="stat-number">100K</span>
+            <span class="stat-label">Next Focused<br>Milestone</span>
           </div>
         </div>
 

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -291,36 +291,36 @@
 
         <article class="engineering-proof">
           <div class="proof-meta">Million Claim Challenge &middot; Local Kubernetes validation</div>
-          <h3>From Faster to Repeatably Faster</h3>
+          <h3>From Fast Runs to Inspectable Evidence</h3>
           <p>
-            Cloud Health Office moved from one-off fast local runs to repeatable claims adjudication benchmarks:
-            configurable Kubernetes Jobs, parallelism sweeps, repeated runs, hidden-cap detection, and workflow correctness checks reported alongside throughput.
-            The latest published result is a 50K local Kubernetes validation on 18 allocated Docker CPUs, not a production cloud benchmark.
+            Cloud Health Office moved from repeatable throughput runs into broader edge-case scoring and operator-visible evidence:
+            expected pends are observed from persisted claim status, unsupported scenarios are separated from mismatches, and the Mass Adjudication console can inspect run summaries and claim-level evidence.
+            The latest published scale result is a 50K local Kubernetes breadth validation on 18 allocated Docker CPUs, not a production cloud benchmark.
           </p>
 
           <div class="proof-metrics" aria-label="Latest Million Claim Challenge local benchmark metrics">
             <div class="proof-metric">
               <strong>50,000</strong>
-              <span>synthetic claims processed</span>
+              <span>synthetic claims processed in the clean breadth run</span>
             </div>
             <div class="proof-metric">
-              <strong>188.64 claims/sec</strong>
-              <span>repeat throughput, about 10.5 claims/sec per allocated CPU</span>
+              <strong>5,767 / 6,500</strong>
+              <span>workflow checks matched with zero scoreable mismatches</span>
             </div>
             <div class="proof-metric">
-              <strong>106 ms / 151 ms</strong>
-              <span>P95 and P99 latency</span>
+              <strong>460 / 460</strong>
+              <span>expected-pend claims observed as pended</span>
             </div>
             <div class="proof-metric">
-              <strong>4,000/4,000</strong>
-              <span>checks matched across four core dispositions</span>
+              <strong>733</strong>
+              <span>unsupported scenarios reported separately</span>
             </div>
           </div>
 
           <p>
             The benchmark distinguishes valid business denials from platform failures. Correct denials are not errors;
-            they are evidence that benefit rules, provider checks, prior authorization logic, and adjudication outcomes are being applied consistently.
-            The next proof milestone is broader coverage across the MCC's 29 edge-case scenarios before pushing toward 250K, 500K, and full-million adjudication runs.
+            unsupported scenarios are not wins; and payment delta remains visible as a diagnostic until amount-level scoring becomes a formal gate.
+            The next proof milestone is 100K with stricter scoring, not scale for scale's sake.
           </p>
           <p style="font-size:0.95rem;color:#888;">
             Local Docker Desktop Kubernetes benchmark, not a production cloud benchmark.


### PR DESCRIPTION
## Summary
- Update canonical positioning to lead with the Part 6 clean 50K breadth result and Part 7 operator-console evidence path
- Refresh homepage and insights MCC proof language away from the older throughput-only framing
- Update the public Million Claim Challenge docs with breadth validation, unsupported separation, pended observation, payment-delta caveat, and 100K next milestone framing

## Verification
- npm run build (src/site)
- git diff --check