### PR TITLE
Record post-928 MCC 100K evidence

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-008/README.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/README.txt
@@ -2,13 +2,13 @@
 
 ## Episode summary
 
-Episode 008 covers the first clean 100,000-claim local Kubernetes validation after payment accuracy, false-pend detection, accumulator handling, and fixture isolation became scored gates.
+Episode 008 covers the clean post-#928 100,000-claim local Kubernetes validation after payment accuracy, false-pend detection, accumulator handling, member fixture isolation, and provider identity hardening became part of the scored path.
 
-The result held: 100,000 processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000 of 2,000 comparable payments within one cent. The episode also explains why the 29:40 timed processing phase and 128-minute Kubernetes job lifecycle are different, and why fixture preparation is now the clearest local scaling target.
+The result held: 100,000 processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000 of 2,000 comparable payments within one cent. The episode also explains why the 27:54 timed processing phase and 34:03 tracked lifecycle are different, and why the next local scaling target is controlled parallelism and internal service/writeback pressure rather than raw Docker CPU or memory.
 
-The pend counts are intentionally reported with scope: 923 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,614 scoreable expected-pay and expected-deny claims.
+The pend counts are intentionally reported with scope: 921 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,614 scoreable expected-pay and expected-deny claims.
 
-Post-#928 note: after the original 100K run, provider-fixture hardening moved scoreable validation providers into wider, role-separated synthetic NPI namespaces. The follow-up 50K verification completed cleanly with zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends, and 1,000/1,000 payment comparisons within tolerance.
+Post-#928 note: provider-fixture hardening moved scoreable validation providers into wider, role-separated synthetic NPI namespaces. The follow-up 50K verification completed cleanly with zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture model.
 
 ## Episode metadata
 
@@ -22,7 +22,8 @@ Post-#928 note: after the original 100K run, provider-fixture hardening moved sc
 
 ## Core message
 
-The stronger correctness system reached 100K cleanly, and the run exposed the next honest bottleneck: local fixture preparation and rising tail latency.
+The stronger correctness system reached 100K cleanly, and the run exposed the next honest scaling question: local throughput and tail latency with plenty of Docker CPU and memory still available.
+The final 100K run also exposed a live-progress presentation issue: expected-pend checks briefly appeared as 920 workflow mismatches during processing and resolved to zero after expected-pend observation completed.
 
 The episode must distinguish:
 
@@ -38,6 +39,8 @@ The episode must distinguish:
 - `benchmark-results.txt` - exact 100K run command, environment, gates, timing, and limitations.
 - `pr-summary.txt` - implementation work that raised the correctness bar before 100K.
 - `podcast-prompt.txt` - episode-specific generation prompt.
+- `raw-validator-output-post928-100k.txt` - raw validator console output from the completed post-#928 100K run.
+- `run-summary-post928-100k.json` - completed dashboard summary returned by claims-service for the post-#928 100K run.
 - `screenshots/episode-008-100k-dashboard.png` - completed 100K run list, run detail, timing, outcome mix, and claim-result evidence.
 - `screenshots/episode-008-100k-outcome-breakdown.png` - business-denial distribution and explicit zero-platform-failure evidence.
 - `screenshots/episode-008-100k-paid-results.png` - retained paid-claim evidence with payment amounts and per-claim stage timing.
@@ -63,4 +66,6 @@ The episode must distinguish:
 - [x] Primary completed-run console screenshot is captured.
 - [x] Unsupported claim sample and persisted payment drilldown are captured.
 - [x] Post-#928 50K provider-fixture verification is recorded.
+- [x] Final post-#928 100K raw validator output is recorded.
+- [x] Live expected-pend progress caveat is recorded.
 - [ ] Published article URL is recorded.

--- a/docs/million-claim-challenge/podcast/episode-008/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/article.txt
@@ -4,15 +4,15 @@ Part 7 moved the Million Claim Challenge evidence out of terminal logs and into 
 
 Then the correctness bar changed.
 
-Payment accuracy became a gate instead of a diagnostic. Expected-pay and expected-deny claims were checked for false pends. Zero-limit accumulator placeholders stopped distorting expected payments. Generated members were isolated so one corpus segment could not contaminate another.
+Payment accuracy became a gate instead of a diagnostic. Expected-pay and expected-deny claims were checked for false pends. Zero-limit accumulator placeholders stopped distorting expected payments. Generated members were isolated so one corpus segment could not contaminate another. Validation providers were moved into role-separated synthetic NPI namespaces so scoreable scenarios could not collide with stale provider-integrity state in a long-lived local tenant.
 
-Only after those changes did Cloud Health Office move to 100,000 claims.
+Only after those changes did Cloud Health Office move back to 100,000 claims.
 
 The result was clean: every claim processed, no platform failures, no scoreable workflow mismatches, no unexpected pends, and every comparable payment within one cent.
 
-The run also exposed the next scaling problem. Adjudication completed in less than 30 minutes, but the complete Kubernetes job took more than two hours because preparing a much larger set of run-scoped fixtures dominated the lifecycle.
+The run also exposed the next local scaling question. Docker Desktop was not out of CPU or memory, and fixture preparation was no longer a two-hour wall-clock problem. The platform finished timed adjudication in 27 minutes and 54 seconds, with the full tracked lifecycle taking about 34 minutes.
 
-That is exactly the kind of result this series is supposed to produce: correctness held, and the next bottleneck became visible.
+That is exactly the kind of result this series is supposed to produce: correctness held, the evidence became inspectable, and the next performance question became sharper.
 
 ## What changed before 100K
 
@@ -31,17 +31,15 @@ The validator now includes:
 - evidence-first claim-result retention
 - in-progress run publication and a completed run summary in the console
 
-The 100K run was not allowed to trade those gates for volume.
-
-There was one more fixture-hardening pass after the original 100K writeup.
+One last fixture-hardening pass mattered before the final 100K rerun.
 
 PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification then found 10 scoreable `TxStarInpatientNoAuth` mismatches: those claims should have denied for missing prior authorization, but provider-integrity evaluation treated the generated rendering provider as excluded. The current provider record was approved and in-network, which pointed to stale or colliding validation-provider identity state in the long-lived local tenant.
 
 PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces: billing providers in the `93...` range, adjudicatable rendering providers in `94...`, and intentionally excluded rendering providers in `95...`.
 
