### PR TITLE
Solve the wall-clock gap: checkpoint instrumentation + caffeinate fix

### DIFF
--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -123,5 +123,16 @@ spec:
             - /tmp/mcc-summary.json
 EOF
 
-kubectl wait -n "$NAMESPACE" --for=condition=complete "job/${JOB_NAME}" --timeout="$JOB_TIMEOUT"
+# macOS idle sleep pauses the Docker Desktop VM -- and every pod inside it --
+# for as long as the Mac is asleep. On a long unattended run that shows up
+# as unexplained wall-clock time with no matching code-side cost: the
+# validator's own Stopwatch (CLOCK_MONOTONIC) doesn't count the paused
+# interval, but timestamps do once the VM resumes. `caffeinate` keeps the
+# system awake for the duration of the wait so multi-hundred-thousand-claim
+# runs aren't silently interrupted.
+if command -v caffeinate >/dev/null 2>&1; then
+  caffeinate -dis kubectl wait -n "$NAMESPACE" --for=condition=complete "job/${JOB_NAME}" --timeout="$JOB_TIMEOUT"
+else
+  kubectl wait -n "$NAMESPACE" --for=condition=complete "job/${JOB_NAME}" --timeout="$JOB_TIMEOUT"
+fi
 kubectl logs -n "$NAMESPACE" "job/${JOB_NAME}"

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -22,6 +22,7 @@ if (options.ShowHelp)
 
 var runId = Guid.NewGuid().ToString("N");
 var runStartedAtUtc = DateTimeOffset.UtcNow;
+Console.WriteLine($"  [checkpoint] Run start :: {runStartedAtUtc:HH:mm:ss.fff}Z (runId={runId})");
 var json = new JsonSerializerOptions(JsonSerializerDefaults.Web)
 {
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -132,9 +133,16 @@ else
     Console.WriteLine("Authorization fixtures: skipped (--no-seed-authorizations)");
 }
 
-var answerKey = MccAnswerKey.FromClaims(
-    claims,
-    priorAuthValidationCapabilities);
+// Previously unmeasured: this ran between "Authorization fixture seeding" and
+// "Member and coverage seeding" with no timing wrapper at all -- any real cost
+// here would have shown up nowhere, not even as a discrepancy, since no phase
+// before or after it would look abnormally slow. Wrapped now so it can be
+// ruled in or out directly instead of by inference.
+var answerKey = await MeasureLifecycleValuePhaseAsync(
+    lifecycleTimings,
+    "Answer key build",
+    "Preparation",
+    () => Task.FromResult(MccAnswerKey.FromClaims(claims, priorAuthValidationCapabilities)));
 
 var memberFixtures = MemberFixturePreparation.Empty;
 var cobCoverageFixtures = FixtureCount.Empty;
@@ -196,16 +204,19 @@ var latestProgressPublishLock = new object();
 
 if (!options.NoPublishSummary)
 {
-    var initialProgress = BuildProgressSummary(
-        results.ToList(),
-        TimeSpan.Zero,
-        options,
-        runId,
-        runStartedAtUtc,
-        "Running",
-        "Processing claims",
-        fixturePreparation);
-    await PublishSummaryAsync(http, options, initialProgress, json, quiet: true);
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Initial progress publish", "Preparation", async () =>
+    {
+        var initialProgress = BuildProgressSummary(
+            results.ToList(),
+            TimeSpan.Zero,
+            options,
+            runId,
+            runStartedAtUtc,
+            "Running",
+            "Processing claims",
+            fixturePreparation);
+        await PublishSummaryAsync(http, options, initialProgress, json, quiet: true);
+    });
 }
 
 var processingStartedAtUtc = DateTimeOffset.UtcNow;
