### PR TITLE
Align site copy with evidence readiness

### DIFF
--- a/src/site/cms-0057f-compliance.html
+++ b/src/site/cms-0057f-compliance.html
@@ -4,15 +4,15 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>CMS-0057-F Compliance — Cloud Health Office | Vendor-Neutral FHIR R4 for Any Payer CAPS Platform</title>
-  <meta name="description" content="Achieve CMS-0057-F compliance without replacing your core admin system. Cloud Health Office is a vendor-neutral FHIR R4 compliance layer that works alongside QNXT, Facets, HealthEdge, and Amisys. Patient Access API, Provider Access API, Prior Auth API."/>
+  <title>CMS-0057-F Readiness — Cloud Health Office | Vendor-Neutral FHIR R4 for Any Payer CAPS Platform</title>
+  <meta name="description" content="Evaluate CMS-0057-F readiness without replacing your core admin system. Cloud Health Office is a vendor-neutral FHIR R4 readiness layer that works alongside QNXT, Facets, HealthEdge, and Amisys. Patient Access API, Provider Access API, Prior Auth API."/>
   <meta name="keywords" content="CMS-0057-F compliance, FHIR R4 payer platform, prior authorization API, Da Vinci PAS, Da Vinci PDex, healthcare interoperability, CAPS platform, QNXT integration, Facets integration, HealthEdge integration, Amisys, health plan technology, X12 278, X12 837, X12 835, X12 270, FHIR compliance layer, vendor neutral healthcare, Kubernetes healthcare, patient access API, provider access API, payer to payer API, CMS interoperability rule, prior auth FHIR, healthcare payer compliance, USCDI, Da Vinci CRD, Da Vinci DTR, core admin processing system, health plan integration"/>
   <link rel="canonical" href="https://cloudhealthoffice.com/cms-0057f-compliance"/>
 
   <!-- Open Graph -->
 
-  <meta property="og:title" content="CMS-0057-F Compliance — Cloud Health Office"/>
-  <meta property="og:description" content="Vendor-neutral CMS-0057-F compliance layer deployable alongside an existing CAPS. FHIR R4 APIs, Da Vinci IGs, X12 EDI, and Kubernetes-native deployment."/>
+  <meta property="og:title" content="CMS-0057-F Readiness — Cloud Health Office"/>
+  <meta property="og:description" content="Vendor-neutral CMS-0057-F readiness layer deployable alongside an existing CAPS. FHIR R4 APIs, Da Vinci IGs, X12 EDI, and Kubernetes-native deployment."/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="https://cloudhealthoffice.com/cms-0057f-compliance"/>
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/og-cms0057f.png"/>
@@ -21,8 +21,8 @@
   <!-- Twitter -->
 
   <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="CMS-0057-F Compliance — Cloud Health Office"/>
-  <meta name="twitter:description" content="Vendor-neutral FHIR R4 compliance layer for payer CAPS platforms. Kubernetes-native and deployable alongside legacy core systems."/>
+  <meta name="twitter:title" content="CMS-0057-F Readiness — Cloud Health Office"/>
+  <meta name="twitter:description" content="Vendor-neutral FHIR R4 readiness layer for payer CAPS platforms. Kubernetes-native and deployable alongside legacy core systems."/>
 
   <!-- JSON-LD: SoftwareApplication -->
 
@@ -33,7 +33,7 @@
     "name": "Cloud Health Office",
     "applicationCategory": "HealthApplication",
     "operatingSystem": "Linux, Kubernetes (AKS, EKS, GKE)",
