### PR TITLE
Score MCC prior-auth wrong-provider and behavioral-health carve-in/parity evidence

### DIFF
--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -60,12 +60,6 @@ public static class MccWorkflowValidation
                 return ExpectedValidation.Unsupported(scenario, expectedCode);
             }
 
-            if (expectedOutcome is ClaimValidationOutcome.Paid
-                && IsUnsupportedBehavioralHealthPaidEdgeCase(claim.EdgeCase.Value))
-            {
-                return ExpectedValidation.Unsupported(scenario, expectedCode);
-            }
-
             if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
                 && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value, effectiveCapabilities))
             {
@@ -198,13 +192,6 @@ public static class MccWorkflowValidation
             EdgeCaseScenario.SubrogationWorkersComp or
             EdgeCaseScenario.SubrogationThirdPartyLiability or
             EdgeCaseScenario.MedicaidSpendDown;
-    }
-
-    private static bool IsUnsupportedBehavioralHealthPaidEdgeCase(EdgeCaseScenario scenario)
-    {
-        return scenario is
-            EdgeCaseScenario.BehavioralHealthCarveIn or
-            EdgeCaseScenario.BehavioralHealthParityCheck;
     }
 
     private static bool IsUnsupportedPriorAuthValidationEdgeCase(

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -14,7 +14,9 @@ public sealed record ExpectedValidation(
         => new(scenario, null, expectedBusinessDenialCode, IsUnsupported: true);
 }
 
-public sealed record MccWorkflowValidationCapabilities(bool ScorePriorAuthValidationEvidence = false)
+public sealed record MccWorkflowValidationCapabilities(
+    bool ScorePriorAuthValidationEvidence = false,
+    bool ScorePriorAuthProviderValidationEvidence = false)
 {
     public static MccWorkflowValidationCapabilities Default { get; } = new();
 }
@@ -209,9 +211,13 @@ public static class MccWorkflowValidation
         EdgeCaseScenario scenario,
         MccWorkflowValidationCapabilities capabilities)
     {
+        if (scenario is EdgeCaseScenario.PriorAuthRequired_WrongProvider)
+        {
+            return !capabilities.ScorePriorAuthProviderValidationEvidence;
+        }
+
         if (scenario is
             EdgeCaseScenario.PriorAuthRequired_ExpiredAuth or
-            EdgeCaseScenario.PriorAuthRequired_WrongProvider or
             EdgeCaseScenario.PriorAuthRequired_WrongProcedure)
         {
             return !capabilities.ScorePriorAuthValidationEvidence;

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -540,6 +540,8 @@ static async Task SeedPriorAuthRulesAsync(HttpClient http, ValidatorOptions opti
     Console.WriteLine($"seeded: prior-auth platform rules ({seeded:N0} new)");
 }
 
+const string BehavioralHealthServiceTypeCode = "Behavioral Health";
+
 static async Task SeedServiceCategoryMappingsAsync(HttpClient http, ValidatorOptions options, JsonSerializerOptions json)
 {
     using var existingResponse = await http.GetAsync($"{options.BenefitUrl}/api/v1/service-category-mappings");
@@ -563,7 +565,7 @@ static async Task SeedServiceCategoryMappingsAsync(HttpClient http, ValidatorOpt
 
     var payload = new
     {
-        serviceTypeCode = "Behavioral Health",
+        serviceTypeCode = BehavioralHealthServiceTypeCode,
         serviceTypeDescription = "MCC behavioral-health carve-out validation category",
         rules = new[]
         {
@@ -601,7 +603,7 @@ static bool IsMccBehavioralHealthMappingPresent(ServiceCategoryMappingSeedView m
 {
     return mapping.PlanId is null
         && mapping.IsActive
-        && string.Equals(mapping.ServiceTypeCode, "Behavioral Health", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(mapping.ServiceTypeCode, BehavioralHealthServiceTypeCode, StringComparison.OrdinalIgnoreCase)
         && mapping.Rules.Any(rule =>
             string.Equals(rule.CodeType, "CPT", StringComparison.OrdinalIgnoreCase)
             && string.Equals(rule.CodePattern, "90785", StringComparison.OrdinalIgnoreCase)
@@ -671,6 +673,17 @@ static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions op
                 deductibleApplies = true,
                 oopApplies = true,
                 priorAuthRequired = true
+            },
+            new
+            {
+                benefitType = "medical",
+                serviceCategory = BehavioralHealthServiceTypeCode,
+                description = "Behavioral Health",
+                cptCodes = new[] { "90791", "90834", "90837", "90847", "90853", "96127" },
+                inNetworkCopay = 25.00m,
+                deductibleApplies = false,
+                oopApplies = true,
+                priorAuthRequired = false
             }
         }
     };

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -94,7 +95,9 @@ var providerPool = await MeasureLifecycleValuePhaseAsync(lifecycleTimings, "Fixt
         claims,
         options.Seed,
         validationPlanId,
-        new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: options.SeedAuthorizations));
+        new MccWorkflowValidationCapabilities(
+            ScorePriorAuthValidationEvidence: options.SeedAuthorizations,
+            ScorePriorAuthProviderValidationEvidence: options.SeedAuthorizations));
     MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
     MccCleanPaidFixture.NormalizeClaims(claims);
     return Task.FromResult(MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId));
@@ -104,14 +107,23 @@ Console.WriteLine(
     $"Provider fixture pool: {providerPool.ProvidersBefore:N0} -> {providerPool.ProvidersAfter:N0} distinct NPIs " +
     $"({providerPool.ReusedAssignments:N0} assignments reused, {providerPool.ProtectedClaims:N0} provider-sensitive claims preserved)");
 
-var scorePriorAuthValidationEvidence = false;
+var priorAuthValidationCapabilities = MccWorkflowValidationCapabilities.Default;
 if (options.SeedAuthorizations)
 {
-    scorePriorAuthValidationEvidence = await MeasureLifecycleValuePhaseAsync(
+    priorAuthValidationCapabilities = await MeasureLifecycleValuePhaseAsync(
         lifecycleTimings,
         "Authorization fixture seeding",
         "Preparation",
-        () => SeedPriorAuthAuthorizationFixturesAsync(http, options, claims, json));
+        async () =>
+        {
+            var seeded = await SeedPriorAuthAuthorizationFixturesAsync(http, options, claims, json);
+            var providerValidationSupported = seeded
+                && await ProbePriorAuthProviderValidationEvidenceAsync(http, options, claims, json);
+
+            return new MccWorkflowValidationCapabilities(
+                ScorePriorAuthValidationEvidence: seeded,
+                ScorePriorAuthProviderValidationEvidence: providerValidationSupported);
+        });
 }
 else
 {
@@ -120,8 +132,7 @@ else
 
 var answerKey = MccAnswerKey.FromClaims(
     claims,
-    new MccWorkflowValidationCapabilities(
-        ScorePriorAuthValidationEvidence: scorePriorAuthValidationEvidence));
+    priorAuthValidationCapabilities);
 
 var memberFixtures = MemberFixturePreparation.Empty;
 var cobCoverageFixtures = FixtureCount.Empty;
@@ -1526,6 +1537,84 @@ static async Task<bool> SeedPriorAuthAuthorizationFixturesAsync(
     catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
     {
         Console.WriteLine($"Authorization fixtures: skipped ({ex.Message})");
+        return false;
+    }
+}
+
+static async Task<bool> ProbePriorAuthProviderValidationEvidenceAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    IEnumerable<SyntheticClaim> claims,
+    JsonSerializerOptions json)
+{
+    var probeClaim = claims
+        .Where(claim => claim.EdgeCase is EdgeCaseScenario.PriorAuthRequired_WrongProvider)
+        .Where(claim => !string.IsNullOrWhiteSpace(claim.PriorAuthNumber))
+        .OrderBy(claim => claim.ClaimId, StringComparer.Ordinal)
+        .FirstOrDefault();
+
+    if (probeClaim is null)
+    {
+        Console.WriteLine("Authorization provider validation evidence: skipped (no wrong-provider fixture claim)");
+        return false;
+    }
+
+    var authNumber = Uri.EscapeDataString(probeClaim.PriorAuthNumber!.Trim());
+    var serviceDate = DateTime.SpecifyKind(probeClaim.DateOfService.Date, DateTimeKind.Utc)
+        .ToString("o", CultureInfo.InvariantCulture);
+    var procedureCode = Uri.EscapeDataString(AuthorizationProcedureCodeForClaim(probeClaim));
+    var providerNpi = Uri.EscapeDataString(probeClaim.RenderingProvider.Npi);
+    var url = $"{options.AuthorizationUrl}/api/authorizations/{authNumber}/validate" +
+              $"?serviceDate={Uri.EscapeDataString(serviceDate)}" +
+              $"&procedureCode={procedureCode}" +
+              $"&providerNpi={providerNpi}";
+
+    try
+    {
+        using var response = await http.GetAsync(url);
+        var body = await response.Content.ReadAsStringAsync();
+
+        if (response.StatusCode is System.Net.HttpStatusCode.NotFound
+            or System.Net.HttpStatusCode.Unauthorized
+            or System.Net.HttpStatusCode.Forbidden)
+        {
+            Console.WriteLine(
+                $"Authorization provider validation evidence: unsupported ({(int)response.StatusCode} from authorization-service)");
+            return false;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.WriteLine(
+                $"Authorization provider validation evidence: unsupported ({(int)response.StatusCode} from authorization-service)");
+            return false;
+        }
+
+        var validation = JsonSerializer.Deserialize<AuthorizationValidationProbeResponse>(body, json);
+        if (validation is { IsValid: false })
+        {
+            Console.WriteLine("Authorization provider validation evidence: supported");
+            return true;
+        }
+
+        Console.WriteLine(
+            "Authorization provider validation evidence: unsupported " +
+            "(wrong-provider probe validated successfully; wrong-provider scenarios will remain unsupported)");
+        return false;
+    }
+    catch (HttpRequestException ex)
+    {
+        Console.WriteLine($"Authorization provider validation evidence: unsupported ({ex.Message})");
+        return false;
+    }
+    catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+    {
+        Console.WriteLine($"Authorization provider validation evidence: unsupported ({ex.Message})");
+        return false;
+    }
+    catch (JsonException ex)
+    {
+        Console.WriteLine($"Authorization provider validation evidence: unsupported ({ex.Message})");
         return false;
     }
 }
@@ -3191,6 +3280,11 @@ internal sealed record AdjudicationResponseDto(
 internal sealed record AdjudicationSummaryWriteResponseDto(
     bool StatusPreserved,
     int PersistedStatus);
+
+internal sealed record AuthorizationValidationProbeResponse(
+    string AuthorizationNumber,
+    bool IsValid,
+    string? ValidationMessage);
 
 internal sealed record MemberStatusUpdateDto(
     string Status,

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderNormalizerTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccValidationProviderNormalizerTests.cs
@@ -19,7 +19,9 @@ public class MccValidationProviderNormalizerTests
             new[] { claim },
             seed: 42,
             runId: RunId,
-            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+            new MccWorkflowValidationCapabilities(
+                ScorePriorAuthValidationEvidence: true,
+                ScorePriorAuthProviderValidationEvidence: true));
 
         Assert.Equal(1, normalized);
         Assert.Equal(MccValidationProviderIdentity.BuildNpi(42, RunId, 0, role: 0), claim.BillingProvider.Npi);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -279,7 +279,6 @@ public class MccWorkflowValidationTests
 
     [Theory]
     [InlineData(EdgeCaseScenario.PriorAuthRequired_ExpiredAuth)]
-    [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProvider)]
     [InlineData(EdgeCaseScenario.PriorAuthRequired_WrongProcedure)]
     public void ExpectedValidationFor_PriorAuthValidationEvidenceCapability_ReturnsScoreableDenial(
         EdgeCaseScenario scenario)
@@ -307,6 +306,72 @@ public class MccWorkflowValidationTests
             actualBusinessDenialCode: MccWorkflowValidation.PriorAuthRequiredCode);
 
         Assert.Equal($"EdgeCase:{scenario}", expected.Scenario);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_WrongProviderWithoutProviderEvidence_ReturnsUnsupported()
+    {
+        var claim = CreateClaim(
+            claimType: "Institutional",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "OnFile",
+            priorAuthNumber: "AUTH-TEST",
+            renderingState: "TX");
+        claim.EdgeCase = EdgeCaseScenario.PriorAuthRequired_WrongProvider;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "197"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(
+            claim,
+            new MccWorkflowValidationCapabilities(ScorePriorAuthValidationEvidence: true));
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.Paid,
+            actualBusinessDenialCode: null);
+
+        Assert.Equal("EdgeCase:PriorAuthRequired_WrongProvider", expected.Scenario);
+        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
+        Assert.True(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+    }
+
+    [Fact]
+    public void ExpectedValidationFor_WrongProviderWithProviderEvidence_ReturnsScoreableDenial()
+    {
+        var claim = CreateClaim(
+            claimType: "Institutional",
+            benefitPlanId: "MCC-PLAN",
+            placeOfService: "21",
+            priorAuthStatus: "OnFile",
+            priorAuthNumber: "AUTH-TEST",
+            renderingState: "TX");
+        claim.EdgeCase = EdgeCaseScenario.PriorAuthRequired_WrongProvider;
+        claim.ExpectedOutcome = new ExpectedOutcome
+        {
+            Disposition = "Denied",
+            DenialReasonCode = "197"
+        };
+
+        var expected = MccWorkflowValidation.ExpectedValidationFor(
+            claim,
+            new MccWorkflowValidationCapabilities(
+                ScorePriorAuthValidationEvidence: true,
+                ScorePriorAuthProviderValidationEvidence: true));
+        var status = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.BusinessDenial,
+            actualBusinessDenialCode: MccWorkflowValidation.PriorAuthRequiredCode);
+
+        Assert.Equal("EdgeCase:PriorAuthRequired_WrongProvider", expected.Scenario);
         Assert.Equal(ClaimValidationOutcome.BusinessDenial, expected.ExpectedOutcome);
         Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, expected.ExpectedBusinessDenialCode);
         Assert.False(expected.IsUnsupported);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -154,7 +154,7 @@ public class MccWorkflowValidationTests
     [Theory]
     [InlineData(EdgeCaseScenario.BehavioralHealthCarveIn)]
     [InlineData(EdgeCaseScenario.BehavioralHealthParityCheck)]
-    public void ExpectedValidationFor_BehavioralHealthPaidEdgeCases_ReturnsUnsupported(
+    public void ExpectedValidationFor_BehavioralHealthPaidEdgeCases_ReturnsScoreablePaid(
         EdgeCaseScenario scenario)
     {
         var claim = CreateClaim(
@@ -174,14 +174,14 @@ public class MccWorkflowValidationTests
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
         var status = MccWorkflowValidation.ValidationStatus(
             expected,
-            ClaimValidationOutcome.BusinessDenial,
-            actualBusinessDenialCode: MccWorkflowValidation.UncoveredServiceCode);
+            ClaimValidationOutcome.Paid,
+            actualBusinessDenialCode: null);
 
         Assert.Equal($"EdgeCase:{scenario}", expected.Scenario);
-        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(ClaimValidationOutcome.Paid, expected.ExpectedOutcome);
         Assert.Null(expected.ExpectedBusinessDenialCode);
-        Assert.True(expected.IsUnsupported);
-        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, status);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Gate scoring of the `PriorAuthRequired_WrongProvider` edge case behind a runtime probe that confirms authorization-service actually enforces provider validation, instead of assuming support.
- Fix `BehavioralHealthCarveIn` / `BehavioralHealthParityCheck` staying stuck at `Unsupported`: the tenant-default "Behavioral Health" service-category mapping (seeded in #949) had no matching benefit configured on the MCC validation plan, so those claims denied with CARC 96 instead of paying. Added the missing benefit category and removed the unsupported gate now that both score deterministically.

## Test plan
- [x] `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj`
- [x] `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests` (108/108 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)