### PR TITLE
Refocus marketing site on MCC evidence

### DIFF
--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Million Claim Challenge — Open Claims Adjudication Benchmark | Cloud Health Office</title>
-  <meta name="description" content="The Million Claim Challenge is a source-available benchmarking tool that generates 1,000,000 synthetic healthcare claims — professional, institutional, dental, and 29 edge case scenarios — with pre-computed expected adjudication outcomes. Benchmark any claims engine against a shared yardstick." />
+  <meta name="description" content="The Million Claim Challenge is a source-available claims adjudication benchmark designed for 1,000,000 synthetic claims. Latest Cloud Health Office proof: clean 100,000-claim local Kubernetes validation with zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent." />
   <meta name="keywords" content="million claim challenge, claims adjudication benchmark, synthetic claim generator, healthcare benchmarking, CMS-0057-F testing, cloud health office benchmark, FHIR R4 compliance testing, healthcare claims testing, payer platform benchmark, claims accuracy testing, COB coordination of benefits testing, prior authorization testing, QNXT benchmark, Facets benchmark, HealthEdge benchmark, adjudication engine accuracy, healthcare QA, claims edge cases, DRG grouper testing, dental claims benchmark, synthetic member generation, synthetic provider generation, benefit plan seeding, fee schedule seeding, X12 834 enrollment, benchmark data seeding, Cosmos DB seeding, claims pipeline benchmarking" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/million-claim-challenge" />
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large" />
@@ -14,11 +14,11 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/million-claim-challenge" />
   <meta property="og:title" content="Million Claim Challenge — Open Claims Adjudication Benchmark" />
-  <meta property="og:description" content="One million synthetic claims. 75,000 seeded members. 5,500 providers. Pre-computed outcomes. The open benchmark for healthcare adjudication engines. Seed prerequisites, generate claims, score results." />
+  <meta property="og:description" content="A source-available adjudication benchmark designed for one million synthetic claims. Latest CHO proof: clean 100K local Kubernetes validation with zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png" />
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="article:published_time" content="2026-04-05T00:00:00Z" />
-  <meta property="article:modified_time" content="2026-07-11T00:00:00Z" />
+  <meta property="article:modified_time" content="2026-07-13T00:00:00Z" />
   <meta property="article:section" content="Testing &amp; Benchmarks" />
   <meta property="article:tag" content="claims adjudication" />
   <meta property="article:tag" content="benchmarking" />
@@ -28,7 +28,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Million Claim Challenge — Open Claims Adjudication Benchmark" />
-  <meta name="twitter:description" content="1,000,000 synthetic claims. 29 edge case scenarios. Pre-computed outcomes. The open benchmark for healthcare adjudication engines." />
+  <meta name="twitter:description" content="Designed for one million synthetic claims. Latest CHO proof: clean 100K local Kubernetes validation with zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent." />
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/og-million-claim-challenge.png" />
 
   <!-- JSON-LD: TechArticle -->
@@ -38,7 +38,7 @@
     "@type": "TechArticle",
     "headline": "Million Claim Challenge — Open Claims Adjudication Benchmark",
     "alternativeHeadline": "Benchmark Any Healthcare Claims Engine With 1 Million Synthetic Claims",
-    "description": "Generate 1,000,000 stratified synthetic healthcare claims — professional CMS-1500, institutional UB-04, dental ADA, and 29 named edge case scenarios — with pre-computed expected adjudication outcomes. Benchmark any claims engine against a shared yardstick.",
+    "description": "Source-available claims adjudication benchmark designed for 1,000,000 stratified synthetic healthcare claims. Latest Cloud Health Office proof is a clean 100,000-claim local Kubernetes validation with zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent.",
     "url": "https://cloudhealthoffice.com/docs/million-claim-challenge",
     "mainEntityOfPage": "https://cloudhealthoffice.com/docs/million-claim-challenge",
     "author": { "@type": "Organization", "name": "Aurelianware, Inc.", "url": "https://github.com/aurelianware" },
@@ -49,7 +49,7 @@
       "logo": { "@type": "ImageObject", "url": "https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" }
     },
     "datePublished": "2026-04-05",
