### PR TITLE
Add inbound X12 834 EDI parser to enrollment-import-service

### DIFF
--- a/src/services/enrollment-import-service/Controllers/EnrollmentController.cs
+++ b/src/services/enrollment-import-service/Controllers/EnrollmentController.cs
@@ -1,5 +1,6 @@
 using EnrollmentImportService.Models;
 using EnrollmentImportService.Services;
+using EnrollmentImportService.Services.Edi;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EnrollmentImportService.Controllers;
@@ -9,14 +10,19 @@ namespace EnrollmentImportService.Controllers;
 public class EnrollmentController : ControllerBase
 {
     private readonly IEnrollmentImportService _importService;
+    private readonly IEnrollment834EdiParser _ediParser;
     private readonly ILogger<EnrollmentController> _logger;
-    
-    public EnrollmentController(IEnrollmentImportService importService, ILogger<EnrollmentController> logger)
+
+    public EnrollmentController(
+        IEnrollmentImportService importService,
+        IEnrollment834EdiParser ediParser,
+        ILogger<EnrollmentController> logger)
     {
         _importService = importService;
+        _ediParser = ediParser;
         _logger = logger;
     }
-    
+
     [HttpPost("import")]
     public async Task<ActionResult<ImportResult>> ImportEnrollment(
         [FromBody] Enrollment834 enrollment,
@@ -26,15 +32,62 @@ public class EnrollmentController : ControllerBase
         {
             return BadRequest("X-Tenant-ID header is required");
         }
-        
+
         _logger.LogInformation("Importing 834 file {FileName} for tenant {TenantId} with {Count} enrollments",
             SanitizeForLog(enrollment.FileName), SanitizeForLog(tenantId), enrollment.TransactionCount);
-        
+
         var result = await _importService.ImportEnrollmentAsync(enrollment, tenantId);
-        
+
         return Ok(result);
     }
-    
+
+    /// <summary>
+    /// Accepts a raw X12 834 EDI file, parses it, and imports it — the
+    /// on-ramp for evaluators dropping in their own enrollment file rather
+    /// than calling /import with an already-structured payload.
+    /// </summary>
+    [HttpPost("import/raw834")]
+    [RequestSizeLimit(20_000_000)]
+    public async Task<ActionResult<ImportResult>> ImportRaw834(
+        [FromForm] IFormFile file,
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            return BadRequest("X-Tenant-ID header is required");
+        }
+
+        if (file is null || file.Length == 0)
+        {
+            return BadRequest("A non-empty 834 file is required.");
+        }
+
+        string ediContent;
+        using (var reader = new StreamReader(file.OpenReadStream()))
+        {
+            ediContent = await reader.ReadToEndAsync();
+        }
+
+        Enrollment834 enrollment;
+        try
+        {
+            enrollment = _ediParser.Parse(ediContent, file.FileName);
+        }
+        catch (X12FormatException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse uploaded 834 file {FileName} for tenant {TenantId}",
+                SanitizeForLog(file.FileName), SanitizeForLog(tenantId));
+            return BadRequest($"Could not parse 834 file: {ex.Message}");
+        }
+
+        _logger.LogInformation("Parsed uploaded 834 file {FileName} for tenant {TenantId} with {Count} enrollments",
+            SanitizeForLog(enrollment.FileName), SanitizeForLog(tenantId), enrollment.TransactionCount);
+
+        var result = await _importService.ImportEnrollmentAsync(enrollment, tenantId);
+
+        return Ok(result);
+    }
+
     [HttpGet("health")]
     public IActionResult Health()
     {

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/Edi/Enrollment834EdiParserTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/Edi/Enrollment834EdiParserTests.cs
@@ -1,0 +1,172 @@
+using EnrollmentImportService.Services.Edi;
+
+namespace EnrollmentImportService.Tests.Services.Edi;
+
+public class Enrollment834EdiParserTests
+{
+    // Same content as docs/testing/test-x12-834-enrollment-sample.edi:
+    // 3 subscribers, two of whom have nested LS/LE dependent loops.
+    private const string SampleEdi = """
+        ISA*00*          *00*          *ZZ*SPONSOR123     *ZZ*PAYER456       *260206*1200*^*00501*000000001*0*P*:~
+        GS*BE*SPONSOR123*PAYER456*20260206*1200*1*X*005010X220A1~
+        ST*834*0001*005010X220A1~
+        BGN*00*ABC123456*20260206*120000*ET***2~
+        REF*38*1234567890~
+        DTP*007*D8*20260201~
+        N1*P5*Acme Corporation*FI*123456789~
+        N1*IN*Blue Shield of California*FI*987654321~
+        INS*Y*18*025*20*A***FT~
+        REF*0F*BSCA123456789~
+        REF*1L*GRP0001~
+        REF*ZZ*EMP001234~
+        DTP*303*D8*20260201~
+        NM1*IL*1*SMITH*JOHN*A***34*123456789~
+        N3*123 MAIN STREET~
+        N4*SAN FRANCISCO*CA*94102~
+        DMG*D8*19850315*M~
+        HD*025**HLT*Blue Shield PPO*EMP~
+        HD*025**DEN*Dental Basic*EMP~
+        HD*025**VIS*Vision Standard*EMP~
+        LS*2700~
+        NM1*70*1*SMITH*JANE*M***34*234567890~
+        DMG*D8*19870520*F~
+        HD*025**HLT*Blue Shield PPO~
+        LE*2700~
+        LS*2700~
+        NM1*70*1*SMITH*MICHAEL*J***34*345678901~
+        N3*123 MAIN STREET~
+        N4*SAN FRANCISCO*CA*94102~
+        DMG*D8*20150610*M~
+        HD*025**HLT*Blue Shield PPO~
+        LE*2700~
+        INS*Y*18*025*20*A***FT~
+        REF*0F*BSCA987654321~
+        REF*1L*GRP0001~
+        REF*ZZ*EMP005678~
+        DTP*303*D8*20260201~
+        NM1*IL*1*JOHNSON*SARAH*L***34*234567890~
+        N3*456 OAK AVENUE*APT 2B~
+        N4*LOS ANGELES*CA*90012~
+        DMG*D8*19920408*F~
+        HD*025**HLT*Blue Shield HMO*ESP~
+        LS*2700~
+        NM1*70*1*JOHNSON*ROBERT*K***34*345678901~
+        DMG*D8*19900115*M~
+        HD*025**HLT*Blue Shield HMO~
+        LE*2700~
+        INS*Y*18*001*25*T***FT~
+        REF*0F*BSCA555666777~
+        DTP*303*D8*20250115~
+        DTP*356*D8*20260131~
+        NM1*IL*1*WILLIAMS*ROBERT*T***34*456789012~
+        N3*789 ELM STREET~
+        N4*SAN DIEGO*CA*92101~
+        DMG*D8*19780922*M~
+        SE*49*0001~
+        GE*1*1~
+        IEA*1*000000001~
+        """;
+
+    private static Enrollment834EdiParser MakeParser() => new();
+
+    [Fact]
+    public void Parse_FindsAllThreeSubscribers()
+    {
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        result.Enrollments.Should().HaveCount(3);
+        result.TransactionCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void Parse_SubscriberDemographics_AreNotOverwrittenByNestedDependentLoop()
+    {
+        // This is the exact bug the Indice.Edi spike surfaced: a naive
+        // scalar binding on the subscriber's NM1/DMG gets silently
+        // overwritten by the LAST NM1/DMG seen, including ones inside the
+        // nested LS/LE dependent loop. The subscriber must keep his own
+        // name and DOB, not his younger dependent's.
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        var smith = result.Enrollments[0];
+        smith.Demographics!.LastName.Should().Be("SMITH");
+        smith.Demographics.FirstName.Should().Be("JOHN");
+        smith.Demographics.DateOfBirth.Should().Be("19850315");
+        smith.Demographics.Gender.Should().Be("M");
+    }
+
+    [Fact]
+    public void Parse_NestedDependents_AreAttributedToTheCorrectSubscriber()
+    {
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        var smith = result.Enrollments[0];
+        smith.Dependents.Should().HaveCount(2);
+
+        smith.Dependents[0].LastName.Should().Be("SMITH");
+        smith.Dependents[0].FirstName.Should().Be("JANE");
+        smith.Dependents[0].DateOfBirth.Should().Be("19870520");
+        smith.Dependents[0].Gender.Should().Be("F");
+
+        smith.Dependents[1].LastName.Should().Be("SMITH");
+        smith.Dependents[1].FirstName.Should().Be("MICHAEL");
+        smith.Dependents[1].DateOfBirth.Should().Be("20150610");
+
+        var johnson = result.Enrollments[1];
+        johnson.Demographics!.LastName.Should().Be("JOHNSON");
+        johnson.Demographics.FirstName.Should().Be("SARAH");
+        johnson.Dependents.Should().ContainSingle();
+        johnson.Dependents[0].FirstName.Should().Be("ROBERT");
+        johnson.Dependents[0].LastName.Should().Be("JOHNSON");
+
+        var williams = result.Enrollments[2];
+        williams.Demographics!.LastName.Should().Be("WILLIAMS");
+        williams.Dependents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_CoverageLines_AreScopedToTheRightPerson_NotFlattenedAcrossTheWholeFamily()
+    {
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        var smith = result.Enrollments[0];
+        smith.Coverage.Should().HaveCount(3); // subscriber: HLT, DEN, VIS
+        smith.Coverage.Select(c => c.InsuranceLineCode).Should().BeEquivalentTo(["HLT", "DEN", "VIS"]);
+
+        smith.Dependents[0].Coverage.Should().ContainSingle(c => c.InsuranceLineCode == "HLT");
+        smith.Dependents[1].Coverage.Should().ContainSingle(c => c.InsuranceLineCode == "HLT");
+    }
+
+    [Fact]
+    public void Parse_ReferenceAndDateFields_MapToTheOwningSubscriber()
+    {
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        var smith = result.Enrollments[0];
+        smith.SubscriberId.Should().Be("BSCA123456789");
+        smith.GroupNumber.Should().Be("GRP0001");
+        smith.EmployeeId.Should().Be("EMP001234");
+        smith.EnrollmentDate.Should().Be("20260201");
+
+        var williams = result.Enrollments[2];
+        williams.BenefitStatus.Should().Be("T");
+        williams.EnrollmentDate.Should().Be("20250115");
+        williams.TerminationDate.Should().Be("20260131");
+    }
+
+    [Fact]
+    public void Parse_SponsorFromHeaderLoop_IsAppliedToEveryMember()
+    {
+        var result = MakeParser().Parse(SampleEdi, "sample.edi");
+
+        result.Enrollments.Should().OnlyContain(m => m.Sponsor!.Name == "Acme Corporation");
+    }
+
+    [Fact]
+    public void Parse_RejectsContentThatIsNotX12()
+    {
+        var act = () => MakeParser().Parse("not an edi file", "bad.edi");
+
+        act.Should().Throw<X12FormatException>();
+    }
+}

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -1,6 +1,7 @@
 using EnrollmentImportService;
 using EnrollmentImportService.Repositories;
 using EnrollmentImportService.Services;
+using EnrollmentImportService.Services.Edi;
 using CloudHealthOffice.Infrastructure.HealthChecks;
 using CloudHealthOffice.Infrastructure.Configuration;
 using CloudHealthOffice.Infrastructure.Json;
@@ -40,6 +41,7 @@ builder.Services.AddScoped<IEnrollmentEventRepository, EnrollmentEventRepository
 builder.Services.AddScoped<IEnrollmentEventPublisher, EnrollmentEventPublisher>();
 builder.Services.AddSingleton<IEnrollmentValidator, EnrollmentValidator>();
 builder.Services.AddScoped<IEnrollmentImportService, EnrollmentImportService.Services.EnrollmentImportService>();
+builder.Services.AddSingleton<IEnrollment834EdiParser, Enrollment834EdiParser>();
 
 // Health checks (MongoDB or Cosmos DB)
 builder.Services.AddChoHealthChecks(options =>

--- a/src/services/enrollment-import-service/Services/Edi/Enrollment834EdiParser.cs
+++ b/src/services/enrollment-import-service/Services/Edi/Enrollment834EdiParser.cs
@@ -1,0 +1,252 @@
+using EnrollmentImportService.Models;
+
+namespace EnrollmentImportService.Services.Edi;
+
+public interface IEnrollment834EdiParser
+{
+    /// <summary>Parses raw X12 834 EDI text into the same <see cref="Enrollment834"/> shape the /import endpoint already accepts.</summary>
+    Enrollment834 Parse(string ediContent, string fileName);
+}
+
+/// <summary>
+/// Walks the 834 segment stream explicitly rather than relying on a
+/// library's declarative loop-grouping: each subscriber is anchored by an
+/// INS segment, and its own NM1/N3/N4/DMG only apply while <em>not</em>
+/// inside a dependent's LS...LE block. A dependent's LS...LE-nested
+/// NM1/N3/N4/DMG is instead routed into a fresh <see cref="Dependent"/> on
+/// the current subscriber. Getting this distinction wrong — attributing a
+/// dependent's demographics to the subscriber, or vice versa — is a
+/// silent-data-corruption bug, not a crash, so the loop state is tracked
+/// with an explicit "are we inside a dependent block" flag rather than a
+/// single flat cursor.
+/// </summary>
+public sealed class Enrollment834EdiParser : IEnrollment834EdiParser
+{
+    public Enrollment834 Parse(string ediContent, string fileName)
+    {
+        var doc = X12Tokenizer.Tokenize(ediContent);
+
+        var result = new Enrollment834
+        {
+            FileName = fileName,
+            ParsedAt = DateTime.UtcNow
+        };
+
+        Sponsor? headerSponsor = null;
+        MemberEnrollment? currentMember = null;
+        Dependent? currentDependent = null;
+        var insideDependentLoop = false;
+
+        foreach (var seg in doc.Segments)
+        {
+            switch (seg.Id)
+            {
+                case "N1" when currentMember is null:
+                    // Loop 1000A/1000B — sponsor/payer context at the header
+                    // level, shared by every member loop that follows in
+                    // this transaction (real files rarely vary this
+                    // per-member; if a file ever does, a later N1 before
+                    // any INS would simply overwrite headerSponsor).
+                    if (seg.Element(0) == "P5")
+                    {
+                        headerSponsor = new Sponsor
+                        {
+                            Qualifier = "P5",
+                            Name = seg.Element(1) ?? string.Empty,
+                            IdQualifier = seg.Element(2),
+                            Id = seg.Element(3)
+                        };
+                    }
+                    break;
+
+                case "INS":
+                    // New subscriber loop starts. Flush whatever we were
+                    // building (there's nothing on the very first INS).
+                    FlushDependent(ref currentDependent, currentMember);
+                    FlushMember(ref currentMember, result);
+
+                    insideDependentLoop = false;
+                    currentMember = new MemberEnrollment
+                    {
+                        Relationship = seg.Element(1) ?? string.Empty,
+                        MaintenanceType = seg.Element(2) ?? string.Empty,
+                        MaintenanceReason = seg.Element(3),
+                        BenefitStatus = seg.Element(4) ?? string.Empty,
+                        Sponsor = headerSponsor,
+                        Demographics = new Demographics()
+                    };
+                    break;
+
+                case "REF" when currentMember is not null && !insideDependentLoop:
+                    ApplyRef(seg, currentMember);
+                    break;
+
+                case "DTP" when currentMember is not null && !insideDependentLoop:
+                    ApplyDtp(seg, currentMember);
+                    break;
+
+                case "LS":
+                    // Start of a dependent (Loop 2000/2100 under 2700).
+                    insideDependentLoop = true;
+                    currentDependent = new Dependent();
+                    break;
+
+                case "LE":
+                    FlushDependent(ref currentDependent, currentMember);
+                    insideDependentLoop = false;
+                    break;
+
+                case "NM1" when insideDependentLoop && currentDependent is not null:
+                    ApplyNm1(seg, currentDependent);
+                    break;
+
+                case "NM1" when currentMember is not null:
+                    ApplyNm1(seg, currentMember.Demographics!);
+                    break;
+
+                case "N3" when insideDependentLoop && currentDependent is not null:
+                    ApplyN3(seg, currentDependent);
+                    break;
+
+                case "N3" when currentMember is not null:
+                    ApplyN3(seg, currentMember.Demographics!);
+                    break;
+
+                case "N4" when insideDependentLoop && currentDependent is not null:
+                    ApplyN4(seg, currentDependent);
+                    break;
+
+                case "N4" when currentMember is not null:
+                    ApplyN4(seg, currentMember.Demographics!);
+                    break;
+
+                case "DMG" when insideDependentLoop && currentDependent is not null:
+                    currentDependent.DateOfBirth = FormatDate(seg.Element(1));
+                    currentDependent.Gender = seg.Element(2);
+                    break;
+
+                case "DMG" when currentMember is not null:
+                    currentMember.Demographics!.DateOfBirth = FormatDate(seg.Element(1));
+                    currentMember.Demographics.Gender = seg.Element(2);
+                    break;
+
+                case "HD" when insideDependentLoop && currentDependent is not null:
+                    (currentDependent.Coverage ??= []).Add(BuildCoverage(seg));
+                    break;
+
+                case "HD" when currentMember is not null:
+                    currentMember.Coverage.Add(BuildCoverage(seg));
+                    break;
+            }
+        }
+
+        FlushDependent(ref currentDependent, currentMember);
+        FlushMember(ref currentMember, result);
+
+        result.TransactionCount = result.Enrollments.Count;
+        return result;
+    }
+
+    private static void FlushDependent(ref Dependent? dependent, MemberEnrollment? owner)
+    {
+        if (dependent is null)
+        {
+            return;
+        }
+        owner?.Dependents.Add(dependent);
+        dependent = null;
+    }
+
+    private static void FlushMember(ref MemberEnrollment? member, Enrollment834 result)
+    {
+        if (member is null)
+        {
+            return;
+        }
+        result.Enrollments.Add(member);
+        member = null;
+    }
+
+    private static void ApplyRef(X12Segment seg, MemberEnrollment member)
+    {
+        var qualifier = seg.Element(0);
+        var value = seg.Element(1);
+        switch (qualifier)
+        {
+            case "0F": member.SubscriberId = value; break;
+            case "1L": member.GroupNumber = value; break;
+            case "ZZ": member.EmployeeId = value; break;
+        }
+    }
+
+    private static void ApplyDtp(X12Segment seg, MemberEnrollment member)
+    {
+        var qualifier = seg.Element(0);
+        var date = FormatDate(seg.Element(2));
+        switch (qualifier)
+        {
+            case "303": member.EnrollmentDate = date; break;
+            case "356": member.TerminationDate = date; break;
+            case "336": member.EmploymentStartDate = date; break;
+        }
+    }
+
+    private static void ApplyNm1(X12Segment seg, Demographics target)
+    {
+        target.EntityType = seg.Element(1);
+        target.LastName = seg.Element(2) ?? string.Empty;
+        target.FirstName = seg.Element(3) ?? string.Empty;
+        target.MiddleName = seg.Element(4);
+        target.Suffix = seg.Element(5);
+        target.IdQualifier = seg.Element(7);
+        target.Id = seg.Element(8);
+    }
+
+    private static void ApplyNm1(X12Segment seg, Dependent target)
+    {
+        target.EntityType = seg.Element(1);
+        target.LastName = seg.Element(2) ?? string.Empty;
+        target.FirstName = seg.Element(3) ?? string.Empty;
+        target.MiddleName = seg.Element(4);
+        target.Suffix = seg.Element(5);
+        target.IdQualifier = seg.Element(7);
+        target.Id = seg.Element(8);
+    }
+
+    private static void ApplyN3(X12Segment seg, Demographics target)
+    {
+        target.Address1 = seg.Element(0);
+        target.Address2 = seg.Element(1);
+    }
+
+    private static void ApplyN3(X12Segment seg, Dependent target)
+    {
+        target.Address1 = seg.Element(0);
+        target.Address2 = seg.Element(1);
+    }
+
+    private static void ApplyN4(X12Segment seg, Demographics target)
+    {
+        target.City = seg.Element(0);
+        target.State = seg.Element(1);
+        target.Zip = seg.Element(2);
+    }
+
+    private static void ApplyN4(X12Segment seg, Dependent target)
+    {
+        target.City = seg.Element(0);
+        target.State = seg.Element(1);
+        target.Zip = seg.Element(2);
+    }
+
+    private static CoverageDetail BuildCoverage(X12Segment seg) => new()
+    {
+        MaintenanceType = seg.Element(0),
+        InsuranceLineCode = seg.Element(2) ?? string.Empty,
+        PlanCoverageDescription = seg.Element(3),
+        CoverageLevel = seg.Element(4)
+    };
+
+    /// <summary>834 dates are CCYYMMDD (D8 qualifier) — pass through as-is; EnrollmentImportService.ParseDate handles the string-&gt;DateTime conversion downstream.</summary>
+    private static string? FormatDate(string? d8Date) => d8Date;
+}

--- a/src/services/enrollment-import-service/Services/Edi/X12Tokenizer.cs
+++ b/src/services/enrollment-import-service/Services/Edi/X12Tokenizer.cs
@@ -1,0 +1,103 @@
+namespace EnrollmentImportService.Services.Edi;
+
+/// <summary>
+/// One X12 segment: the segment id (e.g. "ISA", "INS", "NM1") plus its
+/// elements in order. Element 0 is always the segment id itself is
+/// excluded here — <see cref="Element"/> indexes start at the first
+/// element after the id, matching the EDI convention of NM101, NM102, etc.
+/// minus one (0-based).
+/// </summary>
+public sealed class X12Segment
+{
+    public required string Id { get; init; }
+    public required IReadOnlyList<string> Elements { get; init; }
+
+    /// <summary>0-based element accessor. Returns null when the element is absent or empty.</summary>
+    public string? Element(int index) =>
+        index >= 0 && index < Elements.Count && Elements[index].Length > 0
+            ? Elements[index]
+            : null;
+}
+
+/// <summary>
+/// Thrown when the input cannot be tokenized as X12 (e.g. missing/malformed ISA envelope).
+/// </summary>
+public sealed class X12FormatException(string message) : Exception(message);
+
+/// <summary>A tokenized X12 file: its segments plus the delimiters detected from the ISA envelope.</summary>
+public sealed class X12Document
+{
+    public required IReadOnlyList<X12Segment> Segments { get; init; }
+    public required char ElementSeparator { get; init; }
+    public required char ComponentSeparator { get; init; }
+}
+
+/// <summary>
+/// Splits raw X12 EDI text into segments. Delimiters (element separator,
+/// segment terminator, component separator) are auto-detected from the
+/// ISA envelope per the X12 standard rather than assumed — real files
+/// vary (e.g. "~" vs newline-terminated), and hardcoding a delimiter is
+/// how a parser silently mis-splits a file that uses a different one.
+/// Mirrors the delimiter-detection approach already proven in
+/// containers/x12-parser/parse_x12.py for this repo's other X12 transactions.
+/// </summary>
+public static class X12Tokenizer
+{
+    public static X12Document Tokenize(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            throw new X12FormatException("EDI content is empty.");
+        }
+
+        var trimmed = content.TrimStart();
+        if (!trimmed.StartsWith("ISA", StringComparison.Ordinal))
+        {
+            throw new X12FormatException("EDI content does not start with an ISA segment.");
+        }
+
+        // The ISA segment is a fixed-width 106 characters (including the
+        // trailing segment terminator): element separator is the char
+        // immediately after "ISA", the component separator is ISA16
+        // (element index 15), and the segment terminator is the very
+        // next character after that.
+        if (trimmed.Length < 106)
+        {
+            throw new X12FormatException("ISA segment is shorter than the required 106 characters.");
+        }
+
+        var elementSeparator = trimmed[3];
+        var componentSeparator = trimmed[104];
+        var segmentTerminator = trimmed[105];
+
+        var rawSegments = trimmed.Split(segmentTerminator);
+        var segments = new List<X12Segment>(rawSegments.Length);
+
+        foreach (var raw in rawSegments)
+        {
+            // Segment terminators are sometimes followed by a newline for
+            // readability — strip incidental whitespace, not meaningful content.
+            var candidate = raw.Trim('\r', '\n', ' ', '\t');
+            if (candidate.Length == 0)
+            {
+                continue;
+            }
+
+            var parts = candidate.Split(elementSeparator);
+            var id = parts[0];
+            var elements = parts.Length > 1 ? parts[1..] : [];
+            segments.Add(new X12Segment { Id = id, Elements = elements });
+        }
+
+        return new X12Document
+        {
+            Segments = segments,
+            ElementSeparator = elementSeparator,
+            ComponentSeparator = componentSeparator
+        };
+    }
+
+    /// <summary>Splits a composite element (e.g. "HC:99213:25") on the component separator.</summary>
+    public static string[] SplitComponents(string element, char componentSeparator) =>
+        element.Split(componentSeparator);
+}


### PR DESCRIPTION
## Summary
- `enrollment-import-service` could only accept an already-structured `Enrollment834` JSON payload — nothing in the codebase parsed a raw X12 834 file into that shape. First step of the "let evaluators drop in their own EDI files" onramp.
- A hands-on evaluation of Indice.Edi (a free, MIT-licensed .NET EDI library) found its declarative loop-discrimination attributes (`EdiCondition`/`EdiSegmentGroup`) silently produced **wrong data**, not an error, on the exact case that matters: separating a subscriber's own `NM1`/`DMG` from a dependent's, nested inside the 834's `LS`...`LE` loop. That's a silent-corruption failure mode for a tool whose entire premise is trustworthy comparison data, so this implements the parser as explicit procedural loop-walking instead.

## What's here
- `X12Tokenizer` — splits raw EDI into segments, auto-detecting the element/segment/component delimiters from the ISA envelope rather than assuming `~`, mirroring the approach already proven in `containers/x12-parser/parse_x12.py` for this repo's other X12 transactions.
- `Enrollment834EdiParser` — walks `INS` (subscriber) and `LS`/`LE` (dependent) loops with an explicit "inside a dependent loop" flag, so a subscriber's demographics/coverage can never be silently overwritten by a nested dependent's.
- `POST /api/v1/enrollment/import/raw834` — `IFormFile` upload endpoint (same pattern as `attachment-service`), parses then reuses the existing `ImportEnrollmentAsync`.

## Verification
Tested against the real sample fixture (`docs/testing/test-x12-834-enrollment-sample.edi` — 3 subscribers, 2 with nested `LS`/`LE` dependents):
- All 3 subscribers keep their own name/DOB regardless of nested dependents (the exact bug the Indice.Edi spike surfaced — it returned the *dependent's* name/DOB for the subscriber).
- Dependents are attributed to the correct subscriber.
- Coverage lines are scoped per-person, not flattened across the whole family.
- Malformed input throws a clear `X12FormatException` instead of silently misparsing.

7 new tests, full `enrollment-import-service` suite (38 tests) green.

## Test plan
- [x] `dotnet test` — 38/38 passing, including 7 new parser tests against the real 834 fixture
- [x] `dotnet build` — clean, no warnings
- [ ] Manual upload smoke test against a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)