### PR TITLE
Correct member coverage effective dates that land after service date

### DIFF
--- a/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
+++ b/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
@@ -16,7 +16,7 @@ internal static class MccClaimDateNormalizer
             var dateShift = normalizedServiceDate - originalServiceDate;
 
             claim.DateOfService = claim.DateOfService.Date.Add(dateShift);
-            ShiftMemberCoverageDates(claim.Member, dateShift);
+            ShiftMemberCoverageDates(claim.Member, dateShift, claim.DateOfService);
             ShiftNewbornDateOfBirth(claim, dateShift);
 
             foreach (var line in claim.Lines)
@@ -49,7 +49,7 @@ internal static class MccClaimDateNormalizer
         claim.Member.DateOfBirth = claim.Member.DateOfBirth.Date.Add(dateShift);
     }
 
-    private static void ShiftMemberCoverageDates(SyntheticMember member, TimeSpan dateShift)
+    private static void ShiftMemberCoverageDates(SyntheticMember member, TimeSpan dateShift, DateTime serviceDate)
     {
         if (member.CoverageEffectiveDate != default)
         {
@@ -71,6 +71,33 @@ internal static class MccClaimDateNormalizer
             if (coverage.TermDate.HasValue)
             {
                 coverage.TermDate = coverage.TermDate.Value.Date.Add(dateShift);
+            }
+        }
+
+        // The base member generator (InMemoryReferenceDataProvider.GenerateMember)
+        // draws CoverageEffectiveDate from a fixed 2023 window, uncorrelated with
+        // any claim's service date. Shifting it by the claim's own date delta
+        // preserves whatever relative ordering happened to exist -- good or bad --
+        // rather than fixing it, so roughly 1% of claims end up with a member
+        // whose coverage becomes effective after their own service date, denying
+        // CARC_27 against scenarios that never intended to test that boundary.
+        // Scenarios that need a specific effective/service relationship
+        // (RetroEligibilityTermination, the newborn scenarios) already establish
+        // one explicitly, earlier in generation, before this normalizer runs --
+        // this only corrects claims that would otherwise be left with an
+        // unintentionally invalid eligibility window.
+        if (member.CoverageEffectiveDate.Date > serviceDate.Date)
+        {
+            var correctedEffectiveDate = serviceDate.Date.AddYears(-1);
+            var correctionShift = correctedEffectiveDate - member.CoverageEffectiveDate.Date;
+            member.CoverageEffectiveDate = correctedEffectiveDate;
+
+            foreach (var coverage in member.Coverages)
+            {
+                if (coverage.EffectiveDate != default)
+                {
+                    coverage.EffectiveDate = coverage.EffectiveDate.Date.Add(correctionShift);
+                }
             }
         }
     }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimDateNormalizerTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimDateNormalizerTests.cs
@@ -1,4 +1,5 @@
 using CloudHealthOffice.BenchmarkClaimGenerator.Generators;
+using CloudHealthOffice.BenchmarkClaimGenerator.Models;
 using CloudHealthOffice.BenchmarkClaimGenerator.ReferenceData;
 using CloudHealthOffice.Tools.MccPlatformValidator;
 
@@ -34,5 +35,76 @@ public class MccClaimDateNormalizerTests
         MccClaimDateNormalizer.NormalizeClaimDates([claim], seed: 42);
 
         Assert.Equal(originalDateOfBirth, claim.Member.DateOfBirth.Date);
