### PR TITLE
Fix ExcludedProviderDenied collision: correct integrity fields on stale providers

### DIFF
--- a/src/services/provider-service/Controllers/ProvidersController.cs
+++ b/src/services/provider-service/Controllers/ProvidersController.cs
@@ -569,9 +569,12 @@ public class ProvidersController : ControllerBase
     }
 
     /// <summary>
-    /// Update provider. Active versions are read-only — the repository
-    /// throws <see cref="ProviderVersionStateException"/> which surfaces as 409.
-    /// Use <c>POST /amend</c> to create an editable Draft from the current Active version.
+    /// Update provider. Self-healing: an Active (read-only) provider is
+    /// auto-amended into a Draft, updated with the caller's field values,
+    /// and activated within the same call — see the identical rationale
+    /// on <see cref="AddNetworkParticipation"/>. Existing consumers PUT
+    /// against `Id` (the chain key for legacy single-row chains); on a
+    /// multi-version chain the same `Id` resolves to the head.
     /// </summary>
     [HttpPut("{id}")]
     [ProducesResponseType(typeof(Provider), StatusCodes.Status200OK)]
@@ -587,27 +590,36 @@ public class ProvidersController : ControllerBase
             return NotFound($"Provider {id} not found");
         }
 
-        // Existing consumers PUT against `Id` (the chain key for legacy
-        // single-row chains); on a multi-version chain the same `Id`
-        // resolves to the head, which is read-only. Surface 409 with the
-        // amend instructions so callers know the new flow.
         try
         {
-            provider.Id = existing.Id;
-            provider.ProviderId = existing.ProviderId;
-            provider.VersionId = existing.VersionId;
-            provider.VersionNumber = existing.VersionNumber;
-            provider.VersionState = existing.VersionState;
-            provider.CreatedDate = existing.CreatedDate;
+            var actor = ResolveActorId();
+            var target = existing;
+            var needsActivation = false;
+            if (existing.VersionState != ProviderVersionState.Draft)
+            {
+                target = await _versioning.AmendActiveProviderAsync(existing.ProviderId, actor);
+                needsActivation = true;
+            }
+
+            provider.Id = target.Id;
+            provider.ProviderId = target.ProviderId;
+            provider.VersionId = target.VersionId;
+            provider.VersionNumber = target.VersionNumber;
+            provider.VersionState = target.VersionState;
+            provider.PredecessorVersionId = target.PredecessorVersionId;
+            provider.CreatedDate = target.CreatedDate;
             provider.LastUpdatedDate = DateTime.UtcNow;
 
             // Soft validation (5.5): warn + count any participation that
-            // arrives without panel-gating fields. Fires before the
-            // repository call so even a 409 conflict on a non-Draft row
-            // surfaces the elision.
+            // arrives without panel-gating fields.
             _panelGatingValidator.Inspect("UpdateProvider", TenantId, provider);
 
             var updated = await _providerRepository.UpdateAsync(provider);
+            if (needsActivation)
+            {
+                updated = await _versioning.ActivateVersionAsync(updated.ProviderId, updated.VersionId, actor);
+            }
+
             return Ok(updated);
         }
         catch (ProviderVersionStateException ex) when (ex.IsNotFound)

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using CloudHealthOffice.BenchmarkClaimGenerator;
 using CloudHealthOffice.BenchmarkClaimGenerator.Configuration;
@@ -1965,6 +1966,10 @@ static async Task<FixtureCount> SeedProvidersAsync(
                 provider,
                 json);
         }
+        else
+        {
+            await EnsureProviderExclusionAsync(http, options, providerId, json);
+        }
     }
 
     Console.WriteLine($"seeded: {created:N0} synthetic providers ({existing:N0} already present)");
