### PR TITLE
Add in-progress MCC run telemetry

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -103,6 +103,12 @@
     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">
         @RefreshStatus
     </MudText>
+    @if (_runs.Any(IsRunActive))
+    {
+        <MudChip T="string" Color="Color.Info" Size="Size.Small" Icon="@Icons.Material.Filled.Sync">
+            @_runs.Count(IsRunActive) running
+        </MudChip>
+    }
     <MudSpacer />
     @if (_selectedRun is not null)
     {
@@ -136,6 +142,12 @@
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
                         @($"{ShortId(context.Id)} · p{context.Run.Parallelism}")
                     </MudText>
+                    @if (IsRunActive(context))
+                    {
+                        <MudChip T="string" Size="Size.Small" Color="Color.Info" Icon="@Icons.Material.Filled.Sync" Class="mt-1">
+                            @RunStatusLabel(context)
+                        </MudChip>
+                    }
                 </MudTd>
                 <MudTd DataLabel="Processed">
                     <MudText Typo="Typo.body2">@context.Processed.ToString("N0") / @context.TotalClaims.ToString("N0")</MudText>
@@ -181,6 +193,26 @@
                 </div>
 
                 <MudGrid Spacing="2" Class="mb-3">
+                    @if (IsRunActive(_selectedRun))
+                    {
+                        <MudItem xs="12">
+                            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-1">
+                                <div class="d-flex align-center gap-2">
+                                    <MudText Typo="Typo.body2">
+                                        @RunStatusLabel(_selectedRun): @_selectedRun.Progress?.CompletedClaims.ToString("N0") of @_selectedRun.TotalClaims.ToString("N0") claims observed
+                                    </MudText>
+                                    <MudSpacer />
+                                    <MudText Typo="Typo.caption" Style="font-family: monospace;">
+                                        @LastProgressText(_selectedRun)
+                                    </MudText>
+                                </div>
+                                <MudProgressLinear Value="@PercentProcessed(_selectedRun)"
+                                                   Color="Color.Info"
+                                                   Class="mt-2"
+                                                   Style="height: 6px; border-radius: 3px;" />
+                            </MudAlert>
+                        </MudItem>
+                    }
                     <MudItem xs="6" md="4">@Metric("Processed", $"{_selectedRun.Processed:N0}", "#00ffff")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Paid", $"{_selectedRun.Paid:N0}", "#00ff88")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Pended", $"{_selectedRun.Pended:N0}", "#ffca28")</MudItem>
@@ -194,6 +226,11 @@
                     <MudItem xs="6" md="4">@Metric("Unsupported", $"{_selectedRun.WorkflowUnsupported:N0}", "#cbd5e1")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta))</MudItem>
+                    @if (_selectedRun.Progress is not null)
+                    {
+                        <MudItem xs="6" md="4">@Metric("Run Status", RunStatusLabel(_selectedRun), IsRunActive(_selectedRun) ? "#7dd3fc" : "#00ff88")</MudItem>
+                        <MudItem xs="6" md="4">@Metric("Last Progress", LastProgressText(_selectedRun), "#cbd5e1")</MudItem>
+                    }
                 </MudGrid>
 
                 <MudGrid Spacing="2" Class="mb-3">
@@ -609,6 +646,33 @@
 
     private static double PercentProcessed(MassAdjudicationRunSummary run)
         => run.TotalClaims <= 0 ? 0 : (double)run.Processed / run.TotalClaims * 100;
