### PR TITLE
Redirect schedule demo route

### DIFF
--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -32,6 +32,7 @@
 /docs/provider-verification-guide.html     /docs/provider-verification-guide  301
 /docs/commercial-licensing.html            /docs/commercial-licensing         301
 /contact.html                              /contact                           301
+/schedule-demo                            /contact                           302
 /insights/million-claim-challenge/index.html /insights/million-claim-challenge 301
 /insights/million-claim-challenge/part-5-repeatably-faster.html /insights/million-claim-challenge/part-5-repeatably-faster 301
 /insights/million-claim-challenge/part-6-honest-edge-case-scoring.html /insights/million-claim-challenge/part-6-honest-edge-case-scoring 301

--- a/src/site/staticwebapp.config.json
+++ b/src/site/staticwebapp.config.json
@@ -181,6 +181,11 @@
       "statusCode": 301
     },
     {
+      "route": "/schedule-demo",
+      "redirect": "/contact",
+      "statusCode": 302
+    },
+    {
       "route": "/docs/commercial-licensing",
       "rewrite": "/docs/commercial-licensing.html"
     },


### PR DESCRIPTION
## Summary
- add a `/schedule-demo` redirect to `/contact` in Cloudflare Pages `_redirects`
- mirror the route in `staticwebapp.config.json` so legacy/static hosting config stays aligned

## Why
The public scheduling CTA could land on `https://cloudhealthoffice.com/schedule-demo`, which currently returns a 404. Redirecting to the existing contact form keeps that high-intent path working without creating a duplicate form.

## Validation
- `npm run build` from `src/site`
