### PR TITLE
Wire federal provider-exclusion check into the real adjudication pipeline

### DIFF
--- a/docs/architecture/claim-adjudication-pipeline.md
+++ b/docs/architecture/claim-adjudication-pipeline.md
@@ -15,6 +15,24 @@
 > [`claim-remittance-generation.md`](./claim-remittance-generation.md)
 > doc covers capability 5.10's operator-initiated finalization
 > handoff (Adjudicated → Paid via batched 835 emission).
+>
+> **Addendum, July 2026 — ProviderIntegrityStage added.** Capability
+> 5.10 (see
+> [`integrity-score-consumption.md`](./integrity-score-consumption.md))
+> built `HttpProviderIntegrityGate` — the federal OIG/LEIE/SAM.gov
+> exclusion check — into benefit-plan-service, but it was only ever
+> wired into the standalone `AdjudicationController.Adjudicate` HTTP
+> endpoint, never into this orchestrator. The original 6-stage scope
+> above never included a provider-integrity stage at all, so claims
+> processed through this pipeline (`BenefitCalculationStage` →
+> `calculate-benefits`, which stays exclusion-check-free by design —
+> see D14) were never checked against federal exclusion lists. Found
+> during a Million Claim Challenge scale confirmation; fixed by adding
+> `ProviderIntegrityStage` (Order=150) as a 7th stage, reached via a
+> new side-effect-free endpoint
+> (`GET /api/v1/adjudication/provider-integrity/{npi}`) rather than
+> folding the check into `calculate-benefits` itself. See "Provider
+> integrity stage (added July 2026)" below.
 
 ## Why this exists
 
@@ -48,6 +66,7 @@ POST /api/v1/claims                                     (capability 5.3)
    │   └── iterate stages by Order ascending:                     │
    │                                                              │
    │       100  ScrubbingStage               ★ real (5.4)         │
+   │       150  ProviderIntegrityStage       ★ real (added 7/26)  │
    │       200  NetworkCredentialingStage    ★ real (5.6)         │
    │       300  BenefitCalculationStage      ★ real (5.5)         │
    │       400  NcciEditsStage               ★ real (5.7)         │
@@ -308,6 +327,38 @@ throw `NotImplementedException` because the pipeline doesn't use them.
 Adding those surfaces is a follow-up driven by capability 5.12 (adjustment
 workflow).
 
