### PR TITLE
Fix MCC prior-auth evidence scoring

### DIFF
--- a/src/services/authorization-service/AuthorizationService.Tests/Controllers/AuthorizationsControllerSlaTests.cs
+++ b/src/services/authorization-service/AuthorizationService.Tests/Controllers/AuthorizationsControllerSlaTests.cs
@@ -1,6 +1,8 @@
 using AuthorizationService.Controllers;
 using AuthorizationService.Models;
 using AuthorizationService.Repositories;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -9,14 +11,56 @@ namespace AuthorizationService.Tests.Controllers;
 public class AuthorizationsControllerSlaTests
 {
     private readonly Mock<IAuthorizationRepository> _repositoryMock;
+    private readonly Mock<IWebHostEnvironment> _environmentMock;
     private readonly Mock<ILogger<AuthorizationsController>> _loggerMock;
     private readonly AuthorizationsController _controller;
 
     public AuthorizationsControllerSlaTests()
     {
         _repositoryMock = new Mock<IAuthorizationRepository>();
+        _environmentMock = new Mock<IWebHostEnvironment>();
+        _environmentMock.SetupGet(x => x.EnvironmentName).Returns("Test");
         _loggerMock = new Mock<ILogger<AuthorizationsController>>();
-        _controller = new AuthorizationsController(_repositoryMock.Object, _loggerMock.Object);
+        _controller = new AuthorizationsController(_repositoryMock.Object, _environmentMock.Object, _loggerMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    [Fact]
+    public async Task ValidateAuthorization_AllowsAnonymousLocalValidation()
+    {
+        var authorization = CreateApprovedAuth("AUTH-001", expiresOn: new DateTime(2026, 6, 30, 0, 0, 0, DateTimeKind.Utc));
+        _repositoryMock
+            .Setup(r => r.GetByAuthorizationNumberAsync("AUTH-001"))
+            .ReturnsAsync(authorization);
+
+        var result = await _controller.ValidateAuthorization(
+            "AUTH-001",
+            procedureCode: "99201",
+            serviceDate: new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<AuthorizationValidationResponse>().Subject;
+        response.IsValid.Should().BeFalse();
+        response.ValidationMessage.Should().Be("Authorization expired or not yet active");
+    }
+
+    [Fact]
+    public async Task ValidateAuthorization_ForbidsAnonymousProductionValidation()
+    {
+        _environmentMock.SetupGet(x => x.EnvironmentName).Returns("Production");
+
+        var result = await _controller.ValidateAuthorization(
+            "AUTH-001",
+            procedureCode: "99201",
+            serviceDate: new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        result.Result.Should().BeOfType<ForbidResult>();
+        _repositoryMock.Verify(r => r.GetByAuthorizationNumberAsync(It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -112,5 +156,37 @@ public class AuthorizationsControllerSlaTests
         RequestedServiceDateFrom = DateTime.UtcNow.AddDays(-10),
         Status = AuthorizationStatus.Submitted,
         SubmittedDate = DateTime.UtcNow.AddHours(-hoursAgo),
+    };
+
+    private static Authorization CreateApprovedAuth(string authNumber, DateTime expiresOn) => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        TenantId = "tenant-1",
+        AuthorizationNumber = authNumber,
+        MemberId = "MBR-001",
+        PatientFirstName = "Jane",
+        PatientLastName = "Doe",
+        PatientDateOfBirth = new DateTime(1990, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        LineOfBusiness = LineOfBusiness.Medicaid,
+        RequestingProviderNPI = "1234567890",
+        AuthorizationType = AuthorizationType.PreAuthorization,
+        ServiceTypeCode = "1",
+        LevelOfService = "U",
+        RequestedServiceDateFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        ApprovedServiceDateFrom = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        ApprovedServiceDateTo = expiresOn,
+        ExpirationDate = expiresOn,
+        Status = AuthorizationStatus.Approved,
+        SubmittedDate = DateTime.UtcNow.AddDays(-7),
+        RequestedServices =
+        {
+            new RequestedService
+            {
+                ProcedureCode = "99201",
+                ServiceStatus = "A1",
+                RequestedUnits = 1,
+                ApprovedUnits = 1
+            }
+        }
     };
 }

--- a/src/services/authorization-service/Controllers/AuthorizationsController.cs
+++ b/src/services/authorization-service/Controllers/AuthorizationsController.cs
@@ -100,6 +100,7 @@ public class AuthorizationsController : ControllerBase
     /// Check if authorization is valid for claim submission
     /// CRITICAL for claims processing: validates auth before submitting 837
     /// </summary>
+    [AllowAnonymous]
     [HttpGet("{authNumber}/validate")]
     [ProducesResponseType(typeof(AuthorizationValidationResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -108,6 +109,11 @@ public class AuthorizationsController : ControllerBase
         [FromQuery] string? procedureCode = null,
         [FromQuery] DateTime? serviceDate = null)
     {
+        if (!AllowsAnonymousLocalValidation() && HttpContext?.User.Identity?.IsAuthenticated != true)
+        {
+            return Forbid();
+        }
+
         var checkDate = serviceDate ?? DateTime.UtcNow;
 
         _logger.LogInformation(
@@ -163,6 +169,10 @@ public class AuthorizationsController : ControllerBase
 
         return Ok(response);
     }
+
+    private bool AllowsAnonymousLocalValidation() =>
+        _environment.IsDevelopment() ||
+        string.Equals(_environment.EnvironmentName, "Test", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Seed deterministic prior authorization fixtures for local validation.

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -341,7 +341,7 @@ builder.Services.AddHttpClient(UpstreamClientNames.AuthorizationService, client 
 {
     client.BaseAddress = new Uri(
         builder.Configuration["Services:AuthorizationService"]
-        ?? "http://authorization-service:8080");
+        ?? "http://authorization-service");
     client.Timeout = TimeSpan.FromSeconds(5);
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 }).SetHandlerLifetime(TimeSpan.FromMinutes(5));

--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -515,6 +515,23 @@ public class ClaimRepository : IClaimRepository
         && incomingAdjudication.PayerPayment == 0
         && HasDenialEvidence(incomingAdjudication);
 
+    /// <summary>
+    /// True when an incoming adjudication result is strong enough to attempt
+    /// the narrow live-row contradiction repair after a guarded status write
+    /// was blocked. The live datastore predicate still decides whether a row
+    /// is actually repairable, which lets this cover races where the status
+    /// changed after the caller's pre-write snapshot.
+    /// </summary>
+    public static bool CanAttemptContradictoryStatusRepair(
+        ClaimStatus desiredStatus,
+        AdjudicationResult incomingAdjudication) =>
+        (desiredStatus == ClaimStatus.Approved
+            && incomingAdjudication.PayerPayment > 0
+            && !HasDenialEvidence(incomingAdjudication))
+        || (desiredStatus == ClaimStatus.Denied
+            && incomingAdjudication.PayerPayment == 0
+            && HasDenialEvidence(incomingAdjudication));
+
     private static bool HasDenialEvidence(AdjudicationResult? adjudication) =>
         adjudication is not null
         && (!string.IsNullOrWhiteSpace(adjudication.DenialReasonCode)
@@ -1357,7 +1374,9 @@ public class ClaimRepository : IClaimRepository
                     rowId,
                     resolvedStatus.Value,
                     MapStatusToVersionState(resolvedStatus.Value),
-                    ct)
+                    ct,
+                    adjudicationResult,
+                    head.Status)
                 .ConfigureAwait(false);
         }
 
@@ -1478,7 +1497,7 @@ public class ClaimRepository : IClaimRepository
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
         {
-            if (incomingAdjudication is not null
+            var snapshotAllowsRepair = incomingAdjudication is not null
                 && preWriteStatus is not null
                 && (CanRepairContradictoryDeniedSummary(
                         preWriteStatus.Value,
@@ -1487,7 +1506,11 @@ public class ClaimRepository : IClaimRepository
                     || CanRepairContradictoryApprovedSummary(
                         preWriteStatus.Value,
                         desiredStatus,
-                        incomingAdjudication)))
+                        incomingAdjudication));
+            var liveEvidenceAllowsRepair = incomingAdjudication is not null
+                && CanAttemptContradictoryStatusRepair(desiredStatus, incomingAdjudication);
+
+            if (snapshotAllowsRepair || liveEvidenceAllowsRepair)
             {
                 var repairFilter = desiredStatus == ClaimStatus.Denied
                     ? ContradictoryApprovedRepairFilterPredicate

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -609,7 +609,9 @@ public class ClaimRepositoryMongo : IClaimRepository
                     head.Id,
                     resolvedStatus.Value,
                     ClaimRepository.MapStatusToVersionState(resolvedStatus.Value),
-                    ct)
+                    ct,
+                    adjudicationResult,
+                    head.Status)
                 .ConfigureAwait(false);
         }
 
@@ -715,7 +717,7 @@ public class ClaimRepositoryMongo : IClaimRepository
             return new StatusWriteResult(StatusWriteOutcome.Applied, desiredStatus);
         }
 
-        if (incomingAdjudication is not null
+        var snapshotAllowsRepair = incomingAdjudication is not null
             && preWriteStatus is not null
             && (ClaimRepository.CanRepairContradictoryDeniedSummary(
                     preWriteStatus.Value,
@@ -724,7 +726,11 @@ public class ClaimRepositoryMongo : IClaimRepository
                 || ClaimRepository.CanRepairContradictoryApprovedSummary(
                     preWriteStatus.Value,
                     desiredStatus,
-                    incomingAdjudication)))
+                    incomingAdjudication));
+        var liveEvidenceAllowsRepair = incomingAdjudication is not null
+            && ClaimRepository.CanAttemptContradictoryStatusRepair(desiredStatus, incomingAdjudication);
+
+        if (snapshotAllowsRepair || liveEvidenceAllowsRepair)
         {
             var repairEvidenceFilter = desiredStatus == ClaimStatus.Denied
                 ? b.And(

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -10,6 +10,7 @@ data:
   Services__CoverageService: "http://coverage-service"
   Services__MemberService: "http://member-service"
   Services__ProviderService: "http://provider-service"
+  Services__AuthorizationService: "http://authorization-service"
   Services__BenefitPlanServiceTimeoutSeconds: "5"
   Messaging__AdjudicationMaxConcurrentCalls: "32"
 ---
@@ -76,6 +77,11 @@ spec:
             configMapKeyRef:
               name: claims-service-config
               key: Services__ProviderService
+        - name: Services__AuthorizationService
+          valueFrom:
+            configMapKeyRef:
+              name: claims-service-config
+              key: Services__AuthorizationService
         - name: Services__BenefitPlanServiceTimeoutSeconds
           valueFrom:
             configMapKeyRef:

--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -93,7 +93,7 @@ internal sealed class MccClaimStatusObserver
                         result.BusinessDenialCode),
                     Outcome = observed.Outcome,
                     BusinessDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
-                        ? result.BusinessDenialCode
+                        ? observed.BusinessDenialCode ?? result.BusinessDenialCode
                         : null
                 };
             }
@@ -121,6 +121,13 @@ internal sealed class MccClaimStatusObserver
     public async Task<ClaimValidationResult> DetectUnexpectedPendAsync(
         ClaimValidationResult result,
         CancellationToken cancellationToken = default)
+        => await DetectUnexpectedPendAsync(result, TimeSpan.Zero, TimeSpan.Zero, cancellationToken);
+
+    public async Task<ClaimValidationResult> DetectUnexpectedPendAsync(
+        ClaimValidationResult result,
+        TimeSpan terminalObservationTimeout,
+        TimeSpan terminalObservationInterval,
+        CancellationToken cancellationToken = default)
     {
         if (result.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()
             || string.IsNullOrWhiteSpace(result.SubmittedClaimId)
@@ -131,18 +138,52 @@ internal sealed class MccClaimStatusObserver
 
         try
         {
-            var observed = await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
-            if (observed?.Outcome is not ClaimValidationOutcome.Pended)
+            var shouldWaitForTerminal = ShouldWaitForPersistedTerminalOutcome(result);
+            var observed = shouldWaitForTerminal
+                ? await ObserveTerminalAsync(result.SubmittedClaimId, terminalObservationTimeout, terminalObservationInterval, cancellationToken)
+                : await _source.GetAsync(result.SubmittedClaimId, cancellationToken);
+
+            if (shouldWaitForTerminal && observed is not { IsTerminal: true })
+            {
+                return result with
+                {
+                    ValidationStatus = MccWorkflowValidation.ObservationTimeoutStatus,
+                    Outcome = ClaimValidationOutcome.ObservationTimeout,
+                    FailureStage = "terminal-status-observation",
+                    Error = $"Timed out waiting for persisted claim status to become terminal after {terminalObservationTimeout.TotalSeconds:N0}s"
+                };
+            }
+
+            if (observed?.Outcome is ClaimValidationOutcome.Pended)
+            {
+                return result with
+                {
+                    Outcome = ClaimValidationOutcome.Pended,
+                    ValidationStatus = MccWorkflowValidation.MismatchedStatus,
+                    FailureStage = "false-pend-observation",
+                    Error = $"Expected {result.ExpectedOutcome}, but persisted claim status is pended ({observed.PendCode ?? "no pend code"})"
+                };
+            }
+
+            if (observed is null || !ShouldReconcilePersistedTerminalOutcome(result, observed))
             {
                 return result;
             }
 
+            var expected = ExpectedValidationFromResult(result);
+            var businessDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
+                ? observed.BusinessDenialCode ?? result.BusinessDenialCode
+                : null;
+
             return result with
             {
-                Outcome = ClaimValidationOutcome.Pended,
-                ValidationStatus = MccWorkflowValidation.MismatchedStatus,
-                FailureStage = "false-pend-observation",
-                Error = $"Expected {result.ExpectedOutcome}, but persisted claim status is pended ({observed.PendCode ?? "no pend code"})"
+                Outcome = observed.Outcome,
+                BusinessDenialCode = businessDenialCode,
+                ValidationStatus = MccWorkflowValidation.ValidationStatus(
+                    expected,
+                    observed.Outcome,
+                    businessDenialCode),
+                FailureStage = "terminal-status-observation"
             };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -156,18 +197,83 @@ internal sealed class MccClaimStatusObserver
             };
         }
     }
+
+    private async Task<ObservedClaimStatus?> ObserveTerminalAsync(
+        string submittedClaimId,
+        TimeSpan timeout,
+        TimeSpan interval,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (true)
+        {
+            var observed = await _source.GetAsync(submittedClaimId, cancellationToken);
+            if (observed?.IsTerminal is true)
+            {
+                return observed;
+            }
+
+            var remaining = deadline - DateTimeOffset.UtcNow;
+            if (remaining <= TimeSpan.Zero || timeout <= TimeSpan.Zero)
+            {
+                return observed;
+            }
+
+            var delay = interval <= TimeSpan.Zero || interval < remaining ? interval : remaining;
+            if (delay > TimeSpan.Zero)
+            {
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+    }
+
+    private static bool ShouldWaitForPersistedTerminalOutcome(ClaimValidationResult result)
+        => result.ExpectedOutcome == ClaimValidationOutcome.BusinessDenial.ToString()
+            && result.ValidationStatus == MccWorkflowValidation.MismatchedStatus;
+
+    private static bool ShouldReconcilePersistedTerminalOutcome(
+        ClaimValidationResult result,
+        ObservedClaimStatus observed)
+        => observed.IsTerminal
+            && observed.Outcome is ClaimValidationOutcome.Paid or ClaimValidationOutcome.BusinessDenial
+            && (observed.Outcome != result.Outcome
+                || (observed.Outcome is ClaimValidationOutcome.BusinessDenial
+                    && !string.Equals(
+                        observed.BusinessDenialCode,
+                        result.BusinessDenialCode,
+                        StringComparison.OrdinalIgnoreCase)));
+
+    private static ExpectedValidation ExpectedValidationFromResult(ClaimValidationResult result)
+        => new(
+            result.ValidationScenario,
+            ParseExpectedOutcome(result.ExpectedOutcome),
+            result.ExpectedBusinessDenialCode);
+
+    private static ClaimValidationOutcome? ParseExpectedOutcome(string? expectedOutcome)
+        => expectedOutcome?.Trim() switch
+        {
+            { } value when value.Equals(ClaimValidationOutcome.Paid.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                ClaimValidationOutcome.Paid,
+            { } value when value.Equals(ClaimValidationOutcome.BusinessDenial.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                ClaimValidationOutcome.BusinessDenial,
+            { } value when value.Equals(ClaimValidationOutcome.Pended.ToString(), StringComparison.OrdinalIgnoreCase) =>
+                ClaimValidationOutcome.Pended,
+            _ => null
+        };
 }
 
 internal sealed record ObservedClaimStatus(
     ClaimValidationOutcome Outcome,
     string RawStatus,
     string? PendCode,
-    bool IsTerminal)
+    bool IsTerminal,
+    string? BusinessDenialCode = null)
 {
     public static ObservedClaimStatus FromClaimJson(JsonElement root)
     {
         var rawStatus = TryReadStringOrNumber(root, "status") ?? string.Empty;
         var pendCode = TryReadPendCode(root);
+        var businessDenialCode = MccWorkflowValidation.NormalizeBusinessDenialCode(TryReadBusinessDenialCode(root));
         var outcome = rawStatus.Trim() switch
         {
             "4" => ClaimValidationOutcome.Pended,
@@ -188,7 +294,8 @@ internal sealed record ObservedClaimStatus(
             pendCode,
             outcome is ClaimValidationOutcome.Pended
                 or ClaimValidationOutcome.Paid
-                or ClaimValidationOutcome.BusinessDenial);
+                or ClaimValidationOutcome.BusinessDenial,
+            businessDenialCode);
     }
 
     private static string? TryReadStringOrNumber(JsonElement root, string propertyName)
@@ -217,5 +324,24 @@ internal sealed record ObservedClaimStatus(
         }
 
         return pendCode.GetString();
+    }
+
+    private static string? TryReadBusinessDenialCode(JsonElement root)
+    {
+        if (!root.TryGetProperty("adjudicationResult", out var adjudicationResult)
+            || adjudicationResult.ValueKind is not JsonValueKind.Object
+            || !adjudicationResult.TryGetProperty("denialReasonCode", out var denialReasonCode))
+        {
+            return null;
+        }
+
+        return denialReasonCode.ValueKind switch
+        {
+            JsonValueKind.String => denialReasonCode.GetString(),
+            JsonValueKind.Number => denialReasonCode.TryGetInt32(out var number)
+                ? number.ToString()
+                : denialReasonCode.GetRawText(),
+            _ => null
+        };
     }
 }

--- a/src/tools/mcc-platform-validator/MccValidationProviderNormalizer.cs
+++ b/src/tools/mcc-platform-validator/MccValidationProviderNormalizer.cs
@@ -1,0 +1,47 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+public static class MccValidationProviderNormalizer
+{
+    public static int Normalize(
+        IReadOnlyCollection<SyntheticClaim> claims,
+        int seed,
+        Guid runId,
+        MccWorkflowValidationCapabilities? capabilities = null)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+
+        var scenarioIndex = 0;
+        var normalized = 0;
+        foreach (var claim in claims.OrderBy(c => c.ClaimId, StringComparer.Ordinal))
+        {
+            var expected = MccWorkflowValidation.ExpectedValidationFor(claim, capabilities);
+            if (expected.ExpectedOutcome is null)
+            {
+                continue;
+            }
+
+            MccValidationProviderProfile.ForceAdjudicatable(claim.BillingProvider, claim.DateOfService);
+            claim.BillingProvider.Npi = MccValidationProviderIdentity.BuildNpi(seed, runId, scenarioIndex, role: 0);
+
+            if (!string.Equals(
+                    expected.ExpectedBusinessDenialCode,
+                    MccWorkflowValidation.ProviderExcludedCode,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                MccValidationProviderProfile.ForceAdjudicatable(claim.RenderingProvider, claim.DateOfService);
+                claim.RenderingProvider.Npi = MccValidationProviderIdentity.BuildNpi(seed, runId, scenarioIndex, role: 1);
+            }
+            else
+            {
+                claim.RenderingProvider.Npi = MccValidationProviderIdentity.BuildNpi(seed, runId, scenarioIndex, role: 2);
+            }
+
+            scenarioIndex++;
+            normalized++;
+        }
+
+        return normalized;
+    }
+}

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -154,6 +154,23 @@ public static class MccWorkflowValidation
         return MatchedStatus;
     }
 
+    public static string? NormalizeBusinessDenialCode(string? code)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return null;
+        }
+
+        var trimmed = code.Trim();
+        if (trimmed.Equals("197", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("CARC_197", StringComparison.OrdinalIgnoreCase))
+        {
+            return PriorAuthRequiredCode;
+        }
+
+        return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
+    }
+
     private static ClaimValidationOutcome? OutcomeFromDisposition(string? disposition)
     {
         return disposition?.Trim() switch
@@ -210,15 +227,7 @@ public static class MccWorkflowValidation
     }
 
     private static string? NormalizeExpectedCode(string? code)
-    {
-        if (string.IsNullOrWhiteSpace(code))
-        {
-            return null;
-        }
-
-        var trimmed = code.Trim();
-        return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
-    }
+        => NormalizeBusinessDenialCode(code);
 }
 
 public sealed class MccAnswerKey

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -88,7 +88,11 @@ var claims = await MeasureLifecycleValuePhaseAsync(
 var providerPool = await MeasureLifecycleValuePhaseAsync(lifecycleTimings, "Fixture normalization", "Preparation", () =>
 {
     NormalizePriorAuthEdgeCases(claims, options);
-    NormalizeValidationProviderProfiles(claims, options.Seed, validationPlanId);
+    MccValidationProviderNormalizer.Normalize(
+        claims,
+        options.Seed,
+        validationPlanId,
+        new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: options.SeedAuthorizations));
     MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
     MccCleanPaidFixture.NormalizeClaims(claims);
     return Task.FromResult(MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId));
@@ -399,7 +403,8 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         adjudicationElapsed = stage.Elapsed;
 
         var skipSynchronousWriteback = options.SkipClaimUpdate
-            || expectedValidation.ExpectedOutcome is ClaimValidationOutcome.Pended;
+            || expectedValidation.ExpectedOutcome is ClaimValidationOutcome.Pended
+            || RequiresClaimsServiceWorkflowObservation(claim, expectedValidation);
         var outcome = adjudicated.Success
             ? ClaimValidationOutcome.Paid
             : ClaimValidationOutcome.BusinessDenial;
@@ -619,37 +624,6 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
     InjectUncoveredServiceScenarios(claims);
     InjectPriorAuthScenarios(claims, options);
     return claims;
-}
-
-static void NormalizeValidationProviderProfiles(List<SyntheticClaim> claims, int seed, Guid runId)
-{
-    var scenarioIndex = 0;
-    foreach (var claim in claims.OrderBy(c => c.ClaimId, StringComparer.Ordinal))
-    {
-        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
-        if (expected.ExpectedOutcome is null)
-        {
-            continue;
-        }
-
-        ForceAdjudicatableProviderProfile(claim.BillingProvider, claim.DateOfService);
-        claim.BillingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 0);
-
-        if (!string.Equals(
-                expected.ExpectedBusinessDenialCode,
-                MccWorkflowValidation.ProviderExcludedCode,
-                StringComparison.OrdinalIgnoreCase))
-        {
-            ForceAdjudicatableProviderProfile(claim.RenderingProvider, claim.DateOfService);
-            claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 1);
-        }
-        else
-        {
-            claim.RenderingProvider.Npi = BuildSyntheticValidationProviderNpi(seed, runId, scenarioIndex, role: 2);
-        }
-
-        scenarioIndex++;
-    }
 }
 
 static void InjectCleanPaidScenarios(List<SyntheticClaim> claims)
