### PR TITLE
Expose payment evidence filters

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -638,10 +638,10 @@ public class ClaimsServiceTests
         var handler = new FakeHandler(HttpStatusCode.OK, "[]");
         var sut = CreateService(new HttpClient(handler));
 
-        await sut.GetMassAdjudicationClaimResultsAsync("run/001", "Business Denial", 5000, "Unsupported");
+        await sut.GetMassAdjudicationClaimResultsAsync("run/001", "Business Denial", 5000, "Unsupported", "Mismatched");
 
         handler.CapturedUrls.Should().ContainSingle()
-            .Which.Should().Be("http://localhost:5000/mass-adjudication/runs/run%2F001/claims?limit=1000&outcome=Business%20Denial&validationStatus=Unsupported");
+            .Which.Should().Be("http://localhost:5000/mass-adjudication/runs/run%2F001/claims?limit=1000&outcome=Business%20Denial&validationStatus=Unsupported&paymentStatus=Mismatched");
     }
 
     [Fact]

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -226,7 +226,10 @@
                     <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Unsupported", $"{_selectedRun.WorkflowUnsupported:N0}", "#cbd5e1")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
-                    <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta))</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Payment Gate", PaymentGateLabel(_selectedRun), _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Payment Mismatches", $"{_selectedRun.PaymentMismatches:N0}", _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Max Payment Delta", _selectedRun.MaximumPaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.MaximumPaymentDelta, _selectedRun.PaymentTolerance))</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta, _selectedRun.PaymentTolerance))</MudItem>
                     @if (_selectedRun.Progress is not null)
                     {
                         <MudItem xs="6" md="4">@Metric("Run Status", RunStatusLabel(_selectedRun), IsRunActive(_selectedRun) ? "#7dd3fc" : "#00ff88")</MudItem>
@@ -265,13 +268,15 @@
                     <MudText Typo="Typo.subtitle2" Style="font-weight: 700;">Claim Results</MudText>
                     <MudSpacer />
                     <MudSelect T="string" Value="_claimResultFilter" ValueChanged="OnClaimResultFilterChanged"
-                               Dense="true" Variant="Variant.Outlined" Style="width: 190px;">
+                               Dense="true" Variant="Variant.Outlined" Style="width: 220px;">
                         <MudSelectItem Value="@("")">All results</MudSelectItem>
                         <MudSelectItem Value="@("Paid")">Paid</MudSelectItem>
                         <MudSelectItem Value="@("Pended")">Pended</MudSelectItem>
                         <MudSelectItem Value="@("BusinessDenial")">Business denials</MudSelectItem>
                         <MudSelectItem Value="@("validation:Unsupported")">Unsupported</MudSelectItem>
                         <MudSelectItem Value="@("validation:Mismatched")">Mismatches</MudSelectItem>
+                        <MudSelectItem Value="@("payment:Mismatched")">Payment mismatches</MudSelectItem>
+                        <MudSelectItem Value="@("payment:Scored")">Payment scored</MudSelectItem>
                         <MudSelectItem Value="@("ObservationTimeout")">Observation timeouts</MudSelectItem>
                         <MudSelectItem Value="@("PlatformFailure")">Platform failures</MudSelectItem>
                     </MudSelect>
@@ -342,9 +347,15 @@
                         </MudTd>
                         <MudTd DataLabel="Payment">
                             <MudText Typo="Typo.body2" Style="font-family: monospace;">@(context.ActualPlanPayment?.ToString("C") ?? "-")</MudText>
-                            @if (context.PaymentDelta.HasValue)
+                            @if (context.ExpectedPlanPayment.HasValue)
                             {
                                 <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">
+                                    expected @context.ExpectedPlanPayment.Value.ToString("C")
+                                </MudText>
+                            }
+                            @if (context.PaymentDelta.HasValue)
+                            {
+                                <MudText Typo="Typo.caption" Style="@($"color: {PaymentDeltaColor(context.PaymentDelta, _selectedRun?.PaymentTolerance ?? 0.01m)}; font-family: monospace;")">
                                     delta @context.PaymentDelta.Value.ToString("C")
                                 </MudText>
                             }
@@ -559,7 +570,8 @@
                 _selectedRun.Id,
                 ClaimOutcomeFilter,
                 250,
-                ClaimValidationStatusFilter);
+                ClaimValidationStatusFilter,
+                ClaimPaymentStatusFilter);
             _claimResults.AddRange(results);
         }
         catch (Exception ex)
