### PR TITLE
Clarify MCC live progress evidence

### DIFF
--- a/src/portal/CloudHealthOffice.Portal/Pages/Dashboard.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/Dashboard.razor
@@ -123,7 +123,7 @@
                                     @latestRun.WorkflowMatches.ToString("N0")/@latestRun.WorkflowScenarios.ToString("N0")
                                 </MudText>
                                 <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                    @latestRun.WorkflowMismatches mismatch / @latestRun.WorkflowUnsupported unsupported
+                                    @WorkflowEvidenceCaption(latestRun)
                                 </MudText>
                             </MudItem>
                             <MudItem xs="6" md="3">
@@ -152,7 +152,7 @@
                                 <MudTd DataLabel="Claims">@context.Processed.ToString("N0") / @context.TotalClaims.ToString("N0")</MudTd>
                                 <MudTd DataLabel="Validator">
                                     <MudChip T="string" Size="Size.Small" Color="@GetWorkflowQualityColor(context)" Variant="Variant.Outlined">
-                                        @context.WorkflowMismatches mismatch
+                                        @WorkflowEvidenceChip(context)
                                     </MudChip>
                                 </MudTd>
                                 <MudTd DataLabel="Latency">@context.P95LatencyMilliseconds.ToString("N0") ms P95</MudTd>
