### PR TITLE
Expose MCC fixture preparation evidence

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -248,6 +248,48 @@
                     <MudItem xs="12" md="4">@RunFact("Seeding", $"members {OnOff(_selectedRun.Run.SeedMembers)} · providers {OnOff(_selectedRun.Run.SeedProviders)}")</MudItem>
                 </MudGrid>
 
+                @if (HasFixturePreparation(_selectedRun))
+                {
+                    var fixture = _selectedRun.FixturePreparation!;
+                    <MudDivider Class="my-3" Style="border-color: rgba(0,255,255,0.12);" />
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65); font-weight: 700;">Fixture Preparation</MudText>
+                    <MudGrid Spacing="2" Class="mt-1 mb-3">
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact("Generated Corpus", $"{fixture.GeneratedClaims:N0} claims", PreparationBottleneck(_selectedRun))
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact(
+                                "Provider Pool",
+                                $"{fixture.ProviderPoolDistinctBefore:N0} -> {fixture.ProviderPoolDistinctAfter:N0}",
+                                $"{fixture.ProviderPoolReusedAssignments:N0} reused · {fixture.ProviderPoolProtectedClaims:N0} protected")
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact(
+                                "Members",
+                                $"{fixture.MembersCreated:N0} new / {fixture.MembersExisting:N0} existing",
+                                $"{fixture.MemberStatusesAligned:N0} statuses aligned")
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact(
+                                "COB Coverage",
+                                $"{fixture.CobCoverageCreated:N0} new / {fixture.CobCoverageExisting:N0} existing",
+                                "expected-pend coverage rows")
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact(
+                                "Provider Networks",
+                                $"{fixture.ProviderNetworksCreated:N0} new / {fixture.ProviderNetworksExisting:N0} existing",
+                                "local MCC network fixtures")
+                        </MudItem>
+                        <MudItem xs="12" sm="6" md="4">
+                            @FixtureFact(
+                                "Providers",
+                                $"{fixture.ProvidersCreated:N0} new / {fixture.ProvidersExisting:N0} existing",
+                                ProviderCacheLabel(fixture))
+                        </MudItem>
+                    </MudGrid>
+                }
+
                 <MudGrid Spacing="2">
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.SubmitTiming)</MudItem>
                     <MudItem xs="12" sm="4">@Timing(_selectedRun.AdjudicateTiming)</MudItem>
@@ -722,6 +764,42 @@
     private static double LifecycleDuration(MassAdjudicationRunSummary run)
         => run.LifecycleTimings.Sum(t => t.DurationMilliseconds);
 
