### PR TITLE
Wire prior auth validation into adjudication

### DIFF
--- a/docs/architecture/ADJUDICATION-PIPELINE.md
+++ b/docs/architecture/ADJUDICATION-PIPELINE.md
@@ -78,7 +78,7 @@ The controller runs the following engines in sequence via DI:
 | 2. verify-coverage | coverage-service | 3, 4 | No active coverage → CARC 26 |
 | 3. validate-provider | provider-service | 2, 4 | Not credentialed → CARC 185 |
 | 4. validate-codes | reference-data-service | 2, 3 | Invalid codes → CARC 11 |
-| 5. check-prior-auth | authorization-service | — (depends on 2, 4) | Auth required but missing → CARC 197 |
+| 5. check-prior-auth | authorization-service | — (depends on 2, 4) | Auth required but missing, expired, inactive, or not valid for the procedure when authorization-service has evidence → CARC 197 |
 | 6. adjudicate | benefit-plan-service | — (depends on 2, 3, 5) | See engine pipeline below |
 | 7. update-claim | claims-service | — | — |
 

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -335,6 +335,19 @@ builder.Services.AddScoped<ICoverageClient>(sp =>
         sp.GetRequiredService<HttpCoverageClient>(),
         sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
 
+// Prior-authorization validation. The stage treats lookup degradation as
+// "not enough evidence to deny" while honoring known invalid auth responses.
+builder.Services.AddHttpClient(UpstreamClientNames.AuthorizationService, client =>
+{
+    client.BaseAddress = new Uri(
+        builder.Configuration["Services:AuthorizationService"]
+        ?? "http://authorization-service:8080");
+    client.Timeout = TimeSpan.FromSeconds(5);
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+}).SetHandlerLifetime(TimeSpan.FromMinutes(5));
+builder.Services.AddScoped<HttpAuthorizationValidationClient>();
+builder.Services.AddScoped<IAuthorizationValidationClient, HttpAuthorizationValidationClient>();
+
 // Stages — registered as IEnumerable<IClaimAdjudicationStage>. Capabilities
 // 5.4-5.9 each replace one stub registration with the real stage that
 // wraps the corresponding engine. 5.4/5.6/5.7/5.8/5.9 swap the registration

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -39,18 +39,22 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
     public const string MemberNotEligibleCarc = "27";
     public const string PriorAuthorizationRequiredCode = "197";
     public const string PriorAuthorizationRequiredReason = "Prior authorization required but not provided";
+    public const string PriorAuthorizationInvalidReason = "Prior authorization is not valid for this claim";
 
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
+    private readonly IAuthorizationValidationClient _authorizationValidationClient;
     private readonly ILogger<BenefitCalculationStage> _logger;
 
     public BenefitCalculationStage(
         IBenefitCalculationEngine engine,
         IMemberResolver memberResolver,
+        IAuthorizationValidationClient authorizationValidationClient,
         ILogger<BenefitCalculationStage> logger)
     {
         _engine = engine;
         _memberResolver = memberResolver;
+        _authorizationValidationClient = authorizationValidationClient;
         _logger = logger;
     }
 
@@ -89,14 +93,19 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
                 eligibilityReason);
         }
 
-        if (RequiresPriorAuthorizationDenial(claim))
+        var priorAuthorizationDenialReason = await ResolvePriorAuthorizationDenialReasonAsync(
+            context.TenantId,
+            claim,
+            ct).ConfigureAwait(false);
+
+        if (priorAuthorizationDenialReason is not null)
         {
             context.AdjudicationResult.DenialReasonCode = PriorAuthorizationRequiredCode;
-            context.AdjudicationResult.DenialReason = PriorAuthorizationRequiredReason;
+            context.AdjudicationResult.DenialReason = priorAuthorizationDenialReason;
 
             return ClaimAdjudicationStageResult.Deny(
                 StageName,
-                PriorAuthorizationRequiredReason);
+                priorAuthorizationDenialReason);
         }
 
         var subscriberId = await ResolveSubscriberIdAsync(context, ct).ConfigureAwait(false);
