### PR TITLE
Convert MedicaidSpendDown from unsupported to scored -- closes the unsupported-scenario sweep

### DIFF
--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Generators/EdgeCaseClaimGenerator.cs
@@ -196,8 +196,18 @@ public class EdgeCaseClaimGenerator : IClaimGenerator
                 break;
 
             case EdgeCaseScenario.MedicaidDualEligible:
+                member.DateOfBirth = new DateTime(1940 + random.Next(30), 1 + random.Next(12), 1 + random.Next(28));
+                break;
+
             case EdgeCaseScenario.MedicaidSpendDown:
                 member.DateOfBirth = new DateTime(1940 + random.Next(30), 1 + random.Next(12), 1 + random.Next(28));
+                // "Medically needy" spend-down: the member must incur this much
+                // in medical expense before Medicaid activates for the budget
+                // period. Amount met is deliberately short of the liability so
+                // the scenario always lands in the still-pending window.
+                member.MedicaidSpendDownLiabilityAmount = 500m + random.Next(0, 1000);
+                member.MedicaidSpendDownAmountMet =
+                    member.MedicaidSpendDownLiabilityAmount.Value * (0.3m + (decimal)random.NextDouble() * 0.4m);
                 break;
         }
 

--- a/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticMember.cs
+++ b/src/CloudHealthOffice.BenchmarkClaimGenerator/Models/SyntheticMember.cs
@@ -60,6 +60,17 @@ public class SyntheticMember
     /// </summary>
     public DateTime? PlanChangeEffectiveDate { get; set; }
 
+    /// <summary>
+    /// Medicaid "medically needy" spend-down liability for the member's
+    /// current budget period: incurred medical expense required before
+    /// Medicaid activates. Null for members not enrolled under a spend-down
+    /// eligibility category.
+    /// </summary>
+    public decimal? MedicaidSpendDownLiabilityAmount { get; set; }
+
+    /// <summary>Amount incurred so far toward <see cref="MedicaidSpendDownLiabilityAmount"/>.</summary>
+    public decimal MedicaidSpendDownAmountMet { get; set; }
+
     /// <summary>Line of business (STAR, CHIP, STAR+PLUS, STAR Kids, STAR Health, Commercial, Medicare).</summary>
     public string LineOfBusiness { get; set; } = "STAR";
 

--- a/src/services/claims-service/Models/Claim.cs
+++ b/src/services/claims-service/Models/Claim.cs
@@ -775,7 +775,7 @@ public class PendDetails
 {
     /// <summary>
     /// Short pend reason code consumed by the work queue categorizer.
-    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL, RETROELIG, SUBRO.
+    /// Recognized values: NCCI, MUE, AUTH, NOAUTH, OON, NOCONTRACT, COB, MEDREVIEW, CLINICAL, RETROELIG, SUBRO, SPENDDOWN.
     /// </summary>
     [Required]
     [StringLength(20)]

--- a/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/BenefitCalculationStage.cs
@@ -58,6 +58,15 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
     /// </summary>
     public const string SubrogationReviewPendCode = "SUBRO";
 
+    /// <summary>
+    /// <see cref="PendDetails.PendCode"/> value for claims pended because the
+    /// member is enrolled under a Medicaid "medically needy" spend-down
+    /// eligibility category and has not yet incurred enough medical expense
+    /// in the current budget period to meet their spend-down liability --
+    /// Medicaid coverage isn't confirmed active for this period yet.
+    /// </summary>
+    public const string MedicaidSpendDownPendCode = "SPENDDOWN";
+
     private readonly IBenefitCalculationEngine _engine;
     private readonly IMemberResolver _memberResolver;
     private readonly IAuthorizationValidationClient _authorizationValidationClient;
@@ -132,6 +141,18 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             };
 
             return ClaimAdjudicationStageResult.Pend(StageName, subrogationReason);
