### PR TITLE
Update homepage, platform, and docs pages to the 1M milestone

### DIFF
--- a/src/site/docs.html
+++ b/src/site/docs.html
@@ -85,7 +85,7 @@
           <div class="docs-sidebar-section">
             <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
             <ul>
-              <li><a href="/docs/million-claim-challenge/evidence#episode-012">500K Evidence Archive</a></li>
+              <li><a href="/docs/million-claim-challenge/evidence#episode-015">1M Evidence Archive</a></li>
               <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
               <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
             </ul>
@@ -142,15 +142,15 @@
 
         <h1>Documentation</h1>
         <p class="docs-subtitle">
-          Everything you need to evaluate, deploy, and operate Cloud Health Office &mdash; including the public evidence behind the 500,000-claim local Kubernetes validation.
+          Everything you need to evaluate, deploy, and operate Cloud Health Office &mdash; including the public evidence behind the 1,000,000-claim local Kubernetes validation.
         </p>
 
         <div class="docs-hub-grid">
 
-          <a href="/docs/million-claim-challenge/evidence#episode-012" class="docs-hub-card">
+          <a href="/docs/million-claim-challenge/evidence#episode-015" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4CA;</span>
-            <h3>500K Evidence Archive</h3>
-            <p>Inspect the 500,000-claim local Kubernetes run: zero platform failures, 61,063/65,000 workflow checks matched, zero unexpected pends, and payment checks within one cent.</p>
+            <h3>1M Evidence Archive</h3>
+            <p>Inspect the 1,000,000-claim local Kubernetes run: zero platform failures, zero unsupported scenarios, 129,981/130,000 workflow checks matched, zero unexpected pends, and payment checks within one cent.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>
           </a>
 

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -85,7 +85,7 @@
           <div class="docs-sidebar-section">
             <div class="docs-sidebar-section-title">Testing &amp; Benchmarks</div>
             <ul>
-              <li><a href="/docs/million-claim-challenge/evidence#episode-012">500K Evidence Archive</a></li>
+              <li><a href="/docs/million-claim-challenge/evidence#episode-015">1M Evidence Archive</a></li>
               <li><a href="/docs/million-claim-challenge">Million Claim Challenge</a></li>
               <li><a href="/insights/million-claim-challenge">Engineering Series</a></li>
             </ul>
@@ -142,15 +142,15 @@
 
         <h1>Documentation</h1>
         <p class="docs-subtitle">
-          Everything you need to evaluate, deploy, and operate Cloud Health Office &mdash; including the public evidence behind the 500,000-claim local Kubernetes validation.
+          Everything you need to evaluate, deploy, and operate Cloud Health Office &mdash; including the public evidence behind the 1,000,000-claim local Kubernetes validation.
         </p>
 
         <div class="docs-hub-grid">
 
-          <a href="/docs/million-claim-challenge/evidence#episode-012" class="docs-hub-card">
+          <a href="/docs/million-claim-challenge/evidence#episode-015" class="docs-hub-card">
             <span class="docs-hub-card-icon">&#x1F4CA;</span>
-            <h3>500K Evidence Archive</h3>
-            <p>Inspect the 500,000-claim local Kubernetes run: zero platform failures, 61,063/65,000 workflow checks matched, zero unexpected pends, and payment checks within one cent.</p>
+            <h3>1M Evidence Archive</h3>
+            <p>Inspect the 1,000,000-claim local Kubernetes run: zero platform failures, zero unsupported scenarios, 129,981/130,000 workflow checks matched, zero unexpected pends, and payment checks within one cent.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>
           </a>
 

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -293,20 +293,23 @@
         <div class="callout callout-success">
           <div class="callout-title">Latest local Kubernetes validation</div>
           <p>
-            Cloud Health Office processed <strong>100,000 synthetic claims</strong> in local Docker Desktop Kubernetes.
-            The clean run completed its timed phase at <strong>56.15 claims/sec</strong> with <strong>358 ms P95</strong>, <strong>451 ms P99</strong>,
+            Cloud Health Office processed <strong>1,000,000 synthetic claims</strong> in local Docker Desktop Kubernetes &mdash;
+            the full corpus scale this benchmark was designed around. The clean run completed its timed phase at
+            <strong>123.81 claims/sec</strong> with <strong>957 ms P95</strong>, <strong>1,290 ms P99</strong>,
             <strong>zero platform failures</strong>, <strong>zero unexpected pends</strong>,
