### PR TITLE
Repair contradictory approved claim summaries

### DIFF
--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -453,6 +453,23 @@ public class ClaimRepository : IClaimRepository
         && incomingAdjudication.PayerPayment > 0
         && !HasDenialEvidence(incomingAdjudication);
 
+    /// <summary>
+    /// True for the inverse narrow repair allowed by benchmark summary
+    /// writeback: a row already says Approved, while the incoming summary is
+    /// denied, pays nothing, and carries explicit denial evidence. This
+    /// prevents an impossible "Approved + zero payer payment + denial reason"
+    /// state without weakening pend protection or reopening a consistent
+    /// final disposition.
+    /// </summary>
+    public static bool CanRepairContradictoryApprovedSummary(
+        ClaimStatus preWriteStatus,
+        ClaimStatus desiredStatus,
+        AdjudicationResult incomingAdjudication) =>
+        preWriteStatus == ClaimStatus.Approved
+        && desiredStatus == ClaimStatus.Denied
+        && incomingAdjudication.PayerPayment == 0
+        && HasDenialEvidence(incomingAdjudication);
+
     private static bool HasDenialEvidence(AdjudicationResult? adjudication) =>
         adjudication is not null
         && (!string.IsNullOrWhiteSpace(adjudication.DenialReasonCode)
@@ -1418,12 +1435,19 @@ public class ClaimRepository : IClaimRepository
         {
             if (incomingAdjudication is not null
                 && preWriteStatus is not null
-                && CanRepairContradictoryDeniedSummary(
-                    preWriteStatus.Value,
-                    desiredStatus,
-                    incomingAdjudication))
+                && (CanRepairContradictoryDeniedSummary(
+                        preWriteStatus.Value,
+                        desiredStatus,
+                        incomingAdjudication)
+                    || CanRepairContradictoryApprovedSummary(
+                        preWriteStatus.Value,
+                        desiredStatus,
+                        incomingAdjudication)))
             {
-                var repairOptions = new PatchItemRequestOptions { FilterPredicate = ContradictoryDeniedRepairFilterPredicate };
+                var repairFilter = desiredStatus == ClaimStatus.Denied
+                    ? ContradictoryApprovedRepairFilterPredicate
+                    : ContradictoryDeniedRepairFilterPredicate;
+                var repairOptions = new PatchItemRequestOptions { FilterPredicate = repairFilter };
                 try
                 {
                     await _container.PatchItemAsync<Claim>(rowId, new PartitionKey(tenantId), statusOps, repairOptions, ct);
@@ -1466,6 +1490,19 @@ public class ClaimRepository : IClaimRepository
         "AND (NOT IS_DEFINED(c.adjudicationResult.denialReasonCode) " +
         "OR IS_NULL(c.adjudicationResult.denialReasonCode) " +
         "OR c.adjudicationResult.denialReasonCode = '')";
+
+    private static readonly string ContradictoryApprovedRepairFilterPredicate =
+        $"FROM c WHERE c.status = '{CosmosStatusLiteral(ClaimStatus.Approved)}' " +
+        "AND IS_DEFINED(c.adjudicationResult) " +
+        "AND c.adjudicationResult.payerPayment = 0 " +
+        "AND ((IS_DEFINED(c.adjudicationResult.denialReasonCode) " +
+        "AND NOT IS_NULL(c.adjudicationResult.denialReasonCode) " +
+        "AND c.adjudicationResult.denialReasonCode != '') " +
+        "OR (IS_DEFINED(c.adjudicationResult.denialReason) " +
+        "AND NOT IS_NULL(c.adjudicationResult.denialReason) " +
+        "AND c.adjudicationResult.denialReason != '') " +
+        "OR (IS_DEFINED(c.adjudicationResult.adjustmentReasons) " +
+        "AND ARRAY_LENGTH(c.adjudicationResult.adjustmentReasons) > 0))";
 
     /// <summary>Cosmos patch FilterPredicate for <see cref="IsFinalDisposition"/> — built from <see cref="FinalDispositions"/>; Pended is deliberately absent (re-pending is allowed).</summary>
     private static readonly string FinalDispositionFilterPredicate =

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -716,19 +716,37 @@ public class ClaimRepositoryMongo : IClaimRepository
 
         if (incomingAdjudication is not null
             && preWriteStatus is not null
-            && ClaimRepository.CanRepairContradictoryDeniedSummary(
-                preWriteStatus.Value,
-                desiredStatus,
-                incomingAdjudication))
+            && (ClaimRepository.CanRepairContradictoryDeniedSummary(
+                    preWriteStatus.Value,
+                    desiredStatus,
+                    incomingAdjudication)
+                || ClaimRepository.CanRepairContradictoryApprovedSummary(
+                    preWriteStatus.Value,
+                    desiredStatus,
+                    incomingAdjudication)))
         {
+            var repairEvidenceFilter = desiredStatus == ClaimStatus.Denied
+                ? b.And(
+                    b.Eq(c => c.Status, ClaimStatus.Approved),
+                    b.Eq(c => c.AdjudicationResult!.PayerPayment, 0m),
+                    b.Or(
+                        b.And(
+                            b.Ne(c => c.AdjudicationResult!.DenialReasonCode, null),
+                            b.Ne(c => c.AdjudicationResult!.DenialReasonCode, string.Empty)),
+                        b.And(
+                            b.Ne(c => c.AdjudicationResult!.DenialReason, null),
+                            b.Ne(c => c.AdjudicationResult!.DenialReason, string.Empty)),
+                        b.SizeGt(c => c.AdjudicationResult!.AdjustmentReasons, 0)))
+                : b.And(
+                    b.Eq(c => c.Status, ClaimStatus.Denied),
+                    b.Gt(c => c.AdjudicationResult!.PayerPayment, 0m),
+                    b.Or(
+                        b.Eq(c => c.AdjudicationResult!.DenialReasonCode, null),
+                        b.Eq(c => c.AdjudicationResult!.DenialReasonCode, string.Empty)));
             var repairFilter = b.And(
                 b.Eq(c => c.TenantId, tenantId),
                 b.Eq(c => c.Id, rowId),
-                b.Eq(c => c.Status, ClaimStatus.Denied),
-                b.Gt(c => c.AdjudicationResult!.PayerPayment, 0m),
-                b.Or(
-                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, null),
-                    b.Eq(c => c.AdjudicationResult!.DenialReasonCode, string.Empty)));
+                repairEvidenceFilter);
 
             var repairResult = await _collection.UpdateOneAsync(repairFilter, statusUpdate, cancellationToken: ct);
             if (repairResult.MatchedCount > 0)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -629,6 +629,35 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     }
 
     [Fact]
