### PR TITLE
Score MCC prior auth evidence when seeded

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -14,8 +14,10 @@ BENEFIT_URL="${BENEFIT_URL:-http://benefit-plan-service}"
 MEMBER_URL="${MEMBER_URL:-http://member-service}"
 COVERAGE_URL="${COVERAGE_URL:-http://coverage-service}"
 PROVIDER_URL="${PROVIDER_URL:-http://provider-service}"
+AUTHORIZATION_URL="${AUTHORIZATION_URL:-http://authorization-service}"
 SEED_MEMBERS="${SEED_MEMBERS:-true}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
+SEED_AUTHORIZATIONS="${SEED_AUTHORIZATIONS:-true}"
 CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS="${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS:-15}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
 PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
@@ -91,8 +93,11 @@ spec:
             - "${COVERAGE_URL}"
             - --provider-url
             - "${PROVIDER_URL}"
+            - --authorization-url
+            - "${AUTHORIZATION_URL}"
             $(if [[ "$SEED_MEMBERS" != "true" ]]; then printf -- '- --no-seed-members\n'; fi)
             $(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf -- '- --no-seed-providers\n'; fi)
+            $(if [[ "$SEED_AUTHORIZATIONS" != "true" ]]; then printf -- '- --no-seed-authorizations\n'; fi)
             $(if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then printf -- '- --no-pend-observation\n'; fi)
             - --pend-observation-timeout
             - "${PEND_OBSERVATION_TIMEOUT_SECONDS}"

--- a/src/services/authorization-service/Controllers/AuthorizationsController.cs
+++ b/src/services/authorization-service/Controllers/AuthorizationsController.cs
@@ -14,13 +14,16 @@ namespace AuthorizationService.Controllers;
 public class AuthorizationsController : ControllerBase
 {
     private readonly IAuthorizationRepository _authorizationRepository;
+    private readonly IWebHostEnvironment _environment;
     private readonly ILogger<AuthorizationsController> _logger;
 
     public AuthorizationsController(
         IAuthorizationRepository authorizationRepository,
+        IWebHostEnvironment environment,
         ILogger<AuthorizationsController> logger)
     {
         _authorizationRepository = authorizationRepository;
+        _environment = environment;
         _logger = logger;
     }
 
@@ -159,6 +162,69 @@ public class AuthorizationsController : ControllerBase
         };
 
         return Ok(response);
