### PR TITLE
Make provider network-participation writes self-healing for Active providers

### DIFF
--- a/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
+++ b/src/engines/CloudHealthOffice.PriorAuthRuleEngine/CloudHealthOffice.PriorAuthRuleEngine.csproj
@@ -31,7 +31,7 @@
          on the class. See docs/architecture/shared-cache.md and Addendum A.7.2. -->
     <ProjectReference Include="..\..\services\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
 
-    <PackageReference Include="Microsoft.Azure.Cosmos"              Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver"                      Version="3.7.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />

--- a/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
+++ b/src/engines/CloudHealthOffice.ProviderEnrollmentService/CloudHealthOffice.ProviderEnrollmentService.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <!-- Azure -->
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <!-- MongoDB -->
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
     <!-- HTTP resilience -->

--- a/src/services/accumulator-service/accumulator-service.csproj
+++ b/src/services/accumulator-service/accumulator-service.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/appeals-service/appeals-service.csproj
+++ b/src/services/appeals-service/appeals-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/attachment-service/attachment-service.csproj
+++ b/src/services/attachment-service/attachment-service.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.55.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />

--- a/src/services/authorization-service/authorization-service.csproj
+++ b/src/services/authorization-service/authorization-service.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.7.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/benefit-plan-service/benefit-plan-service.csproj
+++ b/src/services/benefit-plan-service/benefit-plan-service.csproj
@@ -59,7 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/capitation-service/capitation-service.csproj
+++ b/src/services/capitation-service/capitation-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Stripe.net" Version="46.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/consent-service/consent-service.csproj
+++ b/src/services/consent-service/consent-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/coverage-service/coverage-service.csproj
+++ b/src/services/coverage-service/coverage-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/eligibility-service/eligibility-service.csproj
+++ b/src/services/eligibility-service/eligibility-service.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />

--- a/src/services/encounter-service/encounter-service.csproj
+++ b/src/services/encounter-service/encounter-service.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/encounter-submission-service/encounter-submission-service.csproj
+++ b/src/services/encounter-submission-service/encounter-submission-service.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.8.0" />

--- a/src/services/enrollment-import-service/EnrollmentImportService.csproj
+++ b/src/services/enrollment-import-service/EnrollmentImportService.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />

--- a/src/services/fhir-service/fhir-service.csproj
+++ b/src/services/fhir-service/fhir-service.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Appeals.Contracts\CloudHealthOffice.Appeals.Contracts.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.ProviderEnrollmentService\CloudHealthOffice.ProviderEnrollmentService.csproj" />
     <ProjectReference Include="..\..\engines\CloudHealthOffice.PriorAuthRuleEngine\CloudHealthOffice.PriorAuthRuleEngine.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <!-- StackExchange.Redis is pulled in transitively via
          CloudHealthOffice.Infrastructure. fhir-service has no direct
          IConnectionMultiplexer consumer after A.7.2 — the Redis client is

--- a/src/services/idcard-service/idcard-service.csproj
+++ b/src/services/idcard-service/idcard-service.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />

--- a/src/services/member-document-service/member-document-service.csproj
+++ b/src/services/member-document-service/member-document-service.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/member-service/member-service.csproj
+++ b/src/services/member-service/member-service.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/payment-service/payment-service.csproj
+++ b/src/services/payment-service/payment-service.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/personal-representative-service/personal-representative-service.csproj
+++ b/src/services/personal-representative-service/personal-representative-service.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/premium-billing-service/premium-billing-service.csproj
+++ b/src/services/premium-billing-service/premium-billing-service.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Stripe.net" Version="45.15.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -660,7 +660,13 @@ public class ProvidersController : ControllerBase
     }
 
     /// <summary>
-    /// Add network participation to provider
+    /// Add network participation to provider. Self-healing: an Active
+    /// (read-only) provider is auto-amended into a Draft, edited, and
+    /// activated in the same call — the amend → activate cycle has no
+    /// other endpoint that can populate a Draft's contents, so without
+    /// this, adding a participation to any already-Active provider was
+    /// silently impossible (the write always 409'd, and callers that
+    /// treat 409 as "already present" masked the gap indefinitely).
     /// </summary>
     [HttpPost("{id}/network-participations")]
     [ProducesResponseType(typeof(Provider), StatusCodes.Status200OK)]
