### PR TITLE
Align MCC payment evidence scoring

### DIFF
--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -33,13 +33,7 @@ internal static class MccRunSummaryBuilder
         var p99 = Percentile(orderedDurations, 0.99);
         var throughput = results.Count / Math.Max(0.001, elapsed.TotalSeconds);
         var comparable = results
-            .Where(r => r.Outcome is ClaimValidationOutcome.Paid)
-            // Amount scoring is valid only when the expected amount was authored
-            // for the same benefit plan used by local adjudication. Generic MCC
-            // edge cases retain disposition scoring, but their amounts come from
-            // their original synthetic plans and are not contract-comparable.
-            .Where(r => r.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario)
-            .Where(r => r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue)
+            .Where(IsPaymentComparable)
             .ToList();
         var avgDelta = comparable.Count == 0
             ? (decimal?)null
@@ -90,10 +84,8 @@ internal static class MccRunSummaryBuilder
                 r.FailureStage,
                 r.Error,
                 r.ActualPlanPayment,
-                r.ExpectedPlanPayment,
-                r.ActualPlanPayment.HasValue && r.ExpectedPlanPayment.HasValue
-                    ? Math.Abs(r.ActualPlanPayment.Value - r.ExpectedPlanPayment.Value)
-                    : null,
+                IsPaymentComparable(r) ? r.ExpectedPlanPayment : null,
+                PaymentDelta(r),
                 r.Elapsed.TotalMilliseconds,
                 r.SubmitElapsed.TotalMilliseconds,
                 r.AdjudicationElapsed.TotalMilliseconds,
@@ -252,17 +244,29 @@ internal static class MccRunSummaryBuilder
             return 2;
         }
 
-        if (result.Outcome is ClaimValidationOutcome.Paid
-            && result.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario
-            && result.ActualPlanPayment.HasValue
-            && result.ExpectedPlanPayment.HasValue
-            && Math.Abs(result.ActualPlanPayment.Value - result.ExpectedPlanPayment.Value) > PaymentTolerance)
+        var paymentDelta = PaymentDelta(result);
+        if (paymentDelta.HasValue && paymentDelta.Value > PaymentTolerance)
         {
             return 3;
         }
 
         return 100;
     }
+
+    private static bool IsPaymentComparable(ClaimValidationResult result)
+        => result.Outcome is ClaimValidationOutcome.Paid
+        // Amount scoring is valid only when the expected amount was authored
+        // for the same benefit plan used by local adjudication. Generic MCC
+        // edge cases retain disposition scoring, but their amounts come from
+        // their original synthetic plans and are not contract-comparable.
+        && result.ValidationScenario == MccWorkflowValidation.CleanProfessionalPaidScenario
+        && result.ActualPlanPayment.HasValue
+        && result.ExpectedPlanPayment.HasValue;
+
+    private static decimal? PaymentDelta(ClaimValidationResult result)
+        => IsPaymentComparable(result)
+            ? Math.Abs(result.ActualPlanPayment!.Value - result.ExpectedPlanPayment!.Value)
+            : null;
 
     private static double Percentile(double[] values, double percentile)
     {

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -105,6 +105,43 @@ public class MccRunSummaryBuilderTests
         Assert.Contains(summary.ClaimResults, r => r.GeneratedClaimId == "WRONG" && r.PaymentDelta == 1m);
     }
 
+    [Fact]
+    public void Build_PublishesPaymentDeltaOnlyForPaymentComparableRows()
+    {
+        var options = ValidatorOptions.Parse([
+            "--claims", "2",
+            "--claim-results-limit", "10"
+        ]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("CLEAN-WRONG", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 101m, ExpectedPlanPayment = 100m },
+            Result("EDGE-NOT-COMPARABLE", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 250m, ExpectedPlanPayment = 100m }
+        };
+
+        var summary = MccRunSummaryBuilder.Build(
+            results,
+            TimeSpan.FromSeconds(1),
+            options,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        Assert.Equal(1, summary.PaymentComparisons);
+        Assert.Equal(1, summary.PaymentMismatches);
+        Assert.Equal(1m, summary.MaximumPaymentDelta);
+
+        var cleanWrong = Assert.Single(summary.ClaimResults, r => r.GeneratedClaimId == "CLEAN-WRONG");
+        Assert.Equal(101m, cleanWrong.ActualPlanPayment);
+        Assert.Equal(100m, cleanWrong.ExpectedPlanPayment);
+        Assert.Equal(1m, cleanWrong.PaymentDelta);
+
+        var edgeCase = Assert.Single(summary.ClaimResults, r => r.GeneratedClaimId == "EDGE-NOT-COMPARABLE");
+        Assert.Equal(250m, edgeCase.ActualPlanPayment);
+        Assert.Null(edgeCase.ExpectedPlanPayment);
+        Assert.Null(edgeCase.PaymentDelta);
+    }
+
     private static ClaimValidationResult Result(
         string claimId,
         string? scenario,


### PR DESCRIPTION
## Summary
- Limit published payment deltas to claims that are actually payment-comparable under the MCC payment gate.
- Keep generic edge-case claims disposition-scoreable while marking their payment fields as unscored in claim-result evidence.
- Add regression coverage so non-comparable paid edge cases cannot surface as phantom payment mismatches in the console filters.

## Root cause
The run summary payment gate only scores plan-aligned clean professional paid claims, but claim-result evidence was publishing `PaymentDelta` for any row with actual and expected payment values. That let the dashboard payment mismatch filter disagree with the run summary by treating non-comparable edge-case amounts as scored payment failures.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore --filter "FullyQualifiedName~MassAdjudicationRunRepositoryTests" --logger "console;verbosity=minimal"`
- `git diff --check`
- 1K MCC Kubernetes verification run: 1,000 processed, 0 platform failures, 0 workflow mismatches, payment gate 20/20, 0 payment mismatches, max delta $0.00.
- Dashboard API filter check for run `b70b2116cff746f8a181f6847134f423`: `matched 20`, `mismatched 0`, `scored 20`, `unscored 980`.
