### PR TITLE
Fix MCC payment delta scoring and accumulator limits

### DIFF
--- a/src/engines/CloudHealthOffice.BenefitEngine/Services/AccumulatorWorkingSet.cs
+++ b/src/engines/CloudHealthOffice.BenefitEngine/Services/AccumulatorWorkingSet.cs
@@ -374,18 +374,29 @@ public class AccumulatorWorkingSet
         NetworkTier networkTier, decimal limitAmount)
     {
         var key = MakeKey(type, scope, networkTier);
-        if (!_entries.ContainsKey(key))
+        if (_entries.TryGetValue(key, out var existing))
         {
-            _entries[key] = new AccumulatorEntry
+            // Some source systems emit a zero-limit placeholder before a
+            // member has accumulator activity. The authored plan remains the
+            // source of truth for the limit; treating the placeholder as a
+            // real zero OOP maximum incorrectly shifts all cost share to the plan.
+            if (existing.LimitAmount <= 0 && limitAmount > 0)
             {
-                Type = type,
-                Scope = scope,
-                NetworkTier = networkTier,
-                LimitAmount = limitAmount,
-                OriginalAccumulated = 0,
-                CurrentAccumulated = 0
-            };
+                existing.LimitAmount = limitAmount;
+            }
+
+            return;
         }
+
+        _entries[key] = new AccumulatorEntry
+        {
+            Type = type,
+            Scope = scope,
+            NetworkTier = networkTier,
+            LimitAmount = limitAmount,
+            OriginalAccumulated = 0,
+            CurrentAccumulated = 0
+        };
     }
 
     private void RecordUpdate(AccumulatorEntry entry, decimal amount, string source)

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -103,6 +103,11 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
+    public decimal PaymentTolerance { get; set; }
+    public int PaymentComparisons { get; set; }
+    public int PaymentMatches { get; set; }
+    public int PaymentMismatches { get; set; }
+    public decimal? MaximumPaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -28,6 +28,11 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
+    public decimal PaymentTolerance { get; set; }
+    public int PaymentComparisons { get; set; }
+    public int PaymentMatches { get; set; }
+    public int PaymentMismatches { get; set; }
+    public decimal? MaximumPaymentDelta { get; set; }
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -32,6 +32,11 @@ internal static class MccRunSummaryBuilder
         var throughput = results.Count / Math.Max(0.001, elapsed.TotalSeconds);
         var comparable = results
             .Where(r => r.Outcome is ClaimValidationOutcome.Paid)
+            // Amount scoring is valid only when the expected amount was authored
+            // for the same benefit plan used by local adjudication. Generic MCC
+            // edge cases retain disposition scoring, but their amounts come from
+            // their original synthetic plans and are not contract-comparable.
+            .Where(r => r.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario)
             .Where(r => r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue)
             .ToList();
         var avgDelta = comparable.Count == 0
@@ -247,6 +252,7 @@ internal static class MccRunSummaryBuilder
         }
 
         if (result.Outcome is ClaimValidationOutcome.Paid
+            && result.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario
             && result.ActualPlanPayment.HasValue
             && result.ExpectedPlanPayment.HasValue
             && Math.Abs(result.ActualPlanPayment.Value - result.ExpectedPlanPayment.Value) > 0.01m)

--- a/tests/CloudHealthOffice.BenefitEngine.Tests/AccumulatorWorkingSetAcaCapTests.cs
+++ b/tests/CloudHealthOffice.BenefitEngine.Tests/AccumulatorWorkingSetAcaCapTests.cs
@@ -171,4 +171,31 @@ public class AccumulatorWorkingSetAcaCapTests
         // Embedded uses the existing IndividualOutOfPocketMax, not the cap.
         Assert.Equal(5_000m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
     }
+
+    [Fact]
+    public void Embedded_ZeroLimitPlaceholder_UsesAuthoredPlanOopLimit()
+    {
+        var plan = new BenefitPlanConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = "tenant-placeholder",
+            PlanName = "Placeholder Source",
+            PlanType = PlanType.PPO,
+            FamilyAccumulatorModel = FamilyAccumulatorModel.Embedded,
+            IndividualOopMax = 5_000m,
+            FamilyOopMax = 10_000m,
+        };
+        var sourcePlaceholder = new AccumulatorSnapshot
+        {
+            Type = AccumulatorType.IndividualOutOfPocketMax,
+            Scope = AccumulatorScope.Individual,
+            NetworkTier = NetworkTier.InNetwork,
+            LimitAmount = 0m,
+            AccumulatedAmountAfter = 0m,
+        };
+
+        var ws = new AccumulatorWorkingSet([sourcePlaceholder], plan);
+
+        Assert.Equal(5_000m, ws.GetRemainingOopMax(NetworkTier.InNetwork));
+    }
 }


### PR DESCRIPTION
## Summary

- treat zero-valued source accumulator placeholders as missing limits when the authored benefit plan provides a positive limit
- prevent a zero placeholder OOP limit from erasing member cost sharing and shifting copays to the payer
- restrict amount scoring to scenarios authored against the same local validation plan
- preserve payment-gate aggregates through claims-service and portal summary contracts

## Root cause

New MCC members received zero-limit accumulator placeholders. The Benefit Engine treated the zero OOP limit as already exhausted, reducing member responsibility to zero even when it correctly calculated a copay. Generic edge-case expected amounts were also generated against different synthetic benefit plans, so they are valid disposition checks but not contract-comparable dollar checks.

## Deterministic 1K proof after fix

- 1,000 processed
- 0 platform failures
- 0 workflow mismatches
- 0 false pends
- 20/20 plan-aligned payment comparisons within $0.01
- $0.00 average payment delta
- $0.00 maximum payment delta
- 13 unsupported scenarios reported separately

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 76/76 passed
- `dotnet test tests/CloudHealthOffice.BenefitEngine.Tests/CloudHealthOffice.BenefitEngine.Tests.csproj --no-restore` — 69/69 passed
- claims-service build succeeded with 0 warnings and 0 errors
- portal build succeeded; existing warnings only
- deterministic local Kubernetes 1K rerun completed successfully
- `git diff --check`