+## Provider integrity stage (added July 2026)
+
+`ProviderIntegrityStage`, `Order=150`, runs the same federal-exclusion
+(OIG/LEIE/SAM.gov) check `HttpProviderIntegrityGate` has always run for
+`AdjudicationController.Adjudicate` callers — reached here through a new,
+side-effect-free endpoint rather than through `calculate-benefits`
+(D14's shim target), which stays exclusion-check-free by design since
+portal/preview features also call it and must not be blocked by a live
+exclusion check on a hypothetical calculation.
+
+- Checks both `BillingProviderNPI` and `RenderingProviderNPI` (when
+  distinct) — mirrors `NetworkCredentialingStage`'s dual-provider check.
+- A confirmed exclusion (`ProviderIntegrityResult.IsExcluded`) is a
+  `Deny`; `AdjudicationResult.DenialReasonCode`/`DenialReason` are set
+  from the gate's response before the stage returns.
+- Anything the gate could not confidently resolve either way
+  (`RequiresManualReview`, or the HTTP call to benefit-plan-service
+  itself failing) is a `Pend` with `PendCode="MEDREVIEW"` — an
+  already-recognized `PendDetails.PendCode` value with an existing
+  work-queue bucket (`ClaimsController`'s "Medical Review" category).
+  No new pend vocabulary introduced.
+- Unlike `NetworkCredentialingStage`, this stage has no tenant-configurable
+  fail-open mode — a federal exclusion check has no legitimate advisory-only
+  posture. It can be disabled entirely via `EnabledStages` (same contract
+  every stage has), but while enabled it always enforces.
+- `HttpProviderIntegrityGate` itself never fails open: total unavailability
+  (both provider-service and provider-verification-service unreachable) or
+  a live `Failed`/`ManualReviewRequired` verification status both resolve
+  to `Passed=false` + `RequiresManualReview=true`, distinct from a
+  confirmed `IsExcluded` finding. See
+  [`integrity-score-consumption.md`](./integrity-score-consumption.md).
+
 ## Configuration
 
 ```json
@@ -320,6 +371,7 @@ workflow).
     "Pipeline": {
       "EnabledStages": {
         "Scrubbing": true,
+        "ProviderIntegrity": true,
         "NetworkCredentialing": true,
         "BenefitCalculation": true,
         "NcciEdits": true,

--- a/docs/architecture/integrity-score-consumption.md
+++ b/docs/architecture/integrity-score-consumption.md
@@ -4,6 +4,23 @@ Status: 5.10 — verification integrity score surface (Phase 1 closer)
 Services: `src/services/provider-service`, `src/services/benefit-plan-service`, `src/portal`
 Depends on: 5.4.5 (verification write-back), 5.4 (network roster), 5.7 (FHIR Practitioner)
 
+> **Addendum, July 2026.** Until this month, "Adjudication critical
+> path" below was aspirational for real traffic: `HttpProviderIntegrityGate`
+> was only ever reached through the standalone `AdjudicationController.Adjudicate`
+> endpoint (used by the MCC benchmark validator), never through
+> claims-service's actual orchestrated pipeline — `BenefitCalculationStage`
+> called `calculate-benefits`, which by design (D14 in
+> `claim-adjudication-pipeline.md`) never touches provider integrity. Real
+> claims were never checked against federal exclusion lists. Fixed by adding
+> claims-service's `ProviderIntegrityStage` (Order=150), reached through a
+> new side-effect-free `GET /api/v1/adjudication/provider-integrity/{npi}`
+> endpoint rather than folding the check into `calculate-benefits` itself.
+> The gate was also hardened at the same time: total verification
+> unavailability and a live `Failed`/`ManualReviewRequired` status now both
+> resolve to `Passed=false` with a new `RequiresManualReview` flag, rather
+> than the old fail-open `Passthrough()` default. See "Provider integrity
+> stage (added July 2026)" in `claim-adjudication-pipeline.md`.
+
 ## Why a canonical decision tree
 
 Integrity-score data has three consumers patterns that look similar
@@ -61,7 +78,8 @@ Need an integrity score?
 | FHIR Organization projection | `FhirOrganizationProjector` (provider-service) | Cached projection (only when score is on the Provider with `ProviderType.Organization`) |
 | Provider list grid | `Pages/Providers.razor` (portal) | Cached projection (via portal `ProviderService` HTTP client) |
 | Provider detail card | `Pages/ProviderDetailsDialog.razor` (portal) | Cached projection; "Refresh now" button calls live |
-| Adjudication critical path | `HttpProviderIntegrityGate` (benefit-plan-service) | Cached-or-live (default) |
+| Adjudication critical path (standalone endpoint) | `HttpProviderIntegrityGate` via `AdjudicationController.Adjudicate` (benefit-plan-service) | Cached-or-live (default) |
+| Adjudication critical path (real pipeline) | `ProviderIntegrityStage` (claims-service) → `GET /api/v1/adjudication/provider-integrity/{npi}` → `HttpProviderIntegrityGate` (benefit-plan-service) | Cached-or-live (default); added July 2026 — see addendum above |
 | Admin tenant backfill | `IntegrityProjectionAdminController` (provider-service) | Live (per-provider in a loop) |
 | Scheduled re-verification | `IntegrityProjectionWorker` (provider-service) | Live (worker → verification-service) |
 | Per-provider on-demand refresh | `ProvidersController.Refresh` (provider-service) | Live |
@@ -207,8 +225,10 @@ block alongside the rest of the Sentinel palette.
   handled here.
 - **Adjudication-time re-adjudicate-with-fresh.** The
   `IProviderIntegrityGate.CheckAsync` interface gained a
-  `forceRefresh` parameter in 5.10; the only current caller
-  (`AdjudicationController`) passes the default. A future capability
+  `forceRefresh` parameter in 5.10; the only current direct caller
+  (`AdjudicationController`, including the new July 2026
+  `provider-integrity/{npi}` endpoint claims-service's
+  `ProviderIntegrityStage` calls) passes the default. A future capability
   could add an admin-triggered "re-adjudicate against this claim with a
   fresh score" affordance.
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/HttpProviderIntegrityGateTests.cs
@@ -183,7 +183,7 @@ public sealed class HttpProviderIntegrityGateTests
     }
 
     [Fact]
-    public async Task CheckAsync_BothEndpointsFail_ReturnsPassthrough()
+    public async Task CheckAsync_BothEndpointsFail_ReturnsUnavailableForReview()
     {
         var providerHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
         var verificationHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
@@ -191,17 +191,20 @@ public sealed class HttpProviderIntegrityGateTests
 
         var result = await gate.CheckAsync(Npi);
 
-        result.Passed.Should().BeTrue("adjudication is never blocked by infrastructure flakes");
+        result.Passed.Should().BeFalse("adjudication must never silently pay a claim it could not verify");
+        result.IsExcluded.Should().BeFalse("unavailable is not the same as a confirmed exclusion finding");
+        result.RequiresManualReview.Should().BeTrue();
+        result.DenialCode.Should().Be("PROVIDER_VERIFICATION_UNAVAILABLE");
         result.Rating.Should().Be("Unknown");
     }
 
     [Fact]
-    public async Task CheckAsync_PassthroughResult_IsNotCached()
+    public async Task CheckAsync_UnavailableResult_IsNotCached()
     {
-        // Both endpoints fail → passthrough. The gate must NOT cache that
+        // Both endpoints fail → unavailable. The gate must NOT cache that
         // result for the full 1-hour TTL, so a subsequent call after
-        // upstream recovers picks up the real exclusion signal instead
-        // of an hour of stale "passed".
+        // upstream recovers picks up the real signal instead of an hour of
+        // every claim for that NPI being held for review.
         var providerHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
         var verificationHandler = FakeHttpMessageHandler.Throw(new HttpRequestException());
         var gate = BuildGate(providerHandler, verificationHandler);
@@ -210,9 +213,41 @@ public sealed class HttpProviderIntegrityGateTests
         await gate.CheckAsync(Npi);
 
         providerHandler.RequestCount.Should().Be(2,
-            "passthrough is not cached, so the second call retries provider-service");
+            "an unavailable result is not cached, so the second call retries provider-service");
         verificationHandler.RequestCount.Should().Be(2,
-            "passthrough is not cached, so the second call retries verification-service");
+            "an unavailable result is not cached, so the second call retries verification-service");
+    }
+
+    [Fact]
+    public async Task CheckAsync_VerificationServiceReportsFailed_ReturnsUnavailableForReview()
+    {
+        var providerHandler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 40, rating: "Caution", status: "Failed"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeFalse();
+        result.IsExcluded.Should().BeFalse("a Failed verification status is not a confirmed exclusion finding");
+        result.RequiresManualReview.Should().BeTrue();
+        result.DenialCode.Should().Be("PROVIDER_VERIFICATION_UNAVAILABLE");
+    }
+
+    [Fact]
+    public async Task CheckAsync_VerificationServiceReportsManualReviewRequired_ReturnsUnavailableForReview()
+    {
+        var providerHandler = FakeHttpMessageHandler.Status(HttpStatusCode.NotFound);
+        var verificationHandler = FakeHttpMessageHandler.Json(
+            VerificationJson(compositeScore: 55, rating: "Caution", status: "ManualReviewRequired"));
+        var gate = BuildGate(providerHandler, verificationHandler);
+
+        var result = await gate.CheckAsync(Npi);
+
+        result.Passed.Should().BeFalse();
+        result.IsExcluded.Should().BeFalse();
+        result.RequiresManualReview.Should().BeTrue();
+        result.DenialCode.Should().Be("PROVIDER_VERIFICATION_UNAVAILABLE");
     }
 
     [Fact]

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -682,6 +682,33 @@ public class AdjudicationController : ControllerBase
     }
 
     // ═══════════════════════════════════════════════════════════════════
+    // GET /api/v1/adjudication/provider-integrity/{npi}
+    //
+    // Standalone provider-integrity check, side-effect-free. Exposes
+    // IProviderIntegrityGate.CheckAsync over HTTP so claims-service's
+    // ProviderIntegrityStage can run the same federal-exclusion check
+    // AdjudicationController.Adjudicate already runs internally, without
+    // going through calculate-benefits (which stays exclusion-check-free
+    // by design -- it's also called by portal/preview features that must
+    // not be blocked by a live exclusion check on a hypothetical
+    // calculation). See docs/architecture/integrity-score-consumption.md.
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Check a provider's federal-exclusion integrity status.
+    /// Read-only; does not affect any claim or provider record.
+    /// </summary>
+    [HttpGet("provider-integrity/{npi}")]
+    [ProducesResponseType(typeof(ProviderIntegrityResult), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ProviderIntegrityResult>> CheckProviderIntegrity(
+        string npi,
+        CancellationToken ct)
+    {
+        var result = await _providerIntegrityGate.CheckAsync(npi, TenantId, ct: ct);
+        return Ok(result);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
     // POST /api/v1/adjudication/reverse-claim
     //
     // Capability 5.12a — exposes the existing

--- a/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
+++ b/src/services/benefit-plan-service/Controllers/AdjudicationController.cs
@@ -323,7 +323,7 @@ public class AdjudicationController : ControllerBase
             integritySpan?.SetTag("cho.integrity.excluded", providerIntegrity.IsExcluded);
         }
 
-        if (!providerIntegrity.Passed)
+        if (providerIntegrity.IsExcluded)
         {
             adjudicationSpan?.SetTag("cho.outcome", "provider_excluded");
             adjudicationSpan?.SetStatus(ActivityStatusCode.Error, "Provider excluded from federal programs");
@@ -341,6 +341,34 @@ public class AdjudicationController : ControllerBase
                 error = "PROVIDER_EXCLUDED",
                 message = providerIntegrity.DenialReason ?? "Provider excluded from federal healthcare programs",
                 carc = providerIntegrity.DenialCode,
+                integrityScore = providerIntegrity.IntegrityScore,
+                rating = providerIntegrity.Rating,
+                timings = stageTimings,
+            });
+        }
+
+        if (!providerIntegrity.Passed)
+        {
+            // Not a confirmed exclusion -- either RequiresManualReview (verification
+            // unavailable or inconclusive) or a defensive Passed=false with neither
+            // flag set. Either way this must not be reported as PROVIDER_EXCLUDED:
+            // the provider hasn't actually appeared on an exclusion list.
+            adjudicationSpan?.SetTag("cho.outcome", "provider_verification_review_required");
+            adjudicationSpan?.SetStatus(
+                ActivityStatusCode.Error, "Provider integrity could not be confidently verified");
+
+            RecordLatency(sw, claimTypeCode, "provider_verification_review_required");
+
+            _logger.LogWarning(
+                "Claim {ClaimId} pended: provider NPI {Npi} integrity could not be confidently verified",
+                SanitizeForLog(request.ClaimId), SanitizeForLog(request.ProviderNpi));
+
+            return UnprocessableEntity(new
+            {
+                claimId = request.ClaimId,
+                error = providerIntegrity.DenialCode ?? "PROVIDER_VERIFICATION_UNAVAILABLE",
+                message = providerIntegrity.DenialReason
+                    ?? "Provider integrity could not be confidently verified; manual review required",
                 integrityScore = providerIntegrity.IntegrityScore,
                 rating = providerIntegrity.Rating,
                 timings = stageTimings,

--- a/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/HttpProviderIntegrityGate.cs
@@ -42,10 +42,11 @@ namespace BenefitPlanService.Services;
 /// </para>
 ///
 /// <para>
-/// Pass-through results (both upstream services unavailable) are
-/// <em>not</em> cached — operators get a recovered exclusion signal on
-/// the next adjudication call rather than waiting up to an hour for the
-/// cached pass-through to expire.
+/// Unavailable results (both upstream services unreachable, or the live
+/// service itself reports <c>Failed</c>/<c>ManualReviewRequired</c>) are
+/// <em>not</em> cached — operators get a recovered signal on the next
+/// adjudication call rather than waiting up to an hour for a cached
+/// unavailable result to expire.
 /// </para>
 ///
 /// <para>
@@ -57,10 +58,15 @@ namespace BenefitPlanService.Services;
 /// </para>
 ///
 /// <para>
-/// On any service failure the gate returns the existing pass-through
-/// result so adjudication is never blocked by infrastructure flakes; the
-/// scheduled re-verification path in <c>provider-verification-service</c>
-/// remains responsible for catching exclusion drift.
+/// <b>The gate never fails open.</b> When no data source can confirm a
+/// provider is clear -- both provider-service and provider-verification-service
+/// unreachable, or the live service reports <c>Failed</c>/<c>ManualReviewRequired</c>
+/// -- <see cref="ProviderIntegrityResult.Passed"/> is <c>false</c> and
+/// <see cref="ProviderIntegrityResult.RequiresManualReview"/> is <c>true</c>,
+/// distinct from a confirmed <see cref="ProviderIntegrityResult.IsExcluded"/>
+/// finding. Callers should hold such a claim for human review rather than
+/// treat it as either a confirmed exclusion or a clean pass -- adjudication
+/// must never silently pay a claim it could not verify.
 /// </para>
 /// </summary>
 public class HttpProviderIntegrityGate : IProviderIntegrityGate
@@ -109,21 +115,21 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         }
 
         ProviderIntegrityResult result;
-        // Track whether the result came from a real data source. Pass-through
-        // results (both upstream services down) are NOT cached for the full
-        // 1-hour TTL so a recovered exclusion signal is picked up on the next
-        // adjudication call rather than waiting an hour. The cache is still
-        // useful for real responses (request coalescing) and for genuine
-        // pass-throughs we accept a brief retry storm during outages — that's
-        // the lesser evil compared to an hour of pretending Excluded providers
-        // pass.
-        var isPassthrough = false;
+        // Track whether the result came from a confident data source.
+        // Unavailable results (no data source could confirm the provider is
+        // clear) are NOT cached for the full 1-hour TTL so a recovered
+        // signal is picked up on the next adjudication call rather than
+        // waiting an hour. The cache is still useful for real responses
+        // (request coalescing); for genuine outages we accept a brief retry
+        // storm rather than an hour of every claim for that NPI being held
+        // for review after the outage has already recovered.
+        var isUnavailable = false;
 
         if (forceRefresh)
         {
             var live = await CallVerificationServiceAsync(npi, tenantId, ct);
-            isPassthrough = live is null;
-            result = live ?? Passthrough();
+            isUnavailable = live is null;
+            result = live ?? Unavailable();
             RecordDecision(IntegrityGatePath.LiveOnly, result.Rating);
         }
         else
@@ -137,20 +143,32 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
                 // failure — fall back to live verification rather than
                 // failing closed.
                 var live = await CallVerificationServiceAsync(npi, tenantId, ct);
-                isPassthrough = live is null;
-                result = live ?? Passthrough();
+                isUnavailable = live is null;
+                result = live ?? Unavailable();
                 RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
             }
             else if (projection.Score is null || projection.LastVerifiedAt is null)
             {
-                // Projection row exists but never refreshed — fall back to
-                // live and let the local cache absorb subsequent calls.
-                result = await CallVerificationServiceAsync(npi, tenantId, ct)
-                    ?? BuildResultFromProjection(projection);
+                // Projection row exists but was never refreshed -- unlike
+                // the staleness branch below, there is no real prior rating
+                // here (BuildResultFromProjection on an unset IntegrityRating
+                // would read as "not Blocked" i.e. falsely Clear). Fall back
+                // to live; if that also fails, this NPI has no trustworthy
+                // data anywhere and must be treated as unavailable.
+                var live = await CallVerificationServiceAsync(npi, tenantId, ct);
+                isUnavailable = live is null;
+                result = live ?? Unavailable();
                 RecordDecision(IntegrityGatePath.NullFallback, result.Rating);
             }
             else if (IsStale(projection.LastVerifiedAt.Value))
             {
+                // Unlike the branches above, this projection carries a real,
+                // previously-computed rating -- just aged past the
+                // staleness window. If live verification can't refresh it,
+                // trusting the stale-but-real rating is safer than
+                // discarding it as unavailable; the staleness-alerting path
+                // (IntegrityProjectionStalenessReporter) is responsible for
+                // surfacing providers stuck in this state operationally.
                 result = await CallVerificationServiceAsync(npi, tenantId, ct)
                     ?? BuildResultFromProjection(projection);
                 RecordDecision(IntegrityGatePath.StaleFallback, result.Rating);
@@ -162,7 +180,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             }
         }
 
-        if (!isPassthrough) _cache.Set(cacheKey, result, CacheTtl);
+        if (!isUnavailable) _cache.Set(cacheKey, result, CacheTtl);
         return result;
     }
 
@@ -225,7 +243,7 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning(
-                    "Provider verification service returned {StatusCode} for NPI {Npi}; passing through",
+                    "Provider verification service returned {StatusCode} for NPI {Npi}; treating as unavailable",
                     response.StatusCode, SanitizeForLog(npi));
                 return null;
             }
@@ -236,22 +254,32 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
             var rating = NormalizeRating(record.Rating) ?? "Unknown";
             var status = NormalizeStatus(record.Status);
             var isExcluded = status is "Excluded";
+            // "Failed" and "ManualReviewRequired" are not exclusion findings
+            // -- they mean the verification service itself could not reach
+            // a confident determination. Treat them the same as total
+            // unavailability (held for review) rather than a silent pass.
+            var requiresManualReview = !isExcluded && status is "Failed" or "ManualReviewRequired";
             return new ProviderIntegrityResult
             {
-                Passed = status is not ("Excluded" or "Failed"),
+                Passed = !isExcluded && !requiresManualReview,
                 IntegrityScore = record.CompositeScore,
                 Rating = rating,
                 IsExcluded = isExcluded,
-                DenialCode = isExcluded ? "B7" : null,
+                RequiresManualReview = requiresManualReview,
+                DenialCode = isExcluded
+                    ? "B7"
+                    : requiresManualReview ? "PROVIDER_VERIFICATION_UNAVAILABLE" : null,
                 DenialReason = isExcluded
                     ? "Provider is excluded from federal healthcare programs"
-                    : null
+                    : requiresManualReview
+                        ? "Provider verification could not reach a confident determination; manual review required"
+                        : null
             };
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             _logger.LogWarning(ex,
-                "Provider verification service unreachable for NPI {Npi}; passing through",
+                "Provider verification service unreachable for NPI {Npi}; treating as unavailable",
                 SanitizeForLog(npi));
             return null;
         }
@@ -295,10 +323,13 @@ public class HttpProviderIntegrityGate : IProviderIntegrityGate
         _                                => "unknown",
     };
 
-    private static ProviderIntegrityResult Passthrough() => new()
+    private static ProviderIntegrityResult Unavailable() => new()
     {
-        Passed = true,
-        Rating = "Unknown"
+        Passed = false,
+        Rating = "Unknown",
+        RequiresManualReview = true,
+        DenialCode = "PROVIDER_VERIFICATION_UNAVAILABLE",
+        DenialReason = "Provider integrity could not be verified against any data source; manual review required"
     };
 
     private static string SanitizeForLog(string? value)

--- a/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
+++ b/src/services/benefit-plan-service/Services/IProviderIntegrityGate.cs
@@ -56,6 +56,20 @@ public record ProviderIntegrityResult
     /// <summary>True when the provider appears on OIG/LEIE or SAM.gov exclusion lists.</summary>
     public bool IsExcluded { get; init; }
 
+    /// <summary>
+    /// True when the gate could not reach a confident pass/exclude
+    /// determination -- either because no data source was reachable, or
+    /// because the live verification service itself reported a
+    /// <c>Failed</c> or <c>ManualReviewRequired</c> status. Distinct from
+    /// <see cref="IsExcluded"/>: an excluded provider is a confirmed
+    /// finding; a claim for a provider with this flag set could not be
+    /// verified either way and should be held for human review rather than
+    /// silently denied as excluded or silently paid. <see cref="Passed"/>
+    /// is <c>false</c> whenever this is <c>true</c> -- adjudication never
+    /// pays a claim it could not verify.
+    /// </summary>
+    public bool RequiresManualReview { get; init; }
+
     /// <summary>CARC code when denied (e.g., "B7" for provider excluded from federal programs).</summary>
     public string? DenialCode { get; init; }
 

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -289,6 +289,14 @@ builder.Services.AddScoped<ICredentialingStatusClient>(sp =>
         sp.GetRequiredService<HttpCredentialingStatusClient>(),
         sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
 
+// ProviderIntegrityStage — federal exclusion check via benefit-plan-service's
+// provider-integrity endpoint. No caching decorator here: HttpProviderIntegrityGate
+// already caches on the benefit-plan-service side (1-hour IMemoryCache,
+// never-fail-open contract); a second claims-service-side cache would just
+// add staleness risk without a real latency win, since the upstream is
+// already fast on a cache hit.
+builder.Services.AddScoped<IProviderIntegrityClient, HttpProviderIntegrityClient>();
+
 // 5.4 — Claims Scrub Engine (class library). Default standard rule set;
 // per-tenant rule overrides remain a Phase 2 surface.
 builder.Services.AddClaimsScrubEngine();
@@ -353,8 +361,11 @@ builder.Services.AddScoped<IAuthorizationValidationClient, HttpAuthorizationVali
 // wraps the corresponding engine. 5.4/5.6/5.7/5.8/5.9 swap the registration
 // in place rather than going through services.RemoveAll<>() — the stub
 // never shipped to production so there's nothing to remove. 6/6 pipeline
-// stages real after 5.9.
+// stages real after 5.9. ProviderIntegrityStage (Order=150) added later,
+// closing a gap the original 5.5 stage scope never covered — see the
+// stage's own doc comment and docs/architecture/claim-adjudication-pipeline.md.
 builder.Services.AddScoped<IClaimAdjudicationStage, ScrubbingStage>();
+builder.Services.AddScoped<IClaimAdjudicationStage, ProviderIntegrityStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, NetworkCredentialingStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, BenefitCalculationStage>();
 builder.Services.AddScoped<IClaimAdjudicationStage, NcciEditsStage>();

--- a/src/services/claims-service/Services/Adjudication/Stages/ProviderIntegrityStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/ProviderIntegrityStage.cs
@@ -1,0 +1,153 @@
+using ClaimsService.Models;
+using ClaimsService.Services.Resolution;
+
+namespace ClaimsService.Services.Adjudication.Stages;
+
+/// <summary>
+/// Federal provider-exclusion (OIG/LEIE/SAM.gov) check, run against the
+/// billing and rendering providers on the claim.
+///
+/// <para>
+/// <b>Why this stage exists.</b> <c>HttpProviderIntegrityGate</c>
+/// (benefit-plan-service, capability 5.10) has always existed and is well
+/// tested, but was only ever wired into the standalone
+/// <c>AdjudicationController.Adjudicate</c> HTTP endpoint -- not into this
+/// orchestrator. Capability 5.5's six-stage pipeline (Scrubbing,
+/// NetworkCredentialing, BenefitCalculation, NcciEdits,
+/// CoordinationOfBenefits, AiExamination) never included a provider-integrity
+/// stage in its original scope, so real claims processed through
+/// <c>BenefitCalculationStage</c> -&gt; <c>calculate-benefits</c> were never
+/// checked against federal exclusion lists at all. This stage closes that
+/// gap using the exact same gate logic, reached via a new, side-effect-free
+/// endpoint (<c>GET /api/v1/adjudication/provider-integrity/{npi}</c>) so
+/// <c>calculate-benefits</c> itself stays exclusion-check-free -- it's also
+/// called by portal/preview features that must not be blocked by a live
+/// exclusion check on a hypothetical calculation.
+/// </para>
+///
+/// <para>
+/// <b>Resolution semantics.</b> A confirmed exclusion (<c>IsExcluded</c>)
+/// is a <c>Deny</c> -- pipeline short-circuits to PersistenceStage.
+/// Anything the gate could not confidently resolve either way
+/// (<c>RequiresManualReview</c>, or the HTTP call to benefit-plan-service
+/// itself failing) is a <c>Pend</c> with <c>PendCode="MEDREVIEW"</c> --
+/// already a documented, recognized <see cref="PendDetails.PendCode"/>
+/// value with an existing work-queue bucket (no new pend vocabulary).
+/// The gate never fails open (see <c>HttpProviderIntegrityGate</c>'s own
+/// contract), so this stage never silently passes a provider it could not
+/// verify.
+/// </para>
+///
+/// <para>
+/// <b>Not tenant-configurable to fail open.</b> Unlike
+/// <see cref="NetworkCredentialingStage"/>'s <c>FailOpen</c>/<c>SoftValidation</c>
+/// enforcement modes, this stage has no equivalent -- a federal exclusion
+/// check has no legitimate "advisory only" posture. It can be disabled
+/// entirely via <c>EnabledStages</c> (matching every other stage's
+/// contract), but while enabled it always enforces.
+/// </para>
+/// </summary>
+public sealed class ProviderIntegrityStage : IClaimAdjudicationStage
+{
+    public const string StageName = "ProviderIntegrity";
+    public const string MedicalReviewPendCode = "MEDREVIEW";
+
+    private readonly IProviderIntegrityClient _client;
+    private readonly ILogger<ProviderIntegrityStage> _logger;
+
+    public ProviderIntegrityStage(
+        IProviderIntegrityClient client,
+        ILogger<ProviderIntegrityStage> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public string Name => StageName;
+    public int Order => 150;
+    public bool IsRequired => false;
+
+    public async Task<ClaimAdjudicationStageResult> ExecuteAsync(
+        ClaimAdjudicationContext context,
+        CancellationToken ct)
+    {
+        var claim = context.Claim;
+
+        var providersToCheck = new List<(string Role, string Npi)>();
+        if (!string.IsNullOrWhiteSpace(claim.BillingProviderNPI))
+        {
+            providersToCheck.Add(("Billing provider", claim.BillingProviderNPI));
+        }
+
+        if (!string.IsNullOrWhiteSpace(claim.RenderingProviderNPI)
+            && !string.Equals(claim.RenderingProviderNPI, claim.BillingProviderNPI, StringComparison.OrdinalIgnoreCase))
+        {
+            providersToCheck.Add(("Rendering provider", claim.RenderingProviderNPI));
+        }
+
+        if (providersToCheck.Count == 0)
+        {
+            // No provider NPI on the claim at all. ScrubbingStage
+            // (Order=100, runs first) owns rejecting claims missing
+            // required provider identifiers -- nothing to check here.
+            return ClaimAdjudicationStageResult.Pass(StageName);
+        }
+
+        foreach (var (role, npi) in providersToCheck)
+        {
+            var result = await _client.CheckAsync(context.TenantId, npi, ct).ConfigureAwait(false);
+
+            if (result is null)
+            {
+                // Transport failure reaching benefit-plan-service itself.
+                // The gate's "never fail open" contract covers failures
+                // reaching ITS upstreams; if benefit-plan-service is
+                // unreachable at all, apply the same never-fail-open
+                // policy here.
+                _logger.LogWarning(
+                    "Provider integrity check unreachable for claim {ClaimVersionId}, {Role} NPI {Npi}",
+                    SanitizeForLog(context.ClaimVersionId), role, SanitizeForLog(npi));
+                return PendForReview(context, role, "Provider integrity check could not be reached.");
+            }
+
+            if (result.IsExcluded)
+            {
+                context.AdjudicationResult.DenialReasonCode = result.DenialCode ?? "B7";
+                context.AdjudicationResult.DenialReason = result.DenialReason
+                    ?? $"{role} is excluded from federal healthcare programs.";
+                return ClaimAdjudicationStageResult.Deny(StageName, context.AdjudicationResult.DenialReason);
+            }
+
+            if (!result.Passed || result.RequiresManualReview)
+            {
+                return PendForReview(
+                    context,
+                    role,
+                    result.DenialReason ?? "Provider integrity could not be confidently verified.");
+            }
+        }
+
+        return ClaimAdjudicationStageResult.Pass(StageName);
+    }
+
+    private static ClaimAdjudicationStageResult PendForReview(
+        ClaimAdjudicationContext context,
+        string role,
+        string reason)
+    {
+        var formatted = $"{role}: {reason}";
+        context.PendDetails = new PendDetails
+        {
+            PendCode = MedicalReviewPendCode,
+            PendReason = TruncatePendReason(formatted),
+            PendedAt = DateTime.UtcNow,
+        };
+        return ClaimAdjudicationStageResult.Pend(StageName, formatted);
+    }
+
+    private static string? TruncatePendReason(string? reason) =>
+        reason is { Length: > 500 } ? reason[..500] : reason;
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/HttpProviderIntegrityClient.cs
+++ b/src/services/claims-service/Services/Resolution/HttpProviderIntegrityClient.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="IProviderIntegrityClient"/> calling
+/// benefit-plan-service's <c>GET /api/v1/adjudication/provider-integrity/{npi}</c>.
+/// Sibling of <see cref="HttpCredentialingStatusClient"/> in shape:
+/// typed factory client, non-throwing on transport failure.
+/// </summary>
+public class HttpProviderIntegrityClient : IProviderIntegrityClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpProviderIntegrityClient> _logger;
+
+    public HttpProviderIntegrityClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpProviderIntegrityClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<ProviderIntegritySnapshot?> CheckAsync(
+        string tenantId,
+        string npi,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(npi)) return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.BenefitPlanService);
+            var encodedNpi = Uri.EscapeDataString(npi);
+
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"/api/v1/adjudication/provider-integrity/{encodedNpi}");
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Benefit-plan-service returned {StatusCode} resolving provider integrity for NPI {Npi}",
+                    response.StatusCode, SanitizeForLog(npi));
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<ProviderIntegritySnapshot>(JsonOptions, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Provider integrity lookup failed for NPI {Npi} tenant {Tenant}",
+                SanitizeForLog(npi), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+}

--- a/src/services/claims-service/Services/Resolution/IProviderIntegrityClient.cs
+++ b/src/services/claims-service/Services/Resolution/IProviderIntegrityClient.cs
@@ -1,0 +1,40 @@
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Client for benefit-plan-service's <c>GET /api/v1/adjudication/provider-integrity/{npi}</c>
+/// endpoint -- the same <c>HttpProviderIntegrityGate</c> federal-exclusion
+/// check <c>AdjudicationController.Adjudicate</c> runs internally, exposed
+/// standalone so claims-service's <c>ProviderIntegrityStage</c> can run it
+/// without going through <c>calculate-benefits</c> (which stays
+/// exclusion-check-free by design). See
+/// <c>docs/architecture/integrity-score-consumption.md</c>.
+/// </summary>
+public interface IProviderIntegrityClient
+{
+    /// <summary>
+    /// Resolve the integrity result for <paramref name="npi"/>.
+    /// Returns <c>null</c> only on a transport failure reaching
+    /// benefit-plan-service itself -- the gate's own "never fail open"
+    /// contract already covers failures reaching its own upstreams
+    /// (provider-service / provider-verification-service), so a non-null
+    /// result here is always a confident answer, never a fail-open default.
+    /// </summary>
+    Task<ProviderIntegritySnapshot?> CheckAsync(
+        string tenantId,
+        string npi,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Claims-service-side mirror of benefit-plan-service's
+/// <c>ProviderIntegrityResult</c>.
+/// </summary>
+public sealed record ProviderIntegritySnapshot
+{
+    public bool Passed { get; init; }
+    public bool IsExcluded { get; init; }
+    public bool RequiresManualReview { get; init; }
+    public string? DenialCode { get; init; }
+    public string? DenialReason { get; init; }
+    public string? Rating { get; init; }
+}

--- a/src/services/claims-service/Services/Resolution/IProviderIntegrityClient.cs
+++ b/src/services/claims-service/Services/Resolution/IProviderIntegrityClient.cs
@@ -13,11 +13,18 @@ public interface IProviderIntegrityClient
 {
     /// <summary>
     /// Resolve the integrity result for <paramref name="npi"/>.
-    /// Returns <c>null</c> only on a transport failure reaching
-    /// benefit-plan-service itself -- the gate's own "never fail open"
-    /// contract already covers failures reaching its own upstreams
-    /// (provider-service / provider-verification-service), so a non-null
-    /// result here is always a confident answer, never a fail-open default.
+    /// Returns <c>null</c> whenever no result could be obtained from
+    /// benefit-plan-service -- a transport failure reaching it, a
+    /// non-success HTTP status, an empty/whitespace <paramref name="npi"/>,
+    /// or a response body that failed to deserialize. Callers must treat
+    /// <c>null</c> as "could not verify" and hold the claim for review
+    /// (see <c>ProviderIntegrityStage</c>), the same as any other
+    /// inconclusive result -- it is never safe to treat as a pass. A
+    /// non-null result, in turn, is always a confident answer: the gate's
+    /// own "never fail open" contract already covers failures reaching
+    /// its own upstreams (provider-service / provider-verification-service)
+    /// by returning <see cref="ProviderIntegritySnapshot.RequiresManualReview"/>
+    /// rather than a fail-open pass.
     /// </summary>
     Task<ProviderIntegritySnapshot?> CheckAsync(
         string tenantId,

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
@@ -388,6 +388,122 @@ public class AdjudicationControllerTests : IClassFixture<AdjudicationControllerT
     }
 
     // ═══════════════════════════════════════════════════════════════
+    // Adjudicate provider integrity outcomes — a confirmed exclusion must
+    // be distinguished from "could not confidently verify" (manual review
+    // required, verification unavailable, or a defensive Passed=false with
+    // neither flag set). Only IsExcluded may report PROVIDER_EXCLUDED.
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Adjudicate_ProviderExcluded_Returns422WithProviderExcluded()
+    {
+        SetupNewPipelineDefaults();
+        SetupScrubPass();
+        SetupNcciPass();
+        _factory.ProviderIntegrityGate
+            .CheckAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegrityResult
+            {
+                Passed = false,
+                IsExcluded = true,
+                Rating = "Blocked",
+                IntegrityScore = 0,
+                DenialCode = "B7",
+                DenialReason = "Provider is excluded from federal healthcare programs",
+            });
+
+        using var client = CreateClientWithTenant();
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/adjudicate", MakeAdjudicationRequest());
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.Equal("PROVIDER_EXCLUDED", root.GetProperty("error").GetString());
+        Assert.Equal("B7", root.GetProperty("carc").GetString());
+    }
+
+    [Fact]
+    public async Task Adjudicate_ProviderRequiresManualReview_Returns422WithoutProviderExcluded()
+    {
+        SetupNewPipelineDefaults();
+        SetupScrubPass();
+        SetupNcciPass();
+        _factory.ProviderIntegrityGate
+            .CheckAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegrityResult
+            {
+                Passed = false,
+                IsExcluded = false,
+                RequiresManualReview = true,
+                Rating = "Unknown",
+                DenialCode = "PROVIDER_VERIFICATION_UNAVAILABLE",
+                DenialReason = "Provider verification could not reach a confident determination; manual review required",
+            });
+
+        using var client = CreateClientWithTenant();
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/adjudicate", MakeAdjudicationRequest());
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.NotEqual("PROVIDER_EXCLUDED", root.GetProperty("error").GetString());
+        Assert.Equal("PROVIDER_VERIFICATION_UNAVAILABLE", root.GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task Adjudicate_ProviderVerificationUnavailable_Returns422WithoutProviderExcluded()
+    {
+        SetupNewPipelineDefaults();
+        SetupScrubPass();
+        SetupNcciPass();
+        _factory.ProviderIntegrityGate
+            .CheckAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegrityResult
+            {
+                Passed = false,
+                IsExcluded = false,
+                RequiresManualReview = true,
+                Rating = "Unknown",
+                DenialCode = "PROVIDER_VERIFICATION_UNAVAILABLE",
+                DenialReason = "Provider integrity could not be verified against any data source; manual review required",
+            });
+
+        using var client = CreateClientWithTenant();
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/adjudicate", MakeAdjudicationRequest());
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.NotEqual("PROVIDER_EXCLUDED", root.GetProperty("error").GetString());
+        Assert.Equal(
+            "Provider integrity could not be verified against any data source; manual review required",
+            root.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task Adjudicate_ProviderIntegrityDefensiveFalseWithNoFlags_Returns422WithoutProviderExcluded()
+    {
+        // Belt-and-suspenders: even a gate result with Passed=false and
+        // neither IsExcluded nor RequiresManualReview set must never be
+        // reported as a confirmed exclusion.
+        SetupNewPipelineDefaults();
+        SetupScrubPass();
+        SetupNcciPass();
+        _factory.ProviderIntegrityGate
+            .CheckAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegrityResult { Passed = false });
+
+        using var client = CreateClientWithTenant();
+        var response = await client.PostAsJsonAsync("/api/v1/adjudication/adjudicate", MakeAdjudicationRequest());
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var root = body.RootElement;
+        Assert.NotEqual("PROVIDER_EXCLUDED", root.GetProperty("error").GetString());
+        Assert.Equal("PROVIDER_VERIFICATION_UNAVAILABLE", root.GetProperty("error").GetString());
+    }
+
+    // ═══════════════════════════════════════════════════════════════
     // GET /api/v1/adjudication/provider-integrity/{npi} — standalone,
     // side-effect-free integrity check exposed for claims-service's
     // ProviderIntegrityStage (closes the gap where calculate-benefits

--- a/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
+++ b/tests/CloudHealthOffice.AdjudicationController.Tests/AdjudicationControllerTests.cs
@@ -387,6 +387,40 @@ public class AdjudicationControllerTests : IClassFixture<AdjudicationControllerT
         Assert.NotEmpty(result.Accumulators);
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // GET /api/v1/adjudication/provider-integrity/{npi} — standalone,
+    // side-effect-free integrity check exposed for claims-service's
+    // ProviderIntegrityStage (closes the gap where calculate-benefits
+    // never checked federal exclusion at all).
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task CheckProviderIntegrity_DelegatesToGate_ReturnsResultVerbatim()
+    {
+        _factory.ProviderIntegrityGate
+            .CheckAsync("1234567890", TenantId, forceRefresh: false, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegrityResult
+            {
+                Passed = false,
+                IsExcluded = true,
+                Rating = "Blocked",
+                IntegrityScore = 0,
+                DenialCode = "B7",
+                DenialReason = "Provider is excluded from federal healthcare programs",
+            });
+
+        using var client = CreateClientWithTenant();
+
+        var response = await client.GetAsync("/api/v1/adjudication/provider-integrity/1234567890");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProviderIntegrityResult>(Json);
+        Assert.NotNull(result);
+        Assert.False(result!.Passed);
+        Assert.True(result.IsExcluded);
+        Assert.Equal("B7", result.DenialCode);
+    }
+
     [Fact]
     public async Task Adjudicate_ServiceDateAfterMemberTermination_ReturnsCarc27WithoutPricing()
     {

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/ProviderIntegrityStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/ProviderIntegrityStageTests.cs
@@ -1,0 +1,181 @@
+using ClaimsService.Models;
+using ClaimsService.Services.Adjudication;
+using ClaimsService.Services.Adjudication.Stages;
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Adjudication.Stages;
+
+/// <summary>
+/// Behavior coverage for <see cref="ProviderIntegrityStage"/> — the
+/// federal-exclusion check that closes the gap left by capability 5.5's
+/// original six-stage scope (see the stage's own doc comment).
+/// </summary>
+public class ProviderIntegrityStageTests
+{
+    private const string TenantId = "tenant-a";
+    private const string BillingNpi = "1234567890";
+    private const string RenderingNpi = "9000000011";
+
+    private readonly IProviderIntegrityClient _client = Substitute.For<IProviderIntegrityClient>();
+
+    private ProviderIntegrityStage NewStage() =>
+        new(_client, NullLogger<ProviderIntegrityStage>.Instance);
+
+    [Fact]
+    public async Task NoProviderNpiOnClaim_returns_Pass_without_calling_client()
+    {
+        var claim = NewClaim(billingNpi: null, renderingNpi: null);
+        var ctx = NewContext(claim);
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _client.DidNotReceiveWithAnyArgs().CheckAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task ClearProvider_returns_Pass()
+    {
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot { Passed = true });
+
+        var ctx = NewContext(NewClaim(BillingNpi, null));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.True(result.Continue);
+    }
+
+    [Fact]
+    public async Task ExcludedProvider_returns_Deny_and_sets_denial_reason()
+    {
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot
+            {
+                Passed = false,
+                IsExcluded = true,
+                DenialCode = "B7",
+                DenialReason = "Provider is excluded from federal healthcare programs",
+            });
+
+        var ctx = NewContext(NewClaim(BillingNpi, null));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        Assert.False(result.Continue, "Deny short-circuits the remaining non-persistence stages");
+        Assert.Equal("B7", ctx.AdjudicationResult.DenialReasonCode);
+        Assert.Equal(
+            "Provider is excluded from federal healthcare programs",
+            ctx.AdjudicationResult.DenialReason);
+    }
+
+    [Fact]
+    public async Task RequiresManualReview_returns_Pend_with_MEDREVIEW_code()
+    {
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot
+            {
+                Passed = false,
+                IsExcluded = false,
+                RequiresManualReview = true,
+                DenialReason = "Provider verification could not reach a confident determination; manual review required",
+            });
+
+        var ctx = NewContext(NewClaim(BillingNpi, null));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.True(result.Continue, "Pend is recoverable — pipeline continues");
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal(ProviderIntegrityStage.MedicalReviewPendCode, ctx.PendDetails!.PendCode);
+        Assert.Equal("MEDREVIEW", ctx.PendDetails.PendCode);
+    }
+
+    [Fact]
+    public async Task ClientReturnsNull_TransportFailureReachingBenefitPlanService_returns_Pend_not_silent_pass()
+    {
+        // The gate's own "never fail open" contract covers failures
+        // reaching ITS upstreams. If benefit-plan-service itself can't be
+        // reached at all, the stage must apply the same policy rather than
+        // silently passing the claim.
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns((ProviderIntegritySnapshot?)null);
+
+        var ctx = NewContext(NewClaim(BillingNpi, null));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.Equal(ProviderIntegrityStage.MedicalReviewPendCode, ctx.PendDetails!.PendCode);
+    }
+
+    [Fact]
+    public async Task RenderingProviderExcluded_denies_even_when_billing_provider_clear()
+    {
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot { Passed = true });
+        _client.CheckAsync(TenantId, RenderingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot
+            {
+                Passed = false,
+                IsExcluded = true,
+                DenialCode = "B7",
+                DenialReason = "Provider is excluded from federal healthcare programs",
+            });
+
+        var ctx = NewContext(NewClaim(BillingNpi, RenderingNpi));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Deny, result.Outcome);
+        await _client.Received(1).CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>());
+        await _client.Received(1).CheckAsync(TenantId, RenderingNpi, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SameBillingAndRenderingNpi_checks_only_once()
+    {
+        _client.CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>())
+            .Returns(new ProviderIntegritySnapshot { Passed = true });
+
+        var ctx = NewContext(NewClaim(BillingNpi, BillingNpi));
+        var sut = NewStage();
+
+        var result = await sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        await _client.Received(1).CheckAsync(TenantId, BillingNpi, Arg.Any<CancellationToken>());
+    }
+
+    private static AdapterClaim NewClaim(string? billingNpi, string? renderingNpi) => new()
+    {
+        TenantId = TenantId,
+        Id = "claim-1",
+        ClaimNumber = "C-1",
+        ClaimVersionId = "v-1",
+        BillingProviderNPI = billingNpi ?? string.Empty,
+        RenderingProviderNPI = renderingNpi ?? string.Empty,
+        ServiceDateFrom = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        ServiceDateTo = new DateTime(2025, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        BenefitPlanId = "plan-1",
+    };
+
+    private static ClaimAdjudicationContext NewContext(AdapterClaim claim) => new()
+    {
+        TenantId = TenantId,
+        ClaimVersionId = claim.ClaimVersionId,
+        Claim = claim,
+    };
+}


### PR DESCRIPTION
## Summary

- `HttpProviderIntegrityGate` (the OIG/LEIE/SAM.gov federal exclusion check) was only ever reached through the standalone `AdjudicationController.Adjudicate` endpoint — the one the MCC benchmark validator calls. Claims-service's **real** orchestrated pipeline (`BenefitCalculationStage` → `calculate-benefits`) never touched it, so real production claims were never checked against federal exclusion lists at all.
- Adds `ProviderIntegrityStage` (`Order=150`, between Scrubbing and NetworkCredentialing) to claims-service's orchestrator, reached via a new side-effect-free `GET /api/v1/adjudication/provider-integrity/{npi}` endpoint on benefit-plan-service — deliberately not folded into `calculate-benefits`, which stays exclusion-check-free by design since it's also used by portal/preview features.
- A confirmed exclusion is a `Deny`; anything the gate can't confidently resolve (including a transport failure reaching benefit-plan-service) is a `Pend` with the existing `MEDREVIEW` pend code / work-queue bucket — no new pend vocabulary, no tenant-configurable fail-open mode.
- Hardens `HttpProviderIntegrityGate` itself: total verification unavailability, and a live `Failed`/`ManualReviewRequired` status, both now resolve to `Passed=false` with a new `RequiresManualReview` flag — replacing the old fail-open `Passthrough()` default that silently paid claims for unverifiable providers. This is the real mechanism behind the bug originally disclosed in [Part 10](https://cloudhealthoffice.com/insights/million-claim-challenge/part-10-the-migration-cost-that-wasnt) (the earlier stated root cause — a status-mapping issue — didn't hold up on re-review).
- Updates `docs/architecture/claim-adjudication-pipeline.md` and `docs/architecture/integrity-score-consumption.md` to document the gap, the fix, and the new stage.

## Test plan

- [x] `dotnet test` — benefit-plan-service: 319/319 passing (14 gate tests covering the new fail-closed branches)
- [x] `dotnet test` — claims-service: 563/563 passing (7 new `ProviderIntegrityStage` tests)
- [x] `dotnet test` — `AdjudicationController` integration suite: 24/24 passing (1 new endpoint test)
- [x] Verified no other consumers of `ProviderIntegrityResult` or the old `Passthrough()` naming exist outside the changed files
- [ ] Live MCC smoke test with the new stage active (not yet run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)