### PR TITLE
Publish grounded platform and Million Claim Challenge evidence

### DIFF
--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -32,6 +32,11 @@
 /docs/provider-verification-guide.html     /docs/provider-verification-guide  301
 /docs/commercial-licensing.html            /docs/commercial-licensing         301
 /contact.html                              /contact                           301
+/insights/million-claim-challenge/index.html /insights/million-claim-challenge 301
+/insights/million-claim-challenge/part-5-repeatably-faster.html /insights/million-claim-challenge/part-5-repeatably-faster 301
+/insights/million-claim-challenge/part-6-honest-edge-case-scoring.html /insights/million-claim-challenge/part-6-honest-edge-case-scoring 301
+/insights/million-claim-challenge/part-7-operator-console.html /insights/million-claim-challenge/part-7-operator-console 301
+/docs/million-claim-challenge/evidence.html /docs/million-claim-challenge/evidence 301
 
 # ---------------------------------------------------------------------------
 # Rewrites: clean URL  ->  *.html (200, URL stays clean)
@@ -56,6 +61,11 @@
 /docs/provider-verification-guide          /docs/provider-verification-guide.html  200
 /docs/commercial-licensing                 /docs/commercial-licensing.html    200
 /contact                                   /contact.html                      200
+/insights/million-claim-challenge          /insights/million-claim-challenge/index.html 200
+/insights/million-claim-challenge/part-5-repeatably-faster /insights/million-claim-challenge/part-5-repeatably-faster.html 200
+/insights/million-claim-challenge/part-6-honest-edge-case-scoring /insights/million-claim-challenge/part-6-honest-edge-case-scoring.html 200
+/insights/million-claim-challenge/part-7-operator-console /insights/million-claim-challenge/part-7-operator-console.html 200
+/docs/million-claim-challenge/evidence     /docs/million-claim-challenge/evidence.html 200
 
 # ---------------------------------------------------------------------------
 # NOT migrated here (cannot be done with file-based config):

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -268,6 +268,8 @@
             <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
             <ul>
               <li><a href="/docs/million-claim-challenge" class="active">Million Claim Challenge</a></li>
+              <li><a href="/docs/million-claim-challenge/evidence">Evidence Archive</a></li>
+              <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
             </ul>
           </div>
         </div>
@@ -340,7 +342,12 @@
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>,
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">Part 6: From Fast Runs to Honest Edge-Case Scoring</a>,
             and
-            <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-007/article.txt" target="_blank" rel="noopener noreferrer">Part 7: From Benchmark Logs to an Operator Console</a>.
+            <a href="/insights/million-claim-challenge/part-7-operator-console">Part 7: From Benchmark Logs to an Operator Console</a>.
+          </p>
+          <p>
+            <a href="/insights/million-claim-challenge"><strong>Read the complete engineering series</strong></a>
+            or inspect the dated run summaries and raw-source links in the
+            <a href="/docs/million-claim-challenge/evidence"><strong>public evidence archive</strong></a>.
           </p>
         </div>
 

