### PR TITLE
Convert all three Subrogation scenarios from unsupported to scored

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -94,8 +94,28 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
 
         ApplyScenarioMemberContext(claim, scenario);
         ApplyScenarioCoverageWindow(claim, scenario);
+        ApplyScenarioRelatedCauses(claim, scenario, random);
         claim.ExpectedOutcome = ComputeExpectedOutcome(claim, scenario, random);
         return claim;
+    }
+
+    private static void ApplyScenarioRelatedCauses(SyntheticClaim claim, EdgeCaseScenario scenario, Random random)
+    {
+        // X12 837 CLM11-1: AA=Auto Accident, EM=Employment, OA=Other Accident.
+        // Any related-causes code signals potential third-party liability that
+        // requires subrogation investigation before the claim can pay.
+        claim.RelatedCausesCode = scenario switch
+        {
+            EdgeCaseScenario.SubrogationAccidentRelated => "AA",
+            EdgeCaseScenario.SubrogationThirdPartyLiability => "OA",
+            EdgeCaseScenario.SubrogationWorkersComp => "EM",
+            _ => null
+        };
+
+        if (claim.RelatedCausesCode is not null)
+        {
+            claim.AccidentDate = claim.DateOfService.Date.AddDays(-random.Next(1, 30));
+        }
     }
 
     private static void ApplyScenarioMemberContext(SyntheticClaim claim, EdgeCaseScenario scenario)

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticClaim.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticClaim.cs
@@ -71,6 +71,17 @@ public class SyntheticClaim
     /// <summary>Whether this claim is ready for payer-to-payer data exchange.</summary>
     public bool PayerToPayerReady { get; set; }
 
+    /// <summary>
+    /// X12 837 CLM11-1 related-causes code (AA=Auto Accident, EM=Employment,
+    /// OA=Other Accident). Null when the service is unrelated to any
+    /// accident/injury liability. Signals potential third-party/subrogation
+    /// liability requiring investigation before payment.
+    /// </summary>
+    public string? RelatedCausesCode { get; set; }
+
+    /// <summary>X12 837 DTP*439 accident date. Set only when <see cref="RelatedCausesCode"/> is set.</summary>
+    public DateTime? AccidentDate { get; set; }
+
     /// <summary>Pre-computed expected adjudication outcome for benchmarking.</summary>
     public ExpectedOutcome ExpectedOutcome { get; set; } = null!;
 }

--- a/src/services/claims-service/Models/Claim.cs
+++ b/src/services/claims-service/Models/Claim.cs
@@ -259,6 +259,20 @@ public class Claim
     public string? ReferralNumber { get; set; }
 
     /// <summary>
+    /// Related-causes code (AA=Auto Accident, EM=Employment, OA=Other Accident).
+    /// Null when the service is unrelated to any accident/injury liability.
+    /// 837: CLM11-1 (2300 loop)
+    /// </summary>
+    [StringLength(2)]
+    public string? RelatedCausesCode { get; set; }
+
+    /// <summary>
+    /// Accident date. Set only when <see cref="RelatedCausesCode"/> is set.
+    /// 837: DTP*439 (2300 loop)
+    /// </summary>
+    public DateTime? AccidentDate { get; set; }
+
+    /// <summary>
     /// Claim notes/comments
     /// 837: NTE segment
     /// </summary>