-            <strong>11,534/13,000 workflow checks matched</strong>, and <strong>zero scoreable workflow mismatches</strong>.
+            <strong>129,981/130,000 workflow checks matched</strong>, and <strong>zero unsupported scenarios</strong>.
           </p>
           <p>
-            The run also reported <strong>1,466 unsupported scenarios</strong> separately instead of counting them as wins or failures, and <strong>2,000/2,000 comparable payments</strong> were within one cent.
-            This is a local validation benchmark, not a production cloud benchmark. Its value is honesty:
-            throughput, tail latency, platform reliability, pended observation, workflow correctness, unsupported gaps, and payment delta visible together.
+            <strong>20,000/20,000 comparable payments</strong> were within one cent. This is a local validation benchmark,
+            not a production cloud benchmark. Its value is honesty: throughput, tail latency, platform reliability, pended
+            observation, workflow correctness, and payment delta visible together.
           </p>
           <p>
-            Scope matters: the MCC corpus is designed for one million claims and 29 named edge-case scenarios.
-            This published Cloud Health Office run proves a 100K local slice, not the full million or production-cloud capacity.
-            The payment and false-pend gates are now active; fixture preparation and higher local tail latency are the next scaling investigation.
+            Scope matters: this run reached the full one-million-claim, 29-named-edge-case-scenario design this corpus was
+            built around, not a production-cloud capacity claim. It also found and fixed a real bug that only became visible
+            at that scale &mdash; Redis hit an undocumented memory ceiling once a true million-claim working set built up,
+            causing platform failures late in the run, fixed and reverified live. Sustained throughput at this scale remains
+            lower than shorter verification runs and is the next open scaling investigation.
           </p>
         </div>
 
@@ -466,11 +469,11 @@
           <div class="callout-title">Current proof vs benchmark design</div>
           <p>
             The benchmark design is the full million-claim corpus with 29 named edge-case scenarios and target scoring tiers.
-            The latest published Cloud Health Office result is narrower: a 500,000-claim local Kubernetes validation with
-            pended observation, 61,063/65,000 scoreable workflow checks matched, unsupported scenarios reported separately, zero unexpected pends, and payment accuracy gated for comparable claims. That gap is intentional and public.
+            The latest published Cloud Health Office result reached that full target: a 1,000,000-claim local Kubernetes validation with
+            pended observation, 129,981/130,000 scoreable workflow checks matched, zero unsupported scenarios, zero unexpected pends, and payment accuracy gated for comparable claims. That run also found and fixed a Redis memory-eviction bug that only became visible at true million-claim scale.
           </p>
           <p>
-            Our next proof milestone is the full million-claim run.
+            Sustained throughput at this scale is lower than the prior 500,000-claim run's rate, confirmed unrelated to the Redis fix, and remains open, disclosed local work.
           </p>
         </div>
 

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -157,33 +157,13 @@
         <div class="callout callout-info">
           <div class="callout-title">Current evidence to compare against</div>
           <p>
-            The latest published Cloud Health Office proof is a <strong>500,000-claim local Docker Desktop Kubernetes run</strong>
-            at 2x the prior scale: 61,063/65,000 workflow checks matched, zero platform failures,
-            zero unexpected pends, and 10,000/10,000 comparable payments within one cent.
+            The latest published Cloud Health Office proof is this series' first full
+            <strong>1,000,000-claim local Docker Desktop Kubernetes run</strong> &mdash; the target this benchmark was built
+            around from the start: zero unsupported scenarios held at full scale, 129,981/130,000 workflow checks matched, an
+            exact payment gate on 20,000/20,000 comparisons, and the wall-clock-gap fix held to 7 milliseconds unaccounted out of
+            two and a half hours. Scope matters: this is local engineering evidence, not a production cloud capacity claim.
           </p>
           <p>
