### PR TITLE
Bump repo-wide System.Formats.Asn1 CVE floor to 9.0.18

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,11 @@
   <ItemGroup>
     <!-- Fix CVE-2024-43485: System.Formats.Asn1 Remote Code Execution vulnerability -->
     <!-- Severity: High | Advisory: GHSA-447r-wph3-92pm -->
-    <!-- Minimum safe version: 8.0.1 (fixes RCE in certificate parsing) -->
-    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
+    <!-- Minimum safe version: 8.0.1 (fixes RCE in certificate parsing). Pinned to 9.0.18
+         here to match the floor System.Security.Cryptography.Xml 9.0.18 (Portal, PR 953)
+         already requires transitively; both satisfy the CVE fix, and NuGet treated the
+         8.0.1 floor as a downgrade against that transitive requirement otherwise. -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.18" />
     
     <!-- Fix CVE-2024-21907: Newtonsoft.Json Improper Handling vulnerability -->
     <!-- Severity: High | Advisory: GHSA-5crp-9r3c-p9vr -->


### PR DESCRIPTION
## Summary

Fixes the `submit-nuget` failure currently on `main` (and every PR since #953 merged) — `dotnet restore` on the full solution has been broken.

- `src/Directory.Build.props` repo-wide pins `System.Formats.Asn1` to `8.0.1` as a CVE-2024-43485 floor.
- PR #953 bumped Portal's `System.Security.Cryptography.Xml` to `9.0.18`, which requires `System.Formats.Asn1 >= 9.0.18` transitively (via `Microsoft.Bcl.Cryptography` / `System.Security.Cryptography.Pkcs`).
- NuGet treats the repo-wide `8.0.1` floor as a downgrade against that transitive requirement → `NU1605` error, breaking restore for `CloudHealthOffice.Portal` and `CloudHealthOffice.Portal.Tests` solution-wide.

Fix: bump the floor itself to `9.0.18`. It's strictly newer than the CVE-fix version, so the original intent still holds — no per-project override needed.

## Test plan
- [x] `dotnet restore cloudhealthoffice-main.sln` — clean, no errors (previously failed with NU1605)
- [x] `dotnet build src/portal/CloudHealthOffice.Portal.Tests` — clean
- [x] `dotnet test src/portal/CloudHealthOffice.Portal.Tests` — 711/711 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)