### PR TITLE
Raise CPU limits for the adjudication-path services

### DIFF
--- a/src/services/benefit-plan-service/k8s/benefit-plan-service-deployment.yaml
+++ b/src/services/benefit-plan-service/k8s/benefit-plan-service-deployment.yaml
@@ -59,10 +59,10 @@ spec:
           value: "http://claims-service.cloudhealthoffice"
         resources:
           requests:
-            cpu: 100m
+            cpu: 300m
             memory: 128Mi
           limits:
-            cpu: 500m
+            cpu: 1500m
             memory: 512Mi
         livenessProbe:
           httpGet:

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -99,10 +99,10 @@ spec:
               key: connectionString
         resources:
           requests:
-            cpu: 100m
+            cpu: 500m
             memory: 128Mi
           limits:
-            cpu: 500m
+            cpu: 2000m
             memory: 512Mi
         livenessProbe:
           httpGet:

--- a/src/services/provider-service/k8s/provider-service-deployment.yaml
+++ b/src/services/provider-service/k8s/provider-service-deployment.yaml
@@ -52,10 +52,10 @@ spec:
               key: MongoDb__DatabaseName
         resources:
           requests:
-            cpu: 100m
+            cpu: 200m
             memory: 128Mi
           limits:
-            cpu: 500m
+            cpu: 1000m
             memory: 512Mi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- Every service on the adjudication hot path (`claims-service`, `benefit-plan-service`, `provider-service`) shared the same `500m` CPU limit / `100m` request, regardless of actual load.
- Checked `cgroup cpu.stat` inside the live pods during an MCC benchmark run and found real, severe throttling:
  - `claims-service`: **81.3%** of scheduling periods throttled (62,127s cumulative throttled time against 6,327s of actual usage)
  - `provider-service`: 9.5% of periods throttled
  - `benefit-plan-service`: 1-2.3% at idle, but 14.5-23% of periods throttled during an active adjudication run
- The Docker Desktop node has 18 cores and was never more than ~25% utilized at the node level during any of these runs — the ceiling was purely the per-pod cgroup limit, not real capacity.
- Raised limits (requests scaled proportionally): `claims-service` 500m→2000m, `provider-service` 500m→1000m, `benefit-plan-service` 500m→1500m.

## Test plan
- [x] Validated live: `claims-service` throttling dropped to ~0.13% of periods (essentially eliminated), `benefit-plan-service` dropped from 14.5-23% to 2.5-5.9% during an active run
- [x] 5,000-claim/p28 smoke test before vs. after these two rounds of bumps: throughput rose from 92.73 to 106-114 claims/sec (~15-25%), `Submit` avg latency dropped from 123ms to 60-72ms, `Writeback` from 86ms to 45-52ms
- [x] Correctness held throughout every run — 0 mismatched, 0 platform failures, payment gate exact
- [x] `kubectl apply --dry-run=client` clean on all three manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)