@@ -178,10 +187,53 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 
     internal static bool RequiresPriorAuthorizationDenial(AdapterClaim claim)
     {
+        return RequiresPriorAuthorizationValidation(claim)
+            && string.IsNullOrWhiteSpace(claim.PriorAuthorizationNumber);
+    }
+
+    private async Task<string?> ResolvePriorAuthorizationDenialReasonAsync(
+        string tenantId,
+        AdapterClaim claim,
+        CancellationToken ct)
+    {
+        if (!RequiresPriorAuthorizationValidation(claim))
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(claim.PriorAuthorizationNumber))
+        {
+            return PriorAuthorizationRequiredReason;
+        }
+
+        var procedureCode = claim.ClaimLines
+            .OrderBy(line => line.LineNumber)
+            .Select(line => line.ProcedureCode)
+            .FirstOrDefault(code => !string.IsNullOrWhiteSpace(code));
+
+        var validation = await _authorizationValidationClient.ValidateAsync(
+                tenantId,
+                claim.PriorAuthorizationNumber,
+                procedureCode,
+                claim.ServiceDateFrom,
+                ct)
+            .ConfigureAwait(false);
+
+        if (validation is null || validation.IsValid)
+        {
+            return null;
+        }
+
+        return string.IsNullOrWhiteSpace(validation.ValidationMessage)
+            ? PriorAuthorizationInvalidReason
+            : validation.ValidationMessage;
+    }
+
+    private static bool RequiresPriorAuthorizationValidation(AdapterClaim claim)
+    {
         return claim.ClaimType is ClaimsService.Models.ClaimType.Institutional
             && claim.LineOfBusiness is LineOfBusiness.Medicaid
-            && string.Equals(claim.PlaceOfServiceCode, "21", StringComparison.OrdinalIgnoreCase)
-            && string.IsNullOrWhiteSpace(claim.PriorAuthorizationNumber);
+            && string.Equals(claim.PlaceOfServiceCode, "21", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<string> ResolveSubscriberIdAsync(

--- a/src/services/claims-service/Services/Resolution/HttpAuthorizationValidationClient.cs
+++ b/src/services/claims-service/Services/Resolution/HttpAuthorizationValidationClient.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using ClaimsService.Services;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed prior-authorization validation client. 404 and transport
+/// failures return null so adjudication can distinguish "known invalid auth"
+/// from "no authoritative auth signal available".
+/// </summary>
+public sealed class HttpAuthorizationValidationClient : IAuthorizationValidationClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpAuthorizationValidationClient> _logger;
+
+    public HttpAuthorizationValidationClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpAuthorizationValidationClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<AuthorizationValidationResult?> ValidateAsync(
+        string tenantId,
+        string authorizationNumber,
+        string? procedureCode,
+        DateTime serviceDate,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationNumber))
+        {
+            return null;
+        }
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.AuthorizationService);
+            var encodedAuth = Uri.EscapeDataString(authorizationNumber.Trim());
+            var serviceDateQuery = serviceDate.ToUniversalTime()
+                .ToString("o", CultureInfo.InvariantCulture);
+            var url = $"/api/authorizations/{encodedAuth}/validate" +
+                      $"?serviceDate={Uri.EscapeDataString(serviceDateQuery)}";
+
+            if (!string.IsNullOrWhiteSpace(procedureCode))
+            {
+                url += $"&procedureCode={Uri.EscapeDataString(procedureCode.Trim())}";
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Authorization service returned {StatusCode} validating authorization {AuthorizationNumber}",
+                    response.StatusCode,
+                    SanitizeForLog(authorizationNumber));
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<AuthorizationValidationResult>(JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Authorization validation lookup failed for authorization {AuthorizationNumber} tenant {Tenant}",
+                SanitizeForLog(authorizationNumber),
+                SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/IAuthorizationValidationClient.cs
+++ b/src/services/claims-service/Services/Resolution/IAuthorizationValidationClient.cs
@@ -1,0 +1,21 @@
+namespace ClaimsService.Services.Resolution;
+
+public interface IAuthorizationValidationClient
+{
+    Task<AuthorizationValidationResult?> ValidateAsync(
+        string tenantId,
+        string authorizationNumber,
+        string? procedureCode,
+        DateTime serviceDate,
+        CancellationToken ct = default);
+}
+
+public sealed record AuthorizationValidationResult(
+    string AuthorizationNumber,
+    bool IsValid,
+    string? Status,
+    DateTime? ApprovedServiceDateFrom,
+    DateTime? ApprovedServiceDateTo,
+    DateTime? ExpirationDate,
+    decimal? ApprovedUnits,
+    string? ValidationMessage);

--- a/src/services/claims-service/Services/UpstreamClientNames.cs
+++ b/src/services/claims-service/Services/UpstreamClientNames.cs
@@ -36,4 +36,8 @@ public static class UpstreamClientNames
     /// /member/{id}/cob lookup driving CHO-primary vs CHO-secondary
     /// detection.</summary>
     public const string CoverageService = "CoverageService";
+
+    /// <summary>authorization-service — prior-authorization validation
+    /// lookup used by adjudication before paying PA-sensitive claims.</summary>
+    public const string AuthorizationService = "AuthorizationService";
 }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/FakeHttpMessageHandler.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Adapters/FakeHttpMessageHandler.cs
@@ -10,6 +10,7 @@ internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
     private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
     public int RequestCount { get; private set; }
+    public string? LastClientName { get; set; }
 
     public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
     {

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -15,12 +15,16 @@ public class BenefitCalculationStageTests
 {
     private readonly IBenefitCalculationEngine _engine = Substitute.For<IBenefitCalculationEngine>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly IAuthorizationValidationClient _authorizationValidationClient = Substitute.For<IAuthorizationValidationClient>();
     private readonly BenefitCalculationStage _sut;
 
     public BenefitCalculationStageTests()
     {
         _sut = new BenefitCalculationStage(
-            _engine, _memberResolver, NullLogger<BenefitCalculationStage>.Instance);
+            _engine,
+            _memberResolver,
+            _authorizationValidationClient,
+            NullLogger<BenefitCalculationStage>.Instance);
     }
 
     [Fact]
@@ -287,6 +291,8 @@ public class BenefitCalculationStageTests
         Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredCode, ctx.AdjudicationResult.DenialReasonCode);
         Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredReason, ctx.AdjudicationResult.DenialReason);
         await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+        await _authorizationValidationClient.DidNotReceiveWithAnyArgs()
