### PR TITLE
Seed MCC behavioral health service-category mapping

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -9,6 +9,7 @@ IMAGE="${IMAGE:-cloudhealthoffice-mcc-platform-validator:local}"
 CLAIMS="${CLAIMS:-5000}"
 MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
+SEED="${SEED:-42}"
 CLAIMS_URL="${CLAIMS_URL:-http://claims-service}"
 BENEFIT_URL="${BENEFIT_URL:-http://benefit-plan-service}"
 MEMBER_URL="${MEMBER_URL:-http://member-service}"
@@ -19,6 +20,7 @@ SEED_MEMBERS="${SEED_MEMBERS:-true}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 SEED_AUTHORIZATIONS="${SEED_AUTHORIZATIONS:-true}"
 CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS="${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS:-15}"
+SERVICE_CATEGORY_ADMIN_WRITE_ENABLED="${SERVICE_CATEGORY_ADMIN_WRITE_ENABLED:-true}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
 PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
 PEND_OBSERVATION_INTERVAL_MS="${PEND_OBSERVATION_INTERVAL_MS:-1000}"
@@ -59,6 +61,14 @@ if kubectl get deployment -n "$NAMESPACE" claims-service >/dev/null 2>&1; then
   kubectl rollout status deployment/claims-service -n "$NAMESPACE" --timeout=120s >/dev/null
 fi
 
+if kubectl get deployment -n "$NAMESPACE" benefit-plan-service >/dev/null 2>&1; then
+  log "Setting benefit-plan service-category mapping seed gate to ${SERVICE_CATEGORY_ADMIN_WRITE_ENABLED}"
+  kubectl set env deployment/benefit-plan-service \
+    -n "$NAMESPACE" \
+    "ServiceCategoryMapping__AdminWriteEnabled=${SERVICE_CATEGORY_ADMIN_WRITE_ENABLED}" >/dev/null
+  kubectl rollout status deployment/benefit-plan-service -n "$NAMESPACE" --timeout=120s >/dev/null
+fi
+
 log "Running ${CLAIMS} claims in namespace ${NAMESPACE} with wait timeout ${JOB_TIMEOUT}"
 kubectl delete job -n "$NAMESPACE" "$JOB_NAME" --ignore-not-found >/dev/null
 kubectl apply -n "$NAMESPACE" -f - <<EOF
@@ -82,6 +92,8 @@ spec:
             - "${MAX_CLAIMS}"
             - --tenant
             - "${TENANT}"
