### PR TITLE
Raise MongoDB's CPU limit; keep the Submit-chain profiling that found it

### DIFF
--- a/infrastructure/k8s/mongodb-deployment.yaml
+++ b/infrastructure/k8s/mongodb-deployment.yaml
@@ -23,10 +23,10 @@ spec:
         - containerPort: 27017
         resources:
           requests:
-            cpu: "250m"
+            cpu: "1000m"
             memory: "512Mi"
           limits:
-            cpu: "1000m"
+            cpu: "4000m"
             memory: "1Gi"
         env:
         - name: MONGO_INITDB_ROOT_USERNAME

--- a/src/services/claims-service/Services/ClaimSubmissionService.cs
+++ b/src/services/claims-service/Services/ClaimSubmissionService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using ClaimsService.Adapters;
 using ClaimsService.Models;
 using ClaimsService.Models.Messaging;
@@ -176,11 +177,21 @@ public class ClaimSubmissionService : IClaimSubmissionService
             return ClaimSubmissionResult.ValidationFailed(validationErrors);
         }
 
+        // Per-hop timing for the Submit chain -- see ClaimVersionEventPublisher
+        // for the matching breakdown of the three hops inside PublishVersionSubmittedAsync.
+        // This is what found MongoDB's CPU limit as the real bottleneck behind
+        // the "five sequential I/O hops" cost Part 10/11 disclosed but never
+        // measured: claimInsert/eventPublish showed the same low-median,
+        // huge-P95 shape as MongoDB's own cgroup throttling stats, not a cost
+        // inherent to any single hop.
+        var profileSw = Stopwatch.StartNew();
         var adapter = await _adapterFactory.GetAdapterAsync(tenantId, ct);
+        var adapterResolveMs = profileSw.Elapsed.TotalMilliseconds;
 
         ClaimAdapterResponse adapterResponse;
         try
         {
+            profileSw.Restart();
             adapterResponse = await adapter.SubmitClaimAsync(
                 new ClaimSubmissionAdapterRequest
                 {
@@ -202,6 +213,8 @@ public class ClaimSubmissionService : IClaimSubmissionService
             return ClaimSubmissionResult.AdapterNotImplemented(ex.Message);
         }
 
+        var claimInsertMs = profileSw.Elapsed.TotalMilliseconds;
+
         var created = adapterResponse.Claim
             ?? throw new InvalidOperationException(
                 $"Adapter '{adapterResponse.Platform}' returned a null claim from SubmitClaimAsync.");
@@ -216,6 +229,7 @@ public class ClaimSubmissionService : IClaimSubmissionService
         // we log loudly but DO NOT fail the submission — same posture as
         // the Kafka IClaimEventPublisher. The audit chain may have a gap
         // for the affected claim that operators can backfill from logs.
+        profileSw.Restart();
         try
         {
             var domainClaim = created.ToClaim();
@@ -228,6 +242,7 @@ public class ClaimSubmissionService : IClaimSubmissionService
                 "submission persisted, audit chain has a gap",
                 SanitizeForLog(created.Id), SanitizeForLog(created.ClaimVersionId));
         }
+        var eventPublishMs = profileSw.Elapsed.TotalMilliseconds;
 
         // 5.5 dual-emit — Service Bus topic notification triggers the
         // adjudication orchestrator. Mongo append-only above is the
@@ -235,6 +250,7 @@ public class ClaimSubmissionService : IClaimSubmissionService
         // Same degraded-mode posture: failure here logs but does not
         // fail the submission. Operators replay missed messages from
         // the audit chain.
+        profileSw.Restart();
         try
         {
             var sbMessage = new ClaimVersionSubmittedMessage
@@ -264,6 +280,11 @@ public class ClaimSubmissionService : IClaimSubmissionService
                 "submission persisted, adjudication will not auto-trigger",
                 SanitizeForLog(created.Id), SanitizeForLog(created.ClaimVersionId));
         }
