### PR TITLE
Add stricter Million Claim Challenge scoring gates

### DIFF
--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -117,6 +117,45 @@ internal sealed class MccClaimStatusObserver
             }
         }
     }
+
+    public async Task<ClaimValidationResult> DetectUnexpectedPendAsync(
+        ClaimValidationResult result,
+        CancellationToken cancellationToken = default)
+    {
+        if (result.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()
+            || string.IsNullOrWhiteSpace(result.SubmittedClaimId)
+            || result.Outcome is ClaimValidationOutcome.PlatformFailure)
+        {
+            return result;
+        }
+
+        try
+        {
+            var observed = await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
+            if (observed?.Outcome is not ClaimValidationOutcome.Pended)
+            {
+                return result;
+            }
+
+            return result with
+            {
+                Outcome = ClaimValidationOutcome.Pended,
+                ValidationStatus = MccWorkflowValidation.MismatchedStatus,
+                FailureStage = "false-pend-observation",
+                Error = $"Expected {result.ExpectedOutcome}, but persisted claim status is pended ({observed.PendCode ?? "no pend code"})"
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return result with
+            {
+                ValidationStatus = MccWorkflowValidation.ObservationTimeoutStatus,
+                Outcome = ClaimValidationOutcome.ObservationTimeout,
+                FailureStage = "false-pend-observation",
+                Error = $"Claim status observation failed: {ex.Message}"
+            };
+        }
+    }
 }
 
 internal sealed record ObservedClaimStatus(

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -37,6 +37,12 @@ internal static class MccRunSummaryBuilder
         var avgDelta = comparable.Count == 0
             ? (decimal?)null
             : comparable.Average(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
+        const decimal paymentTolerance = 0.01m;
+        var paymentMatches = comparable.Count(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value) <= paymentTolerance);
+        var paymentMismatches = comparable.Count - paymentMatches;
+        var maxPaymentDelta = comparable.Count == 0
+            ? (decimal?)null
+            : comparable.Max(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
         var denialBreakdown = results
             .Where(r => r.Outcome is ClaimValidationOutcome.BusinessDenial)
             .GroupBy(r => r.BusinessDenialCode ?? "UNKNOWN")
@@ -130,6 +136,11 @@ internal static class MccRunSummaryBuilder
             BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
             BuildAdjudicationStepTimings(results),
             avgDelta,
+            paymentTolerance,
+            comparable.Count,
+            paymentMatches,
+            paymentMismatches,
+            maxPaymentDelta,
             denialBreakdown,
             workflowBreakdown,
             failures,
@@ -233,6 +244,14 @@ internal static class MccRunSummaryBuilder
         if (result.ValidationStatus == MccWorkflowValidation.UnsupportedStatus)
         {
             return 2;
+        }
+
+        if (result.Outcome is ClaimValidationOutcome.Paid
+            && result.ActualPlanPayment.HasValue
+            && result.ExpectedPlanPayment.HasValue
+            && Math.Abs(result.ActualPlanPayment.Value - result.ExpectedPlanPayment.Value) > 0.01m)
+        {
+            return 3;
         }
 
         return 100;

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -184,6 +184,7 @@ var orderedResults = results
 if (options.PendObservationEnabled)
 {
     orderedResults = await ObserveExpectedPendResultsAsync(http, options, orderedResults);
+    orderedResults = await DetectUnexpectedPendResultsAsync(http, options, orderedResults);
 }
 
 if (!string.IsNullOrWhiteSpace(options.PendDiagnosticsPath))
@@ -1845,6 +1846,32 @@ static async Task<List<ClaimValidationResult>> ObserveExpectedPendResultsAsync(
         .ToList();
 }
 
+static async Task<List<ClaimValidationResult>> DetectUnexpectedPendResultsAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    List<ClaimValidationResult> results)
+{
+    var candidates = results
+        .Where(r => r.ExpectedOutcome is not null && r.ExpectedOutcome != ClaimValidationOutcome.Pended.ToString())
+        .Where(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure)
+        .ToList();
+    if (candidates.Count == 0) return results;
+
+    Console.WriteLine($"Sweeping {candidates.Count:N0} non-pend claims for unexpected persisted pends.");
+    var observer = new MccClaimStatusObserver(new HttpClaimStatusSource(http, options.ClaimsUrl));
+    var observed = new ConcurrentDictionary<string, ClaimValidationResult>(StringComparer.Ordinal);
+    await Parallel.ForEachAsync(candidates,
+        new ParallelOptions { MaxDegreeOfParallelism = Math.Min(candidates.Count, Math.Max(options.Parallelism, 64)) },
+        async (result, cancellationToken) =>
+            observed[result.GeneratedClaimId] = await observer.DetectUnexpectedPendAsync(result, cancellationToken));
+
+    var falsePends = observed.Values.Count(r => r.FailureStage == "false-pend-observation" && r.Outcome == ClaimValidationOutcome.Pended);
+    Console.WriteLine($"  False-pend sweep: {falsePends:N0} unexpected pends");
+    Console.WriteLine();
+    return results.Select(r => observed.TryGetValue(r.GeneratedClaimId, out var updated) ? updated : r)
+        .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal).ToList();
+}
+
 static List<object> BuildDiagnosisCodes(SyntheticClaim claim)
 {
     var codes = new List<string>();
@@ -2050,6 +2077,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     if (summary.AveragePaymentDelta.HasValue)
     {
         Console.WriteLine($"  Avg payment delta:  ${summary.AveragePaymentDelta:N2}");
+        Console.WriteLine($"  Payment gate:       {summary.PaymentMatches:N0}/{summary.PaymentComparisons:N0} within ${summary.PaymentTolerance:N2} ({summary.PaymentMismatches:N0} mismatched, max ${summary.MaximumPaymentDelta:N2})");
     }
 
     foreach (var denialGroup in summary.BusinessDenialBreakdown.Take(5))
@@ -2152,6 +2180,11 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         null,
         null,
         Array.Empty<MassAdjudicationStageTiming>(),
+        null,
+        0.01m,
+        0,
+        0,
+        0,
         null,
         Array.Empty<MassAdjudicationBusinessDenialSummary>(),
         Array.Empty<MassAdjudicationWorkflowScenarioSummary>(),
@@ -2397,6 +2430,11 @@ internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationStageTiming? WritebackTiming,
     IReadOnlyList<MassAdjudicationStageTiming> AdjudicationStepTimings,
     decimal? AveragePaymentDelta,
+    decimal PaymentTolerance,
+    int PaymentComparisons,
+    int PaymentMatches,
+    int PaymentMismatches,
+    decimal? MaximumPaymentDelta,
     IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
     IReadOnlyList<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown,
     IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures,

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
@@ -107,6 +107,43 @@ public class MccClaimStatusObserverTests
         Assert.True(observed.IsTerminal);
     }
 