@@ -700,7 +712,9 @@
         => $"font-family: monospace; color: {(count == 0 ? "rgba(255,255,255,0.55)" : highlightColor)};";
 
     private string? ClaimOutcomeFilter
-        => string.IsNullOrWhiteSpace(_claimResultFilter) || _claimResultFilter.StartsWith("validation:", StringComparison.Ordinal)
+        => string.IsNullOrWhiteSpace(_claimResultFilter)
+           || _claimResultFilter.StartsWith("validation:", StringComparison.Ordinal)
+           || _claimResultFilter.StartsWith("payment:", StringComparison.Ordinal)
             ? null
             : _claimResultFilter;
 
@@ -709,8 +723,18 @@
             ? _claimResultFilter["validation:".Length..]
             : null;
 
-    private static string PaymentDeltaColor(decimal? paymentDelta)
-        => paymentDelta is null ? "#cbd5e1" : paymentDelta == 0 ? "#00ff88" : "#ffca28";
+    private string? ClaimPaymentStatusFilter
+        => _claimResultFilter.StartsWith("payment:", StringComparison.Ordinal)
+            ? _claimResultFilter["payment:".Length..]
+            : null;
+
+    private static string PaymentGateLabel(MassAdjudicationRunSummary run)
+        => run.PaymentComparisons <= 0
+            ? "-"
+            : $"{run.PaymentMatches:N0} / {run.PaymentComparisons:N0}";
+
+    private static string PaymentDeltaColor(decimal? paymentDelta, decimal tolerance)
+        => paymentDelta is null ? "#cbd5e1" : paymentDelta <= tolerance ? "#00ff88" : "#ff0055";
 
     private static Color OutcomeColor(string outcome) => outcome switch
     {

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -228,8 +228,8 @@
                     <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Payment Gate", PaymentGateLabel(_selectedRun), _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Payment Mismatches", $"{_selectedRun.PaymentMismatches:N0}", _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
-                    <MudItem xs="6" md="4">@Metric("Max Payment Delta", _selectedRun.MaximumPaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.MaximumPaymentDelta, _selectedRun.PaymentTolerance))</MudItem>
-                    <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta, _selectedRun.PaymentTolerance))</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Max Payment Delta", _selectedRun.MaximumPaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.MaximumPaymentDelta, PaymentTolerance(_selectedRun)))</MudItem>
+                    <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta, PaymentTolerance(_selectedRun)))</MudItem>
                     @if (_selectedRun.Progress is not null)
                     {
                         <MudItem xs="6" md="4">@Metric("Run Status", RunStatusLabel(_selectedRun), IsRunActive(_selectedRun) ? "#7dd3fc" : "#00ff88")</MudItem>
@@ -355,7 +355,7 @@
                             }
                             @if (context.PaymentDelta.HasValue)
                             {
-                                <MudText Typo="Typo.caption" Style="@($"color: {PaymentDeltaColor(context.PaymentDelta, _selectedRun?.PaymentTolerance ?? 0.01m)}; font-family: monospace;")">
+                                <MudText Typo="Typo.caption" Style="@($"color: {PaymentDeltaColor(context.PaymentDelta, PaymentTolerance(_selectedRun))}; font-family: monospace;")">
                                     delta @context.PaymentDelta.Value.ToString("C")
                                 </MudText>
                             }