-The rerun after PR #928 processed 50,000 claims cleanly: 5,767 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.
+The post-#928 50K verification processed 50,000 claims cleanly: 5,767 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.
 
-That result does not replace the 100K evidence above. It tightens the fixture model that the next 100K rerun should use.
+That hardened fixture model is what the final 100K run used.
 
 ## The 100K result
 
@@ -50,9 +48,9 @@ The local Docker Desktop Kubernetes run processed 100,000 deterministic syntheti
 The final summary reported:
 
 - 100,000 claims processed
-- 79,164 paid or adjudicated
-- 923 pended
-- 19,913 business denials
+- 79,162 paid or adjudicated
+- 921 pended
+- 19,917 business denials
 - 0 platform failures
 - 0 observation timeouts
 - 11,534 of 13,000 workflow checks matched
@@ -63,42 +61,49 @@ The final summary reported:
 - $0.00 average payment delta
 - $0.00 maximum payment delta
 
-The pend numbers have two scopes. The run ended with 923 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.
+The pend numbers have two scopes. The run ended with 921 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.
 
-Unsupported scenarios remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.
+Unsupported scenarios also remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.
 
 Those are named product gaps, not hidden successes.
 
-## Performance did not scale linearly
+## Performance did not saturate the machine
 
-The timed claim-processing phase completed in 29 minutes and 40.851 seconds.
+The timed claim-processing phase completed in 27 minutes and 54.381 seconds.
 
 That produced:
 
-- 56.15 claims per second
-- 358 ms P95 latency
-- 451 ms P99 latency
-- 199 ms P95 submission time
-- 140 ms P95 adjudication time
-- 102 ms P95 writeback time
+- 59.72 claims per second
+- 296 ms P95 latency
+- 377 ms P99 latency
+- 115 ms P95 submission time
+- 105 ms P95 adjudication time
+- 95 ms P95 writeback time
 
-The previous clean 50K run reached 82.40 claims per second with 129 ms P95 and 178 ms P99 latency.
+The provider-pool fixture work changed the local lifecycle story. Earlier 100K preparation had been dominated by run-scoped provider creation. In this run, the validator reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, and preserved 2,800 provider-sensitive claims. It created 12,748 synthetic providers instead of trying to create a provider record for every repeated reference.
 
-So doubling the corpus did not preserve the smaller run's throughput or tail latency. The platform remained correct, but the longer run created more pressure on the local working set, persistence path, and shared Docker Desktop resources.
+That is why the tracked lifecycle was about 34 minutes instead of more than two hours.
+
+The run still did not scale linearly from smaller benchmarks, and Docker Desktop showed plenty of CPU and memory headroom while the run was active. That points the next investigation away from raw host capacity and toward internal throughput limits: service concurrency, writeback behavior, MongoDB pressure, HTTP client settings, and validator parallelism.
 
 That is not a production capacity conclusion. It is a local scaling signal worth investigating.
 
-## Timed throughput and total job duration are different
+## Timed throughput and preparation are different
 
-The Kubernetes job existed for approximately 128 minutes, while the timed processing phase lasted just under 30 minutes.
+The tracked lifecycle took 34 minutes and 3.458 seconds. The timed adjudication phase took 27 minutes and 54.381 seconds.
 
-Most of that difference came before claims were timed. The validator generated the corpus and prepared the fixtures required to make the run scoreable. It seeded or aligned 99,591 member statuses, added 620 COB coverage rows, and processed a provider fixture set that included 174,202 new providers plus 25,644 already present.
+The remaining tracked time was mostly preparation:
 
-Fixture isolation improved correctness, but the current preparation strategy is expensive at 100K.
+- member and coverage seeding: 2:51.219
+- provider seeding: 3:09.524
+- corpus generation: 0:01.039
+- fixture normalization: 0:00.335
+- expected-pend observation: 0:00.740
+- false-pend sweep: 0:06.120
 
-This distinction matters when reading the result.
+The validator seeded 10,614 synthetic members, reused 88,977 existing members, aligned 99,591 member statuses, found 920 COB coverage rows already present, and found both required provider networks already present.
 
-The platform adjudicated at 56.15 claims per second during the measured phase. The end-to-end developer experience took more than two hours. Both numbers are true, and they answer different questions.
+Both numbers matter. The platform adjudicated at 59.72 claims per second during the measured phase. The full local evidence run, including fixture preparation and observation, took about 34 minutes.
 
 ## What the console should make obvious
 
@@ -115,31 +120,34 @@ For this run, it should make clear:
 - payment comparisons and maximum delta
 - claim-level evidence behind every exception category
 
-The run summary was published successfully, so the completed result is available through the Mass Adjudication console. The next improvement is to make preparation progress and its cost as visible as adjudication progress.
+The run also exposed a live-progress display issue. During processing, expected-pend scenarios can look like workflow mismatches until the post-processing observation pass confirms the persisted pended state. In this run, the console showed 920 live workflow mismatches while processing claims. After expected-pend observation completed, that number correctly resolved to zero.
+
+That is not an adjudication failure, but it is a product lesson: the live console should distinguish unresolved expected-pend checks from true mismatches.
 
 ## The next local optimization target
 
 The next target is not immediately 250K.
 
-First, the fixture path needs to become incremental and bounded. A benchmark claim should reference a deliberately sized reusable provider and member pool unless a scenario specifically requires claim-level isolation. Isolation should be applied where correctness requires it, not by multiplying every reference-data population with the claim count.
+First, the team should run controlled 100K parallelism sweeps with the same seed, fixture model, and correctness gates. The p10 run used only a fraction of the allocated Docker Desktop CPU and memory, so p12 and p16 are natural next experiments.
+
+The acceptance criterion stays the same: performance work cannot weaken the correctness gates.
 
 That suggests several concrete experiments:
 
-- measure fixture-generation and API-seeding stages independently
-- reuse immutable provider fixtures across runs
-- isolate only member records whose scenario state can collide
-- batch or bulk-write fixture data where service contracts permit it
-- report preparation throughput and cache-hit rates
-- rerun 100K with the PR #928 validation-provider namespace hardening
-- rerun 100K after each fixture optimization
+- rerun 100K at p12 and p16 with the same seed
+- measure service concurrency and HTTP client limits
+- inspect MongoDB writeback and accumulator hot paths
+- preserve payment, false-pend, and workflow gates
+- keep unsupported scenarios visible instead of hiding them
+- report CPU, memory, and disk I/O alongside benchmark timing
 