@@ -680,6 +686,21 @@ public class ProvidersController : ControllerBase
             return NotFound($"Provider {id} not found");
         }
 
+        var actor = ResolveActorId();
+        var needsActivation = false;
+        if (provider.VersionState != ProviderVersionState.Draft)
+        {
+            try
+            {
+                provider = await _versioning.AmendActiveProviderAsync(provider.ProviderId, actor);
+                needsActivation = true;
+            }
+            catch (ProviderVersionStateException ex) when (ex.IsNotFound)
+            {
+                return NotFound(new { message = ex.Message, providerId = ex.ProviderId });
+            }
+        }
+
         provider.NetworkParticipations.Add(participation);
         provider.LastUpdatedDate = DateTime.UtcNow;
 
@@ -692,6 +713,11 @@ public class ProvidersController : ControllerBase
         try
         {
             var updated = await _providerRepository.UpdateAsync(provider);
+            if (needsActivation)
+            {
+                updated = await _versioning.ActivateVersionAsync(updated.ProviderId, updated.VersionId, actor);
+            }
+
             return Ok(updated);
         }
         catch (ProviderVersionStateException ex)

--- a/src/services/provider-service/provider-service.csproj
+++ b/src/services/provider-service/provider-service.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/reference-data-service/reference-data-service.csproj
+++ b/src/services/reference-data-service/reference-data-service.csproj
@@ -12,7 +12,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/services/rfai-service/rfai-service.csproj
+++ b/src/services/rfai-service/rfai-service.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/risk-adjustment-service/risk-adjustment-service.csproj
+++ b/src/services/risk-adjustment-service/risk-adjustment-service.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.44.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
+++ b/src/services/shared/CloudHealthOffice.Infrastructure/CloudHealthOffice.Infrastructure.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.11" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
   <PackageReference Include="SharpCompress" Version="0.48.0" />

--- a/src/services/sponsor-service/sponsor-service.csproj
+++ b/src/services/sponsor-service/sponsor-service.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>

--- a/src/services/trading-partner-service/trading-partner-service.csproj
+++ b/src/services/trading-partner-service/trading-partner-service.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <ProjectReference Include="..\shared\CloudHealthOffice.Infrastructure\CloudHealthOffice.Infrastructure.csproj" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />

