### PR TITLE
Record post-934 MCC 100K evidence

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-008/README.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/README.txt
@@ -2,13 +2,13 @@
 
 ## Episode summary
 
-Episode 008 covers the clean post-#928 100,000-claim local Kubernetes validation after payment accuracy, false-pend detection, accumulator handling, member fixture isolation, and provider identity hardening became part of the scored path.
+Episode 008 covers the clean post-#934 100,000-claim local Kubernetes validation after payment accuracy, false-pend detection, accumulator handling, member fixture isolation, provider identity hardening, prior-auth scoring, and provider-exclusion label normalization became part of the scored path.
 
-The result held: 100,000 processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000 of 2,000 comparable payments within one cent. The episode also explains why the 27:54 timed processing phase and 34:03 tracked lifecycle are different, and why the next local scaling target is controlled parallelism and internal service/writeback pressure rather than raw Docker CPU or memory.
+The result held: 100,000 processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends, and 2,000 of 2,000 comparable payments within one cent. The episode also explains why the 30:05 timed processing phase and 38:05 tracked lifecycle are different, and why the next local scaling target is controlled parallelism and internal service/writeback pressure rather than raw Docker CPU or memory.
 
-The pend counts are intentionally reported with scope: 921 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,614 scoreable expected-pay and expected-deny claims.
+The pend counts are intentionally reported with scope: 924 persisted pended outcomes overall, 920 expected-pend claims observed as pended, and zero unexpected pends across 10,934 scoreable expected-pay and expected-deny claims.
 
-Post-#928 note: provider-fixture hardening moved scoreable validation providers into wider, role-separated synthetic NPI namespaces. The follow-up 50K verification completed cleanly with zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture model.
+Post-#934 note: provider-fixture hardening moved scoreable validation providers into wider, role-separated synthetic NPI namespaces, prior-auth evidence became scoreable, and provider-exclusion denial labels were normalized. The follow-up 50K verification completed cleanly with zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture and scoring model.
 
 ## Episode metadata
 
@@ -39,8 +39,13 @@ The episode must distinguish:
 - `benchmark-results.txt` - exact 100K run command, environment, gates, timing, and limitations.
 - `pr-summary.txt` - implementation work that raised the correctness bar before 100K.
 - `podcast-prompt.txt` - episode-specific generation prompt.
-- `raw-validator-output-post928-100k.txt` - raw validator console output from the completed post-#928 100K run.
-- `run-summary-post928-100k.json` - completed dashboard summary returned by claims-service for the post-#928 100K run.
+- `raw-validator-output-post934-100k.txt` - raw validator console output from the completed post-#934 100K run.
+- `run-summary-post934-100k.json` - completed dashboard summary returned by claims-service for the post-#934 100K run.
+- `raw-validator-output-post928-100k.txt` - prior post-#928 100K validator output retained as provenance.
+- `run-summary-post928-100k.json` - prior post-#928 dashboard summary retained as provenance.
+
+The screenshots below are retained visual console evidence from the Part 8 console capture set. The post-#934 raw validator output and dashboard summary JSON are authoritative for the final 100K numbers.
+
 - `screenshots/episode-008-100k-dashboard.png` - completed 100K run list, run detail, timing, outcome mix, and claim-result evidence.
 - `screenshots/episode-008-100k-outcome-breakdown.png` - business-denial distribution and explicit zero-platform-failure evidence.
 - `screenshots/episode-008-100k-paid-results.png` - retained paid-claim evidence with payment amounts and per-claim stage timing.
@@ -65,7 +70,7 @@ The episode must distinguish:
 - [x] The next optimization target is evidence-driven.
 - [x] Primary completed-run console screenshot is captured.
 - [x] Unsupported claim sample and persisted payment drilldown are captured.
-- [x] Post-#928 50K provider-fixture verification is recorded.
-- [x] Final post-#928 100K raw validator output is recorded.
+- [x] Post-#934 50K scoring verification is recorded.
+- [x] Final post-#934 100K raw validator output is recorded.
 - [x] Live expected-pend progress caveat is recorded.
 - [ ] Published article URL is recorded.

--- a/docs/million-claim-challenge/podcast/episode-008/article.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/article.txt
@@ -6,11 +6,15 @@ Then the correctness bar changed.
 
 Payment accuracy became a gate instead of a diagnostic. Expected-pay and expected-deny claims were checked for false pends. Zero-limit accumulator placeholders stopped distorting expected payments. Generated members were isolated so one corpus segment could not contaminate another. Validation providers were moved into role-separated synthetic NPI namespaces so scoreable scenarios could not collide with stale provider-integrity state in a long-lived local tenant.
 
+Then the evidence bar moved again.
+
+Prior-authorization scenarios that had been partially unsupported became scoreable. Provider-exclusion denial codes were normalized so `B7`, `CARC_B7`, and `PROVIDER_EXCLUDED` represented the same expected business outcome instead of producing false mismatches.
+
 Only after those changes did Cloud Health Office move back to 100,000 claims.
 
 The result was clean: every claim processed, no platform failures, no scoreable workflow mismatches, no unexpected pends, and every comparable payment within one cent.
 
-The run also exposed the next local scaling question. Docker Desktop was not out of CPU or memory, and fixture preparation was no longer a two-hour wall-clock problem. The platform finished timed adjudication in 27 minutes and 54 seconds, with the full tracked lifecycle taking about 34 minutes.
+The run also exposed the next local scaling question. Docker Desktop was not out of CPU or memory, and fixture preparation was no longer a two-hour wall-clock problem. The platform finished timed adjudication in 30 minutes and 5 seconds, with the full tracked lifecycle taking about 38 minutes.
 
 That is exactly the kind of result this series is supposed to produce: correctness held, the evidence became inspectable, and the next performance question became sharper.
 
@@ -31,15 +35,17 @@ The validator now includes:
 - evidence-first claim-result retention
 - in-progress run publication and a completed run summary in the console
 
-One last fixture-hardening pass mattered before the final 100K rerun.
+Several final hardening passes mattered before the final 100K rerun.
 
 PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification then found 10 scoreable `TxStarInpatientNoAuth` mismatches: those claims should have denied for missing prior authorization, but provider-integrity evaluation treated the generated rendering provider as excluded. The current provider record was approved and in-network, which pointed to stale or colliding validation-provider identity state in the long-lived local tenant.
 
 PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces: billing providers in the `93...` range, adjudicatable rendering providers in `94...`, and intentionally excluded rendering providers in `95...`.
 
