### PR TITLE
Scale claims-service to relieve CPU throttling under sustained MCC load

### DIFF
--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -23,7 +23,7 @@ metadata:
     app: claims-service
     tier: backend
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: claims-service
@@ -99,10 +99,10 @@ spec:
               key: connectionString
         resources:
           requests:
-            cpu: 500m
+            cpu: 1000m
             memory: 256Mi
           limits:
-            cpu: 2000m
+            cpu: 4000m
             memory: 2048Mi
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- With the MongoDB WiredTiger cache fix (#1000) merged, live cgroup `cpu.stat` profiling during a 150K/300K-claim sustained run identified claims-service — not Mongo or Redis — as the new binding constraint: 1 replica, 2000m CPU limit, throttled ~15% of periods while every other adjudication-path service sat idle.
- The node has plenty of headroom (18 vCPU capacity, ~60% requested namespace-wide), so this was a self-imposed ceiling, not a resource-scarcity problem.
- Raises claims-service from 1 replica (500m/2000m) to 3 replicas (1000m/4000m each) — 12 vCPU aggregate limit instead of 2.

## Verification
A clean 300K-claim run (`mcc-profile-sustained-gap2`, seed 20260803, zero wall-clock gap) measured:

| | Throughput | P95 | P99 |
|---|---|---|---|
| 150K pre-fix baseline (same scale) | 129.37 claims/sec | 663ms | 790ms |
| 500K post-Mongo-fix baseline | 184.43 claims/sec | 600ms | 809ms |
| **300K post-claims-service-fix** | **319.79 claims/sec** | **296ms** | **371ms** |

Nearly tripled the pre-fix throughput and lands close to the 363 claims/sec 20K short-burst reference. Post-fix cgroup samples show 2 of 3 replicas at zero throttling for the entire run; the third saw late-run throttling consistent with HTTP keep-alive connection affinity concentrating load on one pod, not a capacity shortfall.

**Follow-up flagged, not yet a blocker**: MongoDB itself began showing modest throttling (~9% of periods) once claims-service stopped being the bottleneck — will keep an eye on it at larger scale.

## Test plan
- [x] Applied live to the `kind-docker-desktop` cluster via `kubectl patch`, confirmed 3/3 replicas healthy
- [x] Ran a clean 300K-claim MCC profiling job end-to-end with zero wall-clock gap
- [x] Compared cgroup `cpu.stat` throttling counters before/after across claims-service, mongodb, and redis
- [ ] Follow-up flagship-scale (1M) confirmation run once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)