+    private static bool HasFixturePreparation(MassAdjudicationRunSummary run)
+    {
+        var fixture = run.FixturePreparation;
+        return fixture is not null
+            && (fixture.GeneratedClaims > 0
+                || fixture.ProviderPoolDistinctBefore > 0
+                || fixture.MembersCreated > 0
+                || fixture.MembersExisting > 0
+                || fixture.ProvidersCreated > 0
+                || fixture.ProvidersExisting > 0);
+    }
+
+    private static string PreparationBottleneck(MassAdjudicationRunSummary run)
+    {
+        var bottleneck = run.LifecycleTimings
+            .Where(t => string.Equals(t.Category, "Preparation", StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(t => t.DurationMilliseconds)
+            .FirstOrDefault();
+
+        return bottleneck is null
+            ? "preparation timing unavailable"
+            : $"{bottleneck.Label} · {FormatDuration(bottleneck.DurationMilliseconds)}";
+    }
+
+    private static string ProviderCacheLabel(MassAdjudicationFixturePreparation fixture)
+    {
+        var total = fixture.ProvidersCreated + fixture.ProvidersExisting;
+        if (total <= 0)
+        {
+            return "provider seeding disabled";
+        }
+
+        var hitRate = (double)fixture.ProvidersExisting / total;
+        return $"{hitRate:P0} already present";
+    }
+
     private static string FormatDuration(double milliseconds)
     {
         var duration = TimeSpan.FromMilliseconds(Math.Max(0, milliseconds));
@@ -841,6 +919,28 @@
         builder.AddAttribute(8, "Typo", Typo.body2);
         builder.AddAttribute(9, "Style", "color: #e2e8f0; font-family: monospace;");
         builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.CloseElement();
+    };
+
+    private RenderFragment FixtureFact(string label, string value, string detail) => builder =>
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "style", "border: 1px solid rgba(250,204,21,0.25); background: rgba(250,204,21,0.06); border-radius: 8px; padding: 10px; min-height: 76px;");
+        builder.OpenComponent<MudText>(2);
+        builder.AddAttribute(3, "Typo", Typo.caption);
+        builder.AddAttribute(4, "Style", "color: rgba(255,255,255,0.55);");
+        builder.AddAttribute(5, "ChildContent", (RenderFragment)(b => b.AddContent(6, label)));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(7);
+        builder.AddAttribute(8, "Typo", Typo.body2);
+        builder.AddAttribute(9, "Style", "color: #facc15; font-family: monospace; font-weight: 700;");
+        builder.AddAttribute(10, "ChildContent", (RenderFragment)(b => b.AddContent(11, value)));
+        builder.CloseComponent();
+        builder.OpenComponent<MudText>(12);
+        builder.AddAttribute(13, "Typo", Typo.caption);
+        builder.AddAttribute(14, "Style", "color: rgba(255,255,255,0.62);");
+        builder.AddAttribute(15, "ChildContent", (RenderFragment)(b => b.AddContent(16, detail)));
         builder.CloseComponent();
         builder.CloseElement();
     };

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -253,9 +253,12 @@
                     var fixture = _selectedRun.FixturePreparation!;
                     <MudDivider Class="my-3" Style="border-color: rgba(0,255,255,0.12);" />
                     <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65); font-weight: 700;">Fixture Preparation</MudText>
+                    <MudText Typo="Typo.caption" Class="d-block mt-1" Style="color: rgba(255,255,255,0.62);">
+                        Preparation bottleneck: @PreparationBottleneck(_selectedRun)
+                    </MudText>
                     <MudGrid Spacing="2" Class="mt-1 mb-3">
                         <MudItem xs="12" sm="6" md="4">
-                            @FixtureFact("Generated Corpus", $"{fixture.GeneratedClaims:N0} claims", PreparationBottleneck(_selectedRun))
+                            @FixtureFact("Generated Corpus", $"{fixture.GeneratedClaims:N0} claims", "deterministic synthetic claims")
                         </MudItem>
                         <MudItem xs="12" sm="6" md="4">
                             @FixtureFact(
@@ -267,25 +270,25 @@
                             @FixtureFact(
                                 "Members",
                                 $"{fixture.MembersCreated:N0} new / {fixture.MembersExisting:N0} existing",
-                                $"{fixture.MemberStatusesAligned:N0} statuses aligned")
+                                MemberFixtureLabel(_selectedRun, fixture))
                         </MudItem>
                         <MudItem xs="12" sm="6" md="4">
                             @FixtureFact(
                                 "COB Coverage",
                                 $"{fixture.CobCoverageCreated:N0} new / {fixture.CobCoverageExisting:N0} existing",
-                                "expected-pend coverage rows")
+                                CobCoverageLabel(_selectedRun, fixture))
                         </MudItem>
                         <MudItem xs="12" sm="6" md="4">
                             @FixtureFact(
                                 "Provider Networks",
                                 $"{fixture.ProviderNetworksCreated:N0} new / {fixture.ProviderNetworksExisting:N0} existing",
-                                "local MCC network fixtures")
+                                ProviderNetworkLabel(_selectedRun, fixture))
                         </MudItem>
                         <MudItem xs="12" sm="6" md="4">
                             @FixtureFact(
                                 "Providers",
                                 $"{fixture.ProvidersCreated:N0} new / {fixture.ProvidersExisting:N0} existing",
-                                ProviderCacheLabel(fixture))
+                                ProviderCacheLabel(_selectedRun, fixture))
                         </MudItem>
                     </MudGrid>
                 }