-The post-#928 50K verification processed 50,000 claims cleanly: 5,767 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.
+Then PR #931 wired prior-authorization validation into adjudication, PR #932 made seeded prior-auth evidence scoreable, and PR #933 fixed the scoring path so expired-authorization and wrong-procedure scenarios could be counted honestly instead of left unsupported. PR #934 normalized provider-exclusion denial codes so `B7`, `CARC_B7`, and `PROVIDER_EXCLUDED` no longer disagreed as labels when they represented the same exclusion outcome.
 
-That hardened fixture model is what the final 100K run used.
+The post-#934 50K verification processed 50,000 claims cleanly: 5,927 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,467 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.
+
+That hardened fixture and scoring model is what the final 100K run used.
 
 ## The 100K result
 
@@ -48,41 +54,41 @@ The local Docker Desktop Kubernetes run processed 100,000 deterministic syntheti
 The final summary reported:
 
 - 100,000 claims processed
-- 79,162 paid or adjudicated
-- 921 pended
-- 19,917 business denials
+- 78,842 paid or adjudicated
+- 924 pended
+- 20,234 business denials
 - 0 platform failures
 - 0 observation timeouts
-- 11,534 of 13,000 workflow checks matched
+- 11,854 of 13,000 workflow checks matched
 - 0 workflow mismatches
-- 1,466 unsupported scenarios
-- 0 unexpected pends across 10,614 scoreable non-pend claims
+- 1,146 unsupported scenarios
+- 0 unexpected pends across 10,934 scoreable non-pend claims
 - 2,000 of 2,000 comparable payments within one cent
 - $0.00 average payment delta
 - $0.00 maximum payment delta
 
-The pend numbers have two scopes. The run ended with 921 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.
+The pend numbers have two scopes. The run ended with 924 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,934 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.
 
-Unsupported scenarios also remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.
+Unsupported scenarios also remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, the prior-authorization wrong-provider variant, retroactive coverage change, and subrogation workflows.
 
 Those are named product gaps, not hidden successes.
 
 ## Performance did not saturate the machine
 
-The timed claim-processing phase completed in 27 minutes and 54.381 seconds.
+The timed claim-processing phase completed in 30 minutes and 5.013 seconds.
 
 That produced:
 
-- 59.72 claims per second
-- 296 ms P95 latency
-- 377 ms P99 latency
-- 115 ms P95 submission time
-- 105 ms P95 adjudication time
-- 95 ms P95 writeback time
+- 55.40 claims per second
+- 324 ms P95 latency
+- 480 ms P99 latency
+- 194 ms P95 submission time
+- 122 ms P95 adjudication time
+- 101 ms P95 writeback time
 
-The provider-pool fixture work changed the local lifecycle story. Earlier 100K preparation had been dominated by run-scoped provider creation. In this run, the validator reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, and preserved 2,800 provider-sensitive claims. It created 12,748 synthetic providers instead of trying to create a provider record for every repeated reference.
+The provider-pool fixture work changed the local lifecycle story. Earlier 100K preparation had been dominated by run-scoped provider creation. In this run, the validator reduced 199,847 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, and preserved 2,800 provider-sensitive claims. It created 13,383 synthetic providers instead of trying to create a provider record for every repeated reference.
 
-That is why the tracked lifecycle was about 34 minutes instead of more than two hours.
+That is why the tracked lifecycle was about 38 minutes instead of more than two hours.
 
 The run still did not scale linearly from smaller benchmarks, and Docker Desktop showed plenty of CPU and memory headroom while the run was active. That points the next investigation away from raw host capacity and toward internal throughput limits: service concurrency, writeback behavior, MongoDB pressure, HTTP client settings, and validator parallelism.
 
@@ -90,20 +96,23 @@ That is not a production capacity conclusion. It is a local scaling signal worth
 
 ## Timed throughput and preparation are different
 
-The tracked lifecycle took 34 minutes and 3.458 seconds. The timed adjudication phase took 27 minutes and 54.381 seconds.
+The tracked lifecycle took 38 minutes and 5.792 seconds. The timed adjudication phase took 30 minutes and 5.013 seconds.
 
 The remaining tracked time was mostly preparation:
 
-- member and coverage seeding: 2:51.219
-- provider seeding: 3:09.524
-- corpus generation: 0:01.039
-- fixture normalization: 0:00.335
-- expected-pend observation: 0:00.740
-- false-pend sweep: 0:06.120
+- member and coverage seeding: 2:47.051
+- provider seeding: 5:04.155
+- authorization fixture seeding: 0:00.436
+- corpus generation: 0:01.201
+- fixture normalization: 0:00.327
+- expected-pend observation: 0:00.765
+- false-pend sweep: 0:06.644
 
 The validator seeded 10,614 synthetic members, reused 88,977 existing members, aligned 99,591 member statuses, found 920 COB coverage rows already present, and found both required provider networks already present.
 
-Both numbers matter. The platform adjudicated at 59.72 claims per second during the measured phase. The full local evidence run, including fixture preparation and observation, took about 34 minutes.
+Both numbers matter. The platform adjudicated at 55.40 claims per second during the measured phase. The full local evidence run, including fixture preparation and observation, took about 38 minutes.
+
+There is one reproducibility caveat in the local wrapper. The shell command that launched the Kubernetes job timed out while waiting for the job condition, but the Kubernetes job continued running, completed successfully, and published the completed Mass Adjudication summary. That is a local orchestration timeout, not a platform failure.
 
 ## What the console should make obvious
 
@@ -141,7 +150,7 @@ That suggests several concrete experiments:
 - keep unsupported scenarios visible instead of hiding them
 - report CPU, memory, and disk I/O alongside benchmark timing
 
-Unsupported scenarios should become their own product-evidence track. The first likely candidates are the prior-authorization edge variants, followed by retroactive coverage change, Medicaid spend-down, behavioral-health carve-out, and subrogation. They should be converted into scoreable behavior deliberately, not swept into the same PR as a benchmark evidence update.
+Unsupported scenarios should become their own product-evidence track. The first likely candidates are the prior-authorization wrong-provider variant, followed by retroactive coverage change, Medicaid spend-down, behavioral-health carve-out, and subrogation. They should be converted into scoreable behavior deliberately, not swept into the same PR as a benchmark evidence update.
 
 ## What comes after the local ceiling
 

--- a/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/benchmark-results.txt
@@ -2,9 +2,9 @@
 
 ## Run identity
 
-- Date: July 18, 2026 local time / July 19, 2026 UTC
-- Kubernetes job: `mcc-post928-100k-190641`
-- Dashboard run ID: `34db25825df04c8fa75eb5cc0e615291`
+- Date: July 19, 2026 local time / July 19, 2026 UTC
+- Kubernetes job: `mcc-main-100k-p10-112031`
+- Dashboard run ID: `dd0ebe4979e247bc95a980610de7d0be`
 - Environment: local Docker Desktop Kubernetes
 - Tenant: `demo`
 - Validator seed: 42