+            - --seed
+            - "${SEED}"
             - --parallelism
             - "${PARALLELISM}"
             - --claims-url

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/ChoServiceCategoryMappingRepositoryMongoTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Repositories/ChoServiceCategoryMappingRepositoryMongoTests.cs
@@ -1,0 +1,63 @@
+using BenefitPlanService.Repositories;
+using CloudHealthOffice.BenefitEngine.Domain;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace BenefitPlanService.Tests.Repositories;
+
+public sealed class ChoServiceCategoryMappingRepositoryMongoTests
+{
+    [Fact]
+    public void MappingDocument_Serializes_Rules_With_Bson_Safe_Guid_Ids()
+    {
+        var mappingId = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var ruleId = Guid.NewGuid();
+        var mapping = new ServiceCategoryMapping
+        {
+            Id = mappingId,
+            TenantId = "tenant-a",
+            BenefitPlanId = planId,
+            ServiceTypeCode = "MH",
+            ServiceTypeDescription = "Behavioral Health",
+            Rules =
+            [
+                new ProcedureCodeRule
+                {
+                    Id = ruleId,
+                    Priority = 10,
+                    CodeType = "CPT",
+                    CodePattern = "90785",
+                    CodeRangeEnd = "90899",
+                    PlaceOfServiceCode = "11",
+                    RequiredModifier = "GT",
+                    RevenueCode = "0900",
+                }
+            ],
+            EffectiveStart = new DateOnly(2026, 1, 1),
+            EffectiveEnd = new DateOnly(2026, 12, 31),
+            IsActive = true,
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+
+        var doc = ChoServiceCategoryMappingRepositoryMongo.MappingDocument.From(mapping);
+
+        var bson = doc.ToBsonDocument();
+        var persistedRule = bson["rules"].AsBsonArray.Single().AsBsonDocument;
+        persistedRule["id"].AsString.Should().Be(ruleId.ToString());
+
+        var roundTripped = BsonSerializer
+            .Deserialize<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>(bson)
+            .ToEntity();
+
+        roundTripped.Id.Should().Be(mappingId);
+        roundTripped.BenefitPlanId.Should().Be(planId);
+        roundTripped.Rules.Should().ContainSingle();
+        roundTripped.Rules.Single().Id.Should().Be(ruleId);
+        roundTripped.Rules.Single().CodePattern.Should().Be("90785");
+        roundTripped.Rules.Single().CodeRangeEnd.Should().Be("90899");
+        roundTripped.Rules.Single().PlaceOfServiceCode.Should().Be("11");
+        roundTripped.Rules.Single().RequiredModifier.Should().Be("GT");
+        roundTripped.Rules.Single().RevenueCode.Should().Be("0900");
+    }
+}

--- a/src/services/benefit-plan-service/Repositories/ChoServiceCategoryMappingRepositoryMongo.cs
+++ b/src/services/benefit-plan-service/Repositories/ChoServiceCategoryMappingRepositoryMongo.cs
@@ -205,7 +205,7 @@ public sealed class ChoServiceCategoryMappingRepositoryMongo :
         public string ServiceTypeDescription { get; set; } = default!;
 
         [BsonElement("rules")]
-        public List<ProcedureCodeRule> Rules { get; set; } = [];
+        public List<ProcedureCodeRuleDocument> Rules { get; set; } = [];
 
         // DateOnly persisted as ISO-yyyy-MM-dd string for cross-driver
         // portability. The Mongo BSON DateOnly serializer support is patchy
@@ -229,7 +229,7 @@ public sealed class ChoServiceCategoryMappingRepositoryMongo :
             BenefitPlanId = m.BenefitPlanId?.ToString(),
             ServiceTypeCode = m.ServiceTypeCode,
             ServiceTypeDescription = m.ServiceTypeDescription,
-            Rules = m.Rules,
+            Rules = m.Rules.Select(ProcedureCodeRuleDocument.From).ToList(),
             EffectiveStart = m.EffectiveStart?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             EffectiveEnd = m.EffectiveEnd?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             IsActive = m.IsActive,
@@ -243,7 +243,7 @@ public sealed class ChoServiceCategoryMappingRepositoryMongo :
             BenefitPlanId = string.IsNullOrEmpty(BenefitPlanId) ? null : Guid.Parse(BenefitPlanId),
             ServiceTypeCode = ServiceTypeCode,
             ServiceTypeDescription = ServiceTypeDescription,
-            Rules = Rules ?? [],
+            Rules = Rules?.Select(r => r.ToEntity()).ToList() ?? [],
             EffectiveStart = ParseDateOrNull(EffectiveStart),
             EffectiveEnd = ParseDateOrNull(EffectiveEnd),
             IsActive = IsActive,
@@ -259,6 +259,58 @@ public sealed class ChoServiceCategoryMappingRepositoryMongo :
             => string.IsNullOrEmpty(s)
                 ? null
                 : DateOnly.ParseExact(s, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    [BsonIgnoreExtraElements]
+    internal sealed class ProcedureCodeRuleDocument
+    {
+        [BsonElement("id")]
+        public string Id { get; set; } = default!;
+
+        [BsonElement("priority")]
+        public int Priority { get; set; }
+
+        [BsonElement("codeType")]
+        public string CodeType { get; set; } = "CPT";
+
+        [BsonElement("codePattern")]
+        public string CodePattern { get; set; } = default!;
+
+        [BsonElement("codeRangeEnd")]
+        public string? CodeRangeEnd { get; set; }
+
+        [BsonElement("placeOfServiceCode")]
+        public string? PlaceOfServiceCode { get; set; }
+
+        [BsonElement("requiredModifier")]
+        public string? RequiredModifier { get; set; }
+
+        [BsonElement("revenueCode")]
+        public string? RevenueCode { get; set; }
+
+        public static ProcedureCodeRuleDocument From(ProcedureCodeRule r) => new()
+        {
+            Id = (r.Id == Guid.Empty ? Guid.NewGuid() : r.Id).ToString(),
+            Priority = r.Priority,
+            CodeType = r.CodeType,
+            CodePattern = r.CodePattern,
+            CodeRangeEnd = r.CodeRangeEnd,
+            PlaceOfServiceCode = r.PlaceOfServiceCode,
+            RequiredModifier = r.RequiredModifier,
+            RevenueCode = r.RevenueCode,
+        };
+
+        public ProcedureCodeRule ToEntity() => new()
+        {
+            Id = string.IsNullOrWhiteSpace(Id) ? Guid.NewGuid() : Guid.Parse(Id),
+            Priority = Priority,
+            CodeType = CodeType,
+            CodePattern = CodePattern,
+            CodeRangeEnd = CodeRangeEnd,
+            PlaceOfServiceCode = PlaceOfServiceCode,
+            RequiredModifier = RequiredModifier,
+            RevenueCode = RevenueCode,
+        };
     }
 
     [BsonIgnoreExtraElements]

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -58,6 +58,12 @@ public static class MccWorkflowValidation
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
 
+            if (expectedOutcome is ClaimValidationOutcome.Paid
+                && IsUnsupportedBehavioralHealthPaidEdgeCase(claim.EdgeCase.Value))
+            {
+                return ExpectedValidation.Unsupported(scenario, expectedCode);
+            }
+
             if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
                 && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value, effectiveCapabilities))
             {
@@ -190,6 +196,13 @@ public static class MccWorkflowValidation
             EdgeCaseScenario.SubrogationWorkersComp or
             EdgeCaseScenario.SubrogationThirdPartyLiability or
             EdgeCaseScenario.MedicaidSpendDown;
+    }
+
+    private static bool IsUnsupportedBehavioralHealthPaidEdgeCase(EdgeCaseScenario scenario)
+    {
+        return scenario is
+            EdgeCaseScenario.BehavioralHealthCarveIn or
+            EdgeCaseScenario.BehavioralHealthParityCheck;
     }
 
     private static bool IsUnsupportedPriorAuthValidationEdgeCase(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CloudHealthOffice.BenchmarkClaimGenerator;
@@ -71,6 +72,7 @@ await MeasureLifecyclePhaseAsync(lifecycleTimings, "Reference rule seeding", "Pr
 {
     await SeedNcciAsync(http, options, json);
     await SeedPriorAuthRulesAsync(http, options, json);
+    await SeedServiceCategoryMappingsAsync(http, options, json);
 });
 
 var validationPlanId = Guid.NewGuid();
@@ -527,6 +529,74 @@ static async Task SeedPriorAuthRulesAsync(HttpClient http, ValidatorOptions opti
     Console.WriteLine($"seeded: prior-auth platform rules ({seeded:N0} new)");
 }
 
+static async Task SeedServiceCategoryMappingsAsync(HttpClient http, ValidatorOptions options, JsonSerializerOptions json)
+{
+    using var existingResponse = await http.GetAsync($"{options.BenefitUrl}/api/v1/service-category-mappings");
+    if (!existingResponse.IsSuccessStatusCode)
+    {
+        var body = await existingResponse.Content.ReadAsStringAsync();
+        throw new InvalidOperationException(
+            "service-category mapping lookup failed: " +
+            $"{(int)existingResponse.StatusCode} {body}. " +
+            "The MCC validator needs to inspect tenant-default mappings before seeding its " +
+            "behavioral-health carve-out fixture.");
+    }
+
+    var existingBody = await existingResponse.Content.ReadAsStringAsync();
+    var existingMappings = JsonSerializer.Deserialize<List<ServiceCategoryMappingSeedView>>(existingBody, json) ?? [];
+    if (existingMappings.Any(IsMccBehavioralHealthMappingPresent))
+    {
+        Console.WriteLine("seeded: MCC behavioral-health service-category mapping already present");
+        return;
+    }
+
+    var payload = new
+    {
+        serviceTypeCode = "Behavioral Health",
+        serviceTypeDescription = "MCC behavioral-health carve-out validation category",
+        rules = new[]
+        {
+            new
+            {
+                priority = 10,
+                codeType = "CPT",
+                codePattern = "90785",
+                codeRangeEnd = "90899"
+            }
+        },
+        isActive = true
+    };
+
+    using var response = await http.PostAsJsonAsync(
+        $"{options.BenefitUrl}/api/v1/service-category-mappings",
+        payload,
+        json);
+    if (!response.IsSuccessStatusCode)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        throw new InvalidOperationException(
+            "service-category mapping seed failed: " +
+            $"{(int)response.StatusCode} {body}. " +
+            "The MCC validator requires a tenant-applied Behavioral Health mapping so " +
+            "behavioral-health carve-out claims do not fall back to generic POS-based office-visit resolution. " +
+            "For local Kubernetes runs, keep SERVICE_CATEGORY_ADMIN_WRITE_ENABLED=true.");
+    }
+
+    _ = await response.Content.ReadAsStringAsync();
+    Console.WriteLine("seeded: MCC behavioral-health service-category mapping");
+}
+
+static bool IsMccBehavioralHealthMappingPresent(ServiceCategoryMappingSeedView mapping)
+{
+    return mapping.PlanId is null
+        && mapping.IsActive
+        && string.Equals(mapping.ServiceTypeCode, "Behavioral Health", StringComparison.OrdinalIgnoreCase)
+        && mapping.Rules.Any(rule =>
+            string.Equals(rule.CodeType, "CPT", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(rule.CodePattern, "90785", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(rule.CodeRangeEnd, "90899", StringComparison.OrdinalIgnoreCase));
+}
+
 static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions options, Guid planGuid, JsonSerializerOptions json)
 {
     var plan = new
@@ -542,8 +612,8 @@ static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions op
         isActive = true,
         networkTiers = new[]
         {
-            new { tierName = "In-Network", tierLevel = 1, networkId = "mcc-local-network" },
-            new { tierName = "Out-of-Network", tierLevel = 2, networkId = "mcc-local-out-network" }
+            new { tierName = "In-Network", tierLevel = 1, networkId = MccInNetworkId(options) },
+            new { tierName = "Out-of-Network", tierLevel = 2, networkId = MccOutOfNetworkId(options) }
         },
         costSharing = new
         {
@@ -1698,8 +1768,8 @@ static async Task<FixtureCount> SeedProviderNetworksAsync(
 {
     var networks = new[]
     {
-        ("mcc-local-network", "MCC Local In-Network"),
-        ("mcc-local-out-network", "MCC Local Out-of-Network")
+        (MccInNetworkId(options), "MCC Local In-Network"),
+        (MccOutOfNetworkId(options), "MCC Local Out-of-Network")
     };
 
     var created = 0;
@@ -1745,7 +1815,8 @@ static async Task EnsureProviderNetworkParticipationAsync(
     JsonSerializerOptions json)
 {
     var effectiveDate = EffectiveDateForProvider(provider);
-    if (await ProviderHasActiveNetworkParticipationAsync(http, options, provider.Npi, "mcc-local-network", effectiveDate))
+    var networkId = MccInNetworkId(options);
+    if (await ProviderHasActiveNetworkParticipationAsync(http, options, provider.Npi, networkId, effectiveDate))
     {
         return;
     }
@@ -1753,7 +1824,7 @@ static async Task EnsureProviderNetworkParticipationAsync(
     var payload = new
     {
         planId = (string?)null,
-        networkId = "mcc-local-network",
+        networkId,
         lineOfBusiness = LineOfBusinessName(options.LineOfBusiness),
         networkTier = "InNetwork",
         effectiveDate,
@@ -1973,7 +2044,7 @@ static async Task<string> CreateProviderAsync(
             new
             {
                 planId = validationPlanId.ToString(),
-                networkId = provider.IsParticipating ? "mcc-local-network" : "mcc-local-out-network",
+                networkId = provider.IsParticipating ? MccInNetworkId(options) : MccOutOfNetworkId(options),
                 lineOfBusiness = LineOfBusinessName(options.LineOfBusiness),
                 networkTier = provider.IsParticipating ? "InNetwork" : "OutOfNetwork",
                 effectiveDate,
@@ -2211,6 +2282,34 @@ static string LineOfBusinessName(int lineOfBusiness) => lineOfBusiness switch
     5 => "Exchange",
     _ => throw new ArgumentOutOfRangeException(nameof(lineOfBusiness), lineOfBusiness, "Unsupported line-of-business code.")
 };
+
+static string MccInNetworkId(ValidatorOptions options)
+    => MccNetworkId(options, "network");
+
+static string MccOutOfNetworkId(ValidatorOptions options)
+    => MccNetworkId(options, "out-network");
+
+static string MccNetworkId(ValidatorOptions options, string suffix)
+    => $"mcc-{NormalizeIdentifierSegment(options.TenantId)}-{suffix}";
+
+static string NormalizeIdentifierSegment(string value)
+{
+    var builder = new StringBuilder(value.Length);
+    foreach (var c in value.ToLowerInvariant())
+    {
+        if (char.IsLetterOrDigit(c))
+        {
+            builder.Append(c);
+        }
+        else if (builder.Length > 0 && builder[^1] != '-')
+        {
+            builder.Append('-');
+        }
+    }
+
+    var normalized = builder.ToString().Trim('-');
+    return string.IsNullOrWhiteSpace(normalized) ? "tenant" : normalized;
+}
 
 static async Task<ClaimValidationOutcome?> UpdateClaimAdjudicationAsync(
     HttpClient http,
@@ -3024,6 +3123,21 @@ internal sealed record FixtureCount(int Created, int Existing)
 {
     public static FixtureCount Empty { get; } = new(0, 0);
 }
+
+internal sealed record ServiceCategoryMappingSeedView(
+    Guid? PlanId,
+    string ServiceTypeCode,
+    IReadOnlyList<ProcedureCodeRuleSeedView> Rules,
+    bool IsActive);
+
+internal sealed record ProcedureCodeRuleSeedView(
+    int Priority,
+    string CodeType,
+    string CodePattern,
+    string? CodeRangeEnd,
+    string? PlaceOfServiceCode,
+    string? RequiredModifier,
+    string? RevenueCode);
 
 internal sealed record MassAdjudicationBusinessDenialSummary(
     string Code,

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -132,7 +132,7 @@ public class MccWorkflowValidationTests
             priorAuthStatus: "NotRequired",
             priorAuthNumber: null,
             renderingState: "AZ");
-        claim.EdgeCase = EdgeCaseScenario.BehavioralHealthCarveIn;
+        claim.EdgeCase = EdgeCaseScenario.RetroEligibilityAdd;
         claim.ExpectedOutcome = new ExpectedOutcome
         {
             Disposition = "Paid",
@@ -145,10 +145,43 @@ public class MccWorkflowValidationTests
             ClaimValidationOutcome.Paid,
             actualBusinessDenialCode: null);
 
-        Assert.Equal("EdgeCase:BehavioralHealthCarveIn", expected.Scenario);
+        Assert.Equal("EdgeCase:RetroEligibilityAdd", expected.Scenario);
         Assert.Equal(ClaimValidationOutcome.Paid, expected.ExpectedOutcome);
         Assert.Null(expected.ExpectedBusinessDenialCode);
         Assert.Equal("Matched", status);
+    }
+
+    [Theory]
+    [InlineData(EdgeCaseScenario.BehavioralHealthCarveIn)]
+    [InlineData(EdgeCaseScenario.BehavioralHealthParityCheck)]
+    public void ExpectedValidationFor_BehavioralHealthPaidEdgeCases_ReturnsUnsupported(
+        EdgeCaseScenario scenario)
+    {
+        var claim = CreateClaim(
+            claimType: "EdgeCase",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "11",
+            priorAuthStatus: "NotRequired",
+            priorAuthNumber: null,
+            renderingState: "AZ");
+        claim.EdgeCase = scenario;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Paid",
+            ExpectedPaidAmount = 100m
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: MccWorkflowValidation.UncoveredServiceCode);
+
+        Assert.Equal($"EdgeCase:{scenario}", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Null(expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- seed a scoped MCC behavioral-health service-category mapping during local validator reference seeding
- enable the local Kubernetes run script to pass a deterministic seed and turn on the service-category admin write gate
- persist service-category procedure-code rule IDs as BSON-safe strings in Mongo and add a BSON round-trip regression test
- mark behavioral-health carve-in/parity paid edge cases as unsupported until the validator models a separate covered behavioral-health plan context
- scope MCC provider network IDs by tenant so fresh tenants do not collide on shared Mongo IDs

## Why
The behavioral-health carve-out fixture needs CPT 90785-90899 to resolve to Behavioral Health instead of falling back to generic POS-based office-visit resolution. The previous broad mapping seed fixed carve-out but polluted tenant-default service categories and regressed unrelated MCC scoring. This keeps the seed deliberately narrow and keeps paid behavioral-health variants honest as unsupported until their plan context is modeled.

## Validation
- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --filter "FullyQualifiedName~MccWorkflowValidation|FullyQualifiedName~MccFixtureIsolation|FullyQualifiedName~MccValidationProviderNormalizer"`
- `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj`
- `dotnet test src/services/benefit-plan-service/BenefitPlanService.Tests/BenefitPlanService.Tests.csproj --filter "FullyQualifiedName~ServiceCategory|FullyQualifiedName~ChoServiceCategoryMappingRepositoryMongo"`