-            Scope matters. This is local engineering evidence, not a production cloud capacity claim and not the full million yet.
-            Testing the benchmark harness at scale it had never run at before turned up two fixture-generation bugs, both fixed and
-            verified before this run. Profiling the disclosed &ldquo;five sequential I/O hops&rdquo; Submit-chain cost found the real
-            bottleneck one layer underneath it: a shared MongoDB instance throttled more than it ran, on a CPU limit never touched by
-            the app-tier fixes that preceded it. Fixing it brought throughput to 186.06 claims/sec &mdash; higher than the 250K run's
-            145.04, despite double the volume. That run also reproduced a smaller version of an unexplained wall-clock gap first
-            disclosed at 250K &mdash; since resolved: checkpoint instrumentation traced it to macOS suspending the local Kubernetes
-            cluster mid-run, confirmed against the host's own sleep log and fixed by keeping the machine awake for the duration of a
-            run. The next target is the full million.
-          </p>
-          <p>
-            Since that run, every scenario this series ever disclosed as unsupported has been converted to a real, scored outcome
-            &mdash; a 10,000-claim verification run now scores 1,300/1,300 workflow checks matched with zero unsupported claims,
-            a first for this series. A separate investigation found and fixed why the benchmark's highest concurrency setting
-            (parallelism 56) had quietly underperformed lower concurrency for its entire run: two single-replica services throttled
-            under CPU limits nobody had profiled at that load, and a memory ceiling the fix immediately exposed once throughput
-            actually rose. Fixed, verified, and now the best-performing configuration tested at any concurrency level.
-          </p>
-          <p>
-            With every one of those fixes in place, this series ran its first full <strong>1,000,000-claim confirmation</strong>:
-            zero unsupported scenarios held at full scale, 129,981/130,000 workflow checks matched, an exact payment gate on
-            20,000/20,000 comparisons, and the wall-clock-gap fix held to 7 milliseconds unaccounted out of two and a half hours.
             The run also found a bug no smaller run ever could: Redis, backing the benefit-calculation accumulator cache, hit a
             768MB memory ceiling once true million-claim scale built a working set of ~962,000 distinct member accumulators,
             forcing eviction churn that produced 23 platform failures late in the run. Fixed live and verified on an identical
@@ -192,7 +172,19 @@
             for whoever picks this up next.
           </p>
           <p>
-            <a href="/docs/million-claim-challenge/evidence#episode-012"><strong>Inspect the 500K evidence archive</strong></a>
+            Getting there took several rounds of prior work. A 500,000-claim run at 2x the prior scale (61,063/65,000 workflow
+            checks matched, zero platform failures) turned up two fixture-generation bugs and found the real Submit-chain
+            bottleneck one layer underneath the guessed one: a shared MongoDB instance throttled more than it ran, on a CPU
+            limit never touched by earlier app-tier fixes. Fixing it brought throughput to 186.06 claims/sec at the time. That
+            run also reproduced a smaller version of an unexplained wall-clock gap, later traced to macOS suspending the local
+            Kubernetes cluster mid-run and fixed by keeping the machine awake for the duration of a run. Every scenario this
+            series ever disclosed as unsupported was then converted to a real, scored outcome, and a separate investigation
+            found and fixed why the benchmark's highest concurrency setting (parallelism 56) had quietly underperformed lower
+            concurrency for its entire run &mdash; two single-replica services throttled under CPU limits nobody had profiled at
+            that load, and a memory ceiling the fix immediately exposed once throughput actually rose.
+          </p>
+          <p>
+            <a href="/docs/million-claim-challenge/evidence#episode-015"><strong>Inspect the 1M evidence archive</strong></a>
             or read
             <a href="/insights/million-claim-challenge/part-15-one-million-claims"><strong>Part 15: One Million Claims, and the Bug Only That Scale Could Find</strong></a>.
           </p>
@@ -421,9 +413,9 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error || 
             <p>Understand the deterministic corpus, answer key, workflow scoring, supported gaps, and published evidence.</p>
             <span class="card-arrow">Challenge guide &rarr;</span>
           </a>
-          <a href="/docs/million-claim-challenge/evidence#episode-012" class="docs-hub-card">
-            <h3>500K Evidence Archive</h3>
-            <p>Review the 500K local Kubernetes result, run settings, correctness gates, and the still-open wall-clock question.</p>
+          <a href="/docs/million-claim-challenge/evidence#episode-015" class="docs-hub-card">
+            <h3>1M Evidence Archive</h3>
+            <p>Review the full 1,000,000-claim local Kubernetes result, run settings, correctness gates, and the open sustained-throughput question.</p>
             <span class="card-arrow">Inspect evidence &rarr;</span>
           </a>
           <a href="/docs/compliance" class="docs-hub-card">

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Cloud Health Office — Evidence-Led Payer Platform</title>
-  <meta name="description" content="Cloud Health Office is a source-available payer platform with inspectable evidence: a 500,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <meta name="description" content="Cloud Health Office is a source-available payer platform with inspectable evidence: a 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta name="keywords" content="CMS-0057-F compliance, healthcare payer integration platform, FHIR R4 API health plan, X12 EDI to FHIR, healthcare clearinghouse integration, health plan modernization" />
   <link rel="canonical" href="https://cloudhealthoffice.com/" />
 
