### PR TITLE
Normalize MCC provider exclusion code

### DIFF
--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -168,6 +168,12 @@ public static class MccWorkflowValidation
             return PriorAuthRequiredCode;
         }
 
+        if (trimmed.Equals("B7", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("CARC_B7", StringComparison.OrdinalIgnoreCase))
+        {
+            return ProviderExcludedCode;
+        }
+
         return trimmed.All(char.IsDigit) ? $"CARC_{trimmed}" : trimmed;
     }
 

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -75,6 +75,30 @@ public class MccWorkflowValidationTests
         Assert.Equal("Matched", status);
     }
 
+    [Theory]
+    [InlineData("B7")]
+    [InlineData("CARC_B7")]
+    public void ExpectedValidationFor_ExcludedProviderClaim_NormalizesCarcB7(string actualBusinessDenialCode)
+    {
+        var claim = CreateClaim(
+            claimType: "Professional",
+            benefitPlanId: MccWorkflowValidation.ExcludedProviderPlanId,
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        claim.RenderingProvider.CredentialingStatus = "Excluded";
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            MccWorkflowValidation.NormalizeBusinessDenialCode(actualBusinessDenialCode));
+
+        Assert.Equal(MccWorkflowValidation.ProviderExcludedCode, expected.ExpectedBusinessDenialCode);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
+    }
+
     [Fact]
     public void ExpectedValidationFor_UncoveredServiceClaim_ReturnsCoverageDenialScenario()
     {


### PR DESCRIPTION
## Summary
- normalize provider-excluded CARC B7 denial codes to the MCC `PROVIDER_EXCLUDED` business-denial concept
- add regression coverage for excluded-provider validation with both `B7` and `CARC_B7` service output

## Root Cause
The benefit-plan/provider integrity path reports excluded-provider denials using CARC `B7`, while the MCC answer key expects the domain-level `PROVIDER_EXCLUDED` code. The validator was treating those equivalent signals as workflow mismatches.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore`
- 10K local Kubernetes MCC gate: job `mcc-b7-normalize-10k-095908`, dashboard run `5c8af6ae4412462e9e133d2be341a375`
  - 10,000 processed
  - 1,186/1,300 workflow checks matched
  - 0 workflow mismatches
  - 114 unsupported
  - payment gate 200/200 within $0.01
  - `ExcludedProviderDenied` 200/200 matched