+    }
+
+    /// <summary>
+    /// Seed deterministic prior authorization fixtures for local validation.
+    /// </summary>
+    [AllowAnonymous]
+    [HttpPost("dev-seed")]
+    [ApiExplorerSettings(IgnoreApi = true)]
+    [ProducesResponseType(typeof(DevelopmentAuthorizationSeedResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<ActionResult<DevelopmentAuthorizationSeedResponse>> SeedDevelopmentAuthorizations(
+        [FromBody] DevelopmentAuthorizationSeedRequest request)
+    {
+        if (!_environment.IsDevelopment() && !string.Equals(_environment.EnvironmentName, "Test", StringComparison.OrdinalIgnoreCase))
+        {
+            return Forbid();
+        }
+
+        if (request?.Authorizations is not { Count: > 0 })
+        {
+            return BadRequest("At least one authorization fixture is required");
+        }
+
+        var now = DateTime.UtcNow;
+        var created = 0;
+        var updated = 0;
+
+        foreach (var fixture in request.Authorizations)
+        {
+            if (string.IsNullOrWhiteSpace(fixture.AuthorizationNumber))
+            {
+                return BadRequest("Authorization fixtures must include authorizationNumber");
+            }
+
+            fixture.AuthorizationNumber = fixture.AuthorizationNumber.Trim();
+            fixture.MemberId = fixture.MemberId?.Trim() ?? string.Empty;
+            fixture.PatientFirstName = fixture.PatientFirstName?.Trim() ?? string.Empty;
+            fixture.PatientLastName = fixture.PatientLastName?.Trim() ?? string.Empty;
+            fixture.RequestingProviderNPI = fixture.RequestingProviderNPI?.Trim() ?? string.Empty;
+            fixture.CreatedDate = fixture.CreatedDate == default ? now : fixture.CreatedDate;
+            fixture.LastUpdatedDate = now;
+
+            var existing = await _authorizationRepository.GetByAuthorizationNumberAsync(fixture.AuthorizationNumber);
+            if (existing is null)
+            {
+                fixture.Id = string.IsNullOrWhiteSpace(fixture.Id) ? Guid.NewGuid().ToString() : fixture.Id;
+                await _authorizationRepository.CreateAsync(fixture);
+                created++;
+                continue;
+            }
+
+            fixture.Id = existing.Id;
+            fixture.CreatedDate = existing.CreatedDate == default ? fixture.CreatedDate : existing.CreatedDate;
+            await _authorizationRepository.UpdateAsync(fixture);
+            updated++;
+        }
+
+        _logger.LogInformation(
+            "Seeded {Total} development authorization fixtures ({Created} created, {Updated} updated)",
+            created + updated, created, updated);
+
+        return Ok(new DevelopmentAuthorizationSeedResponse(created + updated, created, updated));
     }
 
     /// <summary>
@@ -372,3 +438,7 @@ public class AuthorizationsController : ControllerBase
         return value.Replace("\r", string.Empty).Replace("\n", string.Empty);
     }
 }
+
+public sealed record DevelopmentAuthorizationSeedRequest(List<Authorization> Authorizations);
+
+public sealed record DevelopmentAuthorizationSeedResponse(int Total, int Created, int Updated);

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -14,6 +14,11 @@ public sealed record ExpectedValidation(
         => new(scenario, null, expectedBusinessDenialCode, IsUnsupported: true);
 }
 
+public sealed record MccWorkflowValidationCapabilities(bool ScorePriorAuthValidationEvidence = false)
+{
+    public static MccWorkflowValidationCapabilities Default { get; } = new();
+}
+
 public static class MccWorkflowValidation
 {
     public const string CleanProfessionalPaidScenario = "CleanProfessionalPaid";
@@ -32,8 +37,12 @@ public static class MccWorkflowValidation
     public const string MatchedStatus = "Matched";
     public const string ObservationTimeoutStatus = "ObservationTimeout";
 
-    public static ExpectedValidation ExpectedValidationFor(SyntheticClaim claim)
+    public static ExpectedValidation ExpectedValidationFor(
+        SyntheticClaim claim,
+        MccWorkflowValidationCapabilities? capabilities = null)
     {
+        var effectiveCapabilities = capabilities ?? MccWorkflowValidationCapabilities.Default;
+
         if (claim.EdgeCase is not null && claim.ExpectedOutcome is not null)
         {
             var scenario = $"EdgeCase:{claim.EdgeCase}";
@@ -50,7 +59,7 @@ public static class MccWorkflowValidation
             }
 
             if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
-                && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value))
+                && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value, effectiveCapabilities))
             {
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
@@ -166,12 +175,23 @@ public static class MccWorkflowValidation
             EdgeCaseScenario.MedicaidSpendDown;
     }
 
-    private static bool IsUnsupportedPriorAuthValidationEdgeCase(EdgeCaseScenario scenario)
+    private static bool IsUnsupportedPriorAuthValidationEdgeCase(
+        EdgeCaseScenario scenario,
+        MccWorkflowValidationCapabilities capabilities)
     {
-        return scenario is
+        if (scenario is EdgeCaseScenario.PriorAuthRequired_WrongProvider)
+        {
+            return true;
+        }
+
+        if (scenario is
             EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
-            EdgeCaseScenario.PriorAuthRequired_WrongProvider or
-            EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+            EdgeCaseScenario.PriorAuthRequired_WrongProcedure)
+        {
+            return !capabilities.ScorePriorAuthValidationEvidence;
+        }
+
+        return false;
     }
 
     private static bool IsUnsupportedBusinessDenialEdgeCase(EdgeCaseScenario scenario)
@@ -210,9 +230,12 @@ public sealed class MccAnswerKey
         _entries = entries;
     }
 
-    public static MccAnswerKey FromClaims(IEnumerable<SyntheticClaim> claims)
+    public static MccAnswerKey FromClaims(
+        IEnumerable<SyntheticClaim> claims,
+        MccWorkflowValidationCapabilities? capabilities = null)
     {
         var entries = new Dictionary<string, ExpectedValidation>(StringComparer.Ordinal);
+        var effectiveCapabilities = capabilities ?? MccWorkflowValidationCapabilities.Default;
 
         foreach (var claim in claims)
         {
@@ -226,7 +249,7 @@ public sealed class MccAnswerKey
                 throw new InvalidOperationException($"Duplicate MCC answer-key claim id: {claim.ClaimId}");
             }
 
-            entries.Add(claim.ClaimId, MccWorkflowValidation.ExpectedValidationFor(claim));
+            entries.Add(claim.ClaimId, MccWorkflowValidation.ExpectedValidationFor(claim, effectiveCapabilities));
         }
 
         return new MccAnswerKey(entries);

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -39,11 +39,13 @@ Console.WriteLine($"  Benefit URL: {options.BenefitUrl}");
 Console.WriteLine($"  Member URL:  {options.MemberUrl}");
 Console.WriteLine($"  Coverage URL:{options.CoverageUrl}");
 Console.WriteLine($"  Provider URL:{options.ProviderUrl}");
