### PR TITLE
Reuse equivalent MCC provider fixtures

### DIFF
--- a/src/tools/mcc-platform-validator/MccProviderFixturePool.cs
+++ b/src/tools/mcc-platform-validator/MccProviderFixturePool.cs
@@ -1,0 +1,156 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+public sealed record MccProviderFixturePoolResult(
+    int ProvidersBefore,
+    int ProvidersAfter,
+    int ReusedAssignments,
+    int ProtectedClaims);
+
+/// <summary>
+/// Reuses provider fixtures when every adjudication-relevant profile field is
+/// equivalent. Provider-sensitive prior-authorization scenarios retain their
+/// original identities.
+/// </summary>
+public static class MccProviderFixturePool
+{
+    public static MccProviderFixturePoolResult Apply(
+        IReadOnlyCollection<SyntheticClaim> claims,
+        int seed,
+        Guid runId)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+
+        var providersBefore = DistinctProviderCount(claims);
+        var pool = new Dictionary<ProviderProfileKey, SyntheticProvider>();
+        var reusedAssignments = 0;
+        var fixtureIndex = 0;
+        var protectedClaims = 0;
+
+        foreach (var claim in claims.OrderBy(claim => claim.ClaimId, StringComparer.Ordinal))
+        {
+            if (RequiresProviderIdentityIsolation(claim))
+            {
+                protectedClaims++;
+                continue;
+            }
+
+            claim.BillingProvider = Reuse(
+                pool, claim.BillingProvider, "billing", seed, runId, ref fixtureIndex, ref reusedAssignments);
+            claim.RenderingProvider = Reuse(
+                pool, claim.RenderingProvider, "rendering", seed, runId, ref fixtureIndex, ref reusedAssignments);
+        }
+
+        return new MccProviderFixturePoolResult(
+            providersBefore,
+            DistinctProviderCount(claims),
+            reusedAssignments,
+            protectedClaims);
+    }
+
+    private static SyntheticProvider Reuse(
+        IDictionary<ProviderProfileKey, SyntheticProvider> pool,
+        SyntheticProvider provider,
+        string role,
+        int seed,
+        Guid runId,
+        ref int fixtureIndex,
+        ref int reusedAssignments)
+    {
+        var key = ProviderProfileKey.From(provider, role);
+        if (pool.TryGetValue(key, out var pooled))
+        {
+            reusedAssignments++;
+            return pooled;
+        }
+
+        // Use a run-scoped identity so an older tenant fixture cannot carry
+        // credentialing or network state into this run's canonical profile.
+        provider.Npi = BuildRunScopedNpi(seed, runId, fixtureIndex++);
+        pool[key] = provider;
+        return provider;
+    }
+
+    private static string BuildRunScopedNpi(int seed, Guid runId, int index)
+    {
+        unchecked
+        {
+            var runHash = BitConverter.ToUInt32(runId.ToByteArray(), 4);
+            var combined = runHash ^ (uint)(seed * 1_000_003 + index * 97);
+            var value = combined % 1_000_000;
+            var baseNineDigits = $"92{index % 10}{value:D6}";
+            return $"{baseNineDigits}{CalculateNpiCheckDigit(baseNineDigits)}";
+        }
+    }
+
+    private static int CalculateNpiCheckDigit(string baseNineDigits)
+    {
+        var candidate = $"80840{baseNineDigits}0";
+        var sum = 0;
+        var doubleDigit = false;
+        for (var i = candidate.Length - 1; i >= 0; i--)
+        {
+            var digit = candidate[i] - '0';
+            if (doubleDigit)
+            {
+                digit *= 2;
+                if (digit > 9)
+                {
+                    digit -= 9;
+                }
+            }
+
+            sum += digit;
+            doubleDigit = !doubleDigit;
+        }
+
+        return (10 - (sum % 10)) % 10;
+    }
+
+    private static bool RequiresProviderIdentityIsolation(SyntheticClaim claim)
+        => claim.PriorAuthStatus.Equals("Required", StringComparison.OrdinalIgnoreCase)
+           || claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_AuthOnFile
+               or EdgeCaseScenario.PriorAuthRequired_NoAuth
+               or EdgeCaseScenario.PriorAuthRequired_ExpiredAuth
+               or EdgeCaseScenario.PriorAuthRequired_WrongProvider
+               or EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+
+    private static int DistinctProviderCount(IEnumerable<SyntheticClaim> claims)
+        => claims
+            .SelectMany(claim => new[] { claim.BillingProvider.Npi, claim.RenderingProvider.Npi })
+            .Where(npi => !string.IsNullOrWhiteSpace(npi))
+            .Distinct(StringComparer.Ordinal)
+            .Count();
+
+    private sealed record ProviderProfileKey(
+        string Role,
+        string ProviderType,
+        string SpecialtyCode,
+        string TaxonomyCode,
+        bool IsParticipating,
+        string NetworkStatus,
+        string CredentialingStatus,
+        string State,
+        string ContractType,
+        string FeeScheduleId,
+        DateTime EffectiveDate,
+        DateTime? TermDate,
+        bool AcceptingNewPatients)
+    {
+        public static ProviderProfileKey From(SyntheticProvider provider, string role) => new(
+            role,
+            provider.ProviderType,
+            provider.SpecialtyCode,
+            provider.TaxonomyCode,
+            provider.IsParticipating,
+            provider.NetworkStatus,
+            provider.CredentialingStatus,
+            provider.State,
+            provider.ContractType,
+            provider.FeeScheduleId ?? string.Empty,
+            provider.EffectiveDate.Date,
+            provider.TermDate?.Date,
+            provider.AcceptingNewPatients);
+    }
+}

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -71,7 +71,11 @@ NormalizePriorAuthEdgeCases(claims, options);
 NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
 MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
 MccCleanPaidFixture.NormalizeClaims(claims);