+        }
+
+        if (HasUnmetMedicaidSpendDown(context.ResolvedMember, out var spendDownReason))
+        {
+            context.PendDetails = new PendDetails
+            {
+                PendCode = MedicaidSpendDownPendCode,
+                PendReason = spendDownReason,
+                PendedAt = DateTime.UtcNow,
+            };
+
+            return ClaimAdjudicationStageResult.Pend(StageName, spendDownReason);
         }
 
         var priorAuthorizationDenialReason = await ResolvePriorAuthorizationDenialReasonAsync(
@@ -259,6 +280,22 @@ public sealed class BenefitCalculationStage : IClaimAdjudicationStage
             reason =
                 $"Claim carries related-causes code '{claim.RelatedCausesCode}'; potential third-party " +
                 "liability requires subrogation investigation before this claim can adjudicate.";
+            return true;
+        }
+
+        reason = string.Empty;
+        return false;
+    }
+
+    private static bool HasUnmetMedicaidSpendDown(ResolvedMember? member, out string reason)
+    {
+        if (member?.MedicaidSpendDownLiabilityAmount is decimal liability
+            && member.MedicaidSpendDownAmountMet < liability)
+        {
+            reason =
+                $"Member has a Medicaid spend-down liability of {liability:C} for the current budget " +
+                $"period and has incurred {member.MedicaidSpendDownAmountMet:C} toward it; coverage is " +
+                "not yet confirmed active for this period.";
             return true;
         }
 

--- a/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpMemberResolver.cs
@@ -82,6 +82,8 @@ public class HttpMemberResolver : IMemberResolver
                 EffectiveDate = dto.EffectiveDate,
                 TerminationDate = dto.TerminationDate,
                 PlanChangeEffectiveDate = dto.PlanChangeEffectiveDate,
+                MedicaidSpendDownLiabilityAmount = dto.MedicaidSpendDownLiabilityAmount,
+                MedicaidSpendDownAmountMet = dto.MedicaidSpendDownAmountMet,
             };
         }
         catch (Exception ex) when (ex is HttpRequestException
@@ -109,5 +111,7 @@ public class HttpMemberResolver : IMemberResolver
         public DateTime? EffectiveDate { get; set; }
         public DateTime? TerminationDate { get; set; }
         public DateTime? PlanChangeEffectiveDate { get; set; }
+        public decimal? MedicaidSpendDownLiabilityAmount { get; set; }
+        public decimal MedicaidSpendDownAmountMet { get; set; }
     }
 }

--- a/src/services/claims-service/Services/Resolution/IMemberResolver.cs
+++ b/src/services/claims-service/Services/Resolution/IMemberResolver.cs
@@ -49,4 +49,13 @@ public class ResolvedMember
     /// correction on file for this member.
     /// </summary>
     public DateTime? PlanChangeEffectiveDate { get; init; }
+
+    /// <summary>
+    /// Medicaid spend-down liability for the member's current budget period.
+    /// Null for members not enrolled under a spend-down eligibility category.
+    /// </summary>
+    public decimal? MedicaidSpendDownLiabilityAmount { get; init; }
+
+    /// <summary>Amount incurred so far toward <see cref="MedicaidSpendDownLiabilityAmount"/>.</summary>
+    public decimal MedicaidSpendDownAmountMet { get; init; }
 }

--- a/src/services/member-service/Controllers/MembersController.cs
+++ b/src/services/member-service/Controllers/MembersController.cs
@@ -232,6 +232,8 @@ public class MembersController : ControllerBase
             MaintenanceTypeCode = request.MaintenanceTypeCode,
             MaintenanceReasonCode = request.MaintenanceReasonCode,
             PlanChangeEffectiveDate = request.PlanChangeEffectiveDate,
+            MedicaidSpendDownLiabilityAmount = request.MedicaidSpendDownLiabilityAmount,
+            MedicaidSpendDownAmountMet = request.MedicaidSpendDownAmountMet,
             EmploymentStatus = request.EmploymentStatus,
             TobaccoUser = request.TobaccoUser,
             IsStudent = request.IsStudent,
