### PR TITLE
Point marketing site to Part 9 as the latest proof

### DIFF
--- a/src/site/docs.html
+++ b/src/site/docs.html
@@ -85,7 +85,7 @@
           <div class="docs-sidebar-section">
             <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
             <ul>
-              <li><a href="/docs/million-claim-challenge/evidence#episode-008">100K Evidence Archive</a></li>
+              <li><a href="/docs/million-claim-challenge/evidence#episode-009">100K Evidence Archive</a></li>
               <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
               <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
             </ul>
@@ -147,17 +147,17 @@
 
         <div class="docs-hub-grid">
 
-          <a href="/docs/million-claim-challenge/evidence#episode-008" class="docs-hub-card">
+          <a href="/docs/million-claim-challenge/evidence#episode-009" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4CA;</span>
             <h3>100K Evidence Archive</h3>
             <p>Inspect the clean 100,000-claim local Kubernetes run: zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>
           </a>
 
-          <a href="/insights/million-claim-challenge/part-8-clean-100k" class="docs-hub-card">
+          <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4DD;</span>
-            <h3>Part 8: Clean 100K Run</h3>
-            <p>Read the narrative behind the latest proof: stronger correctness gates held at 100K, while fixture preparation became the next local scaling bottleneck.</p>
+            <h3>Part 9: From Unsupported to Scored</h3>
+            <p>Read the narrative behind the latest proof: prior-auth wrong-provider and behavioral-health scenarios moved from unsupported to deliberately scored platform behavior, still zero mismatches at 100K.</p>
             <span class="card-arrow">Read writeup &rarr;</span>
           </a>
 

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -85,7 +85,7 @@
           <div class="docs-sidebar-section">
             <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
             <ul>
-              <li><a href="/docs/million-claim-challenge/evidence#episode-008">100K Evidence Archive</a></li>
+              <li><a href="/docs/million-claim-challenge/evidence#episode-009">100K Evidence Archive</a></li>
               <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
               <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
             </ul>
@@ -147,17 +147,17 @@
 
         <div class="docs-hub-grid">
 
-          <a href="/docs/million-claim-challenge/evidence#episode-008" class="docs-hub-card">
+          <a href="/docs/million-claim-challenge/evidence#episode-009" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4CA;</span>
             <h3>100K Evidence Archive</h3>
             <p>Inspect the clean 100,000-claim local Kubernetes run: zero platform failures, zero scoreable mismatches, zero unexpected pends, and payment checks within one cent.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>
           </a>
 
-          <a href="/insights/million-claim-challenge/part-8-clean-100k" class="docs-hub-card">
+          <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4DD;</span>
-            <h3>Part 8: Clean 100K Run</h3>
-            <p>Read the narrative behind the latest proof: stronger correctness gates held at 100K, while fixture preparation became the next local scaling bottleneck.</p>
+            <h3>Part 9: From Unsupported to Scored</h3>
+            <p>Read the narrative behind the latest proof: prior-auth wrong-provider and behavioral-health scenarios moved from unsupported to deliberately scored platform behavior, still zero mismatches at 100K.</p>
             <span class="card-arrow">Read writeup &rarr;</span>
           </a>
 

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -343,7 +343,9 @@
             <a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">Part 6: From Fast Runs to Honest Edge-Case Scoring</a>,
             <a href="/insights/million-claim-challenge/part-7-operator-console">Part 7: From Benchmark Logs to an Operator Console</a>,
             and
-            <a href="/insights/million-claim-challenge/part-8-clean-100k">Part 8: The Clean 100,000-Claim Run</a>.
+            <a href="/insights/million-claim-challenge/part-8-clean-100k">Part 8: The Clean 100,000-Claim Run</a>,
+            and
+            <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored">Part 9: From Unsupported to Scored</a>.
           </p>
           <p>
             <a href="/insights/million-claim-challenge"><strong>Read the complete engineering series</strong></a>

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -157,18 +157,21 @@
         <div class="callout callout-info">
           <div class="callout-title">Current evidence to compare against</div>
           <p>
