### PR TITLE
Add MCC lifecycle timing evidence

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -230,6 +230,11 @@
                     <MudItem xs="6" md="4">@Metric("Payment Mismatches", $"{_selectedRun.PaymentMismatches:N0}", _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Max Payment Delta", _selectedRun.MaximumPaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.MaximumPaymentDelta, PaymentTolerance(_selectedRun)))</MudItem>
                     <MudItem xs="6" md="4">@Metric("Avg Payment Delta", _selectedRun.AveragePaymentDelta?.ToString("C") ?? "-", PaymentDeltaColor(_selectedRun.AveragePaymentDelta, PaymentTolerance(_selectedRun)))</MudItem>
+                    @if (_selectedRun.LifecycleTimings.Count > 0)
+                    {
+                        <MudItem xs="6" md="4">@Metric("Preparation", FormatDuration(PreparationDuration(_selectedRun)), "#facc15")</MudItem>
+                        <MudItem xs="6" md="4">@Metric("Tracked Lifecycle", FormatDuration(LifecycleDuration(_selectedRun)), "#7dd3fc")</MudItem>
+                    }
                     @if (_selectedRun.Progress is not null)
                     {
                         <MudItem xs="6" md="4">@Metric("Run Status", RunStatusLabel(_selectedRun), IsRunActive(_selectedRun) ? "#7dd3fc" : "#00ff88")</MudItem>
@@ -248,6 +253,18 @@
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.AdjudicateTiming)</MudItem>
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.WritebackTiming)</MudItem>
                 </MudGrid>
+
+                @if (_selectedRun.LifecycleTimings.Count > 0)
+                {
+                    <MudDivider Class="my-3" Style="border-color: rgba(0,255,255,0.12);" />
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65); font-weight: 700;">Run Lifecycle</MudText>
+                    <MudGrid Spacing="2" Class="mt-1">
+                        @foreach (var timing in _selectedRun.LifecycleTimings)
+                        {
+                            <MudItem xs="12" sm="6" md="4">@LifecycleTiming(timing)</MudItem>
+                        }
+                    </MudGrid>
+                }
 
                 @if (_selectedRun.AdjudicationStepTimings.Count > 0)
                 {
@@ -697,6 +714,24 @@
     private static double ScenarioPercent(int count, int total)
         => total <= 0 ? 0 : (double)count / total * 100;
 
+    private static double PreparationDuration(MassAdjudicationRunSummary run)
+        => run.LifecycleTimings
+            .Where(t => string.Equals(t.Category, "Preparation", StringComparison.OrdinalIgnoreCase))
+            .Sum(t => t.DurationMilliseconds);
+
+    private static double LifecycleDuration(MassAdjudicationRunSummary run)
+        => run.LifecycleTimings.Sum(t => t.DurationMilliseconds);
+
+    private static string FormatDuration(double milliseconds)
+    {
+        var duration = TimeSpan.FromMilliseconds(Math.Max(0, milliseconds));
+        return duration.TotalSeconds < 1
+            ? $"{milliseconds:N0} ms"
+            : duration.TotalHours >= 1
+            ? duration.ToString("h\\:mm\\:ss")
+            : duration.ToString("m\\:ss");
+    }
+
     private static string OnOff(bool value) => value ? "on" : "off";
 
     private static string LineOfBusinessLabel(int lineOfBusiness) => lineOfBusiness switch
@@ -825,6 +860,34 @@
         builder.AddAttribute(8, "Typo", Typo.body2);
         builder.AddAttribute(9, "Style", "color: #7dd3fc; font-family: monospace;");
         builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.CloseElement();
+    };
+
+    private RenderFragment LifecycleTiming(MassAdjudicationLifecycleTiming timing) => builder =>
+    {
+        var categoryColor = string.Equals(timing.Category, "Preparation", StringComparison.OrdinalIgnoreCase)
+            ? "#facc15"
+            : string.Equals(timing.Category, "Processing", StringComparison.OrdinalIgnoreCase)
+                ? "#7dd3fc"
+                : "#cbd5e1";
+
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "style", $"border: 1px solid {categoryColor}55; background: {categoryColor}12; border-radius: 8px; padding: 10px;");
+        builder.OpenComponent<MudText>(2);
+        builder.AddAttribute(3, "Typo", Typo.caption);
+        builder.AddAttribute(4, "Style", "color: rgba(255,255,255,0.55);");
+        builder.AddAttribute(5, "ChildContent", (RenderFragment)(b => b.AddContent(6, timing.Category)));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(7);
+        builder.AddAttribute(8, "Typo", Typo.body2);
+        builder.AddAttribute(9, "Style", $"color: {categoryColor}; font-family: monospace; font-weight: 700;");
+        builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, FormatDuration(timing.DurationMilliseconds))));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(12);
+        builder.AddAttribute(13, "Typo", Typo.caption);
+        builder.AddAttribute(14, "Style", "color: rgba(255,255,255,0.65);");
+        builder.AddAttribute(15, "ChildContent", (RenderFragment)(b => b.AddContent(16, timing.Label)));
         builder.CloseComponent();
         builder.CloseElement();
     };

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -103,6 +103,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
+    public List<MassAdjudicationLifecycleTiming> LifecycleTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public decimal PaymentTolerance { get; set; }
     public int PaymentComparisons { get; set; }
