### PR TITLE
Add MCC payment delta distribution

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -248,6 +248,20 @@
                     <MudItem xs="12" md="4">@RunFact("Seeding", $"members {OnOff(_selectedRun.Run.SeedMembers)} · providers {OnOff(_selectedRun.Run.SeedProviders)}")</MudItem>
                 </MudGrid>
 
+                @if (_selectedRun.PaymentDeltaDistribution.Count > 0)
+                {
+                    <MudDivider Class="my-3" Style="border-color: rgba(0,255,255,0.12);" />
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65); font-weight: 700;">Payment Delta Distribution</MudText>
+                    <MudGrid Spacing="2" Class="mt-1 mb-3">
+                        @foreach (var bucket in _selectedRun.PaymentDeltaDistribution)
+                        {
+                            <MudItem xs="6" sm="4" md="2">
+                                @Metric(bucket.Label, $"{bucket.Count:N0}", PaymentDeltaBucketColor(bucket))
+                            </MudItem>
+                        }
+                    </MudGrid>
+                }
+
                 @if (HasFixturePreparation(_selectedRun))
                 {
                     var fixture = _selectedRun.FixturePreparation!;
@@ -907,6 +921,23 @@
 
     private static string PaymentDeltaColor(decimal? paymentDelta, decimal tolerance)
         => paymentDelta is null ? "#cbd5e1" : paymentDelta <= tolerance ? "#00ff88" : "#ff0055";
+
+    private static string PaymentDeltaBucketColor(MassAdjudicationPaymentDeltaBucket bucket)
+    {
+        if (bucket.Count == 0)
+        {
+            return "#64748b";
+        }
+
+        if (bucket.UpperBoundInclusive is null)
+        {
+            return "#ff0055";
+        }
+
+        return bucket.LowerBoundExclusive is null || bucket.LowerBoundExclusive == 0m
+            ? "#00ff88"
+            : "#facc15";
+    }
 
     private static Color OutcomeColor(string outcome) => outcome switch
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -111,6 +111,7 @@ public class MassAdjudicationRunSummary
     public int PaymentMatches { get; set; }
     public int PaymentMismatches { get; set; }
     public decimal? MaximumPaymentDelta { get; set; }
+    public List<MassAdjudicationPaymentDeltaBucket> PaymentDeltaDistribution { get; set; } = new();
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
@@ -185,6 +186,14 @@ public class MassAdjudicationFixturePreparation
     public int ProviderNetworksExisting { get; set; }
     public int ProvidersCreated { get; set; }
     public int ProvidersExisting { get; set; }
+}
+
+public class MassAdjudicationPaymentDeltaBucket
+{
+    public string Label { get; set; } = string.Empty;
+    public decimal? LowerBoundExclusive { get; set; }
+    public decimal? UpperBoundInclusive { get; set; }
+    public int Count { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -35,6 +35,7 @@ public class MassAdjudicationRunSummary
     public int PaymentMatches { get; set; }
     public int PaymentMismatches { get; set; }
     public decimal? MaximumPaymentDelta { get; set; }
+    public List<MassAdjudicationPaymentDeltaBucket> PaymentDeltaDistribution { get; set; } = new();
     public List<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown { get; set; } = new();
     public List<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown { get; set; } = new();
     public List<MassAdjudicationFailureSummary> SampleFailures { get; set; } = new();
@@ -110,6 +111,14 @@ public class MassAdjudicationFixturePreparation
     public int ProviderNetworksExisting { get; set; }
     public int ProvidersCreated { get; set; }
     public int ProvidersExisting { get; set; }
+}
+
+public class MassAdjudicationPaymentDeltaBucket
+{
+    public string Label { get; set; } = string.Empty;
+    public decimal? LowerBoundExclusive { get; set; }
+    public decimal? UpperBoundInclusive { get; set; }
+    public int Count { get; set; }
 }
 
 public class MassAdjudicationBusinessDenialSummary

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -37,14 +37,18 @@ internal static class MccRunSummaryBuilder
         var comparable = results
             .Where(IsPaymentComparable)
             .ToList();
-        var avgDelta = comparable.Count == 0
+        var paymentDeltas = comparable
+            .Select(r => PaymentDelta(r)!.Value)
+            .ToList();
+        var avgDelta = paymentDeltas.Count == 0
             ? (decimal?)null
-            : comparable.Average(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
-        var paymentMatches = comparable.Count(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value) <= PaymentTolerance);
+            : paymentDeltas.Average();
+        var paymentMatches = paymentDeltas.Count(d => d <= PaymentTolerance);
         var paymentMismatches = comparable.Count - paymentMatches;
-        var maxPaymentDelta = comparable.Count == 0
+        var maxPaymentDelta = paymentDeltas.Count == 0
             ? (decimal?)null
-            : comparable.Max(r => Math.Abs(r.ActualPlanPayment!.Value - r.ExpectedPlanPayment!.Value));
+            : paymentDeltas.Max();
+        var paymentDeltaDistribution = BuildPaymentDeltaDistribution(paymentDeltas);
         var denialBreakdown = results
             .Where(r => r.Outcome is ClaimValidationOutcome.BusinessDenial)
             .GroupBy(r => r.BusinessDenialCode ?? "UNKNOWN")
@@ -143,6 +147,7 @@ internal static class MccRunSummaryBuilder
             paymentMatches,
             paymentMismatches,
             maxPaymentDelta,
+            paymentDeltaDistribution,
             denialBreakdown,
             workflowBreakdown,
             failures,
@@ -190,6 +195,24 @@ internal static class MccRunSummaryBuilder
             .Cast<MassAdjudicationStageTiming>()
             .OrderByDescending(timing => timing.AverageMilliseconds)
             .ToList();
+    }
+
+    private static IReadOnlyList<MassAdjudicationPaymentDeltaBucket> BuildPaymentDeltaDistribution(
+        IReadOnlyCollection<decimal> paymentDeltas)
+    {
+        if (paymentDeltas.Count == 0)
+        {
+            return Array.Empty<MassAdjudicationPaymentDeltaBucket>();
+        }
+
+        return
+        [
+            new("Exact", null, 0m, paymentDeltas.Count(d => d == 0m)),
+            new("Within tolerance", 0m, PaymentTolerance, paymentDeltas.Count(d => d > 0m && d <= PaymentTolerance)),
+            new("<= $1", PaymentTolerance, 1m, paymentDeltas.Count(d => d > PaymentTolerance && d <= 1m)),
+            new("<= $10", 1m, 10m, paymentDeltas.Count(d => d > 1m && d <= 10m)),
+            new("> $10", 10m, null, paymentDeltas.Count(d => d > 10m))
+        ];
     }
 
     private static IReadOnlyList<ClaimValidationResult> SelectPublishedClaimResults(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2206,6 +2206,10 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     {
         Console.WriteLine($"  Avg payment delta:  ${summary.AveragePaymentDelta:N2}");
         Console.WriteLine($"  Payment gate:       {summary.PaymentMatches:N0}/{summary.PaymentComparisons:N0} within ${summary.PaymentTolerance:N2} ({summary.PaymentMismatches:N0} mismatched, max ${summary.MaximumPaymentDelta:N2})");
+        foreach (var bucket in summary.PaymentDeltaDistribution.Where(b => b.Count > 0))
+        {
+            Console.WriteLine($"  Payment delta:      {bucket.Label} ({bucket.Count:N0})");
+        }
     }
 
     foreach (var denialGroup in summary.BusinessDenialBreakdown.Take(5))
@@ -2342,6 +2346,7 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         0,
         0,
         null,
+        Array.Empty<MassAdjudicationPaymentDeltaBucket>(),
         Array.Empty<MassAdjudicationBusinessDenialSummary>(),
         Array.Empty<MassAdjudicationWorkflowScenarioSummary>(),
         Array.Empty<MassAdjudicationFailureSummary>(),
@@ -2593,6 +2598,7 @@ internal sealed record MassAdjudicationRunSummary(
     int PaymentMatches,
     int PaymentMismatches,
     decimal? MaximumPaymentDelta,
+    IReadOnlyList<MassAdjudicationPaymentDeltaBucket> PaymentDeltaDistribution,
     IReadOnlyList<MassAdjudicationBusinessDenialSummary> BusinessDenialBreakdown,
     IReadOnlyList<MassAdjudicationWorkflowScenarioSummary> WorkflowScenarioBreakdown,
     IReadOnlyList<MassAdjudicationFailureSummary> SampleFailures,
@@ -2657,6 +2663,12 @@ internal sealed record MassAdjudicationFixturePreparation(
     int ProviderNetworksExisting,
     int ProvidersCreated,
     int ProvidersExisting);
+
+internal sealed record MassAdjudicationPaymentDeltaBucket(
+    string Label,
+    decimal? LowerBoundExclusive,
+    decimal? UpperBoundInclusive,
+    int Count);
 
 internal sealed record MemberFixturePreparation(int Created, int Existing, int StatusAligned)
 {

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -51,6 +51,13 @@ public class MassAdjudicationRunRepositoryTests
         summary.WorkflowUnsupported = 73;
         summary.WorkflowObservationTimeouts = 2;
         summary.AveragePaymentDelta = 59.36m;
+        summary.PaymentDeltaDistribution.Add(new MassAdjudicationPaymentDeltaBucket
+        {
+            Label = "<= $1",
+            LowerBoundExclusive = 0.01m,
+            UpperBoundInclusive = 1m,
+            Count = 3
+        });
         summary.Status = "Running";
         summary.Progress = new MassAdjudicationRunProgress
         {
@@ -90,6 +97,11 @@ public class MassAdjudicationRunRepositoryTests
         reread.WorkflowUnsupported.Should().Be(73);
         reread.WorkflowObservationTimeouts.Should().Be(2);
         reread.AveragePaymentDelta.Should().Be(59.36m);
+        reread.PaymentDeltaDistribution.Should().ContainSingle(b =>
+            b.Label == "<= $1"
+            && b.LowerBoundExclusive == 0.01m
+            && b.UpperBoundInclusive == 1m
+            && b.Count == 3);
         reread.Status.Should().Be("Running");
         reread.Progress.Should().NotBeNull();
         reread.Progress!.CompletedClaims.Should().Be(2500);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -106,6 +106,40 @@ public class MccRunSummaryBuilderTests
     }
 
     [Fact]
+    public void Build_GroupsPaymentDeltaDistributionForComparableRowsOnly()
+    {
+        var options = ValidatorOptions.Parse(["--claims", "6"]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("EXACT", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid),
+            Result("WITHIN-TOLERANCE", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 100.01m },
+            Result("UNDER-ONE", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 100.50m },
+            Result("UNDER-TEN", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 105m },
+            Result("OVER-TEN", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 125m },
+            Result("EDGE-NOT-COMPARABLE", "EdgeCase:BehavioralHealthCarveIn", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with { ActualPlanPayment = 250m, ExpectedPlanPayment = 100m }
+        };
+
+        var summary = MccRunSummaryBuilder.Build(results, TimeSpan.FromSeconds(1), options, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+
+        Assert.Equal(5, summary.PaymentComparisons);
+        Assert.Equal(2, summary.PaymentMatches);
+        Assert.Equal(3, summary.PaymentMismatches);
+        Assert.Equal(25m, summary.MaximumPaymentDelta);
+        Assert.Equal(5, summary.PaymentDeltaDistribution.Sum(b => b.Count));
+
+        AssertPaymentBucket(summary, "Exact", 1);
+        AssertPaymentBucket(summary, "Within tolerance", 1);
+        AssertPaymentBucket(summary, "<= $1", 1);
+        AssertPaymentBucket(summary, "<= $10", 1);
+        AssertPaymentBucket(summary, "> $10", 1);
+    }
+
+    [Fact]
     public void Build_PublishesPaymentDeltaOnlyForPaymentComparableRows()
     {
         var options = ValidatorOptions.Parse([
@@ -216,6 +250,12 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(2, summary.FixturePreparation.ProviderNetworksExisting);
         Assert.Equal(1_077, summary.FixturePreparation.ProvidersCreated);
         Assert.Equal(19, summary.FixturePreparation.ProvidersExisting);
+    }
+
+    private static void AssertPaymentBucket(MassAdjudicationRunSummary summary, string label, int count)
+    {
+        var bucket = Assert.Single(summary.PaymentDeltaDistribution, b => b.Label == label);
+        Assert.Equal(count, bucket.Count);
     }
 
     private static ClaimValidationResult Result(


### PR DESCRIPTION
## Summary
- Add non-overlapping MCC payment delta distribution buckets to run summaries: exact, within tolerance, <= $1, <= $10, and > $10.
- Keep the distribution scoped to payment-comparable clean professional paid claims, matching the existing payment gate.
- Thread the distribution through the claims-service summary model and portal DTO.
- Surface the distribution in the Mass Adjudication run detail panel.

## Why
The payment gate already reports average and max deltas, but a mean can hide whether payment evidence is clean across the distribution or concentrated in a few larger differences. This gives the console a clearer amount-level evidence trail without treating non-comparable edge-case amounts as scored payment evidence.

## Validation
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --filter MccRunSummaryBuilderTests
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter SaveAsync_preserves_mcc_evidence_summary_fields
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj
- dotnet build src/services/claims-service/claims-service.csproj

Portal build passes with existing unrelated warnings.
