### PR TITLE
Use terminology service for diagnosis metadata

### DIFF
--- a/cloudhealthoffice-main.sln
+++ b/cloudhealthoffice-main.sln
@@ -215,6 +215,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.Appeals.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.Appeals.Contracts.Tests", "src\services\shared\CloudHealthOffice.Appeals.Contracts.Tests\CloudHealthOffice.Appeals.Contracts.Tests.csproj", "{C0E682EC-F646-44F9-B942-68FA1ED04012}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudHealthOffice.TerminologyService.Tests", "tests\CloudHealthOffice.TerminologyService.Tests\CloudHealthOffice.TerminologyService.Tests.csproj", "{1E95421F-497E-469D-B0DF-774DFCE95F8C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1197,6 +1199,18 @@ Global
 		{C0E682EC-F646-44F9-B942-68FA1ED04012}.Release|x64.Build.0 = Release|Any CPU
 		{C0E682EC-F646-44F9-B942-68FA1ED04012}.Release|x86.ActiveCfg = Release|Any CPU
 		{C0E682EC-F646-44F9-B942-68FA1ED04012}.Release|x86.Build.0 = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|x64.Build.0 = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Debug|x86.Build.0 = Debug|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|x64.ActiveCfg = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|x64.Build.0 = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|x86.ActiveCfg = Release|Any CPU
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1291,6 +1305,7 @@ Global
 		{A222A10A-7DAD-450C-9ADB-C32C62558082} = {9903112D-0596-411F-A5B5-4640FD31749A}
 		{C9ADB84C-F447-450B-A837-C877F58FC32B} = {1CF083BF-0A1D-5B5F-37B1-E2F5EFE0303B}
 		{C0E682EC-F646-44F9-B942-68FA1ED04012} = {1CF083BF-0A1D-5B5F-37B1-E2F5EFE0303B}
+		{1E95421F-497E-469D-B0DF-774DFCE95F8C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C10C3349-5BEE-4B34-9987-23F0142F9D98}

--- a/src/services/CHO.TerminologyService/Controllers/TerminologyController.cs
+++ b/src/services/CHO.TerminologyService/Controllers/TerminologyController.cs
@@ -144,6 +144,37 @@ public class TerminologyController : ControllerBase
         return Ok(responses);
     }
 
+    /// <summary>
+    /// GET /fhir/CodeSystem/$lookup - Look up display metadata for a code.
+    ///
+    /// This intentionally returns a compact CHO payload rather than the full
+    /// FHIR Parameters resource so service consumers can cheaply enrich UI
+    /// display fields without taking a dependency on full terminology maps.
+    /// </summary>
+    [HttpGet("fhir/CodeSystem/$lookup")]
+    [ProducesResponseType(typeof(CodeLookupResponse), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> LookupCodeGet(
+        [FromQuery] string system,
+        [FromQuery] string code,
+        [FromQuery] string? tenantId = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(system) || string.IsNullOrWhiteSpace(code))
+        {
+            return BadRequest(new { error = "system and code are required parameters" });
+        }
+
+        var response = await _translationService.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = system,
+            Code = code,
+            TenantId = tenantId
+        }, ct);
+
+        return Ok(response);
+    }
+
     // ──────────────────────────────────────────────────────
     // Admin: Map management
     // ──────────────────────────────────────────────────────

--- a/src/services/CHO.TerminologyService/Data/MongoConceptMapRepository.cs
+++ b/src/services/CHO.TerminologyService/Data/MongoConceptMapRepository.cs
@@ -118,6 +118,41 @@ public class MongoConceptMapRepository : IConceptMapRepository
             .ToListAsync(ct);
     }
 
