### PR TITLE
Fix sponsor-service database name case mismatch

### DIFF
--- a/infrastructure/k8s/sponsor-service-deployment.yaml
+++ b/infrastructure/k8s/sponsor-service-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: cloudhealthoffice
 data:
   ASPNETCORE_ENVIRONMENT: "Production"
+  MongoDb__DatabaseName: "cloudhealthoffice"
 ---
 apiVersion: v1
 kind: Secret
@@ -53,6 +54,11 @@ spec:
             secretKeyRef:
               name: sponsor-service-secrets
               key: MongoDb__ConnectionString
+        - name: MongoDb__DatabaseName
+          valueFrom:
+            configMapKeyRef:
+              name: sponsor-service-config
+              key: MongoDb__DatabaseName
         resources:
           requests:
             memory: "256Mi"

--- a/src/services/sponsor-service/Program.cs
+++ b/src/services/sponsor-service/Program.cs
@@ -39,7 +39,7 @@ if (!string.IsNullOrEmpty(builder.Configuration["MongoDb:ConnectionString"]))
     {
         var wrapper = sp.GetRequiredService<IMongoClient>();
         var configuration = sp.GetRequiredService<IConfiguration>();
-        return wrapper.GetDatabase(configuration["MongoDb:DatabaseName"] ?? "CloudHealthOffice");
+        return wrapper.GetDatabase(configuration["MongoDb:DatabaseName"] ?? "cloudhealthoffice");
     });
 
     builder.Services.AddScoped<ISponsorRepository, SponsorRepositoryMongo>();


### PR DESCRIPTION
## Summary
- `sponsor-service`'s Mongo database-name fallback was `"CloudHealthOffice"` (PascalCase) while every other service uses lowercase `"cloudhealthoffice"`, and its deployment YAML never set `MongoDb__DatabaseName` to override the default.
- Since the lowercase `cloudhealthoffice` database already exists (created by the other services), any write from sponsor-service failed with `MongoWriteException` (code 13297: `db already exists with different case`). Reads worked fine (no db-creation side effect), which is why this went unnoticed — it only broke on the write path.
- Fixed the default to `"cloudhealthoffice"` and added an explicit `MongoDb__DatabaseName` ConfigMap entry + env var, matching the pattern already used by `enrollment-import-service` and `member-service`.

Found while live-testing an unrelated change (delegating enrollment-import-service's Member/Sponsor writes to their owning services) — sponsor creation failed with a 500 every time, tracked down to this pre-existing, independent bug.

## Test plan
- [x] `dotnet test src/services/sponsor-service/SponsorService.Tests` — 5/5 passing
- [x] Applied the fix live via `kubectl set env` and confirmed `POST /api/v1/sponsors` now returns `201` instead of `500` (previously reproduced the exact `MongoWriteException` via direct port-forward + curl)
- [x] Cleaned up the test sponsor document created during verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)