### PR TITLE
Add Part 7 benchmark update note

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-007/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-007/article.txt
@@ -1,5 +1,7 @@
 # Running a Healthcare Claims Platform Locally in Kubernetes, Part 7: From Benchmark Logs to an Operator Console
 
+**Update, July 12, 2026:** Subsequent work added false-pend and plan-aligned payment gates, corrected zero-limit accumulator placeholder handling, and eliminated cross-corpus member fixture collisions. A clean 50,000-claim local Kubernetes verification completed with zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 1,000 of 1,000 comparable payments within one cent. The full investigation and evidence will be covered in Part 8.
+
 Part 6 of this series was about honesty.
 
 Cloud Health Office had moved the Million Claim Challenge beyond raw throughput and into outcome scoring. Paid claims, denied claims, and pended claims could all be correct. Unsupported scenarios were separated from mismatches instead of being quietly counted as wins or failures. Fixture bugs were treated as benchmark bugs. A clean 50,000-claim breadth run gave the project a stronger foundation than a faster but less inspectable number.

--- a/src/site/insights/million-claim-challenge/part-7-operator-console.html
+++ b/src/site/insights/million-claim-challenge/part-7-operator-console.html
@@ -43,7 +43,8 @@
       <a href="/docs/million-claim-challenge/evidence#episode-007">View evidence</a>
       <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/million-claim-challenge/podcast/episode-007/article.txt" target="_blank" rel="noopener noreferrer">View article source</a>
     </div>
-    <p>Part 6 of this series was about honesty.</p>
+    <p><strong>Update, July 12, 2026:</strong> Subsequent work added false-pend and plan-aligned payment gates, corrected zero-limit accumulator placeholder handling, and eliminated cross-corpus member fixture collisions. A clean 50,000-claim local Kubernetes verification completed with zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 1,000 of 1,000 comparable payments within one cent. The full investigation and evidence will be covered in Part 8.</p>
+<p>Part 6 of this series was about honesty.</p>
 <p>Cloud Health Office had moved the Million Claim Challenge beyond raw throughput and into outcome scoring. Paid claims, denied claims, and pended claims could all be correct. Unsupported scenarios were separated from mismatches instead of being quietly counted as wins or failures. Fixture bugs were treated as benchmark bugs. A clean 50,000-claim breadth run gave the project a stronger foundation than a faster but less inspectable number.</p>
 <p>But there was still a gap.</p>
 <p>The proof lived mostly in validator output, benchmark logs, and markdown tables.</p>


### PR DESCRIPTION
## Summary

- add a dated post-publication note to the Part 7 source article
- regenerate the published website article
- preserve the historical Part 7 narrative while directing the full investigation to Part 8

## Evidence captured

The note records the clean 50,000-claim local Kubernetes verification: zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 1,000 of 1,000 comparable payments within one cent.

## Validation

- `cd src/site && npm run build`
- `git diff --check`