@@ -19,13 +19,17 @@
 ## Command
 
 ```text
-CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=10 PROGRESS_EVERY=5000 JOB_NAME=mcc-post928-100k-190641 ./scripts/run-mcc-local-k8s.sh
+JOB_NAME=mcc-main-100k-p10-112031 CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=10 PROGRESS_EVERY=10000 SEED_AUTHORIZATIONS=true SKIP_BUILD=true ./scripts/run-mcc-local-k8s.sh
 ```
+
+The local wrapper timed out while waiting for the Kubernetes job condition, but the Kubernetes job continued running and completed successfully. The pod exited successfully with 0 restarts, and the validator published the completed dashboard summary.
 
 ## Raw artifacts
 
-- `raw-validator-output-post928-100k.txt` - validator console output from the completed 100K run.
-- `run-summary-post928-100k.json` - completed Mass Adjudication run summary returned by claims-service.
+- `raw-validator-output-post934-100k.txt` - validator console output from the completed post-#934 100K run.
+- `run-summary-post934-100k.json` - completed Mass Adjudication run summary returned by claims-service for the post-#934 100K run.
+- `raw-validator-output-post928-100k.txt` - prior post-#928 100K validator output retained as provenance.
+- `run-summary-post928-100k.json` - prior post-#928 dashboard summary retained as provenance.
 
 ## Fixture preparation
 
@@ -34,66 +38,67 @@ CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=10 PROGRESS_EVERY=5000 JOB_NAME=mcc-
 - Injected 2,000 excluded-provider denial scenarios.
 - Injected 2,000 uncovered-service denial scenarios.
 - Injected 2,000 TX STAR inpatient no-authorization scenarios.
-- Provider fixture pool: 199,846 provider references reduced to 13,742 distinct NPIs.
+- Provider fixture pool: 199,847 provider references reduced to 13,742 distinct NPIs.
 - Provider assignments reused: 186,258.
 - Provider-sensitive claims preserved: 2,800.
 - Seeded 10,614 synthetic members; 88,977 already existed; 99,591 statuses aligned.
 - Seeded 0 COB coverage rows; 920 already existed.
 - Seeded 0 provider networks; 2 already existed.
-- Seeded 12,748 synthetic providers; 994 already existed.
+- Seeded 13,383 synthetic providers; 359 already existed.
 
 ## Correctness result
 
 - Total claims: 100,000
 - Processed: 100,000
-- Paid/adjudicated: 79,162
-- Pended: 921
-- Business denials: 19,917
+- Paid/adjudicated: 78,842
+- Pended: 924
+- Business denials: 20,234
 - Platform failures: 0
 - Observation timeouts: 0
 - Expected-pend observation: 920 pended, 0 timed out
-- False-pend sweep: 10,614 scoreable non-pend claims, 0 unexpected pends
-- Workflow scoring: 11,534/13,000 matched, 0 mismatched, 1,466 unsupported, 0 observation timeouts
+- False-pend sweep: 10,934 scoreable non-pend claims, 0 unexpected pends, 2,242 terminal outcomes reconciled
+- Workflow scoring: 11,854/13,000 matched, 0 mismatched, 1,146 unsupported, 0 observation timeouts
 - Payment gate: 2,000/2,000 within $0.01, 0 mismatched
 - Average payment delta: $0.00
 - Maximum payment delta: $0.00
 
-Pend-scope note: the final persisted outcome mix includes 921 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
+Pend-scope note: the final persisted outcome mix includes 924 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,934 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
 
 ## Performance result
 
-- Timed claim-processing elapsed: 27:54.381
-- Throughput: 59.72 claims/second
-- P95 latency: 296 ms
-- P99 latency: 377 ms
-- Submit average/P95: 61 ms / 115 ms
-- Adjudicate average/P95: 69 ms / 105 ms
-- Writeback average/P95: 38 ms / 95 ms
-- Benefit calculation average/P95: 65 ms / 100 ms
-- Provider integrity average/P95: 2 ms / 3 ms
-- Preparation time: 6:02.216
-- Tracked lifecycle: 34:03.458
+- Timed claim-processing elapsed: 30:05.013
+- Throughput: 55.40 claims/second
+- P95 latency: 324 ms
+- P99 latency: 480 ms
+- Submit average/P95: 67 ms / 194 ms
+- Adjudicate average/P95: 70 ms / 122 ms
+- Writeback average/P95: 45 ms / 101 ms
+- Benefit calculation average/P95: 65 ms / 115 ms
+- Provider integrity average/P95: 3 ms / 2 ms
+- Preparation time: 7:53.368
+- Tracked lifecycle: 38:05.792
 
 ## Lifecycle timings
 
-- Service health checks: 0:00.037
-- Reference rule seeding: 0:00.041
-- Validation plan setup: 0:00.017
-- Corpus generation: 0:01.039
-- Fixture normalization: 0:00.335
-- Member and coverage seeding: 2:51.219
-- Provider seeding: 3:09.524
-- Timed adjudication: 27:54.381
-- Expected-pend observation: 0:00.740
-- False-pend sweep: 0:06.120
+- Service health checks: 0:00.056
+- Reference rule seeding: 0:00.120
+- Validation plan setup: 0:00.018
+- Corpus generation: 0:01.201
+- Fixture normalization: 0:00.327
+- Authorization fixture seeding: 0:00.436
+- Member and coverage seeding: 2:47.051
+- Provider seeding: 5:04.155
+- Timed adjudication: 30:05.013
+- Expected-pend observation: 0:00.765
+- False-pend sweep: 0:06.644
 
 ## Business denials
 
 - CARC 96: 9,046
 - CARC 18: 6,000
-- PRIOR_AUTH_REQUIRED: 2,160
-- PROVIDER_EXCLUDED: 2,001
-- NCCI_MUE_EDIT_FAILURE: 396
+- PRIOR_AUTH_REQUIRED: 2,480
+- PROVIDER_EXCLUDED: 2,000
+- NCCI_MUE_EDIT_FAILURE: 394
 - CARC 27: 267
 - SCRUB_VALIDATION_FAILURE: 47
 
@@ -103,15 +108,13 @@ Business denials are valid platform outcomes, not platform failures.
 
 - BehavioralHealthCarveOut: 200
 - MedicaidSpendDown: 120
-- PriorAuthRequired_ExpiredAuth: 160
-- PriorAuthRequired_WrongProcedure: 160
 - PriorAuthRequired_WrongProvider: 160
 - RetroEligibilityCoverageChange: 266
 - SubrogationAccidentRelated: 134
 - SubrogationThirdPartyLiability: 133
 - SubrogationWorkersComp: 133
 
