### PR TITLE
Fix site routes and undeployed API links

### DIFF
--- a/src/services/benefit-plan-service/benefit-plan-service.csproj
+++ b/src/services/benefit-plan-service/benefit-plan-service.csproj
@@ -60,7 +60,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.9.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />

--- a/src/site/DEPLOYMENT.md
+++ b/src/site/DEPLOYMENT.md
@@ -508,17 +508,17 @@ Run this whenever you add or update public docs/quickstart pages:
 
 1. Open Google Search Console for both properties:
   - `https://cloudhealthoffice.com`
-  - `https://portal.cloudhealthoffice.com`
+  - `https://your-portal-host.example`
 2. Submit or re-submit sitemaps:
   - `https://cloudhealthoffice.com/sitemap.xml`
-  - `https://portal.cloudhealthoffice.com/sitemap.xml`
+  - `https://your-portal-host.example/sitemap.xml`
 3. Use URL Inspection and click **Request Indexing** for updated quickstart URLs:
   - `https://cloudhealthoffice.com/portal`
   - `https://cloudhealthoffice.com/portal/api-docs`
-  - `https://portal.cloudhealthoffice.com/quickstarts/local-claims`
+  - `https://your-portal-host.example/quickstarts/local-claims`
 4. Verify crawler accessibility:
   - `https://cloudhealthoffice.com/robots.txt`
-  - `https://portal.cloudhealthoffice.com/robots.txt`
+  - `https://your-portal-host.example/robots.txt`
 5. Re-check Search Console coverage/enhancements after 24-72 hours.
 
 ### Quarterly Reviews

--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -22,6 +22,7 @@
 /release-notes.html                        /release-notes                     301
 /legal/privacy-policy.html                 /legal/privacy-policy              301
 /login.html                                /login                             301
+/docs.html                                /docs                              301
 /docs/quickstart.html                      /docs/quickstart                   301
 /docs/compliance.html                      /docs/compliance                   301
 /docs/architecture.html                    /docs/architecture                 301

--- a/src/site/assets/cho-assessment.md
+++ b/src/site/assets/cho-assessment.md
@@ -451,7 +451,7 @@ Organizations that embrace Cloud Health Office will achieve:
 ### Immediate Actions
 
 1. **Schedule Demo**