-The acceptance criterion stays the same: performance work cannot weaken the correctness gates.
+Unsupported scenarios should become their own product-evidence track. The first likely candidates are the prior-authorization edge variants, followed by retroactive coverage change, Medicaid spend-down, behavioral-health carve-out, and subrogation. They should be converted into scoreable behavior deliberately, not swept into the same PR as a benchmark evidence update.
 
 ## What comes after the local ceiling
 
 The Million Claim Challenge is still aimed at one million claims.
 
-But the local series should continue until the limiting resource is reproducible and explained. It may be CPU, memory, MongoDB, Docker networking, fixture preparation, or a combination of them.
+But the local series should continue until the limiting resource is reproducible and explained. It may be service concurrency, persistence, MongoDB, Docker networking, fixture preparation, or a combination of them.
 
 Once that ceiling is understood, the natural follow-up is a cloud scaling series using the same corpus and gates across Azure Kubernetes Service, Amazon Elastic Kubernetes Service, and Google Kubernetes Engine.
 
@@ -151,4 +159,4 @@ Part 6 made the scoring honest.
 
 Part 7 made the evidence visible.
 
-Part 8 proves that the stronger system can process 100,000 claims cleanly—and shows exactly where the local path needs to improve next.
+Part 8 proves that the stronger system can process 100,000 claims cleanly, with the fixture model hardened and the proof visible in the console.

--- a/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
@@ -2,8 +2,9 @@
 
 ## Run identity
 
-- Date: July 12, 2026
-- Kubernetes job: `mcc-part8-100k`
+- Date: July 18, 2026 local time / July 19, 2026 UTC
+- Kubernetes job: `mcc-post928-100k-190641`
+- Dashboard run ID: `34db25825df04c8fa75eb5cc0e615291`
 - Environment: local Docker Desktop Kubernetes
 - Tenant: `demo`
 - Validator seed: 42
@@ -18,8 +19,13 @@
 ## Command
 
 ```text
-CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_EVERY=5000 ./scripts/run-mcc-local-k8s.sh
+CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=10 PROGRESS_EVERY=5000 JOB_NAME=mcc-post928-100k-190641 ./scripts/run-mcc-local-k8s.sh
 ```
+
+## Raw artifacts
+
+- `raw-validator-output-post928-100k.txt` - validator console output from the completed 100K run.
+- `run-summary-post928-100k.json` - completed Mass Adjudication run summary returned by claims-service.
 
 ## Fixture preparation
 
@@ -28,18 +34,21 @@ CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_
 - Injected 2,000 excluded-provider denial scenarios.
 - Injected 2,000 uncovered-service denial scenarios.
 - Injected 2,000 TX STAR inpatient no-authorization scenarios.
-- Seeded 87,115 synthetic members; 12,476 already existed; 99,591 statuses aligned.
-- Seeded 620 COB coverage rows; 300 already existed.
-- Seeded 174,202 synthetic providers; 25,644 already existed.
-- Provider networks: 0 new; 2 already existed.
+- Provider fixture pool: 199,846 provider references reduced to 13,742 distinct NPIs.
+- Provider assignments reused: 186,258.
+- Provider-sensitive claims preserved: 2,800.
+- Seeded 10,614 synthetic members; 88,977 already existed; 99,591 statuses aligned.
+- Seeded 0 COB coverage rows; 920 already existed.
+- Seeded 0 provider networks; 2 already existed.
+- Seeded 12,748 synthetic providers; 994 already existed.
 
 ## Correctness result
 
 - Total claims: 100,000
 - Processed: 100,000
-- Paid/adjudicated: 79,164
-- Pended: 923
-- Business denials: 19,913
+- Paid/adjudicated: 79,162
+- Pended: 921
+- Business denials: 19,917
 - Platform failures: 0
 - Observation timeouts: 0
 - Expected-pend observation: 920 pended, 0 timed out
@@ -49,28 +58,44 @@ CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_
 - Average payment delta: $0.00
 - Maximum payment delta: $0.00
 
-Pend-scope note: the final persisted outcome mix includes 923 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
+Pend-scope note: the final persisted outcome mix includes 921 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
 
 ## Performance result
 
-- Timed claim-processing elapsed: 29:40.851
-- Throughput: 56.15 claims/second
-- P95 latency: 358 ms
-- P99 latency: 451 ms
-- Submit average/P95: 63 ms / 199 ms
-- Adjudicate average/P95: 75 ms / 140 ms
-- Writeback average/P95: 40 ms / 102 ms
-- Benefit calculation average/P95: 60 ms / 127 ms
-- Provider integrity average/P95: 12 ms / 39 ms
-- Kubernetes job duration: approximately 128 minutes, including corpus generation and fixture preparation
+- Timed claim-processing elapsed: 27:54.381
+- Throughput: 59.72 claims/second
+- P95 latency: 296 ms
+- P99 latency: 377 ms
+- Submit average/P95: 61 ms / 115 ms
+- Adjudicate average/P95: 69 ms / 105 ms
+- Writeback average/P95: 38 ms / 95 ms
+- Benefit calculation average/P95: 65 ms / 100 ms
+- Provider integrity average/P95: 2 ms / 3 ms
+- Preparation time: 6:02.216
+- Tracked lifecycle: 34:03.458
+
+## Lifecycle timings
+
+- Service health checks: 0:00.037
+- Reference rule seeding: 0:00.041
+- Validation plan setup: 0:00.017
+- Corpus generation: 0:01.039
+- Fixture normalization: 0:00.335
+- Member and coverage seeding: 2:51.219
+- Provider seeding: 3:09.524
+- Timed adjudication: 27:54.381
+- Expected-pend observation: 0:00.740
+- False-pend sweep: 0:06.120
 
 ## Business denials
 
 - CARC 96: 9,046
 - CARC 18: 6,000
 - PRIOR_AUTH_REQUIRED: 2,160
-- PROVIDER_EXCLUDED: 2,000
-- NCCI_MUE_EDIT_FAILURE: 393
+- PROVIDER_EXCLUDED: 2,001
+- NCCI_MUE_EDIT_FAILURE: 396
+- CARC 27: 267
+- SCRUB_VALIDATION_FAILURE: 47
 
 Business denials are valid platform outcomes, not platform failures.
 
