### PR TITLE
Scale provider-service to 2 replicas

### DIFF
--- a/src/services/provider-service/k8s/provider-service-deployment.yaml
+++ b/src/services/provider-service/k8s/provider-service-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
     app: provider-service
     tier: backend
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: provider-service


### PR DESCRIPTION
## Summary
- Found via a 250K/p56 confirmation run: `benefit-plan-service`'s `HttpProviderIntegrityGate` logged 30 "Provider service unreachable" warnings over the run's 29-minute sustained load window, from a single-replica `provider-service` dropping connections under concurrency.
- Each occurrence forces the gate's live NPPES-verification fallback path instead of trusting the (correct) cached `provider-service` data.
- That fallback path has its own bug, **not fixed here, tracked separately**: the live verification service's `"Failed"` status silently maps to "not excluded" in `HttpProviderIntegrityGate.cs`'s `NormalizeStatus`/`IsExcluded` logic, rather than being treated as a denial/review case. So a `provider-service` connection hiccup can turn into a wrongly-paid claim. Removing the trigger (provider-service capacity) is the immediate, low-risk fix; the status-mapping gap is adjudication-safety logic and needs its own review, not a reflexive patch.
- Matches `claims-service`'s existing 2-replica pattern.

## Test plan
- [x] `kubectl scale` applied live and confirmed rolled out (2/2 available)
- [ ] Full 250K/p56 re-confirmation pending — will report results separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)