### PR TITLE
Fix MCC validation member ID collisions

### DIFF
--- a/src/tools/mcc-platform-validator/MccCleanPaidFixture.cs
+++ b/src/tools/mcc-platform-validator/MccCleanPaidFixture.cs
@@ -1,0 +1,33 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal static class MccCleanPaidFixture
+{
+    public static void NormalizeClaims(IEnumerable<SyntheticClaim> claims)
+    {
+        foreach (var claim in claims.Where(claim =>
+                     string.Equals(
+                         claim.BenefitPlanId,
+                         MccWorkflowValidation.CleanProfessionalPaidPlanId,
+                         StringComparison.Ordinal)))
+        {
+            NormalizeMember(claim.Member, claim.DateOfService);
+        }
+    }
+
+    public static void NormalizeMember(SyntheticMember member, DateTime serviceDate)
+    {
+        member.CoverageEffectiveDate = serviceDate.Date.AddYears(-1);
+        member.CoverageTermDate = null;
+        member.EnrollmentStatus = "Active";
+        member.MaintenanceTypeCode = "021";
+
+        foreach (var coverage in member.Coverages)
+        {
+            coverage.EffectiveDate = member.CoverageEffectiveDate;
+            coverage.TermDate = null;
+            coverage.Status = "Active";
+        }
+    }
+}

--- a/src/tools/mcc-platform-validator/MccFixtureIsolation.cs
+++ b/src/tools/mcc-platform-validator/MccFixtureIsolation.cs
@@ -77,9 +77,18 @@ internal static class MccFixtureIsolation
     private static string BuildValidationMemberId(string claimId, Guid runId, int ordinal)
     {
         var runSalt = runId.ToString("N")[..8].ToUpperInvariant();
+        var claimType = ClaimTypeDiscriminator(claimId);
         var normalizedClaimId = NormalizeClaimIdSuffix(claimId, ordinal);
 
-        return $"MCCV{runSalt}{normalizedClaimId}";
+        return $"MCCV{runSalt}{claimType}{normalizedClaimId}";
+    }
+
+    private static char ClaimTypeDiscriminator(string claimId)
+    {
+        var parts = claimId.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 && parts[1].Length == 1 && char.IsLetter(parts[1][0])
+            ? char.ToUpperInvariant(parts[1][0])
+            : 'X';
     }
 
     private static string NormalizeClaimIdSuffix(string claimId, int ordinal)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -70,6 +70,7 @@ var claims = await GenerateClaimsAsync(options);
 NormalizePriorAuthEdgeCases(claims, options);
 NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
 MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
+MccCleanPaidFixture.NormalizeClaims(claims);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
@@ -649,7 +650,6 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
     claim.PriorAuthNumber = null;
     claim.PrimaryDiagnosisCode = "Z00.00";
     claim.SecondaryDiagnosisCodes.Clear();
