### PR TITLE
Record post-928 MCC fixture evidence

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-008/README.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/README.txt
@@ -8,6 +8,8 @@ The result held: 100,000 processed, zero platform failures, zero scoreable workf
 
 The pend counts are intentionally reported with scope: 923 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,614 scoreable expected-pay and expected-deny claims.
 
+Post-#928 note: after the original 100K run, provider-fixture hardening moved scoreable validation providers into wider, role-separated synthetic NPI namespaces. The follow-up 50K verification completed cleanly with zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends, and 1,000/1,000 payment comparisons within tolerance.
+
 ## Episode metadata
 
 - Episode title: The Clean 100,000-Claim Run
@@ -60,4 +62,5 @@ The episode must distinguish:
 - [x] The next optimization target is evidence-driven.
 - [x] Primary completed-run console screenshot is captured.
 - [x] Unsupported claim sample and persisted payment drilldown are captured.
+- [x] Post-#928 50K provider-fixture verification is recorded.
 - [ ] Published article URL is recorded.

--- a/docs/million-claim-challenge/podcast/episode-008/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/article.txt
@@ -33,6 +33,16 @@ The validator now includes:
 
 The 100K run was not allowed to trade those gates for volume.
 
+There was one more fixture-hardening pass after the original 100K writeup.
+
+PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification then found 10 scoreable `TxStarInpatientNoAuth` mismatches: those claims should have denied for missing prior authorization, but provider-integrity evaluation treated the generated rendering provider as excluded. The current provider record was approved and in-network, which pointed to stale or colliding validation-provider identity state in the long-lived local tenant.
+
+PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces: billing providers in the `93...` range, adjudicatable rendering providers in `94...`, and intentionally excluded rendering providers in `95...`.
+
+The rerun after PR #928 processed 50,000 claims cleanly: 5,767 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.
+
+That result does not replace the 100K evidence above. It tightens the fixture model that the next 100K rerun should use.
+
 ## The 100K result
 
 The local Docker Desktop Kubernetes run processed 100,000 deterministic synthetic claims with parallelism set to 10.
@@ -120,6 +130,7 @@ That suggests several concrete experiments:
 - isolate only member records whose scenario state can collide
 - batch or bulk-write fixture data where service contracts permit it
 - report preparation throughput and cache-hit rates
+- rerun 100K with the PR #928 validation-provider namespace hardening
 - rerun 100K after each fixture optimization
 
 The acceptance criterion stays the same: performance work cannot weaken the correctness gates.

--- a/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
@@ -97,3 +97,45 @@ The 100K correctness gate passed cleanly. All claims processed; the scoreable wo
 The timed adjudication result and total Kubernetes job duration must remain separate. Timed processing completed in 29:40.851 at 56.15 claims/second. The job lifecycle lasted about 128 minutes because large run-scoped member and provider fixture preparation occurred before timed processing.
 
 This is local Docker Desktop evidence, not a production-cloud capacity claim. The performance result identifies fixture preparation and increased local tail latency as the next scaling investigation.
+
+## Post-#928 provider-fixture verification
+
+After PR #927 anchored validation providers as run-scoped fixtures, a follow-up 50K run still exposed 10 scoreable `TxStarInpatientNoAuth` mismatches. Those claims expected `PRIOR_AUTH_REQUIRED` but adjudicated as `PROVIDER_EXCLUDED`. Spot checks against provider-service showed the current generated rendering provider record was approved and in-network, which pointed to stale or colliding provider-integrity state around the old synthetic validation-provider NPI family.
+
+PR #928 moved MCC scoreable validation providers into wider, role-separated synthetic NPI namespaces:
+
+- `93...` billing providers
+- `94...` adjudicatable rendering providers
+- `95...` intentionally excluded rendering providers
+
+The post-#928 50K rerun was completed as `mcc-provider-namespace-50k-163946`.
+
+### Post-#928 50K correctness result
+
+- Total claims: 50,000
+- Processed: 50,000
+- Paid/adjudicated: 39,407
+- Pended: 463
+- Business denials: 10,130
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 460 pended, 0 timed out
+- False-pend sweep: 5,307 scoreable non-pend claims, 0 unexpected pends
+- Workflow scoring: 5,767/6,500 matched, 0 mismatched, 733 unsupported, 0 observation timeouts
+- Payment gate: 1,000/1,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+- `TxStarInpatientNoAuth`: 1,000/1,000 matched
+
+### Post-#928 50K performance result
+
+- Timed claim-processing elapsed: 14:13.279
+- Throughput: 58.60 claims/second
+- P95 latency: 380 ms
+- P99 latency: 515 ms
+- Preparation time: 2:54.130
+- Tracked lifecycle: 17:14.705
+- Provider fixtures created: 7,568
+- Provider fixtures already present: 491
+
+This post-#928 50K run is not a replacement for the 100K result above. It is the provider-fixture hardening proof point that should be included before the next 100K rerun.