-Total unsupported: 1,466.
+Total unsupported: 1,146.
 
 Unsupported means the scenario is not currently scoreable through the implemented platform/validator path. It is not counted as matched, mismatched, or a platform failure.
 
@@ -126,13 +129,13 @@ Unsupported means the scenario is not currently scoreable through the implemente
 - Medicaid CHIP, dual-eligible, SSI, and TANF: 120/120 matched each
 - Retro eligibility add and termination: 267/267 matched each
 - Behavioral health carve-in and parity-check: 200/200 matched each
-- Prior-auth required auth-on-file and no-auth variants: 160/160 matched each
+- Prior-auth required auth-on-file, expired-auth, no-auth, and wrong-procedure variants: 160/160 matched each
 
 ## Interpretation
 
-The post-#928 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
+The post-#934 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
 
-Timed adjudication and full tracked lifecycle must remain separate. Timed processing completed in 27:54.381 at 59.72 claims/second. The tracked lifecycle completed in 34:03.458 after preparation, processing, expected-pend observation, and false-pend sweep.
+Timed adjudication and full tracked lifecycle must remain separate. Timed processing completed in 30:05.013 at 55.40 claims/second. The tracked lifecycle completed in 38:05.792 after preparation, processing, expected-pend observation, and false-pend sweep.
 
 This is local Docker Desktop evidence, not a production-cloud capacity claim. During the run, Docker Desktop showed significant CPU and memory headroom, so the next performance investigation should focus on internal throughput limits: validator parallelism, service concurrency, HTTP client limits, MongoDB/writeback behavior, and disk I/O.
 
@@ -182,4 +185,27 @@ The post-#928 50K rerun was completed as `mcc-provider-namespace-50k-163946`.
 - Provider fixtures created: 7,568
 - Provider fixtures already present: 491
 
-The post-#928 50K run proved the provider-fixture hardening. The 100K run above proves the same hardened fixture model at the next scale.
+The post-#928 50K run proved the provider-fixture hardening. Later PRs made seeded prior-auth evidence scoreable and normalized provider-exclusion denial labels.
+
+## Post-#934 50K scoring verification
+
+The post-#934 50K rerun was completed as `mcc-main-50k-p10-105103` with dashboard run ID `41301477f0eb437bb6a95bf3bd8d420b`.
+
+- Total claims: 50,000
+- Processed: 50,000
+- Paid/adjudicated: 39,377
+- Pended: 461
+- Business denials: 10,162
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 460 pended, 0 timed out
+- False-pend sweep: 5,467 scoreable non-pend claims, 0 unexpected pends
+- Workflow scoring: 5,927/6,500 matched, 0 mismatched, 573 unsupported, 0 observation timeouts
+- Payment gate: 1,000/1,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+- Throughput: 59.59 claims/second
+- P95 latency: 318 ms
+- P99 latency: 415 ms
+
+The post-#934 50K run proved the prior-auth and provider-exclusion scoring fixes. The 100K run above proves the same hardened scoring model at the next scale.

--- a/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/podcast-prompt.txt
@@ -2,40 +2,40 @@ Create a 10-12 minute two-host engineering podcast episode titled "The Clean 100
 
 Use Alex and Jordan as experienced healthcare platform engineers. Make the discussion natural, analytical, and candid rather than reading the article aloud.
 
-The central story is that Cloud Health Office did not move from 50K to 100K by relaxing validation. Before scaling, the team added a payment gate, a false-pend sweep, corrected zero-limit accumulator placeholder handling, eliminated cross-corpus member fixture collisions, and hardened scoreable validation providers with role-separated synthetic NPI namespaces.
+The central story is that Cloud Health Office did not move from 50K to 100K by relaxing validation. Before scaling, the team added a payment gate, a false-pend sweep, corrected zero-limit accumulator placeholder handling, eliminated cross-corpus member fixture collisions, hardened scoreable validation providers with role-separated synthetic NPI namespaces, made seeded prior-authorization evidence scoreable, and normalized provider-exclusion denial labels.
 
-Include the provider-fixture thread clearly. PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification exposed 10 `TxStarInpatientNoAuth` mismatches caused by provider-integrity evaluation treating generated rendering providers as excluded. PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces (`93...` billing, `94...` adjudicatable rendering, `95...` intentionally excluded). The post-#928 50K rerun was clean: 50,000 processed, 5,767/6,500 workflow checks matched, zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends across 5,307 scoreable non-pend claims, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture model.
+Include the provider-fixture thread clearly. PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification exposed 10 `TxStarInpatientNoAuth` mismatches caused by provider-integrity evaluation treating generated rendering providers as excluded. PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces (`93...` billing, `94...` adjudicatable rendering, `95...` intentionally excluded). Then PR #931 wired prior-auth validation into adjudication, PR #932 made seeded prior-auth evidence scoreable, PR #933 fixed the prior-auth scoring path, and PR #934 normalized provider-exclusion denial codes. The post-#934 50K rerun was clean: 50,000 processed, 5,927/6,500 workflow checks matched, zero workflow mismatches, 460/460 expected pends observed, zero unexpected pends across 5,467 scoreable non-pend claims, and 1,000/1,000 payment comparisons within tolerance. The final 100K run used that hardened fixture and scoring model.
 
-Use these exact final post-#928 100K results:
+Use these exact final post-#934 100K results:
 
 - 100,000 claims processed
-- 79,162 paid or adjudicated
-- 921 persisted pended outcomes
-- 19,917 business denials
+- 78,842 paid or adjudicated
+- 924 persisted pended outcomes
+- 20,234 business denials
 - 0 platform failures
 - 0 workflow mismatches
 - 0 observation timeouts
 - 920 expected-pend claims observed as pended
-- 0 unexpected pends across 10,614 scoreable non-pend claims
-- 11,534 of 13,000 workflow checks matched
-- 1,466 unsupported scenarios
+- 0 unexpected pends across 10,934 scoreable non-pend claims
+- 11,854 of 13,000 workflow checks matched
+- 1,146 unsupported scenarios
 - 2,000 of 2,000 comparable payments within $0.01
 - $0.00 average and maximum payment delta
-- 59.72 claims per second
-- 296 ms P95 and 377 ms P99 latency
-- 27:54.381 timed claim-processing phase
-- 6:02.216 preparation time
-- 34:03.458 tracked lifecycle
+- 55.40 claims per second
+- 324 ms P95 and 480 ms P99 latency
+- 30:05.013 timed claim-processing phase
+- 7:53.368 preparation time
+- 38:05.792 tracked lifecycle
 
 Explain why business denials are valid outcomes and why unsupported scenarios are visible product gaps rather than passes or failures.
 