--- a/src/site/docs/million-claim-challenge/evidence.html
+++ b/src/site/docs/million-claim-challenge/evidence.html
@@ -1,0 +1,614 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Million Claim Challenge Evidence Archive | Cloud Health Office</title>
+  <meta name="description" content="Dated benchmark summaries, environment details, limitations, and raw artifacts for published Million Claim Challenge engineering results.">
+  <link rel="canonical" href="https://cloudhealthoffice.com/docs/million-claim-challenge/evidence">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="Million Claim Challenge Evidence Archive">
+  <meta property="og:description" content="Dated benchmark summaries, environment details, limitations, and raw artifacts for published Million Claim Challenge engineering results.">
+  <meta property="og:url" content="https://cloudhealthoffice.com/docs/million-claim-challenge/evidence">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    <div class="eyebrow">Reproducibility archive</div><h1>Million Claim Challenge Evidence</h1><p>This archive keeps the evidence behind the engineering series visible and reviewable. Results are historical records, not generalized production capacity claims.</p><div class="disclosure"><strong>Interpretation rules:</strong> distinguish platform failures from business dispositions; do not count unsupported scenarios as passes; preserve allocated compute, corpus size, latency, and validator limitations with every result.</div><section id="episode-005"><div class="eyebrow">Part 5 · recorded artifact</div><h2>How the local Kubernetes sweep harness turned isolated fast runs into repeatable performance evidence.</h2><div class="article-links"><a href="/insights/million-claim-challenge/part-5-repeatably-faster">Read article</a><a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-005/benchmark-results.txt" target="_blank" rel="noopener noreferrer">Source artifact</a></div><details class="evidence-block" open><summary>Benchmark results recorded with Episode 005</summary><pre># Episode 005 benchmark results
+
+## Environment
+
+- Environment: local Kubernetes via Docker Desktop
+- Docker resource allocation: 18 CPUs, approximately 24 GB memory
+- Tenant: `demo`
+- Workload: synthetic Million Claim Challenge claim corpus
+- Important caveat: these are local validation benchmarks, not production cloud benchmarks
+
+## 1,000-claim sweep
+
+The first sweep compared parallelism values 8, 10, 11, and 12 with two repeats each.
+
+The strongest result at 1,000 claims was parallelism 11:
+
+| Metric | Value |
+| --- | ---: |
+| Claims processed | 1,000 |
+| Parallelism | 11 |
+| Throughput | 247.10 claims/sec |
+| P95 latency | 100.35 ms |
+| P99 latency | 128.53 ms |
+| Platform failures | 0 |
+| Workflow checks | 160/160 matched |
+
+Interpretation: At 1,000 claims, p=11 had the best combination of throughput, latency, and workflow correctness.
+
+## 10,000-claim sweep
+
+The larger sweep changed the answer.
+
+| Parallelism | Claims/sec | P95 | P99 | Interpretation |
+| ---: | ---: | ---: | ---: | --- |
+| 10 | 209.54 | 103.47 ms | 149.85 ms | Better balance |
+| 12 | 209.81 | 118.19 ms | 170.90 ms | Tiny throughput edge, worse latency |
+
+Conclusion: p=10 is the better 10,000-claim setting despite p=12 having a tiny throughput edge. The latency profile matters.
+
+## Hidden 10,000-claim cap
+
+An attempted 50,000-claim run initially processed only 10,000 claims because the validator had a local safety cap.
+
+The fix was to make the cap explicit:
+
+- keep default max claims at 10,000
+- add an intentional `--max-claims` override
+- have local Kubernetes scripts pass the override when larger `CLAIMS` values are requested
+
+This is an important podcast point: repeatable benchmarking also validates the benchmark tooling.
+
+## True 50,000-claim run
+
+After the max-claims override, the platform completed a true 50,000-claim local Kubernetes run.
+
+| Metric | Value |
+| --- | ---: |
+| Claims requested | 50,000 |
+| Claims generated | 50,000 |
+| Claims processed | 50,000 |
+| Throughput | 157.07 claims/sec |
+| Elapsed time | 5 minutes 18 seconds |
+| P95 latency | 130 ms |
+| P99 latency | 175 ms |
+| Platform failures | 0 |
+| Workflow checks | 4,000/4,000 matched |
+
+The deterministic workflow checks included:
+
+- 1,000 clean paid scenarios
+- 1,000 excluded provider scenarios
+- 1,000 uncovered service scenarios
+- 1,000 prior authorization scenarios
+
+## Repeat benchmark without provider seeding
+
+Once the demo tenant had already been seeded with synthetic providers, the repeat benchmark could skip provider seeding.
+
+| Mode | Elapsed | Claims/sec | P95 | P99 | Platform failures | Workflow checks |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| With provider seed | 5:18 | 157.07 | 130 ms | 175 ms | 0 | 4,000/4,000 |
+| Skip provider seed | 4:25 | 188.64 | 106 ms | 151 ms | 0 | 4,000/4,000 |
+
+Interpretation: skipping provider seeding for repeat runs gives a cleaner adjudication throughput measurement and avoids paying first-run setup cost every time.
+
+## Correctness framing
+
+Correct denials are not failures.
+
+Business denials can be valid outcomes when the platform applies rules correctly. Examples include uncovered services, excluded providers, prior authorization requirements, duplicate logic, coding edits, and benefit plan limits.
+
+Platform failures are unexpected system or workflow failures.
+
+The benchmark must always report speed and correctness together.
+</pre></details></section>
+<section id="episode-006"><div class="eyebrow">Part 6 · recorded artifact</div><h2>Why paid is not the only correct outcome, and why unsupported scenarios must remain visible.</h2><div class="article-links"><a href="/insights/million-claim-challenge/part-6-honest-edge-case-scoring">Read article</a><a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-006/benchmark-results.txt" target="_blank" rel="noopener noreferrer">Source artifact</a><a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-006/raw-validator-output-50k.txt" target="_blank" rel="noopener noreferrer">Raw 50K validator output</a></div><details class="evidence-block" open><summary>Benchmark results recorded with Episode 006</summary><pre># Episode 006 benchmark results
+
+## Environment
+
+- Environment: local Kubernetes via Docker Desktop
+- Docker Desktop resources: 18 CPUs, 25,159,270,400 bytes memory (~23.4 GiB)
+- Tenant: `demo`
+- Workload: synthetic Million Claim Challenge claim corpus
+- Generator seed: 42
+- Line of business: Medicaid (3)
+- Prior-auth scenarios: enabled at 2%
+- Pend observation: enabled
+- Pend observation timeout: 45 seconds
+- Parallelism: 10
+- Member seeding: enabled
+- Provider seeding: enabled
+- Source revision for packet: `8d55a38b` (`Fix MCC COB fixture isolation (#858)`)
+- Raw final 50K validator output: `raw-validator-output-50k.txt`
+- Important caveat: these are local validation benchmarks, not production cloud benchmarks
+
+Tenant-state caveat:
+
+The final 50K run used the long-lived local `demo` tenant, not a freshly reset tenant. The raw seeding log shows 49,425 members and 99,956 providers already present before the run, plus 12 existing COB coverage rows. The validator added 448 synthetic members and 448 COB coverage rows for the final 50K run. A clean cluster should reproduce the same workflow logic, but seeding counts and any state-sensitive behavior can differ.
+
+Payment-delta caveat:
+
+`Avg payment delta` is the average absolute difference, for paid claims only, between the adjudication response's `Totals.PlanPayment` and the synthetic corpus answer key's `ExpectedPaidAmount`. In the final 50K raw output it was `$59.36`. Episode 006 workflow scoring validates disposition and workflow outcomes: paid, denied with the expected business reason, pended, unsupported, or platform failure. Payment-amount accuracy is visible as a diagnostic, but it is not yet a pass/fail scoring gate in this packet.
+
+## Current baseline: 5,000-claim breadth validation
+
+This run was completed after PR 856.
+
+The raw console output was not retained as a separate artifact, but the exact command, summary, and scenario table are recorded below.
+
+Run source revision:
+
+- `0c0b8f14` (`Avoid duplicate MCC newborn mother line codes (#856)`)
+
+Command:
+
+```bash
+CLAIMS=5000 MAX_CLAIMS=5000 PARALLELISM=10 PROGRESS_EVERY=500 SEED_MEMBERS=true SEED_PROVIDERS=true PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 scripts/run-mcc-local-k8s.sh
+```
+
+Summary:
+
+| Metric | Value |
+| --- | ---: |
+| Claims requested | 5,000 |
+| Claims processed | 5,000 |
+| Paid/adjudicated | 3,958 |
+| Pended | 46 |
+| Business denials | 996 |
+| Platform failures | 0 |
+| Observation timeouts | 0 |
+| Expected-pend observations | 46/46 pended |
+| Workflow checks | 577/650 matched |
+| Mismatches | 0 |
+| Unsupported | 73 |
+| Elapsed | 00:59.731 |
+| Throughput | 83.71 claims/sec |
+| P95 latency | 204 ms |
+| P99 latency | 278 ms |
+
+Business denial breakdown:
+
+| Denial | Count |
+| --- | ---: |
+| CARC_96 | 448 |
+| CARC_18 | 300 |
+| PRIOR_AUTH_REQUIRED | 108 |
+| PROVIDER_EXCLUDED | 100 |
+| NCCI_MUE_EDIT_FAILURE | 24 |
+
+Key matched scenario groups:
+
+| Scenario | Result |
+| --- | ---: |
+| CleanProfessionalPaid | 100/100 matched |
+| ExcludedProviderDenied | 100/100 matched |
+| TxStarInpatientNoAuth | 100/100 matched |
+| UncoveredServiceDenied | 100/100 matched |
+| EdgeCase:NewbornAutoAdjudication | 10/10 matched |
+| EdgeCase:NewbornFirstThirtyDays | 10/10 matched |
+| EdgeCase:NewbornMotherClaimLink | 10/10 matched |
+| EdgeCase:RetroEligibilityTermination | 13/13 matched |
+| EdgeCase:CobSecondaryPayer | 10/10 matched |
+| EdgeCase:CobBirthdayRule | 10/10 matched |
+| EdgeCase:CobGenderRule | 10/10 matched |
+| EdgeCase:PriorAuthRequired_NoAuth | 8/8 matched |
+
+Unsupported scenario groups:
+
+| Scenario | Unsupported |
+| --- | ---: |
+| EdgeCase:BehavioralHealthCarveOut | 10 |
+| EdgeCase:MedicaidSpendDown | 6 |
+| EdgeCase:PriorAuthRequired_ExpiredAuth | 8 |
+| EdgeCase:PriorAuthRequired_WrongProcedure | 8 |
+| EdgeCase:PriorAuthRequired_WrongProvider | 8 |
+| EdgeCase:RetroEligibilityCoverageChange | 13 |
+| EdgeCase:SubrogationAccidentRelated | 7 |
+| EdgeCase:SubrogationThirdPartyLiability | 6 |
+| EdgeCase:SubrogationWorkersComp | 7 |
+
+Interpretation:
+
+The 5K run is the first clean breadth baseline for Episode 006. It is not a final publication headline by itself, but it proves that the broader edge-case scoring path can run with zero mismatches and zero platform failures when unsupported scenarios are separated honestly.
+
+## 10,000-claim breadth validation
+
+This run was completed after the COB fixture-isolation fix and before the clean 50K breadth validation run.
+
+The clean 10K run was part of the post-PR-858 confidence gate. The raw console output was not retained as a separate artifact, but the exact command, summary, and scenario table are recorded below.
+
+Run source revision:
+
+- `8d55a38b` (`Fix MCC COB fixture isolation (#858)`)
+
+Command:
+
+```bash
+CLAIMS=10000 MAX_CLAIMS=10000 PARALLELISM=10 PROGRESS_EVERY=1000 SEED_MEMBERS=true SEED_PROVIDERS=true PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 scripts/run-mcc-local-k8s.sh
+```
+
+Summary:
+
+| Metric | Value |
+| --- | ---: |
+| Claims requested | 10,000 |
+| Claims processed | 10,000 |
+| Paid/adjudicated | 7,910 |
+| Pended | 92 |
+| Business denials | 1,998 |
+| Platform failures | 0 |
+| Observation timeouts | 0 |
+| Expected-pend observations | 92/92 pended |
+| Workflow checks | 1,154/1,300 matched |
+| Mismatches | 0 |
+| Unsupported | 146 |
+| Elapsed | 02:08.011 |
+| Throughput | 78.12 claims/sec |
+| P95 latency | 272 ms |
+| P99 latency | 306 ms |
+
+Key matched scenario groups:
+
+| Scenario | Result |
+| --- | ---: |
+| CleanProfessionalPaid | 200/200 matched |
+| ExcludedProviderDenied | 200/200 matched |
+| TxStarInpatientNoAuth | 200/200 matched |
+| UncoveredServiceDenied | 200/200 matched |
+| EdgeCase:NewbornAutoAdjudication | 20/20 matched |
+| EdgeCase:NewbornFirstThirtyDays | 20/20 matched |
+| EdgeCase:NewbornMotherClaimLink | 20/20 matched |
+| EdgeCase:RetroEligibilityTermination | 27/27 matched |
+| EdgeCase:CobSecondaryPayer | 20/20 matched |
+| EdgeCase:CobBirthdayRule | 20/20 matched |
+| EdgeCase:CobGenderRule | 20/20 matched |
+| EdgeCase:PriorAuthRequired_NoAuth | 16/16 matched |
+
+Interpretation:
+
+The post-fix 10K gate passed. The 5K zero-mismatch breadth result held at double the volume, supported COB-pend fixture rows were isolated and seeded one-for-one, expected-pend observation remained reliable, and unsupported scenarios continued to be separated from mismatches.
+
+## Remaining Part 6 validation gate
+
+Part 6 now has 5K, 10K, and 50K breadth validation data.
+
+100K is intentionally out of scope for Part 6. After the clean 50K breadth result, 100K should become its own focused milestone article rather than a late addition to this one.
+
+### 50,000-claim breadth validation
+
+Purpose:
+
+- replace the older narrow 50K result with a broader edge-case validation result
+- confirm the Part 6 story scales from breadth smoke to a meaningful local workload
+- provide a direct bridge from Episode 005 throughput work to Episode 006 correctness work
+
+Run source revision:
+
+- `8d55a38b` (`Fix MCC COB fixture isolation (#858)`)
+
+Command:
+
+```bash
+CLAIMS=50000 MAX_CLAIMS=50000 PARALLELISM=10 PROGRESS_EVERY=5000 SEED_MEMBERS=true SEED_PROVIDERS=true PEND_OBSERVATION_ENABLED=true PEND_OBSERVATION_TIMEOUT_SECONDS=45 scripts/run-mcc-local-k8s.sh
+```
+
+Summary:
+
+| Metric | Value |
+| --- | ---: |
+| Claims requested | 50,000 |
+| Claims processed | 50,000 |
+| Paid/adjudicated | 39,581 |
+| Pended | 460 |
+| Business denials | 9,959 |
+| Platform failures | 0 |
+| Observation timeouts | 0 |
+| Expected-pend observations | 460/460 pended |
+| Workflow checks | 5,767/6,500 matched |
+| Mismatches | 0 |
+| Unsupported | 733 |
+| Elapsed | 12:06.089 |
+| Throughput | 68.86 claims/sec |
+| P95 latency | 298 ms |
+| P99 latency | 369 ms |
+| Avg payment delta | $59.36 |
+
+Timing:
+
+| Stage | Avg | P95 |
+| --- | ---: | ---: |
+| Submit | 44 ms | 130 ms |
+| Adjudicate | 66 ms | 115 ms |
+| Writeback | 36 ms | 98 ms |
+| Benefit calculation | 61 ms | 104 ms |
+| Accumulator read | 60 ms | 103 ms |
+
+Business denial breakdown:
+
+| Denial | Count |
+| --- | ---: |
+| CARC_96 | 4,542 |
+| CARC_18 | 3,000 |
+| PRIOR_AUTH_REQUIRED | 1,080 |
+| PROVIDER_EXCLUDED | 1,000 |
+| NCCI_MUE_EDIT_FAILURE | 187 |
+
+Key matched scenario groups:
+
+| Scenario | Result |
+| --- | ---: |
+| CleanProfessionalPaid | 1,000/1,000 matched |
+| ExcludedProviderDenied | 1,000/1,000 matched |
+| TxStarInpatientNoAuth | 1,000/1,000 matched |
+| UncoveredServiceDenied | 1,000/1,000 matched |
+| EdgeCase:NewbornAutoAdjudication | 100/100 matched |
+| EdgeCase:NewbornFirstThirtyDays | 100/100 matched |
+| EdgeCase:NewbornMotherClaimLink | 100/100 matched |
+| EdgeCase:RetroEligibilityTermination | 133/133 matched |
+| EdgeCase:RetroEligibilityAdd | 134/134 matched |
+| EdgeCase:CobBirthdayRule | 100/100 matched |
+| EdgeCase:CobGenderRule | 100/100 matched |
+| EdgeCase:CobMedicareSecondary | 100/100 matched |
+| EdgeCase:CobPrimaryPayer | 100/100 matched |
+| EdgeCase:CobSecondaryPayer | 100/100 matched |
+| EdgeCase:CobTertiaryPayer | 100/100 matched |
+| EdgeCase:MedicaidCHIP | 60/60 matched |
+| EdgeCase:MedicaidDualEligible | 60/60 matched |
+| EdgeCase:MedicaidSSI | 60/60 matched |
+| EdgeCase:MedicaidTANF | 60/60 matched |
+| EdgeCase:BehavioralHealthCarveIn | 100/100 matched |
+| EdgeCase:BehavioralHealthParityCheck | 100/100 matched |
+| EdgeCase:PriorAuthRequired_NoAuth | 80/80 matched |
+| EdgeCase:PriorAuthRequired_AuthOnFile | 80/80 matched |
+
+Unsupported scenario groups:
+
+| Scenario | Unsupported |
+| --- | ---: |
+| EdgeCase:BehavioralHealthCarveOut | 100 |
+| EdgeCase:MedicaidSpendDown | 60 |
+| EdgeCase:PriorAuthRequired_ExpiredAuth | 80 |
+| EdgeCase:PriorAuthRequired_WrongProcedure | 80 |
+| EdgeCase:PriorAuthRequired_WrongProvider | 80 |
+| EdgeCase:RetroEligibilityCoverageChange | 133 |
+| EdgeCase:SubrogationAccidentRelated | 67 |
+| EdgeCase:SubrogationThirdPartyLiability | 66 |
+| EdgeCase:SubrogationWorkersComp | 67 |
+
+Interpretation:
+
+The 50K gate passed cleanly: every claim processed, expected pends were observed through persisted claim status, there were no platform failures, there were no pend observation timeouts, and there were no workflow mismatches.
+
+This run replaced the earlier one-mismatch 50K result after isolating supported COB-pend members by generated claim. The earlier mismatch was a benchmark fixture-isolation issue: expected-pend COB scenarios could share a generated member, so one scenario could miss its own seeded COB row. The clean rerun confirms `EdgeCase:CobSecondaryPayer` at 100/100 matched.
+
+Pend-observation caveat:
+
+The pend-observation pass polls persisted claim status only for scenarios whose answer-key outcome is `Pended`. It proves expected-pend claims persisted as pended. It does not, by itself, detect the inverse error where a claim expected to pay or deny later persists as pended. A future validator enhancement should add an optional persisted-status sweep for non-pend scenarios to detect false pends.
+
+## Future milestone: 100,000 claims
+
+The next publication candidate after Part 6 is a focused 100K milestone.
+
+That future article should answer a different question: once broader edge-case scoring is established at 50K, how far can the local Kubernetes validation path scale before the next bottleneck appears?
+
+100K should not block Part 6.
+
+## Correctness framing
+
+Correctness is not the same as payment.
+
+In MCC reporting:
+
+- `Matched` means the actual platform outcome agreed with the answer key.
+- `Mismatched` means the platform produced a scoreable outcome that disagreed with the answer key.
+- `Unsupported` means the answer key expects behavior that is not yet observable or implemented in the validator path.
+- `Platform failure` means the platform failed to submit, adjudicate, or write back a claim.
+
+Unsupported scenarios are honest gaps. They are not successes, and they are not platform failures.
+
+The current unsupported bucket is concentrated in subrogation, prior-authorization edge variants, retroactive coverage change, behavioral health carve-out, and Medicaid spend-down scenarios. Those categories are the next adjudication edit-model roadmap, not hidden successes.
+</pre></details></section>
+<section id="episode-007"><div class="eyebrow">Part 7 · recorded artifact</div><h2>Moving benchmark proof from terminal logs into an operator-facing Mass Adjudication console.</h2><div class="article-links"><a href="/insights/million-claim-challenge/part-7-operator-console">Read article</a><a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-007/benchmark-results.txt" target="_blank" rel="noopener noreferrer">Source artifact</a></div><details class="evidence-block" open><summary>Benchmark results recorded with Episode 007</summary><pre># Episode 007 benchmark and console evidence notes
+
+## Environment
+
+- Environment: local Kubernetes via Docker Desktop
+- Tenant: `demo`
+- Workload: synthetic Million Claim Challenge claim corpus
+- Generator seed: 42
+- Line of business: Medicaid (3)
+- Parallelism: 6
+- Claim count: 5,000
+- Member seeding: enabled
+- Provider seeding: enabled
+- Portal URL during inspection: `http://localhost:5026`
+- Claims-service local tunnel during inspection: `http://localhost:18080`
+- Important caveat: this was a local dashboard evidence run, not a production cloud benchmark
+
+Tenant-state caveat:
+
+The run used a long-lived local demo tenant, not a freshly reset tenant. As with Episode 006, local accumulated state can affect seeding counts, duplicate-detection paths, accumulator state, and hot-path timing.
+
+Payment-delta caveat:
+
+`Avg payment delta` remains diagnostic only. It is not yet a pass/fail amount-level scoring gate. Episode 007 keeps it visible in the console story because disposition-level correctness and payment-amount correctness are related but not identical.
+
+Pend-observation caveat:
+
+Expected-pend observation remains one-directional. It verifies expected-pend claims persisted as pended, but it does not yet sweep expected-pay or expected-deny claims for false pends.
+
+## Fresh 5,000-claim dashboard evidence run
+
+Purpose:
+
+- verify the portal can inspect a freshly published mass adjudication run
+- verify claim-result filtering works for unsupported rows
+- verify the post-PR-875 evidence-first sample path is active
+- provide Part 7 with a current local run after the Mass Adjudication console work
+
+Run:
+
+- Run ID: `b376a131a5de4118a49129fd2449eaee`
+- Job name: `mcc-main875-5k-evidence`
+
+Command:
+
+```bash
+SKIP_BUILD=false CLAIMS=5000 MAX_CLAIMS=5000 PARALLELISM=6 PROGRESS_EVERY=1000 SEED_MEMBERS=true SEED_PROVIDERS=true CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS=15 JOB_NAME=mcc-main875-5k-evidence scripts/run-mcc-local-k8s.sh
+```
+
+Summary:
+
+| Metric | Value |
+| --- | ---: |
+| Claims requested | 5,000 |
+| Claims processed | 5,000 |
+| Paid/adjudicated | 3,852 |
+| Pended | 46 |
+| Business denials | 1,102 |
+| Platform failures | 0 |
+| Observation timeouts | 0 |
+| Workflow checks | 577/650 matched |
+| Workflow mismatches | 0 |
+| Unsupported | 73 |
+| Workflow observation timeouts | 0 |
+| Elapsed | 02:11.910 |
+| Throughput | 37.90 claims/sec |
+| P95 latency | 384 ms |
+| P99 latency | 466 ms |
+| Avg payment delta | $66.90 |
+
+Timing:
+
+| Stage | Avg | P95 |
+| --- | ---: | ---: |
+| Submit | 8 ms | 32 ms |
+| Adjudicate | 143 ms | 375 ms |
+| Writeback | 8 ms | 48 ms |
+| Provider integrity hot path | 136 ms | 371 ms |
+| Benefit calculation | 32 ms | 90 ms |
+
+Business denial breakdown:
+
+| Denial | Count |
+| --- | ---: |
+| PROVIDER_EXCLUDED | 854 |
+| PRIOR_AUTH_REQUIRED | 108 |
+| CARC_96 | 100 |
+| NCCI_MUE_EDIT_FAILURE | 24 |
+| CARC_27 | 13 |
+
+Key matched scenario groups:
+
+| Scenario | Result |
+| --- | ---: |
+| CleanProfessionalPaid | 100/100 matched |
+| ExcludedProviderDenied | 100/100 matched |
+| TxStarInpatientNoAuth | 100/100 matched |
+| UncoveredServiceDenied | 100/100 matched |
+| EdgeCase:CobBirthdayRule | 10/10 matched |
+| EdgeCase:CobGenderRule | 10/10 matched |
+| EdgeCase:CobMedicareSecondary | 10/10 matched |
+| EdgeCase:CobPrimaryPayer | 10/10 matched |
+| EdgeCase:CobSecondaryPayer | 10/10 matched |
+| EdgeCase:CobTertiaryPayer | 10/10 matched |
+| EdgeCase:MedicaidCHIP | 6/6 matched |
+| EdgeCase:MedicaidDualEligible | 6/6 matched |
+| EdgeCase:MedicaidSSI | 6/6 matched |
+| EdgeCase:MedicaidTANF | 6/6 matched |
+| EdgeCase:NewbornAutoAdjudication | 10/10 matched |
+| EdgeCase:NewbornFirstThirtyDays | 10/10 matched |
+| EdgeCase:NewbornMotherClaimLink | 10/10 matched |
+| EdgeCase:PriorAuthRequired_AuthOnFile | 8/8 matched |
+| EdgeCase:PriorAuthRequired_NoAuth | 8/8 matched |
+| EdgeCase:RetroEligibilityAdd | 14/14 matched |
+| EdgeCase:RetroEligibilityTermination | 13/13 matched |
+
+Unsupported scenario groups:
+
+| Scenario | Unsupported |
+| --- | ---: |
+| EdgeCase:BehavioralHealthCarveOut | 10 |
+| EdgeCase:MedicaidSpendDown | 6 |
+| EdgeCase:PriorAuthRequired_ExpiredAuth | 8 |
+| EdgeCase:PriorAuthRequired_WrongProcedure | 8 |
+| EdgeCase:PriorAuthRequired_WrongProvider | 8 |
+| EdgeCase:RetroEligibilityCoverageChange | 13 |
+| EdgeCase:SubrogationAccidentRelated | 7 |
+| EdgeCase:SubrogationThirdPartyLiability | 6 |
+| EdgeCase:SubrogationWorkersComp | 7 |
+
+## Portal verification
+
+Dashboard API:
+
+- `GET http://localhost:18080/api/mass-adjudication/runs?limit=1`
+- Confirmed latest run ID: `b376a131a5de4118a49129fd2449eaee`
+
+Unsupported filter:
+
+- `GET http://localhost:18080/api/mass-adjudication/runs/b376a131a5de4118a49129fd2449eaee/claims?validationStatus=Unsupported&amp;pageSize=5`
+- Returned unsupported claim rows, including:
+  - `MCC-E-0000088`, `EdgeCase:RetroEligibilityCoverageChange`
+  - `MCC-E-0000092`, `EdgeCase:RetroEligibilityCoverageChange`
+  - `MCC-E-0000094`, `EdgeCase:RetroEligibilityCoverageChange`
+  - `MCC-E-0000167`, `EdgeCase:PriorAuthRequired_WrongProcedure`
+  - `MCC-E-0000155`, `EdgeCase:PriorAuthRequired_WrongProvider`
+
+Mismatch filter:
+
+- `GET http://localhost:18080/api/mass-adjudication/runs/b376a131a5de4118a49129fd2449eaee/claims?validationStatus=Mismatched&amp;pageSize=5`
+- Returned zero rows because the run had zero workflow mismatches.
+
+## Implementation provenance
+
+PR #874:
+
+- Added validation-status filtering to mass adjudication claim results.
+- Added unsupported and mismatch options to the portal claim-result filter.
+- Updated throughput labels to `claims/sec`.
+
+PR #875:
+
+- Changed validator claim-result sampling to preserve evidence-critical rows before slowest remaining rows.
+- Priority order: platform failures, observation failures, mismatches, unsupported, then slowest remaining claims.
+- Added deterministic tie-breakers by generated claim ID.
+
+## Interpretation
+
+The fresh 5K run is a console-evidence proof, not a new scale claim.
+
+The key result is that the current portal can now inspect a published mass adjudication run, show human-readable MCC claim IDs, filter unsupported results, preserve mismatch rows when they exist, and keep payment delta visible as an unresolved scoring gate.
+</pre></details></section>
+  </main>
+</body>
+</html>

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -324,7 +324,9 @@
           </p>
           <p style="font-size:0.95rem;color:#888;">
             Local Docker Desktop Kubernetes benchmark, not a production cloud benchmark.
