### PR TITLE
Score behavioral health carve-out denial

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -367,7 +367,7 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
             EdgeCaseScenario.SubrogationThirdPartyLiability => ("Pended", "W1", 0.65m),
 
             // Behavioral health
-            EdgeCaseScenario.BehavioralHealthCarveOut => ("Denied", "296", 0m), // CARC 296 = precertification
+            EdgeCaseScenario.BehavioralHealthCarveOut => ("Denied", "96", 0m), // CARC 96 = non-covered charge
             EdgeCaseScenario.BehavioralHealthCarveIn => ("Paid", null, 0.65m),
             EdgeCaseScenario.BehavioralHealthParityCheck => ("Paid", null, 0.65m),
 

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -64,12 +64,6 @@ public static class MccWorkflowValidation
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
 
-            if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
-                && IsUnsupportedBusinessDenialEdgeCase(claim.EdgeCase.Value))
-            {
-                return ExpectedValidation.Unsupported(scenario, expectedCode);
-            }
-
             return expectedOutcome is null
                 && claim.ExpectedOutcome.Disposition.Equals("Pended", StringComparison.OrdinalIgnoreCase)
                     ? new ExpectedValidation(scenario, ClaimValidationOutcome.Pended, expectedCode)
@@ -211,11 +205,6 @@ public static class MccWorkflowValidation
         }
 
         return false;
-    }
-
-    private static bool IsUnsupportedBusinessDenialEdgeCase(EdgeCaseScenario scenario)
-    {
-        return scenario is EdgeCaseScenario.BehavioralHealthCarveOut;
     }
 
     private static bool IsPriorAuthEdgeCase(EdgeCaseScenario scenario)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -623,6 +623,7 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
     InjectExcludedProviderScenarios(claims, options.Seed);
     InjectUncoveredServiceScenarios(claims);
     InjectPriorAuthScenarios(claims, options);
+    NormalizeBehavioralHealthCarveOutScenarios(claims);
     return claims;
 }
 
@@ -922,6 +923,86 @@ static void ForceUncoveredServiceScenario(SyntheticClaim claim)
         }
     };
     claim.TotalCharges = 850.00m;