@@ -1004,11 +978,6 @@ static string BuildSyntheticExcludedProviderNpi(int seed, int index)
         var baseNineDigits = $"900{value:D6}";
         return $"{baseNineDigits}{CalculateNpiCheckDigit(baseNineDigits)}";
     }
-}
-
-static string BuildSyntheticValidationProviderNpi(int seed, Guid runId, int index, int role)
-{
-    return MccValidationProviderIdentity.BuildNpi(seed, runId, index, role);
 }
 
 static int CalculateNpiCheckDigit(string baseNineDigits)
@@ -2121,15 +2090,15 @@ static bool IsKnownBusinessDenialCode(string errorCode)
         "PRIOR_AUTH_REQUIRED";
 
 static string? NormalizeBusinessDenialCode(string? code)
-{
-    if (string.IsNullOrWhiteSpace(code))
-    {
-        return null;
-    }
+    => MccWorkflowValidation.NormalizeBusinessDenialCode(code);
 
-    var trimmed = code.Trim();
-    return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
-}
+static bool RequiresClaimsServiceWorkflowObservation(SyntheticClaim claim, ExpectedValidation expected)
+    => expected.ExpectedOutcome is ClaimValidationOutcome.BusinessDenial
+        && string.Equals(
+            expected.ExpectedBusinessDenialCode,
+            MccWorkflowValidation.PriorAuthRequiredCode,
+            StringComparison.OrdinalIgnoreCase)
+        && !string.IsNullOrWhiteSpace(claim.PriorAuthNumber);
 
 static string LineOfBusinessName(int lineOfBusiness) => lineOfBusiness switch
 {
@@ -2245,10 +2214,15 @@ static async Task<List<ClaimValidationResult>> DetectUnexpectedPendResultsAsync(
     await Parallel.ForEachAsync(candidates,
         new ParallelOptions { MaxDegreeOfParallelism = Math.Min(candidates.Count, Math.Max(options.Parallelism, 64)) },
         async (result, cancellationToken) =>
-            observed[result.GeneratedClaimId] = await observer.DetectUnexpectedPendAsync(result, cancellationToken));
+            observed[result.GeneratedClaimId] = await observer.DetectUnexpectedPendAsync(
+                result,
+                TimeSpan.FromSeconds(options.PendObservationTimeoutSeconds),
+                TimeSpan.FromMilliseconds(options.PendObservationIntervalMilliseconds),
+                cancellationToken));
 
     var falsePends = observed.Values.Count(r => r.FailureStage == "false-pend-observation" && r.Outcome == ClaimValidationOutcome.Pended);
-    Console.WriteLine($"  False-pend sweep: {falsePends:N0} unexpected pends");
+    var terminalReconciliations = observed.Values.Count(r => r.FailureStage == "terminal-status-observation");
+    Console.WriteLine($"  False-pend sweep: {falsePends:N0} unexpected pends, {terminalReconciliations:N0} terminal outcomes reconciled");
     Console.WriteLine();
     return results.Select(r => observed.TryGetValue(r.GeneratedClaimId, out var updated) ? updated : r)
         .OrderBy(r => r.GeneratedClaimId, StringComparer.Ordinal).ToList();

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/ClaimRepositoryVersioningTests.cs
@@ -523,6 +523,42 @@ public class ClaimRepositoryVersioningTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpdateAdjudicationProjectionAsync_withDeniedEvidence_repairsApprovedStatusRace()
+    {
+        // Regression for async pipeline races where the synchronous summary
+        // projected Approved first, then the async adjudication projection
+        // wrote denial evidence. The guarded status patch must repair the
+        // impossible Approved + denial-evidence state without weakening pend
+        // protection.
+        var head = BuildVersion("chain-approved-denial-race", "row-1", n: 1, ClaimVersionState.Adjudicated);
+        head.Status = ClaimStatus.Approved;
+        head.AdjudicationResult = new AdjudicationResult { AllowedAmount = 100m, PayerPayment = 80m };
+        await _repo.CreateAsync(head);
+
+        var ok = await _repo.UpdateAdjudicationProjectionAsync(
+            Tenant,
+            "chain-approved-denial-race",
+            new AdjudicationResult
+            {
+                AllowedAmount = 0m,
+                PayerPayment = 0m,
+                DenialReasonCode = "197",
+                DenialReason = "Authorization expired or not yet active"
+            },
+            Array.Empty<LineAdjudicationResult>(),
+            isPend: false,
+            resolvedStatus: ClaimStatus.Denied);
+
+        ok.Should().BeTrue();
+        var reread = await _repo.GetVersionAsync("chain-approved-denial-race", "row-1");
+        reread!.Status.Should().Be(ClaimStatus.Denied);
+        reread.VersionState.Should().Be(ClaimVersionState.Denied);
+        reread.AdjudicationResult.Should().NotBeNull();
+        reread.AdjudicationResult!.DenialReasonCode.Should().Be("197");
+        reread.AdjudicationResult.DenialReason.Should().Be("Authorization expired or not yet active");
+    }
+
+    [Fact]
     public async Task UpdateAdjudicationProjectionAsync_withIsPendTrue_onAlreadyApprovedClaim_doesNotDowngradeStatus()
     {
         // Precedence rule (task requirement A.3): a claim that already

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
@@ -108,6 +108,25 @@ public class MccClaimStatusObserverTests
     }
 
     [Fact]
+    public void FromClaimJson_ParsesNumericBusinessDenialCode()
+    {
+        using var document = System.Text.Json.JsonDocument.Parse("""
+        {
+          "status": 6,
+          "adjudicationResult": {
+            "denialReasonCode": "197"
+          }
+        }
+        """);
+
+        var observed = ObservedClaimStatus.FromClaimJson(document.RootElement);
+
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, observed.Outcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, observed.BusinessDenialCode);
+        Assert.True(observed.IsTerminal);
+    }
+
+    [Fact]
     public async Task DetectUnexpectedPendAsync_WhenExpectedPaidPersistedPended_ReturnsMismatch()
     {
         var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
@@ -142,6 +161,36 @@ public class MccClaimStatusObserverTests
         var result = await observer.DetectUnexpectedPendAsync(source);
 
         Assert.Equal(source, result);
+    }
+
+    [Fact]
+    public async Task DetectUnexpectedPendAsync_WhenExpectedDeniedDirectPaidButPersistedDenied_ReconcilesToMatched()
+    {
+        var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([
+            new ObservedClaimStatus(
+                ClaimValidationOutcome.BusinessDenial,
+                "Denied",
+                null,
+                IsTerminal: true,
+                MccWorkflowValidation.PriorAuthRequiredCode)
+        ]));
+        var source = Result(ClaimValidationOutcome.Paid) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.BusinessDenial.ToString(),
+            ExpectedBusinessDenialCode = MccWorkflowValidation.PriorAuthRequiredCode,
+            ValidationStatus = MccWorkflowValidation.MismatchedStatus,
+            BusinessDenialCode = null
+        };
+
+        var result = await observer.DetectUnexpectedPendAsync(
+            source,
+            TimeSpan.FromSeconds(1),
+            TimeSpan.Zero);
+
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, result.Outcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, result.BusinessDenialCode);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, result.ValidationStatus);
+        Assert.Equal("terminal-status-observation", result.FailureStage);
     }
 
     private static ClaimValidationResult Result(ClaimValidationOutcome startingOutcome)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderNormalizerTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderNormalizerTests.cs