@@ -461,6 +461,7 @@
 </PermissionGate>
 
 @code {
+    private const decimal LegacyPaymentTolerance = 0.01m;
     private readonly List<MassAdjudicationRunSummary> _runs = new();
     private readonly List<MassAdjudicationClaimResult> _claimResults = new();
     private MassAdjudicationRunSummary? _selectedRun;
@@ -732,6 +733,9 @@
         => run.PaymentComparisons <= 0
             ? "-"
             : $"{run.PaymentMatches:N0} / {run.PaymentComparisons:N0}";
+
+    private static decimal PaymentTolerance(MassAdjudicationRunSummary? run)
+        => run?.PaymentTolerance > 0 ? run.PaymentTolerance : LegacyPaymentTolerance;
 
     private static string PaymentDeltaColor(decimal? paymentDelta, decimal tolerance)
         => paymentDelta is null ? "#cbd5e1" : paymentDelta <= tolerance ? "#00ff88" : "#ff0055";

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -17,7 +17,8 @@ public interface IClaimsService
         string runId,
         string? outcome = null,
         int limit = 250,
-        string? validationStatus = null);
+        string? validationStatus = null,
+        string? paymentStatus = null);
     Task<string> SubmitClaimAsync(SubmitClaimRequest request);
     Task UpdateClaimStatusAsync(string claimId, string status, string? notes = null);
     Task<AdjudicationTransparencyData?> GetAdjudicationDataAsync(string claimId);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -148,7 +148,8 @@ public class ClaimsService : IClaimsService
         string runId,
         string? outcome = null,
         int limit = 250,
-        string? validationStatus = null)
+        string? validationStatus = null,
+        string? paymentStatus = null)
     {
         var baseUrl = _configuration["Services:ClaimsService"];
         try
@@ -162,6 +163,11 @@ public class ClaimsService : IClaimsService
             if (!string.IsNullOrWhiteSpace(validationStatus))
             {
                 query += $"&validationStatus={Uri.EscapeDataString(validationStatus)}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(paymentStatus))
+            {
+                query += $"&paymentStatus={Uri.EscapeDataString(paymentStatus)}";
             }
 
             using var request = CreateMassAdjudicationRequest(

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -55,7 +55,15 @@ public sealed class MassAdjudicationRunsController : ControllerBase
             return NotFound();
         }
 
-        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, validationStatus, paymentStatus, limit, ct);
+        var results = await _repository.ListClaimResultsAsync(
+            tenantId,
+            id,
+            outcome,
+            validationStatus,
+            paymentStatus,
+            run.PaymentTolerance,
+            limit,
+            ct);
         return Ok(results);
     }
 

--- a/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
+++ b/src/services/claims-service/Controllers/MassAdjudicationRunsController.cs
@@ -44,6 +44,7 @@ public sealed class MassAdjudicationRunsController : ControllerBase
         string id,
         [FromQuery] string? outcome = null,
         [FromQuery] string? validationStatus = null,
+        [FromQuery] string? paymentStatus = null,
         [FromQuery] int limit = 250,
         CancellationToken ct = default)
     {
@@ -54,7 +55,7 @@ public sealed class MassAdjudicationRunsController : ControllerBase
             return NotFound();
         }
 
-        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, validationStatus, limit, ct);
+        var results = await _repository.ListClaimResultsAsync(tenantId, id, outcome, validationStatus, paymentStatus, limit, ct);
         return Ok(results);
     }
 

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -13,6 +13,7 @@ public interface IMassAdjudicationRunRepository
         string runId,
         string? outcome,
         string? validationStatus,
+        string? paymentStatus,
         int limit,
         CancellationToken ct = default);
 
@@ -109,6 +110,7 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         string runId,
         string? outcome,
         string? validationStatus,
+        string? paymentStatus,
         int limit,
         CancellationToken ct = default)
     {
@@ -128,11 +130,42 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
             filters.Add(Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.ValidationStatus, validationStatus));
         }
 
+        AddPaymentStatusFilter(filters, paymentStatus);
+
         return await _claimResults
             .Find(Builders<MassAdjudicationClaimResult>.Filter.And(filters))
             .SortByDescending(x => x.ElapsedMilliseconds)
             .Limit(Math.Clamp(limit, 1, 1000))
             .ToListAsync(ct);