@@ -156,6 +157,15 @@ public class MassAdjudicationStageTiming
     public string Label { get; set; } = string.Empty;
     public double AverageMilliseconds { get; set; }
     public double P95Milliseconds { get; set; }
+}
+
+public class MassAdjudicationLifecycleTiming
+{
+    public string Label { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public double DurationMilliseconds { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset CompletedAtUtc { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -27,6 +27,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? AdjudicateTiming { get; set; }
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
+    public List<MassAdjudicationLifecycleTiming> LifecycleTimings { get; set; } = new();
     public decimal? AveragePaymentDelta { get; set; }
     public decimal PaymentTolerance { get; set; }
     public int PaymentComparisons { get; set; }
@@ -81,6 +82,15 @@ public class MassAdjudicationStageTiming
     public string Label { get; set; } = string.Empty;
     public double AverageMilliseconds { get; set; }
     public double P95Milliseconds { get; set; }
+}
+
+public class MassAdjudicationLifecycleTiming
+{
+    public string Label { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public double DurationMilliseconds { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset CompletedAtUtc { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -14,7 +14,8 @@ internal static class MccRunSummaryBuilder
         string status = "Completed",
         int? totalClaimsOverride = null,
         MassAdjudicationRunProgress? progress = null,
-        bool publishClaimResults = true)
+        bool publishClaimResults = true,
+        IReadOnlyList<MassAdjudicationLifecycleTiming>? lifecycleTimings = null)
     {
         var totalClaims = Math.Max(results.Count, totalClaimsOverride ?? results.Count);
         var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
@@ -133,6 +134,7 @@ internal static class MccRunSummaryBuilder
             BuildStageTiming("Adjudicate", results.Select(r => r.AdjudicationElapsed)),
             BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
             BuildAdjudicationStepTimings(results),
+            lifecycleTimings ?? Array.Empty<MassAdjudicationLifecycleTiming>(),
             avgDelta,
             PaymentTolerance,
             comparable.Count,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -48,46 +48,73 @@ Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled
 Console.WriteLine($"  Pend diag:   {(options.PendDiagnosticsPath is not null ? $"enabled -> {options.PendDiagnosticsPath}" : "disabled")}");
 Console.WriteLine();
 
-await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
-await RequireHealthyAsync(http, $"{options.BenefitUrl}/health", "benefit-plan-service");
-if (options.SeedMembers)
-{
-    await RequireHealthyAsync(http, $"{options.MemberUrl}/health", "member-service");
-    await RequireHealthyAsync(http, $"{options.CoverageUrl}/health", "coverage-service");
-}
-if (options.SeedProviders)
-{
-    await RequireHealthyAsync(http, $"{options.ProviderUrl}/health", "provider-service");
-}
+var lifecycleTimings = new List<MassAdjudicationLifecycleTiming>();
 
-await SeedNcciAsync(http, options, json);
-await SeedPriorAuthRulesAsync(http, options, json);
+await MeasureLifecyclePhaseAsync(lifecycleTimings, "Service health checks", "Preparation", async () =>
+{
+    await RequireHealthyAsync(http, $"{options.ClaimsUrl}/health", "claims-service");
+    await RequireHealthyAsync(http, $"{options.BenefitUrl}/health", "benefit-plan-service");
+    if (options.SeedMembers)
+    {
+        await RequireHealthyAsync(http, $"{options.MemberUrl}/health", "member-service");
+        await RequireHealthyAsync(http, $"{options.CoverageUrl}/health", "coverage-service");
+    }
+    if (options.SeedProviders)
+    {
+        await RequireHealthyAsync(http, $"{options.ProviderUrl}/health", "provider-service");
+    }
+});
+
+await MeasureLifecyclePhaseAsync(lifecycleTimings, "Reference rule seeding", "Preparation", async () =>
+{
+    await SeedNcciAsync(http, options, json);
+    await SeedPriorAuthRulesAsync(http, options, json);
+});
 
 var validationPlanId = Guid.NewGuid();
-await CreateValidationPlanAsync(http, options, validationPlanId, json);
+await MeasureLifecyclePhaseAsync(lifecycleTimings, "Validation plan setup", "Preparation", async () =>
+{
+    await CreateValidationPlanAsync(http, options, validationPlanId, json);
+});
 
-var claims = await GenerateClaimsAsync(options);
-NormalizePriorAuthEdgeCases(claims, options);
-NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
-MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
-MccCleanPaidFixture.NormalizeClaims(claims);
-var providerPool = MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId);
+var claims = new List<SyntheticClaim>();
+await MeasureLifecyclePhaseAsync(lifecycleTimings, "Corpus generation", "Preparation", async () =>
+{
+    claims = await GenerateClaimsAsync(options);
+});
+
+MccProviderFixturePoolResult? providerPool = null;
+await MeasureLifecyclePhaseAsync(lifecycleTimings, "Fixture normalization", "Preparation", () =>
+{
+    NormalizePriorAuthEdgeCases(claims, options);
+    NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
+    MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
+    MccCleanPaidFixture.NormalizeClaims(claims);
+    providerPool = MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId);
+    return Task.CompletedTask;
+});
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 Console.WriteLine(
-    $"Provider fixture pool: {providerPool.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
+    $"Provider fixture pool: {providerPool!.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
     $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
 if (options.SeedMembers)
 {
-    await SeedMembersAsync(http, options, claims, json);
-    await SeedCoverageAsync(http, options, claims, validationPlanId, json);
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Member and coverage seeding", "Preparation", async () =>
+    {
+        await SeedMembersAsync(http, options, claims, json);
+        await SeedCoverageAsync(http, options, claims, validationPlanId, json);
+    });
 }
 
 if (options.SeedProviders)
 {
-    await SeedProviderNetworksAsync(http, options, json);
-    await SeedProvidersAsync(http, options, claims, validationPlanId, json);
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Provider seeding", "Preparation", async () =>
+    {
+        await SeedProviderNetworksAsync(http, options, json);
+        await SeedProvidersAsync(http, options, claims, validationPlanId, json);
+    });
 }
 
 var results = new ConcurrentBag<ClaimValidationResult>();
@@ -113,6 +140,7 @@ if (!options.NoPublishSummary)
     await PublishSummaryAsync(http, options, initialProgress, json, quiet: true);
 }
 
+var processingStartedAtUtc = DateTimeOffset.UtcNow;
 total.Start();
 await Parallel.ForEachAsync(
     claims,
@@ -169,6 +197,7 @@ await Parallel.ForEachAsync(
     });
 
 total.Stop();
+AddLifecycleTiming(lifecycleTimings, "Timed adjudication", "Processing", processingStartedAtUtc, DateTimeOffset.UtcNow, total.Elapsed);
 Task? pendingProgressPublish;
 lock (latestProgressPublishLock)
 {
@@ -188,15 +217,24 @@ var orderedResults = results
 
 if (options.PendObservationEnabled)
 {
-    orderedResults = await ObserveExpectedPendResultsAsync(http, options, orderedResults);
-    orderedResults = await DetectUnexpectedPendResultsAsync(http, options, orderedResults);
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Expected-pend observation", "Observation", async () =>
+    {
+        orderedResults = await ObserveExpectedPendResultsAsync(http, options, orderedResults);
+    });
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "False-pend sweep", "Observation", async () =>
+    {
+        orderedResults = await DetectUnexpectedPendResultsAsync(http, options, orderedResults);
+    });
 }
 
 if (!string.IsNullOrWhiteSpace(options.PendDiagnosticsPath))
 {
-    var diagnosticsReport = await PendDiagnostics.CollectAsync(http, options, orderedResults);
-    await PendDiagnostics.WriteReportAsync(options.PendDiagnosticsPath, diagnosticsReport, json);
-    PendDiagnostics.PrintAggregateTable(diagnosticsReport);
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Pend diagnostics", "Diagnostics", async () =>
+    {
+        var diagnosticsReport = await PendDiagnostics.CollectAsync(http, options, orderedResults);
+        await PendDiagnostics.WriteReportAsync(options.PendDiagnosticsPath, diagnosticsReport, json);
+        PendDiagnostics.PrintAggregateTable(diagnosticsReport);
+    });
 }
 
 var summary = MccRunSummaryBuilder.Build(
@@ -209,7 +247,8 @@ var summary = MccRunSummaryBuilder.Build(
     "Completed",
     options.Claims,
     CreateProgress(orderedResults, total.Elapsed, options, "Completed"),
-    publishClaimResults: true);
+    publishClaimResults: true,
+    lifecycleTimings: lifecycleTimings);
 WriteSummary(summary);
 
 if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