+    public async Task<List<ConceptMapEntry>> FindDisplaysByCodeAsync(
+        string system, string code, string? tenantId = null, CancellationToken ct = default)
+    {
+        var activeVersionIds = await _versions.Find(v => v.IsActive)
+            .Project(v => v.Id)
+            .ToListAsync(ct);
+
+        var codeFilter = Builders<ConceptMapEntry>.Filter.Or(
+            Builders<ConceptMapEntry>.Filter.And(
+                Builders<ConceptMapEntry>.Filter.Eq(e => e.SourceSystem, system),
+                Builders<ConceptMapEntry>.Filter.Eq(e => e.SourceCode, code)),
+            Builders<ConceptMapEntry>.Filter.And(
+                Builders<ConceptMapEntry>.Filter.Eq(e => e.TargetSystem, system),
+                Builders<ConceptMapEntry>.Filter.Eq(e => e.TargetCode, code)));
+
+        var activeFilter = Builders<ConceptMapEntry>.Filter.Or(
+            Builders<ConceptMapEntry>.Filter.And(
+                Builders<ConceptMapEntry>.Filter.In(e => e.MapVersionId, activeVersionIds),
+                Builders<ConceptMapEntry>.Filter.Eq(e => e.IsOverride, false)),
+            tenantId != null
+                ? Builders<ConceptMapEntry>.Filter.And(
+                    Builders<ConceptMapEntry>.Filter.Eq(e => e.IsOverride, true),
+                    Builders<ConceptMapEntry>.Filter.Eq(e => e.TenantId, tenantId))
+                : Builders<ConceptMapEntry>.Filter.Eq(e => e.Id, "__never_match__"));
+
+        var filter = Builders<ConceptMapEntry>.Filter.And(codeFilter, activeFilter);
+
+        return await _entries.Find(filter)
+            .Sort(Builders<ConceptMapEntry>.Sort
+                .Descending(e => e.IsOverride)
+                .Ascending(e => e.Priority))
+            .Limit(20)
+            .ToListAsync(ct);
+    }
+
     public async Task BulkInsertAsync(List<ConceptMapEntry> entries, CancellationToken ct = default)
     {
         if (entries.Count == 0) return;

--- a/src/services/CHO.TerminologyService/Models/TranslateModels.cs
+++ b/src/services/CHO.TerminologyService/Models/TranslateModels.cs
@@ -85,3 +85,33 @@ public class TranslatedCoding
     public string Code { get; set; } = string.Empty;
     public string Display { get; set; } = string.Empty;
 }
+
+/// <summary>
+/// Request model for a lightweight CodeSystem/$lookup display lookup.
+/// </summary>
+public class CodeLookupRequest
+{
+    /// <summary>FHIR coding system URI</summary>
+    public string System { get; set; } = string.Empty;
+
+    /// <summary>Code to look up</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Optional tenant ID for plan-specific terminology overrides</summary>
+    public string? TenantId { get; set; }
+}
+
+/// <summary>
+/// Response model for a lightweight code display lookup.
+/// </summary>
+public class CodeLookupResponse
+{
+    public bool Result { get; set; }
+    public string System { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string? Display { get; set; }
+    public string? Message { get; set; }
+    public string? MapVersionId { get; set; }
+    public string? Source { get; set; }
+    public DateTime LookedUpAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/services/CHO.TerminologyService/Services/Interfaces.cs
+++ b/src/services/CHO.TerminologyService/Services/Interfaces.cs
@@ -21,6 +21,11 @@ public interface ITerminologyTranslationService
     Task<List<TranslateResponse>> BatchTranslateAsync(List<TranslateRequest> requests, CancellationToken ct = default);
 
     /// <summary>
+    /// Look up display metadata for a code already expressed in a known code system.
+    /// </summary>
+    Task<CodeLookupResponse> LookupCodeAsync(CodeLookupRequest request, CancellationToken ct = default);
+
+    /// <summary>
     /// Get all loaded map versions (for admin/audit).
     /// </summary>
     Task<List<MapVersion>> GetMapVersionsAsync(CancellationToken ct = default);
@@ -41,6 +46,10 @@ public interface IConceptMapRepository
     Task<List<ConceptMapEntry>> FindByTargetCodeAsync(
         string targetSystem, string targetCode, string sourceSystem,
         string? tenantId = null, CancellationToken ct = default);
+
+    /// <summary>Find active entries where the supplied code appears as source or target.</summary>
+    Task<List<ConceptMapEntry>> FindDisplaysByCodeAsync(
+        string system, string code, string? tenantId = null, CancellationToken ct = default);
 
     /// <summary>Bulk insert entries during map loading.</summary>
     Task BulkInsertAsync(List<ConceptMapEntry> entries, CancellationToken ct = default);

--- a/src/services/CHO.TerminologyService/Services/TerminologyTranslationService.cs
+++ b/src/services/CHO.TerminologyService/Services/TerminologyTranslationService.cs
@@ -133,6 +133,41 @@ public class TerminologyTranslationService : ITerminologyTranslationService
         return results.ToList();
     }
 
+    public async Task<CodeLookupResponse> LookupCodeAsync(CodeLookupRequest request, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(request.System, nameof(request.System));
+        ArgumentException.ThrowIfNullOrEmpty(request.Code, nameof(request.Code));
+
+        var response = new CodeLookupResponse
+        {
+            System = request.System,
+            Code = request.Code
+        };
+
+        var candidates = await _repository.FindDisplaysByCodeAsync(
+            request.System,
+            request.Code,
+            request.TenantId,
+            ct);
+
+        var match = candidates
+            .Select(entry => ToLookupCandidate(entry, request.System, request.Code))
+            .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate.Display));
+
+        if (match is null)
+        {
+            response.Result = false;
+            response.Message = $"No display found for {request.System}|{request.Code}";
+            return response;
+        }
+
+        response.Result = true;
+        response.Display = match.Display;
+        response.MapVersionId = match.MapVersionId;
+        response.Source = match.Source;
+        return response;
+    }
+
     public async Task<List<MapVersion>> GetMapVersionsAsync(CancellationToken ct = default)
     {
         return await _repository.GetAllMapVersionsAsync(ct);
@@ -163,4 +198,23 @@ public class TerminologyTranslationService : ITerminologyTranslationService
         if (mapVersionId.StartsWith("SNOMED", StringComparison.OrdinalIgnoreCase)) return "SNOMED-Intl";
         return "Unknown";
     }