+    }
+
+    private static void AddPaymentStatusFilter(
+        List<FilterDefinition<MassAdjudicationClaimResult>> filters,
+        string? paymentStatus)
+    {
+        if (string.IsNullOrWhiteSpace(paymentStatus))
+        {
+            return;
+        }
+
+        var builder = Builders<MassAdjudicationClaimResult>.Filter;
+        switch (paymentStatus.Trim().ToLowerInvariant())
+        {
+            case "mismatched":
+                filters.Add(builder.Gt(x => x.PaymentDelta, 0.01m));
+                break;
+            case "matched":
+                filters.Add(builder.And(
+                    builder.Ne(x => x.PaymentDelta, null),
+                    builder.Lte(x => x.PaymentDelta, 0.01m)));
+                break;
+            case "scored":
+                filters.Add(builder.Ne(x => x.PaymentDelta, null));
+                break;
+            case "unscored":
+                filters.Add(builder.Eq(x => x.PaymentDelta, null));
+                break;
+        }
     }
 
     public async Task<IReadOnlyList<string>> ListSubmittedClaimIdsAsync(
@@ -237,6 +270,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
         string runId,
         string? outcome,
         string? validationStatus,
+        string? paymentStatus,
         int limit,
         CancellationToken ct = default)
     {
@@ -255,12 +289,28 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
                 query = query.Where(x => string.Equals(x.ValidationStatus, validationStatus, StringComparison.OrdinalIgnoreCase));
             }
 
+            query = ApplyPaymentStatusFilter(query, paymentStatus);
+
             return Task.FromResult<IReadOnlyList<MassAdjudicationClaimResult>>(
                 query
                     .OrderByDescending(x => x.ElapsedMilliseconds)
                     .Take(Math.Clamp(limit, 1, 1000))
                     .ToList());
         }
+    }
+
+    private static IEnumerable<MassAdjudicationClaimResult> ApplyPaymentStatusFilter(
+        IEnumerable<MassAdjudicationClaimResult> query,
+        string? paymentStatus)
+    {
+        return paymentStatus?.Trim().ToLowerInvariant() switch
+        {
+            "mismatched" => query.Where(x => x.PaymentDelta > 0.01m),
+            "matched" => query.Where(x => x.PaymentDelta is <= 0.01m),
+            "scored" => query.Where(x => x.PaymentDelta.HasValue),
+            "unscored" => query.Where(x => !x.PaymentDelta.HasValue),
+            _ => query
+        };
     }
 
     public Task<IReadOnlyList<string>> ListSubmittedClaimIdsAsync(

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -14,6 +14,7 @@ public interface IMassAdjudicationRunRepository
         string? outcome,
         string? validationStatus,
         string? paymentStatus,
+        decimal paymentTolerance,
         int limit,
         CancellationToken ct = default);
 
@@ -111,6 +112,7 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
         string? outcome,
         string? validationStatus,
         string? paymentStatus,
+        decimal paymentTolerance,
         int limit,
         CancellationToken ct = default)
     {
@@ -130,7 +132,7 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
             filters.Add(Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.ValidationStatus, validationStatus));
         }
 
-        AddPaymentStatusFilter(filters, paymentStatus);
+        AddPaymentStatusFilter(filters, paymentStatus, paymentTolerance);
 
         return await _claimResults
             .Find(Builders<MassAdjudicationClaimResult>.Filter.And(filters))
@@ -141,23 +143,25 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
     private static void AddPaymentStatusFilter(
         List<FilterDefinition<MassAdjudicationClaimResult>> filters,
-        string? paymentStatus)
+        string? paymentStatus,
+        decimal paymentTolerance)
     {
         if (string.IsNullOrWhiteSpace(paymentStatus))
         {
             return;
         }
 
+        var tolerance = MassAdjudicationPaymentTolerance.Normalize(paymentTolerance);
         var builder = Builders<MassAdjudicationClaimResult>.Filter;
         switch (paymentStatus.Trim().ToLowerInvariant())
         {
             case "mismatched":
-                filters.Add(builder.Gt(x => x.PaymentDelta, 0.01m));
+                filters.Add(builder.Gt(x => x.PaymentDelta, tolerance));
                 break;
             case "matched":
                 filters.Add(builder.And(
                     builder.Ne(x => x.PaymentDelta, null),
-                    builder.Lte(x => x.PaymentDelta, 0.01m)));
+                    builder.Lte(x => x.PaymentDelta, tolerance)));
                 break;
             case "scored":
                 filters.Add(builder.Ne(x => x.PaymentDelta, null));
