### PR TITLE
Fix portal content offset

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -8,6 +8,7 @@
 <PageTitle>Mass Adjudication Runs — Cloud Health Office</PageTitle>
 
 <PermissionGate Permission="claims:read" RoleName="ClaimsSupervisor">
+<div class="mass-runs-page">
 <MudText Typo="Typo.h4" Class="mb-1" Style="color: #00ffff; font-weight: 700;">
     <MudIcon Icon="@Icons.Material.Filled.Assessment" Class="mr-2" Style="vertical-align: middle;" />
     Mass Adjudication Runs
@@ -445,6 +446,7 @@
         }
     </MudItem>
 </MudGrid>
+</div>
 </PermissionGate>
 
 @code {

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor.css
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor.css
@@ -1,0 +1,9 @@
+.mass-runs-page {
+    margin-top: -8px;
+}
+
+@media (max-width: 768px) {
+    .mass-runs-page {
+        margin-top: -4px;
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor.css
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor.css
@@ -13,6 +13,11 @@
     background-clip: text;
 }
 
+::deep .mud-main-content {
+    /* Keep content clear of the fixed app bar across pages. */
+    padding-top: calc(var(--mud-appbar-height, 48px) + 12px);
+}
+
 @media (max-width: 768px) {
     ::deep .appbar-logo {
         height: 24px;
@@ -22,6 +27,10 @@
 
     ::deep .appbar-title {
         font-size: 0.9rem;
+    }
+
+    ::deep .mud-main-content {
+        padding-top: calc(var(--mud-appbar-height, 48px) + 8px);
     }
 }
 


### PR DESCRIPTION
## What changed

- offsets portal main content below the fixed application bar on desktop and mobile
- adds a page-scoped wrapper for Mass Adjudication Runs
- fine-tunes the Mass Adjudication page's top spacing without affecting other pages

## Why

The fixed app bar could overlap the first page heading, especially in the Mass Adjudication console and narrower viewports. The global layout now reserves the app-bar height, while the run page applies a small scoped adjustment to preserve its intended visual rhythm.

## User impact

Page headings and top-level controls remain visible below the fixed header across viewport sizes. The Mass Adjudication console opens with its title and summary content aligned consistently.

## Validation

- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore`
- `git diff --check`

The build succeeded with existing repository warnings and no errors.