-    "description": "Vendor-neutral CMS-0057-F compliance layer that deploys alongside core admin processing systems (QNXT, Facets, HealthEdge, Amisys). FHIR R4 APIs with Da Vinci IG support, X12 EDI processing, and multi-clearinghouse connectivity.",
+    "description": "Vendor-neutral CMS-0057-F readiness layer that deploys alongside core admin processing systems (QNXT, Facets, HealthEdge, Amisys). FHIR R4 APIs with Da Vinci IG support, X12 EDI processing, and multi-clearinghouse connectivity.",
     "url": "https://cloudhealthoffice.com/cms-0057f-compliance",
     "author": {
       "@type": "Organization",
@@ -48,13 +48,13 @@
     "softwareVersion": "2026",
     "license": "https://mariadb.com/bsl11/",
     "featureList": [
-      "CMS-0057-F Full Compliance",
+      "CMS-0057-F Readiness Surface",
       "FHIR R4 APIs (Patient Access, Provider Access, Payer-to-Payer, Prior Auth)",
       "Da Vinci IGs (PDex, PAS, CRD, DTR)",
       "X12 EDI Processing (270/271, 278, 837, 835, 275)",
       "Multi-Clearinghouse EDI (Availity, Change Healthcare, Optum, Inovalon)",
       "Kubernetes-Native Multi-Cloud Deployment",
-      "HIPAA-Compliant Infrastructure",
+      "HIPAA Security Controls for Deployment Validation",
       "Multi-Tenant Architecture",
       "OAuth 2.0 / SMART on FHIR",
       "Bulk FHIR Export",
@@ -353,7 +353,7 @@
     </div>
     <div class="stat">
       <div class="stat-num green">&lt;1hr</div>
-      <div class="stat-label">Production<br/>Deployment</div>
+      <div class="stat-label">Local<br/>Evaluation</div>
     </div>
   </div>
 </header>
@@ -945,7 +945,7 @@
 <section id="x12-fhir" data-reveal>
   <div class="container">
     <div class="section-label">EDI Transformation</div>
-    <h2 class="section-title">X12 EDI ↔ FHIR R4 — Bidirectional, Production-Tested</h2>
+    <h2 class="section-title">X12 EDI ↔ FHIR R4 — Bidirectional Implementation Evidence</h2>
     <p class="section-desc">X12 transactions from the core admin system can be transformed to FHIR R4 resources conforming to Da Vinci profiles through configurable, auditable mapping pipelines.</p>
 
 ```
@@ -1016,25 +1016,25 @@
 ```
 <div class="api-grid">
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">FHIR R4 ConceptMap</span>
     <h3>ConceptMap/$translate API</h3>
     <p>FHIR-native terminology translation with ~119,000 NLM/UMLS mappings, AMA CPT cross maps (BYOL), and tenant-scoped plan-specific overrides. Single-code and $batch-translate endpoints for real-time and bulk use.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Context-Aware</span>
     <h3>Disambiguation Engine</h3>
     <p>When SNOMED maps to multiple ICD-10-CM codes, the context rule engine uses patient age, gender, state, co-morbidities, and plan coding policy to select the best match — not just the first match.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">CRD + PAS + DTR</span>
     <h3>Da Vinci Integration</h3>
     <p>The CRD server, PAS server, and DTR engine consume the crosswalk at runtime. SNOMED codes from EHRs are translated to payer code space for coverage rules, prior auth decisions, and questionnaire pre-population.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Multi-Tier Maps</span>
     <h3>Map Management</h3>
     <p>Auto-loading at startup, runtime upload via Admin API, SHA-256 version tracking, and full audit trail. Plan-specific overrides support Texas TMPPM, state Medicaid variations, and custom coding policy per tenant.</p>
@@ -1058,25 +1058,25 @@
 ```
 <div class="api-grid">
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">NPPES</span>
     <h3>NPI Registry Validation</h3>
     <p>NPI validity, practice address, taxonomy code, and enumeration status verified against the National Plan and Provider Enumeration System. Daily update cadence.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">OIG / LEIE</span>
     <h3>Federal Exclusion Screening</h3>
     <p>Automatic screening against the OIG List of Excluded Individuals/Entities. Excluded providers are blocked from authorization and claims processing. Monthly sync.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">PECOS + FSMB</span>
     <h3>Enrollment &amp; Licensing</h3>
     <p>Medicare enrollment verification via PECOS and active medical license confirmation via FSMB state licensing data. Disciplinary actions and multi-state compact status tracked.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Integrity Score</span>
     <h3>Composite 0–100 Score</h3>
     <p>Weighted algorithm across all five sources produces a single integrity score per NPI. Configurable thresholds, automatic blocking, and audit-logged verification results for compliance documentation.</p>
@@ -1108,22 +1108,22 @@
     </tr>
   </thead>
   <tbody>
-    <tr><td>Patient Access API</td><td>PDex Patient / Coverage / Claim / EOB</td><td>19</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>Provider Access API</td><td>PDex + PAS ServiceRequest / DocumentRef</td><td>8</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>Payer-to-Payer API</td><td>Bulk FHIR $export / Enrollment Trigger</td><td>6</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>Prior Authorization API</td><td>Da Vinci PAS 2.0.1+</td><td>12</td><td><span class="status-badge done">✅ Production</span></td></tr>
+    <tr><td>Patient Access API</td><td>PDex Patient / Coverage / Claim / EOB</td><td>19</td><td><span class="status-badge done">Implemented</span></td></tr>
+    <tr><td>Provider Access API</td><td>PDex + PAS ServiceRequest / DocumentRef</td><td>8</td><td><span class="status-badge done">Implemented</span></td></tr>
+    <tr><td>Payer-to-Payer API</td><td>Bulk FHIR $export / Enrollment Trigger</td><td>6</td><td><span class="status-badge done">Implemented</span></td></tr>
+    <tr><td>Prior Authorization API</td><td>Da Vinci PAS 2.0.1+</td><td>12</td><td><span class="status-badge done">Implemented</span></td></tr>
     <tr><td>72-Hour Urgent Response</td><td>Compliance Checker — automated tracking</td><td>Auto</td><td><span class="status-badge done">✅ Automated</span></td></tr>
     <tr><td>7-Day Standard Response</td><td>Compliance Checker — automated tracking</td><td>Auto</td><td><span class="status-badge done">✅ Automated</span></td></tr>
     <tr><td>USCDI v1 / v2 Coverage</td><td>US Core 3.1.1+ data class mapping</td><td>Mapped</td><td><span class="status-badge done">✅ Complete</span></td></tr>
-    <tr><td>X12 270 → FHIR</td><td>Patient + CoverageEligibilityRequest</td><td>—</td><td><span class="status-badge prod">Production</span></td></tr>
-    <tr><td>X12 837 → FHIR</td><td>Da Vinci PDex Claim</td><td>—</td><td><span class="status-badge prod">Production</span></td></tr>
-    <tr><td>X12 278 → FHIR</td><td>Da Vinci PAS ServiceRequest</td><td>—</td><td><span class="status-badge prod">Production</span></td></tr>
-    <tr><td>X12 835 → FHIR</td><td>Da Vinci PDex EOB</td><td>—</td><td><span class="status-badge prod">Production</span></td></tr>
-    <tr><td>X12 275 → FHIR</td><td>US Core DocumentReference</td><td>—</td><td><span class="status-badge prod">Production</span></td></tr>
-    <tr><td>OAuth 2.0 / SMART on FHIR</td><td>Azure AD + SMART scopes</td><td>—</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>HIPAA Security</td><td>TLS 1.2+ / AES-256 / Key Vault / BAA</td><td>—</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>Terminology Translation (SNOMED ↔ CPT/ICD)</td><td>FHIR R4 ConceptMap/$translate</td><td>—</td><td><span class="status-badge done">✅ Production</span></td></tr>
-    <tr><td>Provider Verification &amp; Directory</td><td>NPPES / OIG / PECOS / FSMB Integrity Score</td><td>—</td><td><span class="status-badge done">✅ Production</span></td></tr>
+    <tr><td>X12 270 → FHIR</td><td>Patient + CoverageEligibilityRequest</td><td>—</td><td><span class="status-badge prod">Implemented</span></td></tr>
+    <tr><td>X12 837 → FHIR</td><td>Da Vinci PDex Claim</td><td>—</td><td><span class="status-badge prod">Implemented</span></td></tr>
+    <tr><td>X12 278 → FHIR</td><td>Da Vinci PAS ServiceRequest</td><td>—</td><td><span class="status-badge prod">Implemented</span></td></tr>
+    <tr><td>X12 835 → FHIR</td><td>Da Vinci PDex EOB</td><td>—</td><td><span class="status-badge prod">Mapped</span></td></tr>
+    <tr><td>X12 275 → FHIR</td><td>US Core DocumentReference</td><td>—</td><td><span class="status-badge prod">Implemented</span></td></tr>
+    <tr><td>OAuth 2.0 / SMART on FHIR</td><td>Azure AD + SMART scopes</td><td>—</td><td><span class="status-badge done">Implemented</span></td></tr>
+    <tr><td>HIPAA Security Controls</td><td>TLS 1.2+ / AES-256 / Key Vault / BAA</td><td>—</td><td><span class="status-badge done">Validate per deployment</span></td></tr>
+    <tr><td>Terminology Translation (SNOMED ↔ CPT/ICD)</td><td>FHIR R4 ConceptMap/$translate</td><td>—</td><td><span class="status-badge done">Implemented</span></td></tr>
+    <tr><td>Provider Verification &amp; Directory</td><td>NPPES / OIG / PECOS / FSMB Integrity Score</td><td>—</td><td><span class="status-badge done">Implemented</span></td></tr>
   </tbody>
 </table>
 ```
@@ -1176,7 +1176,7 @@
   <div class="timeline-item">
     <div class="timeline-dot"></div>
     <div class="timeline-date">July 2026 — 6 Months Before Deadline</div>
-    <div class="timeline-title">Production Hardening + Audit</div>
+    <div class="timeline-title">Deployment Hardening + Audit</div>
     <div class="timeline-desc">Load testing. Performance optimization. Compliance audit documentation. Provider onboarding campaigns. Security penetration testing.</div>
   </div>
 
@@ -1205,25 +1205,25 @@
 ```
 <div class="api-grid">
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Da Vinci PDex 2.0+</span>
     <h3>Payer Data Exchange</h3>
     <p>Standardized FHIR profiles for payer-sourced data. US Core Patient v3.1.1+, PDex Claim, ExplanationOfBenefit, Coverage. Complete USCDI v1 &amp; v2 data classes.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Da Vinci PAS 2.0.1+</span>
     <h3>Prior Authorization Support</h3>
     <p>ServiceRequest for authorization requests. ClaimResponse for decisions. DocumentReference for attachments. 72-hour urgent and 7-day standard timeline compliance.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Da Vinci CRD 2.0+</span>
     <h3>Coverage Requirements Discovery</h3>
     <p>Real-time coverage rules discovery. Documentation requirements identification during provider workflow. CDS Hooks integration pathway.</p>
   </article>
   <article class="api-card">
-    <span class="status">Production</span>
+    <span class="status">Implemented</span>
     <span class="api-tag">Da Vinci DTR 2.0+</span>
     <h3>Documentation Templates &amp; Rules</h3>
     <p>FHIR Questionnaire and QuestionnaireResponse. Automated clinical documentation collection from payer rules. Reduced provider administrative burden.</p>
@@ -1321,7 +1321,7 @@
     <h4>Testing &amp; Validation</h4>
     <div class="checklist-item">Unit testing for FHIR transformations</div>
     <div class="checklist-item">Integration testing end-to-end workflows</div>
-    <div class="checklist-item">Load testing for production scalability</div>
+    <div class="checklist-item">Load testing for deployment-specific scalability</div>
     <div class="checklist-item">Provider and patient UAT</div>
   </div>
 
@@ -1372,7 +1372,7 @@
   <span style="color:var(--green)">$</span> npm run generate -- interactive --output config.json --generate<br/><br/>
   <span style="color:var(--text-dim)"># Validate CMS-0057-F compliance</span><br/>
   <span style="color:var(--green)">$</span> node dist/src/fhir/examples.js<br/><br/>
-  <span style="color:var(--cyan)">✓ All FHIR endpoints validated. CMS-0057-F compliant.</span>
+  <span style="color:var(--cyan)">✓ FHIR endpoints validated for CMS-0057-F readiness.</span>
 </div>
 ```
 

--- a/src/site/docs/benefit-plan-guide.html
+++ b/src/site/docs/benefit-plan-guide.html
@@ -616,7 +616,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/claims-guide.html
+++ b/src/site/docs/claims-guide.html
@@ -705,7 +705,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/commercial-licensing.html
+++ b/src/site/docs/commercial-licensing.html
@@ -258,7 +258,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/compliance.html
+++ b/src/site/docs/compliance.html
@@ -4,18 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CMS-0057-F Compliance Guide — Cloud Health Office Documentation</title>
-  <meta name="description" content="Complete CMS-0057-F compliance guide for healthcare payers. Patient Access API, Provider Access API, Payer-to-Payer API, Prior Authorization API, SNOMED-to-ICD terminology translation, and provider verification — achieve compliance ahead of the January 2027 deadline." />
+  <meta name="description" content="CMS-0057-F readiness guide for healthcare payers. Patient Access API, Provider Access API, Payer-to-Payer API, Prior Authorization API, SNOMED-to-ICD terminology translation, and provider verification surfaces with implementation evidence." />
   <meta name="keywords" content="CMS-0057-F compliance guide, CMS interoperability rule, healthcare payer FHIR API, prior authorization API compliance, January 2027 deadline, Patient Access API, Da Vinci implementation guide, FHIR R4 healthcare payer, SNOMED CT ICD-10-CM translation, terminology crosswalk, provider verification, NPPES" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/compliance" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/compliance" />
   <meta property="og:title" content="CMS-0057-F Compliance Guide — Cloud Health Office" />
-  <meta property="og:description" content="Achieve CMS-0057-F compliance ahead of the January 2027 deadline. Complete FHIR R4 API implementation with built-in terminology translation and provider verification for healthcare payers." />
+  <meta property="og:description" content="Evaluate the CMS-0057-F readiness surface in Cloud Health Office: FHIR R4 APIs, terminology translation, provider verification, and payer validation evidence." />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org", "@type": "TechArticle",
     "headline": "CMS-0057-F Compliance Guide for Healthcare Payers",
-    "description": "Complete guide to CMS-0057-F (Advancing Interoperability and Improving Prior Authorization) compliance using Cloud Health Office FHIR R4 APIs, terminology crosswalk, and provider verification.",
+    "description": "Guide to CMS-0057-F (Advancing Interoperability and Improving Prior Authorization) readiness using Cloud Health Office FHIR R4 APIs, terminology crosswalk, provider verification, and implementation evidence.",
     "url": "https://cloudhealthoffice.com/docs/compliance",
     "author": { "@type": "Organization", "name": "Aurelianware, Inc." },
     "datePublished": "2026-03-24",
@@ -64,11 +64,11 @@
         <div class="docs-breadcrumb"><a href="/">Home</a><span class="sep">&#x25B8;</span><a href="/docs">Docs</a><span class="sep">&#x25B8;</span><span class="current">CMS-0057-F Compliance</span></div>
 
         <h1>CMS-0057-F Compliance Guide</h1>
-        <p class="docs-subtitle">Cloud Health Office delivers a CMS-0057-F compliance surface &mdash; FHIR R4 APIs, X12 EDI transformation, SNOMED&ndash;CPT&ndash;ICD terminology translation, and multi-source provider verification &mdash; designed to deploy alongside existing payer core admin systems.</p>
+        <p class="docs-subtitle">Cloud Health Office delivers a CMS-0057-F readiness surface &mdash; FHIR R4 APIs, X12 EDI mapping, SNOMED&ndash;CPT&ndash;ICD terminology translation, and multi-source provider verification &mdash; designed to be validated alongside existing payer core admin systems.</p>
 
         <figure class="docs-diagram">
-          <img src="/graphics/cms-0057f-compliance.svg" alt="CMS-0057-F compliance diagram showing Patient Access API, Provider Access API, Prior Authorization, Payer-to-Payer API, and Provider Directory API — all complete" />
-          <figcaption>All five CMS-0057-F required API categories &mdash; implemented and production-tested</figcaption>
+          <img src="/graphics/cms-0057f-compliance.svg" alt="CMS-0057-F readiness diagram showing Patient Access API, Provider Access API, Prior Authorization, Payer-to-Payer API, and Provider Directory API implementation surfaces" />
+          <figcaption>CMS-0057-F API categories &mdash; implementation surfaces with validation evidence</figcaption>
         </figure>
 
         <!-- ============================================================ -->
@@ -80,7 +80,7 @@
 
         <div class="callout callout-warning">
           <div class="callout-title">Deadline: January 1, 2027</div>
-          <p>All impacted payers must have Patient Access, Provider Access, Payer-to-Payer, and Prior Authorization APIs live in production by this date. Cloud Health Office is designed to help payers stand up that compliance surface without replacing the core admin system first.</p>
+          <p>All impacted payers must have Patient Access, Provider Access, Payer-to-Payer, and Prior Authorization APIs live in production by this date. Cloud Health Office is designed to help payers stand up and validate that readiness surface without replacing the core admin system first.</p>
         </div>
 
         <p>Achieving compliance requires more than standing up four FHIR endpoints. The rule depends on Da Vinci Implementation Guides (PAS, CRD, DTR, PDex) that exchange clinical data in <strong>SNOMED CT</strong> &mdash; a code system that payer core admin platforms do not natively speak. It also requires provider directory accuracy and real-time eligibility verification against validated provider records. CHO is built to address the full compliance surface in a single deployable stack: APIs, EDI transformation, terminology translation, and provider data integrity.</p>
@@ -105,8 +105,8 @@
             <tr><td>Terminology Translation (SNOMED &#8596; CPT/ICD)</td><td><span class="badge badge-complete">Complete</span></td><td>ConceptMap/$translate</td><td>FHIR R4 ConceptMap</td></tr>
             <tr><td>Provider Verification &amp; Directory</td><td><span class="badge badge-complete">Complete</span></td><td>Integrity Score Engine</td><td>Da Vinci PDex Plan-Net</td></tr>
             <tr><td>OAuth 2.0 / SMART on FHIR</td><td><span class="badge badge-complete">Complete</span></td><td>Auth flow tests</td><td>SMART App Launch</td></tr>
-            <tr><td>X12 EDI &#8596; FHIR Bidirectional</td><td><span class="badge badge-production">Production</span></td><td>6 parsers, 0 deps</td><td>&mdash;</td></tr>
-            <tr><td>Claims Adjudication Pipeline</td><td><span class="badge badge-production">Production</span></td><td>10-step DAG</td><td>&mdash;</td></tr>
+            <tr><td>X12 EDI &#8596; FHIR Bidirectional</td><td><span class="badge badge-complete">Implemented</span></td><td>Mapping and parser coverage</td><td>&mdash;</td></tr>
+            <tr><td>Claims Adjudication Pipeline</td><td><span class="badge badge-complete">Evidence-backed</span></td><td>MCC benchmark runs</td><td>&mdash;</td></tr>
           </tbody>
         </table>
 
@@ -139,18 +139,18 @@
         <!-- X12 TO FHIR                                                  -->
         <!-- ============================================================ -->
         <h2 id="x12-to-fhir">X12 to FHIR R4 Transformation</h2>
-        <p>Every X12 transaction your core admin system produces is automatically transformed to FHIR R4 resources conforming to Da Vinci profiles. Bidirectional. Real-time. All six parsers are written in-house with zero external dependencies &mdash; no third-party libraries, no open-source tooling relabeled as proprietary.</p>
+        <p>Cloud Health Office includes X12-to-FHIR mapping surfaces for core payer transactions. Some paths are implemented directly in the platform and the X12 container uses purpose-built parsing support where appropriate; production use should validate companion guides, trading-partner variations, and payer-specific mappings.</p>
 
         <table>
           <thead><tr><th>X12 Transaction</th><th>FHIR Resource</th><th>Profile</th><th>Status</th></tr></thead>
           <tbody>
-            <tr><td>X12 270/271 Eligibility</td><td>Patient, CoverageEligibilityRequest/Response</td><td>US Core 3.1.1</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 837 Claims (I/P/D)</td><td>Claim</td><td>Da Vinci PDex</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 835 Remittance</td><td>ExplanationOfBenefit</td><td>Da Vinci PDex</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 278 Prior Auth</td><td>ServiceRequest, ClaimResponse</td><td>Da Vinci PAS</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 276/277 Claim Status</td><td>Claim (status query)</td><td>US Core</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 275 Attachments</td><td>DocumentReference</td><td>US Core</td><td><span class="badge badge-production">Production</span></td></tr>
-            <tr><td>X12 834 Enrollment</td><td>Coverage, Patient</td><td>US Core</td><td><span class="badge badge-production">Production</span></td></tr>
+            <tr><td>X12 270/271 Eligibility</td><td>Patient, CoverageEligibilityRequest/Response</td><td>US Core 3.1.1</td><td><span class="badge badge-complete">Implemented</span></td></tr>
+            <tr><td>X12 837 Claims (I/P/D)</td><td>Claim</td><td>Da Vinci PDex</td><td><span class="badge badge-complete">Implemented</span></td></tr>
+            <tr><td>X12 835 Remittance</td><td>ExplanationOfBenefit</td><td>Da Vinci PDex</td><td><span class="badge badge-complete">Mapped</span></td></tr>
+            <tr><td>X12 278 Prior Auth</td><td>ServiceRequest, ClaimResponse</td><td>Da Vinci PAS</td><td><span class="badge badge-complete">Implemented</span></td></tr>
+            <tr><td>X12 276/277 Claim Status</td><td>Claim (status query)</td><td>US Core</td><td><span class="badge badge-complete">Implemented</span></td></tr>
+            <tr><td>X12 275 Attachments</td><td>DocumentReference</td><td>US Core</td><td><span class="badge badge-complete">Implemented</span></td></tr>
+            <tr><td>X12 834 Enrollment</td><td>Coverage, Patient</td><td>US Core</td><td><span class="badge badge-complete">Implemented</span></td></tr>
           </tbody>
         </table>
 
@@ -259,7 +259,7 @@
           <thead><tr><th>Capability</th><th>CHO</th><th>Typical Implementation</th></tr></thead>
           <tbody>
             <tr><td>FHIR R4 APIs (Patient, Provider, P2P, PA)</td><td><span class="badge badge-complete">Built-in</span></td><td>Varies &mdash; often assembled from open-source tooling</td></tr>
-            <tr><td>X12 EDI Parsers</td><td><span class="badge badge-complete">6 parsers, zero dependencies, in-house</span></td><td>Third-party libraries or manual mapping</td></tr>
+            <tr><td>X12 EDI Mapping</td><td><span class="badge badge-complete">Implemented mapping surfaces</span></td><td>Third-party libraries or manual mapping</td></tr>
             <tr><td>SNOMED &#8596; CPT/ICD Terminology Translation</td><td><span class="badge badge-complete">Native ConceptMap/$translate</span></td><td>Not included &mdash; &ldquo;customer responsibility&rdquo;</td></tr>
             <tr><td>Context-Aware Disambiguation</td><td><span class="badge badge-complete">Rule engine with plan overrides</span></td><td>Not available</td></tr>
             <tr><td>Provider Verification (NPPES, OIG, PECOS, FSMB)</td><td><span class="badge badge-complete">Multi-source Integrity Score</span></td><td>Manual or separate product</td></tr>
@@ -267,7 +267,7 @@
             <tr><td>Benefit Engine (HDHP, HSA, COB, NCCI, DRG)</td><td><span class="badge badge-complete">9 calculation engines</span></td><td>Depends on legacy CAPS</td></tr>
             <tr><td>Core Admin Adapter Pattern</td><td><span class="badge badge-complete">Vendor-neutral ICoreAdminAdapter</span></td><td>Hard-coded to one CAPS</td></tr>
             <tr><td>Multi-Tenant SaaS</td><td><span class="badge badge-complete">X-Tenant-ID isolation</span></td><td>Single-tenant or per-client deployment</td></tr>
-            <tr><td>Implementation Timeline</td><td><span class="badge badge-complete">&lt;1 hour to production</span></td><td>6&ndash;18 months</td></tr>
+            <tr><td>Evaluation Timeline</td><td><span class="badge badge-complete">&lt;1 hour local start</span></td><td>6&ndash;18 months</td></tr>
           </tbody>
         </table>
 
@@ -285,12 +285,12 @@
         <table>
           <thead><tr><th>Requirement</th><th>CMS Effective Date</th><th>CHO Status</th><th>CHO Ready Since</th></tr></thead>
           <tbody>
-            <tr><td>Patient Access API</td><td>January 1, 2026</td><td><span class="badge badge-complete">Live</span></td><td>November 2024</td></tr>
-            <tr><td>Provider Access API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Ready</span></td><td>November 2024</td></tr>
-            <tr><td>Payer-to-Payer API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Ready</span></td><td>November 2024</td></tr>
-            <tr><td>Prior Authorization API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Ready</span></td><td>November 2024</td></tr>
-            <tr><td>Terminology Translation</td><td>Required for CRD/DTR/PAS</td><td><span class="badge badge-complete">Ready</span></td><td>March 2025</td></tr>
-            <tr><td>Provider Directory Accuracy</td><td>Required for Provider Access</td><td><span class="badge badge-complete">Ready</span></td><td>April 2025</td></tr>
+            <tr><td>Patient Access API</td><td>January 1, 2026</td><td><span class="badge badge-complete">Implemented</span></td><td>November 2024</td></tr>
+            <tr><td>Provider Access API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Implemented</span></td><td>November 2024</td></tr>
+            <tr><td>Payer-to-Payer API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Implemented</span></td><td>November 2024</td></tr>
+            <tr><td>Prior Authorization API</td><td>January 1, 2027</td><td><span class="badge badge-complete">Implemented</span></td><td>November 2024</td></tr>
+            <tr><td>Terminology Translation</td><td>Required for CRD/DTR/PAS</td><td><span class="badge badge-complete">Implemented</span></td><td>March 2025</td></tr>
+            <tr><td>Provider Directory Accuracy</td><td>Required for Provider Access</td><td><span class="badge badge-complete">Implemented</span></td><td>April 2025</td></tr>
           </tbody>
         </table>
 

--- a/src/site/docs/eligibility-guide.html
+++ b/src/site/docs/eligibility-guide.html
@@ -550,7 +550,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/fee-schedule-engine.html
+++ b/src/site/docs/fee-schedule-engine.html
@@ -388,7 +388,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/fee-schedule-guide.html
+++ b/src/site/docs/fee-schedule-guide.html
@@ -549,7 +549,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/finance-guide.html
+++ b/src/site/docs/finance-guide.html
@@ -647,7 +647,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/florida-compliance.html
+++ b/src/site/docs/florida-compliance.html
@@ -502,7 +502,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -1070,7 +1070,7 @@ dotnet run --project src/tools/mcc-runner -- --claims 10000 --seed 42</code></pr
           <tbody>
             <tr>
               <td><strong>Infrastructure</strong></td>
-              <td>Deploy Cloud Health Office via the <a href="/docs/quickstart">local Kubernetes Quick Start</a>. Use production-equivalent node sizes for meaningful throughput numbers, and use the <a href="/docs/quickstart-kubernetes">Kubernetes Reference</a> for deeper troubleshooting and resource guidance.</td>
+              <td>Deploy Cloud Health Office via the <a href="/docs/quickstart">local Kubernetes Quick Start</a>. Use realistic node sizes for meaningful throughput numbers, and use the <a href="/docs/quickstart-kubernetes">Kubernetes Reference</a> for deeper troubleshooting and resource guidance.</td>
             </tr>
             <tr>
               <td><strong>Cosmos DB</strong></td>

--- a/src/site/docs/prior-auth-guide.html
+++ b/src/site/docs/prior-auth-guide.html
@@ -675,7 +675,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/provider-enrollment-guide.html
+++ b/src/site/docs/provider-enrollment-guide.html
@@ -469,7 +469,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/provider-verification-guide.html
+++ b/src/site/docs/provider-verification-guide.html
@@ -500,7 +500,7 @@ ProviderVerification__MaxConcurrentVerifications=10</code></pre>
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -4,21 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kubernetes Reference — Cloud Health Office Documentation</title>
-  <meta name="description" content="Run the full Cloud Health Office platform on Docker Desktop Kubernetes — the same architecture, namespaces, and manifests used in production on Azure AKS. Under 15 minutes." />
+  <meta name="description" content="Run the full Cloud Health Office platform on Docker Desktop Kubernetes with the same service shape, namespace, and reference manifests used for cloud deployment evaluation. Under 15 minutes." />
   <meta name="keywords" content="Cloud Health Office Kubernetes, local Kubernetes development, Docker Desktop Kubernetes, healthcare payer platform k8s, microservices local deployment, CMS-0057-F Kubernetes" />
   <link rel="canonical" href="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://cloudhealthoffice.com/docs/quickstart-kubernetes" />
   <meta property="og:title" content="Kubernetes Reference — Cloud Health Office" />
-  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with the same architecture as production: production-shaped microservices, MongoDB, and Redis—identical to Azure AKS." />
+  <meta property="og:description" content="Deploy Cloud Health Office to local Kubernetes with production-shaped microservices, MongoDB, Redis, and reference cloud-deployment patterns." />
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "headline": "Cloud Health Office Kubernetes Reference",
-    "description": "Step-by-step guide to deploying Cloud Health Office on Docker Desktop Kubernetes — matching the production Azure AKS architecture.",
+    "description": "Step-by-step guide to deploying Cloud Health Office on Docker Desktop Kubernetes with production-shaped services and reference cloud-deployment patterns.",
     "url": "https://cloudhealthoffice.com/docs/quickstart-kubernetes",
     "author": { "@type": "Organization", "name": "Aurelianware, Inc." },
     "publisher": { "@type": "Organization", "name": "Cloud Health Office", "url": "https://cloudhealthoffice.com" },
@@ -99,7 +99,7 @@
               <li><a href="#step-4">4. Access the Platform</a></li>
               <li><a href="#step-5">5. Seed &amp; Test</a></li>
               <li><a href="#step-6">6. Verify System Health</a></li>
-              <li><a href="#production-comparison">Production Comparison</a></li>
+              <li><a href="#deployment-comparison">Deployment Comparison</a></li>
               <li><a href="#common-tasks">Common Tasks</a></li>
               <li><a href="#troubleshooting">Troubleshooting</a></li>
               <li><a href="#tear-down">Tear Down</a></li>
@@ -139,12 +139,12 @@
 
         <h1>Kubernetes Reference</h1>
         <p class="docs-subtitle">
-          Run the full Cloud Health Office platform on Docker Desktop Kubernetes &mdash; the same architecture, namespaces, services, and manifests used in production on Azure AKS. No Azure account needed.
+          Run the full Cloud Health Office platform on Docker Desktop Kubernetes &mdash; the same service shape, namespace, and reference manifests used for cloud-deployment evaluation. No Azure account needed.
         </p>
 
         <div class="callout callout-info">
           <div class="callout-title">Quick Start vs Reference</div>
-          <p>The <a href="/docs/quickstart">primary Quick Start</a> is the shortest local Kubernetes path. This reference guide adds deeper troubleshooting, teardown, resource guidance, and common kubectl workflows for the same production-equivalent deployment.</p>
+          <p>The <a href="/docs/quickstart">primary Quick Start</a> is the shortest local Kubernetes path. This reference guide adds deeper troubleshooting, teardown, resource guidance, and common kubectl workflows for the same production-shaped local deployment.</p>
         </div>
 
         <!-- What You Get -->
@@ -159,11 +159,11 @@
             <tr><td>Portal</td><td>1</td><td>Blazor Server UI you can expose on your own portal host after deployment</td></tr>
             <tr><td>MongoDB</td><td>1</td><td>StatefulSet with persistent storage</td></tr>
             <tr><td>Redis</td><td>1</td><td>Data-protection key store and caching</td></tr>
-            <tr><td>Namespace</td><td><code>cloudhealthoffice</code></td><td>Matches production layout</td></tr>
+            <tr><td>Namespace</td><td><code>cloudhealthoffice</code></td><td>Matches the reference cloud layout</td></tr>
           </tbody>
         </table>
 
-        <p>All services communicate over Kubernetes DNS (<code>service-name.cloudhealthoffice</code>) &mdash; identical to production.</p>
+        <p>All services communicate over Kubernetes DNS (<code>service-name.cloudhealthoffice</code>) &mdash; the same service-discovery pattern used by the reference cloud deployment.</p>
 
         <!-- Prerequisites -->
         <h2 id="prerequisites">Prerequisites</h2>
@@ -231,7 +231,7 @@ kubectl cluster-info
           <div class="step-body">
             <h3>One command deploys the entire platform</h3>
 <pre><code>./scripts/deploy-local.sh</code></pre>
-            <p>This builds Docker images for all 30+ services plus the portal, creates the <code>cloudhealthoffice</code> namespace, deploys MongoDB and Redis, creates all Kubernetes secrets, seeds demo data, and deploys all microservices using the same k8s manifests as production.</p>
+            <p>This builds Docker images for all 30+ services plus the portal, creates the <code>cloudhealthoffice</code> namespace, deploys MongoDB and Redis, creates local Kubernetes secrets, seeds demo data, and deploys the microservices using the repository's reference manifests with local patches.</p>
             <p><strong>First run:</strong> ~10&ndash;15 minutes (image builds). <strong>Subsequent runs:</strong> ~2 minutes.</p>
 
             <table>
@@ -327,16 +327,16 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error</co
         </div>
 
         <div class="callout callout-success">
-          <div class="callout-title">You're running production-equivalent Kubernetes!</div>
-          <p>You now have the same production-shaped microservices architecture running locally that you can later expose behind your own portal and API hosts. Same namespace, same DNS, same manifests, same health probes.</p>
+          <div class="callout-title">You're running production-shaped local Kubernetes!</div>
+          <p>You now have the microservices architecture running locally with the same namespace, service DNS pattern, and health probes used by the reference deployment path. A payer production rollout still needs environment-specific security, ingress, identity, data, and operational validation.</p>
         </div>
 
-        <!-- Production Comparison -->
-        <h2 id="production-comparison">How This Matches Production</h2>
+        <!-- Deployment Comparison -->
+        <h2 id="deployment-comparison">How This Maps to a Cloud Deployment</h2>
 
         <table>
           <thead>
-            <tr><th>Aspect</th><th>Local (Docker Desktop)</th><th>Production (Azure AKS)</th></tr>
+            <tr><th>Aspect</th><th>Local (Docker Desktop)</th><th>Reference cloud deployment</th></tr>
           </thead>
           <tbody>
             <tr><td>Namespace</td><td><code>cloudhealthoffice</code></td><td><code>cloudhealthoffice</code></td></tr>
@@ -429,8 +429,8 @@ docker volume prune -f</code></pre>
             <span class="card-arrow">View guide &rarr;</span>
           </a>
           <a href="/docs/deployment" class="docs-hub-card">
-            <h3>Deploy to Production</h3>
-            <p>Move from local Kubernetes to Azure AKS with gated CI/CD releases and HIPAA-compliant infrastructure.</p>
+            <h3>Deployment Reference</h3>
+            <p>Move from local Kubernetes to a reviewed cloud deployment path with gated CI/CD, environment-specific security, and payer validation.</p>
             <span class="card-arrow">Deployment guide &rarr;</span>
           </a>
           <a href="/docs/architecture" class="docs-hub-card">

--- a/src/site/docs/terminology-guide.html
+++ b/src/site/docs/terminology-guide.html
@@ -603,7 +603,7 @@ curl -s -X POST http://localhost:5010/fhir/ConceptMap/\$batch-translate \
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/texas-compliance.html
+++ b/src/site/docs/texas-compliance.html
@@ -522,7 +522,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/docs/texas-tmppm-pa-rules.html
+++ b/src/site/docs/texas-tmppm-pa-rules.html
@@ -452,7 +452,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/graphics/docs-api-landscape.svg
+++ b/src/site/graphics/docs-api-landscape.svg
@@ -16,7 +16,7 @@
   <text x="600" y="40" font-family="Segoe UI, system-ui, sans-serif" font-size="26" font-weight="900"
         fill="#ffffff" text-anchor="middle">API Reference</text>
   <text x="600" y="65" font-family="Segoe UI, system-ui, sans-serif" font-size="14" fill="#00ffff"
-        text-anchor="middle" opacity="0.8">7 Production FHIR R4 APIs &#x2022; OpenAPI 3.1 &#x2022; OAuth 2.0 &#x2022; CMS-0057-F Compliant</text>
+        text-anchor="middle" opacity="0.8">FHIR R4 API Surface &#x2022; OpenAPI 3.1 &#x2022; OAuth 2.0 &#x2022; CMS-0057-F Readiness</text>
 
   <!-- Central hub -->
   <g transform="translate(600, 260)">

--- a/src/site/legal/privacy-policy.html
+++ b/src/site/legal/privacy-policy.html
@@ -647,7 +647,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/portal/api-docs.html
+++ b/src/site/portal/api-docs.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FHIR R4 APIs - Cloud Health Office | Patient Access, Provider Access, Prior Auth</title>
-  <meta name="description" content="CMS-0057-F compliant FHIR R4 APIs for Patient Access, Provider Access, Payer-to-Payer Exchange, and Prior Authorization. Da Vinci PDex, PAS, CRD, DTR implementation guides." />
+  <meta name="description" content="CMS-0057-F readiness API surface for Patient Access, Provider Access, Payer-to-Payer Exchange, and Prior Authorization. Da Vinci PDex, PAS, CRD, DTR implementation guides." />
   <link rel="canonical" href="https://cloudhealthoffice.com/portal/api-docs" />
   <meta property="og:title" content="FHIR R4 APIs - Cloud Health Office" />
-  <meta property="og:description" content="CMS-0057-F compliant FHIR R4 APIs. Patient Access, Provider Access, Payer-to-Payer, Prior Authorization." />
+  <meta property="og:description" content="CMS-0057-F readiness FHIR R4 APIs. Patient Access, Provider Access, Payer-to-Payer, Prior Authorization." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cloudhealthoffice.com/portal/api-docs" />
   <meta property="og:site_name" content="Cloud Health Office" />
@@ -410,7 +410,7 @@ Console.WriteLine(patient.Name[0].Given.First());</code></pre>
       </div>
 
       <div style="padding: 40px 20px; background: var(--dark-gray); border-radius: 12px; max-width: 800px; margin: 0 auto;">
-        <h3>🚀 Ready to Get CMS-0057-F Compliant?</h3>
+        <h3>Ready to Validate CMS-0057-F Readiness?</h3>
         <p style="font-size: 1.1rem; margin: 20px 0;">
           Deploy a FHIR compliance surface alongside your existing core admin system
         </p>
@@ -430,7 +430,7 @@ Console.WriteLine(patient.Name[0].Given.First());</code></pre>
   <footer style="text-align: center; margin-top: 80px; padding: 40px 20px; border-top: 1px solid #333;">
     <p>
       <strong>Cloud Health Office</strong><br>
-      CMS-0057-F Compliant FHIR R4 Platform
+      CMS-0057-F Readiness FHIR R4 Platform
     </p>
     <p style="opacity: 0.8; margin: 20px 0;">
       BSL 1.1 • Source-Available • Automated Validation

--- a/src/site/portal/index.html
+++ b/src/site/portal/index.html
@@ -103,7 +103,7 @@
               </div>
               
               <p style="font-size: 1.1rem; margin-bottom: 20px;">
-                CMS-0057-F compliant FHIR R4 endpoints for Patient Access, Provider Access, Payer-to-Payer, and Prior Authorization
+                CMS-0057-F readiness FHIR R4 endpoints for Patient Access, Provider Access, Payer-to-Payer, and Prior Authorization
               </p>
 
               <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 15px; margin: 25px 0;">
@@ -133,7 +133,7 @@
               </div>
 
               <div style="margin-top: 20px; padding: 15px; background: var(--dark-bg); border-radius: 8px; font-size: 0.85rem;">
-                <strong>✅ Ready to deploy:</strong> Production-grade security • Full X12 ↔ FHIR conversion
+                <strong>✅ Evaluation ready:</strong> Security controls to validate • X12 and FHIR implementation surfaces
               </div>
             </div>
 

--- a/src/site/pricing-api.html
+++ b/src/site/pricing-api.html
@@ -720,7 +720,7 @@
       <div class="footer-grid">
         <div class="footer-brand">
           <h4>Cloud Health Office</h4>
-          <p>The modern integration layer for health plan core administration systems. CMS-0057-F compliant, multi-clearinghouse EDI, FHIR R4 APIs.</p>
+          <p>The modern integration layer for health plan core administration systems. CMS-0057-F readiness, multi-clearinghouse EDI, FHIR R4 APIs.</p>
           <p style="font-size:0.82rem; color:rgba(128,128,128,0.45);">BSL 1.1 &nbsp;&middot;&nbsp; Source-Available Platform</p>
         </div>
         <div class="footer-col">

--- a/src/site/release-notes.html
+++ b/src/site/release-notes.html
@@ -303,12 +303,12 @@
 
   <main id="main-content">
     <div class="release-hero">
-      <span class="version-badge">V4.1 Release</span>
-      <h1>Cloud Health Office V4</h1>
+      <span class="version-badge">Version History</span>
+      <h1>Cloud Health Office Release Notes</h1>
       <p style="font-size: 1.5rem; max-width: 800px; margin: 0 auto;">
-        Production-shape SaaS architecture. Security-scanned release process.<br>
+        Source-available payer platform history. Security-scanned release process.<br>
         36 Microservices. 9 Adjudication Engines.<br>
-        <strong>CMS-0057-F Compliant &mdash; 10 Months Early</strong>
+        <strong>CMS-0057-F Readiness &mdash; Evidence Before the Deadline</strong>
       </p>
     </div>
 
@@ -334,8 +334,8 @@
             <div class="metric-label">Dependency Checks</div>
           </div>
           <div class="metric-card">
-            <div class="metric-value">0</div>
-            <div class="metric-label">Security Vulnerabilities</div>
+            <div class="metric-value">Scan</div>
+            <div class="metric-label">Current Security Posture</div>
           </div>
           <div class="metric-card">
             <div class="metric-value">5</div>
@@ -346,14 +346,14 @@
 
       <!-- V4 Features -->
       <section id="v4-features" class="feature-section">
-        <h2>V4 &mdash; Production SaaS</h2>
-        <p>V4 delivered multi-tenant SaaS isolation, security hardening, cloud portability, and a developer-first API experience. Current security posture should always be evaluated from the latest dependency and secret scans.</p>
+        <h2>V4 &mdash; SaaS Architecture Foundation</h2>
+        <p>V4 delivered multi-tenant isolation, security hardening, cloud portability, and a developer-first API experience. Current security posture should always be evaluated from the latest dependency and secret scans.</p>
 
         <div class="feature-grid">
           <div class="feature-card">
             <span class="status-badge status-new">NEW IN V4</span>
             <h3>Multi-Tenant SaaS Isolation</h3>
-            <p>Enterprise-grade tenant isolation for production SaaS deployments.</p>
+            <p>Tenant isolation patterns for payer evaluation and customer-owned deployments.</p>
             <ul>
               <li>TenantContextService maps Azure AD tenant to CHO tenant</li>
               <li>X-Tenant-ID header injection on all API calls</li>
@@ -492,8 +492,8 @@
 
       <!-- CMS-0057-F Compliance -->
       <section class="feature-section">
-        <h2>CMS-0057-F Compliance Status</h2>
-        <p>Cloud Health Office V4 provides production-ready compliance for all CMS-0057-F requirements, with full FHIR R4, US Core, and Da Vinci Implementation Guide coverage.</p>
+        <h2>CMS-0057-F Readiness Status</h2>
+        <p>Cloud Health Office provides implemented CMS-0057-F readiness surfaces with FHIR R4, US Core, and Da Vinci Implementation Guide coverage that still require payer-specific validation before production use.</p>
 
         <table class="compliance-table">
           <thead>
@@ -509,42 +509,42 @@
               <td>Patient Access API</td>
               <td>FHIR R4 &mdash; Claim, EOB, Coverage, Patient, Encounter</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
             <tr>
               <td>Provider Access API</td>
               <td>FHIR R4 &mdash; Claim, EOB, Patient, Condition, Observation</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
             <tr>
               <td>Prior Authorization API</td>
               <td>FHIR R4 + CDS Hooks &mdash; real-time PA decisions</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
             <tr>
               <td>Payer-to-Payer API</td>
               <td>FHIR R4 &mdash; bidirectional member data exchange</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
             <tr>
               <td>Provider Directory API</td>
               <td>FHIR R4 &mdash; Practitioner, Organization, Location, Network</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
             <tr>
               <td>USCDI v1/v2</td>
               <td>US Core profiles, Da Vinci IGs (PDex, PAS, CRD, DTR, HRex)</td>
               <td>January 1, 2027</td>
-              <td><span class="check-icon">&#10003; Production</span></td>
+              <td><span class="check-icon">&#10003; Implemented</span></td>
             </tr>
           </tbody>
         </table>
 
-        <p><strong>Full compliance documentation:</strong> <a href="/docs/compliance" target="_blank" rel="noopener noreferrer">CMS-0057-F Compliance Guide &rarr;</a></p>
+        <p><strong>Full readiness documentation:</strong> <a href="/docs/compliance" target="_blank" rel="noopener noreferrer">CMS-0057-F Readiness Guide &rarr;</a></p>
       </section>
 
       <!-- V3 Features (Retained) -->
@@ -582,7 +582,7 @@
       <!-- V2 Features (Retained) -->
       <section class="feature-section">
         <h2>V2 Features (Included)</h2>
-        <p>V4 includes all V2 features: complete CMS-0057-F compliance with production-ready FHIR R4 APIs.</p>
+        <p>V4 includes the V2 FHIR surfaces as part of the CMS-0057-F readiness path, with payer-specific validation still required before production use.</p>
 
         <div class="feature-grid">
           <div class="feature-card">
@@ -638,7 +638,7 @@ npm install &amp;&amp; npm test
 
         <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Faurelianware%2Fcloudhealthoffice%2Fmain%2Finfrastructure%2Fazure%2Fmain.json" class="button button-green" target="_blank" rel="noopener noreferrer">Deploy to Azure &rarr;</a>
 
-        <p style="margin-top: 30px; color: #888;">Docker Compose for local evaluation (first run builds images, typically 10&ndash;20 minutes; instant on repeat runs). Kubernetes for production in 1&ndash;2 hours.</p>
+        <p style="margin-top: 30px; color: #888;">Docker Compose for local evaluation (first run builds images, typically 10&ndash;20 minutes; instant on repeat runs). Kubernetes deployment requires customer-specific cloud, identity, security, and data validation.</p>
       </section>
 
       <!-- Documentation Links -->
@@ -659,13 +659,13 @@ npm install &amp;&amp; npm test
 
           <div class="feature-card">
             <h3>CMS-0057-F Compliance</h3>
-            <p>Complete regulatory compliance mapping with FHIR R4 implementation details.</p>
+            <p>Regulatory readiness mapping with FHIR R4 implementation details.</p>
             <a href="/docs/compliance" target="_blank" rel="noopener noreferrer">Read Guide &rarr;</a>
           </div>
 
           <div class="feature-card">
             <h3>Deployment Guide</h3>
-            <p>Production deployment for Azure and Kubernetes with Helm charts.</p>
+            <p>Deployment reference for Azure and Kubernetes with environment-specific validation.</p>
             <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/guides/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer">Read Guide &rarr;</a>
           </div>
         </div>
@@ -673,10 +673,10 @@ npm install &amp;&amp; npm test
 
       <!-- CTA Section -->
       <section class="cta-section" style="text-align: center; margin: 60px 0;">
-        <h2>Production-Ready Payer Platform</h2>
+        <h2>Evidence-Backed Payer Platform</h2>
         <p style="font-size: 1.2rem; max-width: 700px; margin: 20px auto;">
           36 microservices. 9 adjudication engines. 5 FHIR R4 APIs.<br>
-          CMS-0057-F compliance surface. Security-scanned. Deployable to customer-owned cloud infrastructure.
+          CMS-0057-F readiness surface. Security-scanned. Deployable to customer-owned cloud infrastructure after payer validation.
         </p>
         <div style="margin-top: 30px;">
           <a href="https://github.com/aurelianware/cloudhealthoffice" class="button" target="_blank" rel="noopener noreferrer">View on GitHub</a>
@@ -688,7 +688,7 @@ npm install &amp;&amp; npm test
 
   <footer>
     <p>
-      <strong>Cloud Health Office V4 &mdash; Production SaaS</strong><br>
+      <strong>Cloud Health Office &mdash; Source-Available Payer Platform</strong><br>
       36 Microservices. 9 Engines. 5 FHIR R4 APIs. Security-scanned release process.
     </p>
     <p>


### PR DESCRIPTION
## Summary
- reframe CMS/compliance site copy around readiness, implementation evidence, and payer validation instead of production/compliance overclaims
- soften Kubernetes reference language from production-equivalent to production-shaped local/reference deployment
- remove stale zero-vulnerability and production-ready V4 language from release notes and shared site taglines

## Validation
- npm run build (src/site)
- git diff --check
- scanned src/site for stale phrases: production-tested, production-equivalent, zero vulnerabilities, Production-grade, and undeployed portal/API host references

## Notes
- This is copy/documentation/site-positioning only; no product runtime code changes.