+
+    private static bool IsRunActive(MassAdjudicationRunSummary run)
+        => string.Equals(run.Status, "Running", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(run.Progress?.Phase, "Processing claims", StringComparison.OrdinalIgnoreCase);
+
+    private static string RunStatusLabel(MassAdjudicationRunSummary run)
+    {
+        if (!string.IsNullOrWhiteSpace(run.Progress?.Phase) && IsRunActive(run))
+        {
+            return run.Progress.Phase;
+        }
+
+        return string.IsNullOrWhiteSpace(run.Status) ? "Completed" : run.Status;
+    }
+
+    private static string LastProgressText(MassAdjudicationRunSummary run)
+    {
+        var timestamp = run.Progress?.LastPublishedAtUtc;
+        if (timestamp is null || timestamp.Value == default)
+        {
+            return run.LastUpdatedAtUtc == default
+                ? "not published yet"
+                : run.LastUpdatedAtUtc.ToLocalTime().ToString("HH:mm:ss");
+        }
+
+        return timestamp.Value.LocalDateTime.ToString("HH:mm:ss");
+    }
 
     private double DenialPercent(int count)
         => _selectedRun is null || _selectedRun.BusinessDenials <= 0

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -133,7 +133,7 @@ public class MassAdjudicationRunMetadata
 
 public class MassAdjudicationRunProgress
 {
-    public string Phase { get; set; } = "Running";
+    public string Phase { get; set; } = "Processing claims";
     public int RequestedClaims { get; set; }
     public int CompletedClaims { get; set; }
     public int ProcessedClaims { get; set; }

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -80,6 +80,7 @@ public class MemberAccumulators
 public class MassAdjudicationRunSummary
 {
     public string Id { get; set; } = string.Empty;
+    public string Status { get; set; } = "Completed";
     public MassAdjudicationRunMetadata Run { get; set; } = new();
     public int TotalClaims { get; set; }
     public int Processed { get; set; }
@@ -107,6 +108,8 @@ public class MassAdjudicationRunSummary
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
     public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; }
+    public DateTime LastUpdatedAtUtc { get; set; }
+    public MassAdjudicationRunProgress? Progress { get; set; }
 }
 
 public class MassAdjudicationRunMetadata
@@ -126,6 +129,20 @@ public class MassAdjudicationRunMetadata
     public int LineOfBusiness { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationRunProgress
+{
+    public string Phase { get; set; } = "Running";
+    public int RequestedClaims { get; set; }
+    public int CompletedClaims { get; set; }
+    public int ProcessedClaims { get; set; }
+    public int PlatformFailures { get; set; }
+    public double PercentComplete { get; set; }
+    public double CurrentThroughputClaimsPerSecond { get; set; }
+    public double RollingP95LatencyMilliseconds { get; set; }
+    public double RollingP99LatencyMilliseconds { get; set; }
+    public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 
 public class MassAdjudicationStageTiming

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -5,6 +5,7 @@ namespace ClaimsService.Models;
 public class MassAdjudicationRunSummary
 {
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string Status { get; set; } = "Completed";
     public MassAdjudicationRunMetadata Run { get; set; } = new();
     public int TotalClaims { get; set; }
     public int Processed { get; set; }
@@ -33,6 +34,8 @@ public class MassAdjudicationRunSummary
     [BsonIgnore]
     public List<MassAdjudicationClaimResult> ClaimResults { get; set; } = new();
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime LastUpdatedAtUtc { get; set; } = DateTime.UtcNow;
+    public MassAdjudicationRunProgress? Progress { get; set; }
 }
 
 public class MassAdjudicationRunMetadata
@@ -52,6 +55,20 @@ public class MassAdjudicationRunMetadata
     public int LineOfBusiness { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationRunProgress
+{
+    public string Phase { get; set; } = "Running";
+    public int RequestedClaims { get; set; }
+    public int CompletedClaims { get; set; }
+    public int ProcessedClaims { get; set; }
+    public int PlatformFailures { get; set; }
+    public double PercentComplete { get; set; }
+    public double CurrentThroughputClaimsPerSecond { get; set; }
+    public double RollingP95LatencyMilliseconds { get; set; }
+    public double RollingP99LatencyMilliseconds { get; set; }
+    public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 
 public class MassAdjudicationStageTiming

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -59,7 +59,7 @@ public class MassAdjudicationRunMetadata
 
 public class MassAdjudicationRunProgress
 {
-    public string Phase { get; set; } = "Running";
+    public string Phase { get; set; } = "Processing claims";
     public int RequestedClaims { get; set; }
     public int CompletedClaims { get; set; }
     public int ProcessedClaims { get; set; }

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -37,8 +37,18 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
     public async Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
     {
-        summary.Id = Guid.NewGuid().ToString("N");
-        summary.CreatedAtUtc = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
+        if (string.IsNullOrWhiteSpace(summary.Id))
+        {
+            summary.Id = Guid.NewGuid().ToString("N");
+        }
+
+        if (summary.CreatedAtUtc == default)
+        {
+            summary.CreatedAtUtc = now;
+        }
+
+        summary.LastUpdatedAtUtc = now;
 
         var claimResults = summary.ClaimResults;
         foreach (var result in claimResults)
@@ -49,19 +59,31 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
             result.CreatedAtUtc = summary.CreatedAtUtc;
         }
 
-        await _collection.InsertOneAsync(summary, cancellationToken: ct);
+        var runFilter = Builders<MassAdjudicationRunSummary>.Filter.And(
+            Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Run.TenantId, summary.Run.TenantId),
+            Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Id, summary.Id));
+
+        await _collection.ReplaceOneAsync(
+            runFilter,
+            summary,
+            new ReplaceOptions { IsUpsert = true },
+            ct);
+
         if (claimResults.Count > 0)
         {
             try
             {
+                var resultFilter = Builders<MassAdjudicationClaimResult>.Filter.And(
+                    Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, summary.Run.TenantId),
+                    Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.RunId, summary.Id));
+                await _claimResults.DeleteManyAsync(resultFilter, ct);
                 await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
             }
             catch
             {
                 try
                 {
-                    var filter = Builders<MassAdjudicationRunSummary>.Filter.Eq(x => x.Id, summary.Id);
-                    await _collection.DeleteOneAsync(filter, cancellationToken: ct);
+                    await _collection.DeleteOneAsync(runFilter, cancellationToken: ct);
                 }
                 catch
                 {
@@ -152,11 +174,27 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
 
     public Task<MassAdjudicationRunSummary> SaveAsync(MassAdjudicationRunSummary summary, CancellationToken ct = default)
     {
-        summary.Id = Guid.NewGuid().ToString("N");
-        summary.CreatedAtUtc = DateTime.UtcNow;
+        var now = DateTime.UtcNow;
+        if (string.IsNullOrWhiteSpace(summary.Id))
+        {
+            summary.Id = Guid.NewGuid().ToString("N");
+        }
+
+        if (summary.CreatedAtUtc == default)
+        {
+            summary.CreatedAtUtc = now;
+        }
+
+        summary.LastUpdatedAtUtc = now;
 
         lock (_sync)
         {
+            _runs.RemoveAll(x => x.Run.TenantId == summary.Run.TenantId && x.Id == summary.Id);
+            if (summary.ClaimResults.Count > 0)
+            {
+                _claimResults.RemoveAll(x => x.TenantId == summary.Run.TenantId && x.RunId == summary.Id);
+            }
+
             foreach (var result in summary.ClaimResults)
             {
                 result.Id = Guid.NewGuid().ToString("N");

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -71,26 +71,13 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
         if (claimResults.Count > 0)
         {
-            try
-            {
-                var resultFilter = Builders<MassAdjudicationClaimResult>.Filter.And(
-                    Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, summary.Run.TenantId),
-                    Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.RunId, summary.Id));
-                await _claimResults.DeleteManyAsync(resultFilter, ct);
-                await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
-            }
-            catch
-            {
-                try
-                {
-                    await _collection.DeleteOneAsync(runFilter, cancellationToken: ct);
-                }
-                catch
-                {
-                }
-
-                throw;
-            }
+            await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
+            var newResultIds = claimResults.Select(x => x.Id).ToArray();
+            var staleResultFilter = Builders<MassAdjudicationClaimResult>.Filter.And(
+                Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, summary.Run.TenantId),
+                Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.RunId, summary.Id),
+                Builders<MassAdjudicationClaimResult>.Filter.Nin(x => x.Id, newResultIds));
+            await _claimResults.DeleteManyAsync(staleResultFilter, ct);
         }
 
         return summary;
@@ -187,20 +174,30 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
 
         summary.LastUpdatedAtUtc = now;
 
+        foreach (var result in summary.ClaimResults)
+        {
+            result.Id = Guid.NewGuid().ToString("N");
+            result.RunId = summary.Id;
+            result.TenantId = summary.Run.TenantId;
+            result.CreatedAtUtc = summary.CreatedAtUtc;
+        }
+
         lock (_sync)
         {
             _runs.RemoveAll(x => x.Run.TenantId == summary.Run.TenantId && x.Id == summary.Id);
             if (summary.ClaimResults.Count > 0)
             {
-                _claimResults.RemoveAll(x => x.TenantId == summary.Run.TenantId && x.RunId == summary.Id);
+                var newResultIds = summary.ClaimResults
+                    .Select(x => x.Id)
+                    .ToHashSet(StringComparer.Ordinal);
+                _claimResults.RemoveAll(x =>
+                    x.TenantId == summary.Run.TenantId
+                    && x.RunId == summary.Id
+                    && !newResultIds.Contains(x.Id));
             }
 
             foreach (var result in summary.ClaimResults)
             {
-                result.Id = Guid.NewGuid().ToString("N");
-                result.RunId = summary.Id;
-                result.TenantId = summary.Run.TenantId;
-                result.CreatedAtUtc = summary.CreatedAtUtc;
                 _claimResults.Add(result);
             }
 

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -7,8 +7,14 @@ internal static class MccRunSummaryBuilder
         TimeSpan elapsed,
         ValidatorOptions options,
         DateTimeOffset runStartedAtUtc,
-        DateTimeOffset runCompletedAtUtc)
+        DateTimeOffset runCompletedAtUtc,
+        string? runId = null,
+        string status = "Completed",
+        int? totalClaimsOverride = null,
+        MassAdjudicationRunProgress? progress = null,
+        bool publishClaimResults = true)
     {
+        var totalClaims = Math.Max(results.Count, totalClaimsOverride ?? results.Count);
         var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
         var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
         var pended = results.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
@@ -56,7 +62,8 @@ internal static class MccRunSummaryBuilder
             .Take(5)
             .Select(r => new MassAdjudicationFailureSummary(r.GeneratedClaimId, r.FailureStage, r.Error))
             .ToList();
-        var claimResults = SelectPublishedClaimResults(results, options.PublishClaimResultsLimit)
+        var claimResults = publishClaimResults
+            ? SelectPublishedClaimResults(results, options.PublishClaimResultsLimit)
             .Select(r => new MassAdjudicationClaimResult(
                 r.GeneratedClaimId,
                 r.SubmittedClaimId,
@@ -80,9 +87,12 @@ internal static class MccRunSummaryBuilder
                 r.AdjudicationElapsed.TotalMilliseconds,
                 r.UpdateElapsed.TotalMilliseconds,
                 r.AdjudicationStepTimings))
-            .ToList();
+            .ToList()
+            : new List<MassAdjudicationClaimResult>();
 
         return new MassAdjudicationRunSummary(
+            string.IsNullOrWhiteSpace(runId) ? Guid.NewGuid().ToString("N") : runId,
+            status,
             new MassAdjudicationRun(
                 options.TenantId,
                 options.Claims,
@@ -99,7 +109,7 @@ internal static class MccRunSummaryBuilder
                 options.LineOfBusiness,
                 runStartedAtUtc,
                 runCompletedAtUtc),
-            results.Count,
+            totalClaims,
             processed,
             adjudicated,
             pended,
@@ -123,7 +133,10 @@ internal static class MccRunSummaryBuilder
             denialBreakdown,
             workflowBreakdown,
             failures,
-            claimResults);
+            claimResults,
+            runStartedAtUtc.UtcDateTime,
+            DateTimeOffset.UtcNow.UtcDateTime,
+            progress);
     }
 
     private static MassAdjudicationStageTiming? BuildStageTiming(string label, IEnumerable<TimeSpan> durations)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -17,6 +17,7 @@ if (options.ShowHelp)
     return;
 }
 
+var runId = Guid.NewGuid().ToString("N");
 var runStartedAtUtc = DateTimeOffset.UtcNow;
 var json = new JsonSerializerOptions(JsonSerializerDefaults.Web)
 {
@@ -85,11 +86,27 @@ if (options.SeedProviders)
 }
 
 var results = new ConcurrentBag<ClaimValidationResult>();
-var total = Stopwatch.StartNew();
+var total = new Stopwatch();
 var completed = 0;
 var platformFailures = 0;
+var lastProgressPublishTicks = 0L;
 var progressLock = new object();
+var progressPublishTasks = new ConcurrentBag<Task>();
 
+if (!options.NoPublishSummary)
+{
+    var initialProgress = BuildProgressSummary(
+        results.ToList(),
+        TimeSpan.Zero,
+        options,
+        runId,
+        runStartedAtUtc,
+        "Running",
+        "Processing claims");
+    await PublishSummaryAsync(http, options, initialProgress, json, quiet: true);
+}
+
+total.Start();
 await Parallel.ForEachAsync(
     claims,
     new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
@@ -112,10 +129,25 @@ await Parallel.ForEachAsync(
                 var failures = Math.Min(Volatile.Read(ref platformFailures), currentDone);
                 Console.Write($"\r  Processed: {currentDone:N0}/{claims.Count:N0}  processed={currentDone - failures:N0}  platformFailures={failures:N0}");
             }
+
+            if (!options.NoPublishSummary
+                && ShouldPublishProgress(done, claims.Count, ref lastProgressPublishTicks))
+            {
+                var progressSummary = BuildProgressSummary(
+                    results.ToList(),
+                    total.Elapsed,
+                    options,
+                    runId,
+                    runStartedAtUtc,
+                    "Running",
+                    "Processing claims");
+                progressPublishTasks.Add(PublishSummaryAsync(http, options, progressSummary, json, quiet: true));
+            }
         }
     });
 
 total.Stop();
