### PR TITLE
Surface MCC evidence in site navigation

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-006/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-006/benchmark-results.txt
@@ -164,11 +164,11 @@ Interpretation:
 
 The post-fix 10K gate passed. The 5K zero-mismatch breadth result held at double the volume, supported COB-pend fixture rows were isolated and seeded one-for-one, expected-pend observation remained reliable, and unsupported scenarios continued to be separated from mismatches.
 
-## Remaining Part 6 validation gate
+## Part 6 validation boundary
 
 Part 6 now has 5K, 10K, and 50K breadth validation data.
 
-100K is intentionally out of scope for Part 6. After the clean 50K breadth result, 100K should become its own focused milestone article rather than a late addition to this one.
+At publication time, 100K was intentionally out of scope for Part 6. After the clean 50K breadth result, 100K belonged in its own focused milestone article rather than as a late addition to this one. That follow-on milestone was later published in Part 8.
 
 ### 50,000-claim breadth validation
 
@@ -281,13 +281,13 @@ Pend-observation caveat:
 
 The pend-observation pass polls persisted claim status only for scenarios whose answer-key outcome is `Pended`. It proves expected-pend claims persisted as pended. It does not, by itself, detect the inverse error where a claim expected to pay or deny later persists as pended. A future validator enhancement should add an optional persisted-status sweep for non-pend scenarios to detect false pends.
 
-## Future milestone: 100,000 claims
+## Later milestone: 100,000 claims
 
-The next publication candidate after Part 6 is a focused 100K milestone.
+The next publication candidate after Part 6 was a focused 100K milestone.
 
-That future article should answer a different question: once broader edge-case scoring is established at 50K, how far can the local Kubernetes validation path scale before the next bottleneck appears?
+That article needed to answer a different question: once broader edge-case scoring is established at 50K, how far can the local Kubernetes validation path scale before the next bottleneck appears?
 
-100K should not block Part 6.
+Part 8 now records that answer: a clean 100K local Kubernetes run passed the stronger correctness gates and exposed fixture preparation as the next local scaling bottleneck.
 
 ## Correctness framing
 

--- a/src/site/contact.html
+++ b/src/site/contact.html
@@ -369,6 +369,8 @@
           <h5>Documentation</h5>
           <ul>
             <li><a href="/docs/quickstart">Quick Start</a></li>
+            <li><a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a></li>
+            <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
             <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
             <li><a href="/docs/architecture">Architecture</a></li>
             <li><a href="/docs/api">API Reference</a></li>

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Documentation — Cloud Health Office</title>
-  <meta name="description" content="Cloud Health Office documentation. Quick start guides, CMS-0057-F compliance, architecture overview, API reference, and deployment guides for healthcare payer integration." />
+  <meta name="description" content="Cloud Health Office documentation. Quick start guides, 100K Million Claim Challenge evidence, CMS-0057-F compliance, architecture overview, API reference, and deployment guides for healthcare payer integration." />
   <meta name="keywords" content="Cloud Health Office docs, CMS-0057-F compliance guide, healthcare payer integration documentation, FHIR R4 API reference, X12 EDI deployment guide, healthcare platform quick start" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs" />
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs" />
   <meta property="og:title" content="Documentation — Cloud Health Office" />
-  <meta property="og:description" content="Quick start guides, CMS-0057-F compliance, architecture, API reference, and deployment for healthcare payer integration." />
+  <meta property="og:description" content="Quick start guides, 100K Million Claim Challenge evidence, CMS-0057-F compliance, architecture, API reference, and deployment for healthcare payer integration." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <script type="application/ld+json">
@@ -20,7 +20,7 @@
     "@type": "WebPage",
     "name": "Cloud Health Office Documentation",
     "url": "https://cloudhealthoffice.com/docs",