-Make the pend scope explicit: the outcome mix had 921 persisted pended claims, the expected-pend observer verified 920 answer-key pend scenarios, and the false-pend sweep covered the scoreable expected-pay and expected-deny set. Do not imply unsupported scenarios were included in that non-pend sweep.
+Make the pend scope explicit: the outcome mix had 924 persisted pended claims, the expected-pend observer verified 920 answer-key pend scenarios, and the false-pend sweep covered the scoreable expected-pay and expected-deny set. Do not imply unsupported scenarios were included in that non-pend sweep.
 
-Spend meaningful time on the difference between timed adjudication and full tracked lifecycle. The post-#928 provider-pool work reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 assignments, preserved 2,800 provider-sensitive claims, and created 12,748 providers. Correctness held, and fixture preparation became measurable rather than a hidden wall-clock sink.
+Spend meaningful time on the difference between timed adjudication and full tracked lifecycle. The post-#934 provider-pool work reduced 199,847 provider references to 13,742 distinct NPIs, reused 186,258 assignments, preserved 2,800 provider-sensitive claims, and created 13,383 providers. Correctness held, and fixture preparation became measurable rather than a hidden wall-clock sink.
 
 Mention the live-console lesson: during processing, the console showed 920 workflow mismatches because expected-pend checks were still awaiting post-processing observation. After expected-pend observation completed, the final summary correctly reported zero workflow mismatches. Frame this as an in-progress presentation issue, not an adjudication failure.
 
-Compare this result with the post-#928 50K verification at 58.60 claims per second, 380 ms P95, and 515 ms P99. Also note that Docker Desktop showed significant CPU and memory headroom during the 100K run, so the next performance questions are service concurrency, writeback behavior, MongoDB/disk I/O, HTTP client limits, and validator parallelism rather than simply adding more local CPU.
+Compare this result with the post-#934 50K verification at 59.59 claims per second, 318 ms P95, and 415 ms P99. Also note that Docker Desktop showed significant CPU and memory headroom during the 100K run, so the next performance questions are service concurrency, writeback behavior, MongoDB/disk I/O, HTTP client limits, and validator parallelism rather than simply adding more local CPU.
 
 Do not imply a production capacity conclusion. This is local Docker Desktop Kubernetes evidence.
 

--- a/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/pr-summary.txt
@@ -41,17 +41,41 @@
 - Added regression coverage proving role separation and no collisions across the 50K scoreable scenario window.
 - Produced a clean post-fix 50K verification: 50,000 processed, 5,767/6,500 workflow checks matched, 0 workflow mismatches, 460/460 expected pends observed, 0 unexpected pends, and 1,000/1,000 comparable payments within tolerance.
 
-## Post-#928 100K outcome
+## PR #931 - prior-auth validation integration
 
-No platform code was changed to make the 100K result look clean. The final post-#928 run used the stronger gates established above, the hardened validation-provider namespaces, and the provider-pool fixture strategy.
+- Wired prior-authorization validation into the adjudication path so seeded authorization evidence could influence persisted outcomes.
+- Kept the evidence path explicit instead of treating prior-auth behavior as a fixture-only concern.
 
-The run completed cleanly: 100,000 processed, 0 platform failures, 11,534/13,000 workflow checks matched, 0 workflow mismatches, 1,466 unsupported, 920/920 expected pends observed, 0 unexpected pends across 10,614 scoreable non-pend claims, and 2,000/2,000 comparable payments within $0.01 with $0.00 maximum payment delta.
+## PR #932 - score seeded prior-auth evidence
+
+- Made seeded prior-authorization scenarios scoreable in the MCC validator.
+- Moved more prior-auth coverage out of the unsupported bucket and into matched/mismatched workflow evidence.
+
+## PR #933 - prior-auth evidence scoring correction
+
+- Fixed the prior-auth scoring path so expired-authorization and wrong-procedure scenarios could be counted honestly.
+- Preserved the wrong-provider prior-auth variant as unsupported because the current validation path still cannot score that behavior cleanly.
+
+## PR #934 - provider-exclusion denial normalization
+
+- Normalized provider-exclusion denial labels across `B7`, `CARC_B7`, and `PROVIDER_EXCLUDED`.
+- Prevented label-only differences from surfacing as false workflow mismatches when the business outcome was the expected excluded-provider denial.
+
+## Post-#934 50K scoring verification
+
+The post-#934 50K rerun completed cleanly: 50,000 processed, 0 platform failures, 5,927/6,500 workflow checks matched, 0 workflow mismatches, 573 unsupported, 460/460 expected pends observed, 0 unexpected pends across 5,467 scoreable non-pend claims, and 1,000/1,000 comparable payments within $0.01 with $0.00 maximum payment delta.
+
+## Post-#934 100K outcome
+
+No platform code was changed to make the 100K result look clean. The final post-#934 run used the stronger gates established above, the hardened validation-provider namespaces, the prior-auth scoring path, provider-exclusion label normalization, and the provider-pool fixture strategy.
+
+The run completed cleanly: 100,000 processed, 0 platform failures, 11,854/13,000 workflow checks matched, 0 workflow mismatches, 1,146 unsupported, 920/920 expected pends observed, 0 unexpected pends across 10,934 scoreable non-pend claims, and 2,000/2,000 comparable payments within $0.01 with $0.00 maximum payment delta.
 
 The completed summary was published to the Mass Adjudication console. During processing, the live console temporarily showed 920 workflow mismatches because expected-pend checks had not yet been observed. The final summary correctly resolved those provisional checks to matched pends.
 
-## Post-#928 fixture-preparation effect
+## Post-#934 fixture-preparation effect
 
-The final 100K run reduced 199,846 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, preserved 2,800 provider-sensitive claims, and created 12,748 providers. Preparation took 6:02.216 and the tracked lifecycle took 34:03.458.
+The final 100K run reduced 199,847 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, preserved 2,800 provider-sensitive claims, and created 13,383 providers. Preparation took 7:53.368 and the tracked lifecycle took 38:05.792.
 
 ## Claim-detail projection correction discovered during evidence review
 

