### PR TITLE
Update platform.html benchmark numbers from stale 100K to current 500K

### DIFF
--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -253,15 +253,15 @@
         
         <div class="stats-grid">
           <div class="stat-card">
-            <div class="stat-number">100K</div>
-            <div class="stat-label">Clean Local<br>Benchmark</div>
+            <div class="stat-number">500K</div>
+            <div class="stat-label">Local Kubernetes<br>Benchmark</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">0</div>
-            <div class="stat-label">Scoreable Mismatches<br>or Unexpected Pends</div>
+            <div class="stat-number">61,063/65,000</div>
+            <div class="stat-label">Workflow Checks<br>Matched</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">2,000</div>
+            <div class="stat-number">10,000</div>
             <div class="stat-label">Payments Within<br>One Cent</div>
           </div>
           <div class="stat-card">
@@ -293,28 +293,30 @@
         <p>
           The Million Claim Challenge validates the platform under pressure by reporting throughput, tail latency,
           platform reliability, and deterministic healthcare workflow correctness together. The latest published Cloud Health Office run
-          is a clean 100K local Kubernetes validation, not a production cloud benchmark or full-million adjudication run.
+          is a 500,000-claim local Kubernetes validation, not a production cloud benchmark or full-million adjudication run.
         </p>
         <div class="mcc-proof-grid" aria-label="Latest local Million Claim Challenge validation metrics">
           <div class="mcc-proof-metric">
-            <strong>100,000</strong>
+            <strong>500,000</strong>
             <span>claims processed in local Kubernetes</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>56.15 claims/sec</strong>
+            <strong>186.06 claims/sec</strong>
             <span>timed throughput with the stronger scoring gates enabled</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>358 ms / 451 ms</strong>
+            <strong>571 ms / 695 ms</strong>
             <span>P95 and P99 latency</span>
           </div>
           <div class="mcc-proof-metric">
             <strong>0 platform failures</strong>
-            <span>0 mismatches, unexpected pends, or payment mismatches</span>
+            <span>61,063/65,000 workflow checks matched; payment gate exact on 10,000/10,000</span>
           </div>
         </div>
         <p style="font-size:0.95rem; color:#888;">
-          The full MCC design covers one million claims and 29 edge-case scenarios; the next local work is to optimize fixture preparation and explain the reproducible local ceiling before increasing volume again.
+          The full MCC design covers one million claims and 29 edge-case scenarios; the next local work is to close the remaining unsupported scenario families before increasing volume again.
+          <a href="/insights/million-claim-challenge/part-12-the-database-nobody-profiled" style="color:#00ffff;">Read the 500K writeup</a>
+          &middot;
           <a href="/docs/million-claim-challenge" style="color:#00ffff;">See the benchmark methodology &rarr;</a>
         </p>
       </section>
@@ -950,11 +952,11 @@
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">CLASS LIBRARIES</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">2,000</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">10,000</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">PAYMENT CHECKS</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">100K</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">500K</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">LOCAL BENCHMARK</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- `platform.html` had four spots still citing the Part 8-era 100,000-claim run: the top stats-grid cards, the MCC proof strip, and the product-tour summary bar.
- Updated all four to Part 12's 500,000-claim confirmation: 500,000 claims, 186.06 claims/sec, 571ms/695ms P95/P99 latency, 10,000/10,000 payment checks exact.
- The old "0 scoreable mismatches" claim was accurate for the 100K run but not the 500K run (4 genuine mismatches, already disclosed honestly in Part 12's own publish). Reworded to `61,063/65,000 workflow checks matched` rather than leaving a now-false zero-mismatch claim live on the marketing page.
- Linked the proof strip to the Part 12 writeup.

## Test plan
- [x] Grepped the file for any other stale MCC numbers (250K, Part 8-11 pointers, old mismatch language) — none remain
- [x] Reviewed the diff line by line against the real 500K run's raw validator output (`docs/million-claim-challenge/podcast/episode-012/raw-validator-output-500k.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)