-
     ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
     ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
 

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccCleanPaidFixtureTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccCleanPaidFixtureTests.cs
@@ -1,0 +1,64 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccCleanPaidFixtureTests
+{
+    [Fact]
+    public void NormalizeClaims_RepairsCleanFixtureAfterEarlierStateIsOverwritten()
+    {
+        var member = TerminatedMember();
+        var clean = new SyntheticClaim
+        {
+            BenefitPlanId = MccWorkflowValidation.CleanProfessionalPaidPlanId,
+            DateOfService = new DateTime(2026, 6, 15),
+            Member = member
+        };
+
+        MccCleanPaidFixture.NormalizeClaims([clean]);
+
+        AssertActiveForServiceDate(member, clean.DateOfService);
+    }
+
+    [Fact]
+    public void NormalizeMember_RemovesTerminationAndMakesCoverageActiveForServiceDate()
+    {
+        var member = TerminatedMember();
+
+        MccCleanPaidFixture.NormalizeMember(member, new DateTime(2026, 6, 15));
+
+        AssertActiveForServiceDate(member, new DateTime(2026, 6, 15));
+    }
+
+    private static SyntheticMember TerminatedMember() => new()
+    {
+        CoverageEffectiveDate = new DateTime(2020, 1, 1),
+        CoverageTermDate = new DateTime(2025, 1, 1),
+        EnrollmentStatus = "Terminated",
+        MaintenanceTypeCode = "024",
+        Coverages =
+        [
+            new SyntheticCoverage
+            {
+                EffectiveDate = new DateTime(2020, 1, 1),
+                TermDate = new DateTime(2025, 1, 1),
+                Status = "Terminated"
+            }
+        ]
+    };
+
+    private static void AssertActiveForServiceDate(SyntheticMember member, DateTime serviceDate)
+    {
+        Assert.Equal(serviceDate.Date.AddYears(-1), member.CoverageEffectiveDate);
+        Assert.Null(member.CoverageTermDate);
+        Assert.Equal("Active", member.EnrollmentStatus);
+        Assert.Equal("021", member.MaintenanceTypeCode);
+        Assert.All(member.Coverages, coverage =>
+        {
+            Assert.Equal(member.CoverageEffectiveDate, coverage.EffectiveDate);
+            Assert.Null(coverage.TermDate);
+            Assert.Equal("Active", coverage.Status);
+        });
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
@@ -112,9 +112,35 @@ public class MccFixtureIsolationTests
 
         MccFixtureIsolation.IsolateValidationMembers([retroAdd], seed: 42, runId);
 
-        Assert.Equal("MCCV906F49D10000013", retroAdd.Member.MemberId);
+        Assert.Equal("MCCV906F49D1E0000013", retroAdd.Member.MemberId);
         Assert.Equal(retroAdd.Member.MemberId, retroAdd.Member.SubscriberId);
         Assert.DoesNotContain("-", retroAdd.Member.MemberId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IsolateValidationMembers_PreservesClaimTypeToPreventCrossCorpusCollisions()
+    {
+        var professional = new SyntheticClaim
+        {
+            ClaimId = "MCC-P-0000787",
+            ClaimType = "Professional",
+            BenefitPlanId = MccWorkflowValidation.CleanProfessionalPaidPlanId,
+            PlaceOfService = "11",
+            PriorAuthStatus = "NotRequired",
+            Member = new SyntheticMember { MemberId = "SHARED", SubscriberId = "SHARED" }
+        };
+        var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
+        var edge = generator.Generate(787, nameof(EdgeCaseScenario.RetroEligibilityAdd), new Random(42));
+        edge.ClaimId = "MCC-E-0000787";
+        edge.Member.MemberId = "SHARED";
+        edge.Member.SubscriberId = "SHARED";
+        var runId = Guid.Parse("906f49d1-18cc-4d19-9c77-69822ad6d88b");
+
+        MccFixtureIsolation.IsolateValidationMembers([professional, edge], seed: 42, runId);
+
+        Assert.Equal("MCCV906F49D1P0000787", professional.Member.MemberId);
+        Assert.Equal("MCCV906F49D1E0000787", edge.Member.MemberId);
+        Assert.NotEqual(professional.Member.MemberId, edge.Member.MemberId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- include the MCC claim-type discriminator in run-scoped validation member IDs
- prevent professional and edge claims with the same numeric suffix from sharing a member fixture
- normalize clean-paid coverage after run-scoped isolation and immediately before seeding
- add direct regression coverage for professional/edge ID collisions and terminated clean fixtures

## Root cause

Validation member IDs retained only the numeric claim suffix. For example, `MCC-P-0000787` and `MCC-E-0000787` both mapped to the same member ID. A retro-eligibility edge fixture could therefore overwrite a clean-paid member with terminated coverage, producing intermittent CARC 27 denials despite a correct synchronous $150 payment calculation.

## Final 50K verification

- 50,000/50,000 processed
- 0 platform failures
- 0 workflow mismatches
- 0 false pends
- 5,767/6,500 workflow checks matched
- 733 unsupported scenarios reported separately
- 1,000/1,000 payment comparisons within $0.01
- $0.00 average and maximum payment delta
- 82.40 claims/sec
- 129 ms P95 / 178 ms P99
- 10:06.795 elapsed

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 79/79 passed
- `CLAIMS=50000 MAX_CLAIMS=50000 PARALLELISM=6 JOB_NAME=mcc-claim-type-isolation-50k PROGRESS_EVERY=5000 ./scripts/run-mcc-local-k8s.sh`
- `git diff --check`