+    public void CanRepairContradictoryApprovedSummary_only_allows_zeroPay_denial_with_evidence()
+    {
+        var deniedSummary = new AdjudicationResult
+        {
+            PayerPayment = 0m,
+            DenialReasonCode = "197",
+            DenialReason = "Prior authorization required"
+        };
+
+        ClaimRepository.CanRepairContradictoryApprovedSummary(
+                ClaimStatus.Approved,
+                ClaimStatus.Denied,
+                deniedSummary)
+            .Should().BeTrue();
+
+        ClaimRepository.CanRepairContradictoryApprovedSummary(
+                ClaimStatus.Pended,
+                ClaimStatus.Denied,
+                deniedSummary)
+            .Should().BeFalse("pends remain protected from synchronous summary writeback");
+
+        ClaimRepository.CanRepairContradictoryApprovedSummary(
+                ClaimStatus.Approved,
+                ClaimStatus.Denied,
+                new AdjudicationResult { PayerPayment = 0m })
+            .Should().BeFalse("zero payment without denial evidence is not enough to reopen a final status");
+    }
+
+    [Fact]
     public async Task UpdateAdjudicationSummaryAsync_onNonPendedClaim_appliesStatusAndData()
     {
         // Regression: the unguarded, normal case is byte-identical to
@@ -733,6 +762,34 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
         reread.VersionState.Should().Be(ClaimVersionState.Adjudicated);
         reread.AdjudicationResult!.PayerPayment.Should().Be(150m);
         reread.AdjudicationResult.DenialReasonCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAdjudicationSummaryAsync_onApprovedWithDenialEvidence_repairsDeniedSummaryStatus()
+    {
+        var head = BuildVersion("chain-summary-denial-repair", "row-1", n: 1, ClaimVersionState.Adjudicated);
+        head.Status = ClaimStatus.Approved;
+        head.AdjudicationResult = new AdjudicationResult { PayerPayment = 125m };
+        await _repo.CreateAsync(head);
+
+        var result = await _repo.UpdateAdjudicationSummaryAsync(
+            Tenant, "chain-summary-denial-repair",
+            new AdjudicationResult
+            {
+                PayerPayment = 0m,
+                DenialReasonCode = "197",
+                DenialReason = "Prior authorization required"
+            },
+            ClaimStatus.Denied);
+
+        result.Outcome.Should().Be(StatusWriteOutcome.Applied);
+        result.PersistedStatus.Should().Be(ClaimStatus.Denied);
+
+        var reread = await _repo.GetVersionAsync("chain-summary-denial-repair", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Denied);
+        reread.VersionState.Should().Be(ClaimVersionState.Adjudicated);
+        reread.AdjudicationResult!.PayerPayment.Should().Be(0m);
+        reread.AdjudicationResult.DenialReasonCode.Should().Be("197");
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- add a narrow consistency repair for claims whose persisted lifecycle status is `Approved` while an incoming adjudication summary has zero payer payment and explicit denial evidence
- apply the same guarded behavior in Cosmos DB and MongoDB repositories
- preserve existing protection for pended claims and consistent final dispositions
- add predicate and repository regression coverage for the Approved-to-Denied repair

## Why

The post-provider-pooling 100K validation exposed one race between the asynchronous adjudication projection and the validator's fast adjudication summary writeback. The asynchronous path finalized a prior-authorization claim as Approved first. The deterministic summary then persisted zero payment and a prior-authorization denial reason, but the final-status guard suppressed the matching Denied transition.

That left an impossible record: Approved lifecycle status with zero payer payment and explicit denial evidence. The repository already supported the inverse narrow repair for Denied claims receiving a clean paid summary. This change adds the symmetric repair without weakening the general final-status precedence guard.

## Impact

A contradictory Approved record can be repaired to Denied only when the incoming summary pays nothing and contains denial evidence. Pended claims remain protected, and consistent final claims remain immutable through this path.

## Validation

- focused repository tests: 64 passed
- full claims-service suite: 539 passed
- 10K local Kubernetes regression: 10,000 processed, 0 platform failures, 0 workflow mismatches, 0 unexpected pends, payment gate 200/200
- 100K local Kubernetes verification: 100,000 processed, 0 platform failures, 0 workflow mismatches, 0 unexpected pends, payment gate 2,000/2,000
- repaired prior-auth scenario: `PriorAuthRequired_NoAuth` 160/160 matched