@@ -2207,6 +2212,60 @@ static async Task EnsureProviderCredentialingAsync(
     {
         throw new InvalidOperationException(
             $"provider credentialing seed failed ({providerId}): {(int)update.StatusCode} {updateBody}");
+    }
+}
+
+// The provider-fixture pool's run-scoped NPI generation (see
+// MccProviderFixturePool.BuildRunScopedNpi) can collide with a provider
+// created by an earlier run on this shared, long-lived tenant -- the
+// value space is wide but not infinite, and this cluster accumulates
+// providers across many runs. When that happens, GetProviderIdByNpiAsync
+// finds an "existing" provider whose profile has nothing to do with this
+// run's ExcludedProviderDenied fixture. The adjudication-path integrity
+// gate (BenefitPlanService.HttpProviderIntegrityGate) reads
+// Provider.IntegrityScore / IntegrityRating directly from provider-service
+// as the source of truth (falling back to a live verification-service
+// call only when that cached value is null or stale) -- CredentialingStatus
+// set at creation time is not what the gate actually checks. Verify the
+// existing record's integrity fields actually reflect exclusion, and
+// correct them in place if a collision left them clean.
+static async Task EnsureProviderExclusionAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    string providerId,
+    JsonSerializerOptions json)
+{
+    using var response = await http.GetAsync(
+        $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}");
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException(
+            $"provider fetch failed for exclusion check ({providerId}): {(int)response.StatusCode} {body}");
+    }
+
+    var node = JsonNode.Parse(body)
+        ?? throw new InvalidOperationException($"provider fetch returned no body ({providerId})");
+
+    var currentRating = node["integrityRating"]?.GetValue<string>();
+    if (string.Equals(currentRating, "Blocked", StringComparison.OrdinalIgnoreCase))
+    {
+        return;
+    }
+
+    node["integrityScore"] = 0;
+    node["integrityRating"] = "Blocked";
+    node["credentialingStatus"] = "Denied";
+
+    using var update = await http.PutAsJsonAsync(
+        $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}",
+        node,
+        json);
+    var updateBody = await update.Content.ReadAsStringAsync();
+    if (!update.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException(
+            $"provider exclusion correction failed ({providerId}): {(int)update.StatusCode} {updateBody}");
     }
 }
 

--- a/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerNetworkParticipationTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/Controllers/ProvidersControllerNetworkParticipationTests.cs
@@ -104,6 +104,81 @@ public class ProvidersControllerNetworkParticipationTests
         result.Result.Should().BeOfType<NotFoundObjectResult>();
     }
 