-   - [Contact sales for platform walkthrough](https://portal.cloudhealthoffice.com/contact-sales)
+   - [Contact sales for platform walkthrough](/contact)
    - Review your specific payer requirements
    - See live deployment demonstration
 

--- a/src/site/claims-repricing.html
+++ b/src/site/claims-repricing.html
@@ -387,7 +387,7 @@
       <!-- ===== INTERACTIVE DEMO ===== -->
       <section class="assessment-section" id="try-it">
         <h2>Try It — Look Up a Rate</h2>
-        <p>Enter a CPT or HCPCS code to see the Medicare allowed amount. No signup needed.</p>
+        <p>Enter a CPT or HCPCS code to see sample Medicare repricing output. The public API host is not currently deployed.</p>
 
         <div class="lookup-demo">
           <div class="lookup-row">
@@ -436,8 +436,8 @@
             </div>
           </div>
           <p style="text-align:center; margin-top:16px; font-size:0.82rem; color:rgba(176,176,176,0.5);">
-            Powered by the Cloud Health Office Repricing API.
-            <a href="/pricing-api" style="color:#00ffff;">Get your free API key</a> for programmatic access.
+            Powered by the same pricing model used by Cloud Health Office.
+            <a href="/pricing-api" style="color:#00ffff;">Request API access</a> for programmatic evaluation.
           </p>
         </div>
       </section>
@@ -598,43 +598,58 @@
       const resultDiv = document.getElementById('lookupResult');
       resultDiv.classList.remove('visible');
 
-      let url = `https://api.cloudhealthoffice.com/pricing/api/v1/lookup/${encodeURIComponent(code)}?feeScheduleId=${encodeURIComponent(fs)}&facility=${facility}`;
-      if (locality) url += `&locality=${encodeURIComponent(locality)}`;
-
-      try {
-        const resp = await fetch(url);
-        const json = await resp.json();
-
-        if (!json.success || !json.data) {
-          document.getElementById('resultAmount').textContent = 'Not Found';
-          document.getElementById('resultCode').textContent = code;
-          document.getElementById('resultDesc').textContent = json.error?.message || 'Code not found in this fee schedule';
-          document.getElementById('resultWorkRvu').textContent = '—';
-          document.getElementById('resultPeRvu').textContent = '—';
-          document.getElementById('resultMpRvu').textContent = '—';
-          document.getElementById('resultCf').textContent = '—';
-          document.getElementById('resultSetting').textContent = '—';
-          document.getElementById('resultFs').textContent = fs;
-          resultDiv.classList.add('visible');
-          return;
+      const sampleRates = {
+        '99213': {
+          allowedAmount: 92.47,
+          description: 'Established patient office visit, level 3',
+          workRvu: 1.30,
+          practiceExpenseRvu: facility === 'true' ? 0.55 : 1.47,
+          malpracticeRvu: 0.10,
+          conversionFactor: 32.74
+        },
+        '27447': {
+          allowedAmount: 1357.92,
+          description: 'Total knee arthroplasty',
+          workRvu: 20.72,
+          practiceExpenseRvu: facility === 'true' ? 6.25 : 12.64,
+          malpracticeRvu: 3.12,
+          conversionFactor: 32.74
+        },
+        '43239': {
+          allowedAmount: 211.18,
+          description: 'EGD with biopsy',
+          workRvu: 2.39,
+          practiceExpenseRvu: facility === 'true' ? 1.42 : 4.76,
+          malpracticeRvu: 0.24,
+          conversionFactor: 32.74
         }
+      };
 
-        const d = json.data;
-        document.getElementById('resultAmount').textContent = '$' + d.allowedAmount.toFixed(2);
-        document.getElementById('resultCode').textContent = d.procedureCode;
-        document.getElementById('resultDesc').textContent = d.description || '—';
-        document.getElementById('resultWorkRvu').textContent = d.workRvu?.toFixed(2) || '—';
-        document.getElementById('resultPeRvu').textContent = d.practiceExpenseRvu?.toFixed(2) || '—';
-        document.getElementById('resultMpRvu').textContent = d.malpracticeRvu?.toFixed(2) || '—';
-        document.getElementById('resultCf').textContent = d.conversionFactor ? ('$' + d.conversionFactor.toFixed(2)) : '—';
-        document.getElementById('resultSetting').textContent = d.facility ? 'Facility' : 'Non-Facility';
-        document.getElementById('resultFs').textContent = d.feeScheduleId;
+      const d = sampleRates[code.toUpperCase()];
+      if (!d) {
+        document.getElementById('resultAmount').textContent = 'Sample Only';
+        document.getElementById('resultCode').textContent = code;
+        document.getElementById('resultDesc').textContent = 'Try 99213, 27447, or 43239. Hosted lookup access is available by request.';
+        document.getElementById('resultWorkRvu').textContent = '—';
+        document.getElementById('resultPeRvu').textContent = '—';
+        document.getElementById('resultMpRvu').textContent = '—';
+        document.getElementById('resultCf').textContent = '—';
+        document.getElementById('resultSetting').textContent = facility === 'true' ? 'Facility' : 'Non-Facility';
+        document.getElementById('resultFs').textContent = fs;
         resultDiv.classList.add('visible');
-      } catch (err) {
-        document.getElementById('resultAmount').textContent = 'Error';
-        document.getElementById('resultDesc').textContent = 'Could not reach the repricing API. Try again later.';
-        resultDiv.classList.add('visible');
+        return;
       }
+
+      document.getElementById('resultAmount').textContent = '$' + d.allowedAmount.toFixed(2);
+      document.getElementById('resultCode').textContent = code.toUpperCase();
+      document.getElementById('resultDesc').textContent = d.description + (locality ? ' · locality ' + locality : '');
+      document.getElementById('resultWorkRvu').textContent = d.workRvu.toFixed(2);
+      document.getElementById('resultPeRvu').textContent = d.practiceExpenseRvu.toFixed(2);
+      document.getElementById('resultMpRvu').textContent = d.malpracticeRvu.toFixed(2);
+      document.getElementById('resultCf').textContent = '$' + d.conversionFactor.toFixed(2);
+      document.getElementById('resultSetting').textContent = facility === 'true' ? 'Facility' : 'Non-Facility';
+      document.getElementById('resultFs').textContent = fs;
+      resultDiv.classList.add('visible');
     }
     // Allow Enter key in the code input
     document.getElementById('cptCode')?.addEventListener('keydown', function(e) {

--- a/src/site/cms-0057f-compliance.html
+++ b/src/site/cms-0057f-compliance.html
@@ -745,7 +745,7 @@
               font-family: 'JetBrains Mono', monospace;
               font-size: 0.6rem;
               color: rgba(255, 255, 255, 0.3);
-            ">portal.cloudhealthoffice.com/operations/work-queues</div>
+            ">local-demo/operations/work-queues</div>
           </div>
           <img
             src="/graphics/platform-work-queues.png"

--- a/src/site/docs.html
+++ b/src/site/docs.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <meta http-equiv="refresh" content="0;url=/docs" />
+  <link rel="canonical" href="https://cloudhealthoffice.com/docs" />
+  <title>Documentation - Cloud Health Office</title>
+  <script>
+    window.location.replace('/docs');
+  </script>
+</head>
+<body>
+  <main>
+    <h1>Redirecting to Documentation</h1>
+    <p>If you are not redirected automatically, <a href="/docs">continue to the Cloud Health Office documentation</a>.</p>
+  </main>
+</body>
+</html>

--- a/src/site/docs/api.html
+++ b/src/site/docs/api.html
@@ -40,7 +40,7 @@
         <div class="docs-breadcrumb"><a href="/">Home</a><span class="sep">&#x25B8;</span><a href="/docs">Docs</a><span class="sep">&#x25B8;</span><span class="current">API Reference</span></div>
 
         <h1>API Reference</h1>
-        <p class="docs-subtitle">7 production FHIR R4 APIs with OpenAPI 3.1 specs, OAuth 2.0 authentication, and interactive sandbox documentation. All APIs return standard FHIR R4 bundles with Da Vinci and US Core profile conformance.</p>
+        <p class="docs-subtitle">FHIR R4 APIs you can run locally or deploy into your own environment, with OpenAPI 3.1 specs, OAuth 2.0 authentication, and standard FHIR R4 bundles with Da Vinci and US Core profile conformance.</p>
 
         <figure class="docs-diagram">
           <img src="/graphics/docs-api-landscape.svg" alt="API landscape showing 7 FHIR R4 APIs — Patient Access, Provider Access, Prior Authorization, Payer-to-Payer, Claims Scrubbing, Risk Adjustment, and Encounter Service" />
@@ -51,19 +51,19 @@
         <table>
           <thead><tr><th>Environment</th><th>Base URL</th><th>Auth</th></tr></thead>
           <tbody>
-            <tr><td><span class="badge badge-production">Production</span></td><td><code>https://api.cloudhealthoffice.com/fhir/r4</code></td><td>OAuth 2.0 (Azure AD)</td></tr>
-            <tr><td><span class="badge badge-complete">Sandbox</span></td><td><code>https://sandbox.cloudhealthoffice.com/fhir/r4</code></td><td>Test tokens (synthetic data)</td></tr>
+            <tr><td><span class="badge badge-production">Your deployment</span></td><td><code>https://api.your-domain.example/fhir/r4</code></td><td>OAuth 2.0 (Azure AD)</td></tr>
+            <tr><td><span class="badge badge-complete">Hosted pilot</span></td><td>Assigned during pilot setup</td><td>Customer tenant identity</td></tr>
             <tr><td>Local Dev</td><td><code>http://localhost:3000/fhir/r4</code></td><td>Bearer test-token</td></tr>
           </tbody>
         </table>
 
-        <p>Interactive OpenAPI docs are available at the <a href="https://sandbox.cloudhealthoffice.com/?spec=patient-access" target="_blank" rel="noopener noreferrer">API Sandbox</a>. All requests require an <code>X-Tenant-ID</code> header for multi-tenant routing.</p>
+        <p>OpenAPI docs are available from the local or customer-deployed API surface. All requests require an <code>X-Tenant-ID</code> header for multi-tenant routing.</p>
 
         <h2 id="auth">Authentication</h2>
-        <p>Production APIs use OAuth 2.0 with Azure AD (Microsoft Entra ID). The FHIR server publishes a SMART on FHIR configuration at <code>/.well-known/smart-configuration</code> with supported scopes including <code>patient/*.read</code>, <code>user/*.read</code>, and <code>system/*.read</code>.</p>
+        <p>Customer-deployed APIs use OAuth 2.0 with Azure AD (Microsoft Entra ID). The FHIR server publishes a SMART on FHIR configuration at <code>/.well-known/smart-configuration</code> with supported scopes including <code>patient/*.read</code>, <code>user/*.read</code>, and <code>system/*.read</code>.</p>
 
 <pre><code><span class="code-comment"># Discover OAuth endpoints</span>
-curl https://api.cloudhealthoffice.com/fhir/r4/.well-known/smart-configuration
+curl https://api.your-domain.example/fhir/r4/.well-known/smart-configuration
 
 <span class="code-comment"># Get access token (client credentials)</span>
 curl -X POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token \

--- a/src/site/docs/deployment.html
+++ b/src/site/docs/deployment.html
@@ -246,7 +246,7 @@ kubectl exec -it deploy/claims-service -n cloudhealthoffice -- curl -s localhost
 npm run test:e2e -- --environment=prod
 
 <span class="code-comment"># Verify FHIR endpoints</span>
-curl https://api.cloudhealthoffice.com/fhir/r4/metadata | jq .status</code></pre>
+curl https://api.your-domain.example/fhir/r4/metadata | jq .status</code></pre>
 
         <div class="callout callout-info">
           <div class="callout-title">Full deployment reference</div>

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -156,7 +156,7 @@
           </thead>
           <tbody>
             <tr><td>Microservices</td><td>30+</td><td>Claims, Members, Eligibility, Payments, FHIR, Appeals, Capitation, encounters, provider workflows, and supporting services.</td></tr>
-            <tr><td>Portal</td><td>1</td><td>Blazor Server UI &mdash; same as <code>portal.cloudhealthoffice.com</code></td></tr>
+            <tr><td>Portal</td><td>1</td><td>Blazor Server UI you can expose on your own portal host after deployment</td></tr>
             <tr><td>MongoDB</td><td>1</td><td>StatefulSet with persistent storage</td></tr>
             <tr><td>Redis</td><td>1</td><td>Data-protection key store and caching</td></tr>
             <tr><td>Namespace</td><td><code>cloudhealthoffice</code></td><td>Matches production layout</td></tr>
@@ -328,7 +328,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error</co
 
         <div class="callout callout-success">
           <div class="callout-title">You're running production-equivalent Kubernetes!</div>
-          <p>You now have the same production-shaped microservices architecture running locally that powers <code>portal.cloudhealthoffice.com</code> in production. Same namespace, same DNS, same manifests, same health probes.</p>
+          <p>You now have the same production-shaped microservices architecture running locally that you can later expose behind your own portal and API hosts. Same namespace, same DNS, same manifests, same health probes.</p>
         </div>
 
         <!-- Production Comparison -->

--- a/src/site/graphics/docs-api-landscape.svg
+++ b/src/site/graphics/docs-api-landscape.svg
@@ -95,6 +95,6 @@
   <g transform="translate(0, 465)">
     <rect x="0" y="0" width="1200" height="35" fill="rgba(0,255,255,0.03)"/>
     <text x="600" y="22" font-family="Segoe UI, system-ui, sans-serif" font-size="11" fill="rgba(176,176,176,0.5)"
-          text-anchor="middle">Base URL: https://api.cloudhealthoffice.com/fhir/r4 &#x2022; Sandbox: https://sandbox.cloudhealthoffice.com &#x2022; OpenAPI 3.1 Specs Available</text>
+          text-anchor="middle">Base URL: https://api.your-domain.example/fhir/r4 &#x2022; Sandbox: https://sandbox.cloudhealthoffice.com &#x2022; OpenAPI 3.1 Specs Available</text>
   </g>
 </svg>

--- a/src/site/graphics/docs-deployment-pipeline.svg
+++ b/src/site/graphics/docs-deployment-pipeline.svg
@@ -27,7 +27,7 @@
   <g transform="translate(200, 145)">
     <rect x="-75" y="-22" width="150" height="44" rx="7" fill="rgba(0,255,136,0.1)" stroke="#00ff88" stroke-width="1.5"/>
     <text x="0" y="-2" font-family="Segoe UI, system-ui, sans-serif" font-size="12" font-weight="700" fill="#fff" text-anchor="middle">Sign Up</text>
-    <text x="0" y="13" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#b0b0b0" text-anchor="middle">portal.cloudhealthoffice.com</text>
+    <text x="0" y="13" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#b0b0b0" text-anchor="middle">your-portal-host.example</text>
   </g>
   <line x1="280" y1="145" x2="370" y2="145" stroke="#00ff88" stroke-width="1" opacity="0.4" marker-end="url(#arrowGreen)"/>
   <g transform="translate(460, 145)">

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -1035,7 +1035,7 @@
             <svg width="12" height="12" viewBox="0 0 16 16" fill="none" style="flex-shrink: 0;">
               <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
             </svg>
-            portal.cloudhealthoffice.com/operations/work-queues
+            local-demo/operations/work-queues
           </div>
         </div>
 

--- a/src/site/js/markdown-converter.js
+++ b/src/site/js/markdown-converter.js
@@ -97,7 +97,7 @@ function generateHtmlPage(title, content, filename) {
         <p>Compliance first. Progressive modernization next.</p>
         <div style="margin-top: 30px;">
           <a href="platform.html" class="button">Platform Overview</a>
-          <a href="https://portal.cloudhealthoffice.com/contact-sales" class="button button-green" target="_blank" rel="noopener noreferrer">Contact Sales</a>
+          <a href="/contact" class="button button-green" target="_blank" rel="noopener noreferrer">Contact Sales</a>
           <a href="https://github.com/aurelianware/cloudhealthoffice" class="button button-secondary" target="_blank" rel="noopener noreferrer">Clone Repository</a>
         </div>
       </section>

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -540,7 +540,7 @@
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                   <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                 </svg>
-                portal.cloudhealthoffice.com/operations/dashboard
+                local-demo/operations/dashboard
               </div>
             </div>
             <img
@@ -691,7 +691,7 @@
                   <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                     <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                   </svg>
-                  portal.cloudhealthoffice.com/operations/work-queues
+                  local-demo/operations/work-queues
                 </div>
               </div>
               <img
@@ -1210,7 +1210,7 @@
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                   <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                 </svg>
-                portal.cloudhealthoffice.com/finance/ar-balances
+                local-demo/finance/ar-balances
               </div>
             </div>
             <img
@@ -1289,7 +1289,7 @@
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                   <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                 </svg>
-                portal.cloudhealthoffice.com/finance/capitation
+                local-demo/finance/capitation
               </div>
             </div>
             <img
@@ -1368,7 +1368,7 @@
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                   <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                 </svg>
-                portal.cloudhealthoffice.com/finance/premium-billing
+                local-demo/finance/premium-billing
               </div>
             </div>
             <img
@@ -1447,7 +1447,7 @@
                 <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
                   <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
                 </svg>
-                portal.cloudhealthoffice.com/finance/ffs-payments
+                local-demo/finance/ffs-payments
               </div>
             </div>
             <img

--- a/src/site/portal/api-docs.html
+++ b/src/site/portal/api-docs.html
@@ -349,7 +349,7 @@ curl -X POST https://sandbox.cloudhealthoffice.com/scrubbing/v1/claims/validate 
           </summary>
           <pre style="margin-top: 15px; padding: 20px; background: #000; border-radius: 8px; overflow-x: auto;"><code style="color: var(--neon-green);">// Fetch patient data
 const response = await fetch(
-  'https://api.cloudhealthoffice.com/fhir/r4/Patient/PAT001',
+  'https://api.your-domain.example/fhir/r4/Patient/PAT001',
   { headers: { 'Authorization': `Bearer ${accessToken}` } }
 );
 const patient = await response.json();
@@ -363,7 +363,7 @@ console.log(patient.name[0].given); // ["John"]</code></pre>
           <pre style="margin-top: 15px; padding: 20px; background: #000; border-radius: 8px; overflow-x: auto;"><code style="color: var(--neon-green);">import requests
 
 response = requests.get(
-    'https://api.cloudhealthoffice.com/fhir/r4/Patient/PAT001',
+    'https://api.your-domain.example/fhir/r4/Patient/PAT001',
     headers={'Authorization': f'Bearer {access_token}'}
 )
 patient = response.json()
@@ -378,7 +378,7 @@ print(patient['name'][0]['given'])</code></pre>
 using Hl7.Fhir.Model;
 
 var client = new FhirClient(
-    "https://api.cloudhealthoffice.com/fhir/r4");
+    "https://api.your-domain.example/fhir/r4");
 client.OnBeforeRequest += (sender, e) => {
     e.RawRequest.Headers.Add("Authorization", 
         $"Bearer {accessToken}");

--- a/src/site/pricing-api.html
+++ b/src/site/pricing-api.html
@@ -463,7 +463,7 @@
       <div class="hero-radial" aria-hidden="true"></div>
 
       <div class="hero-content">
-        <div class="hero-badge">Claims Repricing API &nbsp;&middot;&nbsp; Free Tier Available</div>
+        <div class="hero-badge">Claims Repricing API &nbsp;&middot;&nbsp; Access by Request</div>
 
         <h1 class="hero-headline">
           Medicare Claims<br>
@@ -472,17 +472,16 @@
 
         <p class="hero-subheadline">
           Vendor-neutral pricing engine supporting RBRVS, OPPS, and MS-DRG fee schedules.<br>
-          Get started free with 1,000 claims/month. No credit card required.
+          Request access for pilots and local evaluation while the public API endpoint is being prepared.
         </p>
 
         <div class="hero-cta">
-          <a href="#signup"
+          <a href="/contact"
              class="button"
-             style="font-size:1.05rem; padding:15px 38px;">Get Free API Key &rarr;</a>
-          <a href="https://api.cloudhealthoffice.com/pricing/swagger"
+             style="font-size:1.05rem; padding:15px 38px;">Request API Access &rarr;</a>
+          <a href="/docs/api"
              class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;"
-             target="_blank" rel="noopener noreferrer">View API Docs &rarr;</a>
+             style="font-size:1.05rem; padding:15px 38px;">View API Docs &rarr;</a>
         </div>
       </div>
 
@@ -494,15 +493,15 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow">How It Works</span>
-          <h2 class="section-title">Three steps to<br><span>instant repricing.</span></h2>
-          <p class="section-subtitle">Submit a claim, get back Medicare-accurate pricing with full RVU, APC, and DRG breakdowns.</p>
+          <h2 class="section-title">Three steps to<br><span>your own repricing API.</span></h2>
+          <p class="section-subtitle">Deploy the source-available service locally or in your cloud, then submit claims for RVU, APC, and DRG breakdowns.</p>
         </div>
 
         <div class="steps-grid">
           <div class="step-card">
             <div class="step-number">1</div>
-            <h3>Sign Up Free</h3>
-            <p>Create an account and get your API key instantly. No credit card, no sales call, no contract.</p>
+            <h3>Request Access</h3>
+            <p>Use the docs and local deployment path today; request hosted API access when you are ready for a guided pilot.</p>
           </div>
           <div class="step-card">
             <div class="step-number">2</div>
@@ -558,22 +557,22 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow">Pricing</span>
-          <h2 class="section-title">Start free.<br><span>Scale when ready.</span></h2>
-          <p class="section-subtitle">No credit card required for the free tier. Upgrade or downgrade anytime.</p>
+          <h2 class="section-title">Start locally.<br><span>Scale when ready.</span></h2>
+          <p class="section-subtitle">The pricing engine can be evaluated locally today. Hosted API access is available by request for pilots.</p>
         </div>
 
         <div class="tier-grid">
           <div class="tier-card">
-            <div class="tier-name">Free</div>
+            <div class="tier-name">Self-hosted Evaluation</div>
             <div class="tier-price">$0<span>/mo</span></div>
-            <div class="tier-volume">1,000 claims/month</div>
+            <div class="tier-volume">Free for non-production use</div>
             <ul class="tier-features">
               <li>All fee schedules (RBRVS, OPPS, MS-DRG)</li>
               <li>Full modifier support</li>
-              <li>REST API access</li>
-              <li>Community support</li>
+              <li>Local REST API deployment</li>
+              <li>Source-available evaluation path</li>
             </ul>
-            <a href="#signup" class="tier-cta tier-cta-primary">Get Started Free</a>
+            <a href="/contact" class="tier-cta tier-cta-primary">Request API Access</a>
           </div>
 
           <div class="tier-card">
@@ -598,8 +597,8 @@
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ff88;">Get Started</span>
-          <h2 class="section-title">Get your free<br><span>API key now.</span></h2>
-          <p class="section-subtitle">No credit card required. Start repricing claims in minutes.</p>
+          <h2 class="section-title">Request<br><span>API access.</span></h2>
+          <p class="section-subtitle">The public API host is not currently deployed. Contact us for pilot access or run the pricing engine locally.</p>
         </div>
 
         <div class="signup-section">
@@ -624,7 +623,7 @@
                   <input type="text" id="lastName" name="lastName" placeholder="Smith" />
                 </div>
               </div>
-              <button type="submit" class="form-submit" id="submitBtn">Get Free API Key</button>
+              <button type="submit" class="form-submit" id="submitBtn">Continue to Contact Sales</button>
             </form>
           </div>
 
@@ -644,10 +643,9 @@
                 <pre id="successCurl"></pre>
               </div>
             </div>
-            <a href="https://api.cloudhealthoffice.com/pricing/swagger"
+            <a href="/docs/api"
                class="button"
-               style="font-size:0.95rem; padding:13px 32px;"
-               target="_blank" rel="noopener noreferrer">View Full API Docs &rarr;</a>
+               style="font-size:0.95rem; padding:13px 32px;">View Full API Docs &rarr;</a>
           </div>
         </div>
       </div>
@@ -667,7 +665,7 @@
             <button class="code-copy" onclick="copyCode('curlExample')">Copy</button>
           </div>
           <div class="code-body">
-            <pre id="curlExample"><span class="code-keyword">curl</span> <span class="code-flag">-X POST</span> <span class="code-string">https://api.cloudhealthoffice.com/pricing/api/v1/reprice</span> \
+            <pre id="curlExample"><span class="code-keyword">curl</span> <span class="code-flag">-X POST</span> <span class="code-string">https://api.your-domain.example/pricing/api/v1/reprice</span> \
   <span class="code-flag">-H</span> <span class="code-string">"X-API-Key: cho_your_api_key"</span> \
   <span class="code-flag">-H</span> <span class="code-string">"Content-Type: application/json"</span> \
   <span class="code-flag">-d</span> <span class="code-string">'{
@@ -696,17 +694,16 @@
         </h2>
 
         <p style="font-size:1.15rem; color:rgba(176,176,176,0.8); margin:24px 0 48px 0; line-height:1.75; position:relative;">
-          Get started with the free tier or talk to our team about enterprise integration.
+          Start with local evaluation or talk to our team about hosted pilot access.
         </p>
 
         <div class="hero-cta" style="position:relative; opacity:1; animation:none;">
-          <a href="#signup"
+          <a href="/contact"
              class="button"
-             style="font-size:1.1rem; padding:17px 48px;">Get Free API Key &rarr;</a>
-          <a href="https://api.cloudhealthoffice.com/pricing/swagger"
+             style="font-size:1.1rem; padding:17px 48px;">Request API Access &rarr;</a>
+          <a href="/docs/api"
              class="button button-secondary"
-             style="font-size:1.1rem; padding:17px 48px;"
-             target="_blank" rel="noopener noreferrer">API Documentation &rarr;</a>
+             style="font-size:1.1rem; padding:17px 48px;">API Documentation &rarr;</a>
         </div>
 
         <p style="margin-top:28px; font-size:0.93rem; color:rgba(128,128,128,0.65); position:relative;">
@@ -784,35 +781,8 @@
       }
 
       submitBtn.disabled = true;
-      submitBtn.textContent = 'Creating API Key...';
-
-      try {
-        const response = await fetch('https://api.cloudhealthoffice.com/pricing/api/v1/signup', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            organizationName: orgName,
-            email: email,
-            firstName: firstName || undefined,
-            lastName: lastName || undefined
-          })
-        });
-
-        if (!response.ok) {
-          const errBody = await response.text();
-          throw new Error(errBody || 'Signup failed');
-        }
-
-        const data = await response.json();
-        const apiKey = data.apiKey || data.key || data.token;
-
-        showSuccess(apiKey);
-      } catch (err) {
-        formError.innerHTML = 'Signup is temporarily unavailable. Please contact <a href="mailto:sales@cloudhealthoffice.com" style="color:#ff6666;">sales@cloudhealthoffice.com</a>.';
-        formError.style.display = 'block';
-        submitBtn.disabled = false;
-        submitBtn.textContent = 'Get Free API Key';
-      }
+      submitBtn.textContent = 'Opening Contact Sales...';
+      window.location.href = '/contact';
     });
 
     function showSuccess(apiKey) {
@@ -822,7 +792,7 @@
       document.getElementById('apiKeyValue').textContent = apiKey;
 
       document.getElementById('successCurl').textContent =
-        'curl -X POST https://api.cloudhealthoffice.com/pricing/api/v1/reprice \\\n' +
+        'curl -X POST https://api.your-domain.example/pricing/api/v1/reprice \\\n' +
         '  -H "X-API-Key: ' + apiKey + '" \\\n' +
         '  -H "Content-Type: application/json" \\\n' +
         '  -d \'{\n' +

--- a/src/site/pricing.html
+++ b/src/site/pricing.html
@@ -909,7 +909,7 @@
 </section>
 
 <footer class="footer">
-  <p>&copy; 2026 Aurelianware, Inc. &middot; <a href="/legal/privacy-policy">Privacy</a> &middot; <a href="/docs">Docs</a> &middot; <a href="https://api.cloudhealthoffice.com">api.cloudhealthoffice.com</a></p>
+  <p>&copy; 2026 Aurelianware, Inc. &middot; <a href="/legal/privacy-policy">Privacy</a> &middot; <a href="/docs">Docs</a> &middot; <a href="/docs/api">API docs</a></p>
 </footer>
 
 </div>

--- a/src/site/schedule-demo/index.html
+++ b/src/site/schedule-demo/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, follow" />
+  <meta http-equiv="refresh" content="0;url=/contact" />
+  <link rel="canonical" href="https://cloudhealthoffice.com/contact" />
+  <title>Schedule a Demo - Cloud Health Office</title>
+  <script>
+    window.location.replace('/contact');
+  </script>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+      color: #b0b0b0;
+      font-family: 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+      text-align: center;
+      padding: 24px;
+    }
+
+    main {
+      max-width: 520px;
+    }
+
+    h1 {
+      color: #fff;
+      font-size: 1.8rem;
+      margin: 0 0 12px;
+    }
+
+    a {
+      color: #00ffff;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Redirecting to Contact Sales</h1>
+    <p>If you are not redirected automatically, <a href="/contact">continue to the Cloud Health Office contact form</a>.</p>
+  </main>
+</body>
+</html>

--- a/src/site/staticwebapp.config.json
+++ b/src/site/staticwebapp.config.json
@@ -99,6 +99,11 @@
       "rewrite": "/docs/index.html"
     },
     {
+      "route": "/docs.html",
+      "redirect": "/docs",
+      "statusCode": 301
+    },
+    {
       "route": "/docs/quickstart.html",
       "redirect": "/docs/quickstart",
       "statusCode": 301


### PR DESCRIPTION
## Summary
- add static fallback pages for `/schedule-demo/` and `/docs.html` so canonical routes do not 404 even when host redirects lag or are bypassed
- document API examples as customer/local deployments instead of live `api.cloudhealthoffice.com` endpoints
- remove public marketing links and browser calls to undeployed `portal.cloudhealthoffice.com` / `api.cloudhealthoffice.com`
- convert the repricing lookup into a local sample demo and route API access requests to Contact Sales

## Why
The live site still returned a 404 for `/schedule-demo` after the redirect-only fix, and the marketing site still implied hosted portal/API subdomains were live. This keeps high-intent routes working and makes the API story honest: evaluators can download and deploy the source-available APIs in their own environment, while hosted pilot access is by request.

## Validation
- `npm run build` from `src/site`
- scanned `src/site` and generated `src/site/dist` for remaining `portal.cloudhealthoffice.com` / `api.cloudhealthoffice.com` references