@@ -90,13 +115,32 @@ Total unsupported: 1,466.
 
 Unsupported means the scenario is not currently scoreable through the implemented platform/validator path. It is not counted as matched, mismatched, or a platform failure.
 
+## Matched scenario footprint
+
+- CleanProfessionalPaid: 2,000/2,000 matched
+- ExcludedProviderDenied: 2,000/2,000 matched
+- UncoveredServiceDenied: 2,000/2,000 matched
+- TxStarInpatientNoAuth: 2,000/2,000 matched
+- COB primary, secondary, tertiary, birthday-rule, gender-rule, and Medicare-secondary: 200/200 matched each
+- Newborn auto-adjudication, first-thirty-days, and mother-claim-link: 200/200 matched each
+- Medicaid CHIP, dual-eligible, SSI, and TANF: 120/120 matched each
+- Retro eligibility add and termination: 267/267 matched each
+- Behavioral health carve-in and parity-check: 200/200 matched each
+- Prior-auth required auth-on-file and no-auth variants: 160/160 matched each
+
 ## Interpretation
 
-The 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
+The post-#928 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
 
-The timed adjudication result and total Kubernetes job duration must remain separate. Timed processing completed in 29:40.851 at 56.15 claims/second. The job lifecycle lasted about 128 minutes because large run-scoped member and provider fixture preparation occurred before timed processing.
+Timed adjudication and full tracked lifecycle must remain separate. Timed processing completed in 27:54.381 at 59.72 claims/second. The tracked lifecycle completed in 34:03.458 after preparation, processing, expected-pend observation, and false-pend sweep.
 
-This is local Docker Desktop evidence, not a production-cloud capacity claim. The performance result identifies fixture preparation and increased local tail latency as the next scaling investigation.
+This is local Docker Desktop evidence, not a production-cloud capacity claim. During the run, Docker Desktop showed significant CPU and memory headroom, so the next performance investigation should focus on internal throughput limits: validator parallelism, service concurrency, HTTP client limits, MongoDB/writeback behavior, and disk I/O.
+
+## Live-progress caveat
+
+During claim processing, the console showed 920 workflow mismatches. That count matched the number of expected-pend scenarios and cleared after the expected-pend observation phase completed. The final run summary reported 0 workflow mismatches.
+
+The live console should distinguish expected-pend checks awaiting observation from true workflow mismatches. Completed summaries are correct; the issue is in-progress presentation.
 
 ## Post-#928 provider-fixture verification
 
@@ -138,4 +182,4 @@ The post-#928 50K rerun was completed as `mcc-provider-namespace-50k-163946`.
 - Provider fixtures created: 7,568
 - Provider fixtures already present: 491
 
-This post-#928 50K run is not a replacement for the 100K result above. It is the provider-fixture hardening proof point that should be included before the next 100K rerun.
+The post-#928 50K run proved the provider-fixture hardening. The 100K run above proves the same hardened fixture model at the next scale.

--- a/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
@@ -2,16 +2,16 @@ Create a 10-12 minute two-host engineering podcast episode titled "The Clean 100
 
 Use Alex and Jordan as experienced healthcare platform engineers. Make the discussion natural, analytical, and candid rather than reading the article aloud.
 
-The central story is that Cloud Health Office did not move from 50K to 100K by relaxing validation. Before scaling, the team added a payment gate, a false-pend sweep, corrected zero-limit accumulator placeholder handling, and eliminated cross-corpus member fixture collisions.
+The central story is that Cloud Health Office did not move from 50K to 100K by relaxing validation. Before scaling, the team added a payment gate, a false-pend sweep, corrected zero-limit accumulator placeholder handling, eliminated cross-corpus member fixture collisions, and hardened scoreable validation providers with role-separated synthetic NPI namespaces.
 
-Also include the post-#928 provider-fixture addendum. After the original 100K run, PR #927 anchored validation providers as run-scoped fixtures, and a follow-up 50K verification exposed 10 `TxStarInpatientNoAuth` mismatches caused by provider-integrity evaluation treating generated rendering providers as excluded. PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces (`93...` billing, `94...` adjudicatable rendering, `95...` intentionally excluded). The post-#928 50K rerun was clean: 50,000 processed, 5,767/6,500 workflow checks matched, zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000/1,000 payment comparisons within tolerance. Make clear that this hardens the fixture model for the next 100K rerun rather than replacing the original 100K evidence.
+Include the provider-fixture thread clearly. PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification exposed 10 `TxStarInpatientNoAuth` mismatches caused by provider-integrity evaluation treating generated rendering providers as excluded. PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces (`93...` billing, `94...` adjudicatable rendering, `95...` intentionally excluded). The post-#928 50K rerun was clean: 50,000 processed, 5,767/6,500 workflow checks matched, zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture model.
 
-Use these exact results:
+Use these exact final post-#928 100K results:
 
 - 100,000 claims processed
-- 79,164 paid or adjudicated
-- 923 persisted pended outcomes
-- 19,913 business denials
+- 79,162 paid or adjudicated
+- 921 persisted pended outcomes
+- 19,917 business denials
 - 0 platform failures
 - 0 workflow mismatches
 - 0 observation timeouts
@@ -21,19 +21,22 @@ Use these exact results:
 - 1,466 unsupported scenarios
 - 2,000 of 2,000 comparable payments within $0.01
 - $0.00 average and maximum payment delta
-- 56.15 claims per second
-- 358 ms P95 and 451 ms P99 latency
-- 29:40.851 timed claim-processing phase
-- approximately 128 minutes total Kubernetes job lifecycle including fixture preparation
+- 59.72 claims per second
+- 296 ms P95 and 377 ms P99 latency
+- 27:54.381 timed claim-processing phase
+- 6:02.216 preparation time
+- 34:03.458 tracked lifecycle
 
 Explain why business denials are valid outcomes and why unsupported scenarios are visible product gaps rather than passes or failures.
 
-Make the pend scope explicit: the outcome mix had 923 persisted pended claims, the expected-pend observer verified 920 answer-key pend scenarios, and the false-pend sweep covered the scoreable expected-pay and expected-deny set. Do not imply unsupported scenarios were included in that non-pend sweep.
+Make the pend scope explicit: the outcome mix had 921 persisted pended claims, the expected-pend observer verified 920 answer-key pend scenarios, and the false-pend sweep covered the scoreable expected-pay and expected-deny set. Do not imply unsupported scenarios were included in that non-pend sweep.
 