+    /// <summary>
+    /// Regression coverage for the ExcludedProviderDenied fixture collision:
+    /// when the MCC validator's run-scoped NPI generation collides with an
+    /// existing provider, correcting that provider's integrity fields (the
+    /// actual source the adjudication-path integrity gate reads) requires
+    /// the same self-healing amend behavior as AddNetworkParticipation.
+    /// </summary>
+    [Fact]
+    public async Task UpdateProvider_against_active_provider_returns_200_not_409()
+    {
+        var toUpdate = BuildUpdatePayload(integrityScore: 0, integrityRating: "Blocked", credentialingStatus: CredentialingStatus.Denied);
+
+        var result = await _controller.UpdateProvider(ProviderId, toUpdate);
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var provider = ok!.Value as Provider;
+        provider.Should().NotBeNull();
+        provider!.VersionState.Should().Be(ProviderVersionState.Active);
+        provider.IntegrityScore.Should().Be(0);
+        provider.IntegrityRating.Should().Be("Blocked");
+        provider.CredentialingStatus.Should().Be(CredentialingStatus.Denied);
+    }
+
+    [Fact]
+    public async Task UpdateProvider_against_active_provider_amends_and_activates_a_new_version()
+    {
+        var toUpdate = BuildUpdatePayload(integrityScore: 0, integrityRating: "Blocked", credentialingStatus: CredentialingStatus.Denied);
+
+        var result = await _controller.UpdateProvider(ProviderId, toUpdate);
+
+        var provider = ((OkObjectResult)result.Result!).Value as Provider;
+        provider!.VersionNumber.Should().Be(2);
+        provider.PredecessorVersionId.Should().NotBeNullOrEmpty();
+
+        _transitions.Items.Should().Contain(t => t.TransitionType == ProviderTransitionType.Amend);
+        _events.Events.Should().Contain(e => e.EventType == ProviderVersionEventType.ProviderVersionActivated);
+    }
+
+    [Fact]
+    public async Task UpdateProvider_against_unknown_provider_returns_404()
+    {
+        var toUpdate = BuildUpdatePayload(integrityScore: 0, integrityRating: "Blocked", credentialingStatus: CredentialingStatus.Denied);
+
+        var result = await _controller.UpdateProvider("does-not-exist", toUpdate);
+
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    private static Provider BuildUpdatePayload(int integrityScore, string integrityRating, CredentialingStatus credentialingStatus) => new()
+    {
+        TenantId = TenantId,
+        NPI = "1234567890",
+        ProviderType = ProviderType.Individual,
+        FirstName = "Test",
+        LastName = "Provider",
+        PrimarySpecialty = "Internal Medicine",
+        TaxonomyCode = "207R00000X",
+        IntegrityScore = integrityScore,
+        IntegrityRating = integrityRating,
+        CredentialingStatus = credentialingStatus,
+        NetworkParticipations = new List<NetworkParticipation>
+        {
+            new()
+            {
+                PlanId = null,
+                NetworkId = "mcc-local-network",
+                LineOfBusiness = LineOfBusiness.Medicaid,
+                NetworkTier = "InNetwork",
+                EffectiveDate = DateTime.UtcNow.AddYears(-2),
+                AcceptingNewPatients = true,
+            }
+        },
+    };
+
     private static NetworkParticipation NewParticipation(string networkId) => new()
     {
         PlanId = null,


### PR DESCRIPTION
## Summary

Same shape as #956, a different collision surface. The full 100K confirmation run after #956 merged came back with 64 mismatches, all in `ExcludedProviderDenied` (previously 0 in Part 9's recorded evidence) — this fixes it.

- **Root cause:** `MccProviderFixturePool.BuildRunScopedNpi` mints run-scoped NPIs from a value space that isn't infinite, and this cluster accumulates providers across many runs over time. When a run-scoped NPI collides with a provider created by an earlier run, `SeedProvidersAsync` treats it as "already exists" and does nothing further for excluded-provider claims — it never verifies the existing record's exclusion fields actually reflect exclusion.
- That mattered because the adjudication-path integrity gate (`HttpProviderIntegrityGate`) reads `Provider.IntegrityScore` / `IntegrityRating` directly from provider-service as its source of truth — `CredentialingStatus` set at creation time is not what actually gates the `PROVIDER_EXCLUDED` denial. A collided provider's stale "Clear"/96 rating meant claims that should have denied were paying instead.
- **Fix:** `EnsureProviderExclusionAsync` verifies the existing record's `IntegrityRating` on every excluded-provider fixture claim and corrects it in place when a collision left it clean. Requires making `ProvidersController.UpdateProvider` self-healing (same amend → edit → activate pattern #956 used for `AddNetworkParticipation`), since it's the only endpoint that can correct an Active provider's integrity fields.

## Verification

- Confirmed the exact broken provider (`Betty Williams`, NPI `9204520842`) directly via the live API: GET showed `integrityRating: "Clear"`; PUT with corrected fields returned 200 with `integrityRating: "Blocked"`, auto-activated to version 2, predecessor link intact.
- Found and fixed a real bug in my first pass at the `UpdateProvider` self-healing fix along the way: the amended draft's `PredecessorVersionId` wasn't being copied onto the caller's payload before `UpdateAsync`, so `ActivateVersionAsync`'s optimistic-concurrency check correctly rejected it. Caught by the new unit tests, not manual testing.
- **Full clean 100K confirmation run** (job `mcc-part9-final2-100k-090601`) with both this fix and #956 active:
  - Workflow checks: **12,214/13,000 matched, 0 mismatched**, 786 unsupported — every single scenario shows 0 mismatched, including `ExcludedProviderDenied` 2,000/2,000.
  - Platform failures: 0. Expected-pend observation: 920/920, 0 timed out. False-pend sweep: 0 unexpected pends. Payment gate: 2,000/2,000 within $0.01, exact.
  - This is the first time Part 9 has actually hit the same "zero mismatches" bar Part 8 originally set.
  - Throughput was slow this run (26.27 claims/sec vs. the 58.55 baseline) — a one-time cost from healing thousands of legacy providers across both this fix and #956 simultaneously. Providers stay healed once corrected, so this shouldn't recur on future runs against the same tenant.

## Test plan
- [x] `dotnet test tests/CloudHealthOffice.ProviderService.Tests` — 388/388 passing, including new regression tests for `UpdateProvider`'s self-healing behavior
- [x] `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests` — 108/108 passing
- [x] Live verification against the actual broken provider from the confirmation run
- [x] 5K smoke test, then full clean 100K confirmation run

🤖 Generated with [Claude Code](https://claude.com/claude-code)