@@ -770,8 +773,16 @@
         return fixture is not null
             && (fixture.GeneratedClaims > 0
                 || fixture.ProviderPoolDistinctBefore > 0
+                || fixture.ProviderPoolDistinctAfter > 0
+                || fixture.ProviderPoolReusedAssignments > 0
+                || fixture.ProviderPoolProtectedClaims > 0
                 || fixture.MembersCreated > 0
                 || fixture.MembersExisting > 0
+                || fixture.MemberStatusesAligned > 0
+                || fixture.CobCoverageCreated > 0
+                || fixture.CobCoverageExisting > 0
+                || fixture.ProviderNetworksCreated > 0
+                || fixture.ProviderNetworksExisting > 0
                 || fixture.ProvidersCreated > 0
                 || fixture.ProvidersExisting > 0);
     }
@@ -788,12 +799,56 @@
             : $"{bottleneck.Label} · {FormatDuration(bottleneck.DurationMilliseconds)}";
     }
 
-    private static string ProviderCacheLabel(MassAdjudicationFixturePreparation fixture)
+    private static string MemberFixtureLabel(MassAdjudicationRunSummary run, MassAdjudicationFixturePreparation fixture)
     {
+        if (!run.Run.SeedMembers)
+        {
+            return "member seeding disabled";
+        }
+
+        var total = fixture.MembersCreated + fixture.MembersExisting;
+        return total <= 0
+            ? "no member fixtures needed"
+            : $"{fixture.MemberStatusesAligned:N0} statuses aligned";
+    }
+
+    private static string CobCoverageLabel(MassAdjudicationRunSummary run, MassAdjudicationFixturePreparation fixture)
+    {
+        if (!run.Run.SeedMembers)
+        {
+            return "member seeding disabled";
+        }
+
+        var total = fixture.CobCoverageCreated + fixture.CobCoverageExisting;
+        return total <= 0
+            ? "no expected-pend COB rows"
+            : "expected-pend coverage rows";
+    }
+
+    private static string ProviderNetworkLabel(MassAdjudicationRunSummary run, MassAdjudicationFixturePreparation fixture)
+    {
+        if (!run.Run.SeedProviders)
+        {
+            return "provider seeding disabled";
+        }
+
+        var total = fixture.ProviderNetworksCreated + fixture.ProviderNetworksExisting;
+        return total <= 0
+            ? "no network fixtures needed"
+            : "local MCC network fixtures";
+    }
+
+    private static string ProviderCacheLabel(MassAdjudicationRunSummary run, MassAdjudicationFixturePreparation fixture)
+    {
+        if (!run.Run.SeedProviders)
+        {
+            return "provider seeding disabled";
+        }
+
         var total = fixture.ProvidersCreated + fixture.ProvidersExisting;
         if (total <= 0)
         {
-            return "provider seeding disabled";
+            return "no provider fixtures needed";
         }
 
         var hitRate = (double)fixture.ProvidersExisting / total;

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -104,6 +104,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public List<MassAdjudicationLifecycleTiming> LifecycleTimings { get; set; } = new();
+    public MassAdjudicationFixturePreparation? FixturePreparation { get; set; }
     public decimal? AveragePaymentDelta { get; set; }
     public decimal PaymentTolerance { get; set; }
     public int PaymentComparisons { get; set; }
@@ -166,6 +167,24 @@ public class MassAdjudicationLifecycleTiming
     public double DurationMilliseconds { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationFixturePreparation
+{
+    public int GeneratedClaims { get; set; }
+    public int ProviderPoolDistinctBefore { get; set; }
+    public int ProviderPoolDistinctAfter { get; set; }
+    public int ProviderPoolReusedAssignments { get; set; }
+    public int ProviderPoolProtectedClaims { get; set; }
+    public int MembersCreated { get; set; }
+    public int MembersExisting { get; set; }
+    public int MemberStatusesAligned { get; set; }
+    public int CobCoverageCreated { get; set; }
+    public int CobCoverageExisting { get; set; }
+    public int ProviderNetworksCreated { get; set; }
+    public int ProviderNetworksExisting { get; set; }
+    public int ProvidersCreated { get; set; }
+    public int ProvidersExisting { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -28,6 +28,7 @@ public class MassAdjudicationRunSummary
     public MassAdjudicationStageTiming? WritebackTiming { get; set; }
     public List<MassAdjudicationStageTiming> AdjudicationStepTimings { get; set; } = new();
     public List<MassAdjudicationLifecycleTiming> LifecycleTimings { get; set; } = new();
+    public MassAdjudicationFixturePreparation? FixturePreparation { get; set; }
     public decimal? AveragePaymentDelta { get; set; }
     public decimal PaymentTolerance { get; set; }
     public int PaymentComparisons { get; set; }
@@ -91,6 +92,24 @@ public class MassAdjudicationLifecycleTiming
     public double DurationMilliseconds { get; set; }
     public DateTimeOffset StartedAtUtc { get; set; }
     public DateTimeOffset CompletedAtUtc { get; set; }
+}
+
+public class MassAdjudicationFixturePreparation
+{
+    public int GeneratedClaims { get; set; }
+    public int ProviderPoolDistinctBefore { get; set; }
+    public int ProviderPoolDistinctAfter { get; set; }
+    public int ProviderPoolReusedAssignments { get; set; }
+    public int ProviderPoolProtectedClaims { get; set; }
+    public int MembersCreated { get; set; }
+    public int MembersExisting { get; set; }
+    public int MemberStatusesAligned { get; set; }
+    public int CobCoverageCreated { get; set; }
+    public int CobCoverageExisting { get; set; }
+    public int ProviderNetworksCreated { get; set; }
+    public int ProviderNetworksExisting { get; set; }
+    public int ProvidersCreated { get; set; }
+    public int ProvidersExisting { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -15,7 +15,8 @@ internal static class MccRunSummaryBuilder
         int? totalClaimsOverride = null,
         MassAdjudicationRunProgress? progress = null,
         bool publishClaimResults = true,
-        IReadOnlyList<MassAdjudicationLifecycleTiming>? lifecycleTimings = null)
+        IReadOnlyList<MassAdjudicationLifecycleTiming>? lifecycleTimings = null,
+        MassAdjudicationFixturePreparation? fixturePreparation = null)
     {
         var totalClaims = Math.Max(results.Count, totalClaimsOverride ?? results.Count);
         var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
@@ -135,6 +136,7 @@ internal static class MccRunSummaryBuilder
             BuildStageTiming("Writeback", results.Select(r => r.UpdateElapsed)),
             BuildAdjudicationStepTimings(results),
             lifecycleTimings ?? Array.Empty<MassAdjudicationLifecycleTiming>(),
+            fixturePreparation,
             avgDelta,
             PaymentTolerance,
             comparable.Count,

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -97,23 +97,53 @@ Console.WriteLine(
     $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
 var answerKey = MccAnswerKey.FromClaims(claims);
 
+var memberFixtures = MemberFixturePreparation.Empty;
+var cobCoverageFixtures = FixtureCount.Empty;
 if (options.SeedMembers)
 {
-    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Member and coverage seeding", "Preparation", async () =>
+    (memberFixtures, cobCoverageFixtures) = await MeasureLifecycleValuePhaseAsync(
+        lifecycleTimings,
+        "Member and coverage seeding",
+        "Preparation",
+        async () =>
     {
-        await SeedMembersAsync(http, options, claims, json);
-        await SeedCoverageAsync(http, options, claims, validationPlanId, json);
+        var members = await SeedMembersAsync(http, options, claims, json);
+        var coverage = await SeedCoverageAsync(http, options, claims, validationPlanId, json);
+        return (members, coverage);
     });
 }
 
+var providerNetworkFixtures = FixtureCount.Empty;
+var providerFixtures = FixtureCount.Empty;
 if (options.SeedProviders)
 {
-    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Provider seeding", "Preparation", async () =>
+    (providerNetworkFixtures, providerFixtures) = await MeasureLifecycleValuePhaseAsync(
+        lifecycleTimings,
+        "Provider seeding",
+        "Preparation",
+        async () =>
     {
-        await SeedProviderNetworksAsync(http, options, json);
-        await SeedProvidersAsync(http, options, claims, validationPlanId, json);
+        var networks = await SeedProviderNetworksAsync(http, options, json);
+        var providers = await SeedProvidersAsync(http, options, claims, validationPlanId, json);
+        return (networks, providers);
     });
 }
+
+var fixturePreparation = new MassAdjudicationFixturePreparation(
+    claims.Count,
+    providerPool.ProvidersBefore,
+    providerPool.ProvidersAfter,
+    providerPool.ReusedAssignments,
+    providerPool.ProtectedClaims,
+    memberFixtures.Created,
+    memberFixtures.Existing,
+    memberFixtures.StatusAligned,
+    cobCoverageFixtures.Created,
+    cobCoverageFixtures.Existing,
+    providerNetworkFixtures.Created,
+    providerNetworkFixtures.Existing,
+    providerFixtures.Created,
+    providerFixtures.Existing);
 
 var results = new ConcurrentBag<ClaimValidationResult>();
 var total = new Stopwatch();
@@ -134,7 +164,8 @@ if (!options.NoPublishSummary)
         runId,
         runStartedAtUtc,
         "Running",
-        "Processing claims");
+        "Processing claims",
+        fixturePreparation);
     await PublishSummaryAsync(http, options, initialProgress, json, quiet: true);
 }
 
@@ -177,7 +208,8 @@ await Parallel.ForEachAsync(
                             runId,
                             runStartedAtUtc,
                             "Running",
-                            "Processing claims");
+                            "Processing claims",
+                            fixturePreparation);
                         var publishTask = PublishProgressSummaryAsync(progressPublishGate, http, options, progressSummary, json);
                         lock (latestProgressPublishLock)
                         {
@@ -246,7 +278,8 @@ var summary = MccRunSummaryBuilder.Build(
     options.Claims,
     CreateProgress(orderedResults, total.Elapsed, options, "Completed"),
     publishClaimResults: true,
-    lifecycleTimings: lifecycleTimings);
+    lifecycleTimings: lifecycleTimings,
+    fixturePreparation: fixturePreparation);
 WriteSummary(summary);
 
 if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
@@ -989,7 +1022,7 @@ static int CalculateNpiCheckDigit(string baseNineDigits)
     return (10 - (sum % 10)) % 10;
 }
 