-            <a href="/docs/million-claim-challenge" style="color:#00ffff;">Read the benchmark methodology &rarr;</a>
+            <a href="/docs/million-claim-challenge" style="color:#00ffff;">Read the methodology</a> &middot;
+            <a href="/insights/million-claim-challenge" style="color:#00ffff;">Engineering series</a> &middot;
+            <a href="/docs/million-claim-challenge/evidence" style="color:#00ffff;">Evidence archive &rarr;</a>
           </p>
         </article>
       </section>

--- a/src/site/insights/million-claim-challenge/index.html
+++ b/src/site/insights/million-claim-challenge/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Million Claim Challenge Engineering Series | Cloud Health Office</title>
+  <meta name="description" content="Engineering field notes documenting how the Million Claim Challenge became a repeatable, inspectable claims-adjudication benchmark.">
+  <link rel="canonical" href="https://cloudhealthoffice.com/insights/million-claim-challenge">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="Million Claim Challenge Engineering Series">
+  <meta property="og:description" content="Engineering field notes documenting how the Million Claim Challenge became a repeatable, inspectable claims-adjudication benchmark.">
+  <meta property="og:url" content="https://cloudhealthoffice.com/insights/million-claim-challenge">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    <div class="eyebrow">Engineering series</div><h1>Million Claim Challenge Field Notes</h1><p>How the benchmark moved from local Kubernetes runs to repeatable measurement, honest workflow scoring, and operator-facing evidence.</p><div class="disclosure"><strong>Current verified scope:</strong> the latest published proof is a 50,000-claim local Kubernetes breadth run. The full million remains the target.</div><article class="evidence-block" style="padding:22px"><div class="eyebrow">Part 5</div><h2 style="margin-top:8px">Running a Healthcare Claims Platform Locally in Kubernetes, Part 5: From Faster to Repeatably Faster</h2><p>How the local Kubernetes sweep harness turned isolated fast runs into repeatable performance evidence.</p><div class="article-links"><a href="/insights/million-claim-challenge/part-5-repeatably-faster">Read article</a><a href="/docs/million-claim-challenge/evidence#episode-005">Inspect evidence</a></div></article>
+<article class="evidence-block" style="padding:22px"><div class="eyebrow">Part 6</div><h2 style="margin-top:8px">Running a Healthcare Claims Platform Locally in Kubernetes, Part 6: From Fast Runs to Honest Edge-Case Scoring</h2><p>Why paid is not the only correct outcome, and why unsupported scenarios must remain visible.</p><div class="article-links"><a href="/insights/million-claim-challenge/part-6-honest-edge-case-scoring">Read article</a><a href="/docs/million-claim-challenge/evidence#episode-006">Inspect evidence</a></div></article>
+<article class="evidence-block" style="padding:22px"><div class="eyebrow">Part 7</div><h2 style="margin-top:8px">Running a Healthcare Claims Platform Locally in Kubernetes, Part 7: From Benchmark Logs to an Operator Console</h2><p>Moving benchmark proof from terminal logs into an operator-facing Mass Adjudication console.</p><div class="article-links"><a href="/insights/million-claim-challenge/part-7-operator-console">Read article</a><a href="/docs/million-claim-challenge/evidence#episode-007">Inspect evidence</a></div></article>
+  </main>
+</body>
+</html>

