### PR TITLE
Convert RetroEligibilityCoverageChange from unsupported to scored

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -124,23 +124,35 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
 
     private static void ApplyScenarioCoverageWindow(SyntheticClaim claim, EdgeCaseScenario scenario)
     {
-        if (scenario is not EdgeCaseScenario.RetroEligibilityTermination)
+        var serviceDate = claim.DateOfService.Date;
+
+        if (scenario is EdgeCaseScenario.RetroEligibilityTermination)
         {
+            claim.Member.CoverageEffectiveDate = serviceDate.AddYears(-1);
+            claim.Member.CoverageTermDate = serviceDate.AddDays(-30);
+            claim.Member.EnrollmentStatus = "Terminated";
+            claim.Member.MaintenanceTypeCode = "024";
+
+            foreach (var coverage in claim.Member.Coverages)
+            {
+                coverage.EffectiveDate = claim.Member.CoverageEffectiveDate;
+                coverage.TermDate = claim.Member.CoverageTermDate;
+                coverage.Status = "Terminated";
+                coverage.MaintenanceTypeCode = "024";
+            }
+
             return;
         }
 
-        var serviceDate = claim.DateOfService.Date;
-        claim.Member.CoverageEffectiveDate = serviceDate.AddYears(-1);
-        claim.Member.CoverageTermDate = serviceDate.AddDays(-30);
-        claim.Member.EnrollmentStatus = "Terminated";
-        claim.Member.MaintenanceTypeCode = "024";
-
-        foreach (var coverage in claim.Member.Coverages)
+        if (scenario is EdgeCaseScenario.RetroEligibilityCoverageChange)
         {
-            coverage.EffectiveDate = claim.Member.CoverageEffectiveDate;
-            coverage.TermDate = claim.Member.CoverageTermDate;
-            coverage.Status = "Terminated";
-            coverage.MaintenanceTypeCode = "024";
+            // A benefit-plan correction recorded today, effective two weeks ago:
+            // the claim's own service date falls inside the retroactive window,
+            // so the plan in force on the date of service can't be trusted
+            // without reconciliation. X12 834 maintenance type code 001 = Change.
+            claim.Member.CoverageEffectiveDate = serviceDate.AddYears(-1);
+            claim.Member.PlanChangeEffectiveDate = serviceDate.AddDays(-14);
+            claim.Member.MaintenanceTypeCode = "001";
         }
     }
 

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticMember.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticMember.cs
@@ -51,6 +51,15 @@ public class SyntheticMember
     /// <summary>X12 834 maintenance type code (021=Addition, 024=Cancel, 001=Change).</summary>
     public string MaintenanceTypeCode { get; set; } = "021";
 
+    /// <summary>
+    /// Retroactive effective date of a benefit-plan/coverage change (X12 834
+    /// maintenance type code 001), when this member record represents a
+    /// correction recorded after claims with earlier service dates may have
+    /// already been submitted. Null for members with no pending retroactive
+    /// change.
+    /// </summary>
+    public DateTime? PlanChangeEffectiveDate { get; set; }
+
     /// <summary>Line of business (STAR, CHIP, STAR+PLUS, STAR Kids, STAR Health, Commercial, Medicare).</summary>
     public string LineOfBusiness { get; set; } = "STAR";
 

