### PR TITLE
Expose pending pend observation telemetry

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -200,7 +200,7 @@
                             <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-1">
                                 <div class="d-flex align-center gap-2">
                                     <MudText Typo="Typo.body2">
-                                        @RunStatusLabel(_selectedRun): @_selectedRun.Progress?.CompletedClaims.ToString("N0") of @_selectedRun.TotalClaims.ToString("N0") claims observed
+                                        @RunProgressText(_selectedRun)
                                     </MudText>
                                     <MudSpacer />
                                     <MudText Typo="Typo.caption" Style="font-family: monospace;">
@@ -224,6 +224,10 @@
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    @if (IsRunActive(_selectedRun) && PendingExpectedPendObservations(_selectedRun) > 0)
+                    {
+                        <MudItem xs="6" md="4">@Metric("Pend Checks Pending", $"{PendingExpectedPendObservations(_selectedRun):N0}", "#ffca28")</MudItem>
+                    }
                     <MudItem xs="6" md="4">@Metric("Unsupported", $"{_selectedRun.WorkflowUnsupported:N0}", "#cbd5e1")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Payment Gate", PaymentGateLabel(_selectedRun), _selectedRun.PaymentMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
@@ -751,6 +755,20 @@
 
         return string.IsNullOrWhiteSpace(run.Status) ? "Completed" : run.Status;
     }
+
+    private static string RunProgressText(MassAdjudicationRunSummary run)
+    {
+        var completedClaims = run.Progress?.CompletedClaims ?? run.Processed;
+        var text = $"{RunStatusLabel(run)}: {completedClaims:N0} of {run.TotalClaims:N0} claims observed";
+        var pending = PendingExpectedPendObservations(run);
+
+        return pending <= 0
+            ? text
+            : $"{text} · {pending:N0} expected pends awaiting observation";
+    }
+
+    private static int PendingExpectedPendObservations(MassAdjudicationRunSummary run)
+        => run.Progress?.PendingExpectedPendObservations ?? 0;
 
     private static string LastProgressText(MassAdjudicationRunSummary run)
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -151,6 +151,7 @@ public class MassAdjudicationRunProgress
     public double CurrentThroughputClaimsPerSecond { get; set; }
     public double RollingP95LatencyMilliseconds { get; set; }
     public double RollingP99LatencyMilliseconds { get; set; }
+    public int PendingExpectedPendObservations { get; set; }
     public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -76,6 +76,7 @@ public class MassAdjudicationRunProgress
     public double CurrentThroughputClaimsPerSecond { get; set; }
     public double RollingP95LatencyMilliseconds { get; set; }
     public double RollingP99LatencyMilliseconds { get; set; }
+    public int PendingExpectedPendObservations { get; set; }
     public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2607,6 +2607,7 @@ static MassAdjudicationRunProgress CreateProgress(
     var completedClaims = results.Count;
     var processedClaims = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+    var pendingExpectedPendObservations = results.Count(r => IsAwaitingExpectedPendObservation(r, phase));
     var throughput = completedClaims / Math.Max(0.001, elapsed.TotalSeconds);
 
     return new MassAdjudicationRunProgress(
@@ -2619,6 +2620,7 @@ static MassAdjudicationRunProgress CreateProgress(
         throughput,
         Percentile(orderedDurations, 0.95),
         Percentile(orderedDurations, 0.99),
+        pendingExpectedPendObservations,
         DateTimeOffset.UtcNow);
 }
 
@@ -2873,6 +2875,7 @@ internal sealed record MassAdjudicationRunProgress(
     double CurrentThroughputClaimsPerSecond,
     double RollingP95LatencyMilliseconds,
     double RollingP99LatencyMilliseconds,
+    int PendingExpectedPendObservations,
     DateTimeOffset LastPublishedAtUtc);
 
 internal sealed record MassAdjudicationStageTiming(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -70,6 +70,7 @@ public class MassAdjudicationRunRepositoryTests
             CurrentThroughputClaimsPerSecond = 75.5,
             RollingP95LatencyMilliseconds = 250,
             RollingP99LatencyMilliseconds = 320,
+            PendingExpectedPendObservations = 46,
             LastPublishedAtUtc = DateTimeOffset.Parse("2026-07-09T19:00:00Z")
         };
         summary.Run.MemberUrl = "https://member";
@@ -106,6 +107,7 @@ public class MassAdjudicationRunRepositoryTests
         reread.Progress.Should().NotBeNull();
         reread.Progress!.CompletedClaims.Should().Be(2500);
         reread.Progress.CurrentThroughputClaimsPerSecond.Should().Be(75.5);
+        reread.Progress.PendingExpectedPendObservations.Should().Be(46);
         reread.Run.MemberUrl.Should().Be("https://member");
         reread.Run.CoverageUrl.Should().Be("https://coverage");
         reread.Run.SeedMembers.Should().BeTrue();


### PR DESCRIPTION
## Summary

Adds a live progress signal for expected-pend claims that are still waiting for the post-processing pend observation pass.

- publish `PendingExpectedPendObservations` from the MCC validator progress payload
- thread the field through the claims-service and portal mass-adjudication progress DTOs
- show a `Pend Checks Pending` tile and progress-text suffix in the Mass Adjudication console while active runs are still processing
- preserve the progress field through BSON serialization coverage

## Why

Expected-pend scenarios can look incomplete while the run is still in the timed processing phase because the persisted pend observation pass happens afterward. The validator already avoids counting those rows as live workflow mismatches; this PR makes that intermediate state visible in the operator console instead of leaving it implicit.

## Validation

- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj --no-restore`
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore` *(passes with existing warnings)*
- `dotnet build src/services/claims-service/claims-service.csproj`
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --filter MassAdjudicationRunRepositoryTests --no-restore`

Note: the first parallel claims-service build/test attempt hit a transient shared `obj/.../apphost` race; both commands passed when rerun sequentially.