+
+    private static LookupCandidate ToLookupCandidate(ConceptMapEntry entry, string system, string code)
+    {
+        if (entry.SourceSystem.Equals(system, StringComparison.Ordinal) &&
+            entry.SourceCode.Equals(code, StringComparison.Ordinal))
+        {
+            return new LookupCandidate(
+                entry.SourceDisplay,
+                entry.MapVersionId,
+                entry.IsOverride ? "PlanOverride" : "ConceptMapSource");
+        }
+
+        return new LookupCandidate(
+            entry.TargetDisplay,
+            entry.MapVersionId,
+            entry.IsOverride ? "PlanOverride" : "ConceptMapTarget");
+    }
+
+    private sealed record LookupCandidate(string Display, string MapVersionId, string Source);
 }

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -142,6 +142,16 @@ builder.Services.AddHttpClient("ReferenceDataService", client =>
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 }).SetHandlerLifetime(TimeSpan.FromMinutes(5));
 
+builder.Services.AddHttpClient(UpstreamClientNames.TerminologyService, client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:TerminologyServiceUrl"]
+        ?? builder.Configuration["Services:TerminologyService"]
+        ?? "http://terminology-service");
+    client.Timeout = TimeSpan.FromSeconds(10);
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+}).SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
 // FL FMMIS encounter submission pipeline
 builder.Services.AddScoped<IProviderService, HttpProviderService>();
 builder.Services.AddScoped<ITenantComplianceConfigService, HttpTenantComplianceConfigService>();

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -116,6 +116,7 @@ public interface IDiagnosisDescriptionLookup
 public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
 {
     private const string CacheKeyPrefix = "claims-service:diagnosis-description:";
+    private const string Icd10CmSystem = "http://hl7.org/fhir/sid/icd-10-cm";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(6);
     private static readonly TimeSpan NegativeCacheDuration = TimeSpan.FromMinutes(10);
 
@@ -150,17 +151,78 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
             return cached?.Description;
         }
 
+        var terminologyDescription = await TryFindTerminologyDescriptionAsync(normalizedCode, ct);
+        if (!string.IsNullOrWhiteSpace(terminologyDescription))
+        {
+            Cache(cacheKey, terminologyDescription);
+            return terminologyDescription;
+        }
+
         if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
         {
             Cache(cacheKey, syntheticDescription);
             return syntheticDescription;
         }
 
-        // CHO.TerminologyService currently owns crosswalk/translation. The
-        // reference-data service is today's ICD-10 code-system display source.
         var referenceDataDescription = await TryFindReferenceDataDescriptionAsync(normalizedCode, ct);
         Cache(cacheKey, referenceDataDescription);
         return referenceDataDescription;
+    }
+
+    private async Task<string?> TryFindTerminologyDescriptionAsync(string code, CancellationToken ct)
+    {
+        var timeoutMilliseconds = Math.Clamp(
+            _configuration.GetValue<int?>("Services:TerminologyDisplayLookupTimeoutMilliseconds") ?? 750,
+            100,
+            3_000);
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.TerminologyService);
+            var response = await client.GetFromJsonAsync<TerminologyCodeLookupResponse>(
+                "fhir/CodeSystem/$lookup" +
+                $"?system={Uri.EscapeDataString(Icd10CmSystem)}" +
+                $"&code={Uri.EscapeDataString(code)}",
+                timeout.Token);
+
+            return response is { Result: true } && !string.IsNullOrWhiteSpace(response.Display)
+                ? response.Display
+                : null;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogDebug(
+                "Terminology ICD-10 display lookup timed out for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Terminology ICD-10 display lookup failed for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Terminology ICD-10 display lookup returned malformed JSON for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Terminology ICD-10 display lookup returned an unsupported response for {Code}",
+                SanitizeForLog(code));
+            return null;
+        }
     }
 
     private async Task<string?> TryFindReferenceDataDescriptionAsync(string code, CancellationToken ct)
@@ -175,7 +237,7 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
             using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeout.CancelAfter(TimeSpan.FromMilliseconds(timeoutMilliseconds));
 
-            var client = _httpClientFactory.CreateClient("ReferenceDataService");
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.ReferenceDataService);
             var response = await client.GetFromJsonAsync<ReferenceDataValidationResponse>(
                 $"api/ReferenceData/icd10/{Uri.EscapeDataString(code)}/validate",
                 timeout.Token);