--- a/src/services/claims-service/Models/Claim.cs
+++ b/src/services/claims-service/Models/Claim.cs
@@ -761,7 +761,7 @@ public class PendDetails
 {
     /// <summary>
     /// Short pend reason code consumed by the work queue categorizer.
-    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL.
+    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL, RETROELIG.
     /// </summary>
     [Required]
     [StringLength(20)]

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -41,6 +41,15 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
     public const string PriorAuthorizationRequiredReason = "Prior authorization required but not provided";
     public const string PriorAuthorizationInvalidReason = "Prior authorization is not valid for this claim";
 
+    /// <summary>
+    /// <see cref="PendDetails.PendCode"/> value for claims pended because a
+    /// retroactive benefit-plan/coverage change (X12 834 maintenance type
+    /// code 001) was recorded with an effective date on or before the
+    /// claim's own service date -- the plan in force on the service date
+    /// can't be trusted without reconciliation.
+    /// </summary>
+    public const string RetroactivePlanChangePendCode = "RETROELIG";
+
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
     private readonly IAuthorizationValidationClient _authorizationValidationClient;
@@ -91,6 +100,18 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             return ClaimAdjudicationStageResult.Deny(
                 StageName,
                 eligibilityReason);
+        }
+
+        if (HasUnreconciledRetroactivePlanChange(context.ResolvedMember, claim.ServiceDateFrom, out var pendReason))
+        {
+            context.PendDetails = new PendDetails
+            {
+                PendCode = RetroactivePlanChangePendCode,
+                PendReason = pendReason,
+                PendedAt = DateTime.UtcNow,
+            };
+
+            return ClaimAdjudicationStageResult.Pend(StageName, pendReason);
         }
 
         var priorAuthorizationDenialReason = await ResolvePriorAuthorizationDenialReasonAsync(
@@ -183,6 +204,24 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
 
         reason = "Active coverage";
         return true;
+    }
+
+    private static bool HasUnreconciledRetroactivePlanChange(
+        ResolvedMember? member,
+        DateTime serviceDate,
+        out string reason)
+    {
+        if (member?.PlanChangeEffectiveDate is DateTime planChangeEffectiveDate
+            && serviceDate.Date >= planChangeEffectiveDate.Date)
+        {
+            reason =
+                $"Member has a retroactive benefit-plan change effective {planChangeEffectiveDate.Date:yyyy-MM-dd}; " +
+                "the plan in force on the service date requires reconciliation before this claim can adjudicate.";
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
     }
 
     internal static bool RequiresPriorAuthorizationDenial(AdapterClaim claim)

--- a/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
@@ -81,6 +81,7 @@ public class HttpMemberResolver : IMemberResolver
                 EnrollmentStatus = dto.Status,
                 EffectiveDate = dto.EffectiveDate,
                 TerminationDate = dto.TerminationDate,
+                PlanChangeEffectiveDate = dto.PlanChangeEffectiveDate,
             };
         }
         catch (Exception ex) when (ex is HttpRequestException
@@ -107,5 +108,6 @@ public class HttpMemberResolver : IMemberResolver
         public string? Status { get; set; }
         public DateTime? EffectiveDate { get; set; }
         public DateTime? TerminationDate { get; set; }
+        public DateTime? PlanChangeEffectiveDate { get; set; }
     }
 }

--- a/src/services/claims-service/Services/Resolution/IMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/IMemberResolver.cs
@@ -42,4 +42,11 @@ public class ResolvedMember
 
     public DateTime? EffectiveDate { get; init; }
     public DateTime? TerminationDate { get; init; }
+
+    /// <summary>
+    /// Retroactive effective date of a benefit-plan/coverage change recorded
+    /// after the fact. Null unless member-service has a pending retroactive
+    /// correction on file for this member.
+    /// </summary>
+    public DateTime? PlanChangeEffectiveDate { get; init; }
 }

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -231,6 +231,7 @@ public class MembersController : ControllerBase
             Status = EnrollmentStatus.Pending,
             MaintenanceTypeCode = request.MaintenanceTypeCode,
             MaintenanceReasonCode = request.MaintenanceReasonCode,
+            PlanChangeEffectiveDate = request.PlanChangeEffectiveDate,
             EmploymentStatus = request.EmploymentStatus,
             TobaccoUser = request.TobaccoUser,
             IsStudent = request.IsStudent,
@@ -840,6 +841,7 @@ public class CreateMemberRequest
     public DateTime? TerminationDate { get; set; }
     public string? MaintenanceTypeCode { get; set; }
     public string? MaintenanceReasonCode { get; set; }
+    public DateTime? PlanChangeEffectiveDate { get; set; }
     public EmploymentStatus? EmploymentStatus { get; set; }
     public bool? TobaccoUser { get; set; }
     public bool? IsStudent { get; set; }

--- a/src/services/member-service/Models/Member.cs
+++ b/src/services/member-service/Models/Member.cs
@@ -180,6 +180,16 @@ public class Member
     public string? MaintenanceReasonCode { get; set; }
 
     /// <summary>
+    /// Retroactive effective date of a benefit-plan/coverage change
+    /// (<see cref="MaintenanceTypeCode"/> 001) recorded after the fact. Null
+    /// unless this member record reflects a correction whose effective date
+    /// precedes when it was processed; claims with a service date on or
+    /// after this date were adjudicated before the correct plan assignment
+    /// was known and require reconciliation.
+    /// </summary>
+    public DateTime? PlanChangeEffectiveDate { get; set; }
+
+    /// <summary>
     /// Employment status from 834 EMP segment
     /// </summary>
     public EmploymentStatus? EmploymentStatus { get; set; }

--- a/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
+++ b/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
@@ -61,6 +61,11 @@ internal static class MccClaimDateNormalizer
             member.CoverageTermDate = member.CoverageTermDate.Value.Date.Add(dateShift);
         }
 
