### PR TITLE
Populate claim diagnosis metadata

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/ReferenceData/DiagnosisCodes.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/ReferenceData/DiagnosisCodes.cs
@@ -4,7 +4,7 @@ namespace CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
 /// Common ICD-10-CM diagnosis codes used in synthetic claim generation.
 /// Codes are organized by clinical category for realistic claim construction.
 /// </summary>
-internal static class DiagnosisCodes
+public static class DiagnosisCodes
 {
     /// <summary>General/primary care diagnosis codes.</summary>
     internal static readonly (string Code, string Description)[] General =
@@ -101,4 +101,27 @@ internal static class DiagnosisCodes
         ("P07.39", "Other preterm newborn"),
         ("P92.5", "Neonatal difficulty in feeding at breast")
     };
+
+    /// <summary>Returns the display description for a known synthetic ICD-10-CM diagnosis code.</summary>
+    public static string? FindDescription(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return null;
+        }
+
+        return AllCodes()
+            .FirstOrDefault(dx => string.Equals(dx.Code, code, StringComparison.OrdinalIgnoreCase))
+            .Description;
+    }
+
+    private static IEnumerable<(string Code, string Description)> AllCodes()
+    {
+        foreach (var diagnosisCode in General) yield return diagnosisCode;
+        foreach (var diagnosisCode in Surgical) yield return diagnosisCode;
+        foreach (var diagnosisCode in Emergency) yield return diagnosisCode;
+        foreach (var diagnosisCode in BehavioralHealth) yield return diagnosisCode;
+        foreach (var diagnosisCode in Dental) yield return diagnosisCode;
+        foreach (var diagnosisCode in Newborn) yield return diagnosisCode;
+    }
 }

--- a/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/ClaimDetailsNew.razor
@@ -266,7 +266,9 @@
                             <MudText Typo="Typo.body2" Style="font-family: monospace; font-weight: 600;">@context.Code</MudText>
                         </MudTd>
                         <MudTd DataLabel="Description">
-                            <MudText Typo="Typo.body2">@context.Description</MudText>
+                            <MudText Typo="Typo.body2">
+                                @(string.IsNullOrWhiteSpace(context.Description) ? "Description unavailable" : context.Description)
+                            </MudText>
                         </MudTd>
                         <MudTd DataLabel="Type">
                             <MudChip Size="Size.Small" Variant="Variant.Outlined">@context.Type</MudChip>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -794,10 +794,31 @@ public class ClaimDetails : ClaimSummary
 
 public class ClaimDiagnosisCode
 {
+    private string _codeQualifier = string.Empty;
+    private string _type = string.Empty;
+
     public string Code { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public string Type { get; set; } = string.Empty; // Principal, Secondary
+    public string CodeQualifier
+    {
+        get => _codeQualifier;
+        set => _codeQualifier = value ?? string.Empty;
+    }
+    public string Type
+    {
+        get => !string.IsNullOrWhiteSpace(_type) ? _type : DiagnosisTypeLabel(CodeQualifier);
+        set => _type = value ?? string.Empty;
+    }
     public int PointerNumber { get; set; }
+
+    private static string DiagnosisTypeLabel(string qualifier)
+        => qualifier.Trim().ToUpperInvariant() switch
+        {
+            "ABK" => "Principal",
+            "ABF" => "Secondary",
+            "" => "Unspecified",
+            _ => qualifier
+        };
 }
 
 public class ClaimServiceLine

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2018,7 +2018,8 @@ static List<object> BuildDiagnosisCodes(SyntheticClaim claim)
         {
             code,
             codeQualifier = index == 0 ? "ABK" : "ABF",
-            pointerNumber = index + 1
+            pointerNumber = index + 1,
+            description = DiagnosisCodes.FindDescription(code)
         })
         .Cast<object>()
         .ToList();

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/DiagnosisCodesTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/DiagnosisCodesTests.cs
@@ -1,0 +1,21 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
+
+namespace CloudHealthOffice.BenchmarkClaimGenerator.Tests;
+
+public class DiagnosisCodesTests
+{
+    [Theory]
+    [InlineData("K08.1", "Complete loss of teeth")]
+    [InlineData("k08.1", "Complete loss of teeth")]
+    [InlineData("Z38.00", "Single liveborn infant, delivered vaginally")]
+    public void FindDescription_ReturnsSyntheticDiagnosisDescription(string code, string expectedDescription)
+    {
+        Assert.Equal(expectedDescription, DiagnosisCodes.FindDescription(code));
+    }
+
+    [Fact]
+    public void FindDescription_ReturnsNullForUnknownCode()
+    {
+        Assert.Null(DiagnosisCodes.FindDescription("ZZZ.999"));
+    }
+}


### PR DESCRIPTION
## Summary
- publish MCC diagnosis descriptions in generated claim payloads using the benchmark generator reference data
- map backend `codeQualifier` values to readable portal labels (`Principal`, `Secondary`, `Unspecified`)
- show an explicit fallback when an older claim has no diagnosis description
- add regression coverage for synthetic diagnosis description lookup

## Why
Claim detail pages were showing diagnosis codes with blank description and type columns. The synthetic corpus already had the diagnosis descriptions, but the validator was not sending them to claim-service, and the portal DTO was not translating `ABK`/`ABF` qualifiers into display labels.

## Validation
- `dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore --logger "console;verbosity=minimal"`
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore`

Portal build passes with existing unrelated warnings.
