### PR TITLE
chore: align validation commands

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,7 +1,8 @@
 # Observability overlay for Cloud Health Office local development.
 #
 # Usage:
-#   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+#   docker compose --profile core --profile finance \
+#     -f docker-compose.yml -f docker-compose.observability.yml up -d
 #
 # Service URLs:
 #   Jaeger UI:     http://localhost:16686

--- a/docs/evidence/REPOSITORY-VALIDATION.md
+++ b/docs/evidence/REPOSITORY-VALIDATION.md
@@ -80,8 +80,8 @@ outputs created by validation commands.
 | TypeScript build | Pass | `npm run build` completed. |
 | Jest tests | Pass | 24 suites passed, 525 tests passed. Coverage: 88.36% statements, 76.44% branches, 93.37% functions, 88.71% lines. |
 | npm lint | Fail locally | ESLint 9.39.5 crashed under Node 26 with an AJV/eslintrc `defaultMeta` error. |
-| Root site build script | Fail | `npm run build:site` points at missing `site/js/markdown-converter.js`; current site files live under `src/site`. |
-| Root site accessibility script | Fail | `npm run validate:site` points at missing `site/js/validate-accessibility.js`; current site files live under `src/site`. |
+| Root site build script | Remediated after baseline | The root `build:site` script now delegates to the current `src/site` package. |
+| Root site accessibility script | Remediated after baseline | The root `validate:site` script now runs the current `src/site` accessibility validator. |
 | Root template validation script | Fail | `npm run validate` expects missing `dist/scripts/utils/validate-all-templates.js`. |
 | Current static site build path | Pass | Running `node build.mjs` from a copied `src/site` tree produced a deployable artifact. |
 | Current site accessibility validator | Pass with reported issues | `node src/site/js/validate-accessibility.js` exited 0 and reported 36 potential accessibility issues. |
@@ -153,9 +153,7 @@ The current static site path was also validated directly because the root npm
 site scripts point at stale paths:
 
 ```bash
-TMP_SITE=$(mktemp -d)
-rsync -a --exclude node_modules src/site/ "$TMP_SITE/site/"
-(cd "$TMP_SITE/site" && node build.mjs)
+npm --prefix src/site run build
 node src/site/js/validate-accessibility.js
 ```
 