@@ -829,9 +829,43 @@
     {
         if (run.PlatformFailures > 0 || run.WorkflowMismatches > 0 || run.ObservationTimeouts > 0)
             return Color.Error;
+        if (IsRunActive(run) && PendingWorkflowObservations(run) > 0)
+            return Color.Warning;
         if (run.WorkflowUnsupported > 0 || run.WorkflowObservationTimeouts > 0)
             return Color.Warning;
         return Color.Success;
+    }
+
+    private static bool IsRunActive(MassAdjudicationRunSummary run)
+        => string.Equals(run.Status, "Running", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(run.Progress?.Phase, "Processing claims", StringComparison.OrdinalIgnoreCase);
+
+    private static int PendingWorkflowObservations(MassAdjudicationRunSummary run)
+    {
+        if (run.Progress is null)
+        {
+            return 0;
+        }
+
+        return run.Progress.PendingWorkflowObservations > 0
+            ? run.Progress.PendingWorkflowObservations
+            : run.Progress.PendingExpectedPendObservations + run.Progress.PendingTerminalStatusObservations;
+    }
+
+    private static string WorkflowEvidenceCaption(MassAdjudicationRunSummary run)
+    {
+        var pending = PendingWorkflowObservations(run);
+        return IsRunActive(run) && pending > 0
+            ? $"{run.WorkflowMismatches:N0} confirmed / {pending:N0} pending / {run.WorkflowUnsupported:N0} unsupported"
+            : $"{run.WorkflowMismatches:N0} mismatch / {run.WorkflowUnsupported:N0} unsupported";
+    }
+
+    private static string WorkflowEvidenceChip(MassAdjudicationRunSummary run)
+    {
+        var pending = PendingWorkflowObservations(run);
+        return IsRunActive(run) && pending > 0
+            ? $"{pending:N0} pending"
+            : $"{run.WorkflowMismatches:N0} mismatch";
     }
 
     private static Color GetQueueColor(string reasonCode) => reasonCode switch

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -223,10 +223,10 @@
                     <MudItem xs="6" md="4">@Metric("Claims/sec", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>
-                    <MudItem xs="6" md="4">@Metric("Workflow Mismatches", $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
-                    @if (IsRunActive(_selectedRun) && PendingExpectedPendObservations(_selectedRun) > 0)
+                    <MudItem xs="6" md="4">@Metric(WorkflowMismatchLabel(_selectedRun), $"{_selectedRun.WorkflowMismatches:N0}", _selectedRun.WorkflowMismatches == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    @if (IsRunActive(_selectedRun) && PendingWorkflowObservations(_selectedRun) > 0)
                     {
-                        <MudItem xs="6" md="4">@Metric("Pend Checks Pending", $"{PendingExpectedPendObservations(_selectedRun):N0}", "#ffca28")</MudItem>
+                        <MudItem xs="6" md="4">@Metric("Checks Pending", $"{PendingWorkflowObservations(_selectedRun):N0}", "#ffca28")</MudItem>
                     }
                     <MudItem xs="6" md="4">@Metric("Unsupported", $"{_selectedRun.WorkflowUnsupported:N0}", "#cbd5e1")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Timeouts", $"{_selectedRun.WorkflowObservationTimeouts:N0}", _selectedRun.WorkflowObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
@@ -760,15 +760,58 @@
     {
         var completedClaims = run.Progress?.CompletedClaims ?? run.Processed;
         var text = $"{RunStatusLabel(run)}: {completedClaims:N0} of {run.TotalClaims:N0} claims observed";
-        var pending = PendingExpectedPendObservations(run);
+        var pending = PendingWorkflowObservations(run);
 
-        return pending <= 0
-            ? text
-            : $"{text} · {pending:N0} expected pends awaiting observation";
+        if (pending <= 0)
+        {
+            return text;
+        }
+
+        var pendingDetails = PendingWorkflowObservationDetails(run);
+        return string.IsNullOrWhiteSpace(pendingDetails)
+            ? $"{text} · {pending:N0} workflow checks awaiting observation"
+            : $"{text} · {pending:N0} workflow checks awaiting observation ({pendingDetails})";
     }
+
+    private static string WorkflowMismatchLabel(MassAdjudicationRunSummary run)
+        => IsRunActive(run) ? "Confirmed Mismatches" : "Workflow Mismatches";
 
     private static int PendingExpectedPendObservations(MassAdjudicationRunSummary run)
         => run.Progress?.PendingExpectedPendObservations ?? 0;
+
+    private static int PendingTerminalStatusObservations(MassAdjudicationRunSummary run)
+        => run.Progress?.PendingTerminalStatusObservations ?? 0;
+
+    private static int PendingWorkflowObservations(MassAdjudicationRunSummary run)
+    {
+        if (run.Progress is null)
+        {
+            return 0;
+        }
+
+        return run.Progress.PendingWorkflowObservations > 0
+            ? run.Progress.PendingWorkflowObservations
+            : PendingExpectedPendObservations(run) + PendingTerminalStatusObservations(run);
+    }
+
+    private static string PendingWorkflowObservationDetails(MassAdjudicationRunSummary run)
+    {
+        var pending = new List<string>();
+        var expectedPends = PendingExpectedPendObservations(run);
+        var terminalStatus = PendingTerminalStatusObservations(run);
+
+        if (expectedPends > 0)
+        {
+            pending.Add($"{expectedPends:N0} pend");
+        }
+
+        if (terminalStatus > 0)
+        {
+            pending.Add($"{terminalStatus:N0} terminal");
+        }
+
+        return string.Join(", ", pending);
+    }
 
     private static string LastProgressText(MassAdjudicationRunSummary run)
     {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -152,6 +152,8 @@ public class MassAdjudicationRunProgress
     public double RollingP95LatencyMilliseconds { get; set; }
     public double RollingP99LatencyMilliseconds { get; set; }
     public int PendingExpectedPendObservations { get; set; }
+    public int PendingTerminalStatusObservations { get; set; }
+    public int PendingWorkflowObservations { get; set; }
     public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -77,6 +77,8 @@ public class MassAdjudicationRunProgress
     public double RollingP95LatencyMilliseconds { get; set; }
     public double RollingP99LatencyMilliseconds { get; set; }
     public int PendingExpectedPendObservations { get; set; }
+    public int PendingTerminalStatusObservations { get; set; }
+    public int PendingWorkflowObservations { get; set; }
     public DateTimeOffset LastPublishedAtUtc { get; set; }
 }
 

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -3,6 +3,7 @@ namespace CloudHealthOffice.Tools.MccPlatformValidator;
 internal static class MccRunSummaryBuilder
 {
     internal const decimal PaymentTolerance = 0.01m;
+    internal const string ProcessingClaimsPhase = "Processing claims";
 
     public static MassAdjudicationRunSummary Build(
         List<ClaimValidationResult> results,
@@ -294,6 +295,27 @@ internal static class MccRunSummaryBuilder
         => IsPaymentComparable(result)
             ? Math.Abs(result.ActualPlanPayment!.Value - result.ExpectedPlanPayment!.Value)
             : null;
+
+    internal static bool IsWorkflowObservationPending(ClaimValidationResult result, string phase)
+        => IsExpectedPendObservationPending(result, phase)
+            || IsTerminalStatusObservationPending(result, phase);
+
+    internal static bool IsExpectedPendObservationPending(ClaimValidationResult result, string phase)
+        => IsProcessingClaimsPhase(phase)
+            && result.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()
+            && result.ValidationStatus == MccWorkflowValidation.MismatchedStatus
+            && result.Outcome is not ClaimValidationOutcome.PlatformFailure
+            && !string.IsNullOrWhiteSpace(result.SubmittedClaimId);
+
+    internal static bool IsTerminalStatusObservationPending(ClaimValidationResult result, string phase)
+        => IsProcessingClaimsPhase(phase)
+            && result.ExpectedOutcome == ClaimValidationOutcome.BusinessDenial.ToString()
+            && result.ValidationStatus == MccWorkflowValidation.MismatchedStatus
+            && result.Outcome is not ClaimValidationOutcome.PlatformFailure
+            && !string.IsNullOrWhiteSpace(result.SubmittedClaimId);
+
+    private static bool IsProcessingClaimsPhase(string phase)
+        => phase.Equals(ProcessingClaimsPhase, StringComparison.OrdinalIgnoreCase);
 
     private static double Percentile(double[] values, double percentile)
     {

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2526,7 +2526,7 @@ static MassAdjudicationRunSummary BuildProgressSummary(
     var workflowMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
     var workflowMismatches = results.Count(r =>
         r.ValidationStatus == MccWorkflowValidation.MismatchedStatus
-        && !IsAwaitingExpectedPendObservation(r, phase));
+        && !MccRunSummaryBuilder.IsWorkflowObservationPending(r, phase));
     var workflowUnsupported = results.Count(r => r.ValidationStatus == MccWorkflowValidation.UnsupportedStatus);
     var workflowObservationTimeouts = results.Count(r => r.ValidationStatus == MccWorkflowValidation.ObservationTimeoutStatus);
     var progress = CreateProgress(results, elapsed, options, phase);
@@ -2588,11 +2588,6 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         progress);
 }
 
-static bool IsAwaitingExpectedPendObservation(ClaimValidationResult result, string phase)
-    => phase.Equals("Processing claims", StringComparison.OrdinalIgnoreCase)
-        && result.ExpectedOutcome == ClaimValidationOutcome.Pended.ToString()
-        && result.ValidationStatus == MccWorkflowValidation.MismatchedStatus;
-
 static MassAdjudicationRunProgress CreateProgress(
     IReadOnlyCollection<ClaimValidationResult> results,
     TimeSpan elapsed,
@@ -2607,7 +2602,9 @@ static MassAdjudicationRunProgress CreateProgress(
     var completedClaims = results.Count;
     var processedClaims = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
-    var pendingExpectedPendObservations = results.Count(r => IsAwaitingExpectedPendObservation(r, phase));
+    var pendingExpectedPendObservations = results.Count(r => MccRunSummaryBuilder.IsExpectedPendObservationPending(r, phase));
+    var pendingTerminalStatusObservations = results.Count(r => MccRunSummaryBuilder.IsTerminalStatusObservationPending(r, phase));
+    var pendingWorkflowObservations = pendingExpectedPendObservations + pendingTerminalStatusObservations;
     var throughput = completedClaims / Math.Max(0.001, elapsed.TotalSeconds);
 
     return new MassAdjudicationRunProgress(
@@ -2621,6 +2618,8 @@ static MassAdjudicationRunProgress CreateProgress(
         Percentile(orderedDurations, 0.95),
         Percentile(orderedDurations, 0.99),
         pendingExpectedPendObservations,
+        pendingTerminalStatusObservations,
+        pendingWorkflowObservations,
         DateTimeOffset.UtcNow);
 }
 
@@ -2876,6 +2875,8 @@ internal sealed record MassAdjudicationRunProgress(
     double RollingP95LatencyMilliseconds,
     double RollingP99LatencyMilliseconds,
     int PendingExpectedPendObservations,
+    int PendingTerminalStatusObservations,
+    int PendingWorkflowObservations,
     DateTimeOffset LastPublishedAtUtc);
 
 internal sealed record MassAdjudicationStageTiming(

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -71,6 +71,8 @@ public class MassAdjudicationRunRepositoryTests
             RollingP95LatencyMilliseconds = 250,
             RollingP99LatencyMilliseconds = 320,
             PendingExpectedPendObservations = 46,
+            PendingTerminalStatusObservations = 12,
+            PendingWorkflowObservations = 58,
             LastPublishedAtUtc = DateTimeOffset.Parse("2026-07-09T19:00:00Z")
         };
         summary.Run.MemberUrl = "https://member";
@@ -108,6 +110,8 @@ public class MassAdjudicationRunRepositoryTests
         reread.Progress!.CompletedClaims.Should().Be(2500);
         reread.Progress.CurrentThroughputClaimsPerSecond.Should().Be(75.5);
         reread.Progress.PendingExpectedPendObservations.Should().Be(46);
+        reread.Progress.PendingTerminalStatusObservations.Should().Be(12);
+        reread.Progress.PendingWorkflowObservations.Should().Be(58);
         reread.Run.MemberUrl.Should().Be("https://member");
         reread.Run.CoverageUrl.Should().Be("https://coverage");
         reread.Run.SeedMembers.Should().BeTrue();

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -252,6 +252,62 @@ public class MccRunSummaryBuilderTests
         Assert.Equal(19, summary.FixturePreparation.ProvidersExisting);
     }
 
+    [Fact]
+    public void IsWorkflowObservationPending_SeparatesReconciliableProgressMismatches()
+    {
+        var expectedPend = Result(
+            "EXPECTED-PEND",
+            "EdgeCase:CobSecondaryPayer",
+            MccWorkflowValidation.MismatchedStatus,
+            ClaimValidationOutcome.Paid) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.Pended.ToString()
+        };
+        var expectedBusinessDenial = Result(
+            "EXPECTED-DENIAL",
+            MccWorkflowValidation.TexasStarInpatientNoAuthScenario,
+            MccWorkflowValidation.MismatchedStatus,
+            ClaimValidationOutcome.Paid) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.BusinessDenial.ToString(),
+            ExpectedBusinessDenialCode = MccWorkflowValidation.PriorAuthRequiredCode
+        };
+        var confirmedMismatch = Result(
+            "CONFIRMED-MISMATCH",
+            MccWorkflowValidation.CleanProfessionalPaidScenario,
+            MccWorkflowValidation.MismatchedStatus,
+            ClaimValidationOutcome.BusinessDenial) with
+        {
+            ExpectedOutcome = ClaimValidationOutcome.Paid.ToString()
+        };
+        var platformFailure = expectedPend with
+        {
+            Outcome = ClaimValidationOutcome.PlatformFailure,
+            SubmittedClaimId = null
+        };
+
+        Assert.True(MccRunSummaryBuilder.IsExpectedPendObservationPending(
+            expectedPend,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+        Assert.True(MccRunSummaryBuilder.IsTerminalStatusObservationPending(
+            expectedBusinessDenial,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+        Assert.True(MccRunSummaryBuilder.IsWorkflowObservationPending(
+            expectedPend,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+        Assert.True(MccRunSummaryBuilder.IsWorkflowObservationPending(
+            expectedBusinessDenial,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+
+        Assert.False(MccRunSummaryBuilder.IsWorkflowObservationPending(
+            confirmedMismatch,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+        Assert.False(MccRunSummaryBuilder.IsWorkflowObservationPending(expectedPend, "Completed"));
+        Assert.False(MccRunSummaryBuilder.IsWorkflowObservationPending(
+            platformFailure,
+            MccRunSummaryBuilder.ProcessingClaimsPhase));
+    }
+
     private static void AssertPaymentBucket(MassAdjudicationRunSummary summary, string label, int count)
     {
         var bucket = Assert.Single(summary.PaymentDeltaDistribution, b => b.Label == label);


### PR DESCRIPTION
## Summary
- distinguish confirmed live-progress workflow mismatches from checks still awaiting persisted-state observation
- publish pending terminal-status workflow observations alongside expected-pend observations
- update the Mass Adjudication console and dashboard wording so active runs show pending checks instead of alarming temporary mismatches
- add validator and repository regression coverage for the new progress counters

## Why
During active MCC runs, expected-pend and terminal-status scenarios can temporarily appear mismatched until later observation phases reconcile persisted claim state. The console was surfacing those as workflow mismatches mid-run, which made the live view look worse than the final evidence.

## Validation
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
- dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj
- dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj
- git diff --check