--- a/src/site/insights/million-claim-challenge/part-5-repeatably-faster.html
+++ b/src/site/insights/million-claim-challenge/part-5-repeatably-faster.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Running a Healthcare Claims Platform Locally in Kubernetes, Part 5: From Faster to Repeatably Faster | Cloud Health Office</title>
+  <meta name="description" content="How the local Kubernetes sweep harness turned isolated fast runs into repeatable performance evidence.">
+  <link rel="canonical" href="https://cloudhealthoffice.com/insights/million-claim-challenge/part-5-repeatably-faster">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="Running a Healthcare Claims Platform Locally in Kubernetes, Part 5: From Faster to Repeatably Faster">
+  <meta property="og:description" content="How the local Kubernetes sweep harness turned isolated fast runs into repeatable performance evidence.">
+  <meta property="og:url" content="https://cloudhealthoffice.com/insights/million-claim-challenge/part-5-repeatably-faster">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    <div class="eyebrow">Million Claim Challenge · Part 5</div>
+    <h1>Running a Healthcare Claims Platform Locally in Kubernetes, Part 5: From Faster to Repeatably Faster</h1>
+    <div class="disclosure"><strong>Evidence scope:</strong> This engineering field note describes local Kubernetes development and validation. It is not a production-cloud capacity claim or evidence that the full one-million-claim corpus has been completed.</div>
+    <div class="article-links">
+      <a href="/docs/million-claim-challenge/evidence#episode-005">View evidence</a>
+      <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-005/article.txt" target="_blank" rel="noopener noreferrer">View article source</a>
+    </div>
+    <p>In the last few iterations of the Million Claim Challenge, CloudHealthOffice made a meaningful jump.</p>
+<p>We were no longer just proving that the platform could run locally in Kubernetes. We were proving that real healthcare administration workflows could execute end to end: claim submission, scrubbing, provider checks, prior authorization logic, benefit plan adjudication, accumulator updates, claim writeback, and outcome reporting.</p>
+<p>But there is a trap in performance work: one fast run can feel like progress, even when it is not yet evidence.</p>
+<p>So this phase was about repeatable measurement.</p>
+<p>Not &quot;it felt faster.&quot;</p>
+<p>Not &quot;this one run looked good.&quot;</p>
+<p>Repeatable measurement.</p>
+<h2 id="a-fast-run-is-not-a-benchmark">A fast run is not a benchmark</h2>
+<p>When tuning a claims platform, throughput alone is not enough.</p>
+<p>A benchmark has to answer more than one question:</p>
+<ul><li>How many claims per second did we process?</li><li>What was the P95 latency?</li><li>What happened at P99?</li><li>Did any platform failures occur?</li><li>Did workflow validation still pass?</li><li>Were business denials correctly distinguished from platform errors?</li><li>Did the same configuration perform consistently across repeated runs?</li></ul>
+<p>For CloudHealthOffice, the Million Claim Challenge is not just a speed test. It is a workflow validation exercise. The goal is to prove that the platform can process claims correctly under pressure, not merely move HTTP requests through a local cluster.</p>
+<h2 id="building-the-sweep-harness">Building the sweep harness</h2>
+<p>To make tuning more disciplined, we added a local Kubernetes sweep harness.</p>
+<p>The script runs the MCC validator across configurable parallelism values and repeats each value multiple times.</p>
+<p>``<code>bash SKIP_BUILD=true \ CLAIMS=1000 \ PARALLELISM_VALUES=&quot;8 10 11 12&quot; \ REPEATS=2 \ ./scripts/sweep-mcc-local-k8s.sh </code>``</p>
+<p>The harness captures raw Kubernetes job logs, machine-readable summary JSON, throughput, P95/P99 latency, stage-level adjudication timings, platform failures, workflow validation counts, and averaged results by parallelism.</p>
+<p>That changed the tuning conversation.</p>
+<p>Instead of guessing which setting is better, we can run a sweep and compare the output.</p>
+<h2 id="the-first-sweep">The first sweep</h2>
+<p>The first sweep compared parallelism values of 8, 10, 11, and 12.</p>
+<p>At 1,000 claims, parallelism 11 was the strongest setting:</p>
+<ul><li>247.10 claims per second</li><li>100.35 ms P95 latency</li><li>128.53 ms P99 latency</li><li>zero platform failures</li><li>160/160 workflow checks matched</li></ul>
+<p>That was a good result.</p>
+<p>But it was also the reason we needed a larger run.</p>
+<p>A setting that wins at 1,000 claims may not win at 10,000. And a setting that wins at 10,000 may behave differently at 50,000.</p>
+<p>That is the whole point of repeatable benchmarking.</p>
+<h2 id="the-10-000-claim-sweep-changed-the-answer">The 10,000-claim sweep changed the answer</h2>
+<p>At 10,000 claims, the answer changed.</p>
+<p>Parallelism 11 was no longer the clean winner. Parallelism 10 became the better balance.</p>
+<p>The 10,000-claim sweep showed:</p>
+<ul><li>p=10: 209.54 claims/sec, 103.47 ms P95, 149.85 ms P99</li><li>p=12: 209.81 claims/sec, 118.19 ms P95, 170.90 ms P99</li></ul>
+<p>Parallelism 12 had a tiny throughput edge, but parallelism 10 had cleaner latency.</p>
+<p>That matters.</p>
+<p>The goal is not to crank parallelism until the throughput number looks impressive. The goal is to find the setting where the system keeps its shape: throughput, tail latency, platform reliability, and workflow correctness together.</p>
+<p>These runs were performed locally on Docker Desktop Kubernetes with Docker allocated 18 CPUs and approximately 24 GB of memory. This is not a production benchmark. It is a local proving ground where the platform can be evaluated repeatably before moving to cloud-scale testing.</p>
+<h2 id="finding-a-benchmark-ceiling">Finding a benchmark ceiling</h2>
+<p>When we tried to move from 10,000 claims to 50,000, we found something important.</p>
+<p>The validator was intentionally capped at 10,000 claims to avoid excessive in-memory allocation during local validation.</p>
+<p>That was a reasonable safety guard earlier in the project.</p>
+<p>But now it was blocking the benchmark.</p>
+<p>So we made the cap explicit.</p>
+<p>The validator keeps the safe default cap, but allows larger runs when the caller intentionally opts in with a max-claims override. The local Kubernetes scripts pass that override when <code>CLAIMS</code> is set higher.</p>
+<p>That is the kind of thing a serious benchmark exposes.</p>
+<p>Not just &quot;how fast is it?&quot;</p>
+<p>But also:</p>
+<ul><li>Are we measuring what we think we are measuring?</li><li>Are there hidden caps?</li><li>Are the scripts honest?</li><li>Does the summary JSON match the requested workload?</li><li>Can the result be reproduced?</li></ul>
+<p>The first attempted 50,000-claim run silently processed 10,000 because of the cap.</p>
+<p>After the fix, the validator reported the real workload:</p>
+<ul><li>50,000 requested</li><li>50,000 generated</li><li>50,000 processed</li></ul>
+<p>That is benchmark discipline.</p>
+<h2 id="the-true-50-000-claim-local-kubernetes-run">The true 50,000-claim local Kubernetes run</h2>
+<p>With the cap fixed, we ran a true 50,000-claim local Kubernetes validation at parallelism 10.</p>
+<p>The result:</p>
+<ul><li>50,000 claims requested</li><li>50,000 claims generated</li><li>50,000 claims processed</li><li>157.07 claims per second</li><li>5 minutes 18 seconds elapsed</li><li>130 ms P95 latency</li><li>175 ms P99 latency</li><li>zero platform failures</li><li>4,000/4,000 workflow checks matched</li></ul>
+<p>This was not just a bigger number.</p>
+<p>It also validated a larger workflow mix:</p>
+<ul><li>1,000 clean paid scenarios</li><li>1,000 excluded provider scenarios</li><li>1,000 uncovered service scenarios</li><li>1,000 prior authorization scenarios</li></ul>
+<p>Every deterministic workflow check matched.</p>
+<p>That is the result that matters most.</p>
+<p>Throughput is important. But throughput without correctness is just fast noise.</p>
+<h2 id="separating-setup-cost-from-adjudication-throughput">Separating setup cost from adjudication throughput</h2>
+<p>After the true 50,000-claim run, we ran one more important test.</p>
+<p>The first successful 50,000-claim validation included provider seeding. That is useful for a first-time local validation because the demo tenant needs synthetic providers before claims can be checked against provider rules.</p>
+<p>But once the tenant has already been seeded, provider setup is no longer part of the steady-state adjudication path.</p>
+<p>So the local Kubernetes scripts now allow repeat benchmark runs to skip provider seeding:</p>
+<p>``<code>bash SEED_PROVIDERS=false </code>``</p>
+<p>That gives a cleaner view of repeat adjudication throughput against an already-prepared tenant.</p>
+<p>The difference was meaningful:</p>
+<ul><li>with provider seeding: 157.07 claims/sec, 130 ms P95, 175 ms P99</li><li>skipping provider seeding: 188.64 claims/sec, 106 ms P95, 151 ms P99</li></ul>
+<p>Both runs still completed with zero platform failures and 4,000/4,000 workflow checks matched.</p>
+<p>That is an important distinction.</p>
+<p>The first run answers, &quot;Can this local environment prepare itself and process the workload correctly?&quot;</p>
+<p>The repeat run answers, &quot;Once setup is out of the way, how fast can the adjudication path run while preserving correctness?&quot;</p>
+<p>Both questions matter. But they should not be blended together without saying so.</p>
+<h2 id="correct-denials-are-not-failures">Correct denials are not failures</h2>
+<p>One of the most important ideas in the Million Claim Challenge is that not every unpaid claim is a problem.</p>
+<p>Some claims should deny.</p>
+<p>A claim might fail business rules because of uncovered services, duplicate logic, excluded providers, prior authorization requirements, coding edits, or plan rules.</p>
+<p>Those are valid outcomes when the platform applies the rules correctly.</p>
+<p>The sweep preserves that distinction.</p>
+<p>A business denial is not counted as a platform failure. A platform failure is an unexpected error, infrastructure issue, service failure, or workflow breakdown.</p>
+<p>That distinction is essential if we are going to benchmark healthcare administration software honestly.</p>
+<p>A platform that pays everything quickly is not impressive.</p>
+<p>A platform that processes claims quickly, applies business rules correctly, explains denials, and records outcomes cleanly is much more interesting.</p>
+<h2 id="where-we-are-now">Where we are now</h2>
+<p>CloudHealthOffice can now run the Million Claim Challenge locally in Kubernetes, validate real workflow outcomes, record mass adjudication runs, inspect claim-level results, sweep performance configurations, and scale beyond the original 10,000-claim validation ceiling.</p>
+<p>The current local result:</p>
+<p>&gt; 50,000 claims processed in Kubernetes, 188.64 claims per second on a repeat run with provider seeding skipped, 106 ms P95 latency, 151 ms P99 latency, zero platform failures, and 4,000/4,000 workflow checks matched.</p>
+<p>That is a very good place to be.</p>
+<p>But more importantly, we now have a way to keep pushing.</p>
+<p>Not by guessing.</p>
+<p>By measuring.</p>
+    <div class="article-links"><a href="/insights/million-claim-challenge">All MCC articles</a><a href="/docs/million-claim-challenge/evidence">Evidence archive</a></div>
+  </main>
+</body>
+</html>

