### PR TITLE
Enrich claim diagnosis metadata

### DIFF
--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -20,6 +20,7 @@ public class ClaimsController : ControllerBase
     private readonly IClaimEventPublisher _eventPublisher;
     private readonly IClaimSubmissionService _submissionService;
     private readonly IClaimFinalizationService _finalizationService;
+    private readonly IClaimDiagnosisMetadataEnricher _diagnosisMetadataEnricher;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ClaimsController> _logger;
 
@@ -32,6 +33,7 @@ public class ClaimsController : ControllerBase
         IClaimEventPublisher eventPublisher,
         IClaimSubmissionService submissionService,
         IClaimFinalizationService finalizationService,
+        IClaimDiagnosisMetadataEnricher diagnosisMetadataEnricher,
         IConfiguration configuration,
         ILogger<ClaimsController> logger)
     {
@@ -43,6 +45,7 @@ public class ClaimsController : ControllerBase
         _eventPublisher = eventPublisher;
         _submissionService = submissionService;
         _finalizationService = finalizationService;
+        _diagnosisMetadataEnricher = diagnosisMetadataEnricher;
         _configuration = configuration;
         _logger = logger;
     }
@@ -185,6 +188,7 @@ public class ClaimsController : ControllerBase
             status: null, lineOfBusiness: null,
             page: 1, pageSize: count);
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claims);
         return Ok(claims);
     }
 
@@ -204,6 +208,7 @@ public class ClaimsController : ControllerBase
             return NotFound($"Claim {id} not found");
         }
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claim);
         return Ok(claim);
     }
 
@@ -248,6 +253,7 @@ public class ClaimsController : ControllerBase
             return NotFound($"Claim {claimNumber} not found");
         }
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claim);
         return Ok(claim);
     }
 
@@ -273,6 +279,7 @@ public class ClaimsController : ControllerBase
         var claims = await _claimRepository.SearchAsync(
             memberId, providerNPI, serviceDateFrom, serviceDateTo, status, lineOfBusiness, page, pageSize);
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claims);
         return Ok(claims);
     }
 
@@ -305,6 +312,7 @@ public class ClaimsController : ControllerBase
                 body.PageNumber,
                 body.PageSize);
 
+            await _diagnosisMetadataEnricher.EnrichAsync(runPage, ct);
             return Ok(new { claims = runPage, totalCount = runTotalCount, pageNumber = body.PageNumber, pageSize = body.PageSize });
         }
 
@@ -318,6 +326,7 @@ public class ClaimsController : ControllerBase
             body.PageNumber,
             body.PageSize);
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claims, ct);
         return Ok(new { claims, totalCount, pageNumber = body.PageNumber, pageSize = body.PageSize });
     }
 

--- a/src/services/claims-service/Controllers/FhirExplanationOfBenefitController.cs
+++ b/src/services/claims-service/Controllers/FhirExplanationOfBenefitController.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Nodes;
 using ClaimsService.Fhir;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
+using ClaimsService.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ClaimsService.Controllers;
@@ -41,15 +42,18 @@ public class FhirExplanationOfBenefitController : ControllerBase
 
     private readonly IClaimRepository _repository;
     private readonly IExplanationOfBenefitProjector _projector;
+    private readonly IClaimDiagnosisMetadataEnricher _diagnosisMetadataEnricher;
     private readonly ILogger<FhirExplanationOfBenefitController> _logger;
 
     public FhirExplanationOfBenefitController(
         IClaimRepository repository,
         IExplanationOfBenefitProjector projector,
+        IClaimDiagnosisMetadataEnricher diagnosisMetadataEnricher,
         ILogger<FhirExplanationOfBenefitController> logger)
     {
         _repository = repository;
         _projector = projector;
+        _diagnosisMetadataEnricher = diagnosisMetadataEnricher;
         _logger = logger;
     }
 
@@ -108,6 +112,7 @@ public class FhirExplanationOfBenefitController : ControllerBase
                 $"ExplanationOfBenefit/{id} not found.");
         }
 