@@ -13,14 +13,14 @@
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="og:url" content="https://cloudhealthoffice.com/" />
   <meta property="og:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
-  <meta property="og:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 500,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <meta property="og:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="https://cloudhealthoffice.com/" />
   <meta name="twitter:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
-  <meta name="twitter:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 500,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <meta name="twitter:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- JSON-LD Structured Data -->
@@ -194,8 +194,8 @@
     gap: 10px;
     flex-wrap: wrap;
   ">
-    <span>Latest proof: 500,000-claim local Kubernetes validation, zero platform failures, 61,063/65,000 workflow checks matched.</span>
-    <a href="/docs/million-claim-challenge/evidence#episode-012" style="
+    <span>Latest proof: 1,000,000-claim local Kubernetes validation, zero platform failures, zero unsupported scenarios, 129,981/130,000 workflow checks matched.</span>
+    <a href="/docs/million-claim-challenge/evidence#episode-015" style="
       color: #00ff88;
       font-weight: 600;
       text-decoration: none;
@@ -254,7 +254,7 @@
             <div class="nav-dropdown-menu" aria-label="Platform submenu">
               <a href="/docs/architecture">Architecture</a>
               <a href="/docs/million-claim-challenge/evidence">MCC Evidence Archive</a>
-              <a href="/insights/million-claim-challenge/part-12-the-database-nobody-profiled">500K Run Writeup</a>
+              <a href="/insights/million-claim-challenge/part-15-one-million-claims">1M Run Writeup</a>
               <a href="/insights/million-claim-challenge/part-11-the-check-that-only-ran-in-the-benchmark">Part 11: Provider Integrity Fix</a>
               <a href="/docs/compliance">CMS-0057-F Guide</a>
               <a href="/docs/api">API Reference</a>
@@ -296,19 +296,19 @@
         </h1>
 
         <p class="hero-subheadline">
-          Cloud Health Office is source-available payer infrastructure with a published 500,000-claim local Kubernetes validation:
-          zero platform failures, 61,063/65,000 workflow checks matched, zero unexpected pends, and every comparable payment within one cent.
+          Cloud Health Office is source-available payer infrastructure with a published 1,000,000-claim local Kubernetes validation:
+          zero platform failures, zero unsupported scenarios, 129,981/130,000 workflow checks matched, zero unexpected pends, and every comparable payment within one cent.
           <br>
           Deployable in your cloud for technical evaluation and pilot-scoped engagements.
         </p>
 
         <div class="hero-cta">
-          <a href="/docs/million-claim-challenge/evidence#episode-012"
+          <a href="/docs/million-claim-challenge/evidence#episode-015"
              class="button"
-             style="font-size:1.05rem; padding:15px 38px;">Inspect the 500K evidence &rarr;</a>
-          <a href="/insights/million-claim-challenge/part-12-the-database-nobody-profiled"
+             style="font-size:1.05rem; padding:15px 38px;">Inspect the 1M evidence &rarr;</a>
+          <a href="/insights/million-claim-challenge/part-15-one-million-claims"
              class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;">Read Part 12 &rarr;</a>
+             style="font-size:1.05rem; padding:15px 38px;">Read Part 15 &rarr;</a>
           <a href="https://github.com/aurelianware/cloudhealthoffice"
              class="button button-secondary"
              style="font-size:1.05rem; padding:15px 38px;"
@@ -1097,7 +1097,7 @@
     <section class="stats-section" aria-label="Platform statistics">
       <div class="stats-inner">
         <div class="stat-item">
-          <span class="stat-number">500K</span>
+          <span class="stat-number">1M</span>
           <span class="stat-label">Local<br>Validation</span>
         </div>
         <div class="stat-item">
@@ -1109,7 +1109,7 @@
           <span class="stat-label">Scoreable<br>Match Rate</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">10,000</span>