@@ -761,7 +775,7 @@ public class PendDetails
 {
     /// <summary>
     /// Short pend reason code consumed by the work queue categorizer.
-    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL, RETROELIG.
+    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL, RETROELIG, SUBRO.
     /// </summary>
     [Required]
     [StringLength(20)]

--- a/src/services/claims-service/Models/ClaimAdapterResponse.cs
+++ b/src/services/claims-service/Models/ClaimAdapterResponse.cs
@@ -125,6 +125,8 @@ public class AdapterClaim
 
     public string? PriorAuthorizationNumber { get; set; }
     public string? ReferralNumber { get; set; }
+    public string? RelatedCausesCode { get; set; }
+    public DateTime? AccidentDate { get; set; }
     public string? ClaimNotes { get; set; }
     public string? EDI837ControlNumber { get; set; }
     public string? EDI835ControlNumber { get; set; }
@@ -185,6 +187,8 @@ public class AdapterClaim
         AiExamination = src.AiExamination,
         PriorAuthorizationNumber = src.PriorAuthorizationNumber,
         ReferralNumber = src.ReferralNumber,
+        RelatedCausesCode = src.RelatedCausesCode,
+        AccidentDate = src.AccidentDate,
         ClaimNotes = src.ClaimNotes,
         EDI837ControlNumber = src.EDI837ControlNumber,
         EDI835ControlNumber = src.EDI835ControlNumber,
@@ -241,6 +245,8 @@ public class AdapterClaim
         AiExamination = AiExamination,
         PriorAuthorizationNumber = PriorAuthorizationNumber,
         ReferralNumber = ReferralNumber,
+        RelatedCausesCode = RelatedCausesCode,
+        AccidentDate = AccidentDate,
         ClaimNotes = ClaimNotes,
         EDI837ControlNumber = EDI837ControlNumber,
         EDI835ControlNumber = EDI835ControlNumber,

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -50,6 +50,14 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
     /// </summary>
     public const string RetroactivePlanChangePendCode = "RETROELIG";
 
+    /// <summary>
+    /// <see cref="PendDetails.PendCode"/> value for claims pended because the
+    /// claim carries an X12 837 CLM11 related-causes code (auto accident,
+    /// employment, or other accident) -- potential third-party liability
+    /// requires subrogation investigation before the claim can pay.
+    /// </summary>
+    public const string SubrogationReviewPendCode = "SUBRO";
+
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
     private readonly IAuthorizationValidationClient _authorizationValidationClient;
@@ -112,6 +120,18 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             };
 
             return ClaimAdjudicationStageResult.Pend(StageName, pendReason);
