### PR TITLE
Fix MCC validation provider NPI namespace

### DIFF
--- a/src/tools/mcc-platform-validator/MccValidationProviderIdentity.cs
+++ b/src/tools/mcc-platform-validator/MccValidationProviderIdentity.cs
@@ -1,0 +1,56 @@
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+public static class MccValidationProviderIdentity
+{
+    private const int SyntheticNpiSpace = 10_000_000;
+
+    public static string BuildNpi(int seed, Guid runId, int scenarioIndex, int role)
+    {
+        if (scenarioIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(scenarioIndex), "Scenario index must be non-negative.");
+        }
+
+        var roleDigit = role switch
+        {
+            0 => 3, // billing providers for scoreable validation scenarios
+            1 => 4, // adjudicatable rendering providers
+            2 => 5, // intentionally excluded rendering providers
+            _ => throw new ArgumentOutOfRangeException(nameof(role), "Validation provider role must be 0, 1, or 2.")
+        };
+
+        unchecked
+        {
+            var runHash = BitConverter.ToUInt32(runId.ToByteArray(), 0);
+            var value = (runHash + (uint)(seed * 1_000_003) + (uint)scenarioIndex) % SyntheticNpiSpace;
+            var baseNineDigits = $"9{roleDigit}{value:D7}";
+            return $"{baseNineDigits}{CalculateNpiCheckDigit(baseNineDigits)}";
+        }
+    }
+
+    private static int CalculateNpiCheckDigit(string baseNineDigits)
+    {
+        const string npiPrefix = "80840";
+        var candidate = $"{npiPrefix}{baseNineDigits}0";
+        var sum = 0;
+        var doubleDigit = false;
+
+        for (var i = candidate.Length - 1; i >= 0; i--)
+        {
+            var digit = candidate[i] - '0';
+            if (doubleDigit)
+            {
+                digit *= 2;
+                if (digit > 9)
+                {
+                    digit -= 9;
+                }
+            }
+
+            sum += digit;
+            doubleDigit = !doubleDigit;
+        }
+
+        return (10 - (sum % 10)) % 10;
+    }
+}

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -973,14 +973,7 @@ static string BuildSyntheticExcludedProviderNpi(int seed, int index)
 
 static string BuildSyntheticValidationProviderNpi(int seed, Guid runId, int index, int role)
 {
-    unchecked
-    {
-        var runHash = BitConverter.ToUInt32(runId.ToByteArray(), 0);
-        var combined = runHash ^ (uint)(seed * 1_000_003 + index * 17 + role);
-        var value = combined % 1_000_000;
-        var baseNineDigits = $"91{role}{value:D6}";
-        return $"{baseNineDigits}{CalculateNpiCheckDigit(baseNineDigits)}";
-    }
+    return MccValidationProviderIdentity.BuildNpi(seed, runId, index, role);
 }
 
 static int CalculateNpiCheckDigit(string baseNineDigits)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderIdentityTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderIdentityTests.cs
@@ -1,0 +1,45 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccValidationProviderIdentityTests
+{
+    private static readonly Guid RunId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Fact]
+    public void BuildNpi_UsesWideRoleSeparatedNamespaces()
+    {
+        var billing = MccValidationProviderIdentity.BuildNpi(42, RunId, 100, role: 0);
+        var rendering = MccValidationProviderIdentity.BuildNpi(42, RunId, 100, role: 1);
+        var excludedRendering = MccValidationProviderIdentity.BuildNpi(42, RunId, 100, role: 2);
+
+        Assert.StartsWith("93", billing, StringComparison.Ordinal);
+        Assert.StartsWith("94", rendering, StringComparison.Ordinal);
+        Assert.StartsWith("95", excludedRendering, StringComparison.Ordinal);
+        Assert.Equal(10, billing.Length);
+        Assert.Equal(10, rendering.Length);
+        Assert.Equal(10, excludedRendering.Length);
+        Assert.NotEqual(billing, rendering);
+        Assert.NotEqual(rendering, excludedRendering);
+    }
+
+    [Fact]
+    public void BuildNpi_DoesNotCollideAcrossFiftyThousandClaimScoreableWindow()
+    {
+        var npis = new HashSet<string>(StringComparer.Ordinal);
+
+        for (var scenarioIndex = 0; scenarioIndex < 6_500; scenarioIndex++)
+        {
+            Assert.True(npis.Add(MccValidationProviderIdentity.BuildNpi(42, RunId, scenarioIndex, role: 0)));
+            Assert.True(npis.Add(MccValidationProviderIdentity.BuildNpi(42, RunId, scenarioIndex, role: 1)));
+            Assert.True(npis.Add(MccValidationProviderIdentity.BuildNpi(42, RunId, scenarioIndex, role: 2)));
+        }
+    }
+
+    [Fact]
+    public void BuildNpi_RejectsUnsupportedRole()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => MccValidationProviderIdentity.BuildNpi(42, RunId, 0, role: 3));
+    }
+}


### PR DESCRIPTION
## Summary

- moves MCC scoreable validation provider NPIs out of the old `91x` synthetic namespace into wider role-separated `93/94/95` namespaces
- centralizes validation-provider NPI generation in `MccValidationProviderIdentity`
- adds regression coverage proving role separation, unsupported-role rejection, and no NPI collisions across the 50K scoreable scenario window

## Why

The post-#927 50K rerun still found 10 workflow mismatches, all in `TxStarInpatientNoAuth`. Those claims expected `PRIOR_AUTH_REQUIRED` but adjudicated as `PROVIDER_EXCLUDED`. Spot checks showed the current provider service record was approved and in-network, which pointed to stale or colliding provider-integrity state in the long-lived local tenant around the old `91x` generated NPI family.

This change gives scoreable validation providers their own wider, role-separated namespaces:

- `93...` billing providers
- `94...` adjudicatable rendering providers
- `95...` intentionally excluded rendering providers

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore`
  - Passed: 91 / 91
- 5K Kubernetes gate after fix: `mcc-provider-namespace-5k-163537`
  - 5,000 / 5,000 processed
  - 577 / 650 workflow checks matched
  - 0 workflow mismatches
  - 46 / 46 expected pends observed
  - 100 / 100 payment comparisons within tolerance
- 50K Kubernetes rerun after fix: `mcc-provider-namespace-50k-163946`
  - 50,000 / 50,000 processed
  - 5,767 / 6,500 workflow checks matched
  - 0 workflow mismatches
  - 460 / 460 expected pends observed
  - 0 unexpected pends across 5,307 scoreable non-pend claims
  - 1,000 / 1,000 payment comparisons within tolerance
  - max payment delta: $0.00
  - `TxStarInpatientNoAuth`: 1,000 / 1,000 matched