+        if (member.PlanChangeEffectiveDate.HasValue)
+        {
+            member.PlanChangeEffectiveDate = member.PlanChangeEffectiveDate.Value.Date.Add(dateShift);
+        }
+
         foreach (var coverage in member.Coverages)
         {
             if (coverage.EffectiveDate != default)

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -187,7 +187,6 @@ public static class MccWorkflowValidation
     private static bool IsUnsupportedPendedEdgeCase(EdgeCaseScenario scenario)
     {
         return scenario is
-            EdgeCaseScenario.RetroEligibilityCoverageChange or
             EdgeCaseScenario.SubrogationAccidentRelated or
             EdgeCaseScenario.SubrogationWorkersComp or
             EdgeCaseScenario.SubrogationThirdPartyLiability or

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1514,6 +1514,7 @@ static async Task<bool> CreateMemberAsync(
         effectiveDate,
         terminationDate = member.CoverageTermDate,
         maintenanceTypeCode = NullIfWhiteSpace(member.MaintenanceTypeCode) ?? "021",
+        planChangeEffectiveDate = member.PlanChangeEffectiveDate,
         eventId = $"mcc-validator-member-created:{options.Seed}:{member.MemberId}"
     };
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -268,6 +268,60 @@ public class BenefitCalculationStageTests
     }
 
     [Fact]
+    public async Task Execute_ServiceDateOnOrAfterRetroactivePlanChange_PendsWithoutEngineCall()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember
+            {
+                MemberId = "MEM-1",
+                IsSubscriber = true,
+                PlanChangeEffectiveDate = claim.ServiceDateFrom.AddDays(-14),
+            },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.True(result.Continue);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal(BenefitCalculationStage.RetroactivePlanChangePendCode, ctx.PendDetails!.PendCode);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_RetroactivePlanChangeEffectiveAfterServiceDate_ContinuesToBenefitEngine()
+    {
+        var planGuid = Guid.NewGuid();
+        var claim = BuildClaim(planGuid.ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember
+            {
+                MemberId = "MEM-1",
+                IsSubscriber = true,
+                PlanChangeEffectiveDate = claim.ServiceDateFrom.AddDays(14),
+            },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals(), Lines = new List<LineBenefitResult>() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.Null(ctx.PendDetails);
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Execute_MedicaidInstitutionalInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
     {
         var claim = BuildClaim(Guid.NewGuid().ToString());


### PR DESCRIPTION
## Summary
- Converts the `RetroEligibilityCoverageChange` MCC benchmark scenario from unsupported (excluded from correctness scoring) to a deliberately scored Pend, closing one of the five remaining unsupported scenario families flagged since Part 9/12.
- Real-world meaning: a benefit-plan/coverage correction recorded after the fact, with an effective date that lands before some claims' service dates were already submitted. The plan in force on the service date can't be trusted without reconciliation, so the claim should pend rather than adjudicate against a possibly-superseded plan assignment.
- Adds `Member.PlanChangeEffectiveDate` (X12 834 maintenance type code `001` = Change) to member-service's real `Member` model, threaded through `CreateMemberRequest` and the `GET /api/v1/members/{id}` response.
- claims-service's `ResolvedMember`/`HttpMemberResolver` pick up the new field, and a new check in `BenefitCalculationStage` — mirroring the existing member-eligibility deny check and `CoordinationOfBenefitsStage`'s Pend pattern — pends (`PendCode "RETROELIG"`) any claim whose service date falls on or after the member's on-file retroactive change date, before the benefit engine runs.
- The corpus generator sets this up the same way it already does for `RetroEligibilityTermination`: a deterministic member/coverage window plus the real maintenance-type code, normalized by `MccClaimDateNormalizer` alongside the other coverage dates it already shifts.
- Removed `RetroEligibilityCoverageChange` from `MccWorkflowValidation`'s unsupported gate now that the pipeline produces a genuine, deterministic Pend for it.

## Test plan
- [x] `dotnet build` clean on member-service, claims-service, mcc-platform-validator, and `CloudHealthOffice.BenchmarkClaimGenerator`
- [x] Existing test suites pass: `CloudHealthOffice.ClaimsService.Tests` (563→565), `CloudHealthOffice.BenchmarkClaimGenerator.Tests` (134)
- [x] Two new `BenefitCalculationStageTests` cases (pends when the change predates service date, continues to the benefit engine otherwise); confirmed via `git stash` that they fail to even compile without the fix (removes `ResolvedMember.PlanChangeEffectiveDate` entirely) and pass with it
- [x] Live 10,000-claim run against the local `kind` cluster: `RetroEligibilityCoverageChange` 26/26 matched (0 mismatched, 0 unsupported); false-pend sweep found no unexpected pends among 1,130 non-pend claims

## Remaining unsupported scenario families after this PR
- MedicaidSpendDown
- SubrogationAccidentRelated, SubrogationThirdPartyLiability, SubrogationWorkersComp

🤖 Generated with [Claude Code](https://claude.com/claude-code)