+await Task.WhenAll(progressPublishTasks);
 Console.WriteLine();
 Console.WriteLine();
 
@@ -135,7 +167,17 @@ if (!string.IsNullOrWhiteSpace(options.PendDiagnosticsPath))
     PendDiagnostics.PrintAggregateTable(diagnosticsReport);
 }
 
-var summary = MccRunSummaryBuilder.Build(orderedResults, total.Elapsed, options, runStartedAtUtc, DateTimeOffset.UtcNow);
+var summary = MccRunSummaryBuilder.Build(
+    orderedResults,
+    total.Elapsed,
+    options,
+    runStartedAtUtc,
+    DateTimeOffset.UtcNow,
+    runId,
+    "Completed",
+    options.Claims,
+    CreateProgress(orderedResults, total.Elapsed, options, "Completed"),
+    publishClaimResults: true);
 WriteSummary(summary);
 
 if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
@@ -2022,27 +2064,116 @@ static async Task WriteSummaryJsonAsync(string path, MassAdjudicationRunSummary 
     Console.WriteLine($"  Summary JSON:       {path}");
 }
 
+static MassAdjudicationRunSummary BuildProgressSummary(
+    List<ClaimValidationResult> results,
+    TimeSpan elapsed,
+    ValidatorOptions options,
+    string runId,
+    DateTimeOffset runStartedAtUtc,
+    string status,
+    string phase)
+{
+    return MccRunSummaryBuilder.Build(
+        results,
+        elapsed,
+        options,
+        runStartedAtUtc,
+        DateTimeOffset.UtcNow,
+        runId,
+        status,
+        options.Claims,
+        CreateProgress(results, elapsed, options, phase),
+        publishClaimResults: false);
+}
+
+static MassAdjudicationRunProgress CreateProgress(
+    IReadOnlyCollection<ClaimValidationResult> results,
+    TimeSpan elapsed,
+    ValidatorOptions options,
+    string phase)
+{
+    var orderedDurations = results
+        .Select(r => r.Elapsed.TotalMilliseconds)
+        .Order()
+        .ToArray();
+    var completedClaims = results.Count;
+    var processedClaims = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+    var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+    var throughput = completedClaims / Math.Max(0.001, elapsed.TotalSeconds);
+
+    return new MassAdjudicationRunProgress(
+        phase,
+        options.Claims,
+        completedClaims,
+        processedClaims,
+        platformFailures,
+        options.Claims <= 0 ? 0 : Math.Clamp((double)completedClaims / options.Claims * 100, 0, 100),
+        throughput,
+        Percentile(orderedDurations, 0.95),
+        Percentile(orderedDurations, 0.99),
+        DateTimeOffset.UtcNow);
+}
+
+static bool ShouldPublishProgress(int completedClaims, int totalClaims, ref long lastPublishTicks)
+{
+    if (completedClaims >= totalClaims)
+    {
+        return true;
+    }
+
+    var nowTicks = DateTimeOffset.UtcNow.Ticks;
+    var previousTicks = Interlocked.Read(ref lastPublishTicks);
+    if (previousTicks > 0 && nowTicks - previousTicks < TimeSpan.FromSeconds(2).Ticks)
+    {
+        return false;
+    }
+
+    return Interlocked.CompareExchange(ref lastPublishTicks, nowTicks, previousTicks) == previousTicks;
+}
+
+static double Percentile(double[] values, double percentile)
+{
+    if (values.Length == 0)
+    {
+        return 0;
+    }
+
+    var index = (int)Math.Ceiling(percentile * values.Length) - 1;
+    return values[Math.Clamp(index, 0, values.Length - 1)];
+}
+
 static async Task PublishSummaryAsync(
     HttpClient http,
     ValidatorOptions options,
     MassAdjudicationRunSummary summary,
-    JsonSerializerOptions json)
+    JsonSerializerOptions json,
+    bool quiet = false)
 {
     try
     {
         using var response = await http.PostAsJsonAsync($"{options.ClaimsUrl}/api/mass-adjudication/runs", summary, json);
         if (response.IsSuccessStatusCode)
         {
-            Console.WriteLine("  Dashboard summary: published");
+            if (!quiet)
+            {
+                Console.WriteLine("  Dashboard summary: published");
+            }
+
             return;
         }
 
         var body = await response.Content.ReadAsStringAsync();
-        Console.WriteLine($"  Dashboard summary: publish skipped ({(int)response.StatusCode} {body})");
+        if (!quiet)
+        {
+            Console.WriteLine($"  Dashboard summary: publish skipped ({(int)response.StatusCode} {body})");
+        }
     }
     catch (Exception ex)
     {
-        Console.WriteLine($"  Dashboard summary: publish skipped ({ex.Message})");
+        if (!quiet)
+        {
+            Console.WriteLine($"  Dashboard summary: publish skipped ({ex.Message})");
+        }
     }
 }
 