--- a/src/site/insights/million-claim-challenge/part-6-honest-edge-case-scoring.html
+++ b/src/site/insights/million-claim-challenge/part-6-honest-edge-case-scoring.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Running a Healthcare Claims Platform Locally in Kubernetes, Part 6: From Fast Runs to Honest Edge-Case Scoring | Cloud Health Office</title>
+  <meta name="description" content="Why paid is not the only correct outcome, and why unsupported scenarios must remain visible.">
+  <link rel="canonical" href="https://cloudhealthoffice.com/insights/million-claim-challenge/part-6-honest-edge-case-scoring">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="Running a Healthcare Claims Platform Locally in Kubernetes, Part 6: From Fast Runs to Honest Edge-Case Scoring">
+  <meta property="og:description" content="Why paid is not the only correct outcome, and why unsupported scenarios must remain visible.">
+  <meta property="og:url" content="https://cloudhealthoffice.com/insights/million-claim-challenge/part-6-honest-edge-case-scoring">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    <div class="eyebrow">Million Claim Challenge · Part 6</div>
+    <h1>Running a Healthcare Claims Platform Locally in Kubernetes, Part 6: From Fast Runs to Honest Edge-Case Scoring</h1>
+    <div class="disclosure"><strong>Evidence scope:</strong> This engineering field note describes local Kubernetes development and validation. It is not a production-cloud capacity claim or evidence that the full one-million-claim corpus has been completed.</div>
+    <div class="article-links">
+      <a href="/docs/million-claim-challenge/evidence#episode-006">View evidence</a>
+      <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-006/article.txt" target="_blank" rel="noopener noreferrer">View article source</a>
+    </div>
+    <p class="source-note">Originally published externally: <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da</a></p>
+<p>In the previous part of this series, Cloud Health Office moved the Million Claim Challenge from one-off local runs into repeatable Kubernetes benchmarking.</p>
+<p>That mattered. Repeatability is the difference between a fast demo and a measurement system. We could run the same workload, vary parallelism, compare latency, separate setup costs from adjudication costs, and finally process a true 50,000-claim local run instead of accidentally measuring a capped 10,000-claim workload.</p>
+<p>But repeatable speed is only one part of the problem.</p>
+<p>For a healthcare claims platform, the harder question is not simply &quot;how many claims per second can it process?&quot;</p>
+<p>The harder question is: did it reach the right outcome?</p>
+<p>That is where Part 6 begins.</p>
+<h2 id="payment-is-not-the-only-successful-outcome">Payment is not the only successful outcome</h2>
+<p>Claims adjudication has a trap that benchmark dashboards can easily fall into: treating paid claims as good and unpaid claims as bad.</p>
+<p>That is not how claims work.</p>
+<p>A claim can deny correctly because the provider is excluded. A claim can deny correctly because the service is uncovered. A claim can deny correctly because prior authorization is required and no authorization is on file. A claim can pend correctly because coordination of benefits needs human or downstream review.</p>
+<p>A correct platform does not maximize payments. It applies the contract, policy, edit, coverage, and workflow rules consistently.</p>
+<p>That is why the Million Claim Challenge has to report workflow outcomes, not just throughput.</p>
+<h2 id="the-uncomfortable-value-of-unsupported">The uncomfortable value of unsupported</h2>
+<p>One of the most important changes in this phase was adding a sharper distinction between three states: matched, mismatched, and unsupported.</p>
+<p>A matched scenario means the platform produced the expected scoreable outcome. A mismatched scenario means the platform produced a scoreable outcome that disagreed with the answer key. An unsupported scenario means the benchmark corpus expects behavior that the current validation path cannot honestly observe or score yet.</p>
+<p>That third category matters. Without it, a benchmark has two bad options: count unsupported behavior as a failure even when the platform has no observable signal for the validator to read, or quietly count it as success, which is worse.</p>
+<p>The Million Claim Challenge does neither.</p>
+<p>Unsupported is an honest gap. It is a work queue, not a win.</p>
+<h2 id="making-pends-observable">Making pends observable</h2>
+<p>Expected-pend scenarios were the first big test of that philosophy.</p>
+<p>The corpus includes scenarios where the expected outcome is not paid and not denied. Some coordination-of-benefits cases, for example, should pend for review.</p>
+<p>The benefit-plan adjudication response is intentionally synchronous. It reports success, denial, totals, and timing. It does not fully represent every persisted claim workflow state.</p>
+<p>The claims service, however, does expose the authoritative persisted status. A claim can be read back with <code>ClaimStatus.Pended</code>, and pend details can include a reason.</p>
+<p>That means the validator should not fake pend results from lower-precision signals. It submits and adjudicates the claim, then observes expected-pend claims through the persisted claim API after the timed benchmark path completes.</p>
+<p>The benchmark timing remains scoped to submit, adjudicate, and writeback. Pend observation happens afterward and is reported separately. That distinction keeps the throughput number clean while making the correctness story more honest.</p>
+<p>There is still an important limitation. The pend-observation pass polls persisted status only for scenarios the answer key expects to pend. It proves those expected-pend claims really pended, but it does not by itself detect the inverse error: a claim expected to pay or deny that later persists as pended. That false-pend sweep is a future validator improvement, and until it exists, the pend numbers in this article should be read as one-directional proof.</p>
+<h2 id="fixture-bugs-are-benchmark-bugs">Fixture bugs are benchmark bugs</h2>
+<p>The next set of fixes was less glamorous and more important.</p>
+<p>Several mismatches were not adjudication failures. They were fixture problems.</p>
+<p>Retroactive eligibility termination depends on dates. The claim service date has to fall after the member coverage termination date. The validator normalizes claim dates into a current local testing window, which is useful for running against live services — but if only the claim date moves and the coverage window does not move with it, the scenario changes meaning. So the retro eligibility fixture had to preserve its date relationship during normalization.</p>
+<p>Newborn scenarios had a similar problem. A newborn claim should involve a newborn at the service date. If the service date moves forward during normalization but the date of birth does not, the claim can stop being a newborn scenario. The fixture also needed to make the member relationship explicit as a dependent child and provide prior authorization for paid inpatient newborn scenarios.</p>
+<p>Then the 5,000-claim breadth run found one more issue: <code>NewbornMotherClaimLink</code> could generate the same procedure code on both lines. That can trigger duplicate or unit-limit edits even though the scenario is supposed to validate a paid newborn workflow. The fix was to make multi-line edge-case fixtures choose distinct procedure codes, and to add regression coverage for the current multi-line edge scenarios.</p>
+<p>This is the kind of detail that makes benchmarks credible. The work is not just making the platform look better. It is making the benchmark harder to fool.</p>
+<h2 id="the-5k-breadth-baseline">The 5K breadth baseline</h2>
+<p>After those fixes, Cloud Health Office ran a 5,000-claim local Kubernetes breadth validation.</p>
+<p>The result:</p>
+<ul><li>5,000 claims processed</li><li>0 platform failures</li><li>46 expected-pend claims observed as pended</li><li>0 pend observation timeouts</li><li>577 of 650 workflow checks matched</li><li>0 workflow mismatches</li><li>73 unsupported scenarios reported separately</li></ul>
+<p>The newborn scenarios that had previously exposed fixture issues were clean: <code>NewbornAutoAdjudication</code>, <code>NewbornFirstThirtyDays</code>, and <code>NewbornMotherClaimLink</code> each finished 10/10 matched. Retro eligibility termination was also clean at 13/13.</p>
+<p>The run also preserved the earlier deterministic validation groups: clean professional paid claims, excluded provider denials, uncovered service denials, and Texas STAR inpatient prior-authorization denials.</p>
+<p>That is the new baseline for Part 6. It is not the final headline.</p>
+<h2 id="why-10k-and-50k-still-matter">Why 10K and 50K still matter</h2>
+<p>A 5,000-claim run is useful because it is fast enough to iterate and large enough to expose fixture collisions that a 1,000-claim smoke can miss. But Part 6 should not stop at 5K.</p>
+<p>The first attempt at a broader 50K run did exactly what a useful benchmark should do: it found a real scoreable mismatch.</p>
+<p>That first 50K attempt showed one workflow mismatch in <code>EdgeCase:CobSecondaryPayer</code>: 99 of 100 matched. That mattered. A single mismatch is not an operational failure, and it is not a reason to throw away the run, but it is also not something to hide.</p>
+<p>The fix was in the benchmark fixture setup, not the adjudication rule. Expected-pend COB scenarios could share a synthetic member with another generated claim, which meant one scenario could miss its own seeded COB coverage row. The validator now isolates supported COB-pend members by generated claim before seeding and adjudication.</p>
+<p>That fix merged as PR #858, <code>Fix MCC COB fixture isolation</code>. It touched only benchmark fixture and seeding code — zero adjudication rules changed. It is the provenance for everything that follows.</p>
+<p>After that, the 10K run became the confidence gate. At 10,000 claims post-fix, the platform processed every claim, observed all 92 expected-pend claims as pended, reported zero platform failures, and finished with 1,154 of 1,300 workflow checks matched, zero mismatches, and 146 unsupported scenarios labeled separately.</p>
+<p>Then a full clean 50K rerun replaced the older narrow 50K proof point.</p>
+<p>At 50,000 claims, the platform processed every claim, observed 460 of 460 expected-pend claims as pended, reported zero platform failures, and finished with 5,767 of 6,500 workflow checks matched, with 733 unsupported scenarios reported separately.</p>
+<p>The 50K run also produced a local throughput result:</p>
+<ul><li>68.86 claims per second</li><li>298 ms P95 latency</li><li>369 ms P99 latency</li></ul>
+<p>Those are local Docker Desktop Kubernetes numbers (18 CPUs, ~23.4 GiB allocated), not production cloud claims, and the run executed against a long-lived local tenant rather than a freshly reset cluster. The raw validator output, exact commands, commit SHAs, and full scenario tables are published alongside this article so the run can be checked, not just believed.</p>
+<h2 id="the-payment-delta-the-number-we-are-not-claiming-yet">The payment delta: the number we are not claiming yet</h2>
+<p>The raw output also reports an average payment delta of $59.36.</p>
+<p>Here is exactly what that number is. For claims that were both expected to pay and actually paid — and where the synthetic corpus defines an expected paid amount — the validator computes the absolute difference between the platform's plan payment and the answer key's expected amount, then averages it.</p>
+<p>Here is what it means for this article: the zero-mismatch result is disposition-level and workflow-level correctness. It says the platform paid what should pay, denied what should deny for the right business reason, and pended what should pend. It does not say the platform paid the right dollar amount.</p>
+<p>A mean also hides a distribution. A $59 average could be many small rounding-scale differences or a few badly wrong payments, and those are very different findings. Before payment accuracy becomes a headline, the validator needs a proper amount-level scoring gate that reports the delta distribution, not just the mean.</p>
+<p>So Part 6 treats the payment delta the same way it treats unsupported scenarios: visible, named, and explicitly not counted as a win. Payment-amount accuracy is the next scoring gate, not a solved problem.</p>
+<h2 id="the-wider-matched-footprint">The wider matched footprint</h2>
+<p>The matched results run broader than the highlights above. The clean 50K run matched the full COB set — primary, secondary, tertiary, birthday-rule, gender-rule, and Medicare-secondary. It matched Medicaid dual-eligible, CHIP, SSI, and TANF scenarios, retro eligibility add and termination, behavioral health carve-in and parity-check, prior-auth on-file and no-auth variants, and all three newborn scenarios.</p>
+<p>The unsupported bucket is equally worth naming. It is concentrated in subrogation, prior-authorization edge variants (expired auth, wrong procedure, wrong provider), retroactive coverage change, behavioral health carve-out, and Medicaid spend-down. That is not a footnote; it is the roadmap for the next layer of adjudication edit-model work.</p>
+<h2 id="what-comes-next">What comes next</h2>
+<p>There is an obvious next milestone: 100,000 claims.</p>
+<p>But that should be its own article and its own proof moment. The disciplined move is to make 50K boring first. And the 100K article should not just be a bigger number — it should be a bigger number under stricter scoring: the false-pend sweep and the payment-amount gate both belong there. Scale plus rigor is the milestone. Scale alone is a rerun.</p>
+<p>The target is not to make every scenario green by definition. The target is to report the truth:</p>
+<ul><li>matched where the platform and answer key agree</li><li>mismatched where a scoreable outcome is wrong</li><li>unsupported where the validation path cannot honestly score the scenario yet</li><li>platform failure where the system fails operationally</li><li>payment delta where a paid claim reached the right disposition but the dollar amount still needs its own scoring gate</li></ul>
+<p>That is a much stronger story than a perfect-looking number with hidden caveats.</p>
+<h2 id="what-this-proves">What this proves</h2>
+<p>This phase proves that the Million Claim Challenge is becoming more than a load test. It is becoming a credibility system.</p>
+<p>It checks whether the benchmark corpus still means what it claims to mean after date normalization. It checks whether pended workflows are observable. It checks whether valid business denials are counted as correct outcomes. It checks whether unsupported scenarios are separated from failures and wins. And it publishes the raw output that lets anyone check the checker.</p>
+<p>The honest path is:</p>
+<p>1. make outcomes observable 2. make fixtures truthful 3. separate unsupported gaps 4. run breadth validation at 5K 5. run the first 50K breadth attempt and find the COB secondary-payer mismatch 6. fix the COB fixture isolation gap in PR #858 7. confirm the fix at 10K 8. rerun 50K cleanly, in full 9. treat 100K — with stricter scoring — as the next focused milestone 10. then climb toward 250K, 500K, and the full million</p>
+<p>The Million Claim Challenge brand is ambitious. It should be.</p>
+<p>But the evidence has to climb the ladder in order.</p>
+<p>Part 6 is that next rung: not just faster claims processing, but honest edge-case scoring under repeatable local Kubernetes load.</p>
+    <div class="article-links"><a href="/insights/million-claim-challenge">All MCC articles</a><a href="/docs/million-claim-challenge/evidence">Evidence archive</a></div>
+  </main>
+</body>
+</html>

