### PR TITLE
Add ICD-10 display catalog

### DIFF
--- a/src/services/CHO.TerminologyService/Data/MongoCodeSystemCatalogRepository.cs
+++ b/src/services/CHO.TerminologyService/Data/MongoCodeSystemCatalogRepository.cs
@@ -1,0 +1,155 @@
+using CHO.TerminologyService.Models;
+using CHO.TerminologyService.Services;
+using MongoDB.Driver;
+
+namespace CHO.TerminologyService.Data;
+
+public sealed class MongoCodeSystemCatalogRepository : ICodeSystemCatalogRepository
+{
+    private readonly IMongoCollection<CodeSystemConcept> _concepts;
+    private readonly ILogger<MongoCodeSystemCatalogRepository> _logger;
+
+    public MongoCodeSystemCatalogRepository(
+        IMongoDatabase database,
+        ILogger<MongoCodeSystemCatalogRepository> logger)
+    {
+        _concepts = database.GetCollection<CodeSystemConcept>("code_system_concepts");
+        _logger = logger;
+        EnsureIndexes();
+    }
+
+    public async Task<CodeSystemDisplay?> FindDisplayAsync(
+        string system,
+        string code,
+        string? tenantId = null,
+        CancellationToken ct = default)
+    {
+        var normalizedSystem = NormalizeSystem(system);
+        var normalizedCode = NormalizeCode(code);
+        if (string.IsNullOrWhiteSpace(normalizedSystem) || string.IsNullOrWhiteSpace(normalizedCode))
+        {
+            return null;
+        }
+
+        var tenantOverrideFilter = !string.IsNullOrWhiteSpace(tenantId)
+            ? Builders<CodeSystemConcept>.Filter.And(
+                Builders<CodeSystemConcept>.Filter.Eq(x => x.IsOverride, true),
+                Builders<CodeSystemConcept>.Filter.Eq(x => x.TenantId, tenantId))
+            : Builders<CodeSystemConcept>.Filter.Eq(x => x.Id, "__never_match__");
+
+        var globalFilter = Builders<CodeSystemConcept>.Filter.And(
+            Builders<CodeSystemConcept>.Filter.Eq(x => x.IsOverride, false),
+            Builders<CodeSystemConcept>.Filter.Eq(x => x.TenantId, null));
+
+        var filter = Builders<CodeSystemConcept>.Filter.And(
+            Builders<CodeSystemConcept>.Filter.Eq(x => x.System, normalizedSystem),
+            Builders<CodeSystemConcept>.Filter.Eq(x => x.Code, normalizedCode),
+            Builders<CodeSystemConcept>.Filter.Ne(x => x.Display, null),
+            Builders<CodeSystemConcept>.Filter.Ne(x => x.Display, string.Empty),
+            Builders<CodeSystemConcept>.Filter.Or(tenantOverrideFilter, globalFilter));
+
+        var concept = await _concepts.Find(filter)
+            .Sort(Builders<CodeSystemConcept>.Sort
+                .Descending(x => x.IsOverride)
+                .Descending(x => x.UpdatedAtUtc))
+            .FirstOrDefaultAsync(ct);
+
+        return concept is null
+            ? null
+            : new CodeSystemDisplay(
+                concept.Display,
+                concept.Version,
+                concept.IsOverride ? "CodeSystemOverride" : concept.Source);
+    }
+
+    public async Task UpsertManyAsync(IEnumerable<CodeSystemConcept> concepts, CancellationToken ct = default)
+    {
+        var writes = concepts
+            .Select(Normalize)
+            .Where(concept =>
+                !string.IsNullOrWhiteSpace(concept.System) &&
+                !string.IsNullOrWhiteSpace(concept.Code) &&
+                !string.IsNullOrWhiteSpace(concept.Display))
+            .Select(concept =>
+            {
+                var filter = Builders<CodeSystemConcept>.Filter.And(
+                    Builders<CodeSystemConcept>.Filter.Eq(x => x.System, concept.System),
+                    Builders<CodeSystemConcept>.Filter.Eq(x => x.Code, concept.Code),
+                    Builders<CodeSystemConcept>.Filter.Eq(x => x.TenantId, concept.TenantId),
+                    Builders<CodeSystemConcept>.Filter.Eq(x => x.IsOverride, concept.IsOverride));
+
+                var update = Builders<CodeSystemConcept>.Update
+                    .Set(x => x.Display, concept.Display)
+                    .Set(x => x.Version, concept.Version)
+                    .Set(x => x.Source, concept.Source)
+                    .Set(x => x.UpdatedAtUtc, concept.UpdatedAtUtc)
+                    .SetOnInsert(x => x.Id, concept.Id)
+                    .SetOnInsert(x => x.System, concept.System)
+                    .SetOnInsert(x => x.Code, concept.Code)
+                    .SetOnInsert(x => x.TenantId, concept.TenantId)
+                    .SetOnInsert(x => x.IsOverride, concept.IsOverride);
+
+                return new UpdateOneModel<CodeSystemConcept>(filter, update)
+                {
+                    IsUpsert = true
+                };
+            })
+            .Cast<WriteModel<CodeSystemConcept>>()
+            .ToList();
+
+        if (writes.Count == 0)
+        {
+            return;
+        }
+
+        await _concepts.BulkWriteAsync(writes, new BulkWriteOptions { IsOrdered = false }, ct);
+        _logger.LogInformation("Upserted {ConceptCount} code-system concepts", writes.Count);
+    }
+
+    private void EnsureIndexes()
+    {
+        _concepts.Indexes.CreateOne(new CreateIndexModel<CodeSystemConcept>(
+            Builders<CodeSystemConcept>.IndexKeys
+                .Ascending(x => x.System)
+                .Ascending(x => x.Code)
+                .Ascending(x => x.TenantId)
+                .Ascending(x => x.IsOverride),
+            new CreateIndexOptions
+            {
+                Name = "idx_code_system_lookup",
+                Unique = true
+            }));
+
+        _logger.LogInformation("MongoDB indexes ensured for code_system_concepts");
+    }
+
+    private static CodeSystemConcept Normalize(CodeSystemConcept concept)
+    {
+        var normalizedSystem = NormalizeSystem(concept.System);
+        var normalizedCode = NormalizeCode(concept.Code);
+        return new CodeSystemConcept
+        {
+            Id = string.IsNullOrWhiteSpace(concept.Id)
+                ? BuildId(normalizedSystem, normalizedCode, concept.TenantId, concept.IsOverride)
+                : concept.Id,
+            System = normalizedSystem,
+            Code = normalizedCode,
+            Display = concept.Display.Trim(),
+            Version = string.IsNullOrWhiteSpace(concept.Version) ? null : concept.Version.Trim(),
+            Source = string.IsNullOrWhiteSpace(concept.Source) ? "CodeSystemCatalog" : concept.Source.Trim(),
+            TenantId = string.IsNullOrWhiteSpace(concept.TenantId) ? null : concept.TenantId.Trim(),
+            IsOverride = concept.IsOverride,
+            UpdatedAtUtc = concept.UpdatedAtUtc == default ? DateTime.UtcNow : concept.UpdatedAtUtc
+        };
+    }
+
+    private static string NormalizeSystem(string system) => system.Trim();
+
+    private static string NormalizeCode(string code) => code.Trim().ToUpperInvariant();
+
+    private static string BuildId(string system, string code, string? tenantId, bool isOverride)
+    {
+        var scope = isOverride ? tenantId ?? "override" : "global";
+        return $"{system}|{code}|{scope}";
+    }
+}