+    }
+
+    // Confirmed live at 50K scale: a member ended up with CoverageEffectiveDate
+    // landing after their own claim's DateOfService, denying CARC_27 against
+    // COB scenarios that never intended to test that boundary. The base
+    // generator (EdgeCaseClaimGenerator.Generate) draws member and claim dates
+    // from non-overlapping fixed base years, so it can't reproduce the bug
+    // directly -- whatever upstream path produced the live failure, the fix
+    // that matters is the normalizer's own safety net: given a member already
+    // in a bad state (effective after service, as InMemoryReferenceDataProvider's
+    // uncorrelated default can produce once shifted through the full pipeline),
+    // NormalizeClaimDates must correct it rather than passing it through.
+    [Fact]
+    public void NormalizeClaimDates_CorrectsMemberEffectiveDateThatWouldLandAfterServiceDate()
+    {
+        var claim = new SyntheticClaim
+        {
+            ClaimId = "MCC-E-0000001",
+            ClaimType = "EdgeCase",
+            EdgeCase = EdgeCaseScenario.CobSecondaryPayer,
+            DateOfService = new DateTime(2024, 6, 7),
+            DateReceived = new DateTime(2024, 6, 20),
+            Member = new SyntheticMember
+            {
+                MemberId = "MBR-0000001",
+                SubscriberId = "MBR-0000001",
+                DateOfBirth = new DateTime(1990, 1, 1),
+                // Deliberately after DateOfService -- reproduces the bad state
+                // a member can be left in before this fix.
+                CoverageEffectiveDate = new DateTime(2024, 6, 21),
+            },
+            Lines = new List<ClaimLine>
+            {
+                new() { LineNumber = 1, ProcedureCode = "99213", ServiceDate = new DateTime(2024, 6, 7) },
+            },
+        };
+
+        MccClaimDateNormalizer.NormalizeClaimDates([claim], seed: 42);
+
+        Assert.True(
+            claim.Member.CoverageEffectiveDate.Date <= claim.DateOfService.Date,
+            $"member effective {claim.Member.CoverageEffectiveDate:d} is still after service date {claim.DateOfService:d}");
+    }
+
+    [Fact]
+    public void NormalizeClaimDates_LeavesAlreadyValidMemberEffectiveDateUntouchedBeyondTheShift()
+    {
+        var claim = new SyntheticClaim
+        {
+            ClaimId = "MCC-E-0000002",
+            ClaimType = "EdgeCase",
+            EdgeCase = EdgeCaseScenario.CobSecondaryPayer,
+            DateOfService = new DateTime(2024, 6, 7),
+            DateReceived = new DateTime(2024, 6, 20),
+            Member = new SyntheticMember
+            {
+                MemberId = "MBR-0000002",
+                SubscriberId = "MBR-0000002",
+                DateOfBirth = new DateTime(1990, 1, 1),
+                CoverageEffectiveDate = new DateTime(2023, 6, 7),
+            },
+            Lines = new List<ClaimLine>
+            {
+                new() { LineNumber = 1, ProcedureCode = "99213", ServiceDate = new DateTime(2024, 6, 7) },
+            },
+        };
+        var originalGapDays = (claim.DateOfService.Date - claim.Member.CoverageEffectiveDate.Date).Days;
+
+        MccClaimDateNormalizer.NormalizeClaimDates([claim], seed: 42);
+
+        Assert.Equal(originalGapDays, (claim.DateOfService.Date - claim.Member.CoverageEffectiveDate.Date).Days);
     }
 }


### PR DESCRIPTION
## Summary

- Investigating a residual COB mismatch (`CobBirthdayRule`, `CobSecondaryPayer`, `CobTertiaryPayer` denied `CARC_27` — service date before member coverage effective date — instead of the expected `Pended`/`CARC_22`) traced to `InMemoryReferenceDataProvider.GenerateMember`: `CoverageEffectiveDate` is drawn from a fixed 2023 window, uncorrelated with any claim's service date. `MccClaimDateNormalizer` shifts both by the same delta to land in the current benchmark window, which preserves whatever relative ordering already existed rather than fixing it.
- Only `RetroEligibilityTermination` and the three newborn scenarios explicitly establish a correct effective/service relationship during generation. Every other scenario, COB included, relies on the uncorrelated default — giving roughly a 1% chance per claim that the member ends up effective after their own service date.
- Fixed by having `ShiftMemberCoverageDates` clamp `CoverageEffectiveDate` (and mirrored `coverage.EffectiveDate` entries) back to one year before the claim's service date whenever the shift would otherwise leave it in the future — the same relationship `RetroEligibilityTermination` and `MccCleanPaidFixture` already establish explicitly elsewhere.

## What's fixed vs. what remains

Verified live by re-running the exact 50K/seed=400 job that surfaced this: **5 of 6** previously-affected COB scenarios are now 100% matched. The remaining mismatches trace to member records created by *earlier* runs before this fix existed, permanently reused since seeding never refreshes `CoverageEffectiveDate` for members that already exist in member-service. Closing that residual gap for good would mean extending member-service's own update API (`UpdateMemberRequest` has no date fields today) — out of scope here, flagged for a separate decision.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 110/110 passing
- [x] Replaced the original test (which swept `EdgeCaseClaimGenerator.Generate` across many seeds) with direct construction — that entry point draws member and claim dates from non-overlapping base years and structurally can't reproduce the bug, so the sweep passed regardless of the fix, which would have been a silently useless test
- [x] New test confirmed to **fail without the fix** (`member effective 7/12/2026 is still after service date 6/28/2026`) and pass with it
- [x] Re-ran the exact 50K/seed=400 job live: 5/6 previously-broken COB scenarios now 100% matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)