--- a/src/site/insights/million-claim-challenge/part-7-operator-console.html
+++ b/src/site/insights/million-claim-challenge/part-7-operator-console.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Running a Healthcare Claims Platform Locally in Kubernetes, Part 7: From Benchmark Logs to an Operator Console | Cloud Health Office</title>
+  <meta name="description" content="Moving benchmark proof from terminal logs into an operator-facing Mass Adjudication console.">
+  <link rel="canonical" href="https://cloudhealthoffice.com/insights/million-claim-challenge/part-7-operator-console">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="Running a Healthcare Claims Platform Locally in Kubernetes, Part 7: From Benchmark Logs to an Operator Console">
+  <meta property="og:description" content="Moving benchmark proof from terminal logs into an operator-facing Mass Adjudication console.">
+  <meta property="og:url" content="https://cloudhealthoffice.com/insights/million-claim-challenge/part-7-operator-console">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    <div class="eyebrow">Million Claim Challenge · Part 7</div>
+    <h1>Running a Healthcare Claims Platform Locally in Kubernetes, Part 7: From Benchmark Logs to an Operator Console</h1>
+    <div class="disclosure"><strong>Evidence scope:</strong> This engineering field note describes local Kubernetes development and validation. It is not a production-cloud capacity claim or evidence that the full one-million-claim corpus has been completed.</div>
+    <div class="article-links">
+      <a href="/docs/million-claim-challenge/evidence#episode-007">View evidence</a>
+      <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-007/article.txt" target="_blank" rel="noopener noreferrer">View article source</a>
+    </div>
+    <p>Part 6 of this series was about honesty.</p>
+<p>Cloud Health Office had moved the Million Claim Challenge beyond raw throughput and into outcome scoring. Paid claims, denied claims, and pended claims could all be correct. Unsupported scenarios were separated from mismatches instead of being quietly counted as wins or failures. Fixture bugs were treated as benchmark bugs. A clean 50,000-claim breadth run gave the project a stronger foundation than a faster but less inspectable number.</p>
+<p>But there was still a gap.</p>
+<p>The proof lived mostly in validator output, benchmark logs, and markdown tables.</p>
+<p>That is useful for engineers. It is not enough for operators.</p>
+<p>If this is supposed to become a real claims processing system, the evidence cannot only live in a terminal scrollback. A claim operations lead should be able to see the run, inspect the outcomes, filter the gaps, open a claim, and understand what happened without becoming a benchmark maintainer.</p>
+<p>That is where Part 7 begins.</p>
+<h2 id="a-benchmark-dashboard-can-hide-the-truth">A benchmark dashboard can hide the truth</h2>
+<p>Dashboards have their own failure mode.</p>
+<p>They can make weak evidence look strong by compressing everything into a green number.</p>
+<p>For healthcare claims, that is dangerous. A run summary that says &quot;50,000 claims processed&quot; is not enough. A run summary that says &quot;zero platform failures&quot; is better, but still incomplete. A run summary that says &quot;5,767 of 6,500 workflow checks matched, zero mismatches, 733 unsupported&quot; is much more honest.</p>
+<p>But even that is still a summary.</p>
+<p>The next question is: can you click into the evidence?</p>
+<p>If a scenario is unsupported, which claim was it? If a mismatch exists, which claim produced it? If pended claims were observed, can the persisted claim state be inspected? If payment delta is visible, can paid claims eventually be drilled into by amount difference?</p>
+<p>The console should preserve the nuance of the benchmark instead of sanding it down.</p>
+<h2 id="building-the-mass-adjudication-console">Building the Mass Adjudication console</h2>
+<p>The first version of the Mass Adjudication console turns local benchmark runs into an operator-facing view.</p>
+<p>It shows each published run with the things that matter during a claims benchmark:</p>
+<ul><li>processed claim count</li><li>claims per second</li><li>P95 and P99 latency</li><li>paid claims</li><li>pended claims</li><li>business denials</li><li>platform failures</li><li>workflow checks</li><li>workflow mismatches</li><li>unsupported scenarios</li><li>observation timeouts</li><li>average payment delta</li></ul>
+<p>The page also keeps the claim-level result table close to the run summary. That matters because run-level metrics are only useful if the underlying claims are reachable.</p>
+<p>The claim table now uses the human-readable Million Claim Challenge IDs, such as <code>MCC-P-0007841</code>, instead of making the internal GUID the main visual anchor. The GUID is still available as a secondary technical identifier, but the screen leads with the identifier a human can connect back to the corpus and benchmark output.</p>
+<p>Claim detail navigation also preserves the originating run. When an operator opens a claim from a mass adjudication run, the claim detail page can return to that run instead of dumping the user back into generic claim search.</p>
+<p>Those sound like small interface decisions.</p>
+<p>They are not.</p>
+<p>They are what turn a benchmark from a one-way report into an evidence trail.</p>
+<h2 id="the-console-exposed-a-proof-system-bug">The console exposed a proof-system bug</h2>
+<p>The most useful thing the dashboard did was not visual.</p>
+<p>It found a flaw in the evidence path.</p>
+<p>After PR #874, the claim results table could filter by validation status. That meant an operator could ask for unsupported claims or mismatched claims directly from the Mass Adjudication page.</p>
+<p>The filter worked.</p>
+<p>But the existing 50K run created an uncomfortable discovery: the run summary reported mismatches, while the stored claim-result sample did not include the mismatched rows.</p>
+<p>That was not a UI bug. It was a sampling bug.</p>
+<p>The validator had been publishing a limited claim-result sample, and that sample was biased toward slow claims. That is useful for latency triage, but it is not enough for correctness triage. A slow paid claim might be operationally interesting, but a mismatched claim is evidence-critical.</p>
+<p>If a dashboard can say &quot;there were mismatches&quot; but cannot show the mismatched claims, the dashboard is not yet an evidence console.</p>
+<p>So PR #875 changed the sampling model.</p>
+<p>Claim-result samples are now evidence-first:</p>
+<p>1. platform failures 2. observation failures 3. workflow mismatches 4. unsupported scenarios 5. slowest remaining claims for latency analysis</p>
+<p>The point is simple: the rows most likely to require human review should not be dropped just because they were not the slowest rows.</p>
+<p>That is an important product lesson. The console did not just display the benchmark. It improved the benchmark's accountability.</p>
+<h2 id="a-fresh-5k-dashboard-evidence-run">A fresh 5K dashboard evidence run</h2>
+<p>After the evidence-first sampling fix, Cloud Health Office ran a fresh 5,000-claim local Kubernetes validation to prove the console path.</p>
+<p>This was not a new scale headline. The Part 6 50K breadth run is still the larger result.</p>
+<p>The purpose of this 5K run was narrower: confirm that a current validator run publishes evidence in a way the portal can inspect.</p>
+<p>The run completed with:</p>
+<ul><li>5,000 claims processed</li><li>3,852 paid or adjudicated</li><li>46 pended</li><li>1,102 business denials</li><li>0 platform failures</li><li>0 observation timeouts</li><li>577 of 650 workflow checks matched</li><li>0 workflow mismatches</li><li>73 unsupported scenarios</li><li>37.90 claims per second</li><li>384 ms P95 latency</li><li>466 ms P99 latency</li><li>$66.90 average payment delta</li></ul>
+<p>The unsupported scenarios were not buried. The console filter could show them directly.</p>
+<p>Examples included retroactive eligibility coverage change and prior-authorization variants where the current validation path still reports unsupported instead of pretending the scenario is validated.</p>
+<p>The mismatch filter returned no rows in this run for the right reason: the run had zero workflow mismatches. That is very different from returning no rows because the sample failed to retain them.</p>
+<p>That distinction is the whole point.</p>
+<h2 id="the-dashboard-changes-how-gaps-feel">The dashboard changes how gaps feel</h2>
+<p>Before the console, unsupported scenarios were mostly a number in a table.</p>
+<p>Now they feel more like a work queue.</p>
+<p>That is the right direction. Unsupported should not be a vague caveat. It should be a set of inspectable claims connected to scenario names, generated claim IDs, outcomes, timings, and eventually the exact edit or workflow capability that needs to be built.</p>
+<p>The same is true for mismatches.</p>
+<p>When a mismatch exists, the useful question is not just &quot;how many?&quot; It is:</p>
+<ul><li>Which scenario produced it?</li><li>What did the answer key expect?</li><li>What did the platform produce?</li><li>Was the claim paid, denied, pended, or failed?</li><li>Was the issue fixture setup, adjudication logic, persistence, or observation?</li></ul>
+<p>The console is not fully there yet, but the shape is clear.</p>
+<p>Benchmark credibility improves when every headline number has a drilldown path.</p>
+<h2 id="why-claims-management-and-mass-adjudication-show-different-things">Why claims management and mass adjudication show different things</h2>
+<p>One design issue became obvious during this phase: the generic Claims page and the Mass Adjudication page are not the same view.</p>
+<p>That is expected.</p>
+<p>Claims management shows operational claim records. It is organized around the current claim inventory.</p>
+<p>Mass adjudication shows benchmark runs. It is organized around run evidence: which claims were part of a specific run, what outcome each claim produced, what validation status it received, how long it took, and whether the run created failures or unsupported results.</p>
+<p>Those views can overlap, but they should not collapse into one another.</p>
+<p>An operator investigating a production claim needs a claim-centric screen. An engineer or claims operations lead reviewing a benchmark needs a run-centric screen.</p>
+<p>Part 7 made the run-centric path much clearer.</p>
+<h2 id="what-the-console-still-does-not-prove">What the console still does not prove</h2>
+<p>This is still a local benchmark system, not a production operations center.</p>
+<p>The run was executed in local Docker Desktop Kubernetes against a long-lived demo tenant. That means accumulated local state can affect seeding behavior and hot paths. The numbers are useful for repeatable local engineering, not for production capacity claims.</p>
+<p>The dashboard also shows average payment delta, but payment-amount accuracy is not yet a scored pass/fail gate. A claim can reach the right disposition while still paying the wrong amount. Part 6 named that gap. Part 7 keeps it visible.</p>
+<p>Pended observation still has the same limitation described in Part 6: it proves expected-pend claims persisted as pended, but it does not yet sweep expected-pay or expected-deny claims to catch false pends.</p>
+<p>And the console does not yet show true live in-progress run telemetry. It can watch for newly published runs and display completed summaries, but the next step is to publish progress while the benchmark is running: submitted, adjudicated, failed, pended, current throughput, rolling latency, and scenario progress.</p>
+<p>Those are not reasons to discount the console.</p>
+<p>They are the next backlog.</p>
+<h2 id="why-this-matters">Why this matters</h2>
+<p>There is a pattern emerging across the Million Claim Challenge work.</p>
+<p>First the benchmark got repeatable.</p>
+<p>Then the scoring got more honest.</p>
+<p>Then pended claims became observable.</p>
+<p>Then unsupported scenarios were separated from mismatches.</p>
+<p>Then the dashboard exposed that correctness evidence needed better sampling.</p>
+<p>That is the right kind of progress.</p>
+<p>The platform is not just chasing bigger numbers. It is building the machinery needed to believe those numbers.</p>
+<p>Part 7 is about that machinery.</p>
+<p>Not just &quot;we ran claims.&quot;</p>
+<p>Not just &quot;we processed them quickly.&quot;</p>
+<p>But:</p>
+<ul><li>the run is visible</li><li>the summary is understandable</li><li>the claim IDs are human-readable</li><li>unsupported scenarios are filterable</li><li>mismatches are preserved for review</li><li>platform failures are not mixed with business denials</li><li>payment delta remains visible as an unsolved scoring gate</li></ul>
+<p>That is how a benchmark starts becoming an audit instrument.</p>
+<h2 id="what-comes-next">What comes next</h2>
+<p>The obvious next milestone is still 100,000 claims.</p>
+<p>But Part 7 makes the bar for 100K higher.</p>
+<p>The next big run should not only be larger. It should be more inspectable while it is running and more reviewable after it finishes.</p>
+<p>Before the 100K article, the strongest next steps are:</p>
+<p>1. publish in-progress run telemetry into the console 2. add a false-pend sweep across expected-pay and expected-deny claims 3. turn payment delta into an amount-level scoring gate 4. rerun 50K with evidence-first claim sampling 5. then run 100K as a focused milestone</p>
+<p>That is the ladder.</p>
+<p>Part 5 made the benchmark repeatable.</p>
+<p>Part 6 made the scoring honest.</p>
+<p>Part 7 made the evidence visible.</p>
+<p>The Million Claim Challenge is still climbing toward the full million, but this is the kind of rung that matters: the proof is moving from logs into the product.</p>
+    <div class="article-links"><a href="/insights/million-claim-challenge">All MCC articles</a><a href="/docs/million-claim-challenge/evidence">Evidence archive</a></div>
+  </main>
+</body>
+</html>

--- a/src/site/package.json
+++ b/src/site/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "node build.mjs"
+    "build": "node scripts/generate-mcc-publications.mjs && node build.mjs"
   }
 }

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Cloud Health Office is a compliance and modernization layer for legacy payer core admin systems. Deploy CMS-0057-F FHIR R4 APIs alongside QNXT, Facets, or HealthEdge without replatforming. Modernize now. Replace later.">
+  <meta name="description" content="Explore the source-available Cloud Health Office payer platform: implemented services, locally measured benchmarks, seeded portal examples, and pilot-stage deployment architecture.">
   <meta name="keywords" content="healthcare EDI platform architecture, FHIR R4 API health plan, X12 EDI to FHIR transformation, CMS-0057-F compliance platform, payer integration microservices, Azure healthcare Kubernetes, healthcare interoperability API">
   <meta name="author" content="Aurelianware">
   <link rel="canonical" href="https://cloudhealthoffice.com/platform">
@@ -13,14 +13,14 @@
   <meta property="og:site_name" content="Cloud Health Office">
   <meta property="og:url" content="https://cloudhealthoffice.com/platform">
   <meta property="og:title" content="FHIR R4 & EDI Platform Architecture — Cloud Health Office">
-  <meta property="og:description" content="How Cloud Health Office works: C# microservices, FHIR R4 APIs, X12 EDI to FHIR transformation, Azure and Kubernetes deployment. Built for CMS-0057-F compliance.">
+  <meta property="og:description" content="An evidence-based view of Cloud Health Office: implemented services, FHIR and X12 capabilities, local benchmarks, and pilot-stage deployment architecture.">
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg">
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://cloudhealthoffice.com/platform">
   <meta name="twitter:title" content="FHIR R4 & EDI Platform Architecture — Cloud Health Office">
-  <meta name="twitter:description" content="How Cloud Health Office works: C# microservices, FHIR R4 APIs, X12 EDI to FHIR transformation, Azure and Kubernetes deployment. Built for CMS-0057-F compliance.">
+  <meta name="twitter:description" content="An evidence-based view of Cloud Health Office: implemented services, FHIR and X12 capabilities, local benchmarks, and pilot-stage deployment architecture.">
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg">
 
   <title>Compliance &amp; Modernization Layer for Legacy Payer Systems — Cloud Health Office</title>
@@ -242,31 +242,31 @@
              style="max-width: 600px; height: auto; margin: 20px 0;">
         <h1>Cloud Health Office Platform</h1>
         <p class="tagline">Compliance &amp; Modernization Layer for Legacy Payer Core Systems</p>
-        <p style="margin-top:20px; font-size:1.2rem;"><strong>Compliance Accelerator to Full CAPS Platform</strong> &bull; Augment mode live. Modular replacement when you&rsquo;re ready.</p>
+        <p style="margin-top:20px; font-size:1.2rem;"><strong>Source-available payer infrastructure</strong> &bull; Available for technical evaluation and pilot deployments.</p>
       </div>
     </div>
 
     <div class="platform-overview">
       <section class="assessment-section">
         <h2>Compliance First. Modernization on Your Terms.</h2>
-        <p>Cloud Health Office is a source-available, Azure-native, HIPAA-engineered compliance layer that deploys alongside your existing core admin system through a focused, security-reviewed pilot path &mdash; delivering CMS-0057-F readiness without replatforming. Activate modular capabilities over time as your modernization roadmap evolves.</p>
+        <p>Cloud Health Office is a source-available collection of payer services, APIs, workflow definitions, and a Blazor operations portal. It is designed to run alongside an existing core admin system and is currently available for technical evaluation and security-reviewed pilots. Production readiness, compliance, integrations, and operating performance must be validated for each payer environment.</p>
         
         <div class="stats-grid">
           <div class="stat-card">
-            <div class="stat-number">&lt;1hr</div>
-            <div class="stat-label">Deployment Time<br>(vs. 6-18 months)</div>
+            <div class="stat-number">50K</div>
+            <div class="stat-label">Latest Published<br>Local Benchmark</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">Self-Service</div>
-            <div class="stat-label">Configuration-Driven<br>Onboarding</div>
+            <div class="stat-number">5,187</div>
+            <div class="stat-label">Automated Tests<br>Reported by CI</div>
           </div>
           <div class="stat-card">
             <div class="stat-number">PMPM</div>
             <div class="stat-label">Pilot-Scoped<br>Commercial Model</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">∞</div>
-            <div class="stat-label">Multi-Payer Tenants<br>(Complete Isolation)</div>
+            <div class="stat-number">Pilot</div>
+            <div class="stat-label">Current Platform<br>Engagement Stage</div>
           </div>
         </div>
       </section>
@@ -275,11 +275,11 @@
       <section class="assessment-section">
         <div class="section-label" style="color:#00ffff; font-size:0.85rem; letter-spacing:2px; text-transform:uppercase; margin-bottom:16px;">Product Line Context</div>
         <h2>One Platform. Four Product Lines.</h2>