-            The latest published Cloud Health Office proof is a clean <strong>100,000-claim local Docker Desktop Kubernetes run</strong>:
-            100,000 claims processed, zero platform failures, zero scoreable workflow mismatches, zero unexpected pends,
-            and 2,000/2,000 comparable payments within one cent. The timed adjudication phase ran at 56.15 claims/sec with 358 ms P95 latency.
+            The latest published Cloud Health Office proof is a clean <strong>100,000-claim local Docker Desktop Kubernetes run</strong>
+            with an expanded scored surface: 12,214/13,000 workflow checks matched, zero scoreable mismatches, zero platform failures,
+            zero unexpected pends, and 2,000/2,000 comparable payments within one cent.
           </p>
           <p>
             Scope matters. This is local engineering evidence, not a production cloud capacity claim and not the full million yet.
-            Fixture preparation dominated the total Kubernetes job duration, so large-run tuning should focus on preparation visibility and bounded seeding before climbing to 250K, 500K, and the full million.
+            This run's timed adjudication phase slowed to 26.27 claims/sec with 895 ms P95 latency, down from the prior run's 58.55 claims/sec &mdash;
+            a one-time cost from two self-healing fixes correcting thousands of accumulated legacy provider records simultaneously, not yet confirmed
+            as one-time by a repeat run. Fixture preparation and this migration cost are the next local scaling bottlenecks to watch before climbing
+            to 250K, 500K, and the full million.
           </p>
           <p>
-            <a href="/docs/million-claim-challenge/evidence#episode-008"><strong>Inspect the 100K evidence archive</strong></a>
+            <a href="/docs/million-claim-challenge/evidence#episode-009"><strong>Inspect the 100K evidence archive</strong></a>
             or read
-            <a href="/insights/million-claim-challenge/part-8-clean-100k"><strong>Part 8: The Clean 100,000-Claim Run</strong></a>.
+            <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored"><strong>Part 9: From Unsupported to Scored</strong></a>.
           </p>
         </div>
 
@@ -184,6 +187,7 @@
             <li><a href="https://medium.com/@markus_31/running-a-healthcare-claims-platform-locally-in-kubernetes-part-6-from-fast-runs-to-honest-4b58288da8da" target="_blank" rel="noopener noreferrer">Part 6: From Fast Runs to Honest Edge-Case Scoring</a></li>
             <li><a href="/insights/million-claim-challenge/part-7-operator-console">Part 7: From Benchmark Logs to an Operator Console</a></li>
             <li><a href="/insights/million-claim-challenge/part-8-clean-100k">Part 8: The Clean 100,000-Claim Run</a></li>
+            <li><a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored">Part 9: From Unsupported to Scored</a></li>
           </ul>
         </div>
 
@@ -388,7 +392,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error || 
             <p>Understand the deterministic corpus, answer key, workflow scoring, supported gaps, and published evidence.</p>
             <span class="card-arrow">Challenge guide &rarr;</span>
           </a>
-          <a href="/docs/million-claim-challenge/evidence#episode-008" class="docs-hub-card">
+          <a href="/docs/million-claim-challenge/evidence#episode-009" class="docs-hub-card">
             <h3>100K Evidence Archive</h3>
             <p>Review the clean 100K local Kubernetes result, run settings, correctness gates, and known scaling bottleneck.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -195,7 +195,7 @@
     flex-wrap: wrap;
   ">
     <span>Latest proof: clean 100,000-claim local Kubernetes validation with zero platform failures and zero scoreable mismatches.</span>
-    <a href="/docs/million-claim-challenge/evidence#episode-008" style="
+    <a href="/docs/million-claim-challenge/evidence#episode-009" style="
       color: #00ff88;
       font-weight: 600;
       text-decoration: none;