+    [Fact]
+    public async Task DetectUnexpectedPendAsync_WhenExpectedPaidPersistedPended_ReturnsMismatch()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.Pended, "Pended", "MED_REVIEW", IsTerminal: true)
+        ]));
+        var source = Result(ClaimValidationOutcome.Paid) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.Paid.ToString(),
+            ValidationStatus = MccWorkflowValidation.MatchedStatus
+        };
+
+        var result = await observer.DetectUnexpectedPendAsync(source);
+
+        Assert.Equal(ClaimValidationOutcome.Pended, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.MismatchedStatus, result.ValidationStatus);
+        Assert.Equal("false-pend-observation", result.FailureStage);
+        Assert.Contains("MED_REVIEW", result.Error);
+    }
+
+    [Fact]
+    public async Task DetectUnexpectedPendAsync_WhenExpectedDeniedPersistedDenied_PreservesResult()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(ClaimValidationOutcome.BusinessDenial, "Denied", null, IsTerminal: true)
+        ]));
+        var source = Result(ClaimValidationOutcome.BusinessDenial) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.BusinessDenial.ToString(),
+            ValidationStatus = MccWorkflowValidation.MatchedStatus
+        };
+
+        var result = await observer.DetectUnexpectedPendAsync(source);
+
+        Assert.Equal(source, result);
+    }
+
     private static ClaimValidationResult Result(ClaimValidationOutcome startingOutcome)
     {
         return new ClaimValidationResult(

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -84,6 +84,27 @@ public class MccRunSummaryBuilderTests
             summary.ClaimResults.Select(r => r.GeneratedClaimId).ToArray());
     }
 
+    [Fact]
+    public void Build_ScoresPaymentAmountsAgainstExplicitTolerance()
+    {
+        var options = ValidatorOptions.Parse(["--claims", "3"]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("EXACT", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid),
+            Result("ROUNDING", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid) with { ActualPlanPayment = 100.01m },
+            Result("WRONG", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid) with { ActualPlanPayment = 101m }
+        };
+
+        var summary = MccRunSummaryBuilder.Build(results, TimeSpan.FromSeconds(1), options, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        Assert.Equal(0.01m, summary.PaymentTolerance);
+        Assert.Equal(3, summary.PaymentComparisons);
+        Assert.Equal(2, summary.PaymentMatches);
+        Assert.Equal(1, summary.PaymentMismatches);
+        Assert.Equal(1m, summary.MaximumPaymentDelta);
+        Assert.Contains(summary.ClaimResults, r => r.GeneratedClaimId == "WRONG" && r.PaymentDelta == 1m);
+    }
+
     private static ClaimValidationResult Result(
         string claimId,
         string? scenario,


### PR DESCRIPTION
## Summary

- detect unexpected persisted pends for scoreable expected-pay and expected-deny claims
- score comparable paid claims against an explicit $0.01 amount tolerance
- report payment comparison, match, mismatch, average-delta, and maximum-delta metrics
- prioritize payment mismatches in published claim-level evidence

## 1K local Kubernetes proof

- 1,000 claims processed
- 0 platform failures
- 0 workflow mismatches
- 0 unexpected pends
- 13 unsupported scenarios reported separately
- 14/43 comparable payments within $0.01
- 29 payment mismatches
- $313.24 maximum payment delta

The new payment gate intentionally blocks the 50K and 100K milestones until the answer key and benefit-calculation model are reconciled.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 76/76 passed
- `CLAIMS=1000 MAX_CLAIMS=1000 PARALLELISM=6 JOB_NAME=mcc-part8-gates-1k PROGRESS_EVERY=100 ./scripts/run-mcc-local-k8s.sh`
- `git diff --check`