+    claim.ExpectedOutcome = new ExpectedOutcome
+    {
+        Disposition = "Denied",
+        DenialReasonCode = MccWorkflowValidation.UncoveredServiceCode,
+        ExpectedAllowedAmount = 0.00m,
+        ExpectedPaidAmount = 0.00m,
+        ExpectedMemberLiability = 0.00m,
+        ExpectedCopay = 0.00m,
+        ExpectedCoinsurance = 0.00m,
+        ExpectedDeductible = 0.00m,
+        ExpectedFhirCompliant = true,
+        ExpectedPriorAuthDecision = "N/A",
+        LineOutcomes = new List<LineOutcome>
+        {
+            new()
+            {
+                LineNumber = 1,
+                Disposition = "Denied",
+                AllowedAmount = 0.00m,
+                PaidAmount = 0.00m,
+                ReasonCode = MccWorkflowValidation.UncoveredServiceCode
+            }
+        }
+    };
+}
+
+static void NormalizeBehavioralHealthCarveOutScenarios(List<SyntheticClaim> claims)
+{
+    var candidates = claims
+        .Where(c => c.EdgeCase is EdgeCaseScenario.BehavioralHealthCarveOut)
+        .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
+        .ToList();
+
+    if (candidates.Count == 0)
+    {
+        Console.WriteLine("Behavioral health carve-out scenarios: skipped (none generated)");
+        return;
+    }
+
+    foreach (var claim in candidates)
+    {
+        ForceBehavioralHealthCarveOutScenario(claim);
+    }
+
+    Console.WriteLine($"Behavioral health carve-out scenarios: normalized {candidates.Count:N0} claims expected to deny");
+}
+
+static void ForceBehavioralHealthCarveOutScenario(SyntheticClaim claim)
+{
+    var serviceDate = claim.DateOfService.Date;
+    claim.PlaceOfService = "11";
+    claim.FrequencyCode = "1";
+    claim.BillType = null;
+    claim.DrgCode = null;
+    claim.PriorAuthStatus = "NotRequired";
+    claim.PriorAuthNumber = null;
+    claim.PrimaryDiagnosisCode = "F41.1";
+    claim.SecondaryDiagnosisCodes.Clear();
+
+    ForceAdjudicatableProviderProfile(claim.RenderingProvider, serviceDate);
+    ForceAdjudicatableProviderProfile(claim.BillingProvider, serviceDate);
+
+    claim.Lines = new List<ClaimLine>
+    {
+        new()
+        {
+            LineNumber = 1,
+            ProcedureCode = "90834",
+            Description = "Psychotherapy, 45 minutes",
+            Modifiers = new List<string>(),
+            RevenueCode = null,
+            DiagnosisPointers = new List<int> { 1 },
+            Units = 1,
+            ChargeAmount = 165.00m,
+            ServiceDate = serviceDate,
+            ServiceEndDate = serviceDate,
+            PlaceOfService = "11"
+        }
+    };
+    claim.TotalCharges = 165.00m;
     claim.ExpectedOutcome = new ExpectedOutcome
     {
         Disposition = "Denied",

--- a/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
+++ b/tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/EdgeCaseClaimGeneratorTests.cs
@@ -132,6 +132,17 @@ public class EdgeCaseClaimGeneratorTests
     }
 
     [Fact]
+    public void Generate_BehavioralHealthCarveOut_DeniesAsNonCoveredService()
+    {
+        var claim = _generator.Generate(1, "BehavioralHealthCarveOut", new Random(42));
+
+        Assert.Equal("Denied", claim.ExpectedOutcome.Disposition);
+        Assert.Equal("96", claim.ExpectedOutcome.DenialReasonCode);
+        Assert.Equal(0m, claim.ExpectedOutcome.ExpectedAllowedAmount);
+        Assert.Equal(0m, claim.ExpectedOutcome.ExpectedPaidAmount);
+    }
+
+    [Fact]
     public void Generate_AllScenarios_ProducePositiveLineCharges()
     {
         foreach (var scenario in Enum.GetValues<EdgeCaseScenario>())

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -66,7 +66,7 @@ public class MccRunSummaryBuilderTests
             Result("MCC-SLOW-MATCHED", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 5_000),
             Result("MCC-MISMATCH-B", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
             Result("MCC-MISMATCH-A", "CleanProfessionalPaid", MccWorkflowValidation.MismatchedStatus, ClaimValidationOutcome.BusinessDenial, elapsedMilliseconds: 10),
-            Result("MCC-UNSUPPORTED", "EdgeCase:BehavioralHealthCarveOut", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 20),
+            Result("MCC-UNSUPPORTED", "EdgeCase:SubrogationWorkersComp", MccWorkflowValidation.UnsupportedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 20),
             Result("MCC-TIMEOUT", "EdgeCase:CobSecondaryPayer", MccWorkflowValidation.ObservationTimeoutStatus, ClaimValidationOutcome.ObservationTimeout, elapsedMilliseconds: 30),
             Result("MCC-MEDIUM-MATCHED-B", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000),
             Result("MCC-MEDIUM-MATCHED-A", "CleanProfessionalPaid", MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid, elapsedMilliseconds: 4_000)

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -351,7 +351,7 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
-    public void ExpectedValidationFor_UnsupportedBusinessDenialEdgeCase_ReturnsUnsupported()
+    public void ExpectedValidationFor_BehavioralHealthCarveOut_ReturnsScoreableCoverageDenial()
     {
         var claim = CreateClaim(
             claimType: "EdgeCase",
@@ -364,20 +364,20 @@ public class MccWorkflowValidationTests
         claim.ExpectedOutcome = new ExpectedOutcome
         {
             Disposition = "Denied",
-            DenialReasonCode = "296"
+            DenialReasonCode = "96"
         };
 
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            ClaimValidationOutcome.Paid,
-            actualBusinessDenialCode: null);
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: MccWorkflowValidation.UncoveredServiceCode);
 
         Assert.Equal("EdgeCase:BehavioralHealthCarveOut", expected.Scenario);
-        Assert.Null(expected.ExpectedOutcome);
-        Assert.Equal("CARC_296", expected.ExpectedBusinessDenialCode);
-        Assert.True(expected.IsUnsupported);
-        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.UncoveredServiceCode, expected.ExpectedBusinessDenialCode);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make the MCC behavioral health carve-out scenario scoreable as a CARC 96 non-covered service denial
- normalize generated carve-out claims into a deterministic psychotherapy claim against the validation plan
- update generator and validator tests so this scenario is no longer treated as unsupported

## Validation
- dotnet test tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests/CloudHealthOffice.BenchmarkClaimGenerator.Tests.csproj
- dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj
- git diff --check