-        <p>The Cloud Health Office (CHO) platform is the technical substrate underlying all four CHO product lines. The same FHIR services, X12 engines, calculation engines, and Argo-orchestrated workflows you'll see described below power every commercial surface CHO ships.</p>
+        <p>The Cloud Health Office (CHO) repository contains the technical building blocks planned for four product lines. Availability differs by product: some capabilities are usable today, while subscription packaging, customer integrations, SLAs, and production validation remain pilot- or roadmap-scoped.</p>
         <p style="margin-top:16px;"><strong>Public Tools</strong> &mdash; free fee-schedule lookup and free-tier claims repricing &mdash; run on the platform's <code>Pricing API</code> and <code>FeeScheduleEngine</code>. Same code, free tier.</p>
-        <p style="margin-top:12px;"><strong>Transactional Services</strong> &mdash; per-call APIs (Claims Repricing, Pricing) for developers, billing companies, TPAs, and integrators &mdash; expose the same engines via metered, self-serve subscription. Every API call exercises the production calculation paths under real load.</p>
-        <p style="margin-top:12px;"><strong>Managed Data Services</strong> &mdash; subscription services for state Medicaid updates, CMS fee schedule updates, provider verification, and terminology &mdash; productize the platform's ingestion and normalization pipelines as recurring-value data products.</p>
-        <p style="margin-top:12px;"><strong>Platform Engagement</strong> &mdash; payer-scale deployments priced per member per month (PMPM) &mdash; engages the entire platform across three layers: <strong>Layer 1 &mdash; Compliance Accelerator</strong> (CMS-0057-F surface alongside legacy core), <strong>Layer 2 &mdash; Progressive Modernization</strong> (domain-by-domain Augment or Replace), and <strong>Layer 3 &mdash; Full CAPS Platform</strong> (cloud-native end-to-end claims administration).</p>
+        <p style="margin-top:12px;"><strong>Transactional Services</strong> &mdash; claims repricing and pricing APIs are implemented in the repository. Self-service API-key provisioning, billing activation, and public production SLAs are still being completed.</p>
+        <p style="margin-top:12px;"><strong>Managed Data Services</strong> &mdash; ingestion, provider-verification, terminology, and fee-schedule components exist in code; subscriber packaging, update cadences, pricing, and SLAs are not yet generally available.</p>
+        <p style="margin-top:12px;"><strong>Platform Engagement</strong> &mdash; pilot-scoped payer deployments follow three intended layers: <strong>Layer 1 &mdash; Compliance Accelerator</strong>, <strong>Layer 2 &mdash; Progressive Modernization</strong>, and <strong>Layer 3 &mdash; Full CAPS Platform</strong>. Layer 3 is the long-term product direction, not evidence of a completed customer cutover.</p>
         <p style="margin-top:16px; color:#aaa;">The capabilities documented on this page are the substrate. The four product lines are the commercial surfaces. Read the rest of this page as the architecture; read the links below for how it sells.</p>
         <p style="margin-top:20px;">
           <a href="/pricing" style="color:#00ffff;">See full pricing across all four product lines &rarr;</a>
@@ -330,9 +330,9 @@
             <h3>Real-Time Prior Authorization</h3>
             <ul>
               <li>278 Health Care Services Review</li>
-              <li>Sub-2-minute processing (&lt;12 days)</li>
+              <li>Configurable workflow and decision routing</li>
               <li>Automated claims adjudication systems correlation</li>
-              <li>Complete audit trail</li>
+              <li>Audit-event capture</li>
               <li>Automated workflow routing</li>
             </ul>
           </div>
@@ -351,19 +351,19 @@
           <div class="capability-card">
             <h3>Eligibility Verification</h3>
             <ul>
-              <li>270/271 real-time eligibility</li>
-              <li>leading clearinghouses</li>
-              <li>Sub-second response times</li>
+              <li>270/271 eligibility workflows</li>
+              <li>Clearinghouse adapter interfaces</li>
+              <li>Environment-specific performance testing required</li>
               <li>Backend system correlation</li>
-              <li>99.9% uptime SLA target</li>
+              <li>No public production SLA yet</li>
             </ul>
           </div>
 
           <div class="capability-card">
             <h3>Enhanced Claim Status (ECS)</h3>
             <ul>
-              <li>X215 Authorization Inquiry</li>
-              <li>X217 Authorization Request</li>
+              <li>276 claim-status inquiry</li>
+              <li>277 claim-status response</li>
               <li>Real-time status tracking</li>
               <li>Historical lookup capabilities</li>
               <li>NCPDP and HIPAA format support</li>
@@ -376,19 +376,19 @@
               <li>277 RFAI automated generation</li>
               <li>275 Attachment processing</li>
               <li>Deadline tracking and notifications</li>
-              <li>Complete audit trail</li>
-              <li>Regulatory compliance built-in</li>
+              <li>Audit-event capture</li>
+              <li>Configurable regulatory deadline rules</li>
             </ul>
           </div>
 
           <div class="capability-card">
-            <h3>Security That Passes Audits</h3>
+            <h3>Security Reference Architecture</h3>
             <ul>
-              <li>Private endpoints everywhere</li>
+              <li>Private-endpoint deployment patterns</li>
               <li>HSM-backed Key Vault Premium</li>
               <li>DCR-based PHI redaction</li>
               <li>Immutable audit logs (7-year retention)</li>
-              <li>Managed identities only</li>
+              <li>Managed-identity support</li>
             </ul>
           </div>
 
@@ -430,7 +430,7 @@
             color: #e5e7eb;
             margin: 0 0 1rem;
             line-height: 1.2;
-          ">This Is What Production Looks Like</h2>
+          ">Portal Walkthrough With Seeded Data</h2>
 
           <p style="
             font-family: 'Inter', -apple-system, sans-serif;
@@ -440,9 +440,9 @@
             margin: 0 auto;
             line-height: 1.6;
           ">
-            Not a mockup. Not a pitch deck. Cloud Health Office — live claims adjudication,
-            work queues, prior authorization, eligibility verification, and CMS-0057-F compliance
-            running in production.
+            These screens are from the functional Blazor portal using synthetic development data.
+            They demonstrate implemented workflows and user-interface coverage; they are not customer
+            production metrics, a production reference deployment, or proof of regulatory compliance.
           </p>
         </div>
 
@@ -493,7 +493,7 @@
             letter-spacing: 0.08em;
             cursor: pointer;
             transition: all 0.2s;
-          ">&#9673; 29 MICROSERVICES</button>
+          ">&#9673; PLATFORM COMPONENTS</button>
         </div>
 
         <!-- ===== TAB: DASHBOARD ===== -->
@@ -571,7 +571,7 @@
                 font-weight: 700;
                 color: #00f0ff;
                 margin-bottom: 4px;
-              ">14,892</div>
+              ">14,892 demo</div>
               <div style="
                 font-size: 0.72rem;
                 color: rgba(255,255,255,0.35);
@@ -591,7 +591,7 @@
                 font-weight: 700;
                 color: #34d399;
                 margin-bottom: 4px;
-              ">87.3%</div>
+              ">87.3% demo</div>
               <div style="
                 font-size: 0.72rem;
                 color: rgba(255,255,255,0.35);
@@ -611,7 +611,7 @@
                 font-weight: 700;
                 color: #e5e7eb;
                 margin-bottom: 4px;
-              ">1.2 sec</div>
+              ">1.2 sec demo</div>
               <div style="
                 font-size: 0.72rem;
                 color: rgba(255,255,255,0.35);
@@ -733,7 +733,7 @@
                 </div>
                 <p style="font-size: 0.75rem; color: rgba(255,255,255,0.35); margin: 0; line-height: 1.45;">
                   Claims requiring authorization without an auth on file. Routed via the
-                  PriorAuthDecisionEngine — CMS-0057-F compliant decisioning with rationale.
+                  PriorAuthDecisionEngine — configurable decision rules, rationale, and deadline tracking.
                 </p>
               </div>
 
@@ -942,20 +942,20 @@
             border-top: 1px solid rgba(0, 240, 255, 0.06);
           ">
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #00f0ff;">31</div>
-              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">MICROSERVICES</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #00f0ff;">36</div>
+              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">SERVICES IN REPO</div>
             </div>
             <div style="text-align: center;">
               <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #a78bfa;">9</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">CLASS LIBRARIES</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">2,589</div>
-              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">TESTS PASSING</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">5,187</div>
+              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">TESTS REPORTED</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">250K+</div>
-              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">REPO CLONES</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">50K</div>
+              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">LOCAL BENCHMARK</div>
             </div>
           </div>
         </div>
@@ -1019,7 +1019,7 @@
             color: #e5e7eb;
             margin: 0 0 1rem;
             line-height: 1.2;
-          ">29 Microservices. One Adjudication Pipeline.</h2>
+          ">Service-Oriented Claims Administration Architecture</h2>
 
           <p style="
             font-family: 'Inter', -apple-system, sans-serif;
@@ -1029,9 +1029,9 @@
             margin: 0 auto;
             line-height: 1.6;
           ">
-            Cloud Health Office runs as a sidecar to your existing CAPS — QNXT, Facets, or HealthEdge.
-            X12 EDI in, FHIR R4 out, with full claims adjudication, prior auth, eligibility,
-            and CMS-0057-F compliance running on Azure Kubernetes Service.
+            The repository includes independently deployable .NET services, calculation engines, X12 workflows,
+            and FHIR APIs designed for Kubernetes. The architecture supports integration with systems such as
+            QNXT, Facets, or HealthEdge, but each connector and production topology requires customer-specific validation.
           </p>
         </div>
 
@@ -1047,7 +1047,7 @@
         ">
           <img
             src="/graphics/platform-architecture.png"
-            alt="Cloud Health Office platform architecture — 29 C# microservices on Azure Kubernetes Service with X12 EDI intake, FHIR R4 APIs, claims adjudication pipeline, and CMS-0057-F compliance layer"
+            alt="Cloud Health Office reference architecture with C# services, X12 EDI intake, FHIR R4 APIs, and a claims adjudication pipeline"
             style="width: 100%; display: block; background: #080c14;"
             loading="lazy"
           />
@@ -1519,11 +1519,10 @@
 
       <section class="cta-section">
         <h2>See How It Works With Your Core System</h2>
-        <p>Detailed technical analysis of augmentation mode, compliance deployment, and long-term modernization roadmap.</p>
+        <p>Review the intended augmentation model, current implementation, and long-term modernization roadmap.</p>
         <p style="font-size: 1.2rem; margin: 30px 0;">
-          <strong>CMS-0057-F compliant in weeks.</strong>
-          <strong>No changes to existing operations.</strong>
-          <strong>Gradual path to modular replacement.</strong>
+          <strong>Pilot the CMS-0057-F API surface alongside your existing core.</strong>
+          Scope, security, conformance, integration effort, and deployment timing are established during technical discovery.
         </p>
         <a href="/solutions-payers" class="button">For Health Plans →</a>
         <a href="/contact" class="button button-green">Contact Sales</a>
@@ -1531,7 +1530,7 @@
 
       <section class="assessment-section">
         <h2>Architecture Overview</h2>
-        <p>Kubernetes-native infrastructure leveraging Argo Workflows on AKS, Service Bus, Data Lake Gen2, and container-based microservices for complete X12 transaction processing.</p>
+        <p>Reference infrastructure uses Argo Workflows on AKS, Service Bus, Data Lake Gen2, and containerized services. The repository provides deployable building blocks, not a universal production configuration.</p>
         
         <div class="card">
           <h3>Deployment Components</h3>
@@ -1548,7 +1547,7 @@
 
         <div class="card">
           <h3>Multi-Tenant Architecture</h3>
-          <p>Each payer tenant receives complete logical isolation while sharing infrastructure efficiency:</p>
+          <p>The reference design uses the following logical-isolation controls. Their effectiveness must be verified in each deployed environment:</p>
           <ul>
             <li>Dedicated Argo workflow templates per payer</li>
             <li>Isolated Service Bus topics and subscriptions</li>
@@ -1560,8 +1559,8 @@
       </section>
 
       <section class="assessment-section">
-        <h2>One-Click to Production</h2>
-        <p>Configuration-driven deployment via CLI wizard. No programming expertise required.</p>
+        <h2>Reference Deployment Workflow</h2>
+        <p>The CLI can generate a payer-specific starting point. A production deployment still requires architecture review, security validation, integration testing, data migration planning, observability, and operational acceptance.</p>
         
         <pre><code># Step 1: Run onboarding wizard (5 minutes)
 node dist/scripts/cli/payer-onboarding-wizard.js
@@ -1575,12 +1574,12 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 # Step 4: Configure trading partners (10 minutes)
 ./configure-hipaa-trading-partners.ps1
 
-# Total: ~50 minutes from zero to production</code></pre>
+# Example only: timing varies; this does not constitute production readiness</code></pre>
       </section>
 
       <section class="cta-section">
         <h2>Ready to Modernize Your Payer Operations?</h2>
-        <p>Start with CMS-0057-F compliance on your existing core system. Expand to modular replacement at your own pace.</p>
+        <p>Start with a technical evaluation or pilot against your own requirements. Expand only after conformance, security, integration, and operating results are verified.</p>
         <div style="margin-top: 30px;">
           <a href="/solutions-payers" class="button">For Health Plans →</a>
           <a href="https://github.com/aurelianware/cloudhealthoffice" class="button button-secondary" target="_blank" rel="noopener noreferrer">Clone Repository</a>