@@ -225,6 +264,41 @@ if (!options.NoPublishSummary)
 if (orderedResults.Any(r => r.Outcome is ClaimValidationOutcome.PlatformFailure))
 {
     Environment.ExitCode = 1;
+}
+
+static async Task MeasureLifecyclePhaseAsync(
+    ICollection<MassAdjudicationLifecycleTiming> timings,
+    string label,
+    string category,
+    Func<Task> action)
+{
+    var startedAtUtc = DateTimeOffset.UtcNow;
+    var sw = Stopwatch.StartNew();
+    try
+    {
+        await action();
+    }
+    finally
+    {
+        sw.Stop();
+        AddLifecycleTiming(timings, label, category, startedAtUtc, DateTimeOffset.UtcNow, sw.Elapsed);
+    }
+}
+
+static void AddLifecycleTiming(
+    ICollection<MassAdjudicationLifecycleTiming> timings,
+    string label,
+    string category,
+    DateTimeOffset startedAtUtc,
+    DateTimeOffset completedAtUtc,
+    TimeSpan duration)
+{
+    timings.Add(new MassAdjudicationLifecycleTiming(
+        label,
+        category,
+        Math.Max(0, duration.TotalMilliseconds),
+        startedAtUtc,
+        completedAtUtc));
 }
 
 static async Task<ClaimValidationResult> ProcessClaimAsync(
@@ -2070,6 +2144,7 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");
     Console.WriteLine($"  P95 latency:        {summary.P95LatencyMilliseconds:N0} ms");
     Console.WriteLine($"  P99 latency:        {summary.P99LatencyMilliseconds:N0} ms");
+    WriteLifecycleTimings(summary.LifecycleTimings);
     WriteStageTiming(summary.SubmitTiming);
     WriteStageTiming(summary.AdjudicateTiming);
     WriteStageTiming(summary.WritebackTiming);
@@ -2109,6 +2184,31 @@ static void WriteStageTiming(MassAdjudicationStageTiming? timing)
 
     Console.WriteLine($"  {timing.Label,-12} avg/p95: {timing.AverageMilliseconds:N0} ms / {timing.P95Milliseconds:N0} ms");
 }