@@ -271,6 +275,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
         string? outcome,
         string? validationStatus,
         string? paymentStatus,
+        decimal paymentTolerance,
         int limit,
         CancellationToken ct = default)
     {
@@ -289,7 +294,7 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
                 query = query.Where(x => string.Equals(x.ValidationStatus, validationStatus, StringComparison.OrdinalIgnoreCase));
             }
 
-            query = ApplyPaymentStatusFilter(query, paymentStatus);
+            query = ApplyPaymentStatusFilter(query, paymentStatus, paymentTolerance);
 
             return Task.FromResult<IReadOnlyList<MassAdjudicationClaimResult>>(
                 query
@@ -301,12 +306,14 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
 
     private static IEnumerable<MassAdjudicationClaimResult> ApplyPaymentStatusFilter(
         IEnumerable<MassAdjudicationClaimResult> query,
-        string? paymentStatus)
+        string? paymentStatus,
+        decimal paymentTolerance)
     {
+        var tolerance = MassAdjudicationPaymentTolerance.Normalize(paymentTolerance);
         return paymentStatus?.Trim().ToLowerInvariant() switch
         {
-            "mismatched" => query.Where(x => x.PaymentDelta > 0.01m),
-            "matched" => query.Where(x => x.PaymentDelta is <= 0.01m),
+            "mismatched" => query.Where(x => x.PaymentDelta > tolerance),
+            "matched" => query.Where(x => x.PaymentDelta <= tolerance),
             "scored" => query.Where(x => x.PaymentDelta.HasValue),
             "unscored" => query.Where(x => !x.PaymentDelta.HasValue),
             _ => query
@@ -330,4 +337,12 @@ public sealed class InMemoryMassAdjudicationRunRepository : IMassAdjudicationRun
                     .ToList());
         }
     }
+}
+
+internal static class MassAdjudicationPaymentTolerance
+{
+    internal const decimal LegacyDefault = 0.01m;
+
+    internal static decimal Normalize(decimal paymentTolerance)
+        => paymentTolerance > 0 ? paymentTolerance : LegacyDefault;
 }

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -2,6 +2,8 @@ namespace CloudHealthOffice.Tools.MccPlatformValidator;
 
 internal static class MccRunSummaryBuilder
 {
+    internal const decimal PaymentTolerance = 0.01m;
+
     public static MassAdjudicationRunSummary Build(
         List<ClaimValidationResult> results,
         TimeSpan elapsed,
@@ -42,8 +44,7 @@ internal static class MccRunSummaryBuilder
         var avgDelta = comparable.Count == 0
             ? (decimal?)null
             : comparable.Average(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
-        const decimal paymentTolerance = 0.01m;
-        var paymentMatches = comparable.Count(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value) <= paymentTolerance);
+        var paymentMatches = comparable.Count(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value) <= PaymentTolerance);
         var paymentMismatches = comparable.Count - paymentMatches;
         var maxPaymentDelta = comparable.Count == 0
             ? (decimal?)null
@@ -141,7 +142,7 @@ internal static class MccRunSummaryBuilder
             BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
             BuildAdjudicationStepTimings(results),
             avgDelta,
-            paymentTolerance,
+            PaymentTolerance,
             comparable.Count,
             paymentMatches,
             paymentMismatches,
@@ -255,7 +256,7 @@ internal static class MccRunSummaryBuilder
             && result.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario
             && result.ActualPlanPayment.HasValue
             && result.ExpectedPlanPayment.HasValue
-            && Math.Abs(result.ActualPlanPayment.Value - result.ExpectedPlanPayment.Value) > 0.01m)
+            && Math.Abs(result.ActualPlanPayment.Value - result.ExpectedPlanPayment.Value) > PaymentTolerance)
         {
             return 3;
         }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2185,7 +2185,7 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         null,
         Array.Empty<MassAdjudicationStageTiming>(),
         null,