--- a/docs/million-claim-challenge/podcast/episode-008/raw-validator-output-post934-100k.txt
+++ b/docs/million-claim-challenge/podcast/episode-008/raw-validator-output-post934-100k.txt
@@ -1,0 +1,131 @@
+Million Claim Challenge - Platform Validator
+  Tenant:      demo
+  Claims URL:  http://claims-service
+  Benefit URL: http://benefit-plan-service
+  Member URL:  http://member-service
+  Coverage URL:http://coverage-service
+  Provider URL:http://provider-service
+  Auth URL:    http://authorization-service
+  Claims:      100,000
+  Seed:        42
+  Parallelism: 10
+  LOB:         Medicaid (3)
+  PA scenarios: enabled (2 %)
+  Auth fixtures: enabled
+  Pend observe: enabled (45s/1000ms)
+  Pend diag:   disabled
+
+healthy: claims-service
+healthy: benefit-plan-service
+healthy: member-service
+healthy: coverage-service
+healthy: provider-service
+seeded: NCCI baseline
+seeded: prior-auth platform rules (0 new)
+created: validation benefit plan e29aae4d-a049-43e6-b678-ddbdf7a4d2a4
+Clean paid scenarios: injected 2,000 professional claims expected to pay
+Excluded provider scenarios: injected 2,000 professional claims expected to deny
+Uncovered service scenarios: injected 2,000 professional claims expected to deny
+PA scenarios: injected 2,000 TX STAR inpatient claims without auth
+Generated 100,000 MCC claims in memory
+Provider fixture pool: 199,847 -> 13,742 distinct NPIs (186,258 assignments reused, 2,800 provider-sensitive claims preserved)
+Authorization fixtures: seeded 480 prior authorization fixtures (480 new, 0 updated)
+seeded: 10,614 synthetic members (88,977 already present, 99,591 status-aligned)
+seeded: 0 COB coverage rows (920 already present)
+seeded: 0 provider networks (2 already present)
+seeded: 13,383 synthetic providers (359 already present)
+  Processed: 10,000/100,000  processed=10,000  platformFailures=0  Processed: 20,000/100,000  processed=20,000  platformFailures=0  Processed: 30,000/100,000  processed=30,000  platformFailures=0  Processed: 40,000/100,000  processed=40,000  platformFailures=0  Processed: 50,000/100,000  processed=50,000  platformFailures=0  Processed: 60,000/100,000  processed=60,000  platformFailures=0  Processed: 70,000/100,000  processed=70,000  platformFailures=0  Processed: 80,000/100,000  processed=80,000  platformFailures=0  Processed: 90,000/100,000  processed=90,000  platformFailures=0  Processed: 100,000/100,000  processed=100,000  platformFailures=0
+
+Observing 920 expected-pend claims for up to 45s; benchmark timing excludes this polling window.
+  Pend observation:  920 pended, 0 timed out
+
+Sweeping 10,934 non-pend claims for unexpected persisted pends.
+  False-pend sweep: 0 unexpected pends, 2,242 terminal outcomes reconciled
+
+Validation summary
+  Total claims:       100,000
+  Processed:          100,000
+  Paid/adjudicated:   78,842
+  Pended:             924
+  Business denials:   20,234
+  Platform failures:  0
+  Observation timeout: 0
+  Workflow checks:    11,854/13,000 matched (0 mismatched, 1,146 unsupported, 0 observation timeouts)
+  Elapsed:            30:05.013
+  Throughput:         55.40 claims/sec
+  P95 latency:        324 ms
+  P99 latency:        480 ms
+  Preparation time:   7:53.368
+  Tracked lifecycle:  38:05.792
+  Lifecycle.Service health checks        0:00.056
+  Lifecycle.Reference rule seeding       0:00.120
+  Lifecycle.Validation plan setup        0:00.018
+  Lifecycle.Corpus generation            0:01.201
+  Lifecycle.Fixture normalization        0:00.327
+  Lifecycle.Authorization fixture seeding 0:00.436
+  Lifecycle.Member and coverage seeding  2:47.051
+  Lifecycle.Provider seeding             5:04.155
+  Lifecycle.Timed adjudication           30:05.013
+  Lifecycle.Expected-pend observation    0:00.765
+  Lifecycle.False-pend sweep             0:06.644
+  Submit       avg/p95: 67 ms / 194 ms
+  Adjudicate   avg/p95: 70 ms / 122 ms
+  Writeback    avg/p95: 45 ms / 101 ms
+  Adjudicate.benefitCalculation avg/p95: 65 ms / 115 ms
+  Adjudicate.benefitCalculation.accumulatorRead avg/p95: 64 ms / 113 ms
+  Adjudicate.providerIntegrity avg/p95: 3 ms / 2 ms
+  Adjudicate.benefitCalculation.accumulatorWrite avg/p95: 1 ms / 2 ms
+  Adjudicate.ncci avg/p95: 1 ms / 3 ms
+  Adjudicate.rateResolution avg/p95: 1 ms / 2 ms
+  Adjudicate.priorAuth avg/p95: 0 ms / 0 ms
+  Adjudicate.scrub avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.lineProcessing avg/p95: 0 ms / 0 ms
+  Adjudicate.terminology avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.workingSet avg/p95: 0 ms / 0 ms
+  Adjudicate.routing avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.snapshot avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.planLookup avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.totals avg/p95: 0 ms / 0 ms
+  Adjudicate.benefitCalculation.outcome avg/p95: 0 ms / 0 ms
+  Avg payment delta:  $0.00
+  Payment gate:       2,000/2,000 within $0.01 (0 mismatched, max $0.00)
+  Payment delta:      Exact (2,000)
+  Business denial: CARC_96 (9,046)
+  Business denial: CARC_18 (6,000)
+  Business denial: PRIOR_AUTH_REQUIRED (2,480)
+  Business denial: PROVIDER_EXCLUDED (2,000)
+  Business denial: NCCI_MUE_EDIT_FAILURE (394)
+  Scenario: CleanProfessionalPaid 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthCarveIn 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthCarveOut 0/200 matched (0 mismatched, 200 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:BehavioralHealthParityCheck 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobBirthdayRule 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobGenderRule 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobMedicareSecondary 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobPrimaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobSecondaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:CobTertiaryPayer 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidCHIP 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidDualEligible 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidSSI 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidSpendDown 0/120 matched (0 mismatched, 120 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:MedicaidTANF 120/120 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornAutoAdjudication 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornFirstThirtyDays 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:NewbornMotherClaimLink 200/200 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_AuthOnFile 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_ExpiredAuth 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_NoAuth 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_WrongProcedure 160/160 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:PriorAuthRequired_WrongProvider 0/160 matched (0 mismatched, 160 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityAdd 267/267 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityCoverageChange 0/266 matched (0 mismatched, 266 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:RetroEligibilityTermination 267/267 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationAccidentRelated 0/134 matched (0 mismatched, 134 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationThirdPartyLiability 0/133 matched (0 mismatched, 133 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: EdgeCase:SubrogationWorkersComp 0/133 matched (0 mismatched, 133 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: ExcludedProviderDenied 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: TxStarInpatientNoAuth 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Scenario: UncoveredServiceDenied 2,000/2,000 matched (0 mismatched, 0 unsupported, 0 observation timeouts, 0 unspecified)
+  Summary JSON:       /tmp/mcc-summary.json
+  Dashboard summary: published

--- a/docs/million-claim-challenge/podcast/episode-008/run-summary-post934-100k.json
+++ b/docs/million-claim-challenge/podcast/episode-008/run-summary-post934-100k.json
@@ -1,0 +1,603 @@
+{
+  "id": "dd0ebe4979e247bc95a980610de7d0be",
+  "status": "Completed",
+  "run": {
+    "tenantId": "demo",
+    "requestedClaims": 100000,
+    "seed": 42,
+    "parallelism": 10,
+    "claimsUrl": "http://claims-service",
+    "benefitUrl": "http://benefit-plan-service",
+    "memberUrl": "http://member-service",
+    "coverageUrl": "http://coverage-service",
+    "providerUrl": "http://provider-service",
+    "seedMembers": true,
+    "seedProviders": true,
+    "skipClaimUpdate": false,
+    "lineOfBusiness": 3,
+    "startedAtUtc": "2026-07-19T18:20:34.0979915+00:00",
+    "completedAtUtc": "2026-07-19T19:45:14.6468068+00:00"
+  },
+  "totalClaims": 100000,
+  "processed": 100000,
+  "paid": 78842,
+  "pended": 924,
+  "businessDenials": 20234,
+  "observationTimeouts": 0,
+  "platformFailures": 0,
+  "workflowScenarios": 13000,
+  "workflowMatches": 11854,
+  "workflowMismatches": 0,
+  "workflowUnsupported": 1146,
+  "workflowObservationTimeouts": 0,
+  "elapsed": "00:30:05.0137089",
+  "throughputClaimsPerSecond": 55.40124127973597,
+  "p95LatencyMilliseconds": 324.3242,
+  "p99LatencyMilliseconds": 480.1829,
+  "submitTiming": {
+    "label": "Submit",
+    "averageMilliseconds": 66.65273755099955,
+    "p95Milliseconds": 193.9667
+  },
+  "adjudicateTiming": {
+    "label": "Adjudicate",
+    "averageMilliseconds": 69.52045026800054,
+    "p95Milliseconds": 122.1375
+  },
+  "writebackTiming": {
+    "label": "Writeback",
+    "averageMilliseconds": 44.81700115330091,
+    "p95Milliseconds": 101.3137
+  },
+  "adjudicationStepTimings": [
+    {
+      "label": "Adjudicate.benefitCalculation",
+      "averageMilliseconds": 64.51345650264874,
+      "p95Milliseconds": 114.6604
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.accumulatorRead",
+      "averageMilliseconds": 63.635505500742475,
+      "p95Milliseconds": 113.3871
+    },
+    {
+      "label": "Adjudicate.providerIntegrity",
+      "averageMilliseconds": 2.6850995228863854,
+      "p95Milliseconds": 2.2724
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.accumulatorWrite",
+      "averageMilliseconds": 0.7771649944599767,
+      "p95Milliseconds": 1.9136
+    },
+    {
+      "label": "Adjudicate.ncci",
+      "averageMilliseconds": 0.6071088511600464,
+      "p95Milliseconds": 2.7121
+    },
+    {
+      "label": "Adjudicate.rateResolution",
+      "averageMilliseconds": 0.6013394560330193,
+      "p95Milliseconds": 1.504
+    },
+    {
+      "label": "Adjudicate.priorAuth",
+      "averageMilliseconds": 0.06760771139412547,
+      "p95Milliseconds": 0.0856
+    },
+    {
+      "label": "Adjudicate.scrub",
+      "averageMilliseconds": 0.0512747930000029,
+      "p95Milliseconds": 0.0826
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.lineProcessing",
+      "averageMilliseconds": 0.03771081826701274,
+      "p95Milliseconds": 0.0806
+    },
+    {
+      "label": "Adjudicate.terminology",
+      "averageMilliseconds": 0.02605126409670521,
+      "p95Milliseconds": 0.0142
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.workingSet",
+      "averageMilliseconds": 0.008064407332919214,
+      "p95Milliseconds": 0.0168
+    },
+    {
+      "label": "Adjudicate.routing",
+      "averageMilliseconds": 0.005563245999999469,
+      "p95Milliseconds": 0.0052
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.snapshot",
+      "averageMilliseconds": 0.004242064252545251,
+      "p95Milliseconds": 0.0063
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.planLookup",
+      "averageMilliseconds": 0.0034687034716584498,
+      "p95Milliseconds": 0.0065
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.totals",
+      "averageMilliseconds": 0.0023562299276607933,
+      "p95Milliseconds": 0.0035
+    },
+    {
+      "label": "Adjudicate.benefitCalculation.outcome",
+      "averageMilliseconds": 0.001578439578743352,
+      "p95Milliseconds": 0.0026
+    }
+  ],
+  "lifecycleTimings": [
+    {
+      "label": "Service health checks",
+      "category": "Preparation",
+      "durationMilliseconds": 56.933,
+      "startedAtUtc": "2026-07-19T18:20:34.112294+00:00",
+      "completedAtUtc": "2026-07-19T18:20:34.1692303+00:00"
+    },
+    {
+      "label": "Reference rule seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 120.2742,
+      "startedAtUtc": "2026-07-19T18:20:34.169497+00:00",
+      "completedAtUtc": "2026-07-19T18:20:34.2897727+00:00"
+    },
+    {
+      "label": "Validation plan setup",
+      "category": "Preparation",
+      "durationMilliseconds": 18.2693,
+      "startedAtUtc": "2026-07-19T18:20:34.2897843+00:00",
+      "completedAtUtc": "2026-07-19T18:20:34.3080548+00:00"
+    },
+    {
+      "label": "Corpus generation",
+      "category": "Preparation",
+      "durationMilliseconds": 1201.9247,
+      "startedAtUtc": "2026-07-19T18:20:34.3083989+00:00",
+      "completedAtUtc": "2026-07-19T18:20:35.510326+00:00"
+    },
+    {
+      "label": "Fixture normalization",
+      "category": "Preparation",
+      "durationMilliseconds": 327.762,
+      "startedAtUtc": "2026-07-19T18:20:35.5103488+00:00",
+      "completedAtUtc": "2026-07-19T18:20:35.8381136+00:00"
+    },
+    {
+      "label": "Authorization fixture seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 436.1109,
+      "startedAtUtc": "2026-07-19T18:20:35.8381926+00:00",
+      "completedAtUtc": "2026-07-19T18:20:36.2743067+00:00"
+    },
+    {
+      "label": "Member and coverage seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 167051.2698,
+      "startedAtUtc": "2026-07-19T18:20:36.4130821+00:00",
+      "completedAtUtc": "2026-07-19T18:23:23.4640189+00:00"
+    },
+    {
+      "label": "Provider seeding",
+      "category": "Preparation",
+      "durationMilliseconds": 304155.9935,
+      "startedAtUtc": "2026-07-19T18:23:23.4641578+00:00",
+      "completedAtUtc": "2026-07-19T18:28:27.6196715+00:00"
+    },
+    {
+      "label": "Timed adjudication",
+      "category": "Processing",
+      "durationMilliseconds": 1805013.7089,
+      "startedAtUtc": "2026-07-19T18:28:27.6489897+00:00",
+      "completedAtUtc": "2026-07-19T19:45:06.969826+00:00"
+    },
+    {
+      "label": "Expected-pend observation",
+      "category": "Observation",
+      "durationMilliseconds": 765.5303,
+      "startedAtUtc": "2026-07-19T19:45:07.2365745+00:00",
+      "completedAtUtc": "2026-07-19T19:45:08.0021072+00:00"
+    },
+    {
+      "label": "False-pend sweep",
+      "category": "Observation",
+      "durationMilliseconds": 6644.6763,
+      "startedAtUtc": "2026-07-19T19:45:08.002116+00:00",
+      "completedAtUtc": "2026-07-19T19:45:14.6467944+00:00"
+    }
+  ],
+  "fixturePreparation": {
+    "generatedClaims": 100000,
+    "providerPoolDistinctBefore": 199847,
+    "providerPoolDistinctAfter": 13742,
+    "providerPoolReusedAssignments": 186258,
+    "providerPoolProtectedClaims": 2800,
+    "membersCreated": 10614,
+    "membersExisting": 88977,
+    "memberStatusesAligned": 99591,
+    "cobCoverageCreated": 0,
+    "cobCoverageExisting": 920,
+    "providerNetworksCreated": 0,
+    "providerNetworksExisting": 2,
+    "providersCreated": 13383,
+    "providersExisting": 359
+  },
+  "averagePaymentDelta": 0.00,
+  "paymentTolerance": 0.01,
+  "paymentComparisons": 2000,
+  "paymentMatches": 2000,
+  "paymentMismatches": 0,
+  "maximumPaymentDelta": 0.00,
+  "paymentDeltaDistribution": [
+    {
+      "label": "Exact",
+      "lowerBoundExclusive": null,
+      "upperBoundInclusive": 0,
+      "count": 2000
+    },
+    {
+      "label": "Within tolerance",
+      "lowerBoundExclusive": 0,
+      "upperBoundInclusive": 0.01,
+      "count": 0
+    },
+    {
+      "label": "<= $1",
+      "lowerBoundExclusive": 0.01,
+      "upperBoundInclusive": 1,
+      "count": 0
+    },
+    {
+      "label": "<= $10",
+      "lowerBoundExclusive": 1,
+      "upperBoundInclusive": 10,
+      "count": 0
+    },
+    {
+      "label": "> $10",
+      "lowerBoundExclusive": 10,
+      "upperBoundInclusive": null,
+      "count": 0
+    }
+  ],
+  "businessDenialBreakdown": [
+    {
+      "code": "CARC_96",
+      "count": 9046
+    },
+    {
+      "code": "CARC_18",
+      "count": 6000
+    },
+    {
+      "code": "PRIOR_AUTH_REQUIRED",
+      "count": 2480
+    },
+    {
+      "code": "PROVIDER_EXCLUDED",
+      "count": 2000
+    },
+    {
+      "code": "NCCI_MUE_EDIT_FAILURE",
+      "count": 394
+    },
+    {
+      "code": "CARC_27",
+      "count": 267
+    },
+    {
+      "code": "SCRUB_VALIDATION_FAILURE",
+      "count": 47
+    }
+  ],
+  "workflowScenarioBreakdown": [
+    {
+      "scenario": "CleanProfessionalPaid",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthCarveIn",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthCarveOut",
+      "total": 200,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 200,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:BehavioralHealthParityCheck",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobBirthdayRule",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobGenderRule",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobMedicareSecondary",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobPrimaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobSecondaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:CobTertiaryPayer",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidCHIP",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidDualEligible",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidSSI",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidSpendDown",
+      "total": 120,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 120,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:MedicaidTANF",
+      "total": 120,
+      "matches": 120,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornAutoAdjudication",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornFirstThirtyDays",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:NewbornMotherClaimLink",
+      "total": 200,
+      "matches": 200,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_AuthOnFile",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_ExpiredAuth",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_NoAuth",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_WrongProcedure",
+      "total": 160,
+      "matches": 160,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:PriorAuthRequired_WrongProvider",
+      "total": 160,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 160,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityAdd",
+      "total": 267,
+      "matches": 267,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityCoverageChange",
+      "total": 266,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 266,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:RetroEligibilityTermination",
+      "total": 267,
+      "matches": 267,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationAccidentRelated",
+      "total": 134,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 134,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationThirdPartyLiability",
+      "total": 133,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 133,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "EdgeCase:SubrogationWorkersComp",
+      "total": 133,
+      "matches": 0,
+      "mismatches": 0,
+      "unsupported": 133,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "ExcludedProviderDenied",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "TxStarInpatientNoAuth",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    },
+    {
+      "scenario": "UncoveredServiceDenied",
+      "total": 2000,
+      "matches": 2000,
+      "mismatches": 0,
+      "unsupported": 0,
+      "observationTimeouts": 0,
+      "unspecified": 0
+    }
+  ],
+  "sampleFailures": [],
+  "claimResults": [],
+  "createdAtUtc": "2026-07-19T18:20:34.097Z",
+  "lastUpdatedAtUtc": "2026-07-19T19:45:15.128Z",
+  "progress": {
+    "phase": "Completed",
+    "requestedClaims": 100000,
+    "completedClaims": 100000,
+    "processedClaims": 100000,
+    "platformFailures": 0,
+    "percentComplete": 100,
+    "currentThroughputClaimsPerSecond": 55.40124127973597,
+    "rollingP95LatencyMilliseconds": 794.8101,
+    "rollingP99LatencyMilliseconds": 980.624,
+    "lastPublishedAtUtc": "2026-07-19T19:45:14.6514263+00:00"
+  }
+}


### PR DESCRIPTION
## Summary

- updates Episode 008 to use the final post-#934 100K MCC evidence run
- adds the post-#934 raw validator output and Mass Adjudication dashboard summary JSON
- records the post-#934 50K scoring gate, prior-auth scoring provenance, provider-exclusion label normalization, and wrapper-timeout caveat

## Validation

- `git diff --cached --check`
- JSON arithmetic check for outcome, workflow, denial, unsupported, and payment totals

## Notes

This is a docs/evidence packet update. The post-#934 raw validator output and dashboard summary JSON are authoritative for the final numbers; existing screenshots remain visual console examples from the Part 8 capture set.