-Spend meaningful time on the difference between timed adjudication and total developer wait time. Fixture preparation seeded or aligned almost 100,000 member statuses and processed roughly 200,000 provider records. Correctness held, but the fixture strategy became the clearest local scaling bottleneck.
+Spend meaningful time on the difference between timed adjudication and full tracked lifecycle. The post-#928 provider-pool work reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 assignments, preserved 2,800 provider-sensitive claims, and created 12,748 providers. Correctness held, and fixture preparation became measurable rather than a hidden wall-clock sink.
 
-Compare the result with the prior clean 50K run at 82.40 claims per second, 129 ms P95, and 178 ms P99. Do not imply a production capacity conclusion. Frame the lower 100K throughput and higher latency as a local scaling signal.
+Mention the live-console lesson: during processing, the console showed 920 workflow mismatches because expected-pend checks were still awaiting post-processing observation. After expected-pend observation completed, the final summary correctly reported zero workflow mismatches. Frame this as an in-progress presentation issue, not an adjudication failure.
 
-End with the next ladder: optimize and measure fixture preparation, rerun 100K, locate the reproducible local ceiling, then use the same deterministic corpus and correctness gates for a future AKS/EKS/GKE cloud scaling series.
+Compare this result with the post-#928 50K verification at 58.60 claims per second, 380 ms P95, and 515 ms P99. Also note that Docker Desktop showed significant CPU and memory headroom during the 100K run, so the next performance questions are service concurrency, writeback behavior, MongoDB/disk I/O, HTTP client limits, and validator parallelism rather than simply adding more local CPU.
 
-The next 100K rerun should use the post-#928 validation-provider namespace hardening.
+Do not imply a production capacity conclusion. This is local Docker Desktop Kubernetes evidence.
+
+End with the next ladder: run controlled p12/p16 100K sweeps with the same seed and correctness gates, fix the live expected-pend progress presentation, start converting unsupported categories into scoreable product behavior, locate the reproducible local ceiling, then use the same deterministic corpus and gates for a future AKS/EKS/GKE cloud scaling series.

--- a/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
@@ -41,13 +41,17 @@
 - Added regression coverage proving role separation and no collisions across the 50K scoreable scenario window.
 - Produced a clean post-fix 50K verification: 50,000 processed, 5,767/6,500 workflow checks matched, 0 workflow mismatches, 460/460 expected pends observed, 0 unexpected pends, and 1,000/1,000 comparable payments within tolerance.
 
-## 100K outcome
+## Post-#928 100K outcome
 
-No platform code was changed to make the 100K result look clean. The run used the stronger gates established above and published its completed summary to the console.
+No platform code was changed to make the 100K result look clean. The final post-#928 run used the stronger gates established above, the hardened validation-provider namespaces, and the provider-pool fixture strategy.
 
-## Post-100K fixture-hardening note
+The run completed cleanly: 100,000 processed, 0 platform failures, 11,534/13,000 workflow checks matched, 0 workflow mismatches, 1,466 unsupported, 920/920 expected pends observed, 0 unexpected pends across 10,614 scoreable non-pend claims, and 2,000/2,000 comparable payments within $0.01 with $0.00 maximum payment delta.
 
-The PR #927/#928 provider-fixture hardening happened after the original 100K run. It does not replace the 100K evidence, but it is now part of the fixture model that should be used before publishing the next 100K rerun.
+The completed summary was published to the Mass Adjudication console. During processing, the live console temporarily showed 920 workflow mismatches because expected-pend checks had not yet been observed. The final summary correctly resolved those provisional checks to matched pends.
+
+## Post-#928 fixture-preparation effect
+
+The final 100K run reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, preserved 2,800 provider-sensitive claims, and created 12,748 providers. Preparation took 6:02.216 and the tracked lifecycle took 34:03.458.
 
 ## Claim-detail projection correction discovered during evidence review
 