--- a/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
@@ -4,6 +4,8 @@ Use Alex and Jordan as experienced healthcare platform engineers. Make the discu
 
 The central story is that Cloud Health Office did not move from 50K to 100K by relaxing validation. Before scaling, the team added a payment gate, a false-pend sweep, corrected zero-limit accumulator placeholder handling, and eliminated cross-corpus member fixture collisions.
 
+Also include the post-#928 provider-fixture addendum. After the original 100K run, PR #927 anchored validation providers as run-scoped fixtures, and a follow-up 50K verification exposed 10 `TxStarInpatientNoAuth` mismatches caused by provider-integrity evaluation treating generated rendering providers as excluded. PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces (`93...` billing, `94...` adjudicatable rendering, `95...` intentionally excluded). The post-#928 50K rerun was clean: 50,000 processed, 5,767/6,500 workflow checks matched, zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000/1,000 payment comparisons within tolerance. Make clear that this hardens the fixture model for the next 100K rerun rather than replacing the original 100K evidence.
+
 Use these exact results:
 
 - 100,000 claims processed
@@ -33,3 +35,5 @@ Spend meaningful time on the difference between timed adjudication and total dev
 Compare the result with the prior clean 50K run at 82.40 claims per second, 129 ms P95, and 178 ms P99. Do not imply a production capacity conclusion. Frame the lower 100K throughput and higher latency as a local scaling signal.
 
 End with the next ladder: optimize and measure fixture preparation, rerun 100K, locate the reproducible local ceiling, then use the same deterministic corpus and correctness gates for a future AKS/EKS/GKE cloud scaling series.
+
+The next 100K rerun should use the post-#928 validation-provider namespace hardening.

--- a/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
@@ -28,9 +28,26 @@
 - Added a clone-to-console Million Claim Challenge path to the public Quick Start.
 - Documented a safe 1K starting run, clean-gate interpretation, console navigation, and guarded 10K/100K progression.
 
+## PR #927 - validation provider fixture anchoring
+
+- Anchored MCC validation providers as run-scoped fixtures instead of relying on reusable generated identities alone.
+- Confirmed the fixture path still exposed a follow-up 50K signal: 10 `TxStarInpatientNoAuth` claims denied for `PROVIDER_EXCLUDED` instead of `PRIOR_AUTH_REQUIRED`.
+- Triaged that signal to stale or colliding provider-integrity state around the old synthetic validation-provider NPI family in the long-lived local tenant.
+
+## PR #928 - validation provider NPI namespace hardening
+
+- Moved MCC scoreable validation providers out of the old `91x` synthetic NPI family.
+- Added wider, role-separated synthetic NPI namespaces: `93...` for billing providers, `94...` for adjudicatable rendering providers, and `95...` for intentionally excluded rendering providers.
+- Added regression coverage proving role separation and no collisions across the 50K scoreable scenario window.
+- Produced a clean post-fix 50K verification: 50,000 processed, 5,767/6,500 workflow checks matched, 0 workflow mismatches, 460/460 expected pends observed, 0 unexpected pends, and 1,000/1,000 comparable payments within tolerance.
+
 ## 100K outcome
 
 No platform code was changed to make the 100K result look clean. The run used the stronger gates established above and published its completed summary to the console.
+
+## Post-100K fixture-hardening note
+
+The PR #927/#928 provider-fixture hardening happened after the original 100K run. It does not replace the 100K evidence, but it is now part of the fixture model that should be used before publishing the next 100K rerun.
 
 ## Claim-detail projection correction discovered during evidence review
 


### PR DESCRIPTION
## Summary

- records the post-#928 MCC provider-fixture hardening evidence in the Episode 008 packet
- adds the clean post-#928 50K verification numbers to the article, benchmark results, README, podcast prompt, and PR summary
- clarifies that the post-#928 50K rerun hardens the fixture model for the next 100K rerun rather than replacing the original 100K result

## Why

After PR #927 anchored validation providers as run-scoped fixtures, a follow-up 50K run still exposed 10 scoreable `TxStarInpatientNoAuth` mismatches. PR #928 moved validation providers into wider, role-separated synthetic NPI namespaces and the rerun completed cleanly.

This PR preserves that evidence trail in the Part 8 packet before the next 100K run.

## Validation

- Documentation-only change
- Reviewed the packet diff for consistency across `article.txt`, `benchmark-results.txt`, `pr-summary.txt`, `README.txt`, and `podcast-prompt.txt`
- No code tests run