+        var sbSendMs = profileSw.Elapsed.TotalMilliseconds;
+
+        _logger.LogDebug(
+            "SubmitProfile.Submit adapterResolveMs={AdapterResolveMs} claimInsertMs={ClaimInsertMs} eventPublishMs={EventPublishMs} serviceBusSendMs={ServiceBusSendMs}",
+            adapterResolveMs, claimInsertMs, eventPublishMs, sbSendMs);
 
         _logger.LogInformation(
             "Claim {ClaimId} submitted via adapter {Platform} (chain {ClaimVersionId} v{VersionNumber}) for tenant {TenantId}",

--- a/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
+++ b/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json.Nodes;
 using ClaimsService.Models;
 using MongoDB.Driver;
@@ -264,7 +265,16 @@ public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublishe
         evt.Id = $"{evt.PartitionKey}:{evt.EventId}";
         if (evt.OccurredAt == default) evt.OccurredAt = DateTime.UtcNow;
 
+        // Per-hop timing for the three Mongo round-trips in this method.
+        // Part 10/11 disclosed the Submit chain's five sequential I/O hops as
+        // a known, unfixed bottleneck without ever measuring which one
+        // dominated. It turned out to be none of them individually -- all
+        // three showed the same low-median, huge-P95 shape, tracing back to
+        // MongoDB's own CPU limit being undersized for the number of
+        // services sharing it, not a cost inherent to any single hop.
+        var profileSw = Stopwatch.StartNew();
         var existing = await GetByEventIdAsync(evt.TenantId, evt.ClaimVersionId, evt.EventId, ct);
+        var idempotencyCheckMs = profileSw.Elapsed.TotalMilliseconds;
         if (existing != null)
         {
             _logger.LogDebug(
@@ -275,10 +285,17 @@ public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublishe
 
         for (var attempt = 0; attempt < MaxRetries; attempt++)
         {
+            profileSw.Restart();
             evt.Version = await GetNextVersionAsync(evt.TenantId, evt.ClaimVersionId, ct);
+            var versionQueryMs = profileSw.Elapsed.TotalMilliseconds;
             try
             {
+                profileSw.Restart();
                 await _collection.InsertOneAsync(evt, cancellationToken: ct);
+                var insertMs = profileSw.Elapsed.TotalMilliseconds;
+                _logger.LogDebug(
+                    "SubmitProfile.VersionEvent idempotencyCheckMs={IdempotencyCheckMs} versionQueryMs={VersionQueryMs} insertMs={InsertMs}",
+                    idempotencyCheckMs, versionQueryMs, insertMs);
                 return evt;
             }
             catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)


### PR DESCRIPTION
## Summary

- Part 10/11 disclosed the Submit chain's five sequential I/O hops (Mongo claim insert, idempotency check, version-number query, version-event insert, Service Bus send) as a known, unfixed bottleneck without ever measuring which one dominated. Added per-hop timing across `ClaimSubmissionService` and `ClaimVersionEventPublisher` to find out.
- The answer: **none of them individually**. All four Mongo-touching hops showed the same shape — low median (2-20ms) but P95/P99 spiking to 80-185ms — the signature of resource contention, not per-operation cost.
- Checked MongoDB's own cgroup stats the same way Part 10 checked claims-service's: `nr_periods=928,143`, `nr_throttled=120,381` (12.97% of periods), `throttled_usec=61,950,174,085` against `usage_usec=22,994,190,530` — MongoDB had spent more cumulative time throttled than actually running, on a 1-core limit shared by claims-service (×2), member-service, provider-service, benefit-plan-service, and coverage-service. Never touched by PR #968, which raised the app-tier services' own limits but not the shared database underneath them.
- Raised MongoDB from `250m`/`1000m` (request/limit) to `1000m`/`4000m`, the same proportional bump #968 gave the app tier.

## Verified live

Same 20K/seed=555 job, before and after:

| | Before | After |
|---|---|---|
| `claimInsert` avg/P95 | 39.37ms / 89.43ms | 6.89ms / 13.37ms |
| `eventPublish` avg/P95 | 45.65ms / 105.23ms | 8.22ms / 20.72ms |
| Submit avg (validator-reported) | ~86ms | 24ms |
| Throughput | ~120-150 claims/sec | **412.05 claims/sec** |
| MongoDB throttled periods | 12.97% | 0.21% |
| Workflow scoring | — | 2,443/2,600 matched, 0 mismatched |

## What's kept vs. removed

Kept the profiling as permanent low-volume observability rather than reverting it now that it's answered the question — demoted from `LogInformation` to `LogDebug` so it doesn't add log volume in production, comments updated to reflect it's no longer temporary.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` (claims-service) — 563/563 passing
- [x] Applied live to the local cluster, confirmed via fresh `cgroup cpu.stat` immediately post-rollout (0 throttled periods at baseline)
- [x] Re-ran the exact same profiling job pre/post fix — results above

🤖 Generated with [Claude Code](https://claude.com/claude-code)