@@ -842,6 +844,8 @@ public class CreateMemberRequest
     public string? MaintenanceTypeCode { get; set; }
     public string? MaintenanceReasonCode { get; set; }
     public DateTime? PlanChangeEffectiveDate { get; set; }
+    public decimal? MedicaidSpendDownLiabilityAmount { get; set; }
+    public decimal MedicaidSpendDownAmountMet { get; set; }
     public EmploymentStatus? EmploymentStatus { get; set; }
     public bool? TobaccoUser { get; set; }
     public bool? IsStudent { get; set; }

--- a/src/services/member-service/Models/Member.cs
+++ b/src/services/member-service/Models/Member.cs
@@ -190,6 +190,22 @@ public class Member
     public DateTime? PlanChangeEffectiveDate { get; set; }
 
     /// <summary>
+    /// Medicaid "medically needy" spend-down liability for the member's
+    /// current budget period: the dollar amount of incurred medical
+    /// expenses the member must accumulate before Medicaid coverage
+    /// activates for that period. Null for members not enrolled under a
+    /// spend-down eligibility category.
+    /// </summary>
+    public decimal? MedicaidSpendDownLiabilityAmount { get; set; }
+
+    /// <summary>
+    /// Cumulative amount the member has incurred toward
+    /// <see cref="MedicaidSpendDownLiabilityAmount"/> in the current budget
+    /// period. Meaningless when the liability amount is null.
+    /// </summary>
+    public decimal MedicaidSpendDownAmountMet { get; set; }
+
+    /// <summary>
     /// Employment status from 834 EMP segment
     /// </summary>
     public EmploymentStatus? EmploymentStatus { get; set; }

--- a/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
+++ b/src/tools/mcc-platform-validator/MccWorkflowValidation.cs
@@ -54,12 +54,6 @@ public static class MccWorkflowValidation
                     ? PriorAuthRequiredCode
                     : NormalizeExpectedCode(claim.ExpectedOutcome.DenialReasonCode);
 
-            if (expectedOutcome is ClaimValidationOutcome.Pended
-                && IsUnsupportedPendedEdgeCase(claim.EdgeCase.Value))
-            {
-                return ExpectedValidation.Unsupported(scenario, expectedCode);
-            }
-
             if (expectedOutcome is ClaimValidationOutcome.BusinessDenial
                 && IsUnsupportedPriorAuthValidationEdgeCase(claim.EdgeCase.Value, effectiveCapabilities))
             {
@@ -182,11 +176,6 @@ public static class MccWorkflowValidation
             { } value when value.Equals("Pended", StringComparison.OrdinalIgnoreCase) => ClaimValidationOutcome.Pended,
             _ => null
         };
-    }
-
-    private static bool IsUnsupportedPendedEdgeCase(EdgeCaseScenario scenario)
-    {
-        return scenario is EdgeCaseScenario.MedicaidSpendDown;
     }
 
     private static bool IsUnsupportedPriorAuthValidationEdgeCase(

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1515,6 +1515,8 @@ static async Task<bool> CreateMemberAsync(
         terminationDate = member.CoverageTermDate,
         maintenanceTypeCode = NullIfWhiteSpace(member.MaintenanceTypeCode) ?? "021",
         planChangeEffectiveDate = member.PlanChangeEffectiveDate,
+        medicaidSpendDownLiabilityAmount = member.MedicaidSpendDownLiabilityAmount,
+        medicaidSpendDownAmountMet = member.MedicaidSpendDownAmountMet,
         eventId = $"mcc-validator-member-created:{options.Seed}:{member.MemberId}"
     };
 

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/Stages/BenefitCalculationStageTests.cs
@@ -371,6 +371,62 @@ public class BenefitCalculationStageTests
     }
 
     [Fact]