@@ -2148,6 +2279,8 @@ internal sealed record ClaimValidationResult(
     JsonElement? SyncAdjudicationSnapshot = null);
 
 internal sealed record MassAdjudicationRunSummary(
+    string Id,
+    string Status,
     MassAdjudicationRun Run,
     int TotalClaims,
     int Processed,
@@ -2173,7 +2306,10 @@ internal sealed record MassAdjudicationRunSummary(
     IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
     IReadOnlyList<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown,
     IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures,
-    IReadOnlyList<MassAdjudicationClaimResult> ClaimResults);
+    IReadOnlyList<MassAdjudicationClaimResult> ClaimResults,
+    DateTime CreatedAtUtc,
+    DateTime LastUpdatedAtUtc,
+    MassAdjudicationRunProgress? Progress);
 
 internal sealed record MassAdjudicationRun(
     string TenantId,
@@ -2191,6 +2327,18 @@ internal sealed record MassAdjudicationRun(
     int LineOfBusiness,
     DateTimeOffset StartedAtUtc,
     DateTimeOffset CompletedAtUtc);
+
+internal sealed record MassAdjudicationRunProgress(
+    string Phase,
+    int RequestedClaims,
+    int CompletedClaims,
+    int ProcessedClaims,
+    int PlatformFailures,
+    double PercentComplete,
+    double CurrentThroughputClaimsPerSecond,
+    double RollingP95LatencyMilliseconds,
+    double RollingP99LatencyMilliseconds,
+    DateTimeOffset LastPublishedAtUtc);
 
 internal sealed record MassAdjudicationStageTiming(
     string Label,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -91,7 +91,9 @@ var completed = 0;
 var platformFailures = 0;
 var lastProgressPublishTicks = 0L;
 var progressLock = new object();
-var progressPublishTasks = new ConcurrentBag<Task>();
+var progressPublishGate = new SemaphoreSlim(1, 1);
+Task? latestProgressPublishTask = null;
+var latestProgressPublishLock = new object();
 
 if (!options.NoPublishSummary)
 {
@@ -133,21 +135,45 @@ await Parallel.ForEachAsync(
             if (!options.NoPublishSummary
                 && ShouldPublishProgress(done, claims.Count, ref lastProgressPublishTicks))
             {
-                var progressSummary = BuildProgressSummary(
-                    results.ToList(),
-                    total.Elapsed,
-                    options,
-                    runId,
-                    runStartedAtUtc,
-                    "Running",
-                    "Processing claims");
-                progressPublishTasks.Add(PublishSummaryAsync(http, options, progressSummary, json, quiet: true));
+                if (progressPublishGate.Wait(0))
+                {
+                    try
+                    {
+                        var progressSummary = BuildProgressSummary(
+                            results.ToList(),
+                            total.Elapsed,
+                            options,
+                            runId,
+                            runStartedAtUtc,
+                            "Running",
+                            "Processing claims");
+                        var publishTask = PublishProgressSummaryAsync(progressPublishGate, http, options, progressSummary, json);
+                        lock (latestProgressPublishLock)
+                        {
+                            latestProgressPublishTask = publishTask;
+                        }
+                    }
+                    catch
+                    {
+                        progressPublishGate.Release();
+                        throw;
+                    }
+                }
             }
         }
     });
 
 total.Stop();
-await Task.WhenAll(progressPublishTasks);
+Task? pendingProgressPublish;
+lock (latestProgressPublishLock)
+{
+    pendingProgressPublish = latestProgressPublishTask;
+}
+
+if (pendingProgressPublish is not null)
+{
+    await pendingProgressPublish;
+}
 Console.WriteLine();
 Console.WriteLine();
 
@@ -2073,17 +2099,67 @@ static MassAdjudicationRunSummary BuildProgressSummary(
     string status,
     string phase)
 {
-    return MccRunSummaryBuilder.Build(
-        results,
-        elapsed,
-        options,
-        runStartedAtUtc,
-        DateTimeOffset.UtcNow,
+    var runCompletedAtUtc = DateTimeOffset.UtcNow;
+    var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+    var paid = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
+    var pended = results.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
+    var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
+    var observationTimeouts = results.Count(r => r.Outcome is ClaimValidationOutcome.ObservationTimeout);
+    var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+    var workflowScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
+    var workflowMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
+    var workflowMismatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus);
+    var workflowUnsupported = results.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus);
+    var workflowObservationTimeouts = results.Count(r => r.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus);
+    var progress = CreateProgress(results, elapsed, options, phase);
+
+    return new MassAdjudicationRunSummary(
         runId,
         status,
+        new MassAdjudicationRun(
+            options.TenantId,
+            options.Claims,
+            options.Seed,
+            options.Parallelism,
+            options.ClaimsUrl,
+            options.BenefitUrl,
+            options.MemberUrl,
+            options.CoverageUrl,
+            options.ProviderUrl,
+            options.SeedMembers,
+            options.SeedProviders,
+            options.SkipClaimUpdate,
+            options.LineOfBusiness,
+            runStartedAtUtc,
+            runCompletedAtUtc),
         options.Claims,
-        CreateProgress(results, elapsed, options, phase),
-        publishClaimResults: false);
+        processed,
+        paid,
+        pended,
+        businessDenials,
+        observationTimeouts,
+        platformFailures,
+        workflowScenarios,
+        workflowMatches,
+        workflowMismatches,
+        workflowUnsupported,
+        workflowObservationTimeouts,
+        elapsed,
+        progress.CurrentThroughputClaimsPerSecond,
+        progress.RollingP95LatencyMilliseconds,
+        progress.RollingP99LatencyMilliseconds,
+        null,
+        null,
+        null,
+        Array.Empty<MassAdjudicationStageTiming>(),
+        null,
+        Array.Empty<MassAdjudicationBusinessDenialSummary>(),
+        Array.Empty<MassAdjudicationWorkflowScenarioSummary>(),
+        Array.Empty<MassAdjudicationFailureSummary>(),
+        Array.Empty<MassAdjudicationClaimResult>(),
+        runStartedAtUtc.UtcDateTime,
+        runCompletedAtUtc.UtcDateTime,
+        progress);
 }
 
 static MassAdjudicationRunProgress CreateProgress(
@@ -2093,6 +2169,7 @@ static MassAdjudicationRunProgress CreateProgress(
     string phase)
 {
     var orderedDurations = results
+        .Take(500)
         .Select(r => r.Elapsed.TotalMilliseconds)
         .Order()
         .ToArray();
@@ -2112,6 +2189,23 @@ static MassAdjudicationRunProgress CreateProgress(
         Percentile(orderedDurations, 0.95),
         Percentile(orderedDurations, 0.99),
         DateTimeOffset.UtcNow);
+}
+
+static async Task PublishProgressSummaryAsync(
+    SemaphoreSlim gate,
+    HttpClient http,
+    ValidatorOptions options,
+    MassAdjudicationRunSummary summary,
+    JsonSerializerOptions json)
+{
+    try
+    {
+        await PublishSummaryAsync(http, options, summary, json, quiet: true);
+    }
+    finally
+    {
+        gate.Release();
+    }
 }
 
 static bool ShouldPublishProgress(int completedClaims, int totalClaims, ref long lastPublishTicks)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -245,7 +245,7 @@ public class MassAdjudicationRunRepositoryTests
     }
 
     [Fact]
