### PR TITLE
docs: clarify episode 8 pend scoring scope

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-008/README.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/README.txt
@@ -6,6 +6,8 @@ Episode 008 covers the first clean 100,000-claim local Kubernetes validation aft
 
 The result held: 100,000 processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000 of 2,000 comparable payments within one cent. The episode also explains why the 29:40 timed processing phase and 128-minute Kubernetes job lifecycle are different, and why fixture preparation is now the clearest local scaling target.
 
+The pend counts are intentionally reported with scope: 923 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,614 scoreable expected-pay and expected-deny claims.
+
 ## Episode metadata
 
 - Episode title: The Clean 100,000-Claim Run
@@ -51,6 +53,7 @@ The episode must distinguish:
 
 - [x] Exact 100K results are recorded.
 - [x] Payment and false-pend gates are explained.
+- [x] Persisted-pend, expected-pend, and false-pend sweep scopes are separated.
 - [x] Unsupported scenarios remain visible and separate.
 - [x] Timed processing and total job duration are not conflated.
 - [x] Local results are not presented as production capacity.

--- a/docs/million-claim-challenge/podcast/episode-008/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/article.txt
@@ -53,6 +53,8 @@ The final summary reported:
 - $0.00 average payment delta
 - $0.00 maximum payment delta
 
+The pend numbers have two scopes. The run ended with 923 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.
+
 Unsupported scenarios remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.
 
 Those are named product gaps, not hidden successes.

--- a/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
@@ -49,6 +49,8 @@ CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_
 - Average payment delta: $0.00
 - Maximum payment delta: $0.00
 
+Pend-scope note: the final persisted outcome mix includes 923 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
+
 ## Performance result
 
 - Timed claim-processing elapsed: 29:40.851

--- a/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
@@ -7,9 +7,13 @@ The central story is that Cloud Health Office did not move from 50K to 100K by r
 Use these exact results:
 
 - 100,000 claims processed
+- 79,164 paid or adjudicated
+- 923 persisted pended outcomes
+- 19,913 business denials
 - 0 platform failures
 - 0 workflow mismatches
 - 0 observation timeouts
+- 920 expected-pend claims observed as pended
 - 0 unexpected pends across 10,614 scoreable non-pend claims
 - 11,534 of 13,000 workflow checks matched
 - 1,466 unsupported scenarios
@@ -21,6 +25,8 @@ Use these exact results:
 - approximately 128 minutes total Kubernetes job lifecycle including fixture preparation
 
 Explain why business denials are valid outcomes and why unsupported scenarios are visible product gaps rather than passes or failures.
+
+Make the pend scope explicit: the outcome mix had 923 persisted pended claims, the expected-pend observer verified 920 answer-key pend scenarios, and the false-pend sweep covered the scoreable expected-pay and expected-deny set. Do not imply unsupported scenarios were included in that non-pend sweep.
 
 Spend meaningful time on the difference between timed adjudication and total developer wait time. Fixture preparation seeded or aligned almost 100,000 member statuses and processed roughly 200,000 provider records. Correctness held, but the fixture strategy became the clearest local scaling bottleneck.
 

--- a/src/site/docs/million-claim-challenge/evidence.html
+++ b/src/site/docs/million-claim-challenge/evidence.html
@@ -660,6 +660,8 @@ CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_
 - Average payment delta: $0.00
 - Maximum payment delta: $0.00
 
+Pend-scope note: the final persisted outcome mix includes 923 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
+
 ## Performance result
 
 - Timed claim-processing elapsed: 29:40.851

--- a/src/site/insights/million-claim-challenge/part-8-clean-100k.html
+++ b/src/site/insights/million-claim-challenge/part-8-clean-100k.html
@@ -61,6 +61,7 @@
 <p>The local Docker Desktop Kubernetes run processed 100,000 deterministic synthetic claims with parallelism set to 10.</p>
 <p>The final summary reported:</p>
 <ul><li>100,000 claims processed</li><li>79,164 paid or adjudicated</li><li>923 pended</li><li>19,913 business denials</li><li>0 platform failures</li><li>0 observation timeouts</li><li>11,534 of 13,000 workflow checks matched</li><li>0 workflow mismatches</li><li>1,466 unsupported scenarios</li><li>0 unexpected pends across 10,614 scoreable non-pend claims</li><li>2,000 of 2,000 comparable payments within one cent</li><li>$0.00 average payment delta</li><li>$0.00 maximum payment delta</li></ul>
+<p>The pend numbers have two scopes. The run ended with 923 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.</p>
 <p>Unsupported scenarios remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.</p>
 <p>Those are named product gaps, not hidden successes.</p>
 <h2 id="performance-did-not-scale-linearly">Performance did not scale linearly</h2>


### PR DESCRIPTION
## Summary
- clarify the difference between total persisted pended outcomes, expected-pend observation, and false-pend sweep scope in the Episode 8 packet
- update the podcast prompt and README acceptance checklist with the same scope distinction
- regenerate the public Part 8 article and MCC evidence archive from the source packet

## Validation
- `npm run build` from `src/site`