+Console.WriteLine($"  Auth URL:    {options.AuthorizationUrl}");
 Console.WriteLine($"  Claims:      {options.Claims:N0}");
 Console.WriteLine($"  Seed:        {options.Seed}");
 Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
 Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
+Console.WriteLine($"  Auth fixtures:{(options.SeedAuthorizations ? " enabled" : " disabled")}");
 Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled ({options.PendObservationTimeoutSeconds}s/{options.PendObservationIntervalMilliseconds}ms)" : " disabled")}");
 Console.WriteLine($"  Pend diag:   {(options.PendDiagnosticsPath is not null ? $"enabled -> {options.PendDiagnosticsPath}" : "disabled")}");
 Console.WriteLine();
@@ -95,7 +97,25 @@ Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 Console.WriteLine(
     $"Provider fixture pool: {providerPool.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
     $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
-var answerKey = MccAnswerKey.FromClaims(claims);
+
+var scorePriorAuthValidationEvidence = false;
+if (options.SeedAuthorizations)
+{
+    scorePriorAuthValidationEvidence = await MeasureLifecycleValuePhaseAsync(
+        lifecycleTimings,
+        "Authorization fixture seeding",
+        "Preparation",
+        () => SeedPriorAuthAuthorizationFixturesAsync(http, options, claims, json));
+}
+else
+{
+    Console.WriteLine("Authorization fixtures: skipped (--no-seed-authorizations)");
+}
+
+var answerKey = MccAnswerKey.FromClaims(
+    claims,
+    new MccWorkflowValidationCapabilities(
+        ScorePriorAuthValidationEvidence: scorePriorAuthValidationEvidence));
 
 var memberFixtures = MemberFixturePreparation.Empty;
 var cobCoverageFixtures = FixtureCount.Empty;
@@ -755,9 +775,24 @@ static void NormalizePriorAuthEdgeCases(List<SyntheticClaim> claims, ValidatorOp
         return;
     }
 
-    foreach (var claim in claims.Where(claim => claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_NoAuth))
+    foreach (var claim in claims.Where(claim => claim.EdgeCase is
+                 EdgeCaseScenario.PriorAuthRequired_AuthOnFile
+                 or EdgeCaseScenario.PriorAuthRequired_NoAuth
+                 or EdgeCaseScenario.PriorAuthRequired_ExpiredAuth
+                 or EdgeCaseScenario.PriorAuthRequired_WrongProvider
+                 or EdgeCaseScenario.PriorAuthRequired_WrongProcedure))
     {
-        ForceTexasMedicaidInpatientPriorAuthScenario(claim);
+        var priorAuthNumber = claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_NoAuth
+            ? null
+            : claim.PriorAuthNumber;
+        var priorAuthStatus = claim.EdgeCase switch
+        {
+            EdgeCaseScenario.PriorAuthRequired_NoAuth => "Required",
+            EdgeCaseScenario.PriorAuthRequired_ExpiredAuth => "Expired",
+            _ => "OnFile"
+        };
+
+        ForceTexasMedicaidInpatientPriorAuthScenario(claim, priorAuthStatus, priorAuthNumber);
     }
 }
 
@@ -1276,13 +1311,19 @@ static async Task CreateCobCoverageAsync(
     }
 }
 