@@ -340,7 +351,10 @@ var summary = MccRunSummaryBuilder.Build(
 postProcessingStopwatch.Stop();
 postProcessingTimings.Add(("Summary build", postProcessingStopwatch.Elapsed));
 
+postProcessingStopwatch.Restart();
 WriteSummary(summary);
+postProcessingStopwatch.Stop();
+postProcessingTimings.Add(("Write summary console output", postProcessingStopwatch.Elapsed));
 
 if (!string.IsNullOrWhiteSpace(options.SummaryJsonPath))
 {
@@ -358,7 +372,7 @@ if (!options.NoPublishSummary)
     postProcessingTimings.Add(("Dashboard publish", postProcessingStopwatch.Elapsed));
 }
 
-WritePostProcessingTimings(postProcessingTimings, lifecycleTimings);
+WritePostProcessingTimings(postProcessingTimings, lifecycleTimings, runStartedAtUtc);
 
 if (orderedResults.Any(r => r.Outcome is ClaimValidationOutcome.PlatformFailure))
 {
@@ -393,7 +407,16 @@ static async Task<T> MeasureLifecycleValuePhaseAsync<T>(
     finally
     {
         sw.Stop();
-        AddLifecycleTiming(timings, label, category, startedAtUtc, DateTimeOffset.UtcNow, sw.Elapsed);
+        var completedAtUtc = DateTimeOffset.UtcNow;
+        AddLifecycleTiming(timings, label, category, startedAtUtc, completedAtUtc, sw.Elapsed);
+        // Investigating the wall-clock gap first disclosed in Part 10 (reproduced,
+        // smaller, in Part 12): print an absolute-timestamp checkpoint for every
+        // phase as it completes, immediately, not just an aggregate duration at
+        // the end. A gap between one phase's "completed" and the next phase's
+        // "started" here -- something no duration sum can reveal -- is exactly
+        // what's still unexplained.
+        Console.WriteLine(
+            $"  [checkpoint] {label} :: started {startedAtUtc:HH:mm:ss.fff}Z, completed {completedAtUtc:HH:mm:ss.fff}Z, stopwatch {sw.Elapsed}");
     }
 }
 
@@ -3172,22 +3195,29 @@ static string FormatDuration(TimeSpan duration)
 /// </summary>
 static void WritePostProcessingTimings(
     List<(string Label, TimeSpan Duration)> postProcessingTimings,
-    IReadOnlyCollection<MassAdjudicationLifecycleTiming> lifecycleTimings)
+    IReadOnlyCollection<MassAdjudicationLifecycleTiming> lifecycleTimings,
+    DateTimeOffset runStartedAtUtc)
 {
-    if (postProcessingTimings.Count == 0)
-    {
-        return;
-    }
-
-    var postProcessingTotal = TimeSpan.FromTicks(postProcessingTimings.Sum(t => t.Duration.Ticks));
-    Console.WriteLine($"  Post-processing:    {FormatDuration(postProcessingTotal)}");
-    foreach (var (label, duration) in postProcessingTimings)
-    {
-        Console.WriteLine($"  PostProcessing.{label,-20} {FormatDuration(duration)}");
-    }
-
     var lifecycleTotal = TimeSpan.FromMilliseconds(lifecycleTimings.Sum(t => t.DurationMilliseconds));
-    Console.WriteLine($"  Grand total (tracked lifecycle + post-processing): {FormatDuration(lifecycleTotal + postProcessingTotal)}");
+    var postProcessingTotal = postProcessingTimings.Count == 0
+        ? TimeSpan.Zero
+        : TimeSpan.FromTicks(postProcessingTimings.Sum(t => t.Duration.Ticks));
+
+    if (postProcessingTimings.Count > 0)
+    {
+        Console.WriteLine($"  Post-processing:    {FormatDuration(postProcessingTotal)}");
+        foreach (var (label, duration) in postProcessingTimings)
+        {
+            Console.WriteLine($"  PostProcessing.{label,-20} {FormatDuration(duration)}");
+        }
+    }
+
+    var trackedTotal = lifecycleTotal + postProcessingTotal;
+    var actualWallClock = DateTimeOffset.UtcNow - runStartedAtUtc;
+    var unaccounted = actualWallClock - trackedTotal;
+    Console.WriteLine($"  Grand total (tracked lifecycle + post-processing): {FormatDuration(trackedTotal)}");
+    Console.WriteLine($"  Actual wall clock (run start to now):              {FormatDuration(actualWallClock)}");
+    Console.WriteLine($"  Unaccounted:                                       {FormatDuration(unaccounted)}");
 }
 
 static async Task WriteSummaryJsonAsync(string path, MassAdjudicationRunSummary summary, JsonSerializerOptions json)


### PR DESCRIPTION
## Summary
- Adds absolute-timestamp checkpoint logging to every MCC validator lifecycle phase, plus a tracked "Initial progress publish" phase and a new "Actual wall clock" / "Unaccounted" comparison in the post-processing summary — closing every previously-untracked window between phases.
- Root-causes the wall-clock gap disclosed in Part 10 (~45 min) and Part 12 (~17 min): two live 150K confirmation runs isolated the residual gap to a Stopwatch-vs-wall-clock mismatch inside a single phase each time. Cross-referencing `pmset -g log` found two real macOS Idle Sleep events on this machine whose durations (38s, 641s) match the two runs' unaccounted gaps (36.1s, 638.75s) to within ~2 seconds — the Docker Desktop VM (and every pod inside it) was being suspended mid-run by the host. Not a code, Kubernetes, or MongoDB defect, and it explains why neither gap tracked with claim volume.
- Fixes it: `scripts/run-mcc-local-k8s.sh` now wraps the blocking `kubectl wait` with `caffeinate -dis` so unattended multi-hundred-thousand-claim runs on this machine can't be interrupted by idle sleep.

## Verification
Same 150K-claim job (seed 777, parallelism 56) run twice for a clean before/after:
- Before (no caffeinate): `Unaccounted: 10:38.753` out of a 28:44.971 wall clock, matched almost exactly to a live `pmset -g log` sleep event (641s logged duration vs. 638.75s unaccounted).
- After (`caffeinate -dis` wrapping the wait): `Unaccounted: 0:00.060` out of a 22:27.905 wall clock — effectively zero.

## Test plan
- [x] `dotnet build src/tools/mcc-platform-validator/mcc-platform-validator.csproj -c Release`
- [x] Live 150K-claim run against the local `kind` cluster before the fix, reproducing a ~10:39 unaccounted gap
- [x] Live 150K-claim run after the fix, confirming the gap closes to ~60ms
- [x] `bash -n scripts/run-mcc-local-k8s.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)