@@ -239,6 +301,12 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
         value.Replace("\r", "").Replace("\n", "");
 
     private sealed record CachedDiagnosisDescription(string? Description);
+
+    private sealed class TerminologyCodeLookupResponse
+    {
+        public bool Result { get; set; }
+        public string? Display { get; set; }
+    }
 
     private sealed class ReferenceDataValidationResponse
     {

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -151,17 +151,17 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
             return cached?.Description;
         }
 
+        if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
+        {
+            Cache(cacheKey, syntheticDescription);
+            return syntheticDescription;
+        }
+
         var terminologyDescription = await TryFindTerminologyDescriptionAsync(normalizedCode, ct);
         if (!string.IsNullOrWhiteSpace(terminologyDescription))
         {
             Cache(cacheKey, terminologyDescription);
             return terminologyDescription;
-        }
-
-        if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
-        {
-            Cache(cacheKey, syntheticDescription);
-            return syntheticDescription;
         }
 
         var referenceDataDescription = await TryFindReferenceDataDescriptionAsync(normalizedCode, ct);

--- a/src/services/claims-service/Services/UpstreamClientNames.cs
+++ b/src/services/claims-service/Services/UpstreamClientNames.cs
@@ -26,7 +26,10 @@ public static class UpstreamClientNames
     /// <summary>member-service — capability 5.5 member resolver.</summary>
     public const string MemberService = "MemberService";
 
-    /// <summary>reference-data-service — terminology lookups.</summary>
+    /// <summary>terminology-service — authoritative coding-system display/crosswalk lookups.</summary>
+    public const string TerminologyService = "TerminologyService";
+
+    /// <summary>reference-data-service — fallback coding-system lookups.</summary>
     public const string ReferenceDataService = "ReferenceDataService";
 
     /// <summary>coverage-service — capability 5.8 Coordination of Benefits

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
@@ -11,25 +11,26 @@ namespace CloudHealthOffice.ClaimsService.Tests.Services;
 public sealed class DiagnosisMetadataEnricherTests
 {
     [Fact]
-    public async Task FindDescriptionAsync_TerminologyHit_ReturnsTerminologyDisplay()
+    public async Task FindDescriptionAsync_TerminologyHitForUnknownCode_ReturnsTerminologyDisplay()
     {
         var terminologyHandler = FakeHttpMessageHandler.Json(
-            """{"result":true,"display":"Terminology display for diabetes"}""");
+            """{"result":true,"display":"Terminology display for custom code"}""");
         var referenceHandler = FakeHttpMessageHandler.Throw(
             new InvalidOperationException("Reference data should not be called when terminology resolves."));
         var lookup = CreateLookup(referenceHandler, terminologyHandler);
 
-        var description = await lookup.FindDescriptionAsync("E11.9");
+        var description = await lookup.FindDescriptionAsync("ZZZ.456");
 
-        Assert.Equal("Terminology display for diabetes", description);
+        Assert.Equal("Terminology display for custom code", description);
         Assert.Equal(1, terminologyHandler.RequestCount);
         Assert.Equal(0, referenceHandler.RequestCount);
     }
 
     [Fact]