-static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
+static void ForceTexasMedicaidInpatientPriorAuthScenario(
+    SyntheticClaim claim,
+    string priorAuthStatus = "Required",
+    string? priorAuthNumber = null)
 {
+    claim.ClaimType = "Institutional";
     claim.PlaceOfService = "21";
     claim.BillType = "0111";
-    claim.PriorAuthStatus = "Required";
-    claim.PriorAuthNumber = null;
+    claim.PriorAuthStatus = priorAuthStatus;
+    claim.PriorAuthNumber = priorAuthNumber;
 
+    ForceAdjudicatableProviderProfile(claim.RenderingProvider, claim.DateOfService);
+    ForceAdjudicatableProviderProfile(claim.BillingProvider, claim.DateOfService);
     claim.RenderingProvider.State = "TX";
     claim.BillingProvider.State = "TX";
 
@@ -1290,6 +1331,241 @@ static void ForceTexasMedicaidInpatientPriorAuthScenario(SyntheticClaim claim)
     {
         line.PlaceOfService = "21";
     }
+}
+
+static async Task<bool> SeedPriorAuthAuthorizationFixturesAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    IReadOnlyCollection<SyntheticClaim> claims,
+    JsonSerializerOptions json)
+{
+    if (!options.PriorAuthScenariosEnabled)
+    {
+        Console.WriteLine("Authorization fixtures: skipped (prior-auth scenarios disabled)");
+        return false;
+    }
+
+    if (options.LineOfBusiness != 3)
+    {
+        Console.WriteLine("Authorization fixtures: skipped (claims-service prior-auth validation is currently Medicaid-only)");
+        return false;
+    }
+
+    var fixtureClaims = claims
+        .Where(IsPriorAuthAuthorizationFixtureScenario)
+        .Where(claim => !string.IsNullOrWhiteSpace(claim.PriorAuthNumber))
+        .GroupBy(claim => claim.PriorAuthNumber!, StringComparer.OrdinalIgnoreCase)
+        .Select(group => group.OrderBy(claim => claim.ClaimId, StringComparer.Ordinal).First())
+        .OrderBy(claim => claim.PriorAuthNumber, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    if (fixtureClaims.Count == 0)
+    {
+        Console.WriteLine("Authorization fixtures: skipped (no scoreable prior-auth claims with auth numbers)");
+        return false;
+    }
+
+    var payload = new
+    {
+        authorizations = fixtureClaims.Select(claim => BuildPriorAuthAuthorizationFixture(claim, options)).ToList()
+    };
+
+    try
+    {
+        using var response = await http.PostAsJsonAsync($"{options.AuthorizationUrl}/api/authorizations/dev-seed", payload, json);
+        var body = await response.Content.ReadAsStringAsync();
+
+        if (response.StatusCode is System.Net.HttpStatusCode.NotFound
+            or System.Net.HttpStatusCode.Unauthorized
+            or System.Net.HttpStatusCode.Forbidden)
+        {
+            Console.WriteLine($"Authorization fixtures: skipped ({(int)response.StatusCode} from authorization-service)");
+            return false;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Authorization fixture seed failed: {(int)response.StatusCode} {body}");
+        }
+
+        if (!TryReadAuthorizationFixtureSeedResponse(body, out var total, out var created, out var updated))
+        {
+            Console.WriteLine("Authorization fixtures: skipped (authorization-service did not expose compatible dev-seed evidence)");
+            return false;
+        }
+
+        Console.WriteLine(
+            $"Authorization fixtures: seeded {total:N0} prior authorization fixtures ({created:N0} new, {updated:N0} updated)");
+        return total > 0;
+    }
+    catch (HttpRequestException ex)
+    {
+        Console.WriteLine($"Authorization fixtures: skipped ({ex.Message})");
+        return false;
+    }
+    catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+    {
+        Console.WriteLine($"Authorization fixtures: skipped ({ex.Message})");
+        return false;
+    }
+}
+
+static bool IsPriorAuthAuthorizationFixtureScenario(SyntheticClaim claim)
+{
+    return claim.EdgeCase is
+        EdgeCaseScenario.PriorAuthRequired_AuthOnFile or
+        EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
+        EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+}
+
+static object BuildPriorAuthAuthorizationFixture(SyntheticClaim claim, ValidatorOptions options)
+{
+    var serviceDate = DateTime.SpecifyKind(claim.DateOfService.Date, DateTimeKind.Utc);
+    var expired = claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_ExpiredAuth;
+    var approvedFrom = expired ? serviceDate.AddDays(-90) : serviceDate.AddDays(-30);
+    var approvedTo = expired ? serviceDate.AddDays(-30) : serviceDate.AddDays(30);
+    var expirationDate = expired ? serviceDate.AddDays(-1) : serviceDate.AddDays(30);
+    var firstLine = claim.Lines.OrderBy(line => line.LineNumber).FirstOrDefault();
+    var units = claim.Lines.Sum(line => line.Units <= 0 ? 1 : line.Units);
+
+    return new
+    {
+        tenantId = options.TenantId,
+        authorizationNumber = claim.PriorAuthNumber,
+        memberId = claim.Member.MemberId,
+        patientFirstName = NullIfWhiteSpace(claim.Member.FirstName) ?? "MCC",
+        patientLastName = NullIfWhiteSpace(claim.Member.LastName) ?? "Member",
+        patientDateOfBirth = DateTime.SpecifyKind(
+            claim.Member.DateOfBirth == default ? serviceDate.AddYears(-30) : claim.Member.DateOfBirth.Date,
+            DateTimeKind.Utc),
+        lineOfBusiness = "Medicaid",
+        requestingProviderNPI = claim.RenderingProvider.Npi,
+        requestingProviderName = NullIfWhiteSpace(claim.RenderingProvider.FullName) ?? "MCC Provider",
+        servicingProviderNPI = claim.RenderingProvider.Npi,
+        servicingProviderName = NullIfWhiteSpace(claim.RenderingProvider.FullName) ?? "MCC Provider",
+        authorizationType = "PreAuthorization",
+        certificationType = "I",
+        serviceTypeCode = "48",
+        levelOfService = "E",
+        requestedServiceDateFrom = serviceDate,
+        requestedServiceDateTo = serviceDate,
+        diagnosisCodes = BuildAuthorizationDiagnosisCodes(claim),
+        requestedServices = new[]
+        {
+            new
+            {
+                procedureCode = AuthorizationProcedureCodeForClaim(claim),
+                procedureDescription = NullIfWhiteSpace(firstLine?.Description) ?? "MCC prior authorization fixture service",
+                modifiers = firstLine?.Modifiers ?? new List<string>(),
+                requestedUnits = units,
+                unitType = "UN",
+                placeOfServiceCode = "21",
+                revenueCode = NullIfWhiteSpace(firstLine?.RevenueCode),
+                approvedUnits = units,
+                serviceStatus = "A1"
+            }
+        },
+        status = "Approved",
+        reviewDecision = "A1",
+        approvedUnits = units,
+        approvedServiceDateFrom = approvedFrom,
+        approvedServiceDateTo = approvedTo,
+        expirationDate,
+        submittedDate = serviceDate.AddDays(-45),
+        reviewedDate = serviceDate.AddDays(-40),
+        createdBy = "mcc-platform-validator",
+        lastUpdatedBy = "mcc-platform-validator",
+        notes = $"MCC fixture for {claim.ClaimId}/{claim.EdgeCase}"
+    };
+}
+
+static List<object> BuildAuthorizationDiagnosisCodes(SyntheticClaim claim)
+{
+    var codes = new List<string>();
+    if (!string.IsNullOrWhiteSpace(claim.PrimaryDiagnosisCode))
+    {
+        codes.Add(claim.PrimaryDiagnosisCode);
+    }
+
+    codes.AddRange(claim.SecondaryDiagnosisCodes.Where(code => !string.IsNullOrWhiteSpace(code)));
+    if (codes.Count == 0)
+    {
+        codes.Add("Z00.00");
+    }
+
+    return codes
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .Select((code, index) => new
+        {
+            code,
+            codeQualifier = index == 0 ? "BK" : "BF",
+            description = DiagnosisCodes.FindDescription(code)
+        })
+        .Cast<object>()
+        .ToList();
+}
+
+static string AuthorizationProcedureCodeForClaim(SyntheticClaim claim)
+{
+    var actualProcedureCode = NullIfWhiteSpace(
+        claim.Lines.OrderBy(line => line.LineNumber).FirstOrDefault()?.ProcedureCode) ?? "99213";
+
+    return claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_WrongProcedure
+        ? DifferentProcedureCode(actualProcedureCode)
+        : actualProcedureCode;
+}
+
+static string DifferentProcedureCode(string procedureCode)
+    => string.Equals(procedureCode, "99213", StringComparison.OrdinalIgnoreCase) ? "99214" : "99213";
+
+static bool TryReadAuthorizationFixtureSeedResponse(
+    string body,
+    out int total,
+    out int created,
+    out int updated)
+{
+    total = 0;
+    created = 0;
+    updated = 0;
+
+    try
+    {
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        var hasTotal = TryGetInt32Property(root, "total", out total);
+        TryGetInt32Property(root, "created", out created);
+        TryGetInt32Property(root, "updated", out updated);
+        return hasTotal;
+    }
+    catch (JsonException)
+    {
+        return false;
+    }
+}
+
+static bool TryGetInt32Property(JsonElement element, string propertyName, out int value)
+{
+    foreach (var property in element.EnumerateObject())
+    {
+        if (!string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        if (property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetInt32(out value))
+        {
+            return true;
+        }
+
+        if (property.Value.ValueKind == JsonValueKind.String
+            && int.TryParse(property.Value.GetString(), out value))
+        {
+            return true;
+        }
+    }
+
+    value = 0;
+    return false;
 }
 
 static async Task<FixtureCount> SeedProvidersAsync(
@@ -2469,8 +2745,10 @@ static void PrintUsage()
       --member-url <url>         Member service URL (default: http://localhost:5003)
       --coverage-url <url>       Coverage service URL (default: http://localhost:5005)
       --provider-url <url>       Provider service URL (default: http://localhost:5004)
+      --authorization-url <url>  Authorization service URL (default: http://authorization-service)
       --no-seed-members          Skip synthetic member seeding
       --no-seed-providers        Skip synthetic provider seeding
+      --no-seed-authorizations   Skip prior authorization fixture seeding
       --skip-claim-update        Do not write adjudication projection back to claims-service
       --no-pend-observation      Do not poll claims-service for expected-pend claim status
       --pend-observation-timeout <seconds>

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -9,8 +9,10 @@ public sealed record ValidatorOptions(
     string MemberUrl,
     string CoverageUrl,
     string ProviderUrl,
+    string AuthorizationUrl,
     bool SeedMembers,
     bool SeedProviders,
+    bool SeedAuthorizations,
     bool SkipClaimUpdate,
     bool PendObservationEnabled,
     int PendObservationTimeoutSeconds,
@@ -62,11 +64,17 @@ public sealed record ValidatorOptions(
                 case "--provider-url" when i + 1 < args.Length:
                     options.ProviderUrl = args[++i].TrimEnd('/');
                     break;
+                case "--authorization-url" when i + 1 < args.Length:
+                    options.AuthorizationUrl = args[++i].TrimEnd('/');
+                    break;
                 case "--no-seed-members":
                     options.SeedMembers = false;
                     break;
                 case "--no-seed-providers":
                     options.SeedProviders = false;
+                    break;
+                case "--no-seed-authorizations":
+                    options.SeedAuthorizations = false;
                     break;
                 case "--skip-claim-update":
                     options.SkipClaimUpdate = true;
@@ -146,8 +154,10 @@ public sealed record ValidatorOptions(
             options.MemberUrl.TrimEnd('/'),
             options.CoverageUrl.TrimEnd('/'),
             options.ProviderUrl.TrimEnd('/'),
+            options.AuthorizationUrl.TrimEnd('/'),
             options.SeedMembers,
             options.SeedProviders,
+            options.SeedAuthorizations,
             options.SkipClaimUpdate,
             options.PendObservationEnabled,
             Math.Clamp(options.PendObservationTimeoutSeconds, 1, 300),
@@ -176,8 +186,10 @@ public sealed record ValidatorOptions(
         public string MemberUrl { get; set; } = "http://localhost:5003";
         public string CoverageUrl { get; set; } = "http://localhost:5005";
         public string ProviderUrl { get; set; } = "http://localhost:5004";
+        public string AuthorizationUrl { get; set; } = "http://authorization-service";
         public bool SeedMembers { get; set; } = true;
         public bool SeedProviders { get; set; } = true;
+        public bool SeedAuthorizations { get; set; } = true;
         public bool SkipClaimUpdate { get; set; }
         public bool PendObservationEnabled { get; set; } = true;
         public int PendObservationTimeoutSeconds { get; set; } = 45;

--- a/tests/CloudHealthOffice.AuthorizationService.Tests/AuthorizationsControllerTests.cs
+++ b/tests/CloudHealthOffice.AuthorizationService.Tests/AuthorizationsControllerTests.cs
@@ -197,6 +197,80 @@ public class AuthorizationsControllerTests : IClassFixture<AuthorizationApiFacto
         Assert.True(result.TryGetProperty("isValid", out _));
     }
 
+    [Fact]
+    public async Task DevSeed_WhenAuthorizationIsNew_CreatesApprovedFixture()
+    {
+        var authNumber = $"AUTH-SEED-{Guid.NewGuid():N}";
+        _factory.AuthorizationRepository.GetByAuthorizationNumberAsync(authNumber)
+            .Returns((Authorization?)null);
+        _factory.AuthorizationRepository.CreateAsync(Arg.Any<Authorization>())
+            .Returns(call => call.Arg<Authorization>());
+
+        var response = await _client.PostAsJsonAsync("/api/authorizations/dev-seed", new
+        {
+            authorizations = new[]
+            {
+                BuildSeedAuthorizationPayload(authNumber)
+            }
+        }, Json);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+        Assert.Equal(1, result.GetProperty("total").GetInt32());
+        Assert.Equal(1, result.GetProperty("created").GetInt32());
+        Assert.Equal(0, result.GetProperty("updated").GetInt32());
+        await _factory.AuthorizationRepository.Received(1).CreateAsync(
+            Arg.Is<Authorization>(authorization =>
+                authorization.AuthorizationNumber == authNumber
+                && authorization.Status == AuthorizationStatus.Approved));
+    }
+
+    [Fact]
+    public async Task DevSeed_WhenAuthorizationExists_UpdatesExistingFixture()
+    {
+        var authNumber = $"AUTH-SEED-{Guid.NewGuid():N}";
+        var existing = new Authorization
+        {
+            Id = Guid.NewGuid().ToString(),
+            TenantId = "test-tenant",
+            AuthorizationNumber = authNumber,
+            MemberId = "MBR-EXISTING",
+            PatientFirstName = "Existing",
+            PatientLastName = "Member",
+            PatientDateOfBirth = DateTime.UtcNow.AddYears(-30),
+            LineOfBusiness = LineOfBusiness.Medicaid,
+            RequestingProviderNPI = "1234567890",
+            AuthorizationType = AuthorizationType.PreAuthorization,
+            ServiceTypeCode = "48",
+            RequestedServiceDateFrom = DateTime.UtcNow.Date,
+            Status = AuthorizationStatus.Submitted,
+            CreatedDate = DateTime.UtcNow.AddDays(-3)
+        };
+        _factory.AuthorizationRepository.GetByAuthorizationNumberAsync(authNumber)
+            .Returns(existing);
+        _factory.AuthorizationRepository.UpdateAsync(Arg.Any<Authorization>())
+            .Returns(call => call.Arg<Authorization>());
+
+        var response = await _client.PostAsJsonAsync("/api/authorizations/dev-seed", new
+        {
+            authorizations = new[]
+            {
+                BuildSeedAuthorizationPayload(authNumber)
+            }
+        }, Json);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>(Json);
+        Assert.Equal(1, result.GetProperty("total").GetInt32());
+        Assert.Equal(0, result.GetProperty("created").GetInt32());
+        Assert.Equal(1, result.GetProperty("updated").GetInt32());
+        await _factory.AuthorizationRepository.Received(1).UpdateAsync(
+            Arg.Is<Authorization>(authorization =>
+                authorization.Id == existing.Id
+                && authorization.AuthorizationNumber == authNumber
+                && authorization.Status == AuthorizationStatus.Approved));
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     // DELETE /api/authorizations/{id} — Cancel Authorization
     // ═══════════════════════════════════════════════════════════════════
@@ -234,5 +308,55 @@ public class AuthorizationsControllerTests : IClassFixture<AuthorizationApiFacto
         var response = await noAuthClient.GetAsync("/api/authorizations/search?page=1&pageSize=10");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private static object BuildSeedAuthorizationPayload(string authNumber)
+    {
+        var serviceDate = DateTime.UtcNow.Date.AddDays(7);
+        return new
+        {
+            tenantId = "test-tenant",
+            authorizationNumber = authNumber,
+            memberId = "MBR-SEED-001",
+            patientFirstName = "Seed",
+            patientLastName = "Member",
+            patientDateOfBirth = DateTime.UtcNow.Date.AddYears(-30),
+            lineOfBusiness = "Medicaid",
+            requestingProviderNPI = "1234567890",
+            requestingProviderName = "Seed Provider",
+            servicingProviderNPI = "1234567890",
+            servicingProviderName = "Seed Provider",
+            authorizationType = "PreAuthorization",
+            certificationType = "I",
+            serviceTypeCode = "48",
+            levelOfService = "E",
+            requestedServiceDateFrom = serviceDate,
+            requestedServiceDateTo = serviceDate,
+            diagnosisCodes = new[]
+            {
+                new { code = "Z00.00", codeQualifier = "BK", description = "General examination" }
+            },
+            requestedServices = new[]
+            {
+                new
+                {
+                    procedureCode = "99213",
+                    procedureDescription = "Office visit",
+                    requestedUnits = 1,
+                    unitType = "UN",
+                    placeOfServiceCode = "21",
+                    approvedUnits = 1,
+                    serviceStatus = "A1"
+                }
+            },
+            status = "Approved",
+            reviewDecision = "A1",
+            approvedUnits = 1,
+            approvedServiceDateFrom = serviceDate.AddDays(-1),
+            approvedServiceDateTo = serviceDate.AddDays(30),
+            expirationDate = serviceDate.AddDays(30),
+            submittedDate = serviceDate.AddDays(-10),
+            reviewedDate = serviceDate.AddDays(-9)
+        };
     }
 }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -190,7 +190,7 @@ public class MccWorkflowValidationTests
     [InlineData(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth)]
     [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProvider)]
     [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProcedure)]
-    public void ExpectedValidationFor_UnsupportedPriorAuthValidationEdgeCase_ReturnsUnsupported(
+    public void ExpectedValidationFor_PriorAuthValidationEdgeCaseWithoutCapabilities_ReturnsUnsupported(
         EdgeCaseScenario scenario)
     {
         var claim = CreateClaim(
@@ -218,6 +218,68 @@ public class MccWorkflowValidationTests
         Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
         Assert.True(expected.IsUnsupported);
         Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+    }
+
+    [Theory]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth)]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProcedure)]
+    public void ExpectedValidationFor_PriorAuthValidationEvidenceCapability_ReturnsScoreableDenial(
+        EdgeCaseScenario scenario)
+    {
+        var claim = CreateClaim(
+            claimType: "Institutional",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: scenario is EdgeCaseScenario.PriorAuthRequired_ExpiredAuth ? "Expired" : "OnFile",
+            priorAuthNumber: "AUTH-TEST",
+            renderingState: "TX");
+        claim.EdgeCase = scenario;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "197"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(
+            claim,
+            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: MccWorkflowValidation.PriorAuthRequiredCode);
+
+        Assert.Equal($"EdgeCase:{scenario}", expected.Scenario);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_WrongProviderPriorAuthRemainsUnsupportedWithCapabilities()
+    {
+        var claim = CreateClaim(
+            claimType: "Institutional",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "OnFile",
+            priorAuthNumber: "AUTH-TEST",
+            renderingState: "TX");
+        claim.EdgeCase = EdgeCaseScenario.PriorAuthRequired_WrongProvider;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "197"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(
+            claim,
+            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+
+        Assert.Equal("EdgeCase:PriorAuthRequired_WrongProvider", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
     }
 
     [Fact]

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -56,6 +56,22 @@ public class ValidatorOptionsTests
     }
 
     [Fact]
+    public void Parse_WhenAuthorizationUrlProvided_AppliesOverride()
+    {
+        var options = ValidatorOptions.Parse(["--authorization-url", "http://authorization-service/"]);
+
+        Assert.Equal("http://authorization-service", options.AuthorizationUrl);
+    }
+
+    [Fact]
+    public void Parse_WhenNoSeedAuthorizationsProvided_DisablesAuthorizationSeeding()
+    {
+        var options = ValidatorOptions.Parse(["--no-seed-authorizations"]);
+
+        Assert.False(options.SeedAuthorizations);
+    }
+
+    [Fact]
     public void Parse_WhenPendObservationOptionsProvided_AppliesOverrides()
     {
         var options = ValidatorOptions.Parse([


### PR DESCRIPTION
## Summary
- add a development/test-only authorization fixture seed endpoint for deterministic MCC prior-auth evidence
- seed authorization fixtures from the MCC validator and only enable expired-auth / wrong-procedure scoring when that seed succeeds
- keep wrong-provider prior-auth scenarios unsupported because the authorization validation endpoint does not currently validate provider NPI
- pass the authorization URL and seed toggle through the local Kubernetes runner

## Why
The MCC prior-auth edge cases should move out of `Unsupported` only when the validator can prove the backing authorization-service evidence exists. This keeps the benchmark honest: scoreable cases become scoreable, while unsupported service capabilities stay visibly unsupported.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore`
- `dotnet test tests/CloudHealthOffice.AuthorizationService.Tests/CloudHealthOffice.AuthorizationService.Tests.csproj --no-restore`