### PR TITLE
Extend NCCI lookup cache TTL from 10 minutes to 6 hours

### DIFF
--- a/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Services/NcciLookupCache.cs
@@ -5,7 +5,12 @@ namespace CloudHealthOffice.NcciEngine.Services;
 
 internal sealed class NcciLookupCache
 {
-    private static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(10);
+    // NCCI/MUE reference data is quarterly (CMS cadence); explicit updates go through
+    // ImportQuarterlyUpdateAsync -> InvalidateTenant, which bypasses this TTL entirely.
+    // The TTL only bounds staleness for edits made outside that path, so it can be long
+    // without risking masking a real update -- a short TTL just forces avoidable re-lookups
+    // on every distinct (code-pair, service-date) combination within a single long run.
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromHours(6);
 
     private readonly ConcurrentDictionary<PairCacheKey, CacheEntry<NcciEditPair>> _pairs = new();
     private readonly ConcurrentDictionary<MueCacheKey, CacheEntry<MueEntry>> _mues = new();


### PR DESCRIPTION
## Summary
- After the CPU-throttling fix landed, `ncci` became the second-largest remaining per-claim adjudication cost (45-50ms avg, ~200ms P95) — a 10-minute cache TTL meant entries for the same (code-pair, service-date) combination kept expiring and re-fetching within a single long benchmark run.
- NCCI/MUE reference data is quarterly (CMS cadence), and explicit updates already go through `ImportQuarterlyUpdateAsync` → `InvalidateTenant`, which bypasses this TTL entirely — the TTL only bounds staleness for edits made outside that path, so it can safely be long without risking a masked update.
- Bumped `NcciLookupCache.DefaultTtl` from 10 minutes to 6 hours. No new warm-up logic needed (unlike the accumulator/provider-integrity investigation) — this just lets naturally-computed entries survive for the length of a real run.

## Test plan
- [x] `dotnet build` clean, 0 warnings/errors
- [x] `dotnet test tests/CloudHealthOffice.NcciEngine.Tests` — 29/29 passing (no test depends on the specific TTL value)
- [x] Validated live on a 5,000-claim/p28 run (on top of the earlier CPU and accumulator-cache fixes): throughput rose from 106.89 to **203.80 claims/sec**, `ncci` avg/P95 dropped from 50ms/206ms to 22ms/101ms, correctness held — 611/650 workflow checks matched, 0 mismatched, payment gate 100/100 exact

🤖 Generated with [Claude Code](https://claude.com/claude-code)