-    "dateModified": "2026-07-11",
+    "dateModified": "2026-07-13",
     "proficiencyLevel": "Intermediate",
     "about": [
       { "@type": "Thing", "name": "Claims Adjudication" },
@@ -341,8 +341,9 @@
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-then-validating-real-workflows-db3b6d691ac2" target="_blank" rel="noopener noreferrer">Part 1: Running a Healthcare Claims Platform Locally in Kubernetes, Then Validating Real Workflows</a>,
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-2-from-it-runs-to-it-measures-b36c915f08b9" target="_blank" rel="noopener noreferrer">Part 2: From It Runs to It Measures</a>,
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">Part 6: From Fast Runs to Honest Edge-Case Scoring</a>,
+            <a href="/insights/million-claim-challenge/part-7-operator-console">Part 7: From Benchmark Logs to an Operator Console</a>,
             and
-            <a href="/insights/million-claim-challenge/part-7-operator-console">Part 7: From Benchmark Logs to an Operator Console</a>.
+            <a href="/insights/million-claim-challenge/part-8-clean-100k">Part 8: The Clean 100,000-Claim Run</a>.
           </p>
           <p>
             <a href="/insights/million-claim-challenge"><strong>Read the complete engineering series</strong></a>

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Cloud Health Office — CMS-0057-F Compliance Layer for Legacy Payer Systems</title>
-  <meta name="description" content="Meet CMS-0057-F without replacing your core admin platform. Cloud Health Office is the compliance and modernization layer for QNXT, Facets, HealthEdge, and legacy payer systems. FHIR R4, X12 EDI, your cloud." />
+  <title>Cloud Health Office — Evidence-Led Payer Platform</title>
+  <meta name="description" content="Cloud Health Office is a source-available payer platform with inspectable evidence: a clean 100,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta name="keywords" content="CMS-0057-F compliance, healthcare payer integration platform, FHIR R4 API health plan, X12 EDI to FHIR, healthcare clearinghouse integration, health plan modernization" />
   <link rel="canonical" href="https://cloudhealthoffice.com/" />
 
@@ -12,15 +12,15 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="og:url" content="https://cloudhealthoffice.com/" />
-  <meta property="og:title" content="Cloud Health Office — CMS-0057-F Compliance Layer for Legacy Payer Systems" />
-  <meta property="og:description" content="Meet CMS-0057-F without replacing your core admin platform. Cloud Health Office is the compliance and modernization layer for QNXT, Facets, HealthEdge, and legacy payer systems." />
+  <meta property="og:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
+  <meta property="og:description" content="Source-available payer infrastructure with inspectable benchmark evidence: clean 100,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="https://cloudhealthoffice.com/" />
-  <meta name="twitter:title" content="Cloud Health Office — CMS-0057-F Compliance Layer for Legacy Payer Systems" />
-  <meta name="twitter:description" content="Meet CMS-0057-F without replacing your core admin platform. Cloud Health Office is the compliance and modernization layer for QNXT, Facets, HealthEdge, and legacy payer systems." />
+  <meta name="twitter:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
+  <meta name="twitter:description" content="Source-available payer infrastructure with inspectable benchmark evidence: clean 100,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- JSON-LD Structured Data -->
@@ -31,7 +31,7 @@
     "name": "Cloud Health Office",
     "url": "https://cloudhealthoffice.com",
     "logo": "https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg",
-    "description": "Compliance and modernization layer for legacy payer core administration systems. Meet CMS-0057-F without replacing your core admin platform. FHIR R4 APIs, multi-clearinghouse EDI, and your cloud.",
+    "description": "Source-available payer platform with inspectable benchmark evidence, CMS-0057-F APIs, FHIR R4 workflows, multi-clearinghouse EDI, and your-cloud deployment.",
     "foundingDate": "2024",
     "contactPoint": {
       "@type": "ContactPoint",
@@ -52,7 +52,7 @@
     "operatingSystem": "Cloud (Azure, AWS, GCP, Kubernetes)",
     "url": "https://cloudhealthoffice.com",
     "softwareVersion": "2026",
-    "description": "Compliance and modernization layer for legacy payer core admin systems. CMS-0057-F compliance without replatforming. Works alongside QNXT, Facets, HealthEdge. BSL 1.1 licensed.",
+    "description": "Source-available payer infrastructure with inspectable claims-processing evidence, CMS-0057-F APIs, FHIR R4 workflows, and X12 EDI services. BSL 1.1 licensed.",
     "author": {
       "@type": "Organization",
       "name": "Aurelianware, Inc.",
@@ -194,13 +194,13 @@
     gap: 10px;
     flex-wrap: wrap;
   ">
-    <span>&#x1F3E5; Now selecting our Founding Client &mdash; founding-client terms, your cloud, compliance-first.</span>
-    <a href="#founding-partner" style="
+    <span>Latest proof: clean 100,000-claim local Kubernetes validation with zero platform failures and zero scoreable mismatches.</span>
+    <a href="/docs/million-claim-challenge/evidence#episode-008" style="
       color: #00ff88;
       font-weight: 600;
       text-decoration: none;
       white-space: nowrap;
-    " aria-label="Learn more about the Founding Client Program">Learn More &rarr;</a>
+    " aria-label="Inspect the Million Claim Challenge evidence archive">Inspect evidence &rarr;</a>
     <button id="fp-banner-dismiss" aria-label="Dismiss founding client banner" style="
       background: none;
       border: none;
@@ -253,6 +253,8 @@
             <a href="/platform" class="nav-dropdown-toggle">Platform</a>
             <div class="nav-dropdown-menu" aria-label="Platform submenu">
               <a href="/docs/architecture">Architecture</a>
+              <a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a>
+              <a href="/insights/million-claim-challenge/part-8-clean-100k">100K Run Writeup</a>
               <a href="/docs/compliance">CMS-0057-F Guide</a>
               <a href="/docs/api">API Reference</a>
               <div class="nav-dropdown-divider" aria-hidden="true"></div>
@@ -285,25 +287,27 @@
              alt="Cloud Health Office The Sentinel"
              class="hero-logo" />
 
-        <div class="hero-badge">Source-Available &nbsp;&middot;&nbsp; Kubernetes-Native &nbsp;&middot;&nbsp; CMS-0057-F Ready</div>
+        <div class="hero-badge">Source-Available &nbsp;&middot;&nbsp; Evidence-Led &nbsp;&middot;&nbsp; Kubernetes-Native</div>
 
         <h1 class="hero-headline">
-          Be Ready for CMS-0057-F.<br>
-          On Your Terms.
+          Claims platform evidence<br>
+          you can inspect.
         </h1>
 
         <p class="hero-subheadline">
-          Cloud Health Office deploys in your own cloud subscription &mdash; no black-box dependency, no PHI leaving your walls.<br>
-          Ready for pilot deployment today. <strong style="color:#00ff88;">Founding-client terms available.</strong>
+          Cloud Health Office is source-available payer infrastructure with a published clean 100,000-claim local Kubernetes validation:
+          zero platform failures, zero scoreable mismatches, zero unexpected pends, and every comparable payment within one cent.
+          <br>
+          Deployable in your cloud for technical evaluation and pilot-scoped engagements.
         </p>
 
         <div class="hero-cta">
-          <a href="#founding-partner-form"
+          <a href="/docs/million-claim-challenge/evidence#episode-008"
              class="button"
-             style="font-size:1.05rem; padding:15px 38px;">Become Our Founding Client &rarr;</a>
-          <a href="#cms-explainer"
+             style="font-size:1.05rem; padding:15px 38px;">Inspect the 100K evidence &rarr;</a>
+          <a href="/insights/million-claim-challenge/part-8-clean-100k"
              class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;">Learn about CMS-0057-F readiness &rarr;</a>
+             style="font-size:1.05rem; padding:15px 38px;">Read Part 8 &rarr;</a>
           <a href="https://github.com/aurelianware/cloudhealthoffice"
              class="button button-secondary"
              style="font-size:1.05rem; padding:15px 38px;"
@@ -324,16 +328,16 @@
       <div style="max-width: 860px; margin: 0 auto; text-align: center;">
         <span class="section-eyebrow" style="color:#00ff88;">CMS-0057-F</span>
         <h2 style="font-size: clamp(1.4rem, 3vw, 2rem); color:#00ff88; text-shadow:0 0 20px rgba(0,255,136,0.3); margin: 12px 0 20px 0;">
-          Why CMS-0057-F Changes Everything
+          Compliance still matters. Evidence makes it credible.
         </h2>
         <p style="font-size: 1rem; color: rgba(200,200,200,0.85); line-height: 1.75; margin: 0 auto 24px auto; max-width: 720px;">
-          The Making Care Primary (MCP) model under CMS-0057-F accelerates ACO accountability for total cost of care,
-          requiring ACOs and primary care practices to demonstrate real-time care coordination and accurate attribution
-          well before the compliance window closes. Health systems that wait until 2026 will spend the following year
-          firefighting, not transforming.
+          CMS-0057-F raises the bar for payer interoperability, prior authorization APIs, payer-to-payer exchange,
+          and operational auditability. Teams that wait until the compliance window is fully open will spend the following year
+          reconciling vendors, interfaces, and evidence after the fact.
           <br><br>
-          The organizations that engage now &mdash; validating workflows, building attribution logic, and proving
-          interoperability &mdash; will enter the compliance window with a working system, not a procurement.
+          The organizations that engage now &mdash; validating workflows, building attribution logic, proving
+          interoperability, and testing real adjudication behavior &mdash; will enter the compliance window with evidence,
+          not only vendor promises.
         </p>
         <a href="/cms-0057f-compliance" class="button button-secondary" style="font-size:0.95rem; padding:12px 28px;">
           Read the CMS-0057-F Summary &rarr;
@@ -381,8 +385,8 @@
 
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x2705;</div>
-            <h3 style="color:#00ff88;">CMS-0057-F in Production</h3>
-            <p>Go live with documented, tested, audit-ready implementations of prior authorization APIs, payer-to-payer exchange, and provider access APIs &mdash; before the compliance window closes.</p>
+            <h3 style="color:#00ff88;">CMS-0057-F Pilot Path</h3>
+            <p>Validate documented, tested implementations of prior authorization APIs, payer-to-payer exchange, and provider access APIs &mdash; before the compliance window closes.</p>
           </div>
 
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
@@ -394,7 +398,7 @@
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x1F512;</div>
             <h3 style="color:#00ff88;">Enterprise-Grade Controls</h3>
-            <p>Production HIPAA controls, RBAC, full audit logging, and deployment isolation from day one. Built for health plan compliance requirements &mdash; not retrofitted after the fact.</p>
+            <p>HIPAA-oriented controls, RBAC, audit logging, and deployment isolation from day one. Built for health plan compliance requirements &mdash; not retrofitted after the fact.</p>
           </div>
         </div>
 
@@ -426,7 +430,7 @@
         <div class="section-header">
           <span class="section-eyebrow">The Process</span>
           <h2 id="how-it-works-heading" class="section-title">How It Works</h2>
-          <p class="section-subtitle">From application to production in under 8 weeks &mdash; in your own cloud subscription.</p>
+          <p class="section-subtitle">From application to a scoped pilot in under 8 weeks &mdash; in your own cloud subscription.</p>
         </div>
 
         <div style="
@@ -498,10 +502,10 @@
               font-size: 1.1rem; font-weight: 700; color: #00ffff;
               margin-bottom: 20px;
             ">3</div>
-            <h3 style="font-size: 1.15rem; margin-bottom: 10px;">Go live &amp; co-develop</h3>
+            <h3 style="font-size: 1.15rem; margin-bottom: 10px;">Validate &amp; co-develop</h3>
             <p style="font-size: 0.9rem; color: rgba(176,176,176,0.75); line-height: 1.65;">
-              Your team is live in production. We run joint sprints to build out workflows, tune attribution
-              logic, and prioritize your roadmap based on real-world findings.
+              Your team validates the platform in a production-shaped environment. We run joint sprints to build out workflows, tune attribution
+              logic, and prioritize your roadmap based on measurable findings.
             </p>
             <p style="font-size: 0.82rem; color: rgba(0,255,136,0.5); margin-top: 14px; font-weight: 600;">Ongoing collaboration</p>
           </div>
@@ -566,7 +570,7 @@
       border-top: 1px solid rgba(0,255,255,0.08);
     ">
       <div class="proof-quote">
-        <p class="proof-quote-text">&ldquo;Our Founding Client won&rsquo;t be a proof of concept &mdash; they&rsquo;ll deploy a production-shaped platform, running in their own environment, under their own control, at zero licensing cost.&rdquo;</p>
+        <p class="proof-quote-text">&ldquo;Our Founding Client won&rsquo;t be evaluating a slide deck &mdash; they&rsquo;ll validate a production-shaped platform, running in their own environment, under their own control, at zero licensing cost.&rdquo;</p>
         <div class="proof-quote-byline">&mdash; Cloud Health Office Team</div>
       </div>
     </section>
@@ -1092,20 +1096,20 @@
     <section class="stats-section" aria-label="Platform statistics">
       <div class="stats-inner">
         <div class="stat-item">
-          <span class="stat-number">36</span>
-          <span class="stat-label">Microservices<br>+ 9 Engines</span>
+          <span class="stat-number">100K</span>
+          <span class="stat-label">Clean Local<br>Validation</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">50K</span>
-          <span class="stat-label">MCC Breadth<br>Run</span>
+          <span class="stat-number">0</span>
+          <span class="stat-label">Platform<br>Failures</span>
         </div>
         <div class="stat-item">
           <span class="stat-number">0</span>
           <span class="stat-label">Scoreable<br>Mismatches</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">5,767</span>
-          <span class="stat-label">Workflow Checks<br>Matched</span>
+          <span class="stat-number">2,000</span>
+          <span class="stat-label">Payment Checks<br>Within One Cent</span>
         </div>
       </div>
     </section>
@@ -1115,44 +1119,46 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
-          <h2 class="section-title">1,000,000 claims. One shared yardstick.</h2>
-          <p class="section-subtitle">A source-available, deterministic benchmark corpus &mdash; professional, institutional, dental, and 29 named edge-case scenarios &mdash; with pre-computed expected adjudication outcomes. The benchmark is designed for one million claims; the latest published Cloud Health Office proof is a clean 100K local Kubernetes run with zero platform failures, zero scoreable mismatches, zero unexpected pends, and every comparable payment within one cent.</p>
+          <h2 class="section-title">The proof ladder is public.</h2>
+          <p class="section-subtitle">The Million Claim Challenge is designed for one million deterministic synthetic claims across professional, institutional, dental, and 29 named edge-case scenarios. The latest published Cloud Health Office proof is the clean 100K local Kubernetes run: every claim processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and every comparable payment within one cent.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">
           <div class="stat-item">
-            <span class="stat-number">1M</span>
-            <span class="stat-label">Synthetic<br>Claims</span>
+            <span class="stat-number">11,534</span>
+            <span class="stat-label">Workflow Checks<br>Matched</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">29</span>
-            <span class="stat-label">Edge Case<br>Scenarios</span>
+            <span class="stat-number">0</span>
+            <span class="stat-label">Unexpected<br>Pends</span>
           </div>
           <div class="stat-item">
             <span class="stat-number">1,466</span>
             <span class="stat-label">Unsupported<br>Separated</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">100K</span>
-            <span class="stat-label">Clean Local<br>Milestone</span>
+            <span class="stat-number">$0.00</span>
+            <span class="stat-label">Average Payment<br>Delta</span>
           </div>
         </div>
 
         <div style="text-align:center; margin-bottom:48px;">
-          <a href="/docs/million-claim-challenge" class="button button-secondary">Explore the Million Claim Challenge &rarr;</a>
+          <a href="/docs/million-claim-challenge/evidence#episode-008" class="button">Inspect the 100K Evidence &rarr;</a>
+          <a href="/docs/million-claim-challenge" class="button button-secondary">Explore the Benchmark Methodology &rarr;</a>
         </div>
 
         <div class="section-header">
-          <span class="section-eyebrow" style="color:#00ff88;">Recent Activity</span>
-          <h2 class="section-title" style="font-size:1.4rem;">Shipped in v4.4.0 &mdash; Claims Phase 1 Closure</h2>
+          <span class="section-eyebrow" style="color:#00ff88;">What the Evidence Says</span>
+          <h2 class="section-title" style="font-size:1.4rem;">Current proof, next bottleneck.</h2>
         </div>
         <p style="text-align:center; color:#999; max-width:700px; margin:0 auto 24px;">
-          14 capabilities spanning the full claim lifecycle: submit &rarr; adjudicate &rarr; pay &rarr; adjust &rarr; reverse. See
-          <a href="https://github.com/aurelianware/cloudhealthoffice/pull/725" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">#725</a>,
-          <a href="https://github.com/aurelianware/cloudhealthoffice/pull/733" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">#733</a>,
-          <a href="https://github.com/aurelianware/cloudhealthoffice/pull/740" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">#740</a>, and the
-          <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">full changelog</a> for all 14 PRs.
+          The 100K result is a local Docker Desktop Kubernetes validation, not a production cloud capacity claim and not the full million yet.
+          It proves the stronger scoring gates can hold at 100K, while exposing the next local bottleneck: fixture preparation dominated the total job lifecycle.
+          That is the next optimization target before 250K, 500K, and the full million.
         </p>
+        <div style="text-align:center;">
+          <a href="/insights/million-claim-challenge/part-8-clean-100k" class="button button-secondary">Read the 100K writeup &rarr;</a>
+        </div>
       </div>
     </section>
 
@@ -1163,8 +1169,8 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ff88;">CMS-0057-F</span>
-          <h2 class="section-title" style="color:#00ff88; text-shadow:0 0 30px rgba(0,255,136,0.35);">Compliant. 18 Months Early.</h2>
-          <p class="section-subtitle">The January 2027 deadline is not a future problem. It was solved in production, now.</p>
+          <h2 class="section-title" style="color:#00ff88; text-shadow:0 0 30px rgba(0,255,136,0.35);">CMS-0057-F Surface, Source Visible.</h2>
+          <p class="section-subtitle">The compliance APIs are implemented and inspectable today. Production readiness, integrations, and operating evidence should be validated in each payer environment.</p>
         </div>
 
         <figure style="margin:0 auto 40px auto; max-width:1000px;">

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -253,16 +253,16 @@
         
         <div class="stats-grid">
           <div class="stat-card">
-            <div class="stat-number">50K</div>
-            <div class="stat-label">Latest Published<br>Local Benchmark</div>
+            <div class="stat-number">100K</div>
+            <div class="stat-label">Clean Local<br>Benchmark</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">5,187</div>
-            <div class="stat-label">Automated Tests<br>Reported by CI</div>
+            <div class="stat-number">0</div>
+            <div class="stat-label">Scoreable Mismatches<br>or Unexpected Pends</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">PMPM</div>
-            <div class="stat-label">Pilot-Scoped<br>Commercial Model</div>
+            <div class="stat-number">2,000</div>
+            <div class="stat-label">Payments Within<br>One Cent</div>
           </div>
           <div class="stat-card">
             <div class="stat-number">Pilot</div>
@@ -950,11 +950,11 @@
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">CLASS LIBRARIES</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">5,187</div>
-              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">TESTS REPORTED</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">2,000</div>
+              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">PAYMENT CHECKS</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">50K</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">100K</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">LOCAL BENCHMARK</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- refocus the homepage hero, banner, and MCC proof section around the clean 100K evidence instead of stale release/version language
- update platform proof metrics from the older 50K/test-count framing to the current 100K validation gates
- refresh Million Claim Challenge metadata and field-note links so snippets include the current 100K proof and Part 8 writeup

## Why
The public site was still leading with CMS/release-era framing in places, including a v4.4 shipped block and older 50K benchmark metrics. The current story is stronger and more honest: Cloud Health Office has inspectable 100K local Kubernetes evidence, with clear limits and next bottlenecks.

## Validation
- `npm run build` in `src/site`