+            .ValidateAsync(default!, default!, default, default, default);
     }
 
     [Fact]
@@ -332,6 +338,87 @@ public class BenefitCalculationStageTests
             ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
         };
 
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _authorizationValidationClient.Received(1).ValidateAsync(
+            "tenant-1",
+            "AUTH-123",
+            "99213",
+            claim.ServiceDateFrom,
+            Arg.Any<CancellationToken>());
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Execute_InpatientWithInvalidPriorAuth_DeniesWithoutEngineCall()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.LineOfBusiness = LineOfBusiness.Medicaid;
+        claim.ClaimType = ClaimType.Institutional;
+        claim.PlaceOfServiceCode = "21";
+        claim.PriorAuthorizationNumber = "AUTH-EXPIRED";
+
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _authorizationValidationClient.ValidateAsync(
+                "tenant-1",
+                "AUTH-EXPIRED",
+                "99213",
+                claim.ServiceDateFrom,
+                Arg.Any<CancellationToken>())
+            .Returns(new AuthorizationValidationResult(
+                "AUTH-EXPIRED",
+                false,
+                "Approved",
+                claim.ServiceDateFrom.AddDays(-30),
+                claim.ServiceDateFrom.AddDays(-1),
+                claim.ServiceDateFrom.AddDays(-1),
+                1,
+                "Authorization expired or not yet active"));
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue);
+        Assert.Equal(BenefitCalculationStage.PriorAuthorizationRequiredCode, ctx.AdjudicationResult.DenialReasonCode);
+        Assert.Equal("Authorization expired or not yet active", ctx.AdjudicationResult.DenialReason);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_InpatientWithPriorAuthLookupDegraded_ContinuesToBenefitEngine()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.LineOfBusiness = LineOfBusiness.Medicaid;
+        claim.ClaimType = ClaimType.Institutional;
+        claim.PlaceOfServiceCode = "21";
+        claim.PriorAuthorizationNumber = "AUTH-UNKNOWN";
+
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _authorizationValidationClient.ValidateAsync(
+                "tenant-1",
+                "AUTH-UNKNOWN",
+                "99213",
+                claim.ServiceDateFrom,
+                Arg.Any<CancellationToken>())
+            .Returns((AuthorizationValidationResult?)null);
         _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
             .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals() });
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/HttpAuthorizationValidationClientTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/HttpAuthorizationValidationClientTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using ClaimsService.Services;
+using ClaimsService.Services.Resolution;
+using CloudHealthOffice.ClaimsService.Tests.Adapters;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+public sealed class HttpAuthorizationValidationClientTests
+{
+    [Fact]
+    public async Task ValidateAsync_SendsTenantProcedureAndServiceDate()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            captured = request;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "authorizationNumber": "AUTH-EXPIRED",
+                      "isValid": false,
+                      "status": "Approved",
+                      "approvedServiceDateFrom": "2026-01-01T00:00:00Z",
+                      "approvedServiceDateTo": "2026-01-31T00:00:00Z",
+                      "expirationDate": "2026-01-31T00:00:00Z",
+                      "approvedUnits": 1,
+                      "validationMessage": "Authorization expired or not yet active"
+                    }
+                    """,
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            };
+        });
+        var sut = CreateClient(handler);
+
+        var result = await sut.ValidateAsync(
+            "tenant-1",
+            "AUTH-EXPIRED",
+            "99213",
+            new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.NotNull(result);
+        Assert.False(result!.IsValid);
+        Assert.Equal("AUTH-EXPIRED", result.AuthorizationNumber);
+        Assert.Equal("Authorization expired or not yet active", result.ValidationMessage);
+        Assert.NotNull(captured);
+        Assert.Equal(UpstreamClientNames.AuthorizationService, handler.LastClientName);
+        Assert.Equal("tenant-1", captured!.Headers.GetValues("X-Tenant-ID").Single());
+        Assert.Contains("/api/authorizations/AUTH-EXPIRED/validate", captured.RequestUri!.PathAndQuery);
+        Assert.Contains("procedureCode=99213", captured.RequestUri.PathAndQuery);
+        Assert.Contains("serviceDate=", captured.RequestUri.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_NotFound_ReturnsNull()
+    {
+        var handler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var sut = CreateClient(handler);
+
+        var result = await sut.ValidateAsync(
+            "tenant-1",
+            "AUTH-UNKNOWN",
+            "99213",
+            DateTime.UtcNow);
+
+        Assert.Null(result);
+    }
+
+    private static HttpAuthorizationValidationClient CreateClient(FakeHttpMessageHandler handler)
+        => new(
+            new NamedHttpClientFactory(handler),
+            NullLogger<HttpAuthorizationValidationClient>.Instance);
+
+    private sealed class NamedHttpClientFactory : IHttpClientFactory
+    {
+        private readonly FakeHttpMessageHandler _handler;
+
+        public NamedHttpClientFactory(FakeHttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            _handler.LastClientName = name;
+            return new HttpClient(_handler, disposeHandler: false)
+            {
+                BaseAddress = new Uri("http://authorization-service.test")
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an authorization-service validation client for claims-service prior-auth checks
- deny Medicaid institutional inpatient claims when authorization-service returns known invalid prior-auth evidence
- preserve fail-open/degraded behavior when prior-auth lookup is unavailable or inconclusive
- document the expanded prior-auth adjudication behavior

## Why
The MCC unsupported backlog includes prior-auth edge variants. This PR adds the production-shaped adjudication seam needed to honor real authorization evidence before we convert those benchmark cases from unsupported to scoreable. It does not relabel MCC unsupported scenarios yet because the validator still needs authoritative auth fixture seeding.

## Validation
- `dotnet build src/services/claims-service/claims-service.csproj --no-restore`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter "BenefitCalculationStageTests|HttpAuthorizationValidationClientTests" --no-restore`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore`