@@ -192,7 +190,8 @@ actionlint .github/workflows/*.yml
 docker compose -f docker-compose.yml config --quiet
 docker compose --profile core -f docker-compose.yml config --quiet
 docker compose -f docker-compose.development.yml config --quiet
-docker compose -f docker-compose.observability.yml config --quiet
+docker compose --profile core --profile finance \
+  -f docker-compose.yml -f docker-compose.observability.yml config --quiet
 
 kubectl version --client
 kubectl apply --dry-run=client --validate=false -f infrastructure/k8s --recursive

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "build:site": "node site/js/markdown-converter.js",
+    "build:site": "npm --prefix src/site run build",
     "inject:metrics": "node scripts/inject-test-metrics.js",
-    "validate:site": "node site/js/validate-accessibility.js",
+    "validate:site": "node src/site/js/validate-accessibility.js",
     "generate": "node dist/scripts/cli/payer-generator-cli.js",
     "generate-pdf": "./scripts/generate-whitepaper-pdf.sh",
     "test": "jest",

--- a/src/site/docs/million-claim-challenge/evidence.html
+++ b/src/site/docs/million-claim-challenge/evidence.html
@@ -613,8 +613,9 @@ The key result is that the current portal can now inspect a published mass adjud
 
 ## Run identity
 
-- Date: July 12, 2026
-- Kubernetes job: `mcc-part8-100k`
+- Date: July 19, 2026 local time / July 19, 2026 UTC
+- Kubernetes job: `mcc-main-100k-p10-112031`
+- Dashboard run ID: `dd0ebe4979e247bc95a980610de7d0be`
 - Environment: local Docker Desktop Kubernetes
 - Tenant: `demo`
 - Validator seed: 42
@@ -629,8 +630,21 @@ The key result is that the current portal can now inspect a published mass adjud
 ## Command
 
 ```text
-CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_EVERY=5000 ./scripts/run-mcc-local-k8s.sh
+JOB_NAME=mcc-main-100k-p10-112031 CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=10 PROGRESS_EVERY=10000 SEED_AUTHORIZATIONS=true SKIP_BUILD=true ./scripts/run-mcc-local-k8s.sh
 ```
+
+The local wrapper timed out while waiting for the Kubernetes job condition, but the Kubernetes job continued running and completed successfully. The pod exited successfully with 0 restarts, and the validator published the completed dashboard summary.
+
+## Raw artifacts
+
+- `raw-validator-output-post934-100k.txt` - validator console output from the completed post-#934 100K run.
+- `run-summary-post934-100k.json` - completed Mass Adjudication run summary returned by claims-service for the post-#934 100K run.
+- `raw-validator-output-post937-100k-p12.txt` - validator console output from the completed 100K p12 confirmation run.
+- `run-summary-post937-100k-p12.json` - completed Mass Adjudication run summary returned by claims-service for the 100K p12 confirmation run.
+- `raw-validator-output-post937-100k-p16.txt` - validator console output from the completed 100K p16 pressure run.
+- `run-summary-post937-100k-p16.json` - completed Mass Adjudication run summary returned by claims-service for the 100K p16 pressure run.
+- `raw-validator-output-post928-100k.txt` - prior post-#928 100K validator output retained as provenance.
+- `run-summary-post928-100k.json` - prior post-#928 dashboard summary retained as provenance.
 
 ## Fixture preparation
 
@@ -639,49 +653,69 @@ CLAIMS=100000 MAX_CLAIMS=100000 JOB_NAME=mcc-part8-100k PARALLELISM=10 PROGRESS_
 - Injected 2,000 excluded-provider denial scenarios.
 - Injected 2,000 uncovered-service denial scenarios.
 - Injected 2,000 TX STAR inpatient no-authorization scenarios.
-- Seeded 87,115 synthetic members; 12,476 already existed; 99,591 statuses aligned.
-- Seeded 620 COB coverage rows; 300 already existed.
-- Seeded 174,202 synthetic providers; 25,644 already existed.
-- Provider networks: 0 new; 2 already existed.
+- Provider fixture pool: 199,847 provider references reduced to 13,742 distinct NPIs.
+- Provider assignments reused: 186,258.
+- Provider-sensitive claims preserved: 2,800.
+- Seeded 10,614 synthetic members; 88,977 already existed; 99,591 statuses aligned.
+- Seeded 0 COB coverage rows; 920 already existed.
+- Seeded 0 provider networks; 2 already existed.
+- Seeded 13,383 synthetic providers; 359 already existed.
 
 ## Correctness result
 
 - Total claims: 100,000
 - Processed: 100,000
-- Paid/adjudicated: 79,164
-- Pended: 923
-- Business denials: 19,913
+- Paid/adjudicated: 78,842
+- Pended: 924
+- Business denials: 20,234
 - Platform failures: 0
 - Observation timeouts: 0
 - Expected-pend observation: 920 pended, 0 timed out
-- False-pend sweep: 10,614 scoreable non-pend claims, 0 unexpected pends
-- Workflow scoring: 11,534/13,000 matched, 0 mismatched, 1,466 unsupported, 0 observation timeouts
+- False-pend sweep: 10,934 scoreable non-pend claims, 0 unexpected pends, 2,242 terminal outcomes reconciled
+- Workflow scoring: 11,854/13,000 matched, 0 mismatched, 1,146 unsupported, 0 observation timeouts
 - Payment gate: 2,000/2,000 within $0.01, 0 mismatched
 - Average payment delta: $0.00
 - Maximum payment delta: $0.00
 
-Pend-scope note: the final persisted outcome mix includes 923 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,614 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
+Pend-scope note: the final persisted outcome mix includes 924 pended claims. The expected-pend observer independently verified 920 answer-key pend scenarios as pended. The false-pend sweep then checked 10,934 scoreable expected-pay and expected-deny claims and found 0 unexpected pends. Unsupported scenarios remain outside the scoreable non-pend sweep.
 
 ## Performance result
 
-- Timed claim-processing elapsed: 29:40.851
-- Throughput: 56.15 claims/second
-- P95 latency: 358 ms
-- P99 latency: 451 ms
-- Submit average/P95: 63 ms / 199 ms
-- Adjudicate average/P95: 75 ms / 140 ms
-- Writeback average/P95: 40 ms / 102 ms
-- Benefit calculation average/P95: 60 ms / 127 ms
-- Provider integrity average/P95: 12 ms / 39 ms
-- Kubernetes job duration: approximately 128 minutes, including corpus generation and fixture preparation
+- Timed claim-processing elapsed: 30:05.013
+- Throughput: 55.40 claims/second
+- P95 latency: 324 ms
+- P99 latency: 480 ms
+- Submit average/P95: 67 ms / 194 ms
+- Adjudicate average/P95: 70 ms / 122 ms
+- Writeback average/P95: 45 ms / 101 ms
+- Benefit calculation average/P95: 65 ms / 115 ms
+- Provider integrity average/P95: 3 ms / 2 ms
+- Preparation time: 7:53.368
+- Tracked lifecycle: 38:05.792
+
+## Lifecycle timings
+
+- Service health checks: 0:00.056
+- Reference rule seeding: 0:00.120
+- Validation plan setup: 0:00.018
+- Corpus generation: 0:01.201
+- Fixture normalization: 0:00.327
+- Authorization fixture seeding: 0:00.436
+- Member and coverage seeding: 2:47.051
+- Provider seeding: 5:04.155
+- Timed adjudication: 30:05.013
+- Expected-pend observation: 0:00.765
+- False-pend sweep: 0:06.644
 
 ## Business denials
 
 - CARC 96: 9,046
 - CARC 18: 6,000
-- PRIOR_AUTH_REQUIRED: 2,160
+- PRIOR_AUTH_REQUIRED: 2,480
 - PROVIDER_EXCLUDED: 2,000
-- NCCI_MUE_EDIT_FAILURE: 393
+- NCCI_MUE_EDIT_FAILURE: 394
+- CARC 27: 267
+- SCRUB_VALIDATION_FAILURE: 47
 
 Business denials are valid platform outcomes, not platform failures.
 
@@ -689,25 +723,211 @@ Business denials are valid platform outcomes, not platform failures.
 
 - BehavioralHealthCarveOut: 200
 - MedicaidSpendDown: 120
-- PriorAuthRequired_ExpiredAuth: 160
-- PriorAuthRequired_WrongProcedure: 160
 - PriorAuthRequired_WrongProvider: 160
 - RetroEligibilityCoverageChange: 266
 - SubrogationAccidentRelated: 134
 - SubrogationThirdPartyLiability: 133
 - SubrogationWorkersComp: 133
 
-Total unsupported: 1,466.
+Total unsupported: 1,146.
 
 Unsupported means the scenario is not currently scoreable through the implemented platform/validator path. It is not counted as matched, mismatched, or a platform failure.
 
+## Matched scenario footprint
+
+- CleanProfessionalPaid: 2,000/2,000 matched
+- ExcludedProviderDenied: 2,000/2,000 matched
+- UncoveredServiceDenied: 2,000/2,000 matched
+- TxStarInpatientNoAuth: 2,000/2,000 matched
+- COB primary, secondary, tertiary, birthday-rule, gender-rule, and Medicare-secondary: 200/200 matched each
+- Newborn auto-adjudication, first-thirty-days, and mother-claim-link: 200/200 matched each
+- Medicaid CHIP, dual-eligible, SSI, and TANF: 120/120 matched each
+- Retro eligibility add and termination: 267/267 matched each
+- Behavioral health carve-in and parity-check: 200/200 matched each
+- Prior-auth required auth-on-file, expired-auth, no-auth, and wrong-procedure variants: 160/160 matched each
+
 ## Interpretation
 
-The 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
+The post-#934 100K correctness gate passed cleanly. All claims processed; the scoreable workflow set produced no mismatches; expected-pend observation produced no timeouts; the non-pend sweep found no unexpected pends; and all 2,000 comparable payments matched within one cent.
 
-The timed adjudication result and total Kubernetes job duration must remain separate. Timed processing completed in 29:40.851 at 56.15 claims/second. The job lifecycle lasted about 128 minutes because large run-scoped member and provider fixture preparation occurred before timed processing.
+Timed adjudication and full tracked lifecycle must remain separate. Timed processing completed in 30:05.013 at 55.40 claims/second. The tracked lifecycle completed in 38:05.792 after preparation, processing, expected-pend observation, and false-pend sweep.
 
-This is local Docker Desktop evidence, not a production-cloud capacity claim. The performance result identifies fixture preparation and increased local tail latency as the next scaling investigation.
+This is local Docker Desktop evidence, not a production-cloud capacity claim. During the run, Docker Desktop showed significant CPU and memory headroom, so the next performance investigation should focus on internal throughput limits: validator parallelism, service concurrency, HTTP client limits, MongoDB/writeback behavior, and disk I/O.
+
+## Post-#937 100K p12 parallelism confirmation
+
+After the p10 100K run, the first controlled parallelism follow-up raised validator parallelism from 10 to 12 while keeping the same seed, claim count, fixture model, payment gate, false-pend sweep, and workflow scoring rules.
+
+- Date: July 19, 2026 local time / July 19, 2026 UTC
+- Kubernetes job: `mcc-main-100k-p12-140034`
+- Dashboard run ID: `918f36d680a84a309b2e35944d5a4b6b`
+- Claims: 100,000
+- Parallelism: 12
+- Validator seed: 42
+- Line of business: Medicaid
+- Prior-authorization scenario rate: 2%
+- Pend observation: enabled, 45-second bound, 1-second polling interval
+- Wrapper timeout: `JOB_TIMEOUT=120m`
+- Dashboard summary: published
+
+```text
+JOB_NAME=mcc-main-100k-p12-140034 CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=12 PROGRESS_EVERY=10000 SEED_AUTHORIZATIONS=true JOB_TIMEOUT=120m SKIP_BUILD=false ./scripts/run-mcc-local-k8s.sh
+```
+
+PR #937 made `JOB_TIMEOUT` a first-class runner option after this long-run validation exposed the need for a larger wrapper wait window. The timeout setting affects local orchestration only; it does not change validator scoring or adjudication behavior.
+
+### Post-#937 100K p12 correctness result
+
+- Total claims: 100,000
+- Processed: 100,000
+- Paid/adjudicated: 78,813
+- Pended: 928
+- Business denials: 20,259
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 920 pended, 0 timed out
+- False-pend sweep: 10,934 scoreable non-pend claims, 0 unexpected pends, 2,064 terminal outcomes reconciled
+- Workflow scoring: 11,854/13,000 matched, 0 mismatched, 1,146 unsupported, 0 observation timeouts
+- Payment gate: 2,000/2,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+
+### Post-#937 100K p12 performance result
+
+- Timed claim-processing elapsed: 28:28.006
+- Throughput: 58.55 claims/second
+- P95 latency: 416 ms
+- P99 latency: 580 ms
+- Submit average/P95: 79 ms / 219 ms
+- Adjudicate average/P95: 75 ms / 183 ms
+- Writeback average/P95: 51 ms / 170 ms
+- Benefit calculation average/P95: 72 ms / 179 ms
+- Preparation time: 5:54.074
+- Tracked lifecycle: 34:29.990
+
+The p12 run preserved the correctness gates and improved throughput from 55.40 to 58.55 claims/second compared with p10. Tail latency moved the other direction: P95 increased from 324 ms to 416 ms and P99 increased from 480 ms to 580 ms. That is the useful signal from this sweep. Higher parallelism helped throughput a little, but the latency curve was already starting to push back.
+
+## Post-#937 100K p16 pressure run
+
+The second controlled follow-up raised validator parallelism from 12 to 16 while preserving the same seed, claim count, fixture model, payment gate, false-pend sweep, and workflow scoring rules.
+
+- Date: July 19, 2026 local time / July 19-20, 2026 UTC
+- Kubernetes job: `mcc-main-100k-p16-161929`
+- Dashboard run ID: `6c0223b957114911931c8472687d496b`
+- Claims: 100,000
+- Parallelism: 16
+- Validator seed: 42
+- Line of business: Medicaid
+- Prior-authorization scenario rate: 2%
+- Pend observation: enabled, 45-second bound, 1-second polling interval
+- Wrapper timeout: `JOB_TIMEOUT=120m`
+- Dashboard summary: published
+
+```text
+JOB_NAME=mcc-main-100k-p16-161929 CLAIMS=100000 MAX_CLAIMS=100000 PARALLELISM=16 PROGRESS_EVERY=10000 SEED_AUTHORIZATIONS=true JOB_TIMEOUT=120m SKIP_BUILD=false ./scripts/run-mcc-local-k8s.sh
+```
+
+### Post-#937 100K p16 correctness result
+
+- Total claims: 100,000
+- Processed: 100,000
+- Paid/adjudicated: 78,721
+- Pended: 922
+- Business denials: 20,357
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 920 pended, 0 timed out
+- False-pend sweep: 10,934 scoreable non-pend claims, 0 unexpected pends, 2,023 terminal outcomes reconciled
+- Workflow scoring: 11,854/13,000 matched, 0 mismatched, 1,146 unsupported, 0 observation timeouts
+- Payment gate: 2,000/2,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+
+### Post-#937 100K p16 performance result
+
+- Timed claim-processing elapsed: 30:14.613
+- Throughput: 55.11 claims/second
+- P95 latency: 518 ms
+- P99 latency: 683 ms
+- Submit average/P95: 116 ms / 294 ms
+- Adjudicate average/P95: 104 ms / 206 ms
+- Writeback average/P95: 71 ms / 192 ms
+- Benefit calculation average/P95: 102 ms / 201 ms
+- Preparation time: 5:36.195
+- Tracked lifecycle: 35:58.823
+
+The p16 run preserved the correctness gates but lost the p12 throughput gain and increased tail latency. Compared with p12, throughput fell from 58.55 to 55.11 claims/second, P95 increased from 416 ms to 518 ms, and P99 increased from 580 ms to 683 ms. That makes p12 the better local setting for this fixture model, and it argues for service/writeback tuning before any 250K attempt.
+
+## Live-progress caveat
+
+During claim processing, the console can show workflow mismatches before expected-pend observation has reconciled persisted status. In the p10 run, the live console showed 920 workflow mismatches. In the p16 run, the live console showed 320 workflow mismatches mid-run. Both cleared after final scoring; the completed summaries reported 0 workflow mismatches.
+
+The live console should distinguish expected-pend checks awaiting observation from true workflow mismatches. Completed summaries are correct; the issue is in-progress presentation.
+
+## Post-#928 provider-fixture verification
+
+After PR #927 anchored validation providers as run-scoped fixtures, a follow-up 50K run still exposed 10 scoreable `TxStarInpatientNoAuth` mismatches. Those claims expected `PRIOR_AUTH_REQUIRED` but adjudicated as `PROVIDER_EXCLUDED`. Spot checks against provider-service showed the current generated rendering provider record was approved and in-network, which pointed to stale or colliding provider-integrity state around the old synthetic validation-provider NPI family.
+
+PR #928 moved MCC scoreable validation providers into wider, role-separated synthetic NPI namespaces:
+
+- `93...` billing providers
+- `94...` adjudicatable rendering providers
+- `95...` intentionally excluded rendering providers
+
+The post-#928 50K rerun was completed as `mcc-provider-namespace-50k-163946`.
+
+### Post-#928 50K correctness result
+
+- Total claims: 50,000
+- Processed: 50,000
+- Paid/adjudicated: 39,407
+- Pended: 463
+- Business denials: 10,130
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 460 pended, 0 timed out
+- False-pend sweep: 5,307 scoreable non-pend claims, 0 unexpected pends
+- Workflow scoring: 5,767/6,500 matched, 0 mismatched, 733 unsupported, 0 observation timeouts
+- Payment gate: 1,000/1,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+- `TxStarInpatientNoAuth`: 1,000/1,000 matched
+
+### Post-#928 50K performance result
+
+- Timed claim-processing elapsed: 14:13.279
+- Throughput: 58.60 claims/second
+- P95 latency: 380 ms
+- P99 latency: 515 ms
+- Preparation time: 2:54.130
+- Tracked lifecycle: 17:14.705
+- Provider fixtures created: 7,568
+- Provider fixtures already present: 491
+
+The post-#928 50K run proved the provider-fixture hardening. Later PRs made seeded prior-auth evidence scoreable and normalized provider-exclusion denial labels.
+
+## Post-#934 50K scoring verification
+
+The post-#934 50K rerun was completed as `mcc-main-50k-p10-105103` with dashboard run ID `41301477f0eb437bb6a95bf3bd8d420b`.
+
+- Total claims: 50,000
+- Processed: 50,000
+- Paid/adjudicated: 39,377
+- Pended: 461
+- Business denials: 10,162
+- Platform failures: 0
+- Observation timeouts: 0
+- Expected-pend observation: 460 pended, 0 timed out
+- False-pend sweep: 5,467 scoreable non-pend claims, 0 unexpected pends
+- Workflow scoring: 5,927/6,500 matched, 0 mismatched, 573 unsupported, 0 observation timeouts
+- Payment gate: 1,000/1,000 within $0.01, 0 mismatched
+- Average payment delta: $0.00
+- Maximum payment delta: $0.00
+- Throughput: 59.59 claims/second
+- P95 latency: 318 ms
+- P99 latency: 415 ms
+
+The post-#934 50K run proved the prior-auth and provider-exclusion scoring fixes. The 100K run above proves the same hardened scoring model at the next scale.
 </pre></details></section>
   </main>
 </body>

--- a/src/site/insights/million-claim-challenge/part-8-clean-100k.html
+++ b/src/site/insights/million-claim-challenge/part-8-clean-100k.html
@@ -45,58 +45,73 @@
     </div>
     <p>Part 7 moved the Million Claim Challenge evidence out of terminal logs and into an operator console.</p>
 <p>Then the correctness bar changed.</p>
-<p>Payment accuracy became a gate instead of a diagnostic. Expected-pay and expected-deny claims were checked for false pends. Zero-limit accumulator placeholders stopped distorting expected payments. Generated members were isolated so one corpus segment could not contaminate another.</p>
-<p>Only after those changes did Cloud Health Office move to 100,000 claims.</p>
+<p>Payment accuracy became a gate instead of a diagnostic. Expected-pay and expected-deny claims were checked for false pends. Zero-limit accumulator placeholders stopped distorting expected payments. Generated members were isolated so one corpus segment could not contaminate another. Validation providers were moved into role-separated synthetic NPI namespaces so scoreable scenarios could not collide with stale provider-integrity state in a long-lived local tenant.</p>
+<p>Then the evidence bar moved again.</p>
+<p>Prior-authorization scenarios that had been partially unsupported became scoreable. Provider-exclusion denial codes were normalized so <code>B7</code>, <code>CARC_B7</code>, and <code>PROVIDER_EXCLUDED</code> represented the same expected business outcome instead of producing false mismatches.</p>
+<p>Only after those changes did Cloud Health Office move back to 100,000 claims.</p>
 <p>The result was clean: every claim processed, no platform failures, no scoreable workflow mismatches, no unexpected pends, and every comparable payment within one cent.</p>
-<p>The run also exposed the next scaling problem. Adjudication completed in less than 30 minutes, but the complete Kubernetes job took more than two hours because preparing a much larger set of run-scoped fixtures dominated the lifecycle.</p>
-<p>That is exactly the kind of result this series is supposed to produce: correctness held, and the next bottleneck became visible.</p>
+<p>The run also exposed the next local scaling question. Docker Desktop was not out of CPU or memory, and fixture preparation was no longer a two-hour wall-clock problem. The platform finished timed adjudication in 30 minutes and 5 seconds, with the full tracked lifecycle taking about 38 minutes.</p>
+<p>That is exactly the kind of result this series is supposed to produce: correctness held, the evidence became inspectable, and the next performance question became sharper.</p>
 <h2 id="what-changed-before-100k">What changed before 100K</h2>
 <p>The previous 50K result proved broader outcome scoring, but it still left important questions open.</p>
 <p>A claim could reach the expected paid disposition while paying the wrong amount. Expected-pend claims were observed, but expected-pay and expected-deny claims were not swept for accidental pends. Placeholder accumulator limits could be interpreted as real zero-dollar limits. Reused generated member identities could let fixture state cross scenario boundaries.</p>
 <p>Those are not cosmetic benchmark concerns. They affect whether the answer key and the platform are actually evaluating the same claim context.</p>
 <p>The validator now includes:</p>
 <ul><li>a plan-aligned payment gate with a one-cent tolerance</li><li>a persisted false-pend sweep for scoreable non-pend claims</li><li>corrected zero-limit accumulator handling</li><li>cross-corpus member fixture isolation</li><li>evidence-first claim-result retention</li><li>in-progress run publication and a completed run summary in the console</li></ul>
-<p>The 100K run was not allowed to trade those gates for volume.</p>
+<p>Several final hardening passes mattered before the final 100K rerun.</p>
+<p>PR #927 anchored validation providers as run-scoped fixtures. A follow-up 50K verification then found 10 scoreable <code>TxStarInpatientNoAuth</code> mismatches: those claims should have denied for missing prior authorization, but provider-integrity evaluation treated the generated rendering provider as excluded. The current provider record was approved and in-network, which pointed to stale or colliding validation-provider identity state in the long-lived local tenant.</p>
+<p>PR #928 moved scoreable validation providers into wider, role-separated synthetic NPI namespaces: billing providers in the <code>93...</code> range, adjudicatable rendering providers in <code>94...</code>, and intentionally excluded rendering providers in <code>95...</code>.</p>
+<p>Then PR #931 wired prior-authorization validation into adjudication, PR #932 made seeded prior-auth evidence scoreable, and PR #933 fixed the scoring path so expired-authorization and wrong-procedure scenarios could be counted honestly instead of left unsupported. PR #934 normalized provider-exclusion denial codes so <code>B7</code>, <code>CARC_B7</code>, and <code>PROVIDER_EXCLUDED</code> no longer disagreed as labels when they represented the same exclusion outcome.</p>
+<p>The post-#934 50K verification processed 50,000 claims cleanly: 5,927 of 6,500 workflow checks matched, zero workflow mismatches, 460 of 460 expected-pend claims observed, zero unexpected pends across 5,467 scoreable non-pend claims, and 1,000 of 1,000 payment comparisons within tolerance with a $0.00 maximum payment delta.</p>
+<p>That hardened fixture and scoring model is what the final 100K run used.</p>
 <h2 id="the-100k-result">The 100K result</h2>
 <p>The local Docker Desktop Kubernetes run processed 100,000 deterministic synthetic claims with parallelism set to 10.</p>
 <p>The final summary reported:</p>
-<ul><li>100,000 claims processed</li><li>79,164 paid or adjudicated</li><li>923 pended</li><li>19,913 business denials</li><li>0 platform failures</li><li>0 observation timeouts</li><li>11,534 of 13,000 workflow checks matched</li><li>0 workflow mismatches</li><li>1,466 unsupported scenarios</li><li>0 unexpected pends across 10,614 scoreable non-pend claims</li><li>2,000 of 2,000 comparable payments within one cent</li><li>$0.00 average payment delta</li><li>$0.00 maximum payment delta</li></ul>
-<p>The pend numbers have two scopes. The run ended with 923 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,614 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.</p>
-<p>Unsupported scenarios remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, prior-authorization edge variants, retroactive coverage change, and subrogation workflows.</p>
+<ul><li>100,000 claims processed</li><li>78,842 paid or adjudicated</li><li>924 pended</li><li>20,234 business denials</li><li>0 platform failures</li><li>0 observation timeouts</li><li>11,854 of 13,000 workflow checks matched</li><li>0 workflow mismatches</li><li>1,146 unsupported scenarios</li><li>0 unexpected pends across 10,934 scoreable non-pend claims</li><li>2,000 of 2,000 comparable payments within one cent</li><li>$0.00 average payment delta</li><li>$0.00 maximum payment delta</li></ul>
+<p>The pend numbers have two scopes. The run ended with 924 persisted pended outcomes overall. The validator specifically observed 920 expected-pend claims as pended, then swept 10,934 scoreable expected-pay and expected-deny claims and found zero unexpected pends. That distinction matters because unsupported scenarios remain separate from the scored non-pend set.</p>
+<p>Unsupported scenarios also remained separate from passes and failures. They were concentrated in behavioral-health carve-out, Medicaid spend-down, the prior-authorization wrong-provider variant, retroactive coverage change, and subrogation workflows.</p>
 <p>Those are named product gaps, not hidden successes.</p>
-<h2 id="performance-did-not-scale-linearly">Performance did not scale linearly</h2>
-<p>The timed claim-processing phase completed in 29 minutes and 40.851 seconds.</p>
+<h2 id="performance-did-not-saturate-the-machine">Performance did not saturate the machine</h2>
+<p>The timed claim-processing phase completed in 30 minutes and 5.013 seconds.</p>
 <p>That produced:</p>
-<ul><li>56.15 claims per second</li><li>358 ms P95 latency</li><li>451 ms P99 latency</li><li>199 ms P95 submission time</li><li>140 ms P95 adjudication time</li><li>102 ms P95 writeback time</li></ul>
-<p>The previous clean 50K run reached 82.40 claims per second with 129 ms P95 and 178 ms P99 latency.</p>
-<p>So doubling the corpus did not preserve the smaller run's throughput or tail latency. The platform remained correct, but the longer run created more pressure on the local working set, persistence path, and shared Docker Desktop resources.</p>
+<ul><li>55.40 claims per second</li><li>324 ms P95 latency</li><li>480 ms P99 latency</li><li>194 ms P95 submission time</li><li>122 ms P95 adjudication time</li><li>101 ms P95 writeback time</li></ul>
+<p>The provider-pool fixture work changed the local lifecycle story. Earlier 100K preparation had been dominated by run-scoped provider creation. In this run, the validator reduced 199,847 provider references to 13,742 distinct NPIs, reused 186,258 provider assignments, and preserved 2,800 provider-sensitive claims. It created 13,383 synthetic providers instead of trying to create a provider record for every repeated reference.</p>
+<p>That is why the tracked lifecycle was about 38 minutes instead of more than two hours.</p>
+<p>The run still did not scale linearly from smaller benchmarks, and Docker Desktop showed plenty of CPU and memory headroom while the run was active. That points the next investigation away from raw host capacity and toward internal throughput limits: service concurrency, writeback behavior, MongoDB pressure, HTTP client settings, and validator parallelism.</p>
 <p>That is not a production capacity conclusion. It is a local scaling signal worth investigating.</p>
-<h2 id="timed-throughput-and-total-job-duration-are-different">Timed throughput and total job duration are different</h2>
-<p>The Kubernetes job existed for approximately 128 minutes, while the timed processing phase lasted just under 30 minutes.</p>
-<p>Most of that difference came before claims were timed. The validator generated the corpus and prepared the fixtures required to make the run scoreable. It seeded or aligned 99,591 member statuses, added 620 COB coverage rows, and processed a provider fixture set that included 174,202 new providers plus 25,644 already present.</p>
-<p>Fixture isolation improved correctness, but the current preparation strategy is expensive at 100K.</p>
-<p>This distinction matters when reading the result.</p>
-<p>The platform adjudicated at 56.15 claims per second during the measured phase. The end-to-end developer experience took more than two hours. Both numbers are true, and they answer different questions.</p>
+<h2 id="timed-throughput-and-preparation-are-different">Timed throughput and preparation are different</h2>
+<p>The tracked lifecycle took 38 minutes and 5.792 seconds. The timed adjudication phase took 30 minutes and 5.013 seconds.</p>
+<p>The remaining tracked time was mostly preparation:</p>
+<ul><li>member and coverage seeding: 2:47.051</li><li>provider seeding: 5:04.155</li><li>authorization fixture seeding: 0:00.436</li><li>corpus generation: 0:01.201</li><li>fixture normalization: 0:00.327</li><li>expected-pend observation: 0:00.765</li><li>false-pend sweep: 0:06.644</li></ul>
+<p>The validator seeded 10,614 synthetic members, reused 88,977 existing members, aligned 99,591 member statuses, found 920 COB coverage rows already present, and found both required provider networks already present.</p>
+<p>Both numbers matter. The platform adjudicated at 55.40 claims per second during the measured phase. The full local evidence run, including fixture preparation and observation, took about 38 minutes.</p>
+<p>There was one reproducibility caveat in the local wrapper. The shell command that launched the Kubernetes job timed out while waiting for the job condition, but the Kubernetes job continued running, completed successfully, and published the completed Mass Adjudication summary. That was a local orchestration timeout, not a platform failure. The wrapper now supports a configurable <code>JOB_TIMEOUT</code> so larger local runs can wait long enough without changing validator scoring behavior.</p>
 <h2 id="what-the-console-should-make-obvious">What the console should make obvious</h2>
 <p>A useful operator console should not show only the best-looking number.</p>
 <p>For this run, it should make clear:</p>
 <ul><li>when fixture preparation started and ended</li><li>when timed submission began</li><li>current and final throughput</li><li>platform failures versus business dispositions</li><li>expected pends versus unexpected pends</li><li>matched, mismatched, unsupported, and timed-out workflow checks</li><li>payment comparisons and maximum delta</li><li>claim-level evidence behind every exception category</li></ul>
-<p>The run summary was published successfully, so the completed result is available through the Mass Adjudication console. The next improvement is to make preparation progress and its cost as visible as adjudication progress.</p>
+<p>The run also exposed a live-progress display issue. During processing, expected-pend scenarios can look like workflow mismatches until the post-processing observation pass confirms the persisted pended state. In this run, the console showed 920 live workflow mismatches while processing claims. After expected-pend observation completed, that number correctly resolved to zero.</p>
+<p>That is not an adjudication failure, but it is a product lesson: the live console should distinguish unresolved expected-pend checks from true mismatches.</p>
 <h2 id="the-next-local-optimization-target">The next local optimization target</h2>
 <p>The next target is not immediately 250K.</p>
-<p>First, the fixture path needs to become incremental and bounded. A benchmark claim should reference a deliberately sized reusable provider and member pool unless a scenario specifically requires claim-level isolation. Isolation should be applied where correctness requires it, not by multiplying every reference-data population with the claim count.</p>
-<p>That suggests several concrete experiments:</p>
-<ul><li>measure fixture-generation and API-seeding stages independently</li><li>reuse immutable provider fixtures across runs</li><li>isolate only member records whose scenario state can collide</li><li>batch or bulk-write fixture data where service contracts permit it</li><li>report preparation throughput and cache-hit rates</li><li>rerun 100K after each fixture optimization</li></ul>
+<p>First, the team should run controlled 100K parallelism sweeps with the same seed, fixture model, and correctness gates. The p10 run used only a fraction of the allocated Docker Desktop CPU and memory, so p12 and p16 were natural experiments.</p>
+<p>The first of those sweeps is now complete. At p12, the same 100,000-claim gate stayed clean: 100,000 processed, zero platform failures, zero workflow mismatches, 920 of 920 expected-pend claims observed, zero unexpected pends across 10,934 scoreable non-pend claims, and 2,000 of 2,000 payment comparisons within one cent.</p>
+<p>Throughput improved from 55.40 to 58.55 claims per second. Tail latency moved the other direction: P95 increased from 324 ms to 416 ms and P99 increased from 480 ms to 580 ms. That is a good benchmark result because it is not a slogan. It says p12 buys some throughput, but the latency curve is starting to push back.</p>
+<p>The p16 run answered the next question. It also stayed correct: 100,000 processed, zero platform failures, zero workflow mismatches, 920 of 920 expected-pend claims observed, zero unexpected pends across 10,934 scoreable non-pend claims, and 2,000 of 2,000 payment comparisons within one cent.</p>
+<p>But p16 did not improve the local result. Throughput fell to 55.11 claims per second, P95 rose to 518 ms, and P99 rose to 683 ms. That makes the p16 run useful evidence in the other direction. The local system had enough raw Docker CPU and memory, but adding validator concurrency pushed internal service, persistence, or writeback pressure past the efficient point.</p>
 <p>The acceptance criterion stays the same: performance work cannot weaken the correctness gates.</p>
+<p>That suggests several concrete experiments:</p>
+<ul><li>analyze the p12/p16 crossover before attempting 250K</li><li>measure service concurrency and HTTP client limits</li><li>inspect MongoDB writeback and accumulator hot paths</li><li>preserve payment, false-pend, and workflow gates</li><li>keep unsupported scenarios visible instead of hiding them</li><li>report CPU, memory, and disk I/O alongside benchmark timing</li></ul>
+<p>Unsupported scenarios should become their own product-evidence track. The first likely candidates are the prior-authorization wrong-provider variant, followed by retroactive coverage change, Medicaid spend-down, behavioral-health carve-out, and subrogation. They should be converted into scoreable behavior deliberately, not swept into the same PR as a benchmark evidence update.</p>
 <h2 id="what-comes-after-the-local-ceiling">What comes after the local ceiling</h2>
 <p>The Million Claim Challenge is still aimed at one million claims.</p>
-<p>But the local series should continue until the limiting resource is reproducible and explained. It may be CPU, memory, MongoDB, Docker networking, fixture preparation, or a combination of them.</p>
+<p>But the local series should continue until the limiting resource is reproducible and explained. It may be service concurrency, persistence, MongoDB, Docker networking, fixture preparation, or a combination of them.</p>
 <p>Once that ceiling is understood, the natural follow-up is a cloud scaling series using the same corpus and gates across Azure Kubernetes Service, Amazon Elastic Kubernetes Service, and Google Kubernetes Engine.</p>
 <p>The comparison should not ask only which cloud is fastest. It should ask how much infrastructure, time, and cost each environment needs to preserve zero platform failures, zero scoreable mismatches, zero unexpected pends, payment accuracy, and inspectable evidence.</p>
 <p>Part 5 made the benchmark repeatable.</p>
 <p>Part 6 made the scoring honest.</p>
 <p>Part 7 made the evidence visible.</p>
-<p>Part 8 proves that the stronger system can process 100,000 claims cleanly—and shows exactly where the local path needs to improve next.</p>
+<p>Part 8 proves that the stronger system can process 100,000 claims cleanly, with the fixture model hardened and the proof visible in the console.</p>
     <div class="article-links"><a href="/insights/million-claim-challenge">All MCC articles</a><a href="/docs/million-claim-challenge/evidence">Evidence archive</a></div>
   </main>
 </body>


### PR DESCRIPTION
## Summary

- point the root site build and accessibility scripts at the current `src/site` implementation
- document the observability compose overlay with the profiles it actually depends on
- refresh the generated public MCC Part 8 article and evidence pages with the current site build output

## Why

The repository validation baseline showed a few false-negative command failures caused by stale paths and an incomplete compose invocation. This keeps the validation surface aligned with the current repository layout while preserving the remaining known gaps as separate follow-up work.

## Validation

- `npm run build:site`
- `npm run validate:site` (exits 0; still reports the existing 36 potential accessibility issues)
- `docker compose --profile core --profile finance -f docker-compose.yml -f docker-compose.observability.yml config --quiet`
- `npx markdownlint-cli docs/evidence/REPOSITORY-VALIDATION.md`