-    public async Task FindDescriptionAsync_TerminologyUnavailable_UsesSyntheticFallback()
+    public async Task FindDescriptionAsync_SyntheticHit_DoesNotCallTerminology()
     {
-        var terminologyHandler = FakeHttpMessageHandler.Status(HttpStatusCode.ServiceUnavailable);
+        var terminologyHandler = FakeHttpMessageHandler.Throw(
+            new InvalidOperationException("Terminology should not be called for known synthetic codes."));
         var referenceHandler = FakeHttpMessageHandler.Throw(
             new InvalidOperationException("Reference data should not be called for known synthetic codes."));
         var lookup = CreateLookup(referenceHandler, terminologyHandler);
@@ -37,7 +38,7 @@ public sealed class DiagnosisMetadataEnricherTests
         var description = await lookup.FindDescriptionAsync("M79.3");
 
         Assert.Equal("Panniculitis, unspecified", description);
-        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(0, terminologyHandler.RequestCount);
         Assert.Equal(0, referenceHandler.RequestCount);
     }
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
@@ -11,10 +11,57 @@ namespace CloudHealthOffice.ClaimsService.Tests.Services;
 public sealed class DiagnosisMetadataEnricherTests
 {
     [Fact]
+    public async Task FindDescriptionAsync_TerminologyHit_ReturnsTerminologyDisplay()
+    {
+        var terminologyHandler = FakeHttpMessageHandler.Json(
+            """{"result":true,"display":"Terminology display for diabetes"}""");
+        var referenceHandler = FakeHttpMessageHandler.Throw(
+            new InvalidOperationException("Reference data should not be called when terminology resolves."));
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
+
+        var description = await lookup.FindDescriptionAsync("E11.9");
+
+        Assert.Equal("Terminology display for diabetes", description);
+        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(0, referenceHandler.RequestCount);
+    }
+
+    [Fact]
+    public async Task FindDescriptionAsync_TerminologyUnavailable_UsesSyntheticFallback()
+    {
+        var terminologyHandler = FakeHttpMessageHandler.Status(HttpStatusCode.ServiceUnavailable);
+        var referenceHandler = FakeHttpMessageHandler.Throw(
+            new InvalidOperationException("Reference data should not be called for known synthetic codes."));
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
+
+        var description = await lookup.FindDescriptionAsync("M79.3");
+
+        Assert.Equal("Panniculitis, unspecified", description);
+        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(0, referenceHandler.RequestCount);
+    }
+
+    [Fact]
+    public async Task FindDescriptionAsync_TerminologyUnavailable_UsesReferenceDataFallback()
+    {
+        var terminologyHandler = FakeHttpMessageHandler.Status(HttpStatusCode.ServiceUnavailable);
+        var referenceHandler = FakeHttpMessageHandler.Json(
+            """{"description":"Reference data display"}""");
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
+
+        var description = await lookup.FindDescriptionAsync("ZZZ.123");
+
+        Assert.Equal("Reference data display", description);
+        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(1, referenceHandler.RequestCount);
+    }
+
+    [Fact]
     public async Task EnrichAsync_MalformedReferenceDataResponse_DoesNotFailClaimRead()
     {
-        var handler = FakeHttpMessageHandler.Json("<html>bad gateway</html>");
-        var lookup = CreateLookup(handler);
+        var terminologyHandler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var referenceHandler = FakeHttpMessageHandler.Json("<html>bad gateway</html>");
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
         var enricher = new ClaimDiagnosisMetadataEnricher(lookup);
         var claim = new Claim
         {
@@ -26,7 +73,8 @@ public sealed class DiagnosisMetadataEnricherTests
 
         await enricher.EnrichAsync(claim);
 
-        Assert.Equal(1, handler.RequestCount);
+        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(1, referenceHandler.RequestCount);
         Assert.Null(claim.DiagnosisCodes[0].Description);
         Assert.Equal("ABK", claim.DiagnosisCodes[0].CodeQualifier);
         Assert.Equal(1, claim.DiagnosisCodes[0].PointerNumber);
@@ -35,18 +83,20 @@ public sealed class DiagnosisMetadataEnricherTests
     [Fact]
     public async Task EnrichAsync_ClaimList_LooksUpDistinctMissingCodesOnce()
     {
-        var handler = new FakeHttpMessageHandler(request =>
+        var terminologyHandler = new FakeHttpMessageHandler(request =>
         {
-            var code = request.RequestUri?.Segments.LastOrDefault(s => s != "validate")?.Trim('/') ?? string.Empty;
+            var code = QueryValue(request.RequestUri, "code") ?? string.Empty;
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(
-                    $$"""{"description":"Description for {{code}}"}""",
+                    $$"""{"result":true,"display":"Description for {{code}}"}""",
                     System.Text.Encoding.UTF8,
                     "application/json")
             };
         });
-        var lookup = CreateLookup(handler);
+        var referenceHandler = FakeHttpMessageHandler.Throw(
+            new InvalidOperationException("Reference data should not be called when terminology resolves."));
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
         var enricher = new ClaimDiagnosisMetadataEnricher(lookup);
         var claims = new[]
         {
@@ -69,41 +119,80 @@ public sealed class DiagnosisMetadataEnricherTests
 
         await enricher.EnrichAsync(claims);
 
-        Assert.Equal(2, handler.RequestCount);
+        Assert.Equal(2, terminologyHandler.RequestCount);
+        Assert.Equal(0, referenceHandler.RequestCount);
         Assert.Equal("Description for ZZZ.101", claims[0].DiagnosisCodes[0].Description);
         Assert.Equal("Description for ZZZ.202", claims[0].DiagnosisCodes[1].Description);
         Assert.Equal("Description for ZZZ.101", claims[1].DiagnosisCodes[0].Description);
     }
 
-    private static DiagnosisDescriptionLookup CreateLookup(FakeHttpMessageHandler handler)
+    private static DiagnosisDescriptionLookup CreateLookup(
+        FakeHttpMessageHandler referenceDataHandler,
+        FakeHttpMessageHandler? terminologyHandler = null)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Services:ReferenceDataDisplayLookupTimeoutMilliseconds"] = "500"
+                ["Services:ReferenceDataDisplayLookupTimeoutMilliseconds"] = "500",
+                ["Services:TerminologyDisplayLookupTimeoutMilliseconds"] = "500"
             })
             .Build();
 
         return new DiagnosisDescriptionLookup(
-            new ReferenceDataHttpClientFactory(handler),
+            new DiagnosisLookupHttpClientFactory(
+                referenceDataHandler,
+                terminologyHandler ?? FakeHttpMessageHandler.Status(HttpStatusCode.NotFound)),
             new MemoryCache(new MemoryCacheOptions()),
             configuration,
             NullLogger<DiagnosisDescriptionLookup>.Instance);
     }
 
-    private sealed class ReferenceDataHttpClientFactory : IHttpClientFactory
+    private static string? QueryValue(Uri? uri, string key)
     {
-        private readonly HttpMessageHandler _handler;
-
-        public ReferenceDataHttpClientFactory(HttpMessageHandler handler)
+        var query = uri?.Query.TrimStart('?');
+        if (string.IsNullOrWhiteSpace(query))
         {
-            _handler = handler;
+            return null;
         }
 
-        public HttpClient CreateClient(string name) =>
-            new(_handler, disposeHandler: false)
+        foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tokens = part.Split('=', 2);
+            if (tokens.Length == 2 && tokens[0].Equals(key, StringComparison.OrdinalIgnoreCase))
             {
-                BaseAddress = new Uri("http://reference-data.test/")
+                return Uri.UnescapeDataString(tokens[1]);
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class DiagnosisLookupHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _referenceDataHandler;
+        private readonly HttpMessageHandler _terminologyHandler;
+
+        public DiagnosisLookupHttpClientFactory(
+            HttpMessageHandler referenceDataHandler,
+            HttpMessageHandler terminologyHandler)
+        {
+            _referenceDataHandler = referenceDataHandler;
+            _terminologyHandler = terminologyHandler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            var (handler, baseAddress) = name switch
+            {
+                UpstreamClientNames.TerminologyService => (_terminologyHandler, "http://terminology.test/"),
+                UpstreamClientNames.ReferenceDataService => (_referenceDataHandler, "http://reference-data.test/"),
+                _ => throw new InvalidOperationException($"Unexpected client: {name}")
             };
+
+            return new HttpClient(handler, disposeHandler: false)
+            {
+                BaseAddress = new Uri(baseAddress)
+            };
+        }
     }
 }

--- a/tests/CloudHealthOffice.TerminologyService.Tests/CloudHealthOffice.TerminologyService.Tests.csproj
+++ b/tests/CloudHealthOffice.TerminologyService.Tests/CloudHealthOffice.TerminologyService.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="EphemeralMongo7" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\services\CHO.TerminologyService\CHO.TerminologyService.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/CloudHealthOffice.TerminologyService.Tests/MongoConceptMapRepositoryTests.cs
+++ b/tests/CloudHealthOffice.TerminologyService.Tests/MongoConceptMapRepositoryTests.cs
@@ -1,0 +1,122 @@
+using CHO.TerminologyService.Data;
+using CHO.TerminologyService.Models;
+using EphemeralMongo;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+
+namespace CloudHealthOffice.TerminologyService.Tests;
+
+public sealed class MongoConceptMapRepositoryTests : IAsyncLifetime
+{
+    private const string Icd10CmSystem = "http://hl7.org/fhir/sid/icd-10-cm";
+    private const string SnomedSystem = "http://snomed.info/sct";
+
+    private IMongoRunner _runner = null!;
+    private IMongoDatabase _database = null!;
+    private MongoConceptMapRepository _repository = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        _database = client.GetDatabase($"terminology_repo_test_{Guid.NewGuid():N}");
+        _repository = new MongoConceptMapRepository(
+            _database,
+            NullLogger<MongoConceptMapRepository>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* EphemeralMongo.Core 2.0.0 / MongoDB.Driver 3.x disposal mismatch. */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task FindDisplaysByCodeAsync_ReturnsActiveEntriesAndTenantOverrideFirst()
+    {
+        await _database.GetCollection<MapVersion>("map_versions").InsertManyAsync(
+        [
+            new()
+            {
+                Id = "active-map",
+                MapName = "SNOMED-ICD10",
+                SourceSystem = SnomedSystem,
+                TargetSystem = Icd10CmSystem,
+                IsActive = true
+            },
+            new()
+            {
+                Id = "old-map",
+                MapName = "SNOMED-ICD10",
+                SourceSystem = SnomedSystem,
+                TargetSystem = Icd10CmSystem,
+                IsActive = false
+            }
+        ]);
+        await _database.GetCollection<ConceptMapEntry>("concept_map_entries").InsertManyAsync(
+        [
+            Entry("active-priority-2", mapVersionId: "active-map", priority: 2, targetDisplay: "Active target display"),
+            Entry("active-priority-1", mapVersionId: "active-map", priority: 1, targetDisplay: "Active preferred display"),
+            Entry("inactive", mapVersionId: "old-map", priority: 0, targetDisplay: "Inactive display"),
+            Entry("tenant-a-override", isOverride: true, tenantId: "tenant-a", priority: 99, targetDisplay: "Tenant A display"),
+            Entry("tenant-b-override", isOverride: true, tenantId: "tenant-b", priority: 0, targetDisplay: "Tenant B display")
+        ]);
+
+        var results = await _repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65", "tenant-a");
+
+        Assert.Collection(
+            results,
+            entry => Assert.Equal("tenant-a-override", entry.Id),
+            entry => Assert.Equal("active-priority-1", entry.Id),
+            entry => Assert.Equal("active-priority-2", entry.Id));
+    }
+
+    [Fact]
+    public async Task FindDisplaysByCodeAsync_WithoutTenant_DoesNotReturnOverrides()
+    {
+        await _database.GetCollection<MapVersion>("map_versions").InsertOneAsync(new MapVersion
+        {
+            Id = "active-map",
+            MapName = "SNOMED-ICD10",
+            SourceSystem = SnomedSystem,
+            TargetSystem = Icd10CmSystem,
+            IsActive = true
+        });
+        await _database.GetCollection<ConceptMapEntry>("concept_map_entries").InsertManyAsync(
+        [
+            Entry("active", mapVersionId: "active-map", targetDisplay: "Active target display"),
+            Entry("tenant-a-override", isOverride: true, tenantId: "tenant-a", targetDisplay: "Tenant A display")
+        ]);
+
+        var results = await _repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65");
+
+        var result = Assert.Single(results);
+        Assert.Equal("active", result.Id);
+    }
+
+    private static ConceptMapEntry Entry(
+        string id,
+        string mapVersionId = "override",
+        bool isOverride = false,
+        string? tenantId = null,
+        int priority = 1,
+        string targetDisplay = "Type 2 diabetes mellitus with hyperglycemia")
+    {
+        return new ConceptMapEntry
+        {
+            Id = id,
+            SourceSystem = SnomedSystem,
+            SourceCode = "44054006",
+            SourceDisplay = "Diabetes mellitus type 2",
+            TargetSystem = Icd10CmSystem,
+            TargetCode = "E11.65",
+            TargetDisplay = targetDisplay,
+            MapVersionId = mapVersionId,
+            IsOverride = isOverride,
+            TenantId = tenantId,
+            Priority = priority
+        };
+    }
+}

--- a/tests/CloudHealthOffice.TerminologyService.Tests/TerminologyTranslationServiceLookupTests.cs
+++ b/tests/CloudHealthOffice.TerminologyService.Tests/TerminologyTranslationServiceLookupTests.cs
@@ -1,0 +1,197 @@
+using CHO.TerminologyService.Configuration;
+using CHO.TerminologyService.Models;
+using CHO.TerminologyService.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace CloudHealthOffice.TerminologyService.Tests;
+
+public sealed class TerminologyTranslationServiceLookupTests
+{
+    private const string Icd10CmSystem = "http://hl7.org/fhir/sid/icd-10-cm";
+    private const string SnomedSystem = "http://snomed.info/sct";
+
+    [Fact]
+    public async Task LookupCodeAsync_SourceCodeMatch_ReturnsSourceDisplay()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<ConceptMapEntry>
+            {
+                new()
+                {
+                    SourceSystem = Icd10CmSystem,
+                    SourceCode = "E11.65",
+                    SourceDisplay = "Type 2 diabetes mellitus with hyperglycemia",
+                    TargetSystem = SnomedSystem,
+                    TargetCode = "44054006",
+                    TargetDisplay = "Diabetes mellitus type 2",
+                    MapVersionId = "ICD10-SNOMED-2026"
+                }
+            }));
+        var service = CreateService(repository);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "E11.65"
+        });
+
+        Assert.True(response.Result);
+        Assert.Equal("Type 2 diabetes mellitus with hyperglycemia", response.Display);
+        Assert.Equal("ConceptMapSource", response.Source);
+        Assert.Equal("ICD10-SNOMED-2026", response.MapVersionId);
+    }
+
+    [Fact]
+    public async Task LookupCodeAsync_TargetCodeMatch_ReturnsTargetDisplay()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<ConceptMapEntry>
+            {
+                new()
+                {
+                    SourceSystem = SnomedSystem,
+                    SourceCode = "44054006",
+                    SourceDisplay = "Diabetes mellitus type 2",
+                    TargetSystem = Icd10CmSystem,
+                    TargetCode = "E11.65",
+                    TargetDisplay = "Type 2 diabetes mellitus with hyperglycemia",
+                    MapVersionId = "SNOMED-ICD10-2026"
+                }
+            }));
+        var service = CreateService(repository);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "E11.65"
+        });
+
+        Assert.True(response.Result);
+        Assert.Equal("Type 2 diabetes mellitus with hyperglycemia", response.Display);
+        Assert.Equal("ConceptMapTarget", response.Source);
+        Assert.Equal("SNOMED-ICD10-2026", response.MapVersionId);
+    }
+
+    [Fact]
+    public async Task LookupCodeAsync_BlankCandidateDisplay_ReturnsFirstPopulatedDisplay()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<ConceptMapEntry>
+            {
+                new()
+                {
+                    SourceSystem = SnomedSystem,
+                    SourceCode = "44054006",
+                    SourceDisplay = "Diabetes mellitus type 2",
+                    TargetSystem = Icd10CmSystem,
+                    TargetCode = "E11.65",
+                    TargetDisplay = "",
+                    MapVersionId = "SNOMED-ICD10-RF2"
+                },
+                new()
+                {
+                    SourceSystem = SnomedSystem,
+                    SourceCode = "73211009",
+                    SourceDisplay = "Diabetes mellitus",
+                    TargetSystem = Icd10CmSystem,
+                    TargetCode = "E11.65",
+                    TargetDisplay = "Type 2 diabetes mellitus with hyperglycemia",
+                    MapVersionId = "SNOMED-ICD10-CURATED"
+                }
+            }));
+        var service = CreateService(repository);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "E11.65"
+        });
+
+        Assert.True(response.Result);
+        Assert.Equal("Type 2 diabetes mellitus with hyperglycemia", response.Display);
+        Assert.Equal("SNOMED-ICD10-CURATED", response.MapVersionId);
+    }
+
+    [Fact]
+    public async Task LookupCodeAsync_TenantOverride_ReturnsPlanOverrideSource()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        repository.FindDisplaysByCodeAsync(Icd10CmSystem, "K08.1", "tenant-a", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<ConceptMapEntry>
+            {
+                new()
+                {
+                    SourceSystem = Icd10CmSystem,
+                    SourceCode = "K08.1",
+                    SourceDisplay = "Loss of teeth due to accident, extraction, or local periodontal disease",
+                    TargetSystem = SnomedSystem,
+                    TargetCode = "25540007",
+                    TargetDisplay = "Loss of teeth",
+                    MapVersionId = "PLAN-OVERRIDE-1",
+                    IsOverride = true,
+                    TenantId = "tenant-a"
+                }
+            }));
+        var service = CreateService(repository);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "K08.1",
+            TenantId = "tenant-a"
+        });
+
+        Assert.True(response.Result);
+        Assert.Equal("Loss of teeth due to accident, extraction, or local periodontal disease", response.Display);
+        Assert.Equal("PlanOverride", response.Source);
+        await repository.Received(1)
+            .FindDisplaysByCodeAsync(Icd10CmSystem, "K08.1", "tenant-a", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LookupCodeAsync_NoPopulatedDisplay_ReturnsFalse()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        repository.FindDisplaysByCodeAsync(Icd10CmSystem, "E11.65", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<ConceptMapEntry>
+            {
+                new()
+                {
+                    SourceSystem = SnomedSystem,
+                    SourceCode = "44054006",
+                    SourceDisplay = "Diabetes mellitus type 2",
+                    TargetSystem = Icd10CmSystem,
+                    TargetCode = "E11.65",
+                    TargetDisplay = "",
+                    MapVersionId = "SNOMED-ICD10-RF2"
+                }
+            }));
+        var service = CreateService(repository);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "E11.65"
+        });
+
+        Assert.False(response.Result);
+        Assert.Null(response.Display);
+        Assert.Contains("No display found", response.Message);
+    }
+
+    private static TerminologyTranslationService CreateService(IConceptMapRepository repository)
+    {
+        return new TerminologyTranslationService(
+            repository,
+            Substitute.For<IContextRuleEngine>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<TerminologyTranslationService>.Instance,
+            Options.Create(new TerminologyServiceOptions()));
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight Terminology Service `CodeSystem/$lookup` endpoint for code display metadata
- make claims-service diagnosis enrichment use Terminology first, then synthetic and reference-data fallbacks
- preserve best-effort claim reads when terminology/reference-data lookups fail or return malformed payloads
- expand diagnosis enrichment tests for terminology hits, fallback behavior, malformed responses, and list batching

## Why
Claim detail and EOB views should display diagnosis descriptions from the platform terminology layer when available, without making claim reads depend on an upstream terminology service being healthy.

## Validation
- `dotnet build src/services/CHO.TerminologyService/CHO.TerminologyService.csproj --no-restore -p:UseAppHost=false`
- `dotnet build src/services/claims-service/claims-service.csproj --no-restore -p:UseAppHost=false`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter DiagnosisMetadataEnricherTests --no-restore -p:UseAppHost=false --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter ClaimsControllerTests --no-restore -p:UseAppHost=false --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "FullyQualifiedName~Fhir" --no-restore -p:UseAppHost=false --logger "console;verbosity=minimal"`