+        await _diagnosisMetadataEnricher.EnrichAsync(claim, ct);
         var projected = _projector.Project(claim);
         return new ContentResult
         {
@@ -191,6 +196,7 @@ public class FhirExplanationOfBenefitController : ControllerBase
                     // existence-of-resource through the status code.
                     return BuildBundleResponse(Array.Empty<Claim>(), total: 0);
                 }
+                await _diagnosisMetadataEnricher.EnrichAsync(single, ct);
                 return BuildBundleResponse(new[] { single }, total: 1);
             }
 
@@ -206,6 +212,7 @@ public class FhirExplanationOfBenefitController : ControllerBase
                 page: pageNumber,
                 pageSize: pageSize);
 
+            await _diagnosisMetadataEnricher.EnrichAsync(items, ct);
             return BuildBundleResponse(items, totalCount);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -102,6 +102,8 @@ builder.Services.AddSingleton<IExplanationOfBenefitProjector, ExplanationOfBenef
 
 // 277CA acknowledgment generator
 builder.Services.AddScoped<IClaimAcknowledgmentService, ClaimAcknowledgmentService>();
+builder.Services.AddScoped<IDiagnosisDescriptionLookup, DiagnosisDescriptionLookup>();
+builder.Services.AddScoped<IClaimDiagnosisMetadataEnricher, ClaimDiagnosisMetadataEnricher>();
 
 // 5.10 — claim finalization (Approved/PartiallyPaid → Paid). Owns the
 // idempotent Paid transition with version-event chain advancement and

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -1,0 +1,242 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Caching.Memory;
+using ClaimsService.Models;
+
+namespace ClaimsService.Services;
+
+public interface IClaimDiagnosisMetadataEnricher
+{
+    Task EnrichAsync(Claim claim, CancellationToken ct = default);
+    Task EnrichAsync(IEnumerable<Claim> claims, CancellationToken ct = default);
+}
+
+public sealed class ClaimDiagnosisMetadataEnricher : IClaimDiagnosisMetadataEnricher
+{
+    private readonly IDiagnosisDescriptionLookup _descriptionLookup;
+
+    public ClaimDiagnosisMetadataEnricher(IDiagnosisDescriptionLookup descriptionLookup)
+    {
+        _descriptionLookup = descriptionLookup;
+    }
+
+    public async Task EnrichAsync(IEnumerable<Claim> claims, CancellationToken ct = default)
+    {
+        foreach (var claim in claims)
+        {
+            await EnrichAsync(claim, ct);
+        }
+    }
+
+    public async Task EnrichAsync(Claim claim, CancellationToken ct = default)
+    {
+        for (var index = 0; index < claim.DiagnosisCodes.Count; index++)
+        {
+            var diagnosis = claim.DiagnosisCodes[index];
+            if (diagnosis.PointerNumber <= 0)
+            {
+                diagnosis.PointerNumber = index + 1;
+            }
+
+            if (string.IsNullOrWhiteSpace(diagnosis.CodeQualifier))
+            {
+                diagnosis.CodeQualifier = diagnosis.PointerNumber <= 1 ? "ABK" : "ABF";
+            }
+
+            if (string.IsNullOrWhiteSpace(diagnosis.Description))
+            {
+                diagnosis.Description = await _descriptionLookup.FindDescriptionAsync(diagnosis.Code, ct);
+            }
+        }
+    }
+}
+
+public interface IDiagnosisDescriptionLookup
+{
+    Task<string?> FindDescriptionAsync(string? code, CancellationToken ct = default);
+}
+
+public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
+{
+    private const string CacheKeyPrefix = "claims-service:diagnosis-description:";
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(6);
+    private static readonly TimeSpan NegativeCacheDuration = TimeSpan.FromMinutes(10);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IMemoryCache _cache;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DiagnosisDescriptionLookup> _logger;
+
+    public DiagnosisDescriptionLookup(
+        IHttpClientFactory httpClientFactory,
+        IMemoryCache cache,
+        IConfiguration configuration,
+        ILogger<DiagnosisDescriptionLookup> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _cache = cache;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<string?> FindDescriptionAsync(string? code, CancellationToken ct = default)
+    {
+        var normalizedCode = NormalizeCode(code);
+        if (normalizedCode is null)
+        {
+            return null;
+        }
+
+        var cacheKey = CacheKeyPrefix + normalizedCode;
+        if (_cache.TryGetValue<CachedDiagnosisDescription>(cacheKey, out var cached))
+        {
+            return cached?.Description;
+        }
+
+        if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
+        {
+            Cache(cacheKey, syntheticDescription);
+            return syntheticDescription;
+        }
+
+        // CHO.TerminologyService currently owns crosswalk/translation. The
+        // reference-data service is today's ICD-10 code-system display source.
+        var referenceDataDescription = await TryFindReferenceDataDescriptionAsync(normalizedCode, ct);
+        Cache(cacheKey, referenceDataDescription);
+        return referenceDataDescription;
+    }
+
+    private async Task<string?> TryFindReferenceDataDescriptionAsync(string code, CancellationToken ct)
+    {
+        var timeoutMilliseconds = Math.Clamp(
+            _configuration.GetValue<int?>("Services:ReferenceDataDisplayLookupTimeoutMilliseconds") ?? 750,
+            100,
+            3_000);
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+            var client = _httpClientFactory.CreateClient("ReferenceDataService");
+            var response = await client.GetFromJsonAsync<ReferenceDataValidationResponse>(
+                $"api/ReferenceData/icd10/{Uri.EscapeDataString(code)}/validate",
+                timeout.Token);
+
+            return string.IsNullOrWhiteSpace(response?.Description)
+                ? null
+                : response.Description;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogDebug(
+                "Reference data ICD-10 display lookup timed out for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Reference data ICD-10 display lookup failed for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+    }
+
+    private void Cache(string cacheKey, string? description)
+    {
+        _cache.Set(
+            cacheKey,
+            new CachedDiagnosisDescription(description),
+            description is null ? NegativeCacheDuration : CacheDuration);
+    }
+
+    private static string? NormalizeCode(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return null;
+        }
+
+        return code.Trim().ToUpperInvariant();
+    }
+
+    private static string SanitizeForLog(string value) =>
+        value.Replace("\r", "").Replace("\n", "");
+
+    private sealed record CachedDiagnosisDescription(string? Description);
+
+    private sealed class ReferenceDataValidationResponse
+    {
+        public string? Description { get; set; }
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> SyntheticDiagnosisDescriptions =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["J06.9"] = "Acute upper respiratory infection, unspecified",
+            ["J20.9"] = "Acute bronchitis, unspecified",
+            ["J18.9"] = "Pneumonia, unspecified organism",
+            ["M54.5"] = "Low back pain",
+            ["M79.3"] = "Panniculitis, unspecified",
+            ["R10.9"] = "Unspecified abdominal pain",
+            ["R51.9"] = "Headache, unspecified",
+            ["I10"] = "Essential (primary) hypertension",
+            ["E11.9"] = "Type 2 diabetes mellitus without complications",
+            ["E11.65"] = "Type 2 diabetes mellitus with hyperglycemia",
+            ["E78.5"] = "Dyslipidemia, unspecified",
+            ["F41.1"] = "Generalized anxiety disorder",
+            ["F32.1"] = "Major depressive disorder, single episode, moderate",
+            ["K21.0"] = "Gastro-esophageal reflux disease with esophagitis",
+            ["N39.0"] = "Urinary tract infection, site not specified",
+            ["J45.20"] = "Mild intermittent asthma, uncomplicated",
+            ["L30.9"] = "Dermatitis, unspecified",
+            ["H66.90"] = "Otitis media, unspecified, unspecified ear",
+            ["B34.9"] = "Viral infection, unspecified",
+            ["Z00.00"] = "Encounter for general adult medical examination without abnormal findings",
+            ["K80.20"] = "Calculus of gallbladder without cholecystitis without obstruction",
+            ["K40.90"] = "Unilateral inguinal hernia, without obstruction or gangrene, not specified as recurrent",
+            ["M17.11"] = "Primary osteoarthritis, right knee",
+            ["M17.12"] = "Primary osteoarthritis, left knee",
+            ["M16.11"] = "Primary osteoarthritis, right hip",
+            ["G56.00"] = "Carpal tunnel syndrome, unspecified upper limb",
+            ["H25.11"] = "Age-related nuclear cataract, right eye",
+            ["K35.80"] = "Unspecified acute appendicitis",
+            ["M75.110"] = "Incomplete rotator cuff tear of right shoulder",
+            ["N20.0"] = "Calculus of kidney",
+            ["I21.3"] = "ST elevation (STEMI) myocardial infarction of unspecified site",
+            ["I63.9"] = "Cerebral infarction, unspecified",
+            ["S72.001A"] = "Fracture of unspecified part of neck of right femur, initial encounter",
+            ["S52.501A"] = "Unspecified fracture of the lower end of right radius, initial encounter",
+            ["K92.2"] = "Gastrointestinal hemorrhage, unspecified",
+            ["R55"] = "Syncope and collapse",
+            ["R07.9"] = "Chest pain, unspecified",
+            ["S06.0X0A"] = "Concussion without loss of consciousness, initial encounter",
+            ["T78.2XXA"] = "Anaphylactic shock, unspecified, initial encounter",
+            ["J96.00"] = "Acute respiratory failure, unspecified whether with hypoxia or hypercapnia",
+            ["F33.1"] = "Major depressive disorder, recurrent, moderate",
+            ["F41.0"] = "Panic disorder without agoraphobia",
+            ["F43.10"] = "Post-traumatic stress disorder, unspecified",
+            ["F10.20"] = "Alcohol dependence, uncomplicated",
+            ["F11.20"] = "Opioid dependence, uncomplicated",
+            ["F31.9"] = "Bipolar disorder, unspecified",
+            ["F84.0"] = "Autistic disorder",
+            ["F90.9"] = "Attention-deficit hyperactivity disorder, unspecified type",
+            ["K02.9"] = "Dental caries, unspecified",
+            ["K04.0"] = "Pulpitis",
+            ["K05.10"] = "Chronic gingivitis, plaque induced",
+            ["K05.31"] = "Chronic periodontitis, localized, moderate",
+            ["K08.1"] = "Complete loss of teeth",
+            ["K08.401"] = "Partial loss of teeth, unspecified cause, class I",
+            ["K12.1"] = "Other forms of stomatitis",
+            ["M26.69"] = "Other specified disorders of temporomandibular joint",
+            ["K03.0"] = "Excessive attrition of teeth",
+            ["S02.5XXA"] = "Fracture of tooth (traumatic), initial encounter",
+            ["Z38.00"] = "Single liveborn infant, delivered vaginally",
+            ["Z38.01"] = "Single liveborn infant, delivered by cesarean",
+            ["P59.9"] = "Neonatal jaundice, unspecified",
+            ["P22.1"] = "Transient tachypnea of newborn",
+            ["P07.39"] = "Other preterm newborn",
+            ["P92.5"] = "Neonatal difficulty in feeding at breast"
+        };
+}

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.Extensions.Caching.Memory;
 using ClaimsService.Models;
 
@@ -21,13 +22,25 @@ public sealed class ClaimDiagnosisMetadataEnricher : IClaimDiagnosisMetadataEnri
 
     public async Task EnrichAsync(IEnumerable<Claim> claims, CancellationToken ct = default)
     {
+        var pendingDescriptions = new List<PendingDiagnosisDescription>();
         foreach (var claim in claims)
         {
-            await EnrichAsync(claim, ct);
+            PrepareDiagnosisMetadata(claim, pendingDescriptions);
         }
+
+        await PopulateDescriptionsAsync(pendingDescriptions, ct);
     }
 
     public async Task EnrichAsync(Claim claim, CancellationToken ct = default)
+    {
+        var pendingDescriptions = new List<PendingDiagnosisDescription>();
+        PrepareDiagnosisMetadata(claim, pendingDescriptions);
+        await PopulateDescriptionsAsync(pendingDescriptions, ct);
+    }
+
+    private static void PrepareDiagnosisMetadata(
+        Claim claim,
+        List<PendingDiagnosisDescription> pendingDescriptions)
     {
         for (var index = 0; index < claim.DiagnosisCodes.Count; index++)
         {
@@ -44,10 +57,55 @@ public sealed class ClaimDiagnosisMetadataEnricher : IClaimDiagnosisMetadataEnri
 
             if (string.IsNullOrWhiteSpace(diagnosis.Description))
             {
-                diagnosis.Description = await _descriptionLookup.FindDescriptionAsync(diagnosis.Code, ct);
+                var normalizedCode = NormalizeCode(diagnosis.Code);
+                if (normalizedCode is not null)
+                {
+                    pendingDescriptions.Add(new PendingDiagnosisDescription(diagnosis, normalizedCode));
+                }
             }
         }
     }
+
+    private async Task PopulateDescriptionsAsync(
+        IReadOnlyCollection<PendingDiagnosisDescription> pendingDescriptions,
+        CancellationToken ct)
+    {
+        if (pendingDescriptions.Count == 0)
+        {
+            return;
+        }
+
+        var lookups = pendingDescriptions
+            .Select(x => x.Code)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                code => code,
+                code => _descriptionLookup.FindDescriptionAsync(code, ct),
+                StringComparer.OrdinalIgnoreCase);
+
+        await Task.WhenAll(lookups.Values);
+
+        foreach (var pending in pendingDescriptions)
+        {
+            var description = await lookups[pending.Code];
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                pending.Diagnosis.Description = description;
+            }
+        }
+    }
+
+    private static string? NormalizeCode(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return null;
+        }
+
+        return code.Trim().ToUpperInvariant();
+    }
+
+    private sealed record PendingDiagnosisDescription(DiagnosisCode Diagnosis, string Code);
 }
 
 public interface IDiagnosisDescriptionLookup