@@ -1,0 +1,108 @@
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccValidationProviderNormalizerTests
+{
+    private static readonly Guid RunId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    [Theory]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth)]
+    [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProcedure)]
+    public void Normalize_IsolatesPriorAuthValidationEvidenceWhenScoringIsEnabled(EdgeCaseScenario scenario)
+    {
+        var claim = PriorAuthClaim(scenario);
+
+        var normalized = MccValidationProviderNormalizer.Normalize(
+            new[] { claim },
+            seed: 42,
+            runId: RunId,
+            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+
+        Assert.Equal(1, normalized);
+        Assert.Equal(MccValidationProviderIdentity.BuildNpi(42, RunId, 0, role: 0), claim.BillingProvider.Npi);
+        Assert.Equal(MccValidationProviderIdentity.BuildNpi(42, RunId, 0, role: 1), claim.RenderingProvider.Npi);
+        AssertAdjudicatable(claim.BillingProvider);
+        AssertAdjudicatable(claim.RenderingProvider);
+    }
+
+    [Fact]
+    public void Normalize_LeavesPriorAuthValidationEvidenceUnsupportedWhenScoringIsDisabled()
+    {
+        var claim = PriorAuthClaim(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth);
+
+        var normalized = MccValidationProviderNormalizer.Normalize(
+            new[] { claim },
+            seed: 42,
+            runId: RunId);
+
+        Assert.Equal(0, normalized);
+        Assert.Equal("1111111111", claim.BillingProvider.Npi);
+        Assert.Equal("2222222222", claim.RenderingProvider.Npi);
+    }
+
+    [Fact]
+    public void Normalize_LeavesWrongProviderPriorAuthUnsupportedEvenWhenScoringIsEnabled()
+    {
+        var claim = PriorAuthClaim(EdgeCaseScenario.PriorAuthRequired_WrongProvider);
+
+        var normalized = MccValidationProviderNormalizer.Normalize(
+            new[] { claim },
+            seed: 42,
+            runId: RunId,
+            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+
+        Assert.Equal(0, normalized);
+        Assert.Equal("1111111111", claim.BillingProvider.Npi);
+        Assert.Equal("2222222222", claim.RenderingProvider.Npi);
+    }
+
+    private static SyntheticClaim PriorAuthClaim(EdgeCaseScenario scenario)
+    {
+        return new SyntheticClaim
+        {
+            ClaimId = "MCC-E-0000001",
+            ClaimType = "Institutional",
+            EdgeCase = scenario,
+            DateOfService = new DateTime(2026, 6, 20),
+            PlaceOfService = "21",
+            PriorAuthStatus = scenario is EdgeCaseScenario.PriorAuthRequired_ExpiredAuth ? "Expired" : "OnFile",
+            PriorAuthNumber = "AUTH-TEST",
+            BillingProvider = Provider("1111111111"),
+            RenderingProvider = Provider("2222222222"),
+            ExpectedOutcome = new ExpectedOutcome
+            {
+                Disposition = "Denied",
+                DenialReasonCode = "197"
+            }
+        };
+    }
+
+    private static SyntheticProvider Provider(string npi) => new()
+    {
+        Npi = npi,
+        ProviderType = "Individual",
+        SpecialtyCode = "207Q00000X",
+        TaxonomyCode = "207Q00000X",
+        IsParticipating = false,
+        NetworkStatus = "Excluded",
+        CredentialingStatus = "Excluded",
+        State = "TX",
+        ContractType = "FeeForService",
+        FeeScheduleId = "FS-MEDICAID",
+        EffectiveDate = new DateTime(2026, 7, 1),
+        TermDate = new DateTime(2026, 7, 10),
+        AcceptingNewPatients = false
+    };
+
+    private static void AssertAdjudicatable(SyntheticProvider provider)
+    {
+        Assert.True(provider.IsParticipating);
+        Assert.Equal("InNetwork", provider.NetworkStatus);
+        Assert.Equal("Active", provider.CredentialingStatus);
+        Assert.True(provider.AcceptingNewPatients);
+        Assert.Null(provider.TermDate);
+        Assert.Equal(new DateTime(2024, 6, 20, 0, 0, 0, DateTimeKind.Utc), provider.EffectiveDate);
+    }
+}


### PR DESCRIPTION
## Summary
- score prior-auth expired and wrong-procedure MCC cases from persisted claims-service evidence when authorization fixtures are enabled
- preserve validation-provider fixture semantics while normalizing provider profiles for scoreable scenarios
- repair adjudication projection status races when denied evidence arrives after an approved snapshot
- wire claims-service to the in-cluster authorization service and allow local/test authorization validation calls

## Why
The 100K in-progress dashboard exposed a large prior-auth workflow mismatch count. The synchronous benefit-plan response can report paid while the claims-service workflow later persists the authoritative prior-auth denial. The validator now skips conflicting sync writeback for those cases and reconciles terminal persisted status during the non-pend observation sweep.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore --filter "FullyQualifiedName~ClaimRepositoryVersioningTests"`
- `dotnet test src/services/authorization-service/AuthorizationService.Tests/AuthorizationService.Tests.csproj --no-restore`
- 1K local K8s MCC gate: 1,000 processed, 0 platform failures, 120/130 workflow checks matched, 0 mismatched, 10 unsupported, 0 observation timeouts
- Prior-auth expired/wrong-procedure scenarios matched after persisted terminal reconciliation