+    public async Task Execute_MedicaidSpendDownLiabilityNotYetMet_PendsWithoutEngineCall()
+    {
+        var claim = BuildClaim(Guid.NewGuid().ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember
+            {
+                MemberId = "MEM-1",
+                IsSubscriber = true,
+                MedicaidSpendDownLiabilityAmount = 800m,
+                MedicaidSpendDownAmountMet = 300m,
+            },
+        };
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pend, result.Outcome);
+        Assert.True(result.Continue);
+        Assert.NotNull(ctx.PendDetails);
+        Assert.Equal(BenefitCalculationStage.MedicaidSpendDownPendCode, ctx.PendDetails!.PendCode);
+        await _engine.DidNotReceiveWithAnyArgs().CalculateAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task Execute_MedicaidSpendDownLiabilityMet_ContinuesToBenefitEngine()
+    {
+        var planGuid = Guid.NewGuid();
+        var claim = BuildClaim(planGuid.ToString());
+        var ctx = new ClaimAdjudicationContext
+        {
+            TenantId = "tenant-1",
+            ClaimVersionId = claim.Id,
+            Claim = claim,
+            ResolvedMember = new ResolvedMember
+            {
+                MemberId = "MEM-1",
+                IsSubscriber = true,
+                MedicaidSpendDownLiabilityAmount = 800m,
+                MedicaidSpendDownAmountMet = 800m,
+            },
+        };
+
+        _engine.CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new BenefitResolutionResult { Success = true, Totals = new ClaimTotals(), Lines = new List<LineBenefitResult>() });
+
+        var result = await _sut.ExecuteAsync(ctx, CancellationToken.None);
+
+        Assert.Equal(ClaimAdjudicationOutcome.Pass, result.Outcome);
+        Assert.Null(ctx.PendDetails);
+        await _engine.Received(1).CalculateAsync(Arg.Any<BenefitResolutionRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Execute_MedicaidInstitutionalInpatientWithoutPriorAuth_DeniesWithoutEngineCall()
     {
         var claim = BuildClaim(Guid.NewGuid().ToString());

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureIsolationTests.cs
@@ -144,17 +144,20 @@ public class MccFixtureIsolationTests
     }
 
     [Fact]
-    public void IsolateValidationMembers_LeavesUnsupportedScenariosUnchanged()
+    public void IsolateValidationMembers_IsolatesFormerlyUnsupportedSubrogationScenario()
     {
+        // SubrogationWorkersComp was unsupported (and thus skipped by isolation,
+        // since ExpectedOutcome was null) before it was converted to a real scored
+        // Pend. Now that it's scoreable, it must be isolated like any other scored
+        // edge case -- confirms the isolation pass keys off ExpectedOutcome, not a
+        // scenario allowlist that would otherwise need updating by hand.
         var generator = new EdgeCaseClaimGenerator(new InMemoryReferenceDataProvider());
         var subrogation = generator.Generate(2, nameof(EdgeCaseScenario.SubrogationWorkersComp), new Random(43));
-        var originalMemberId = subrogation.Member.MemberId;
+        var runId = Guid.Parse("906f49d1-18cc-4d19-9c77-69822ad6d88b");
 
-        MccFixtureIsolation.IsolateValidationMembers(
-            [subrogation],
-            seed: 42,
-            runId: Guid.Parse("906f49d1-18cc-4d19-9c77-69822ad6d88b"));
+        MccFixtureIsolation.IsolateValidationMembers([subrogation], seed: 42, runId);
 
-        Assert.Equal(originalMemberId, subrogation.Member.MemberId);
+        Assert.Equal("MCCV906F49D1E0000002", subrogation.Member.MemberId);
+        Assert.Equal(subrogation.Member.MemberId, subrogation.Member.SubscriberId);
     }
 }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccWorkflowValidationTests.cs
@@ -419,8 +419,12 @@ public class MccWorkflowValidationTests
     }
 
     [Fact]