@@ -254,7 +254,7 @@
             <div class="nav-dropdown-menu" aria-label="Platform submenu">
               <a href="/docs/architecture">Architecture</a>
               <a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a>
-              <a href="/insights/million-claim-challenge/part-8-clean-100k">100K Run Writeup</a>
+              <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored">100K Run Writeup</a>
               <a href="/docs/compliance">CMS-0057-F Guide</a>
               <a href="/docs/api">API Reference</a>
               <div class="nav-dropdown-divider" aria-hidden="true"></div>
@@ -302,12 +302,12 @@
         </p>
 
         <div class="hero-cta">
-          <a href="/docs/million-claim-challenge/evidence#episode-008"
+          <a href="/docs/million-claim-challenge/evidence#episode-009"
              class="button"
              style="font-size:1.05rem; padding:15px 38px;">Inspect the 100K evidence &rarr;</a>
-          <a href="/insights/million-claim-challenge/part-8-clean-100k"
+          <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored"
              class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;">Read Part 8 &rarr;</a>
+             style="font-size:1.05rem; padding:15px 38px;">Read Part 9 &rarr;</a>
           <a href="https://github.com/aurelianware/cloudhealthoffice"
              class="button button-secondary"
              style="font-size:1.05rem; padding:15px 38px;"
@@ -1143,7 +1143,7 @@
         </div>
 
         <div style="text-align:center; margin-bottom:48px;">
-          <a href="/docs/million-claim-challenge/evidence#episode-008" class="button">Inspect the 100K Evidence &rarr;</a>
+          <a href="/docs/million-claim-challenge/evidence#episode-009" class="button">Inspect the 100K Evidence &rarr;</a>
           <a href="/docs/million-claim-challenge" class="button button-secondary">Explore the Benchmark Methodology &rarr;</a>
         </div>
 
@@ -1157,7 +1157,7 @@
           That is the next optimization target before 250K, 500K, and the full million.
         </p>
         <div style="text-align:center;">
-          <a href="/insights/million-claim-challenge/part-8-clean-100k" class="button button-secondary">Read the 100K writeup &rarr;</a>
+          <a href="/insights/million-claim-challenge/part-9-from-unsupported-to-scored" class="button button-secondary">Read the 100K writeup &rarr;</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Now that Part 9 has hit the same zero-mismatch bar Part 8 set (with an expanded scored surface: 12,214/13,000 matched vs. 11,854/13,000), swap the homepage hero CTA, nav dropdown, "Inspect the 100K evidence" links, and evidence-archive anchors from Part 8/`#episode-008` to Part 9/`#episode-009`.
- Update the docs hub cards on `docs.html`/`docs/index.html` from "Part 8: Clean 100K Run" to "Part 9: From Unsupported to Scored".
- Append Part 9 to the chronological field-note lists on `quickstart.html` and `million-claim-challenge.html` (Part 8 stays listed as history).
- Update `quickstart.html`'s "Current evidence to compare against" callout with Part 9's numbers, including an honest note on the throughput regression (26.27 vs. 58.55 claims/sec) attributed in the Part 9 article to a one-time provider-healing migration cost, unconfirmed until a repeat run checks it.
- Left a few Part 8-specific mentions untouched on purpose: the "Episode 008 evidence archive" timing comparison in quickstart.html's reproducibility notes (Part 9's ~1h3m timed-adjudication is a known outlier, not representative of what a fresh reproduction run should expect) and the insights index archive page, which correctly lists both episodes.

## Test plan
- [x] Verified `part-9-from-unsupported-to-scored.html` and the `#episode-009` evidence anchor both exist
- [x] Grepped for remaining `part-8-clean-100k`/`episode-008` references — confirmed the only survivors are legitimate historical mentions (archive entry, chronological lists, the one intentionally-preserved timing comparison)
- [x] Diff reviewed for secrets — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)