--- a/src/services/CHO.TerminologyService/Models/CodeSystemModels.cs
+++ b/src/services/CHO.TerminologyService/Models/CodeSystemModels.cs
@@ -1,0 +1,19 @@
+namespace CHO.TerminologyService.Models;
+
+/// <summary>
+/// A displayable code-system concept, stored independently from ConceptMap crosswalks.
+/// </summary>
+public class CodeSystemConcept
+{
+    public string Id { get; set; } = string.Empty;
+    public string System { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Display { get; set; } = string.Empty;
+    public string? Version { get; set; }
+    public string Source { get; set; } = "CodeSystemCatalog";
+    public string? TenantId { get; set; }
+    public bool IsOverride { get; set; }
+    public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
+}
+
+public sealed record CodeSystemDisplay(string Display, string? Version, string Source);

--- a/src/services/CHO.TerminologyService/Program.cs
+++ b/src/services/CHO.TerminologyService/Program.cs
@@ -1,6 +1,7 @@
 using CHO.TerminologyService.Configuration;
 using CHO.TerminologyService.Data;
 using CHO.TerminologyService.Services;
+using CHO.TerminologyService.Services.CodeSystemCatalog;
 using CHO.TerminologyService.Services.Loaders;
 using CHO.TerminologyService.Services.Rules;
 using MongoDB.Driver;
@@ -46,8 +47,10 @@ builder.Services.AddSingleton<IMongoDatabase>(sp =>
 // Services
 // ──────────────────────────────────────────────────────
 builder.Services.AddSingleton<IConceptMapRepository, MongoConceptMapRepository>();
+builder.Services.AddSingleton<ICodeSystemCatalogRepository, MongoCodeSystemCatalogRepository>();
 builder.Services.AddSingleton<IContextRuleEngine, ContextRuleEngine>();
 builder.Services.AddSingleton<ITerminologyTranslationService, TerminologyTranslationService>();
+builder.Services.AddHostedService<CodeSystemCatalogSeedService>();
 
 // Map loaders (register all implementations)
 builder.Services.AddSingleton<IMapLoader, Rf2MapLoader>();

--- a/src/services/CHO.TerminologyService/README.md
+++ b/src/services/CHO.TerminologyService/README.md
@@ -145,6 +145,11 @@ available there, it falls back to display text present on active ConceptMap
 entries. This keeps ICD-10-CM claim displays independent from SNOMED-to-ICD
 crosswalk files, whose target displays may be blank in RF2 source data.
 
+The built-in MCC/demo ICD-10-CM seed uses the shared
+`SyntheticIcd10CmCatalog` reference data also used by claims-service as its
+fail-soft fallback when TerminologyService is unavailable, so the startup seed
+and local fallback do not drift independently.
+
 ### Load a crosswalk map
 
 ```bash

--- a/src/services/CHO.TerminologyService/README.md
+++ b/src/services/CHO.TerminologyService/README.md
@@ -1,9 +1,10 @@
 # CHO.TerminologyService
 
-FHIR ConceptMap/$translate terminology crosswalk microservice for Cloud Health Office.
+FHIR ConceptMap/$translate and CodeSystem/$lookup terminology microservice for Cloud Health Office.
 
-Translates between SNOMED CT, ICD-10-CM, and CPT code systems — the built-in
-terminology layer that ships with CHO for CMS-0057 compliance.
+Translates between SNOMED CT, ICD-10-CM, and CPT code systems, and provides
+display metadata for known code systems — the built-in terminology layer that
+ships with CHO for CMS-0057 compliance.
 
 ## Why This Exists
 
@@ -30,9 +31,17 @@ with plan-specific override support for state Medicaid rules (TMPPM, etc.).
 │  │ Loader (RF2/CSV) │  │ (MongoDB versioned)  │  │
 │  └─────────────────┘  └──────────┬───────────┘  │
 │  ┌─────────────────┐  ┌──────────▼───────────┐  │
+│  │ CodeSystem      │→ │ Code Display Catalog │  │
+│  │ seed/import     │  │ (MongoDB versioned)  │  │
+│  └─────────────────┘  └──────────┬───────────┘  │
+│  ┌─────────────────┐  ┌──────────▼───────────┐  │
 │  │ FHIR $translate │← │ Context Rule Engine   │  │
 │  │ API endpoint    │  │ (age/gender/state)    │  │
 │  └─────────────────┘  └──────────────────────┘  │
+│  ┌────────────────────────────────────────────┐  │
+│  │ FHIR $lookup API endpoint                  │  │
+│  │ CodeSystem catalog → ConceptMap fallback   │  │
+│  └────────────────────────────────────────────┘  │
 │  ┌────────────────────────────────────────────┐  │
 │  │ Plan-Specific Overrides                    │  │
 │  │ (TMPPM, Medicaid state rules, local codes) │  │
@@ -110,6 +119,31 @@ Content-Type: application/json
   { "system": "http://snomed.info/sct", "code": "871751006", "targetSystem": "http://hl7.org/fhir/sid/icd-10-cm" }
 ]
 ```
+
+### Look up code display metadata
+
+```bash
+GET /fhir/CodeSystem/$lookup?system=http://hl7.org/fhir/sid/icd-10-cm&code=E11.65
+```
+
+Response:
+
+```json
+{
+  "result": true,
+  "system": "http://hl7.org/fhir/sid/icd-10-cm",
+  "code": "E11.65",
+  "display": "Type 2 diabetes mellitus with hyperglycemia",
+  "mapVersionId": "mcc-seed-2026",
+  "source": "BuiltInIcd10CmCatalog",
+  "lookedUpAt": "2026-07-15T20:30:00Z"
+}
+```
+
+The lookup path checks the code-system display catalog first. If no display is
+available there, it falls back to display text present on active ConceptMap
+entries. This keeps ICD-10-CM claim displays independent from SNOMED-to-ICD
+crosswalk files, whose target displays may be blank in RF2 source data.
 
 ### Load a crosswalk map
 

--- a/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/BuiltInIcd10CmCatalog.cs
+++ b/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/BuiltInIcd10CmCatalog.cs
@@ -1,3 +1,4 @@
+using CloudHealthOffice.Infrastructure.ReferenceData;
 using CHO.TerminologyService.Models;
 
 namespace CHO.TerminologyService.Services.CodeSystemCatalog;
@@ -9,72 +10,9 @@ internal static class BuiltInIcd10CmCatalog
     private const string Version = "mcc-seed-2026";
 
     public static IReadOnlyList<CodeSystemConcept> Concepts { get; } =
-    [
-        Concept("J06.9", "Acute upper respiratory infection, unspecified"),
-        Concept("J20.9", "Acute bronchitis, unspecified"),
-        Concept("J18.9", "Pneumonia, unspecified organism"),
-        Concept("M54.5", "Low back pain"),
-        Concept("M79.3", "Panniculitis, unspecified"),
-        Concept("R10.9", "Unspecified abdominal pain"),
-        Concept("R51.9", "Headache, unspecified"),
-        Concept("I10", "Essential (primary) hypertension"),
-        Concept("E11.9", "Type 2 diabetes mellitus without complications"),
-        Concept("E11.65", "Type 2 diabetes mellitus with hyperglycemia"),
-        Concept("E78.5", "Dyslipidemia, unspecified"),
-        Concept("F41.1", "Generalized anxiety disorder"),
-        Concept("F32.1", "Major depressive disorder, single episode, moderate"),
-        Concept("K21.0", "Gastro-esophageal reflux disease with esophagitis"),
-        Concept("N39.0", "Urinary tract infection, site not specified"),
-        Concept("J45.20", "Mild intermittent asthma, uncomplicated"),
-        Concept("L30.9", "Dermatitis, unspecified"),
-        Concept("H66.90", "Otitis media, unspecified, unspecified ear"),
-        Concept("B34.9", "Viral infection, unspecified"),
-        Concept("Z00.00", "Encounter for general adult medical examination without abnormal findings"),
-        Concept("K80.20", "Calculus of gallbladder without cholecystitis without obstruction"),
-        Concept("K40.90", "Unilateral inguinal hernia, without obstruction or gangrene, not specified as recurrent"),
-        Concept("M17.11", "Primary osteoarthritis, right knee"),
-        Concept("M17.12", "Primary osteoarthritis, left knee"),
-        Concept("M16.11", "Primary osteoarthritis, right hip"),
-        Concept("G56.00", "Carpal tunnel syndrome, unspecified upper limb"),
-        Concept("H25.11", "Age-related nuclear cataract, right eye"),
-        Concept("K35.80", "Unspecified acute appendicitis"),
-        Concept("M75.110", "Incomplete rotator cuff tear of right shoulder"),
-        Concept("N20.0", "Calculus of kidney"),
-        Concept("I21.3", "ST elevation (STEMI) myocardial infarction of unspecified site"),
-        Concept("I63.9", "Cerebral infarction, unspecified"),
-        Concept("S72.001A", "Fracture of unspecified part of neck of right femur, initial encounter"),
-        Concept("S52.501A", "Unspecified fracture of the lower end of right radius, initial encounter"),
-        Concept("K92.2", "Gastrointestinal hemorrhage, unspecified"),
-        Concept("R55", "Syncope and collapse"),
-        Concept("R07.9", "Chest pain, unspecified"),
-        Concept("S06.0X0A", "Concussion without loss of consciousness, initial encounter"),
-        Concept("T78.2XXA", "Anaphylactic shock, unspecified, initial encounter"),
-        Concept("J96.00", "Acute respiratory failure, unspecified whether with hypoxia or hypercapnia"),
-        Concept("F33.1", "Major depressive disorder, recurrent, moderate"),
-        Concept("F41.0", "Panic disorder without agoraphobia"),
-        Concept("F43.10", "Post-traumatic stress disorder, unspecified"),
-        Concept("F10.20", "Alcohol dependence, uncomplicated"),
-        Concept("F11.20", "Opioid dependence, uncomplicated"),
-        Concept("F31.9", "Bipolar disorder, unspecified"),
-        Concept("F84.0", "Autistic disorder"),
-        Concept("F90.9", "Attention-deficit hyperactivity disorder, unspecified type"),
-        Concept("K02.9", "Dental caries, unspecified"),
-        Concept("K04.0", "Pulpitis"),
-        Concept("K05.10", "Chronic gingivitis, plaque induced"),
-        Concept("K05.31", "Chronic periodontitis, localized, moderate"),
-        Concept("K08.1", "Complete loss of teeth"),
-        Concept("K08.401", "Partial loss of teeth, unspecified cause, class I"),
-        Concept("K12.1", "Other forms of stomatitis"),
-        Concept("M26.69", "Other specified disorders of temporomandibular joint"),
-        Concept("K03.0", "Excessive attrition of teeth"),
-        Concept("S02.5XXA", "Fracture of tooth (traumatic), initial encounter"),
-        Concept("Z38.00", "Single liveborn infant, delivered vaginally"),
-        Concept("Z38.01", "Single liveborn infant, delivered by cesarean"),
-        Concept("P59.9", "Neonatal jaundice, unspecified"),
-        Concept("P22.1", "Transient tachypnea of newborn"),
-        Concept("P07.39", "Other preterm newborn"),
-        Concept("P92.5", "Neonatal difficulty in feeding at breast")
-    ];
+        SyntheticIcd10CmCatalog.Diagnoses
+            .Select(diagnosis => Concept(diagnosis.Code, diagnosis.Display))
+            .ToList();
 
     private static CodeSystemConcept Concept(string code, string display)
     {

--- a/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/BuiltInIcd10CmCatalog.cs
+++ b/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/BuiltInIcd10CmCatalog.cs
@@ -1,0 +1,90 @@
+using CHO.TerminologyService.Models;
+
+namespace CHO.TerminologyService.Services.CodeSystemCatalog;
+
+internal static class BuiltInIcd10CmCatalog
+{
+    public const string System = "http://hl7.org/fhir/sid/icd-10-cm";
+    private const string Source = "BuiltInIcd10CmCatalog";
+    private const string Version = "mcc-seed-2026";
+
+    public static IReadOnlyList<CodeSystemConcept> Concepts { get; } =
+    [
+        Concept("J06.9", "Acute upper respiratory infection, unspecified"),
+        Concept("J20.9", "Acute bronchitis, unspecified"),
+        Concept("J18.9", "Pneumonia, unspecified organism"),
+        Concept("M54.5", "Low back pain"),
+        Concept("M79.3", "Panniculitis, unspecified"),
+        Concept("R10.9", "Unspecified abdominal pain"),
+        Concept("R51.9", "Headache, unspecified"),
+        Concept("I10", "Essential (primary) hypertension"),
+        Concept("E11.9", "Type 2 diabetes mellitus without complications"),
+        Concept("E11.65", "Type 2 diabetes mellitus with hyperglycemia"),
+        Concept("E78.5", "Dyslipidemia, unspecified"),
+        Concept("F41.1", "Generalized anxiety disorder"),
+        Concept("F32.1", "Major depressive disorder, single episode, moderate"),
+        Concept("K21.0", "Gastro-esophageal reflux disease with esophagitis"),
+        Concept("N39.0", "Urinary tract infection, site not specified"),
+        Concept("J45.20", "Mild intermittent asthma, uncomplicated"),
+        Concept("L30.9", "Dermatitis, unspecified"),
+        Concept("H66.90", "Otitis media, unspecified, unspecified ear"),
+        Concept("B34.9", "Viral infection, unspecified"),
+        Concept("Z00.00", "Encounter for general adult medical examination without abnormal findings"),
+        Concept("K80.20", "Calculus of gallbladder without cholecystitis without obstruction"),
+        Concept("K40.90", "Unilateral inguinal hernia, without obstruction or gangrene, not specified as recurrent"),
+        Concept("M17.11", "Primary osteoarthritis, right knee"),
+        Concept("M17.12", "Primary osteoarthritis, left knee"),
+        Concept("M16.11", "Primary osteoarthritis, right hip"),
+        Concept("G56.00", "Carpal tunnel syndrome, unspecified upper limb"),
+        Concept("H25.11", "Age-related nuclear cataract, right eye"),
+        Concept("K35.80", "Unspecified acute appendicitis"),
+        Concept("M75.110", "Incomplete rotator cuff tear of right shoulder"),
+        Concept("N20.0", "Calculus of kidney"),
+        Concept("I21.3", "ST elevation (STEMI) myocardial infarction of unspecified site"),
+        Concept("I63.9", "Cerebral infarction, unspecified"),
+        Concept("S72.001A", "Fracture of unspecified part of neck of right femur, initial encounter"),
+        Concept("S52.501A", "Unspecified fracture of the lower end of right radius, initial encounter"),
+        Concept("K92.2", "Gastrointestinal hemorrhage, unspecified"),
+        Concept("R55", "Syncope and collapse"),
+        Concept("R07.9", "Chest pain, unspecified"),
+        Concept("S06.0X0A", "Concussion without loss of consciousness, initial encounter"),
+        Concept("T78.2XXA", "Anaphylactic shock, unspecified, initial encounter"),
+        Concept("J96.00", "Acute respiratory failure, unspecified whether with hypoxia or hypercapnia"),
+        Concept("F33.1", "Major depressive disorder, recurrent, moderate"),
+        Concept("F41.0", "Panic disorder without agoraphobia"),
+        Concept("F43.10", "Post-traumatic stress disorder, unspecified"),
+        Concept("F10.20", "Alcohol dependence, uncomplicated"),
+        Concept("F11.20", "Opioid dependence, uncomplicated"),
+        Concept("F31.9", "Bipolar disorder, unspecified"),
+        Concept("F84.0", "Autistic disorder"),
+        Concept("F90.9", "Attention-deficit hyperactivity disorder, unspecified type"),
+        Concept("K02.9", "Dental caries, unspecified"),
+        Concept("K04.0", "Pulpitis"),
+        Concept("K05.10", "Chronic gingivitis, plaque induced"),
+        Concept("K05.31", "Chronic periodontitis, localized, moderate"),
+        Concept("K08.1", "Complete loss of teeth"),
+        Concept("K08.401", "Partial loss of teeth, unspecified cause, class I"),
+        Concept("K12.1", "Other forms of stomatitis"),
+        Concept("M26.69", "Other specified disorders of temporomandibular joint"),
+        Concept("K03.0", "Excessive attrition of teeth"),
+        Concept("S02.5XXA", "Fracture of tooth (traumatic), initial encounter"),
+        Concept("Z38.00", "Single liveborn infant, delivered vaginally"),
+        Concept("Z38.01", "Single liveborn infant, delivered by cesarean"),
+        Concept("P59.9", "Neonatal jaundice, unspecified"),
+        Concept("P22.1", "Transient tachypnea of newborn"),
+        Concept("P07.39", "Other preterm newborn"),
+        Concept("P92.5", "Neonatal difficulty in feeding at breast")
+    ];
+
+    private static CodeSystemConcept Concept(string code, string display)
+    {
+        return new CodeSystemConcept
+        {
+            System = System,
+            Code = code,
+            Display = display,
+            Version = Version,
+            Source = Source
+        };
+    }
+}

--- a/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/CodeSystemCatalogSeedService.cs
+++ b/src/services/CHO.TerminologyService/Services/CodeSystemCatalog/CodeSystemCatalogSeedService.cs
@@ -1,0 +1,25 @@
+namespace CHO.TerminologyService.Services.CodeSystemCatalog;
+
+internal sealed class CodeSystemCatalogSeedService : IHostedService
+{
+    private readonly ICodeSystemCatalogRepository _repository;
+    private readonly ILogger<CodeSystemCatalogSeedService> _logger;
+
+    public CodeSystemCatalogSeedService(
+        ICodeSystemCatalogRepository repository,
+        ILogger<CodeSystemCatalogSeedService> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _repository.UpsertManyAsync(BuiltInIcd10CmCatalog.Concepts, cancellationToken);
+        _logger.LogInformation(
+            "Seeded {ConceptCount} built-in ICD-10-CM code-system concepts",
+            BuiltInIcd10CmCatalog.Concepts.Count);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/CHO.TerminologyService/Services/Interfaces.cs
+++ b/src/services/CHO.TerminologyService/Services/Interfaces.cs
@@ -71,6 +71,17 @@ public interface IConceptMapRepository
 }
 
 /// <summary>
+/// Repository for display metadata owned by a code system, independent of ConceptMap crosswalks.
+/// </summary>
+public interface ICodeSystemCatalogRepository
+{
+    Task<CodeSystemDisplay?> FindDisplayAsync(
+        string system, string code, string? tenantId = null, CancellationToken ct = default);
+
+    Task UpsertManyAsync(IEnumerable<CodeSystemConcept> concepts, CancellationToken ct = default);
+}
+
+/// <summary>
 /// Loads crosswalk data from various source formats.
 /// Implementations: Rf2MapLoader (NLM SNOMED), CsvMapLoader (AMA CPT cross maps, plan-specific overrides).
 /// </summary>

--- a/src/services/CHO.TerminologyService/Services/TerminologyTranslationService.cs
+++ b/src/services/CHO.TerminologyService/Services/TerminologyTranslationService.cs
@@ -17,6 +17,7 @@ namespace CHO.TerminologyService.Services;
 public class TerminologyTranslationService : ITerminologyTranslationService
 {
     private readonly IConceptMapRepository _repository;
+    private readonly ICodeSystemCatalogRepository _codeSystemCatalog;
     private readonly IContextRuleEngine _ruleEngine;
     private readonly IMemoryCache _cache;
     private readonly ILogger<TerminologyTranslationService> _logger;
@@ -24,12 +25,14 @@ public class TerminologyTranslationService : ITerminologyTranslationService
 
     public TerminologyTranslationService(
         IConceptMapRepository repository,
+        ICodeSystemCatalogRepository codeSystemCatalog,
         IContextRuleEngine ruleEngine,
         IMemoryCache cache,
         ILogger<TerminologyTranslationService> logger,
         IOptions<TerminologyServiceOptions> options)
     {
         _repository = repository;
+        _codeSystemCatalog = codeSystemCatalog;
         _ruleEngine = ruleEngine;
         _cache = cache;
         _logger = logger;
@@ -143,6 +146,20 @@ public class TerminologyTranslationService : ITerminologyTranslationService
             System = request.System,
             Code = request.Code
         };
+
+        var codeSystemDisplay = await _codeSystemCatalog.FindDisplayAsync(
+            request.System,
+            request.Code,
+            request.TenantId,
+            ct);
+        if (codeSystemDisplay is not null)
+        {
+            response.Result = true;
+            response.Display = codeSystemDisplay.Display;
+            response.MapVersionId = codeSystemDisplay.Version;
+            response.Source = codeSystemDisplay.Source;
+            return response;
+        }
 
         var candidates = await _repository.FindDisplaysByCodeAsync(
             request.System,

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -151,17 +151,17 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
             return cached?.Description;
         }
 
-        if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
-        {
-            Cache(cacheKey, syntheticDescription);
-            return syntheticDescription;
-        }
-
         var terminologyDescription = await TryFindTerminologyDescriptionAsync(normalizedCode, ct);
         if (!string.IsNullOrWhiteSpace(terminologyDescription))
         {
             Cache(cacheKey, terminologyDescription);
             return terminologyDescription;
+        }
+
+        if (SyntheticDiagnosisDescriptions.TryGetValue(normalizedCode, out var syntheticDescription))
+        {
+            Cache(cacheKey, syntheticDescription);
+            return syntheticDescription;
         }
 
         var referenceDataDescription = await TryFindReferenceDataDescriptionAsync(normalizedCode, ct);

--- a/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
+++ b/src/services/claims-service/Services/DiagnosisMetadataEnricher.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using CloudHealthOffice.Infrastructure.ReferenceData;
 using Microsoft.Extensions.Caching.Memory;
 using ClaimsService.Models;
 
@@ -314,71 +315,8 @@ public sealed class DiagnosisDescriptionLookup : IDiagnosisDescriptionLookup
     }
 
     private static readonly IReadOnlyDictionary<string, string> SyntheticDiagnosisDescriptions =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["J06.9"] = "Acute upper respiratory infection, unspecified",
-            ["J20.9"] = "Acute bronchitis, unspecified",
-            ["J18.9"] = "Pneumonia, unspecified organism",
-            ["M54.5"] = "Low back pain",
-            ["M79.3"] = "Panniculitis, unspecified",
-            ["R10.9"] = "Unspecified abdominal pain",
-            ["R51.9"] = "Headache, unspecified",
-            ["I10"] = "Essential (primary) hypertension",
-            ["E11.9"] = "Type 2 diabetes mellitus without complications",
-            ["E11.65"] = "Type 2 diabetes mellitus with hyperglycemia",
-            ["E78.5"] = "Dyslipidemia, unspecified",
-            ["F41.1"] = "Generalized anxiety disorder",
-            ["F32.1"] = "Major depressive disorder, single episode, moderate",
-            ["K21.0"] = "Gastro-esophageal reflux disease with esophagitis",
-            ["N39.0"] = "Urinary tract infection, site not specified",
-            ["J45.20"] = "Mild intermittent asthma, uncomplicated",
-            ["L30.9"] = "Dermatitis, unspecified",
-            ["H66.90"] = "Otitis media, unspecified, unspecified ear",
-            ["B34.9"] = "Viral infection, unspecified",
-            ["Z00.00"] = "Encounter for general adult medical examination without abnormal findings",
-            ["K80.20"] = "Calculus of gallbladder without cholecystitis without obstruction",
-            ["K40.90"] = "Unilateral inguinal hernia, without obstruction or gangrene, not specified as recurrent",
-            ["M17.11"] = "Primary osteoarthritis, right knee",
-            ["M17.12"] = "Primary osteoarthritis, left knee",
-            ["M16.11"] = "Primary osteoarthritis, right hip",
-            ["G56.00"] = "Carpal tunnel syndrome, unspecified upper limb",
-            ["H25.11"] = "Age-related nuclear cataract, right eye",
-            ["K35.80"] = "Unspecified acute appendicitis",
-            ["M75.110"] = "Incomplete rotator cuff tear of right shoulder",
-            ["N20.0"] = "Calculus of kidney",
-            ["I21.3"] = "ST elevation (STEMI) myocardial infarction of unspecified site",
-            ["I63.9"] = "Cerebral infarction, unspecified",
-            ["S72.001A"] = "Fracture of unspecified part of neck of right femur, initial encounter",
-            ["S52.501A"] = "Unspecified fracture of the lower end of right radius, initial encounter",
-            ["K92.2"] = "Gastrointestinal hemorrhage, unspecified",
-            ["R55"] = "Syncope and collapse",
-            ["R07.9"] = "Chest pain, unspecified",
-            ["S06.0X0A"] = "Concussion without loss of consciousness, initial encounter",
-            ["T78.2XXA"] = "Anaphylactic shock, unspecified, initial encounter",
-            ["J96.00"] = "Acute respiratory failure, unspecified whether with hypoxia or hypercapnia",
-            ["F33.1"] = "Major depressive disorder, recurrent, moderate",
-            ["F41.0"] = "Panic disorder without agoraphobia",
-            ["F43.10"] = "Post-traumatic stress disorder, unspecified",
-            ["F10.20"] = "Alcohol dependence, uncomplicated",
-            ["F11.20"] = "Opioid dependence, uncomplicated",
-            ["F31.9"] = "Bipolar disorder, unspecified",
-            ["F84.0"] = "Autistic disorder",
-            ["F90.9"] = "Attention-deficit hyperactivity disorder, unspecified type",
-            ["K02.9"] = "Dental caries, unspecified",
-            ["K04.0"] = "Pulpitis",
-            ["K05.10"] = "Chronic gingivitis, plaque induced",
-            ["K05.31"] = "Chronic periodontitis, localized, moderate",
-            ["K08.1"] = "Complete loss of teeth",
-            ["K08.401"] = "Partial loss of teeth, unspecified cause, class I",
-            ["K12.1"] = "Other forms of stomatitis",
-            ["M26.69"] = "Other specified disorders of temporomandibular joint",
-            ["K03.0"] = "Excessive attrition of teeth",
-            ["S02.5XXA"] = "Fracture of tooth (traumatic), initial encounter",
-            ["Z38.00"] = "Single liveborn infant, delivered vaginally",
-            ["Z38.01"] = "Single liveborn infant, delivered by cesarean",
-            ["P59.9"] = "Neonatal jaundice, unspecified",
-            ["P22.1"] = "Transient tachypnea of newborn",
-            ["P07.39"] = "Other preterm newborn",
-            ["P92.5"] = "Neonatal difficulty in feeding at breast"
-        };
+        SyntheticIcd10CmCatalog.Diagnoses.ToDictionary(
+            diagnosis => diagnosis.Code,
+            diagnosis => diagnosis.Display,
+            StringComparer.OrdinalIgnoreCase);
 }

--- a/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ReferenceData/SyntheticIcd10CmCatalogTests.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure.Tests/ReferenceData/SyntheticIcd10CmCatalogTests.cs
@@ -1,0 +1,24 @@
+using CloudHealthOffice.Infrastructure.ReferenceData;
+
+namespace CloudHealthOffice.Infrastructure.Tests.ReferenceData;
+
+public sealed class SyntheticIcd10CmCatalogTests
+{
+    [Fact]
+    public void Diagnoses_HaveUniqueCodesAndDisplays()
+    {
+        Assert.All(SyntheticIcd10CmCatalog.Diagnoses, diagnosis =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(diagnosis.Code));
+            Assert.False(string.IsNullOrWhiteSpace(diagnosis.Display));
+        });
+
+        var duplicateCodes = SyntheticIcd10CmCatalog.Diagnoses
+            .GroupBy(diagnosis => diagnosis.Code, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        Assert.Empty(duplicateCodes);
+    }
+}

--- a/src/services/shared/CloudHealthOffice.Infrastructure/ReferenceData/SyntheticIcd10CmCatalog.cs
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/ReferenceData/SyntheticIcd10CmCatalog.cs
@@ -1,0 +1,79 @@
+namespace CloudHealthOffice.Infrastructure.ReferenceData;
+
+/// <summary>
+/// ICD-10-CM display metadata used by the synthetic MCC/demo claim corpus.
+/// </summary>
+public static class SyntheticIcd10CmCatalog
+{
+    public static IReadOnlyList<SyntheticIcd10CmDiagnosis> Diagnoses { get; } =
+    [
+        Diagnosis("J06.9", "Acute upper respiratory infection, unspecified"),
+        Diagnosis("J20.9", "Acute bronchitis, unspecified"),
+        Diagnosis("J18.9", "Pneumonia, unspecified organism"),
+        Diagnosis("M54.5", "Low back pain"),
+        Diagnosis("M79.3", "Panniculitis, unspecified"),
+        Diagnosis("R10.9", "Unspecified abdominal pain"),
+        Diagnosis("R51.9", "Headache, unspecified"),
+        Diagnosis("I10", "Essential (primary) hypertension"),
+        Diagnosis("E11.9", "Type 2 diabetes mellitus without complications"),
+        Diagnosis("E11.65", "Type 2 diabetes mellitus with hyperglycemia"),
+        Diagnosis("E78.5", "Dyslipidemia, unspecified"),
+        Diagnosis("F41.1", "Generalized anxiety disorder"),
+        Diagnosis("F32.1", "Major depressive disorder, single episode, moderate"),
+        Diagnosis("K21.0", "Gastro-esophageal reflux disease with esophagitis"),
+        Diagnosis("N39.0", "Urinary tract infection, site not specified"),
+        Diagnosis("J45.20", "Mild intermittent asthma, uncomplicated"),
+        Diagnosis("L30.9", "Dermatitis, unspecified"),
+        Diagnosis("H66.90", "Otitis media, unspecified, unspecified ear"),
+        Diagnosis("B34.9", "Viral infection, unspecified"),
+        Diagnosis("Z00.00", "Encounter for general adult medical examination without abnormal findings"),
+        Diagnosis("K80.20", "Calculus of gallbladder without cholecystitis without obstruction"),
+        Diagnosis("K40.90", "Unilateral inguinal hernia, without obstruction or gangrene, not specified as recurrent"),
+        Diagnosis("M17.11", "Primary osteoarthritis, right knee"),
+        Diagnosis("M17.12", "Primary osteoarthritis, left knee"),
+        Diagnosis("M16.11", "Primary osteoarthritis, right hip"),
+        Diagnosis("G56.00", "Carpal tunnel syndrome, unspecified upper limb"),
+        Diagnosis("H25.11", "Age-related nuclear cataract, right eye"),
+        Diagnosis("K35.80", "Unspecified acute appendicitis"),
+        Diagnosis("M75.110", "Incomplete rotator cuff tear of right shoulder"),
+        Diagnosis("N20.0", "Calculus of kidney"),
+        Diagnosis("I21.3", "ST elevation (STEMI) myocardial infarction of unspecified site"),
+        Diagnosis("I63.9", "Cerebral infarction, unspecified"),
+        Diagnosis("S72.001A", "Fracture of unspecified part of neck of right femur, initial encounter"),
+        Diagnosis("S52.501A", "Unspecified fracture of the lower end of right radius, initial encounter"),
+        Diagnosis("K92.2", "Gastrointestinal hemorrhage, unspecified"),
+        Diagnosis("R55", "Syncope and collapse"),
+        Diagnosis("R07.9", "Chest pain, unspecified"),
+        Diagnosis("S06.0X0A", "Concussion without loss of consciousness, initial encounter"),
+        Diagnosis("T78.2XXA", "Anaphylactic shock, unspecified, initial encounter"),
+        Diagnosis("J96.00", "Acute respiratory failure, unspecified whether with hypoxia or hypercapnia"),
+        Diagnosis("F33.1", "Major depressive disorder, recurrent, moderate"),
+        Diagnosis("F41.0", "Panic disorder without agoraphobia"),
+        Diagnosis("F43.10", "Post-traumatic stress disorder, unspecified"),
+        Diagnosis("F10.20", "Alcohol dependence, uncomplicated"),
+        Diagnosis("F11.20", "Opioid dependence, uncomplicated"),
+        Diagnosis("F31.9", "Bipolar disorder, unspecified"),
+        Diagnosis("F84.0", "Autistic disorder"),
+        Diagnosis("F90.9", "Attention-deficit hyperactivity disorder, unspecified type"),
+        Diagnosis("K02.9", "Dental caries, unspecified"),
+        Diagnosis("K04.0", "Pulpitis"),
+        Diagnosis("K05.10", "Chronic gingivitis, plaque induced"),
+        Diagnosis("K05.31", "Chronic periodontitis, localized, moderate"),
+        Diagnosis("K08.1", "Complete loss of teeth"),
+        Diagnosis("K08.401", "Partial loss of teeth, unspecified cause, class I"),
+        Diagnosis("K12.1", "Other forms of stomatitis"),
+        Diagnosis("M26.69", "Other specified disorders of temporomandibular joint"),
+        Diagnosis("K03.0", "Excessive attrition of teeth"),
+        Diagnosis("S02.5XXA", "Fracture of tooth (traumatic), initial encounter"),
+        Diagnosis("Z38.00", "Single liveborn infant, delivered vaginally"),
+        Diagnosis("Z38.01", "Single liveborn infant, delivered by cesarean"),
+        Diagnosis("P59.9", "Neonatal jaundice, unspecified"),
+        Diagnosis("P22.1", "Transient tachypnea of newborn"),
+        Diagnosis("P07.39", "Other preterm newborn"),
+        Diagnosis("P92.5", "Neonatal difficulty in feeding at breast")
+    ];
+
+    private static SyntheticIcd10CmDiagnosis Diagnosis(string code, string display) => new(code, display);
+}
+
+public sealed record SyntheticIcd10CmDiagnosis(string Code, string Display);

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/DiagnosisMetadataEnricherTests.cs
@@ -27,10 +27,25 @@ public sealed class DiagnosisMetadataEnricherTests
     }
 
     [Fact]