-    public async Task SaveAsync_when_claim_result_insert_fails_deletes_inserted_summary()
+    public async Task SaveAsync_when_claim_result_insert_fails_preserves_existing_summary_and_claim_results()
     {
         var database = Substitute.For<IMongoDatabase>();
         var runs = Substitute.For<IMongoCollection<MassAdjudicationRunSummary>>();
@@ -260,11 +260,6 @@ public class MassAdjudicationRunRepositoryTests
                 Arg.Any<MongoCollectionSettings?>())
             .Returns(claimResults);
 
-        claimResults
-            .DeleteManyAsync(
-                Arg.Any<FilterDefinition<MassAdjudicationClaimResult>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Substitute.For<DeleteResult>()));
         runs
             .ReplaceOneAsync(
                 Arg.Any<FilterDefinition<MassAdjudicationRunSummary>>(),
@@ -292,8 +287,11 @@ public class MassAdjudicationRunRepositoryTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("insert failed");
-        await runs.Received(1).DeleteOneAsync(
+        await runs.DidNotReceive().DeleteOneAsync(
             Arg.Any<FilterDefinition<MassAdjudicationRunSummary>>(),
+            Arg.Any<CancellationToken>());
+        await claimResults.DidNotReceive().DeleteManyAsync(
+            Arg.Any<FilterDefinition<MassAdjudicationClaimResult>>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -50,6 +50,20 @@ public class MassAdjudicationRunRepositoryTests
         summary.WorkflowUnsupported = 73;
         summary.WorkflowObservationTimeouts = 2;
         summary.AveragePaymentDelta = 59.36m;
+        summary.Status = "Running";
+        summary.Progress = new MassAdjudicationRunProgress
+        {
+            Phase = "Processing claims",
+            RequestedClaims = 5000,
+            CompletedClaims = 2500,
+            ProcessedClaims = 2499,
+            PlatformFailures = 1,
+            PercentComplete = 50,
+            CurrentThroughputClaimsPerSecond = 75.5,
+            RollingP95LatencyMilliseconds = 250,
+            RollingP99LatencyMilliseconds = 320,
+            LastPublishedAtUtc = DateTimeOffset.Parse("2026-07-09T19:00:00Z")
+        };
         summary.Run.MemberUrl = "https://member";
         summary.Run.CoverageUrl = "https://coverage";
         summary.Run.SeedMembers = true;
@@ -75,6 +89,10 @@ public class MassAdjudicationRunRepositoryTests
         reread.WorkflowUnsupported.Should().Be(73);
         reread.WorkflowObservationTimeouts.Should().Be(2);
         reread.AveragePaymentDelta.Should().Be(59.36m);
+        reread.Status.Should().Be("Running");
+        reread.Progress.Should().NotBeNull();
+        reread.Progress!.CompletedClaims.Should().Be(2500);
+        reread.Progress.CurrentThroughputClaimsPerSecond.Should().Be(75.5);
         reread.Run.MemberUrl.Should().Be("https://member");
         reread.Run.CoverageUrl.Should().Be("https://coverage");
         reread.Run.SeedMembers.Should().BeTrue();
@@ -84,6 +102,92 @@ public class MassAdjudicationRunRepositoryTests
             && s.Total == 10
             && s.Matches == 9
             && s.ObservationTimeouts == 1);
+    }
+
+    [Fact]
+    public async Task SaveAsync_upserts_progress_updates_without_creating_duplicate_runs()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var runId = Guid.NewGuid().ToString("N");
+        var initial = CreateSummary();
+        initial.Id = runId;
+        initial.Status = "Running";
+        initial.TotalClaims = 1000;
+        initial.Processed = 100;
+        initial.Progress = new MassAdjudicationRunProgress
+        {
+            Phase = "Processing claims",
+            RequestedClaims = 1000,
+            CompletedClaims = 100,
+            ProcessedClaims = 100,
+            PercentComplete = 10,
+            LastPublishedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        var update = CreateSummary();
+        update.Id = runId;
+        update.Status = "Running";
+        update.TotalClaims = 1000;
+        update.Processed = 400;
+        update.Progress = new MassAdjudicationRunProgress
+        {
+            Phase = "Processing claims",
+            RequestedClaims = 1000,
+            CompletedClaims = 400,
+            ProcessedClaims = 400,
+            PercentComplete = 40,
+            LastPublishedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        await repo.SaveAsync(initial);
+        await repo.SaveAsync(update);
+
+        var runs = await repo.ListAsync(initial.Run.TenantId, 10);
+
+        runs.Should().ContainSingle();
+        runs[0].Id.Should().Be(runId);
+        runs[0].Processed.Should().Be(400);
+        runs[0].Progress!.CompletedClaims.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task SaveAsync_progress_only_update_preserves_existing_claim_results()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var runId = Guid.NewGuid().ToString("N");
+        var completed = CreateSummary();
+        completed.Id = runId;
+        completed.Status = "Completed";
+        completed.ClaimResults.Add(new MassAdjudicationClaimResult
+        {
+            GeneratedClaimId = "GEN-EVIDENCE",
+            SubmittedClaimId = "claim-001",
+            ClaimType = "Professional",
+            Outcome = "Paid",
+            ValidationStatus = "Matched",
+            ElapsedMilliseconds = 100
+        });
+
+        var progressOnly = CreateSummary();
+        progressOnly.Id = runId;
+        progressOnly.Status = "Running";
+        progressOnly.Progress = new MassAdjudicationRunProgress
+        {
+            Phase = "Processing claims",
+            RequestedClaims = 1000,
+            CompletedClaims = 500,
+            ProcessedClaims = 500,
+            PercentComplete = 50,
+            LastPublishedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        var saved = await repo.SaveAsync(completed);
+        await repo.SaveAsync(progressOnly);
+
+        var claimResults = await repo.ListClaimResultsAsync(saved.Run.TenantId, runId, null, null, 10);
+
+        claimResults.Should().ContainSingle()
+            .Which.GeneratedClaimId.Should().Be("GEN-EVIDENCE");
     }
 
     [Fact]
@@ -156,6 +260,18 @@ public class MassAdjudicationRunRepositoryTests
                 Arg.Any<MongoCollectionSettings?>())
             .Returns(claimResults);
 
+        claimResults
+            .DeleteManyAsync(
+                Arg.Any<FilterDefinition<MassAdjudicationClaimResult>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Substitute.For<DeleteResult>()));
+        runs
+            .ReplaceOneAsync(
+                Arg.Any<FilterDefinition<MassAdjudicationRunSummary>>(),
+                Arg.Any<MassAdjudicationRunSummary>(),
+                Arg.Any<ReplaceOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Substitute.For<ReplaceOneResult>()));
         claimResults
             .InsertManyAsync(
                 Arg.Any<IEnumerable<MassAdjudicationClaimResult>>(),


### PR DESCRIPTION
## Summary
- publish stable in-progress MCC run summaries from the validator while a run is processing
- upsert mass adjudication run summaries by tenant/run id so the console shows one live row
- surface running status, progress, last-published time, live claims/sec, and rolling latency in the portal
- preserve final evidence-first claim samples and avoid publishing partial claim rows during progress updates

## Tests
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter MassAdjudicationRunRepositoryTests
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --filter MccRunSummaryBuilderTests
- dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --filter ClaimsServiceTests
- git diff --check

## Notes
This adds live completed-claim telemetry. True submitted/adjudicated/writeback stage counters are still a follow-up because the current validator only observes those stages inside each completed claim result.