### PR TITLE
Anchor MCC validation provider fixtures

### DIFF
--- a/src/tools/mcc-platform-validator/MccValidationProviderProfile.cs
+++ b/src/tools/mcc-platform-validator/MccValidationProviderProfile.cs
@@ -1,0 +1,26 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+public static class MccValidationProviderProfile
+{
+    public static void ForceAdjudicatable(SyntheticProvider provider, DateTime serviceDate)
+    {
+        provider.IsParticipating = true;
+        provider.NetworkStatus = "InNetwork";
+        provider.CredentialingStatus = "Active";
+        provider.TermDate = null;
+        provider.AcceptingNewPatients = true;
+        provider.EffectiveDate = DateTime.SpecifyKind(serviceDate.Date.AddYears(-2), DateTimeKind.Utc);
+    }
+
+    public static void ForceCleanProfessionalPaid(SyntheticProvider provider, DateTime serviceDate)
+    {
+        ForceAdjudicatable(provider, serviceDate);
+        provider.State = "AZ";
+        provider.SpecialtyCode = "207Q00000X";
+        provider.SpecialtyDescription = "Family Medicine";
+        provider.TaxonomyCode = "207Q00000X";
+        provider.ContractType = "FeeForService";
+    }
+}

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -612,7 +612,7 @@ static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int
             continue;
         }
 
-        ForceAdjudicatableProviderProfile(claim.BillingProvider);
+        ForceAdjudicatableProviderProfile(claim.BillingProvider, claim.DateOfService);
         claim.BillingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 0);
 
         if (!string.Equals(
@@ -620,7 +620,7 @@ static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int
                 MccWorkflowValidation.ProviderExcludedCode,
                 StringComparison.OrdinalIgnoreCase))
         {
-            ForceAdjudicatableProviderProfile(claim.RenderingProvider);
+            ForceAdjudicatableProviderProfile(claim.RenderingProvider, claim.DateOfService);
             claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 1);
         }
         else
@@ -763,6 +763,7 @@ static void NormalizePriorAuthEdgeCases(List<SyntheticClaim> claims, ValidatorOp
 
 static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
 {
+    var serviceDate = claim.DateOfService.Date;
     claim.BenefitPlanId = MccWorkflowValidation.CleanProfessionalPaidPlanId;
     claim.PlaceOfService = "11";
     claim.FrequencyCode = "1";
@@ -772,10 +773,9 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
     claim.PriorAuthNumber = null;
     claim.PrimaryDiagnosisCode = "Z00.00";
     claim.SecondaryDiagnosisCodes.Clear();
-    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
-    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider, serviceDate);
+    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider, serviceDate);
 
