### PR TITLE
Isolate EdgeCase-tagged claims from scenario injection and provider pooling

### DIFF
--- a/src/tools/mcc-platform-validator/MccProviderFixturePool.cs
+++ b/src/tools/mcc-platform-validator/MccProviderFixturePool.cs
@@ -10,8 +10,9 @@ public sealed record MccProviderFixturePoolResult(
 
 /// <summary>
 /// Reuses provider fixtures when every adjudication-relevant profile field is
-/// equivalent. Provider-sensitive prior-authorization scenarios retain their
-/// original identities.
+/// equivalent. Provider-sensitive prior-authorization scenarios, and claims
+/// whose provider identity was deliberately forced (e.g. the excluded-provider
+/// scenario), retain their original identities.
 /// </summary>
 public static class MccProviderFixturePool
 {
@@ -114,7 +115,21 @@ public static class MccProviderFixturePool
                or EdgeCaseScenario.PriorAuthRequired_NoAuth
                or EdgeCaseScenario.PriorAuthRequired_ExpiredAuth
                or EdgeCaseScenario.PriorAuthRequired_WrongProvider
-               or EdgeCaseScenario.PriorAuthRequired_WrongProcedure;
+               or EdgeCaseScenario.PriorAuthRequired_WrongProcedure
+           // InjectExcludedProviderScenarios (Program.cs) forces this claim's
+           // rendering provider to a deliberately-excluded identity before
+           // this pool runs. Without isolation, pooling can hand that same
+           // excluded provider object to an unrelated claim whose profile
+           // happens to match post-force (credentialing/network status are
+           // both forced to "Excluded" and aren't otherwise distinctive at
+           // scale) -- silently turning an unrelated scenario into a
+           // provider-exclusion denial. Only shows up once claim volume is
+           // large enough to pressure the pool into reusing this identity;
+           // confirmed via a 50K run where two unrelated edge-case claims
+           // (BehavioralHealthCarveOut, RetroEligibilityAdd) were denied
+           // PROVIDER_EXCLUDED against a rendering NPI that resolved to a
+           // seeded "Excluded ProviderNN" fixture.
+           || string.Equals(claim.BenefitPlanId, MccWorkflowValidation.ExcludedProviderPlanId, StringComparison.Ordinal);
 
     private static int DistinctProviderCount(IEnumerable<SyntheticClaim> claims)
         => claims

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -861,8 +861,22 @@ static async Task<List<SyntheticClaim>> GenerateClaimsAsync(ValidatorOptions opt
 
 static void InjectCleanPaidScenarios(List<SyntheticClaim> claims)
 {
+    // EdgeCase-tagged claims (BehavioralHealthCarveOut, RetroEligibilityAdd,
+    // CobSecondaryPayer, etc.) are excluded from every Inject*Scenarios
+    // candidate pool below. Without this, a claim the corpus generator
+    // already tagged with a specific edge case could be silently
+    // overwritten here -- BenefitPlanId, provider identity, and
+    // ExpectedOutcome all get reassigned, but the claim keeps its original
+    // EdgeCase label, so the answer key still scores it against the
+    // original scenario's expectation while its actual data reflects a
+    // different one entirely. Confirmed at 50K scale: BehavioralHealthCarveOut
+    // and RetroEligibilityAdd claims picked up here or by
+    // InjectExcludedProviderScenarios ended up denied PROVIDER_EXCLUDED
+    // against a genuinely-excluded rendering NPI, scored as a mismatch
+    // against CARC_96 / Paid because the EdgeCase label never changed.
     var candidates = claims
-        .Where(c => c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase))
+        .Where(c => c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && c.EdgeCase is null)
         .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
         .ToList();
 
@@ -889,6 +903,7 @@ static void InjectExcludedProviderScenarios(List<SyntheticClaim> claims, int see
     var candidates = claims
         .Where(c =>
             c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && c.EdgeCase is null
             && !string.Equals(c.BenefitPlanId, MccWorkflowValidation.CleanProfessionalPaidPlanId, StringComparison.Ordinal))
         .OrderBy(c => c.ClaimId, StringComparer.Ordinal)
         .ToList();
@@ -916,6 +931,7 @@ static void InjectUncoveredServiceScenarios(List<SyntheticClaim> claims)
     var candidates = claims
         .Where(c =>
             c.ClaimType.Equals("Professional", StringComparison.OrdinalIgnoreCase)
+            && c.EdgeCase is null
             && !string.Equals(c.BenefitPlanId, MccWorkflowValidation.CleanProfessionalPaidPlanId, StringComparison.Ordinal)
             && !string.Equals(c.BenefitPlanId, MccWorkflowValidation.ExcludedProviderPlanId, StringComparison.Ordinal))
         .OrderBy(c => c.ClaimId, StringComparer.Ordinal)


### PR DESCRIPTION
## Summary

- Investigating a 50K-claim run turned up 4 workflow mismatches, two of which (`BehavioralHealthCarveOut`, `RetroEligibilityAdd`) were denied `PROVIDER_EXCLUDED` against a rendering NPI that genuinely resolved to a seeded "Excluded ProviderNN" fixture in provider-service — confirmed via `GET /api/providers/npi/{npi}`. The adjudicator was correct given the data it received; the bug is in the validator's own corpus generation.
- Root cause: `InjectCleanPaidScenarios`, `InjectExcludedProviderScenarios`, and `InjectUncoveredServiceScenarios` each select their "2% of claims" candidates by `ClaimType`/`BenefitPlanId` only — none of them check whether the corpus generator already tagged a claim with a specific `EdgeCase` (`BehavioralHealthCarveOut`, `RetroEligibilityAdd`, etc.). At low claim counts the odds of picking an already-tagged claim are low; at 50K they aren't. When one of these injectors overwrites an already-tagged claim, it reassigns `BenefitPlanId`, provider identity, and `ExpectedOutcome` — but never clears the original `EdgeCase` label, so the claim keeps scoring against its original scenario's expectation while its actual data now reflects a completely different one.
- Fixed by adding `c.EdgeCase is null` to all three candidate filters, so none of them can ever draw from a claim the generator already assigned a specific scenario to.
- Also hardened `MccProviderFixturePool.Apply` to isolate `ExcludedProviderDenied`-scenario claims the same way prior-auth-sensitive claims already are, as defense in depth against a pooled-identity reuse path even if a future injector reintroduces this class of bug.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] Re-ran the exact 50K/seed=400 job that first surfaced this: `BehavioralHealthCarveOut` and `RetroEligibilityAdd` both now match 100% (was 99/100 and 133/134), `ExcludedProviderDenied` stayed clean at 1,000/1,000
- [ ] Three mismatches remain in this run, but all three are now concentrated in the COB family (`CobBirthdayRule`, `CobSecondaryPayer`, `CobTertiaryPayer`) — a separate, apparently member-eligibility-date-related issue, not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)