-static async Task SeedMembersAsync(
+static async Task<MemberFixturePreparation> SeedMembersAsync(
     HttpClient http,
     ValidatorOptions options,
     IReadOnlyCollection<SyntheticClaim> claims,
@@ -1036,6 +1069,7 @@ static async Task SeedMembersAsync(
     }
 
     Console.WriteLine($"seeded: {created:N0} synthetic members ({existing:N0} already present, {statusAligned:N0} status-aligned)");
+    return new MemberFixturePreparation(created, existing, statusAligned);
 }
 
 static async Task<bool> MemberExistsAsync(HttpClient http, ValidatorOptions options, string memberId)
@@ -1134,7 +1168,7 @@ static async Task<bool> UpdateMemberSeedStatusAsync(
     return true;
 }
 
-static async Task SeedCoverageAsync(
+static async Task<FixtureCount> SeedCoverageAsync(
     HttpClient http,
     ValidatorOptions options,
     IReadOnlyCollection<SyntheticClaim> claims,
@@ -1151,7 +1185,7 @@ static async Task SeedCoverageAsync(
     if (cobClaims.Count == 0)
     {
         Console.WriteLine("seeded: 0 COB coverage rows (no supported COB-pend scenarios)");
-        return;
+        return FixtureCount.Empty;
     }
 
     var created = 0;
@@ -1169,6 +1203,7 @@ static async Task SeedCoverageAsync(
     }
 
     Console.WriteLine($"seeded: {created:N0} COB coverage rows ({existing:N0} already present)");
+    return new FixtureCount(created, existing);
 }
 
 static bool IsCobPendScenario(SyntheticClaim claim)
@@ -1277,7 +1312,7 @@ static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
     }
 }
 
-static async Task SeedProvidersAsync(
+static async Task<FixtureCount> SeedProvidersAsync(
     HttpClient http,
     ValidatorOptions options,
     IReadOnlyCollection<SyntheticClaim> claims,
@@ -1326,9 +1361,10 @@ static async Task SeedProvidersAsync(
     }
 
     Console.WriteLine($"seeded: {created:N0} synthetic providers ({existing:N0} already present)");
+    return new FixtureCount(created, existing);
 }
 
-static async Task SeedProviderNetworksAsync(
+static async Task<FixtureCount> SeedProviderNetworksAsync(
     HttpClient http,
     ValidatorOptions options,
     JsonSerializerOptions json)
@@ -1354,6 +1390,7 @@ static async Task SeedProviderNetworksAsync(
     }
 
     Console.WriteLine($"seeded: {created:N0} provider networks ({existing:N0} already present)");
+    return new FixtureCount(created, existing);
 }
 
 static async Task<bool> ProviderNetworkExistsAsync(HttpClient http, ValidatorOptions options, string networkId)
@@ -2240,7 +2277,8 @@ static MassAdjudicationRunSummary BuildProgressSummary(
     string runId,
     DateTimeOffset runStartedAtUtc,
     string status,
-    string phase)
+    string phase,
+    MassAdjudicationFixturePreparation fixturePreparation)
 {
     var runCompletedAtUtc = DateTimeOffset.UtcNow;
     var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
@@ -2296,6 +2334,7 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         null,
         Array.Empty<MassAdjudicationStageTiming>(),
         Array.Empty<MassAdjudicationLifecycleTiming>(),
+        fixturePreparation,
         null,
         MccRunSummaryBuilder.PaymentTolerance,
         0,
@@ -2546,6 +2585,7 @@ internal sealed record MassAdjudicationRunSummary(
     MassAdjudicationStageTiming? WritebackTiming,
     IReadOnlyList<MassAdjudicationStageTiming> AdjudicationStepTimings,
     IReadOnlyList<MassAdjudicationLifecycleTiming> LifecycleTimings,
+    MassAdjudicationFixturePreparation? FixturePreparation,
     decimal? AveragePaymentDelta,
     decimal PaymentTolerance,
     int PaymentComparisons,
@@ -2600,6 +2640,32 @@ internal sealed record MassAdjudicationLifecycleTiming(
     double DurationMilliseconds,
     DateTimeOffset StartedAtUtc,
     DateTimeOffset CompletedAtUtc);
+
+internal sealed record MassAdjudicationFixturePreparation(
+    int GeneratedClaims,
+    int ProviderPoolDistinctBefore,
+    int ProviderPoolDistinctAfter,
+    int ProviderPoolReusedAssignments,
+    int ProviderPoolProtectedClaims,
+    int MembersCreated,
+    int MembersExisting,
+    int MemberStatusesAligned,
+    int CobCoverageCreated,
+    int CobCoverageExisting,
+    int ProviderNetworksCreated,
+    int ProviderNetworksExisting,
+    int ProvidersCreated,
+    int ProvidersExisting);
+
+internal sealed record MemberFixturePreparation(int Created, int Existing, int StatusAligned)
+{
+    public static MemberFixturePreparation Empty { get; } = new(0, 0, 0);
+}
+
+internal sealed record FixtureCount(int Created, int Existing)
+{
+    public static FixtureCount Empty { get; } = new(0, 0);
+}
 
 internal sealed record MassAdjudicationBusinessDenialSummary(
     string Code,

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -171,6 +171,50 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(completedAt, timing.CompletedAtUtc);
     }
 
+    [Fact]
+    public void Build_IncludesFixturePreparationSummary()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-07-14T00:00:00Z");
+        var completedAt = DateTimeOffset.Parse("2026-07-14T00:00:01Z");
+        var options = ValidatorOptions.Parse(["--claims", "1"]);
+        var fixturePreparation = new MassAdjudicationFixturePreparation(
+            GeneratedClaims: 1_000,
+            ProviderPoolDistinctBefore: 2_000,
+            ProviderPoolDistinctAfter: 1_096,
+            ProviderPoolReusedAssignments: 904,
+            ProviderPoolProtectedClaims: 28,
+            MembersCreated: 108,
+            MembersExisting: 892,
+            MemberStatusesAligned: 1_000,
+            CobCoverageCreated: 0,
+            CobCoverageExisting: 9,
+            ProviderNetworksCreated: 0,
+            ProviderNetworksExisting: 2,
+            ProvidersCreated: 1_077,
+            ProvidersExisting: 19);
+
+        var summary = MccRunSummaryBuilder.Build(
+            [Result("MCC-1", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)],
+            TimeSpan.FromSeconds(1),
+            options,
+            startedAt,
+            completedAt,
+            fixturePreparation: fixturePreparation);
+
+        Assert.NotNull(summary.FixturePreparation);
+        Assert.Equal(1_000, summary.FixturePreparation.GeneratedClaims);
+        Assert.Equal(2_000, summary.FixturePreparation.ProviderPoolDistinctBefore);
+        Assert.Equal(1_096, summary.FixturePreparation.ProviderPoolDistinctAfter);
+        Assert.Equal(904, summary.FixturePreparation.ProviderPoolReusedAssignments);
+        Assert.Equal(28, summary.FixturePreparation.ProviderPoolProtectedClaims);
+        Assert.Equal(108, summary.FixturePreparation.MembersCreated);
+        Assert.Equal(892, summary.FixturePreparation.MembersExisting);
+        Assert.Equal(1_000, summary.FixturePreparation.MemberStatusesAligned);
+        Assert.Equal(9, summary.FixturePreparation.CobCoverageExisting);
+        Assert.Equal(1_077, summary.FixturePreparation.ProvidersCreated);
+        Assert.Equal(19, summary.FixturePreparation.ProvidersExisting);
+    }
+
     private static ClaimValidationResult Result(
         string claimId,
         string? scenario,

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -210,7 +210,10 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(108, summary.FixturePreparation.MembersCreated);
         Assert.Equal(892, summary.FixturePreparation.MembersExisting);
         Assert.Equal(1_000, summary.FixturePreparation.MemberStatusesAligned);
+        Assert.Equal(0, summary.FixturePreparation.CobCoverageCreated);
         Assert.Equal(9, summary.FixturePreparation.CobCoverageExisting);
+        Assert.Equal(0, summary.FixturePreparation.ProviderNetworksCreated);
+        Assert.Equal(2, summary.FixturePreparation.ProviderNetworksExisting);
         Assert.Equal(1_077, summary.FixturePreparation.ProvidersCreated);
         Assert.Equal(19, summary.FixturePreparation.ProvidersExisting);
     }


### PR DESCRIPTION
## Summary

- adds a typed fixture-preparation summary to MCC mass adjudication run summaries
- publishes generated-claim, provider-pool, member, COB coverage, provider-network, and provider seeding counts
- surfaces those counts in the Mass Adjudication console with a preparation bottleneck label
- adds a validator summary-builder regression test for fixture preparation evidence

## Why

Part 8 made fixture preparation the visible local scaling bottleneck. Lifecycle timing showed where time went, but the console still did not show the row-level preparation evidence behind that timing. This PR makes the run summary explain whether preparation cost came from new fixture creation, existing fixture reuse, provider-pool reduction, or disabled seeding.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet build src/services/claims-service/claims-service.csproj --no-restore`
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore`

Portal build still reports existing unrelated warnings in other pages/services; no new errors.
