### PR TITLE
Fix ParseDate not recognizing X12's D8 date format

### DIFF
--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -176,6 +176,39 @@ public class EnrollmentImportServiceTests
     }
 
     [Fact]
+    public async Task Import_ParsesX12D8Dates_NotJustTheDashedFormatTestFixturesHappenToUse()
+    {
+        // NewSubscriber's EnrollmentDate above is "2026-01-01" (dashed, ISO-ish) —
+        // DateTime.TryParse already handles that, so it never would have caught
+        // the real bug. Actual 834 dates are X12's D8 format (CCYYMMDD, no
+        // separators, e.g. "19780922"), which DateTime.TryParse silently fails
+        // to recognize as a date at all (confirmed empirically: it returns
+        // false, not an exception) rather than a differently-formatted date.
+        var (svc, _, repo) = Build();
+
+        Member? created = null;
+        repo.Setup(r => r.CreateMemberAsync(It.IsAny<Member>()))
+            .Callback<Member>(m => created = m)
+            .ReturnsAsync((Member m) => m);
+
+        var enrollment = NewSubscriber("M-dob");
+        enrollment.EnrollmentDate = "20260101";
+        enrollment.Demographics!.DateOfBirth = "19780922";
+
+        var batch = new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-dob",
+            Enrollments = new() { enrollment }
+        };
+        await svc.ImportEnrollmentAsync(batch, "t1");
+
+        created.Should().NotBeNull();
+        created!.DateOfBirth.Should().Be(new DateTime(1978, 9, 22));
+        created.EnrollmentDate.Should().Be(new DateTime(2026, 1, 1));
+    }
+
+    [Fact]
     public void ClassifyEvent_TerminationWithCobra_IsCobraTerminated()
     {
         var e = NewSubscriber("M-1");

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using EnrollmentImportService.Models;
@@ -525,14 +526,27 @@ public class EnrollmentImportService : IEnrollmentImportService
         return $"M{lastName}{dob}{random}";
     }
     
+    /// <summary>
+    /// Parses an 834 date. The 834 always carries dates in X12's D8 format
+    /// (CCYYMMDD, e.g. "19780922") — DateTime.TryParse doesn't recognize
+    /// that as a date at all (it looks like a plain number, not any
+    /// culture's date format) and silently returns false, which is why
+    /// DateOfBirth/EnrollmentDate/TerminationDate were all coming back
+    /// null despite being present in the source segment. TryParseExact
+    /// with the explicit D8 format fixes all three; the general TryParse
+    /// fallback stays for any caller that isn't handing this raw 834 text.
+    /// </summary>
     private DateTime? ParseDate(string? dateString)
     {
         if (string.IsNullOrEmpty(dateString))
             return null;
-        
-        if (DateTime.TryParse(dateString, out var date))
+
+        if (DateTime.TryParseExact(dateString, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var d8Date))
+            return d8Date;
+
+        if (DateTime.TryParse(dateString, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             return date;
-        
+
         return null;
     }
 


### PR DESCRIPTION
## Summary
`DateOfBirth`, `EnrollmentDate`, and `TerminationDate` were all silently coming back `null` on real 834 imports — flagged in #1005 as a known, separate pre-existing bug, now fixed.

**Root cause**: `ParseDate` used `DateTime.TryParse`, which doesn't recognize X12's D8 date format (`CCYYMMDD`, e.g. `"19780922"`) as a date at all. Confirmed empirically — it just returns `false`, no exception. To the general parser it looks like a plain 8-digit number, not any culture's date format.

The bug was invisible to existing tests because `EnrollmentImportServiceTests`' `NewSubscriber()` fixture hand-writes `EnrollmentDate` as `"2026-01-01"` (dashed, ISO-ish) rather than real 834 text — `DateTime.TryParse` handles that fine, so the fixture never exercised the actual parsing path a real uploaded file goes through.

## Fix
Try `TryParseExact` with the explicit `"yyyyMMdd"` format first, falling back to the general `TryParse` for any caller not handing this raw 834 text.

## Verification
Added a regression test using the real D8 format (`"19780922"`) and verified it the honest way: confirmed it **fails** against the old code first (`Expected DateOfBirth to be <1978-09-22>, but found <null>`), then confirmed it passes with the fix.

39/39 tests green (38 previous + 1 new).

## Test plan
- [x] `dotnet test` — 39/39 passing
- [x] `dotnet build` — clean
- [x] Regression test verified to fail against pre-fix code, pass against post-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)