@@ -138,6 +196,22 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
             _logger.LogDebug(
                 ex,
                 "Reference data ICD-10 display lookup failed for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Reference data ICD-10 display lookup returned malformed JSON for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Reference data ICD-10 display lookup returned an unsupported response for {Code}",
                 SanitizeForLog(code));
             return null;
         }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsControllerTests.cs
@@ -153,6 +153,33 @@ public class ClaimsControllerTests : IClassFixture<ClaimsApiFactory>
     }
 
     [Fact]
+    public async Task GetClaimById_EnrichesDiagnosisMetadataForDisplay()
+    {
+        var claim = CreateValidClaim();
+        claim.Id = "claim-dx";
+        claim.DiagnosisCodes = new List<DiagnosisCode>
+        {
+            new() { Code = "K08.1" },
+            new() { Code = "M79.3", CodeQualifier = "", PointerNumber = 2 }
+        };
+
+        _repo.GetByIdAsync("claim-dx").Returns(claim);
+
+        var response = await _client.GetAsync("/api/claims/claim-dx");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var returned = await response.Content.ReadFromJsonAsync<Claim>();
+        Assert.NotNull(returned);
+        Assert.Equal("Complete loss of teeth", returned!.DiagnosisCodes[0].Description);
+        Assert.Equal("ABK", returned.DiagnosisCodes[0].CodeQualifier);
+        Assert.Equal(1, returned.DiagnosisCodes[0].PointerNumber);
+        Assert.Equal("Panniculitis, unspecified", returned.DiagnosisCodes[1].Description);
+        Assert.Equal("ABF", returned.DiagnosisCodes[1].CodeQualifier);
+        Assert.Equal(2, returned.DiagnosisCodes[1].PointerNumber);
+    }
+
+    [Fact]
     public async Task GetClaimById_NonexistentClaim_Returns404()
     {
         _repo.GetByIdAsync("nonexistent").Returns((Claim?)null);

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using ClaimsService.Models;
+using ClaimsService.Services;
+using CloudHealthOffice.ClaimsService.Tests.Adapters;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services;
+
+public sealed class DiagnosisMetadataEnricherTests
+{
+    [Fact]
+    public async Task EnrichAsync_MalformedReferenceDataResponse_DoesNotFailClaimRead()
+    {
+        var handler = FakeHttpMessageHandler.Json("<html>bad gateway</html>");
+        var lookup = CreateLookup(handler);
+        var enricher = new ClaimDiagnosisMetadataEnricher(lookup);
+        var claim = new Claim
+        {
+            DiagnosisCodes =
+            [
+                new() { Code = "ZZZ.999" }
+            ]
+        };
+
+        await enricher.EnrichAsync(claim);
+
+        Assert.Equal(1, handler.RequestCount);
+        Assert.Null(claim.DiagnosisCodes[0].Description);
+        Assert.Equal("ABK", claim.DiagnosisCodes[0].CodeQualifier);
+        Assert.Equal(1, claim.DiagnosisCodes[0].PointerNumber);
+    }
+
+    [Fact]
+    public async Task EnrichAsync_ClaimList_LooksUpDistinctMissingCodesOnce()
+    {
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            var code = request.RequestUri?.Segments.LastOrDefault(s => s != "validate")?.Trim('/') ?? string.Empty;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    $$"""{"description":"Description for {{code}}"}""",
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            };
+        });
+        var lookup = CreateLookup(handler);
+        var enricher = new ClaimDiagnosisMetadataEnricher(lookup);
+        var claims = new[]
+        {
+            new Claim
+            {
+                DiagnosisCodes =
+                [
+                    new() { Code = "ZZZ.101" },
+                    new() { Code = "ZZZ.202" }
+                ]
+            },
+            new Claim
+            {
+                DiagnosisCodes =
+                [
+                    new() { Code = "ZZZ.101" }
+                ]
+            }
+        };
+
+        await enricher.EnrichAsync(claims);
+
+        Assert.Equal(2, handler.RequestCount);
+        Assert.Equal("Description for ZZZ.101", claims[0].DiagnosisCodes[0].Description);
+        Assert.Equal("Description for ZZZ.202", claims[0].DiagnosisCodes[1].Description);
+        Assert.Equal("Description for ZZZ.101", claims[1].DiagnosisCodes[0].Description);
+    }
+
+    private static DiagnosisDescriptionLookup CreateLookup(FakeHttpMessageHandler handler)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Services:ReferenceDataDisplayLookupTimeoutMilliseconds"] = "500"
+            })
+            .Build();
+
+        return new DiagnosisDescriptionLookup(
+            new ReferenceDataHttpClientFactory(handler),
+            new MemoryCache(new MemoryCacheOptions()),
+            configuration,
+            NullLogger<DiagnosisDescriptionLookup>.Instance);
+    }
+
+    private sealed class ReferenceDataHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public ReferenceDataHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name) =>
+            new(_handler, disposeHandler: false)
+            {
+                BaseAddress = new Uri("http://reference-data.test/")
+            };
+    }
+}


### PR DESCRIPTION
## Summary
- Add a claims-service diagnosis metadata enricher for read/projection paths.
- Populate missing diagnosis pointer numbers, ABK/ABF qualifiers, and display descriptions for claim detail/search responses.
- Enrich FHIR ExplanationOfBenefit read and search projections so exported/displayed EOB data has the same diagnosis metadata.
- Use today’s ICD-10 display source from reference-data-service, with a local MCC/demo fallback; terminology service remains the crosswalk/translate service for now.

## Why
Claim detail screens were showing ICD-10 codes without descriptions or type qualifiers even when the underlying line and amount data was otherwise populated. This keeps persisted claim data clean while making read-time API responses useful for portal and EOB display.

## Validation
- `dotnet build src/services/claims-service/claims-service.csproj --no-restore -p:UseAppHost=false`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter ClaimsControllerTests --no-restore -p:UseAppHost=false`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~Fhir" --no-restore -p:UseAppHost=false`