-    public async Task FindDescriptionAsync_SyntheticHit_DoesNotCallTerminology()
+    public async Task FindDescriptionAsync_TerminologyHitForSyntheticCode_ReturnsTerminologyDisplay()
     {
-        var terminologyHandler = FakeHttpMessageHandler.Throw(
-            new InvalidOperationException("Terminology should not be called for known synthetic codes."));
+        var terminologyHandler = FakeHttpMessageHandler.Json(
+            """{"result":true,"display":"Terminology catalog display for diabetes"}""");
+        var referenceHandler = FakeHttpMessageHandler.Throw(
+            new InvalidOperationException("Reference data should not be called when terminology resolves."));
+        var lookup = CreateLookup(referenceHandler, terminologyHandler);
+
+        var description = await lookup.FindDescriptionAsync("E11.65");
+
+        Assert.Equal("Terminology catalog display for diabetes", description);
+        Assert.Equal(1, terminologyHandler.RequestCount);
+        Assert.Equal(0, referenceHandler.RequestCount);
+    }
+
+    [Fact]
+    public async Task FindDescriptionAsync_TerminologyUnavailable_UsesSyntheticFallback()
+    {
+        var terminologyHandler = FakeHttpMessageHandler.Status(HttpStatusCode.ServiceUnavailable);
         var referenceHandler = FakeHttpMessageHandler.Throw(
             new InvalidOperationException("Reference data should not be called for known synthetic codes."));
         var lookup = CreateLookup(referenceHandler, terminologyHandler);
@@ -38,7 +53,7 @@ public sealed class DiagnosisMetadataEnricherTests
         var description = await lookup.FindDescriptionAsync("M79.3");
 
         Assert.Equal("Panniculitis, unspecified", description);
-        Assert.Equal(0, terminologyHandler.RequestCount);
+        Assert.Equal(1, terminologyHandler.RequestCount);
         Assert.Equal(0, referenceHandler.RequestCount);
     }
 