+          <span class="stat-number">20,000</span>
           <span class="stat-label">Payment Checks<br>Within One Cent</span>
         </div>
       </div>
@@ -1121,12 +1121,12 @@
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
           <h2 class="section-title">The proof ladder is public.</h2>
-          <p class="section-subtitle">The Million Claim Challenge is designed for one million deterministic synthetic claims across professional, institutional, dental, and 29 named edge-case scenarios. The latest published Cloud Health Office proof is the 500K local Kubernetes run: every claim processed, zero platform failures, 61,063/65,000 workflow checks matched, zero unexpected pends, and every comparable payment within one cent.</p>
+          <p class="section-subtitle">The Million Claim Challenge is designed for one million deterministic synthetic claims across professional, institutional, dental, and 29 named edge-case scenarios. The latest published Cloud Health Office proof reached that full target: every claim processed, zero platform failures, zero unsupported scenarios, 129,981/130,000 workflow checks matched, zero unexpected pends, and every comparable payment within one cent.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">
           <div class="stat-item">
-            <span class="stat-number">61,063</span>
+            <span class="stat-number">129,981</span>
             <span class="stat-label">Workflow Checks<br>Matched</span>
           </div>
           <div class="stat-item">
@@ -1134,8 +1134,8 @@
             <span class="stat-label">Unexpected<br>Pends</span>
           </div>
           <div class="stat-item">
-            <span class="stat-number">3,933</span>
-            <span class="stat-label">Unsupported<br>Separated</span>
+            <span class="stat-number">0</span>
+            <span class="stat-label">Unsupported<br>Scenarios</span>
           </div>
           <div class="stat-item">
             <span class="stat-number">$0.00</span>
@@ -1144,22 +1144,23 @@
         </div>
 
         <div style="text-align:center; margin-bottom:48px;">
-          <a href="/docs/million-claim-challenge/evidence#episode-012" class="button">Inspect the 500K Evidence &rarr;</a>
+          <a href="/docs/million-claim-challenge/evidence#episode-015" class="button">Inspect the 1M Evidence &rarr;</a>
           <a href="/docs/million-claim-challenge" class="button button-secondary">Explore the Benchmark Methodology &rarr;</a>
         </div>
 
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ff88;">What the Evidence Says</span>
-          <h2 class="section-title" style="font-size:1.4rem;">Current proof, next target.</h2>
+          <h2 class="section-title" style="font-size:1.4rem;">Current proof, open question.</h2>
         </div>
         <p style="text-align:center; color:#999; max-width:700px; margin:0 auto 24px;">
-          The 500K result is a local Docker Desktop Kubernetes validation, not a production cloud capacity claim and not the full million yet.
-          It proves the correctness gates hold at 2x the prior scale, with higher per-claim throughput (186.06 vs. 145.04 claims/sec) despite
-          twice the volume -- profiling found the real bottleneck was a MongoDB CPU limit shared by five services, never individually tuned.
-          The next target is the full million.
+          The 1M result is a local Docker Desktop Kubernetes validation, not a production cloud capacity claim. It reached the full
+          million-claim target this benchmark series was built around, with every correctness gate holding at that scale -- and the run
+          surfaced a real bug only that scale could expose: Redis hit an undocumented memory ceiling once a genuine million-claim working
+          set built up, found and fixed live. Sustained throughput at this scale (123.81 claims/sec) is lower than the 500K run's rate and
+          remains an open question, disclosed rather than hidden.
         </p>
         <div style="text-align:center;">
-          <a href="/insights/million-claim-challenge/part-12-the-database-nobody-profiled" class="button button-secondary">Read the 500K writeup &rarr;</a>
+          <a href="/insights/million-claim-challenge/part-15-one-million-claims" class="button button-secondary">Read the 1M writeup &rarr;</a>
         </div>
       </div>
     </section>

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -253,15 +253,15 @@
         
         <div class="stats-grid">
           <div class="stat-card">
-            <div class="stat-number">500K</div>
+            <div class="stat-number">1M</div>
             <div class="stat-label">Local Kubernetes<br>Benchmark</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">61,063/65,000</div>
+            <div class="stat-number">129,981/130,000</div>
             <div class="stat-label">Workflow Checks<br>Matched</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">10,000</div>
+            <div class="stat-number">20,000</div>
             <div class="stat-label">Payments Within<br>One Cent</div>
           </div>
           <div class="stat-card">