+var providerPool = MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId);
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
+Console.WriteLine(
+    $"Provider fixture pool: {providerPool.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
+    $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
 if (options.SeedMembers)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccProviderFixturePoolTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccProviderFixturePoolTests.cs
@@ -1,0 +1,91 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccProviderFixturePoolTests
+{
+    [Fact]
+    public void Apply_ReusesEquivalentProvidersByRole()
+    {
+        var claims = new[]
+        {
+            Claim("MCC-P-1", Provider("1000000001"), Provider("2000000001")),
+            Claim("MCC-P-2", Provider("1000000002"), Provider("2000000002"))
+        };
+
+        var result = MccProviderFixturePool.Apply(claims, 42, RunId);
+
+        Assert.Equal(4, result.ProvidersBefore);
+        Assert.Equal(2, result.ProvidersAfter);
+        Assert.Equal(2, result.ReusedAssignments);
+        Assert.Same(claims[0].BillingProvider, claims[1].BillingProvider);
+        Assert.Same(claims[0].RenderingProvider, claims[1].RenderingProvider);
+    }
+
+    [Fact]
+    public void Apply_DoesNotReuseDifferentAdjudicationProfiles()
+    {
+        var active = Provider("1000000001");
+        var excluded = Provider("1000000002");
+        excluded.CredentialingStatus = "Excluded";
+        excluded.NetworkStatus = "Excluded";
+
+        var claims = new[]
+        {
+            Claim("MCC-P-1", active, Provider("2000000001")),
+            Claim("MCC-P-2", excluded, Provider("2000000002"))
+        };
+
+        var result = MccProviderFixturePool.Apply(claims, 42, RunId);
+
+        Assert.Equal(3, result.ProvidersAfter);
+        Assert.NotSame(claims[0].BillingProvider, claims[1].BillingProvider);
+    }
+
+    [Fact]
+    public void Apply_PreservesProviderSensitivePriorAuthorizationClaims()
+    {
+        var first = Claim("MCC-E-1", Provider("1000000001"), Provider("2000000001"));
+        first.EdgeCase = EdgeCaseScenario.PriorAuthRequired_WrongProvider;
+        first.PriorAuthStatus = "OnFile";
+        var second = Claim("MCC-I-2", Provider("1000000002"), Provider("2000000002"));
+        second.PriorAuthStatus = "Required";
+
+        var result = MccProviderFixturePool.Apply(new[] { first, second }, 42, RunId);
+
+        Assert.Equal(4, result.ProvidersAfter);
+        Assert.Equal(2, result.ProtectedClaims);
+        Assert.Equal("1000000001", first.BillingProvider.Npi);
+        Assert.Equal("1000000002", second.BillingProvider.Npi);
+    }
+
+    private static SyntheticClaim Claim(
+        string id,
+        SyntheticProvider billingProvider,
+        SyntheticProvider renderingProvider) => new()
+    {
+        ClaimId = id,
+        BillingProvider = billingProvider,
+        RenderingProvider = renderingProvider,
+        PriorAuthStatus = "NotRequired"
+    };
+
+    private static SyntheticProvider Provider(string npi) => new()
+    {
+        Npi = npi,
+        ProviderType = "Individual",
+        SpecialtyCode = "207Q00000X",
+        TaxonomyCode = "207Q00000X",
+        IsParticipating = true,
+        NetworkStatus = "InNetwork",
+        CredentialingStatus = "Active",
+        State = "AZ",
+        ContractType = "FeeForService",
+        FeeScheduleId = "FS-MEDICAID",
+        EffectiveDate = new DateTime(2024, 1, 1),
+        AcceptingNewPatients = true
+    };
+
+    private static readonly Guid RunId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+}


### PR DESCRIPTION
## What changed

- pool billing and rendering provider fixtures when their adjudication-relevant profiles are equivalent
- assign canonical pooled providers a run-scoped NPI so stale tenant state cannot affect a new validation run
- preserve distinct provider identities for prior-authorization scenarios where provider identity affects the expected result
- report provider counts, reused assignments, and protected claims in validator output
- add focused tests for reuse, profile separation, and prior-auth isolation

## Why

The 100K validation generated and seeded nearly two providers per claim even though most providers shared the same adjudication profile. Provider fixture seeding became a major local scale bottleneck and added unnecessary tenant data.

The first pooling smoke exposed stale provider state when an existing NPI became the canonical fixture. Run-scoped canonical NPIs remove that cross-run contamination while retaining the fixture reduction.

## Impact

Equivalent claims reuse a small set of provider fixtures, reducing provider creation and seeding work without changing scored claim outcomes. Provider-sensitive prior-auth claims continue using isolated identities.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 82 passed
- 1,000-claim local Kubernetes smoke — 1,000 processed, 0 platform failures, 0 workflow mismatches, 0 unexpected pends, payment gate 20/20 within $0.01
- smoke provider pool — 2,000 distinct assignments reduced to 1,096 NPIs, with 904 assignments reused and 28 provider-sensitive claims preserved