-        0.01m,
+        MccRunSummaryBuilder.PaymentTolerance,
         0,
         0,
         0,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -184,7 +184,7 @@ public class MassAdjudicationRunRepositoryTests
         var saved = await repo.SaveAsync(completed);
         await repo.SaveAsync(progressOnly);
 
-        var claimResults = await repo.ListClaimResultsAsync(saved.Run.TenantId, runId, null, null, 10);
+        var claimResults = await repo.ListClaimResultsAsync(saved.Run.TenantId, runId, null, null, null, 10);
 
         claimResults.Should().ContainSingle()
             .Which.GeneratedClaimId.Should().Be("GEN-EVIDENCE");
@@ -230,18 +230,106 @@ public class MassAdjudicationRunRepositoryTests
             saved.Id,
             outcome: null,
             validationStatus: "Unsupported",
+            paymentStatus: null,
             limit: 10);
         var unsupportedPaid = await repo.ListClaimResultsAsync(
             saved.Run.TenantId,
             saved.Id,
             outcome: "Paid",
             validationStatus: "Unsupported",
+            paymentStatus: null,
             limit: 10);
 
         unsupported.Select(x => x.GeneratedClaimId)
             .Should().Equal("GEN-PAID-UNSUPPORTED", "GEN-DENIAL-UNSUPPORTED");
         unsupportedPaid.Should().ContainSingle()
             .Which.GeneratedClaimId.Should().Be("GEN-PAID-UNSUPPORTED");
+    }
+
+    [Fact]
+    public async Task ListClaimResultsAsync_filters_by_payment_status()
+    {
+        var repo = new InMemoryMassAdjudicationRunRepository();
+        var summary = CreateSummary();
+        summary.ClaimResults.AddRange(new[]
+        {
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAYMENT-EXACT",
+                ClaimType = "Professional",
+                Outcome = "Paid",
+                ValidationStatus = "Matched",
+                PaymentDelta = 0m,
+                ElapsedMilliseconds = 10
+            },
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAYMENT-ROUNDING",
+                ClaimType = "Professional",
+                Outcome = "Paid",
+                ValidationStatus = "Matched",
+                PaymentDelta = 0.01m,
+                ElapsedMilliseconds = 20
+            },
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAYMENT-MISMATCH",
+                ClaimType = "Professional",
+                Outcome = "Paid",
+                ValidationStatus = "Matched",
+                PaymentDelta = 1.23m,
+                ElapsedMilliseconds = 30
+            },
+            new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = "GEN-PAYMENT-UNSCORED",
+                ClaimType = "Professional",
+                Outcome = "BusinessDenial",
+                ValidationStatus = "Matched",
+                PaymentDelta = null,
+                ElapsedMilliseconds = 40
+            }
+        });
+
+        var saved = await repo.SaveAsync(summary);
+
+        var mismatched = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: null,
+            validationStatus: null,
+            paymentStatus: "Mismatched",
+            limit: 10);
+        var matched = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: null,
+            validationStatus: null,
+            paymentStatus: "Matched",
+            limit: 10);
+        var scored = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: null,
+            validationStatus: null,
+            paymentStatus: "Scored",
+            limit: 10);
+        var unscored = await repo.ListClaimResultsAsync(
+            saved.Run.TenantId,
+            saved.Id,
+            outcome: null,
+            validationStatus: null,
+            paymentStatus: "Unscored",
+            limit: 10);
+
+        mismatched.Should().ContainSingle()
+            .Which.GeneratedClaimId.Should().Be("GEN-PAYMENT-MISMATCH");
+        matched.Select(x => x.GeneratedClaimId)
+            .Should().Equal("GEN-PAYMENT-ROUNDING", "GEN-PAYMENT-EXACT");
+        scored.Select(x => x.GeneratedClaimId)
+            .Should().Equal("GEN-PAYMENT-MISMATCH", "GEN-PAYMENT-ROUNDING", "GEN-PAYMENT-EXACT");
+        unscored.Should().ContainSingle()
+            .Which.GeneratedClaimId.Should().Be("GEN-PAYMENT-UNSCORED");
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -184,7 +184,7 @@ public class MassAdjudicationRunRepositoryTests
         var saved = await repo.SaveAsync(completed);
         await repo.SaveAsync(progressOnly);
 