+        }
+
+        if (HasUnreviewedSubrogationIndicator(claim, out var subrogationReason))
+        {
+            context.PendDetails = new PendDetails
+            {
+                PendCode = SubrogationReviewPendCode,
+                PendReason = subrogationReason,
+                PendedAt = DateTime.UtcNow,
+            };
+
+            return ClaimAdjudicationStageResult.Pend(StageName, subrogationReason);
         }
 
         var priorAuthorizationDenialReason = await ResolvePriorAuthorizationDenialReasonAsync(
@@ -217,6 +237,28 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             reason =
                 $"Member has a retroactive benefit-plan change effective {planChangeEffectiveDate.Date:yyyy-MM-dd}; " +
                 "the plan in force on the service date requires reconciliation before this claim can adjudicate.";
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
+    }
+
+    private static readonly HashSet<string> RecognizedRelatedCausesCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AA", // Auto Accident
+        "EM", // Employment
+        "OA", // Other Accident
+    };
+
+    private static bool HasUnreviewedSubrogationIndicator(AdapterClaim claim, out string reason)
+    {
+        if (!string.IsNullOrWhiteSpace(claim.RelatedCausesCode)
+            && RecognizedRelatedCausesCodes.Contains(claim.RelatedCausesCode))
+        {
+            reason =
+                $"Claim carries related-causes code '{claim.RelatedCausesCode}'; potential third-party " +
+                "liability requires subrogation investigation before this claim can adjudicate.";
             return true;
         }
 

--- a/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
+++ b/src/tools/mcc-platform-validator/MccClaimDateNormalizer.cs
@@ -19,6 +19,11 @@ internal static class MccClaimDateNormalizer
             ShiftMemberCoverageDates(claim.Member, dateShift, claim.DateOfService);
             ShiftNewbornDateOfBirth(claim, dateShift);
 
+            if (claim.AccidentDate.HasValue)
+            {
+                claim.AccidentDate = claim.AccidentDate.Value.Date.Add(dateShift);
+            }
+
             foreach (var line in claim.Lines)
             {
                 line.ServiceDate = line.ServiceDate.Date.Add(dateShift);

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -186,11 +186,7 @@ public static class MccWorkflowValidation
 
     private static bool IsUnsupportedPendedEdgeCase(EdgeCaseScenario scenario)
     {
-        return scenario is
-            EdgeCaseScenario.SubrogationAccidentRelated or
-            EdgeCaseScenario.SubrogationWorkersComp or
-            EdgeCaseScenario.SubrogationThirdPartyLiability or
-            EdgeCaseScenario.MedicaidSpendDown;
+        return scenario is EdgeCaseScenario.MedicaidSpendDown;
     }
 
     private static bool IsUnsupportedPriorAuthValidationEdgeCase(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -2627,7 +2627,9 @@ static async Task<SubmittedClaim> SubmitClaimAsync(
         status = 1,
         submittedDate = claim.DateReceived,
         receivedDate = claim.DateReceived,
-        priorAuthorizationNumber = claim.PriorAuthNumber
+        priorAuthorizationNumber = claim.PriorAuthNumber,
+        relatedCausesCode = claim.RelatedCausesCode,
+        accidentDate = claim.AccidentDate
     };
 
     using var response = await http.PostAsJsonAsync($"{options.ClaimsUrl}/api/v1/claims", payload, json);

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -321,6 +321,55 @@ public class BenefitCalculationStageTests
         await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData("AA")]
+    [InlineData("EM")]
+    [InlineData("OA")]
+    public async Task Execute_ClaimHasRelatedCausesCode_PendsWithoutEngineCall(string relatedCausesCode)
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        claim.RelatedCausesCode = relatedCausesCode;
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.True(result.Continue);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal(BenefitCalculationStage.SubrogationReviewPendCode, ctx.PendDetails!.PendCode);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_ClaimHasNoRelatedCausesCode_ContinuesToBenefitEngine()
+    {
+        var planGuid = Guid.NewGuid();
+        var claim = BuildClaim(planGuid.ToString());
+        claim.RelatedCausesCode = null;
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember { MemberId = "MEM-1", IsSubscriber = true },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals(), Lines = new List<LineBenefitResult>() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.Null(ctx.PendDetails);
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task Execute_MedicaidInstitutionalInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
     {


### PR DESCRIPTION
## Summary
- Converts `SubrogationAccidentRelated`, `SubrogationThirdPartyLiability`, and `SubrogationWorkersComp` from unsupported to deliberately scored Pends, all in one PR since they share the same underlying fix.
- Real-world meaning: a claim carrying an X12 837 CLM11 related-causes code (auto accident, employment, or other accident) may have a third-party payer — an auto insurer, workers' comp carrier, or liability policy — who should pay before CHO does. These claims need subrogation investigation, not automatic payment.
- Adds `SyntheticClaim.RelatedCausesCode`/`AccidentDate` (BenchmarkClaimGenerator) and the same pair on claims-service's `Claim`/`AdapterClaim` (plus their lossless `From()`/`ToClaim()` round-trip mappers).
- A new check in `BenefitCalculationStage` — alongside the retroactive-plan-change pend added in #987 — pends (`PendCode "SUBRO"`) any claim carrying a recognized related-causes code (`AA`=Auto Accident, `EM`=Employment, `OA`=Other Accident), before the benefit engine runs.
- One field and one check cover all three scenarios: the generator maps `SubrogationAccidentRelated`→`AA`, `SubrogationThirdPartyLiability`→`OA`, `SubrogationWorkersComp`→`EM`. Converting all three together avoided leaving two nearly-free conversions sitting unsupported once the capability existed.
- Kept `AccidentRelated`'s existing diagnosis/procedure/POS differentiation as scenario flavor; the real scoring signal is now `RelatedCausesCode`, not those proxies (which were previously overfit-prone — ordinary ER visits share the same POS).
- Removed all three from `MccWorkflowValidation`'s unsupported gate.

## Test plan
- [x] `dotnet build` clean on claims-service, mcc-platform-validator, `CloudHealthOffice.BenchmarkClaimGenerator`
- [x] Existing test suites pass: `CloudHealthOffice.ClaimsService.Tests` (565), `CloudHealthOffice.BenchmarkClaimGenerator.Tests` (134)
- [x] 4 new `BenefitCalculationStageTests` cases (all three related-causes codes pend correctly; absence of the code continues to the benefit engine)
- [x] Live 10,000-claim run against the local `kind` cluster: all three scenarios 100% matched (14/14, 13/13, 13/13; 0 mismatched, 0 unsupported); `RetroEligibilityCoverageChange` still 26/26 (no regression from #987); false-pend sweep found 0 unexpected pends among 1,130 non-pend claims

## Remaining unsupported scenario families after this PR
- `MedicaidSpendDown` — the only one left, and the most build-heavy: it requires a genuinely new benefit-tracking concept (accumulator-style spend-down-liability tracking) rather than a claim-level indicator like the four converted so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)