--- a/src/site/scripts/generate-mcc-publications.mjs
+++ b/src/site/scripts/generate-mcc-publications.mjs
@@ -1,0 +1,181 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = resolve(scriptDir, '..');
+const repoRoot = resolve(siteRoot, '../..');
+const outputDir = join(siteRoot, 'insights', 'million-claim-challenge');
+const githubBase = 'https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast';
+
+const publications = [
+  {
+    episode: '005',
+    part: 'Part 5',
+    slug: 'part-5-repeatably-faster',
+    summary: 'How the local Kubernetes sweep harness turned isolated fast runs into repeatable performance evidence.'
+  },
+  {
+    episode: '006',
+    part: 'Part 6',
+    slug: 'part-6-honest-edge-case-scoring',
+    summary: 'Why paid is not the only correct outcome, and why unsupported scenarios must remain visible.'
+  },
+  {
+    episode: '007',
+    part: 'Part 7',
+    slug: 'part-7-operator-console',
+    summary: 'Moving benchmark proof from terminal logs into an operator-facing Mass Adjudication console.'
+  }
+];
+
+const escapeHtml = (value) => value
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;');
+
+const inlineMarkdown = (value) => escapeHtml(value)
+  .replace(/`([^`]+)`/g, '<code>$1</code>')
+  .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+  .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+  .replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+
+function renderArticle(source) {
+  const lines = source.replace(/\r/g, '').split('\n');
+  const title = lines.find((line) => line.startsWith('# '))?.slice(2).trim() ?? 'Million Claim Challenge';
+  const body = [];
+  let paragraph = [];
+  let list = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length) body.push(`<p>${inlineMarkdown(paragraph.join(' '))}</p>`);
+    paragraph = [];
+  };
+  const flushList = () => {
+    if (list.length) body.push(`<ul>${list.map((item) => `<li>${inlineMarkdown(item)}</li>`).join('')}</ul>`);
+    list = [];
+  };
+
+  for (const line of lines.slice(lines.indexOf(`# ${title}`) + 1)) {
+    if (!line.trim()) {
+      flushParagraph();
+      flushList();
+    } else if (line.startsWith('## ')) {
+      flushParagraph();
+      flushList();
+      const heading = line.slice(3).trim();
+      const id = heading.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+      body.push(`<h2 id="${id}">${inlineMarkdown(heading)}</h2>`);
+    } else if (line.startsWith('- ')) {
+      flushParagraph();
+      list.push(line.slice(2));
+    } else if (line.startsWith('Published article: ')) {
+      flushParagraph();
+      body.push(`<p class="source-note">Originally published externally: ${inlineMarkdown(line.slice(19))}</p>`);
+    } else {
+      flushList();
+      paragraph.push(line.trim());
+    }
+  }
+  flushParagraph();
+  flushList();
+  return { title, body: body.join('\n') };
+}
+
+const pageShell = ({ title, description, canonical, content, type = 'article' }) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)} | Cloud Health Office</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <link rel="canonical" href="${canonical}">
+  <meta property="og:type" content="${type}">
+  <meta property="og:site_name" content="Cloud Health Office">
+  <meta property="og:title" content="${escapeHtml(title)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:url" content="${canonical}">
+  <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/css/sentinel.css">
+  <script src="/js/mobile-nav.js"></script>
+  <style>
+    .publication { max-width: 860px; margin: 0 auto; padding: 64px 24px 96px; }
+    .publication-nav { margin-bottom: 40px; color: #8b949e; }
+    .publication-nav a { color: #00ffff; }
+    .eyebrow { color: #00ff88; font-size: .8rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    .publication h1 { font-size: clamp(2rem, 5vw, 3.4rem); line-height: 1.08; margin: 12px 0 20px; }
+    .publication h2 { margin-top: 52px; color: #00ffff; }
+    .publication p, .publication li { color: #c9d1d9; font-size: 1.05rem; line-height: 1.8; }
+    .publication code { color: #00ff88; background: #111820; padding: .12rem .35rem; border-radius: 4px; }
+    .disclosure { border-left: 4px solid #f0b429; background: rgba(240,180,41,.08); padding: 18px 22px; margin: 30px 0; }
+    .source-note { font-size: .9rem !important; color: #8b949e !important; }
+    .article-links { display: flex; flex-wrap: wrap; gap: 12px; margin: 40px 0; }
+    .article-links a { border: 1px solid rgba(0,255,255,.35); border-radius: 6px; padding: 10px 14px; color: #00ffff; text-decoration: none; }
+    .evidence-block { margin: 28px 0; border: 1px solid rgba(0,255,255,.22); border-radius: 8px; overflow: hidden; }
+    .evidence-block summary { cursor: pointer; padding: 18px 20px; color: #00ffff; font-weight: 700; background: #0d1117; }
+    .evidence-block pre { white-space: pre-wrap; overflow-wrap: anywhere; margin: 0; padding: 22px; background: #080c10; color: #c9d1d9; font-size: .84rem; line-height: 1.55; }
+  </style>
+</head>
+<body>
+  <main class="publication">
+    <nav class="publication-nav"><a href="/">Home</a> / <a href="/insights">Insights</a> / <a href="/docs/million-claim-challenge">Million Claim Challenge</a></nav>
+    ${content.trim()}
+  </main>
+</body>
+</html>`;
+
+mkdirSync(outputDir, { recursive: true });
+
+for (const publication of publications) {
+  const episodeDir = join(repoRoot, 'docs', 'million-claim-challenge', 'podcast', `episode-${publication.episode}`);
+  const rendered = renderArticle(readFileSync(join(episodeDir, 'article.txt'), 'utf8'));
+  const canonical = `https://cloudhealthoffice.com/insights/million-claim-challenge/${publication.slug}`;
+  const content = `
+    <div class="eyebrow">Million Claim Challenge · ${publication.part}</div>
+    <h1>${escapeHtml(rendered.title)}</h1>
+    <div class="disclosure"><strong>Evidence scope:</strong> This engineering field note describes local Kubernetes development and validation. It is not a production-cloud capacity claim or evidence that the full one-million-claim corpus has been completed.</div>
+    <div class="article-links">
+      <a href="/docs/million-claim-challenge/evidence#episode-${publication.episode}">View evidence</a>
+      <a href="${githubBase}/episode-${publication.episode}/article.txt" target="_blank" rel="noopener noreferrer">View article source</a>
+    </div>
+    ${rendered.body}
+    <div class="article-links"><a href="/insights/million-claim-challenge">All MCC articles</a><a href="/docs/million-claim-challenge/evidence">Evidence archive</a></div>`;
+  writeFileSync(join(outputDir, `${publication.slug}.html`), pageShell({ title: rendered.title, description: publication.summary, canonical, content }));
+}
+
+const cards = publications.map((publication) => {
+  const article = renderArticle(readFileSync(join(repoRoot, 'docs', 'million-claim-challenge', 'podcast', `episode-${publication.episode}`, 'article.txt'), 'utf8'));
+  return `<article class="evidence-block" style="padding:22px"><div class="eyebrow">${publication.part}</div><h2 style="margin-top:8px">${escapeHtml(article.title)}</h2><p>${escapeHtml(publication.summary)}</p><div class="article-links"><a href="/insights/million-claim-challenge/${publication.slug}">Read article</a><a href="/docs/million-claim-challenge/evidence#episode-${publication.episode}">Inspect evidence</a></div></article>`;
+}).join('\n');
+
+writeFileSync(join(outputDir, 'index.html'), pageShell({
+  title: 'Million Claim Challenge Engineering Series',
+  description: 'Engineering field notes documenting how the Million Claim Challenge became a repeatable, inspectable claims-adjudication benchmark.',
+  canonical: 'https://cloudhealthoffice.com/insights/million-claim-challenge',
+  type: 'website',
+  content: `<div class="eyebrow">Engineering series</div><h1>Million Claim Challenge Field Notes</h1><p>How the benchmark moved from local Kubernetes runs to repeatable measurement, honest workflow scoring, and operator-facing evidence.</p><div class="disclosure"><strong>Current verified scope:</strong> the latest published proof is a 50,000-claim local Kubernetes breadth run. The full million remains the target.</div>${cards}`
+}));
+
+const evidenceSections = publications.map((publication) => {
+  const episodeDir = join(repoRoot, 'docs', 'million-claim-challenge', 'podcast', `episode-${publication.episode}`);
+  const evidence = escapeHtml(readFileSync(join(episodeDir, 'benchmark-results.txt'), 'utf8'));
+  const rawLink = publication.episode === '006'
+    ? `<a href="${githubBase}/episode-006/raw-validator-output-50k.txt" target="_blank" rel="noopener noreferrer">Raw 50K validator output</a>`
+    : '';
+  return `<section id="episode-${publication.episode}"><div class="eyebrow">${publication.part} · recorded artifact</div><h2>${escapeHtml(publication.summary)}</h2><div class="article-links"><a href="/insights/million-claim-challenge/${publication.slug}">Read article</a><a href="${githubBase}/episode-${publication.episode}/benchmark-results.txt" target="_blank" rel="noopener noreferrer">Source artifact</a>${rawLink}</div><details class="evidence-block" open><summary>Benchmark results recorded with Episode ${publication.episode}</summary><pre>${evidence}</pre></details></section>`;
+}).join('\n');
+
+const evidenceOutputDir = join(siteRoot, 'docs', 'million-claim-challenge');
+mkdirSync(evidenceOutputDir, { recursive: true });
+writeFileSync(join(evidenceOutputDir, 'evidence.html'), pageShell({
+  title: 'Million Claim Challenge Evidence Archive',
+  description: 'Dated benchmark summaries, environment details, limitations, and raw artifacts for published Million Claim Challenge engineering results.',
+  canonical: 'https://cloudhealthoffice.com/docs/million-claim-challenge/evidence',
+  type: 'website',
+  content: `<div class="eyebrow">Reproducibility archive</div><h1>Million Claim Challenge Evidence</h1><p>This archive keeps the evidence behind the engineering series visible and reviewable. Results are historical records, not generalized production capacity claims.</p><div class="disclosure"><strong>Interpretation rules:</strong> distinguish platform failures from business dispositions; do not count unsupported scenarios as passes; preserve allocated compute, corpus size, latency, and validator limitations with every result.</div>${evidenceSections}`
+}));
+
+console.log(`Generated ${publications.length} articles, an article index, and an evidence archive.`);

--- a/src/site/sitemap.xml
+++ b/src/site/sitemap.xml
@@ -110,9 +110,39 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/million-claim-challenge</loc>
-    <lastmod>2026-04-05</lastmod>
+    <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/docs/million-claim-challenge/evidence</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/insights/million-claim-challenge</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/insights/million-claim-challenge/part-5-repeatably-faster</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/insights/million-claim-challenge/part-6-honest-edge-case-scoring</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/insights/million-claim-challenge/part-7-operator-console</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/benefit-plan-guide</loc>

--- a/src/site/staticwebapp.config.json
+++ b/src/site/staticwebapp.config.json
@@ -324,6 +324,31 @@
       "rewrite": "/docs/million-claim-challenge.html"
     },
     {
+      "route": "/docs/million-claim-challenge/evidence.html",
+      "redirect": "/docs/million-claim-challenge/evidence",
+      "statusCode": 301
+    },
+    {
+      "route": "/docs/million-claim-challenge/evidence",
+      "rewrite": "/docs/million-claim-challenge/evidence.html"
+    },
+    {
+      "route": "/insights/million-claim-challenge",
+      "rewrite": "/insights/million-claim-challenge/index.html"
+    },
+    {
+      "route": "/insights/million-claim-challenge/part-5-repeatably-faster",
+      "rewrite": "/insights/million-claim-challenge/part-5-repeatably-faster.html"
+    },
+    {
+      "route": "/insights/million-claim-challenge/part-6-honest-edge-case-scoring",
+      "rewrite": "/insights/million-claim-challenge/part-6-honest-edge-case-scoring.html"
+    },
+    {
+      "route": "/insights/million-claim-challenge/part-7-operator-console",
+      "rewrite": "/insights/million-claim-challenge/part-7-operator-console.html"
+    },
+    {
       "route": "/docs/prior-auth-guide.html",
       "redirect": "/docs/prior-auth-guide",
       "statusCode": 301


### PR DESCRIPTION
## Summary

- ground the Platform page in implemented, pilot-stage, and locally measured reality
- publish Million Claim Challenge Parts 5-7 as first-party engineering articles
- add a public evidence archive with dated benchmark summaries and raw artifact links
- add clean routes, sitemap discovery, and automatic publication generation during the site build

## Evidence boundaries

- labels portal and finance screenshots as seeded demo data
- identifies the latest published result as a 50K local Kubernetes validation
- does not present the run as production-cloud capacity or completion of the full million
- preserves unsupported scenarios separately from scoreable mismatches

## Validation

- `cd src/site && npm run build`
- `git diff --check`
- parsed `src/site/staticwebapp.config.json` successfully