-    var serviceDate = claim.DateOfService.Date;
     claim.Lines = new List<ClaimLine>
     {
         new()
@@ -820,6 +820,7 @@ static void ForceCleanProfessionalPaidScenario(SyntheticClaim claim)
 
 static void ForceExcludedProviderScenario(SyntheticClaim claim, int seed, int index)
 {
+    var serviceDate = claim.DateOfService.Date;
     claim.BenefitPlanId = MccWorkflowValidation.ExcludedProviderPlanId;
     claim.PlaceOfService = "11";
     claim.FrequencyCode = "1";
@@ -830,11 +831,10 @@ static void ForceExcludedProviderScenario(SyntheticClaim claim, int seed, int in
     claim.PrimaryDiagnosisCode = "Z00.00";
     claim.SecondaryDiagnosisCodes.Clear();
 
-    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
-    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider, serviceDate);
+    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider, serviceDate);
     ForceExcludedProviderProfile(claim.RenderingProvider, seed, index);
 
-    var serviceDate = claim.DateOfService.Date;
     claim.Lines = new List<ClaimLine>
     {
         new()
@@ -881,6 +881,7 @@ static void ForceExcludedProviderScenario(SyntheticClaim claim, int seed, int in
 
 static void ForceUncoveredServiceScenario(SyntheticClaim claim)
 {
+    var serviceDate = claim.DateOfService.Date;
     claim.BenefitPlanId = MccWorkflowValidation.UncoveredServicePlanId;
     claim.PlaceOfService = "31";
     claim.FrequencyCode = "1";
@@ -891,10 +892,9 @@ static void ForceUncoveredServiceScenario(SyntheticClaim claim)
     claim.PrimaryDiagnosisCode = "Z00.00";
     claim.SecondaryDiagnosisCodes.Clear();
 
-    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider);
-    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider);
+    ForceCleanProfessionalPaidProviderProfile(claim.RenderingProvider, serviceDate);
+    ForceCleanProfessionalPaidProviderProfile(claim.BillingProvider, serviceDate);
 
-    var serviceDate = claim.DateOfService.Date;
     claim.Lines = new List<ClaimLine>
     {
         new()
@@ -939,27 +939,14 @@ static void ForceUncoveredServiceScenario(SyntheticClaim claim)
     };
 }
 
-static void ForceCleanProfessionalPaidProviderProfile(SyntheticProvider provider)
+static void ForceCleanProfessionalPaidProviderProfile(SyntheticProvider provider, DateTime serviceDate)
 {
-    provider.IsParticipating = true;
-    provider.NetworkStatus = "InNetwork";
-    provider.CredentialingStatus = "Active";
-    provider.TermDate = null;
-    provider.AcceptingNewPatients = true;
-    provider.State = "AZ";
-    provider.SpecialtyCode = "207Q00000X";
-    provider.SpecialtyDescription = "Family Medicine";
-    provider.TaxonomyCode = "207Q00000X";
-    provider.ContractType = "FeeForService";
+    MccValidationProviderProfile.ForceCleanProfessionalPaid(provider, serviceDate);
 }
 
-static void ForceAdjudicatableProviderProfile(SyntheticProvider provider)
+static void ForceAdjudicatableProviderProfile(SyntheticProvider provider, DateTime serviceDate)
 {
-    provider.IsParticipating = true;
-    provider.NetworkStatus = "InNetwork";
-    provider.CredentialingStatus = "Active";
-    provider.TermDate = null;
-    provider.AcceptingNewPatients = true;
+    MccValidationProviderProfile.ForceAdjudicatable(provider, serviceDate);
 }
 
 static void ForceExcludedProviderProfile(SyntheticProvider provider, int seed, int index)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderProfileTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderProfileTests.cs
@@ -1,0 +1,55 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccValidationProviderProfileTests
+{
+    [Fact]
+    public void ForceAdjudicatable_AnchorsProviderBeforeServiceDate()
+    {
+        var provider = new SyntheticProvider
+        {
+            NetworkStatus = "Excluded",
+            CredentialingStatus = "Excluded",
+            IsParticipating = false,
+            AcceptingNewPatients = false,
+            EffectiveDate = new DateTime(2026, 7, 1),
+            TermDate = new DateTime(2026, 7, 10)
+        };
+
+        MccValidationProviderProfile.ForceAdjudicatable(provider, new DateTime(2026, 6, 20));
+
+        Assert.True(provider.IsParticipating);
+        Assert.Equal("InNetwork", provider.NetworkStatus);
+        Assert.Equal("Active", provider.CredentialingStatus);
+        Assert.True(provider.AcceptingNewPatients);
+        Assert.Null(provider.TermDate);
+        Assert.Equal(new DateTime(2024, 6, 20, 0, 0, 0, DateTimeKind.Utc), provider.EffectiveDate);
+    }
+
+    [Fact]
+    public void ForceCleanProfessionalPaid_KeepsAdjudicatableProfileAndProfessionalMetadata()
+    {
+        var provider = new SyntheticProvider
+        {
+            State = "TX",
+            SpecialtyCode = "1223G0001X",
+            SpecialtyDescription = "Dentist",
+            TaxonomyCode = "1223G0001X",
+            ContractType = "Capitated",
+            EffectiveDate = new DateTime(2026, 7, 1)
+        };
+
+        MccValidationProviderProfile.ForceCleanProfessionalPaid(provider, new DateTime(2026, 6, 20));
+
+        Assert.Equal("AZ", provider.State);
+        Assert.Equal("207Q00000X", provider.SpecialtyCode);
+        Assert.Equal("Family Medicine", provider.SpecialtyDescription);
+        Assert.Equal("207Q00000X", provider.TaxonomyCode);
+        Assert.Equal("FeeForService", provider.ContractType);
+        Assert.Equal("InNetwork", provider.NetworkStatus);
+        Assert.Equal("Active", provider.CredentialingStatus);
+        Assert.Equal(new DateTime(2024, 6, 20, 0, 0, 0, DateTimeKind.Utc), provider.EffectiveDate);
+    }
+}


### PR DESCRIPTION
## Summary
- anchor MCC validation provider profiles relative to each claim service date
- extract reusable provider-profile normalization into `MccValidationProviderProfile`
- add focused tests for adjudicatable and clean-professional provider metadata

## Why
A 1K MCC verification run confirmed PR #926's payment-delta distribution was publishing correctly, but it also exposed a separate fixture issue: prior-auth edge-case claims could be denied as `PROVIDER_EXCLUDED` before the prior-auth rule was evaluated. The affected providers were active/in-network after normalization, but their effective dates could still be later than the claim service date.

This PR makes validation provider fixtures effective two years before the claim service date, clearing the network/credentialing path so the intended prior-auth behavior is what gets scored.

## Validation
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore`
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore`
- Local Kubernetes 1K MCC run: `CLAIMS=1000 MAX_CLAIMS=1000 PARALLELISM=10 PROGRESS_EVERY=100 ./scripts/run-mcc-local-k8s.sh`
  - 1,000 processed
  - 0 platform failures
  - 117/130 workflow checks matched
  - 0 workflow mismatches
  - 13 unsupported
  - 0 unexpected pends
  - payment gate 20/20 within $0.01
  - payment delta distribution: `Exact (20)`
- Confirmed stored run summary via claims-service API includes the full payment delta distribution array.
