### PR TITLE
Parallelize MCC provider/member fixture seeding, surface progress

### DIFF
--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1307,35 +1307,48 @@ static async Task<MemberFixturePreparation> SeedMembersAsync(
     var created = 0;
     var existing = 0;
     var statusAligned = 0;
+    var processed = 0;
+    var progressInterval = SeedingProgressInterval(members.Count);
+    var progressLock = new object();
 
-    foreach (var member in members)
-    {
-        if (await MemberExistsAsync(http, options, member.MemberId))
+    await Parallel.ForEachAsync(
+        members,
+        new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
+        async (member, _) =>
         {
-            existing++;
-            if (await UpdateMemberSeedStatusAsync(http, options, member, json))
+            if (await MemberExistsAsync(http, options, member.MemberId))
             {
-                statusAligned++;
+                Interlocked.Increment(ref existing);
+                if (await UpdateMemberSeedStatusAsync(http, options, member, json))
+                {
+                    Interlocked.Increment(ref statusAligned);
+                }
             }
-            continue;
-        }
+            else
+            {
+                var didCreate = await CreateMemberAsync(http, options, member, json);
+                if (didCreate)
+                {
+                    Interlocked.Increment(ref created);
+                }
+                else
+                {
+                    Interlocked.Increment(ref existing);
+                }
 
-        var didCreate = await CreateMemberAsync(http, options, member, json);
-        if (didCreate)
-        {
-            created++;
-        }
-        else
-        {
-            existing++;
-        }
+                if (await UpdateMemberSeedStatusAsync(http, options, member, json))
+                {
+                    Interlocked.Increment(ref statusAligned);
+                }
+            }
 
-        if (await UpdateMemberSeedStatusAsync(http, options, member, json))
-        {
-            statusAligned++;
-        }
+            WriteSeedingProgress("members", Interlocked.Increment(ref processed), members.Count, progressInterval, progressLock);
+        });
+
+    if (members.Count > 0)
+    {
+        Console.WriteLine();
     }
-
     Console.WriteLine($"seeded: {created:N0} synthetic members ({existing:N0} already present, {statusAligned:N0} status-aligned)");
     return new MemberFixturePreparation(created, existing, statusAligned);
 }
@@ -1920,6 +1933,22 @@ static bool TryGetInt32Property(JsonElement element, string propertyName, out in
     return false;
 }
 
+static int SeedingProgressInterval(int total) =>
+    total <= 0 ? 1 : Math.Max(1, Math.Min(2_000, total / 20));
+
+static void WriteSeedingProgress(string label, int done, int total, int interval, object progressLock)
+{
+    if (total <= 0 || (done % interval != 0 && done != total))
+    {
+        return;
+    }
+
+    lock (progressLock)
+    {
+        Console.Write($"\r  Seeding {label}: {done:N0}/{total:N0}");
+    }
+}
+
 static async Task<FixtureCount> SeedProvidersAsync(
     HttpClient http,
     ValidatorOptions options,
@@ -1937,41 +1966,53 @@ static async Task<FixtureCount> SeedProvidersAsync(
 
     var created = 0;
     var existing = 0;
+    var processed = 0;
+    var progressInterval = SeedingProgressInterval(providers.Count);
+    var progressLock = new object();
 
-    foreach (var provider in providers)
+    await Parallel.ForEachAsync(
+        providers,
+        new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
+        async (provider, _) =>
+        {
+            var providerId = await GetProviderIdByNpiAsync(http, options, provider.Npi);
+            if (providerId is not null)
+            {
+                Interlocked.Increment(ref existing);
+            }
+            else
+            {
+                providerId = await CreateProviderAsync(http, options, provider, validationPlanId, json);
+                Interlocked.Increment(ref created);
+            }
+
+            if (!IsProviderExcluded(provider))
+            {
+                await EnsureProviderCredentialingAsync(
+                    http,
+                    options,
+                    providerId,
+                    EffectiveDateForProvider(provider),
+                    json);
+                await EnsureProviderNetworkParticipationAsync(
+                    http,
+                    options,
+                    providerId,
+                    provider,
+                    json);
+            }
+            else
+            {
+                await EnsureProviderExclusionAsync(http, options, providerId, json);
+            }
+
+            WriteSeedingProgress("providers", Interlocked.Increment(ref processed), providers.Count, progressInterval, progressLock);
+        });
+
+    if (providers.Count > 0)
     {
-        var providerId = await GetProviderIdByNpiAsync(http, options, provider.Npi);
-        if (providerId is not null)
-        {
-            existing++;
-        }
-        else
-        {
-            providerId = await CreateProviderAsync(http, options, provider, validationPlanId, json);
-            created++;
-        }
-
-        if (!IsProviderExcluded(provider))
-        {
-            await EnsureProviderCredentialingAsync(
-                http,
-                options,
-                providerId,
-                EffectiveDateForProvider(provider),
-                json);
-            await EnsureProviderNetworkParticipationAsync(
-                http,
-                options,
-                providerId,
-                provider,
-                json);
-        }
-        else
-        {
-            await EnsureProviderExclusionAsync(http, options, providerId, json);
-        }
+        Console.WriteLine();
     }
-
     Console.WriteLine($"seeded: {created:N0} synthetic providers ({existing:N0} already present)");
     return new FixtureCount(created, existing);
 }


### PR DESCRIPTION
## Summary
- `SeedProvidersAsync` and `SeedMembersAsync` in the MCC platform validator were sequential `foreach` loops, each record making a chain of HTTP round-trips (lookup, create-if-missing, then credentialing/network-participation or member-status alignment). On large runs this was the invisible long pole: on a 250K-claim run, provider seeding (30K+ records) and member seeding (200K+ records) produced zero console output for the entire phase.
- Both loops are independent per-record (grouped by distinct NPI/member ID before the loop starts, no shared mutable state beyond simple counters), so both now run through `Parallel.ForEachAsync` at `--parallelism`, the same pattern already used for the timed claim-processing loop.
- Added a shared `WriteSeedingProgress` helper that prints a periodic in-place `Seeding providers/members: X/Y` line (interval scales with total record count, capped at every 2,000 records) so these phases are no longer silent on large runs.

## Test plan
- [x] `dotnet build` clean, 0 warnings/errors
- [x] `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests` — 108/108 passing (no existing coverage of these specific functions; they're exercised live against real services)
- [x] Validated end to end on a fresh 250,000-claim confirmation run (the largest run to date on this cluster): provider seeding (30,087 records) completed in 6:56, member seeding (247,585 operations) in 15:07 — previously the dominant, unbounded-duration phase of the job lifecycle
- [x] The confirmation run itself came back fully clean with the new seeding code: 30,534/32,500 workflow checks matched, **0 mismatched**, 1,966 unsupported (exactly the projected count), 0 platform failures, payment gate 5,000/5,000 exact — no new correctness regressions from parallelizing seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)