### PR TITLE
Add Part 10 to sitemap, dedupe repeated entries

### DIFF
--- a/src/site/sitemap.xml
+++ b/src/site/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://cloudhealthoffice.com/</loc>
-    <lastmod>2026-03-24</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
@@ -32,8 +32,8 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/pricing-api</loc>
-    <lastmod>2026-03-21</lastmod>
-    <priority>0.9</priority>
+    <lastmod>2026-06-20</lastmod>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/claims-repricing</loc>
@@ -67,12 +67,12 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/quickstart</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
@@ -115,19 +115,19 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/million-claim-challenge</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/million-claim-challenge/evidence</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/insights/million-claim-challenge</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -162,34 +162,40 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://cloudhealthoffice.com/docs/benefit-plan-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <loc>https://cloudhealthoffice.com/insights/million-claim-challenge/part-10-the-migration-cost-that-wasnt</loc>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://cloudhealthoffice.com/docs/benefit-plan-guide</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/claims-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/prior-auth-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/eligibility-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/fee-schedule-guide</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/provider-verification-guide</loc>
@@ -199,9 +205,9 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/provider-enrollment-guide</loc>
-    <lastmod>2026-06-10</lastmod>
+    <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/docs/texas-compliance</loc>
@@ -215,54 +221,13 @@
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://cloudhealthoffice.com/pricing-api</loc>
-    <lastmod>2026-06-20</lastmod>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://cloudhealthoffice.com/docs/benefit-plan-guide</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://cloudhealthoffice.com/docs/claims-guide</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://cloudhealthoffice.com/docs/eligibility-guide</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://cloudhealthoffice.com/docs/fee-schedule-engine</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://cloudhealthoffice.com/docs/fee-schedule-guide</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
     <loc>https://cloudhealthoffice.com/docs/florida-compliance</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://cloudhealthoffice.com/docs/prior-auth-guide</loc>
-    <lastmod>2026-06-20</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://cloudhealthoffice.com/docs/provider-enrollment-guide</loc>
     <lastmod>2026-06-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -299,4 +264,5 @@
     <lastmod>2026-06-01</lastmod>
     <priority>0.5</priority>
   </url>
+
 </urlset>


### PR DESCRIPTION
## Summary
- Added the Part 10 article URL to `sitemap.xml` (missing since publish — the file is a manually-maintained list, not auto-generated).
- Bumped `lastmod` to today on every page whose content actually changed today: homepage, docs hub (`/docs`), quickstart, the MCC challenge guide, the evidence archive, and the insights index.
- Deduped 7 URLs that each had two `<url>` entries (`pricing-api` and five docs guide pages), keeping whichever had the most recent `lastmod`. Harmless for crawling, but not valid sitemap practice and worth cleaning up before a fresh Search Console submission.
- `robots.txt` already correctly references `https://cloudhealthoffice.com/sitemap.xml` — no change needed there.

## Test plan
- [x] Parsed with `xml.etree.ElementTree` — valid XML, 48 unique URL entries, 0 duplicates
- [x] Confirmed the Part 10 URL and its `lastmod`/`changefreq`/`priority` are present and match the pattern used for Part 5-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)