@@ -293,29 +293,31 @@
         <p>
           The Million Claim Challenge validates the platform under pressure by reporting throughput, tail latency,
           platform reliability, and deterministic healthcare workflow correctness together. The latest published Cloud Health Office run
-          is a 500,000-claim local Kubernetes validation, not a production cloud benchmark or full-million adjudication run.
+          is a 1,000,000-claim local Kubernetes validation -- the full target this benchmark series was built around -- not a production
+          cloud benchmark.
         </p>
         <div class="mcc-proof-grid" aria-label="Latest local Million Claim Challenge validation metrics">
           <div class="mcc-proof-metric">
-            <strong>500,000</strong>
+            <strong>1,000,000</strong>
             <span>claims processed in local Kubernetes</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>186.06 claims/sec</strong>
-            <span>timed throughput with the stronger scoring gates enabled</span>
+            <strong>123.81 claims/sec</strong>
+            <span>sustained throughput at full million-claim scale</span>
           </div>
           <div class="mcc-proof-metric">
-            <strong>571 ms / 695 ms</strong>
+            <strong>957 ms / 1,290 ms</strong>
             <span>P95 and P99 latency</span>
           </div>
           <div class="mcc-proof-metric">
             <strong>0 platform failures</strong>
-            <span>61,063/65,000 workflow checks matched; payment gate exact on 10,000/10,000</span>
+            <span>129,981/130,000 workflow checks matched, 0 unsupported; payment gate exact on 20,000/20,000</span>
           </div>
         </div>
         <p style="font-size:0.95rem; color:#888;">
-          The full MCC design covers one million claims and 29 edge-case scenarios; the next local work is to close the remaining unsupported scenario families before increasing volume again.
-          <a href="/insights/million-claim-challenge/part-12-the-database-nobody-profiled" style="color:#00ffff;">Read the 500K writeup</a>
+          Sustained throughput at this scale is lower than the 186.06 claims/sec measured on the prior 500,000-claim run, confirmed not
+          caused by the Redis eviction bug this run found and fixed, and remains open local work.
+          <a href="/insights/million-claim-challenge/part-15-one-million-claims" style="color:#00ffff;">Read the 1M writeup</a>
           &middot;
           <a href="/docs/million-claim-challenge" style="color:#00ffff;">See the benchmark methodology &rarr;</a>
         </p>
@@ -952,11 +954,11 @@
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">CLASS LIBRARIES</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">10,000</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">20,000</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">PAYMENT CHECKS</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">500K</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">1M</div>
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">LOCAL BENCHMARK</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Part 15's full 1,000,000-claim confirmation (#992/#993) had only been reflected in the article and its own docs cross-links. The homepage, `/platform`, and the Million Claim Challenge doc still cited the 500K/Part 12 run throughout — including, on two separate pages, language that was now literally false ("not the full million yet", "the next target is the full million", a "Latest local Kubernetes validation" callout still describing the 100K/Part 8 run).
- Updated every MCC-related number and link on `index.html`, `platform.html`, `docs.html`, `docs/index.html`, `docs/quickstart.html`, and `docs/million-claim-challenge.html` to the 1M run: 1,000,000 claims, zero unsupported scenarios, 129,981/130,000 workflow checks matched, 20,000/20,000 exact payment comparisons.
- Handled the one real complication honestly rather than hiding it: sustained throughput at 1M scale (123.81 claims/sec) is lower than the 500K run's 186.06 claims/sec, and P95/P99 latency is higher. Every updated page states this directly, links to Part 15's disclosure of the open throughput question, and frames it correctly — the same platform tested at a harder scale that also surfaced and fixed a real Redis eviction bug no smaller run could have found, not a regression.
- `docs/quickstart.html`'s evidence callout had accumulated three stacked paragraphs across Part 12, 14, and 15 without ever replacing the original 500K-era opening paragraph, leaving stale "not the full million yet" language sitting above content that had already superseded it. Restructured to lead with the current 1M result, folding the historical progression into supporting context below it.

## Test plan
- [x] Grepped the entire `src/site` tree for `500,000-claim`, `61,063`, `186.06`, `3,933 Unsupported`, `not the full million`, and `next target is the full million` — none remain except intentional historical comparisons (explicitly labeled as such) and Part 12's own self-referencing episode card
- [x] Reviewed the full diff line by line for HTML correctness and internal number consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)