### PR TITLE
Bump fast-uri to clear high-severity npm audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,9 +3604,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- The `Dependency Security Scan` check flagged `fast-uri` 3.1.2 (a transitive dependency of `ajv` 8.18.0) as vulnerable to [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6), affecting the range `>=3.0.0 <3.1.3`.
- Ran `npm update fast-uri`, which bumped it to 3.1.4 within ajv's existing `^3.0.1` dependency constraint — no other package versions changed.
- `npm audit --omit=dev --audit-level=moderate` (what CI's Security Scan workflow actually runs) now reports 0 vulnerabilities.
- Unrelated to this PR: `npm audit` (full, including dev deps) still shows 2 pre-existing dev-only findings (`@babel/core`, `js-yaml`), which the CI check doesn't scan against since it's `--omit=dev`. Left those out of scope here.

## Test plan
- [x] `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities (previously 1 high)
- [x] Lockfile diff is a single patch-version bump, no dependency tree changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)