-    "description": "Complete documentation for the Cloud Health Office healthcare payer integration platform.",
+    "description": "Complete documentation for the Cloud Health Office healthcare payer integration platform, including quick starts, Million Claim Challenge evidence, architecture, APIs, and deployment references.",
     "isPartOf": {
       "@type": "WebSite",
       "name": "Cloud Health Office",
@@ -83,6 +83,14 @@
             </ul>
           </div>
           <div class="docs-sidebar-section">
+            <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
+            <ul>
+              <li><a href="/docs/million-claim-challenge/evidence#episode-008">100K Evidence Archive</a></li>
+              <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
+              <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
+            </ul>
+          </div>
+          <div class="docs-sidebar-section">
             <div class="docs-sidebar-section-title">Guides</div>
             <ul>
               <li><a href="/docs/compliance">CMS-0057-F Compliance</a></li>
@@ -134,10 +142,24 @@
 
         <h1>Documentation</h1>
         <p class="docs-subtitle">
-          Everything you need to evaluate, deploy, and operate Cloud Health Office — the integration layer for healthcare payer core administration systems.
+          Everything you need to evaluate, deploy, and operate Cloud Health Office &mdash; including the public evidence behind the clean 100,000-claim local Kubernetes validation.
         </p>
 
         <div class="docs-hub-grid">
+
+          <a href="/docs/million-claim-challenge/evidence#episode-008" class="docs-hub-card">
+            <span class="docs-hub-card-icon">&#x1F4CA;</span>
+            <h3>100K Evidence Archive</h3>
+            <p>Inspect the clean 100,000-claim local Kubernetes run: zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent.</p>
+            <span class="card-arrow">Inspect evidence &rarr;</span>
+          </a>
+
+          <a href="/insights/million-claim-challenge/part-8-clean-100k" class="docs-hub-card">
+            <span class="docs-hub-card-icon">&#x1F4DD;</span>
+            <h3>Part 8: Clean 100K Run</h3>
+            <p>Read the narrative behind the latest proof: stronger correctness gates held at 100K, while fixture preparation became the next local scaling bottleneck.</p>
+            <span class="card-arrow">Read writeup &rarr;</span>
+          </a>
 
           <a href="/docs/quickstart" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x26A1;</span>
@@ -149,8 +171,15 @@
           <a href="/docs/quickstart-kubernetes" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x2638;</span>
             <h3>Kubernetes Reference <span class="time-estimate">~15 min</span></h3>
-            <p>Deploy the full local Kubernetes platform on Docker Desktop Kubernetes — identical namespace, DNS, and manifests as production Azure AKS.</p>
+            <p>Deploy the full local Kubernetes platform on Docker Desktop Kubernetes with the same namespace, DNS, and manifest shape used for cloud validation.</p>
             <span class="card-arrow">Kubernetes guide &rarr;</span>
+          </a>
+
+          <a href="/docs/million-claim-challenge" class="docs-hub-card">
+            <span class="docs-hub-card-icon">&#x1F9EA;</span>
+            <h3>Million Claim Challenge</h3>
+            <p>Understand the deterministic corpus, answer key, workflow scoring, unsupported scenarios, payment gate, and proof ladder toward the full million.</p>
+            <span class="card-arrow">Benchmark guide &rarr;</span>
           </a>
 
           <a href="/docs/compliance" class="docs-hub-card">
@@ -170,14 +199,14 @@
           <a href="/docs/api" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F517;</span>
             <h3>API Reference</h3>
-            <p>7 production FHIR R4 APIs with OpenAPI 3.1 specs. Patient Access, Provider Access, Prior Authorization, Payer-to-Payer, Claims Scrubbing, Risk Adjustment, and Encounter.</p>
+            <p>FHIR R4 APIs with OpenAPI 3.1 specs. Patient Access, Provider Access, Prior Authorization, Payer-to-Payer, Claims Scrubbing, Risk Adjustment, and Encounter.</p>
             <span class="card-arrow">Browse APIs &rarr;</span>
           </a>
 
           <a href="/docs/deployment" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F680;</span>
             <h3>Deployment</h3>
-            <p>From local Kubernetes to production AKS, EKS, or GKE. SaaS signup, self-hosted deployment, GitHub Actions CI/CD, Bicep IaC, and Helm charts.</p>
+            <p>From local Kubernetes to AKS, EKS, or GKE with environment-specific validation. Self-hosted deployment, GitHub Actions CI/CD, Bicep IaC, and Helm charts.</p>
             <span class="card-arrow">Deploy &rarr;</span>
           </a>
 
@@ -264,7 +293,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F API surface, multi-clearinghouse EDI, FHIR R4 APIs, and inspectable claims benchmark evidence.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">
@@ -283,6 +312,8 @@
           <ul>
             <li><a href="/docs/quickstart">Quick Start</a></li>
             <li><a href="/docs/quickstart-kubernetes">Kubernetes Reference</a></li>
+            <li><a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a></li>
+            <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
             <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
             <li><a href="/docs/architecture">Architecture</a></li>
             <li><a href="/docs/api">API Reference</a></li>

--- a/src/site/docs/million-claim-challenge/evidence.html
+++ b/src/site/docs/million-claim-challenge/evidence.html
@@ -297,11 +297,11 @@ Interpretation:
 
 The post-fix 10K gate passed. The 5K zero-mismatch breadth result held at double the volume, supported COB-pend fixture rows were isolated and seeded one-for-one, expected-pend observation remained reliable, and unsupported scenarios continued to be separated from mismatches.
 
-## Remaining Part 6 validation gate
+## Part 6 validation boundary
 
 Part 6 now has 5K, 10K, and 50K breadth validation data.
 
-100K is intentionally out of scope for Part 6. After the clean 50K breadth result, 100K should become its own focused milestone article rather than a late addition to this one.
+At publication time, 100K was intentionally out of scope for Part 6. After the clean 50K breadth result, 100K belonged in its own focused milestone article rather than as a late addition to this one. That follow-on milestone was later published in Part 8.
 
 ### 50,000-claim breadth validation
 
@@ -414,13 +414,13 @@ Pend-observation caveat:
 
 The pend-observation pass polls persisted claim status only for scenarios whose answer-key outcome is `Pended`. It proves expected-pend claims persisted as pended. It does not, by itself, detect the inverse error where a claim expected to pay or deny later persists as pended. A future validator enhancement should add an optional persisted-status sweep for non-pend scenarios to detect false pends.
 
-## Future milestone: 100,000 claims
+## Later milestone: 100,000 claims
 
-The next publication candidate after Part 6 is a focused 100K milestone.
+The next publication candidate after Part 6 was a focused 100K milestone.
 
-That future article should answer a different question: once broader edge-case scoring is established at 50K, how far can the local Kubernetes validation path scale before the next bottleneck appears?
+That article needed to answer a different question: once broader edge-case scoring is established at 50K, how far can the local Kubernetes validation path scale before the next bottleneck appears?
 
-100K should not block Part 6.
+Part 8 now records that answer: a clean 100K local Kubernetes run passed the stronger correctness gates and exposed fixture preparation as the next local scaling bottleneck.
 
 ## Correctness framing
 

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1229,6 +1229,8 @@
           <h5>Documentation</h5>
           <ul>
             <li><a href="/docs/quickstart">Quick Start</a></li>
+            <li><a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a></li>
+            <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
             <li><a href="/docs/compliance">CMS-0057-F Guide</a></li>
             <li><a href="/docs/architecture">Architecture</a></li>
             <li><a href="/docs/api">API Reference</a></li>


### PR DESCRIPTION
## Summary
- surface the clean 100K MCC evidence near the top of the docs home
- add benchmark/evidence links to docs sidebar and public footers
- update Episode 006 evidence wording so it points forward to the now-published Part 8 milestone instead of describing 100K as future
- soften docs-home production wording toward validation/evidence language

## Why
After refocusing the homepage and Quick Start around inspectable MCC evidence, the docs index and navigation still made the evidence path too easy to miss. This PR makes the 100K proof discoverable from docs home and common footer paths.

## Validation
- `npm run build` in `src/site`
