### PR TITLE
Refresh provider lastVerifiedAt on every seeding pass

### DIFF
--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2044,6 +2044,7 @@ static async Task<FixtureCount> SeedProvidersAsync(
                     providerId,
                     provider,
                     json);
+                await EnsureProviderVerificationFreshnessAsync(http, options, providerId, json);
             }
             else
             {
@@ -2333,7 +2334,8 @@ static async Task EnsureProviderExclusionAsync(
         ?? throw new InvalidOperationException($"provider fetch returned no body ({providerId})");
 
     var currentRating = node["integrityRating"]?.GetValue<string>();
-    if (string.Equals(currentRating, "Blocked", StringComparison.OrdinalIgnoreCase))
+    var ratingIsBlocked = string.Equals(currentRating, "Blocked", StringComparison.OrdinalIgnoreCase);
+    if (ratingIsBlocked && IsProviderVerificationFresh(node))
     {
         return;
     }
@@ -2341,6 +2343,7 @@ static async Task EnsureProviderExclusionAsync(
     node["integrityScore"] = 0;
     node["integrityRating"] = "Blocked";
     node["credentialingStatus"] = "Denied";
+    SetFreshProviderVerificationTimestamps(node);
 
     using var update = await http.PutAsJsonAsync(
         $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}",
@@ -2352,6 +2355,70 @@ static async Task EnsureProviderExclusionAsync(
         throw new InvalidOperationException(
             $"provider exclusion correction failed ({providerId}): {(int)update.StatusCode} {updateBody}");
     }
+}
+
+// benefit-plan-service's HttpProviderIntegrityGate falls back to a live
+// NPPES-registry check (provider-verification-service) whenever a
+// provider's lastVerifiedAt ages past its 7-day StalenessFallbackThreshold.
+// MCC's synthetic NPIs were never real NPPES-registered numbers, so that
+// live check always answers "excluded/not found" -- wrongly denying
+// claims for providers this run needs to be Clear. lastVerifiedAt is only
+// ever set at provider creation; on this long-lived, heavily reused
+// tenant, most seeding passes find the provider already correct and skip
+// writing entirely, letting the timestamp age past the threshold across
+// days of repeated runs. Refresh it well inside that window on every
+// seeding pass, independent of whether credentialing/exclusion fields
+// need correcting.
+static async Task EnsureProviderVerificationFreshnessAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    string providerId,
+    JsonSerializerOptions json)
+{
+    using var response = await http.GetAsync(
+        $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}");
+    var body = await response.Content.ReadAsStringAsync();
+    if (!response.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException(
+            $"provider fetch failed for verification freshness check ({providerId}): {(int)response.StatusCode} {body}");
+    }
+
+    var node = JsonNode.Parse(body)
+        ?? throw new InvalidOperationException($"provider fetch returned no body ({providerId})");
+
+    if (IsProviderVerificationFresh(node))
+    {
+        return;
+    }
+
+    SetFreshProviderVerificationTimestamps(node);
+
+    using var update = await http.PutAsJsonAsync(
+        $"{options.ProviderUrl}/api/v1/providers/{Uri.EscapeDataString(providerId)}",
+        node,
+        json);
+    var updateBody = await update.Content.ReadAsStringAsync();
+    if (!update.IsSuccessStatusCode)
+    {
+        throw new InvalidOperationException(
+            $"provider verification freshness refresh failed ({providerId}): {(int)update.StatusCode} {updateBody}");
+    }
+}
+
+static bool IsProviderVerificationFresh(JsonNode node)
+{
+    var raw = node["lastVerifiedAt"]?.GetValue<string>();
+    return !string.IsNullOrWhiteSpace(raw)
+        && DateTimeOffset.TryParse(raw, out var lastVerifiedAt)
+        && DateTimeOffset.UtcNow - lastVerifiedAt < TimeSpan.FromDays(3);
+}
+
+static void SetFreshProviderVerificationTimestamps(JsonNode node)
+{
+    var now = DateTimeOffset.UtcNow;
+    node["lastVerifiedAt"] = JsonValue.Create(now);
+    node["nextVerificationDue"] = JsonValue.Create(now.AddDays(30));
 }
 
 static async Task<string> CreateProviderAsync(


### PR DESCRIPTION
## Summary
- Found via the 250K/p56 confirmation run: 5 of 32,500 workflow checks failed (2 mismatched, 3 observation timeouts), scattered across unrelated scenarios (`BehavioralHealthCarveIn`, `BehavioralHealthCarveOut`, `RetroEligibilityAdd`, `RetroEligibilityTermination`) with no shared business logic — but all five shared the same `businessDenialCode` (`PROVIDER_EXCLUDED`) and elevated `providerIntegrity` latency (216-344ms vs. the typical <50ms).
- Root cause: benefit-plan-service's `HttpProviderIntegrityGate` falls back to a live NPPES-registry check (`provider-verification-service`) whenever a provider's `lastVerifiedAt` ages past its 7-day `StalenessFallbackThreshold`. MCC's synthetic provider NPIs were never real NPPES-registered numbers, so that live check always answers `NPI_NOT_FOUND` — wrongly denying claims for providers this run needs to be Clear.
- `lastVerifiedAt` is only ever set once, at provider creation. Both `EnsureProviderCredentialingAsync` and the prior `EnsureProviderExclusionAsync` early-return without touching it whenever the provider is already in the correct state — the common case on this long-lived, heavily reused tenant. As this benchmark tenant's fixture data has aged across multiple days of testing, a growing slice of the pool has crossed the 7-day line, making this a **worsening** problem, not a one-off.

## Fix
- Added `EnsureProviderVerificationFreshnessAsync` for the non-excluded path.
- Extended `EnsureProviderExclusionAsync`'s existing GET-then-conditional-PUT to also refresh `lastVerifiedAt`/`nextVerificationDue` (reuses the same round trip, no extra network call for that path).
- Both check a 3-day freshness margin, comfortably inside the 7-day staleness trigger.

## Test plan
- [x] `dotnet build` clean, 0 warnings/errors
- [x] `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests` — 108/108 passing
- [x] Validated live: confirmed both code paths (excluded and non-excluded) refresh a real seeded provider's `lastVerifiedAt` to the current run's timestamp
- [x] Follow-up 5,000-claim/p28 run (after a benefit-plan-service restart to also clear the unrelated per-pod integrity-cache staleness issue) came back fully clean — 611/650 matched, 0 mismatched, 0 observation timeouts, 0 platform failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)