-    public void ExpectedValidationFor_UnsupportedPendedEdgeCase_ReturnsUnsupported()
+    public void ExpectedValidationFor_SubrogationEdgeCase_ReturnsScoreablePendedOutcome()
     {
+        // SubrogationWorkersComp was the last remaining unsupported-pended edge case
+        // before it and its siblings were converted to real scored Pends; this
+        // replaces the old unsupported-gate regression test now that the gate itself
+        // has no members left.
         var claim = CreateClaim(
             claimType: "EdgeCase",
             benefitPlanId: "MCC-PLAN",
@@ -436,16 +440,21 @@ public class MccWorkflowValidationTests
         };
 
         var expected = MccWorkflowValidation.ExpectedValidationFor(claim);
-        var status = MccWorkflowValidation.ValidationStatus(
+        var statusWhenPended = MccWorkflowValidation.ValidationStatus(
+            expected,
+            ClaimValidationOutcome.Pended,
+            actualBusinessDenialCode: null);
+        var statusWhenDenied = MccWorkflowValidation.ValidationStatus(
             expected,
             ClaimValidationOutcome.BusinessDenial,
             actualBusinessDenialCode: "CARC_96");
 
         Assert.Equal("EdgeCase:SubrogationWorkersComp", expected.Scenario);
-        Assert.Null(expected.ExpectedOutcome);
+        Assert.Equal(ClaimValidationOutcome.Pended, expected.ExpectedOutcome);
         Assert.Equal("W1", expected.ExpectedBusinessDenialCode);
-        Assert.True(expected.IsUnsupported);
-        Assert.Equal(MccWorkflowValidation.UnsupportedStatus, status);
+        Assert.False(expected.IsUnsupported);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, statusWhenPended);
+        Assert.Equal(MccWorkflowValidation.MismatchedStatus, statusWhenDenied);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Converts `MedicaidSpendDown` — the last of five scenario families this series has carried as unsupported since Part 9 — from unsupported to a deliberately scored Pend. **Closes the full unsupported-scenario sweep.**
- Real-world meaning: under Medicaid's "medically needy" spend-down category, a member whose income exceeds the standard eligibility threshold can still qualify by incurring enough medical expense in a budget period to "spend down" to the limit. Until that liability is met, Medicaid coverage for the period isn't confirmed active, so claims should pend rather than adjudicate against a plan that may not yet apply.
- Adds `Member.MedicaidSpendDownLiabilityAmount`/`AmountMet` to member-service's real `Member` model, threaded through `CreateMemberRequest` and the member response, the same pattern as #987 and #988's member-level fields.
- claims-service's `ResolvedMember`/`HttpMemberResolver` pick them up, and a third check in `BenefitCalculationStage` — alongside the retroactive-plan-change and subrogation pends — pends (`PendCode "SPENDDOWN"`) when the member's accumulated amount hasn't yet met their spend-down liability.
- Unlike the other four families, this one genuinely needed a new benefit concept rather than a reused claim-level indicator. Modeled as a member-level eligibility fact (mirrors `PlanChangeEffectiveDate`) rather than routing through the production deductible/OOP accumulator engine, since spend-down is an eligibility gate, not a benefit calculation.
- With this converted, `MccWorkflowValidation`'s unsupported-pended-edge-case gate has no remaining members, so it's removed entirely rather than left as dead code.

## Test plan
- [x] `dotnet build` clean on member-service, claims-service, mcc-platform-validator, `CloudHealthOffice.BenchmarkClaimGenerator`
- [x] Existing test suites pass: `CloudHealthOffice.ClaimsService.Tests` (569), `CloudHealthOffice.BenchmarkClaimGenerator.Tests` (134)
- [x] 2 new `BenefitCalculationStageTests` cases (liability not yet met pends; liability met continues to the benefit engine)
- [x] Live 10,000-claim run against the local `kind` cluster: `MedicaidSpendDown` 12/12 matched (0 mismatched, 0 unsupported). **Workflow checks: 1,300/1,300 matched — first time this series has run with zero unsupported claims.** `RetroEligibilityCoverageChange` (26/26) and all three Subrogation scenarios (14/14, 13/13, 13/13) held with no regression from #987/#988. False-pend sweep found 0 unexpected pends among 1,130 non-pend claims.

## Series milestone
This closes out the unsupported-scenario sweep started with #987 (`RetroEligibilityCoverageChange`) and continued with #988 (all three `Subrogation` variants). All five families flagged unsupported since Part 9 are now deliberately scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)