-        var claimResults = await repo.ListClaimResultsAsync(saved.Run.TenantId, runId, null, null, null, 10);
+        var claimResults = await repo.ListClaimResultsAsync(saved.Run.TenantId, runId, null, null, null, 0.01m, 10);
 
         claimResults.Should().ContainSingle()
             .Which.GeneratedClaimId.Should().Be("GEN-EVIDENCE");
@@ -231,6 +231,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: null,
             validationStatus: "Unsupported",
             paymentStatus: null,
+            paymentTolerance: 0.01m,
             limit: 10);
         var unsupportedPaid = await repo.ListClaimResultsAsync(
             saved.Run.TenantId,
@@ -238,6 +239,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: "Paid",
             validationStatus: "Unsupported",
             paymentStatus: null,
+            paymentTolerance: 0.01m,
             limit: 10);
 
         unsupported.Select(x => x.GeneratedClaimId)
@@ -247,7 +249,7 @@ public class MassAdjudicationRunRepositoryTests
     }
 
     [Fact]
-    public async Task ListClaimResultsAsync_filters_by_payment_status()
+    public async Task ListClaimResultsAsync_filters_by_payment_status_using_run_tolerance()
     {
         var repo = new InMemoryMassAdjudicationRunRepository();
         var summary = CreateSummary();
@@ -268,7 +270,7 @@ public class MassAdjudicationRunRepositoryTests
                 ClaimType = "Professional",
                 Outcome = "Paid",
                 ValidationStatus = "Matched",
-                PaymentDelta = 0.01m,
+                PaymentDelta = 0.05m,
                 ElapsedMilliseconds = 20
             },
             new MassAdjudicationClaimResult
@@ -277,7 +279,7 @@ public class MassAdjudicationRunRepositoryTests
                 ClaimType = "Professional",
                 Outcome = "Paid",
                 ValidationStatus = "Matched",
-                PaymentDelta = 1.23m,
+                PaymentDelta = 0.06m,
                 ElapsedMilliseconds = 30
             },
             new MassAdjudicationClaimResult
@@ -299,6 +301,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: null,
             validationStatus: null,
             paymentStatus: "Mismatched",
+            paymentTolerance: 0.05m,
             limit: 10);
         var matched = await repo.ListClaimResultsAsync(
             saved.Run.TenantId,
@@ -306,6 +309,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: null,
             validationStatus: null,
             paymentStatus: "Matched",
+            paymentTolerance: 0.05m,
             limit: 10);
         var scored = await repo.ListClaimResultsAsync(
             saved.Run.TenantId,
@@ -313,6 +317,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: null,
             validationStatus: null,
             paymentStatus: "Scored",
+            paymentTolerance: 0.05m,
             limit: 10);
         var unscored = await repo.ListClaimResultsAsync(
             saved.Run.TenantId,
@@ -320,6 +325,7 @@ public class MassAdjudicationRunRepositoryTests
             outcome: null,
             validationStatus: null,
             paymentStatus: "Unscored",
+            paymentTolerance: 0.05m,
             limit: 10);
 
         mismatched.Should().ContainSingle()


### PR DESCRIPTION
## Summary

- add a server-side `paymentStatus` filter for mass adjudication claim results
- expose payment mismatch and scored-payment filters in the Mass Adjudication console
- show payment gate, payment mismatches, max delta, expected payment, and delta coloring in the portal evidence view

## Why

The benchmark already stores payment comparison evidence, but the console could only show a passive average delta. This makes payment accuracy inspectable so a run can prove whether comparable paid claims stayed inside tolerance and surface the claim-level rows when they do not.

## Validation

- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore`
- `dotnet test src/portal/CloudHealthOffice.Portal.Tests/CloudHealthOffice.Portal.Tests.csproj --no-restore`