+
+static void WriteLifecycleTimings(IReadOnlyList<MassAdjudicationLifecycleTiming> timings)
+{
+    if (timings.Count == 0)
+    {
+        return;
+    }
+
+    var preparationMilliseconds = timings
+        .Where(t => string.Equals(t.Category, "Preparation", StringComparison.OrdinalIgnoreCase))
+        .Sum(t => t.DurationMilliseconds);
+    var lifecycleMilliseconds = timings.Sum(t => t.DurationMilliseconds);
+
+    Console.WriteLine($"  Preparation time:   {FormatDuration(TimeSpan.FromMilliseconds(preparationMilliseconds))}");
+    Console.WriteLine($"  Tracked lifecycle:  {FormatDuration(TimeSpan.FromMilliseconds(lifecycleMilliseconds))}");
+    foreach (var timing in timings)
+    {
+        Console.WriteLine($"  Lifecycle.{timing.Label,-28} {FormatDuration(TimeSpan.FromMilliseconds(timing.DurationMilliseconds))}");
+    }
+}
+
+static string FormatDuration(TimeSpan duration)
+    => duration.TotalHours >= 1
+        ? duration.ToString("h\\:mm\\:ss")
+        : duration.ToString("m\\:ss\\.fff");
 
 static async Task WriteSummaryJsonAsync(string path, MassAdjudicationRunSummary summary, JsonSerializerOptions json)
 {
@@ -2184,6 +2284,7 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         null,
         null,
         Array.Empty<MassAdjudicationStageTiming>(),
+        Array.Empty<MassAdjudicationLifecycleTiming>(),
         null,
         MccRunSummaryBuilder.PaymentTolerance,
         0,
@@ -2433,6 +2534,7 @@ internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationStageTiming? AdjudicateTiming,
     MassAdjudicationStageTiming? WritebackTiming,
     IReadOnlyList<MassAdjudicationStageTiming> AdjudicationStepTimings,
+    IReadOnlyList<MassAdjudicationLifecycleTiming> LifecycleTimings,
     decimal? AveragePaymentDelta,
     decimal PaymentTolerance,
     int PaymentComparisons,
@@ -2480,6 +2582,13 @@ internal sealed record MassAdjudicationStageTiming(
     string Label,
     double AverageMilliseconds,
     double P95Milliseconds);
+
+internal sealed record MassAdjudicationLifecycleTiming(
+    string Label,
+    string Category,
+    double DurationMilliseconds,
+    DateTimeOffset StartedAtUtc,
+    DateTimeOffset CompletedAtUtc);
 
 internal sealed record MassAdjudicationBusinessDenialSummary(
     string Code,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -77,25 +77,23 @@ await MeasureLifecyclePhaseAsync(lifecycleTimings, "Validation plan setup", "Pre
     await CreateValidationPlanAsync(http, options, validationPlanId, json);
 });
 
-var claims = new List<SyntheticClaim>();
-await MeasureLifecyclePhaseAsync(lifecycleTimings, "Corpus generation", "Preparation", async () =>
-{
-    claims = await GenerateClaimsAsync(options);
-});
+var claims = await MeasureLifecycleValuePhaseAsync(
+    lifecycleTimings,
+    "Corpus generation",
+    "Preparation",
+    () => GenerateClaimsAsync(options));
 
-MccProviderFixturePoolResult? providerPool = null;
-await MeasureLifecyclePhaseAsync(lifecycleTimings, "Fixture normalization", "Preparation", () =>
+var providerPool = await MeasureLifecycleValuePhaseAsync(lifecycleTimings, "Fixture normalization", "Preparation", () =>
 {
     NormalizePriorAuthEdgeCases(claims, options);
     NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
     MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
     MccCleanPaidFixture.NormalizeClaims(claims);
-    providerPool = MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId);
-    return Task.CompletedTask;
+    return Task.FromResult(MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId));
 });
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 Console.WriteLine(
-    $"Provider fixture pool: {providerPool!.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
+    $"Provider fixture pool: {providerPool.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
     $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
@@ -272,11 +270,24 @@ static async Task MeasureLifecyclePhaseAsync(
     string category,
     Func<Task> action)
 {
+    await MeasureLifecycleValuePhaseAsync(timings, label, category, async () =>
+    {
+        await action();
+        return true;
+    });
+}
+
+static async Task<T> MeasureLifecycleValuePhaseAsync<T>(
+    ICollection<MassAdjudicationLifecycleTiming> timings,
+    string label,
+    string category,
+    Func<Task<T>> action)
+{
     var startedAtUtc = DateTimeOffset.UtcNow;
     var sw = Stopwatch.StartNew();
     try
     {
-        await action();
+        return await action();
     }
     finally
     {

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -142,6 +142,35 @@ public class MccRunSummaryBuilderTests
         Assert.Null(edgeCase.PaymentDelta);
     }
 
+    [Fact]
+    public void Build_IncludesLifecycleTimings()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-07-13T00:00:00Z");
+        var completedAt = DateTimeOffset.Parse("2026-07-13T00:00:01Z");
+        var options = ValidatorOptions.Parse(["--claims", "1"]);
+        var phase = new MassAdjudicationLifecycleTiming(
+            "Corpus generation",
+            "Preparation",
+            1_000,
+            startedAt,
+            completedAt);
+
+        var summary = MccRunSummaryBuilder.Build(
+            [Result("MCC-1", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)],
+            TimeSpan.FromSeconds(1),
+            options,
+            startedAt,
+            completedAt,
+            lifecycleTimings: [phase]);
+
+        var timing = Assert.Single(summary.LifecycleTimings);
+        Assert.Equal("Corpus generation", timing.Label);
+        Assert.Equal("Preparation", timing.Category);
+        Assert.Equal(1_000, timing.DurationMilliseconds);
+        Assert.Equal(startedAt, timing.StartedAtUtc);
+        Assert.Equal(completedAt, timing.CompletedAtUtc);
+    }
+
     private static ClaimValidationResult Result(
         string claimId,
         string? scenario,


### PR DESCRIPTION
## Summary
- Add generic lifecycle timing evidence to MCC mass-adjudication run summaries.
- Record validator phases for health checks, reference seeding, validation plan setup, corpus generation, fixture normalization, member/coverage seeding, provider seeding, timed adjudication, pend observation, false-pend sweep, and optional diagnostics.
- Surface preparation time, tracked lifecycle time, and per-phase timing cards in the Mass Adjudication console when new summaries include the data.
- Add regression coverage for lifecycle timing serialization through the MCC summary builder.

## Why
Part 8 made the distinction between timed adjudication and total Kubernetes job duration important. The console could show claim-processing metrics, but it could not yet explain where preparation time went. This adds a generic timing shape that still supports the current mass-adjudication page and can later be reused by payment, 834, or other run evidence surfaces.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore --filter "FullyQualifiedName~MassAdjudicationRunRepositoryTests" --logger "console;verbosity=minimal"`
- `dotnet build src/services/claims-service/claims-service.csproj --no-restore`
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore`

Portal build still reports existing unrelated warnings in other pages/services; no new build errors.