--- a/tests/CloudHealthOffice.TerminologyService.Tests/MongoCodeSystemCatalogRepositoryTests.cs
+++ b/tests/CloudHealthOffice.TerminologyService.Tests/MongoCodeSystemCatalogRepositoryTests.cs
@@ -1,0 +1,109 @@
+using CHO.TerminologyService.Data;
+using CHO.TerminologyService.Models;
+using EphemeralMongo;
+using Microsoft.Extensions.Logging.Abstractions;
+using MongoDB.Driver;
+
+namespace CloudHealthOffice.TerminologyService.Tests;
+
+public sealed class MongoCodeSystemCatalogRepositoryTests : IAsyncLifetime
+{
+    private const string Icd10CmSystem = "http://hl7.org/fhir/sid/icd-10-cm";
+
+    private IMongoRunner _runner = null!;
+    private MongoCodeSystemCatalogRepository _repository = null!;
+
+    public Task InitializeAsync()
+    {
+        _runner = MongoRunner.Run(new MongoRunnerOptions { ConnectionTimeout = TimeSpan.FromSeconds(30) });
+        var client = new MongoClient(_runner.ConnectionString);
+        var database = client.GetDatabase($"code_system_catalog_test_{Guid.NewGuid():N}");
+        _repository = new MongoCodeSystemCatalogRepository(
+            database,
+            NullLogger<MongoCodeSystemCatalogRepository>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        try { _runner.Dispose(); }
+        catch (TypeLoadException) { /* EphemeralMongo.Core 2.0.0 / MongoDB.Driver 3.x disposal mismatch. */ }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task FindDisplayAsync_ReturnsGlobalDisplay()
+    {
+        await _repository.UpsertManyAsync(
+        [
+            Concept("E11.65", "Type 2 diabetes mellitus with hyperglycemia")
+        ]);
+
+        var display = await _repository.FindDisplayAsync(Icd10CmSystem, "e11.65");
+
+        Assert.NotNull(display);
+        Assert.Equal("Type 2 diabetes mellitus with hyperglycemia", display.Display);
+        Assert.Equal("BuiltInIcd10CmCatalog", display.Source);
+        Assert.Equal("mcc-seed-2026", display.Version);
+    }
+
+    [Fact]
+    public async Task FindDisplayAsync_TenantOverrideWinsOverGlobalDisplay()
+    {
+        await _repository.UpsertManyAsync(
+        [
+            Concept("K08.1", "Complete loss of teeth"),
+            Concept(
+                "K08.1",
+                "Plan-specific complete tooth loss display",
+                tenantId: "tenant-a",
+                isOverride: true,
+                source: "PlanCatalogOverride")
+        ]);
+
+        var display = await _repository.FindDisplayAsync(Icd10CmSystem, "K08.1", "tenant-a");
+
+        Assert.NotNull(display);
+        Assert.Equal("Plan-specific complete tooth loss display", display.Display);
+        Assert.Equal("CodeSystemOverride", display.Source);
+    }
+
+    [Fact]
+    public async Task FindDisplayAsync_WithoutTenant_DoesNotReturnTenantOverride()
+    {
+        await _repository.UpsertManyAsync(
+        [
+            Concept("K08.1", "Complete loss of teeth"),
+            Concept(
+                "K08.1",
+                "Plan-specific complete tooth loss display",
+                tenantId: "tenant-a",
+                isOverride: true)
+        ]);
+
+        var display = await _repository.FindDisplayAsync(Icd10CmSystem, "K08.1");
+
+        Assert.NotNull(display);
+        Assert.Equal("Complete loss of teeth", display.Display);
+        Assert.Equal("BuiltInIcd10CmCatalog", display.Source);
+    }
+
+    private static CodeSystemConcept Concept(
+        string code,
+        string display,
+        string? tenantId = null,
+        bool isOverride = false,
+        string source = "BuiltInIcd10CmCatalog")
+    {
+        return new CodeSystemConcept
+        {
+            System = Icd10CmSystem,
+            Code = code,
+            Display = display,
+            Version = "mcc-seed-2026",
+            Source = source,
+            TenantId = tenantId,
+            IsOverride = isOverride
+        };
+    }
+}

--- a/tests/CloudHealthOffice.TerminologyService.Tests/TerminologyTranslationServiceLookupTests.cs
+++ b/tests/CloudHealthOffice.TerminologyService.Tests/TerminologyTranslationServiceLookupTests.cs
@@ -14,6 +14,33 @@ public sealed class TerminologyTranslationServiceLookupTests
     private const string SnomedSystem = "http://snomed.info/sct";
 
     [Fact]
+    public async Task LookupCodeAsync_CodeSystemCatalogHit_ReturnsCatalogDisplayWithoutConceptMapLookup()
+    {
+        var repository = Substitute.For<IConceptMapRepository>();
+        var catalog = Substitute.For<ICodeSystemCatalogRepository>();
+        catalog.FindDisplayAsync(Icd10CmSystem, "E11.65", null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CodeSystemDisplay?>(
+                new CodeSystemDisplay(
+                    "Type 2 diabetes mellitus with hyperglycemia",
+                    "mcc-seed-2026",
+                    "BuiltInIcd10CmCatalog")));
+        var service = CreateService(repository, catalog);
+
+        var response = await service.LookupCodeAsync(new CodeLookupRequest
+        {
+            System = Icd10CmSystem,
+            Code = "E11.65"
+        });
+
+        Assert.True(response.Result);
+        Assert.Equal("Type 2 diabetes mellitus with hyperglycemia", response.Display);
+        Assert.Equal("BuiltInIcd10CmCatalog", response.Source);
+        Assert.Equal("mcc-seed-2026", response.MapVersionId);
+        await repository.DidNotReceiveWithAnyArgs()
+            .FindDisplaysByCodeAsync(default!, default!, default, default);
+    }
+
+    [Fact]
     public async Task LookupCodeAsync_SourceCodeMatch_ReturnsSourceDisplay()
     {
         var repository = Substitute.For<IConceptMapRepository>();
@@ -185,10 +212,20 @@ public sealed class TerminologyTranslationServiceLookupTests
         Assert.Contains("No display found", response.Message);
     }
 
-    private static TerminologyTranslationService CreateService(IConceptMapRepository repository)
+    private static TerminologyTranslationService CreateService(
+        IConceptMapRepository repository,
+        ICodeSystemCatalogRepository? catalog = null)
     {
+        if (catalog is null)
+        {
+            catalog = Substitute.For<ICodeSystemCatalogRepository>();
+            catalog.FindDisplayAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<CodeSystemDisplay?>(null));
+        }
+
         return new TerminologyTranslationService(
             repository,
+            catalog,
             Substitute.For<IContextRuleEngine>(),
             new MemoryCache(new MemoryCacheOptions()),
             NullLogger<TerminologyTranslationService>.Instance,


### PR DESCRIPTION
## Summary
- Add a Mongo-backed CodeSystem catalog for terminology display metadata.
- Seed a built-in ICD-10-CM catalog for the MCC/demo diagnosis code set.
- Make TerminologyService `$lookup` resolve CodeSystem display metadata before falling back to ConceptMap displays.
- Restore claims diagnosis enrichment to terminology-first lookup with synthetic/reference-data fallbacks.

## Why
Diagnosis display metadata should come from the terminology layer instead of being treated as claim adjudication state. This gives the portal a real lookup source for ICD-10 descriptions while preserving local fallback behavior when terminology is unavailable.

## Validation
- `dotnet build src/services/CHO.TerminologyService/CHO.TerminologyService.csproj -p:UseAppHost=false --no-restore`
- `dotnet build src/services/claims-service/claims-service.csproj -p:UseAppHost=false --no-restore`
- `dotnet test tests/CloudHealthOffice.TerminologyService.Tests/CloudHealthOffice.TerminologyService.Tests.csproj -p:UseAppHost=false --logger "console;verbosity=minimal"`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter DiagnosisMetadataEnricherTests -p:UseAppHost=false --logger "console;verbosity=minimal"`