--- a/src/tools/migration-wizard/migration-wizard.csproj
+++ b/src/tools/migration-wizard/migration-wizard.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
     <PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
   </ItemGroup>

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerNetworkParticipationTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerNetworkParticipationTests.cs
@@ -1,0 +1,155 @@
+using CloudHealthOffice.ProviderService.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ProviderService.Controllers;
+using ProviderService.Models;
+using ProviderService.Services;
+
+namespace CloudHealthOffice.ProviderService.Tests.Controllers;
+
+/// <summary>
+/// Regression coverage for <c>POST /api/v1/providers/{id}/network-participations</c>
+/// against an Active provider. Before this fix, <see cref="IProviderRepository.UpdateAsync"/>
+/// (see <see cref="InMemoryProviderRepository"/>) always rejected non-Draft rows with
+/// <see cref="ProviderVersionStateException"/>, which the controller translated to a bare
+/// 409 — silently leaving the participation unadded, because the only other endpoint that
+/// could produce an editable Draft (<c>POST /amend</c>) had no paired endpoint to populate
+/// that Draft's contents before activating it. The fix makes the endpoint self-healing: an
+/// Active provider is auto-amended, edited, and activated within the same call.
+/// </summary>
+public class ProvidersControllerNetworkParticipationTests
+{
+    private const string TenantId = "tenant-a";
+    private const string ProviderId = "p-001";
+
+    private readonly InMemoryProviderRepository _providerRepository;
+    private readonly InMemoryProviderTransitionRepository _transitions;
+    private readonly FakeProviderVersionEventPublisher _events;
+    private readonly ProviderVersioningService _versioning;
+    private readonly PanelGatingValidator _panelGatingValidator;
+    private readonly ProvidersController _controller;
+
+    public ProvidersControllerNetworkParticipationTests()
+    {
+        _providerRepository = new InMemoryProviderRepository { TenantId = TenantId };
+        _transitions = new InMemoryProviderTransitionRepository();
+        _events = new FakeProviderVersionEventPublisher();
+        _versioning = new ProviderVersioningService(
+            _providerRepository, _transitions, _events,
+            NullLogger<ProviderVersioningService>.Instance);
+        _panelGatingValidator = new PanelGatingValidator(
+            NullLogger<PanelGatingValidator>.Instance,
+            new StaticOptionsMonitor(new NetworkParticipationBackfillOptions()));
+
+        SeedActiveProviderWithOneParticipation();
+
+        _controller = new ProvidersController(
+            providerRepository: _providerRepository,
+            versioning: _versioning,
+            adapterFactory: null!,
+            integrityProjection: null!,
+            panelGatingValidator: _panelGatingValidator,
+            credentialing: null!,
+            logger: NullLogger<ProvidersController>.Instance);
+
+        var ctx = new DefaultHttpContext();
+        ctx.Items["TenantId"] = TenantId;
+        _controller.ControllerContext = new ControllerContext { HttpContext = ctx };
+    }
+
+    [Fact]
+    public async Task AddNetworkParticipation_against_active_provider_returns_200_not_409()
+    {
+        var result = await _controller.AddNetworkParticipation(ProviderId, NewParticipation("mcc-demo-network"));
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var provider = ok!.Value as Provider;
+        provider.Should().NotBeNull();
+        provider!.VersionState.Should().Be(ProviderVersionState.Active);
+    }
+
+    [Fact]
+    public async Task AddNetworkParticipation_against_active_provider_preserves_existing_participations()
+    {
+        var result = await _controller.AddNetworkParticipation(ProviderId, NewParticipation("mcc-demo-network"));
+
+        var provider = ((OkObjectResult)result.Result!).Value as Provider;
+        provider!.NetworkParticipations.Should().HaveCount(2);
+        provider.NetworkParticipations.Should().Contain(p => p.NetworkId == "mcc-local-network");
+        provider.NetworkParticipations.Should().Contain(p => p.NetworkId == "mcc-demo-network");
+    }
+
+    [Fact]
+    public async Task AddNetworkParticipation_against_active_provider_amends_and_activates_a_new_version()
+    {
+        var result = await _controller.AddNetworkParticipation(ProviderId, NewParticipation("mcc-demo-network"));
+
+        var provider = ((OkObjectResult)result.Result!).Value as Provider;
+        provider!.VersionNumber.Should().Be(2);
+        provider.PredecessorVersionId.Should().NotBeNullOrEmpty();
+
+        _transitions.Items.Should().Contain(t => t.TransitionType == ProviderTransitionType.Amend);
+        _events.Events.Should().Contain(e => e.EventType == ProviderVersionEventType.ProviderVersionActivated);
+    }
+
+    [Fact]
+    public async Task AddNetworkParticipation_against_unknown_provider_returns_404()
+    {
+        var result = await _controller.AddNetworkParticipation("does-not-exist", NewParticipation("mcc-demo-network"));
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    private static NetworkParticipation NewParticipation(string networkId) => new()
+    {
+        PlanId = null,
+        NetworkId = networkId,
+        LineOfBusiness = LineOfBusiness.Medicaid,
+        NetworkTier = "InNetwork",
+        EffectiveDate = DateTime.UtcNow.AddYears(-1),
+        AcceptingNewPatients = true,
+    };
+
+    private void SeedActiveProviderWithOneParticipation()
+    {
+        _providerRepository.CreateAsync(new Provider
+        {
+            Id = ProviderId,
+            ProviderId = ProviderId,
+            TenantId = TenantId,
+            NPI = "1234567890",
+            ProviderType = ProviderType.Individual,
+            FirstName = "Test",
+            LastName = "Provider",
+            PrimarySpecialty = "Internal Medicine",
+            TaxonomyCode = "207R00000X",
+            VersionId = ProviderId,
+            VersionNumber = 1,
+            VersionState = ProviderVersionState.Active,
+            NetworkParticipations = new List<NetworkParticipation>
+            {
+                new()
+                {
+                    PlanId = null,
+                    NetworkId = "mcc-local-network",
+                    LineOfBusiness = LineOfBusiness.Medicaid,
+                    NetworkTier = "InNetwork",
+                    EffectiveDate = DateTime.UtcNow.AddYears(-2),
+                    AcceptingNewPatients = true,
+                }
+            },
+        }).GetAwaiter().GetResult();
+    }
+
+    private sealed class StaticOptionsMonitor : IOptionsMonitor<NetworkParticipationBackfillOptions>
+    {
+        public StaticOptionsMonitor(NetworkParticipationBackfillOptions value) => CurrentValue = value;
+        public NetworkParticipationBackfillOptions CurrentValue { get; }
+        public NetworkParticipationBackfillOptions Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<NetworkParticipationBackfillOptions, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Root-causes and fixes the 32 residual mismatches from the Part 9 100K confirmation run, which `benchmark-results.txt` documented as out-of-scope follow-up at the time.

- **Root cause:** `EnsureProviderNetworkParticipationAsync` in the MCC validator treats any `409` from `POST {id}/network-participations` as "already participates" and moves on. In reality, provider-service rejects that write with 409 whenever the provider is Active (mutations require amend → edit → activate), and **no endpoint existed to populate an amended Draft's contents before activating it** — so the write silently, permanently failed for any provider that became Active before #949 introduced tenant-scoped network IDs. Those providers stayed registered only under the old `mcc-local-network` ID, so `NetworkCredentialingStage`'s `FailClosed` default correctly denied claims against the plan's real (tenant-scoped) network — including COB-scenario claims, which lost their otherwise-correct `Pend` outcome to that `Deny` under normal Deny-beats-Pend precedence.
- **Fix:** `AddNetworkParticipation` is now self-healing — an Active provider is auto-amended into a Draft, edited, and activated within the same call, so the endpoint's documented contract actually holds for every caller, not just the MCC validator.
- **Incidental fix:** bumps the remaining 28 `Microsoft.Azure.Cosmos` references from 3.61.0 → 3.62.0 to match the 3 projects #952 already bumped. The split version blocked rebuilding claims-service/provider-service locally, and independently explains the "Failed to restore" CI flakiness seen on unrelated recent PRs (#954, #951).

## Verification

- Confirmed the original 409 directly against the specific broken provider from the Part 9 run, then confirmed it now returns 200 with both the legacy and new network participations present, auto-activated to version 2.
- 60K-claim confirmation run before/after:

| Scenario | Before | After |
|---|---|---|
| CobBirthdayRule | 118/120 | **120/120** |
| CobGenderRule | 119/120 | **120/120** |
| CobPrimaryPayer | 119/120 | **120/120** |
| CobSecondaryPayer | 118/120 | **120/120** |
| CobTertiaryPayer | 118/120 | **120/120** |
| MedicaidDualEligible | 69/72 | **72/72** |

All previously-passing scenarios remain clean. The one unrelated fluctuation observed (`ExcludedProviderDenied`, 33/1200 mismatched) reproduces the same pre-existing provider-NPI-pool-reuse collision pattern already present in the originally-recorded Part 9 evidence at a similar rate (64/2000) — confirmed via the `providerIntegrity` adjudication-step timing (sub-millisecond, meaning the assigned provider was never flagged excluded) — and is unrelated to this change.

## Test plan
- [x] `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — 385/385 passing, including 4 new regression tests for the self-healing behavior
- [x] `dotnet build` claims-service, provider-service, benefit-plan-service, authorization-service — all clean post version-bump
- [x] Direct live repro/fix verification against the specific broken provider from the Part 9 run
- [x] 60K-claim end-to-end confirmation run on local Docker Desktop Kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)