### PR TITLE
Fix undersized MongoDB WiredTiger cache throttling sustained throughput

### DIFF
--- a/infrastructure/k8s/mongodb-deployment.yaml
+++ b/infrastructure/k8s/mongodb-deployment.yaml
@@ -19,15 +19,18 @@ spec:
       containers:
       - name: mongodb
         image: mongo:6.0
+        args:
+          - --wiredTigerCacheSizeGB
+          - "3.5"
         ports:
         - containerPort: 27017
         resources:
           requests:
             cpu: "1000m"
-            memory: "512Mi"
+            memory: "2Gi"
           limits:
             cpu: "4000m"
-            memory: "1Gi"
+            memory: "8Gi"
         env:
         - name: MONGO_INITDB_ROOT_USERNAME
           valueFrom:


### PR DESCRIPTION
## Summary
- MongoDB's WiredTiger cache auto-sizes to `max(256MB, (memLimit-1GB)/2)`. The 1Gi memory limit set in Part 12 (raised for CPU headroom only) floored the cache at the 256MB minimum against a ~48GB working set in the `cloudhealthoffice` database.
- Profiling during the 1M-claim runs showed 128.9M forced application-thread page reads from disk to cache, totaling 8.36 cumulative hours — the same eviction-thrash signature already confirmed and fixed for Redis in Part 15.
- Raises `resources.requests.memory` 512Mi→2Gi and `resources.limits.memory` 1Gi→8Gi, and pins the cache explicitly via `--wiredTigerCacheSizeGB 3.5` so it no longer silently depends on the auto-sizing formula.

## Verification
A clean 500K-claim run (`mcc-mongo-cache-fix-verify-v2`, seed 20260801, zero wall-clock gap — `Unaccounted: 0:00.054`) measured:

| | Throughput | P95 | P99 |
|---|---|---|---|
| 1M baseline (pre-Redis-fix) | 107.91 claims/sec | 1008ms | 1302ms |
| 1M baseline (post-Redis-fix, pre-Mongo-fix) | 123.81 claims/sec | 957ms | 1290ms |
| **This fix (500K, post-Mongo-fix)** | **184.43 claims/sec** | **600ms** | **809ms** |

A 49% throughput gain and ~37% latency reduction versus the most recent baseline. Post-run WiredTiger cache sat at 3.00GB/3.76GB (79%) instead of pinned at the 256MB ceiling — 5.6M application-thread forced page reads for this run, vs. the pre-fix cumulative 128.9M.

Workflow checks matched 64,992/65,000 (8 scattered mismatches across unrelated edge-case scenarios, 0 unsupported, 0 observation timeouts) — consistent with pre-existing minor mismatch noise seen at this scale, unrelated to this change.

## Test plan
- [x] Applied live to the `kind-docker-desktop` cluster, confirmed `wt_cache_max_gb` = 3.50 via `mongosh`
- [x] Ran a clean 500K-claim MCC verification job end-to-end with zero wall-clock gap
- [x] Confirmed throughput/latency improvement and reduced forced page reads vs. baselines
- [ ] Follow-up flagship-scale (1M) confirmation run once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)