--- a/docs/million-claim-challenge/podcast/episode-008/raw-validator-output-post928-100k.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/raw-validator-output-post928-100k.txt
@@ -1,0 +1,127 @@
+Million Claim Challenge - Platform Validator
+  Tenant:      demo
+  Claims URL:  http://claims-service
+  Benefit URL: http://benefit-plan-service
+  Member URL:  http://member-service
+  Coverage URL:http://coverage-service
+  Provider URL:http://provider-service
+  Claims:      100,000
+  Seed:        42
+  Parallelism: 10
+  LOB:         Medicaid (3)
+  PA scenarios: enabled (2 %)
+  Pend observe: enabled (45s/1000ms)
+  Pend diag:   disabled
+
+healthy: claims-service
+healthy: benefit-plan-service
+healthy: member-service
+healthy: coverage-service
+healthy: provider-service
+seeded: NCCI baseline
+seeded: prior-auth platform rules (0 new)
+created: validation benefit plan 1df2aac8-9939-4922-9a24-3758a42aa06d
+Clean paid scenarios: injected 2,000 professional claims expected to pay
+Excluded provider scenarios: injected 2,000 professional claims expected to deny
+Uncovered service scenarios: injected 2,000 professional claims expected to deny
+PA scenarios: injected 2,000 TX STAR inpatient claims without auth
+Generated 100,000 MCC claims in memory
+Provider fixture pool: 199,846 -> 13,742 distinct NPIs (186,258 assignments reused, 2,800 provider-sensitive claims preserved)
+seeded: 10,614 synthetic members (88,977 already present, 99,591 status-aligned)
+seeded: 0 COB coverage rows (920 already present)
+seeded: 0 provider networks (2 already present)
+seeded: 12,748 synthetic providers (994 already present)
+  Processed: 5,000/100,000  processed=5,000  platformFailures=0  Processed: 10,000/100,000  processed=10,000  platformFailures=0  Processed: 15,000/100,000  processed=15,000  platformFailures=0  Processed: 20,000/100,000  processed=20,000  platformFailures=0  Processed: 25,000/100,000  processed=25,000  platformFailures=0  Processed: 30,000/100,000  processed=30,000  platformFailures=0  Processed: 35,000/100,000  processed=35,000  platformFailures=0  Processed: 40,000/100,000  processed=40,000  platformFailures=0  Processed: 45,000/100,000  processed=45,000  platformFailures=0  Processed: 50,000/100,000  processed=50,000  platformFailures=0  Processed: 55,000/100,000  processed=55,000  platformFailures=0  Processed: 60,000/100,000  processed=60,000  platformFailures=0  Processed: 65,000/100,000  processed=65,000  platformFailures=0  Processed: 70,000/100,000  processed=70,000  platformFailures=0  Processed: 75,000/100,000  processed=75,000  platformFailures=0  Processed: 80,000/100,000  processed=80,000  platformFailures=0  Processed: 85,000/100,000  processed=85,000  platformFailures=0  Processed: 90,000/100,000  processed=90,000  platformFailures=0  Processed: 95,000/100,000  processed=95,000  platformFailures=0  Processed: 100,000/100,000  processed=100,000  platformFailures=0
+
+Observing 920 expected-pend claims for up to 45s; benchmark timing excludes this polling window.
+  Pend observation:  920 pended, 0 timed out
+
+Sweeping 10,614 non-pend claims for unexpected persisted pends.
+  False-pend sweep: 0 unexpected pends
+
+Validation summary
+  Total claims:       100,000
+  Processed:          100,000
+  Paid/adjudicated:   79,162
+  Pended:             921
+  Business denials:   19,917
+  Platform failures:  0
+  Observation timeout: 0
+  Workflow checks:    11,534/13,000 matched (0 mismatched, 1,466 unsupported, 0 observation timeouts)
+  Elapsed:            27:54.381
+  Throughput:         59.72 claims/sec
+  P95 latency:        296 ms
+  P99 latency:        377 ms
+  Preparation time:   6:02.216
+  Tracked lifecycle:  34:03.458
+  Lifecycle.Service health checks        0:00.037
+  Lifecycle.Reference rule seeding       0:00.041
+  Lifecycle.Validation plan setup        0:00.017
+  Lifecycle.Corpus generation            0:01.039
+  Lifecycle.Fixture normalization        0:00.335
+  Lifecycle.Member and coverage seeding  2:51.219
+  Lifecycle.Provider seeding             3:09.524
+  Lifecycle.Timed adjudication           27:54.381
+  Lifecycle.Expected-pend observation    0:00.740
+  Lifecycle.False-pend sweep             0:06.120
+  Submit       avg/p95: 61 ms / 115 ms
+  Adjudicate   avg/p95: 69 ms / 105 ms
+  Writeback    avg/p95: 38 ms / 95 ms
+  Adjudicate.benefitCalculation avg/p95: 65 ms / 100 ms
+  Adjudicate.benefitCalculation.accumulatorRead avg/p95: 64 ms / 99 ms
+  Adjudicate.providerIntegrity avg/p95: 2 ms / 3 ms
+  Adjudicate.benefitCalculation.accumulatorWrite avg/p95: 1 ms / 2 ms
+  Adjudicate.rateResolution avg/p95: 1 ms / 1 ms
+  Adjudicate.ncci avg/p95: 1 ms / 2 ms
+  Adjudicate.priorAuth avg/p95: 0 ms / 0 ms
+  Adjudicate.scrub avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.lineProcessing avg/p95: 0 ms / 0 ms
+  Adjudicate.terminology avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.workingSet avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.snapshot avg/p95: 0 ms / 0 ms
+  Adjudicate.routing avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.planLookup avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.totals avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.outcome avg/p95: 0 ms / 0 ms
+  Avg payment delta:  $0.00
+  Payment gate:       2,000/2,000 within $0.01 (0 mismatched, max $0.00)
+  Payment delta:      Exact (2,000)
+  Business denial: CARC_96 (9,046)
+  Business denial: CARC_18 (6,000)
+  Business denial: PRIOR_AUTH_REQUIRED (2,160)
+  Business denial: PROVIDER_EXCLUDED (2,001)
+  Business denial: NCCI_MUE_EDIT_FAILURE (396)
+  Scenario: CleanProfessionalPaid 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthCarveIn 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthCarveOut 0/200 matched (0 mismatched, 200 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthParityCheck 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobBirthdayRule 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobGenderRule 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobMedicareSecondary 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobPrimaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobSecondaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobTertiaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidCHIP 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidDualEligible 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidSSI 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidSpendDown 0/120 matched (0 mismatched, 120 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidTANF 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornAutoAdjudication 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornFirstThirtyDays 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornMotherClaimLink 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_AuthOnFile 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_ExpiredAuth 0/160 matched (0 mismatched, 160 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_NoAuth 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_WrongProcedure 0/160 matched (0 mismatched, 160 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_WrongProvider 0/160 matched (0 mismatched, 160 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityAdd 267/267 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityCoverageChange 0/266 matched (0 mismatched, 266 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityTermination 267/267 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationAccidentRelated 0/134 matched (0 mismatched, 134 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationThirdPartyLiability 0/133 matched (0 mismatched, 133 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationWorkersComp 0/133 matched (0 mismatched, 133 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: ExcludedProviderDenied 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: TxStarInpatientNoAuth 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: UncoveredServiceDenied 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Summary JSON:       /tmp/mcc-summary.json
+  Dashboard summary: published

--- a/docs/million-claim-challenge/podcast/episode-008/run-summary-post928-100k.json
+++ b/docs/million-claim-challenge/podcast/episode-008/run-summary-post928-100k.json
@@ -1,0 +1,596 @@
+{
+  "id": "34db25825df04c8fa75eb5cc0e615291",
+  "status": "Completed",
+  "run": {
+    "tenantId": "demo",
+    "requestedClaims": 100000,
+    "seed": 42,
+    "parallelism": 10,
+    "claimsUrl": "http://claims-service",
+    "benefitUrl": "http://benefit-plan-service",
+    "memberUrl": "http://member-service",
+    "coverageUrl": "http://coverage-service",
+    "providerUrl": "http://provider-service",
+    "seedMembers": true,
+    "seedProviders": true,
+    "skipClaimUpdate": false,
+    "lineOfBusiness": 3,
+    "startedAtUtc": "2026-07-19T02:06:45.0835365+00:00",
+    "completedAtUtc": "2026-07-19T02:40:48.8045668+00:00"
+  },
+  "totalClaims": 100000,
+  "processed": 100000,
+  "paid": 79162,
+  "pended": 921,
+  "businessDenials": 19917,
+  "observationTimeouts": 0,
+  "platformFailures": 0,
+  "workflowScenarios": 13000,
+  "workflowMatches": 11534,
+  "workflowMismatches": 0,
+  "workflowUnsupported": 1466,
+  "workflowObservationTimeouts": 0,
+  "elapsed": "00:27:54.3819445",
+  "throughputClaimsPerSecond": 59.723529824529834,
+  "p95LatencyMilliseconds": 295.5705,
+  "p99LatencyMilliseconds": 376.5081,
+  "submitTiming": {
+    "label": "Submit",
+    "averageMilliseconds": 60.709815642000294,
+    "p95Milliseconds": 114.8552
+  },
+  "adjudicateTiming": {
+    "label": "Adjudicate",
+    "averageMilliseconds": 68.7206876300009,
+    "p95Milliseconds": 105.2357
+  },
+  "writebackTiming": {
+    "label": "Writeback",
+    "averageMilliseconds": 38.305512075090256,
+    "p95Milliseconds": 95.3812
+  },
+  "adjudicationStepTimings": [
+    {
+      "label": "Adjudicate.benefitCalculation",
+      "averageMilliseconds": 64.6645442514902,
+      "p95Milliseconds": 99.6757
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.accumulatorRead",
+      "averageMilliseconds": 63.84093923304148,
+      "p95Milliseconds": 98.8819
+    },
+    {
+      "label": "Adjudicate.providerIntegrity",
+      "averageMilliseconds": 1.5796151290215652,
+      "p95Milliseconds": 3.1338
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.accumulatorWrite",
+      "averageMilliseconds": 0.7229846520003771,
+      "p95Milliseconds": 1.6462
+    },
+    {
+      "label": "Adjudicate.rateResolution",
+      "averageMilliseconds": 0.6000605756393959,
+      "p95Milliseconds": 1.3755
+    },
+    {
+      "label": "Adjudicate.ncci",
+      "averageMilliseconds": 0.5287516442728092,
+      "p95Milliseconds": 2.172
+    },
+    {
+      "label": "Adjudicate.priorAuth",
+      "averageMilliseconds": 0.054665035101605204,
+      "p95Milliseconds": 0.083
+    },
+    {
+      "label": "Adjudicate.scrub",
+      "averageMilliseconds": 0.049681465000003026,
+      "p95Milliseconds": 0.0823
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.lineProcessing",
+      "averageMilliseconds": 0.038301479044244975,
+      "p95Milliseconds": 0.0832
+    },
+    {
+      "label": "Adjudicate.terminology",
+      "averageMilliseconds": 0.02468210324927218,
+      "p95Milliseconds": 0.014
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.workingSet",
+      "averageMilliseconds": 0.008178562793680063,
+      "p95Milliseconds": 0.0167
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.snapshot",
+      "averageMilliseconds": 0.004738624394243178,
+      "p95Milliseconds": 0.0065
+    },
+    {
+      "label": "Adjudicate.routing",
+      "averageMilliseconds": 0.00429130199999941,
+      "p95Milliseconds": 0.0051
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.planLookup",
+      "averageMilliseconds": 0.0033913401801755187,
+      "p95Milliseconds": 0.006
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.totals",
+      "averageMilliseconds": 0.002375623626864812,
+      "p95Milliseconds": 0.0039
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.outcome",
+      "averageMilliseconds": 0.0014405718734220698,
+      "p95Milliseconds": 0.0024
+    }
+  ],
+  "lifecycleTimings": [
+    {
+      "label": "Service health checks",
+      "category": "Preparation",
+      "durationMilliseconds": 37.4576,
+      "startedAtUtc": "2026-07-19T02:06:45.095638+00:00",
+      "completedAtUtc": "2026-07-19T02:06:45.1330994+00:00"
+    },
+    {
+      "label": "Reference rule seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 41.5954,
+      "startedAtUtc": "2026-07-19T02:06:45.1332863+00:00",
+      "completedAtUtc": "2026-07-19T02:06:45.1748828+00:00"
+    },
+    {
+      "label": "Validation plan setup",
+      "category": "Preparation",
+      "durationMilliseconds": 17.5704,
+      "startedAtUtc": "2026-07-19T02:06:45.1748915+00:00",
+      "completedAtUtc": "2026-07-19T02:06:45.1924633+00:00"
+    },
+    {
+      "label": "Corpus generation",
+      "category": "Preparation",
+      "durationMilliseconds": 1039.7178,
+      "startedAtUtc": "2026-07-19T02:06:45.1932757+00:00",
+      "completedAtUtc": "2026-07-19T02:06:46.2329956+00:00"
+    },
+    {
+      "label": "Fixture normalization",
+      "category": "Preparation",
+      "durationMilliseconds": 335.5228,
+      "startedAtUtc": "2026-07-19T02:06:46.2330272+00:00",
+      "completedAtUtc": "2026-07-19T02:06:46.5685519+00:00"
+    },
+    {
+      "label": "Member and coverage seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 171219.6291,
+      "startedAtUtc": "2026-07-19T02:06:46.6981369+00:00",
+      "completedAtUtc": "2026-07-19T02:09:37.9181577+00:00"
+    },
+    {
+      "label": "Provider seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 189524.7948,
+      "startedAtUtc": "2026-07-19T02:09:37.9182707+00:00",
+      "completedAtUtc": "2026-07-19T02:12:47.4429746+00:00"
+    },
+    {
+      "label": "Timed adjudication",
+      "category": "Processing",
+      "durationMilliseconds": 1674381.9445,
+      "startedAtUtc": "2026-07-19T02:12:47.466181+00:00",
+      "completedAtUtc": "2026-07-19T02:40:41.8637255+00:00"
+    },
+    {
+      "label": "Expected-pend observation",
+      "category": "Observation",
+      "durationMilliseconds": 740.1167,
+      "startedAtUtc": "2026-07-19T02:40:41.9439205+00:00",
+      "completedAtUtc": "2026-07-19T02:40:42.6840437+00:00"
+    },
+    {
+      "label": "False-pend sweep",
+      "category": "Observation",
+      "durationMilliseconds": 6120.4018,
+      "startedAtUtc": "2026-07-19T02:40:42.6840526+00:00",
+      "completedAtUtc": "2026-07-19T02:40:48.8045594+00:00"
+    }
+  ],
+  "fixturePreparation": {
+    "generatedClaims": 100000,
+    "providerPoolDistinctBefore": 199846,
+    "providerPoolDistinctAfter": 13742,
+    "providerPoolReusedAssignments": 186258,
+    "providerPoolProtectedClaims": 2800,
+    "membersCreated": 10614,
+    "membersExisting": 88977,
+    "memberStatusesAligned": 99591,
+    "cobCoverageCreated": 0,
+    "cobCoverageExisting": 920,
+    "providerNetworksCreated": 0,
+    "providerNetworksExisting": 2,
+    "providersCreated": 12748,
+    "providersExisting": 994
+  },
+  "averagePaymentDelta": 0.00,
+  "paymentTolerance": 0.01,
+  "paymentComparisons": 2000,
+  "paymentMatches": 2000,
+  "paymentMismatches": 0,
+  "maximumPaymentDelta": 0.00,
+  "paymentDeltaDistribution": [
+    {
+      "label": "Exact",
+      "lowerBoundExclusive": null,
+      "upperBoundInclusive": 0,
+      "count": 2000
+    },
+    {
+      "label": "Within tolerance",
+      "lowerBoundExclusive": 0,
+      "upperBoundInclusive": 0.01,
+      "count": 0
+    },
+    {
+      "label": "<= $1",
+      "lowerBoundExclusive": 0.01,
+      "upperBoundInclusive": 1,
+      "count": 0
+    },
+    {
+      "label": "<= $10",
+      "lowerBoundExclusive": 1,
+      "upperBoundInclusive": 10,
+      "count": 0
+    },
+    {
+      "label": "> $10",
+      "lowerBoundExclusive": 10,
+      "upperBoundInclusive": null,
+      "count": 0
+    }
+  ],
+  "businessDenialBreakdown": [
+    {
+      "code": "CARC_96",
+      "count": 9046
+    },
+    {
+      "code": "CARC_18",
+      "count": 6000
+    },
+    {
+      "code": "PRIOR_AUTH_REQUIRED",
+      "count": 2160
+    },
+    {
+      "code": "PROVIDER_EXCLUDED",
+      "count": 2001
+    },
+    {
+      "code": "NCCI_MUE_EDIT_FAILURE",
+      "count": 396
+    },
+    {
+      "code": "CARC_27",
+      "count": 267
+    },
+    {
+      "code": "SCRUB_VALIDATION_FAILURE",
+      "count": 47
+    }
+  ],
+  "workflowScenarioBreakdown": [
+    {
+      "scenario": "CleanProfessionalPaid",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthCarveIn",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthCarveOut",
+      "total": 200,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 200,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthParityCheck",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobBirthdayRule",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobGenderRule",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobMedicareSecondary",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobPrimaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobSecondaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobTertiaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidCHIP",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidDualEligible",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidSSI",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidSpendDown",
+      "total": 120,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 120,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidTANF",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornAutoAdjudication",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornFirstThirtyDays",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornMotherClaimLink",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_AuthOnFile",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_ExpiredAuth",
+      "total": 160,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 160,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_NoAuth",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_WrongProcedure",
+      "total": 160,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 160,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_WrongProvider",
+      "total": 160,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 160,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityAdd",
+      "total": 267,
+      "matches": 267,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityCoverageChange",
+      "total": 266,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 266,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityTermination",
+      "total": 267,
+      "matches": 267,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationAccidentRelated",
+      "total": 134,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 134,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationThirdPartyLiability",
+      "total": 133,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 133,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationWorkersComp",
+      "total": 133,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 133,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "ExcludedProviderDenied",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "TxStarInpatientNoAuth",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "UncoveredServiceDenied",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    }
+  ],
+  "sampleFailures": [],
+  "claimResults": [],
+  "createdAtUtc": "2026-07-19T02:06:45.083Z",
+  "lastUpdatedAtUtc": "2026-07-19T02:40:49.331Z",
+  "progress": {
+    "phase": "Completed",
+    "requestedClaims": 100000,
+    "completedClaims": 100000,
+    "processedClaims": 100000,
+    "platformFailures": 0,
+    "percentComplete": 100,
+    "currentThroughputClaimsPerSecond": 59.723529824529834,
+    "rollingP95LatencyMilliseconds": 259.6633,
+    "rollingP99LatencyMilliseconds": 762.3975,
+    "lastPublishedAtUtc": "2026-07-19T02:40:48.8086998+00:00"
+  }
+}

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2274,7 +2274,9 @@ static MassAdjudicationRunSummary BuildProgressSummary(
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
     var workflowScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
     var workflowMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
-    var workflowMismatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus);
+    var workflowMismatches = results.Count(r =>
+        r.ValidationStatus == MccWorkflowValidation.MismatchedStatus
+        && !IsAwaitingExpectedPendObservation(r, phase));
     var workflowUnsupported = results.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus);
     var workflowObservationTimeouts = results.Count(r => r.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus);
     var progress = CreateProgress(results, elapsed, options, phase);
@@ -2335,6 +2337,11 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         runCompletedAtUtc.UtcDateTime,
         progress);
 }
+
+static bool IsAwaitingExpectedPendObservation(ClaimValidationResult result, string phase)
+    => phase.Equals("Processing claims", StringComparison.OrdinalIgnoreCase)
+        && result.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()
+        && result.ValidationStatus == MccWorkflowValidation.MismatchedStatus;
 
 static MassAdjudicationRunProgress CreateProgress(
     IReadOnlyCollection<ClaimValidationResult> results,


### PR DESCRIPTION
## Summary

- Record the final post-#928 100K Million Claim Challenge evidence packet for Part 8.
- Add the raw validator output and run-summary JSON artifacts for the clean 100K run.
- Refresh article, benchmark results, podcast prompt, README, and PR summary with the final numbers.
- Suppress provisional expected-pend workflow mismatches in live progress summaries while pend observation is still pending.

## Why

The completed run reached 100,000 processed claims with zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000/2,000 comparable payments within one cent. During the live run, expected-pend claims appeared as provisional workflow mismatches before the observation pass completed, so the progress summary now avoids presenting those pending observations as true mismatches while the phase is still `Processing claims`.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj`
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj`