### PR TITLE
Fix 834 maintenance type 025 (Reinstatement) being silently skipped

### DIFF
--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -278,6 +278,66 @@ public class EnrollmentImportServiceTests
     }
 
     [Fact]
+    public async Task Import_Reinstatement_OfKnownMember_UpdatesRatherThanSkips()
+    {
+        // Regression guard: maintenance type "025" (Reinstatement) used to fall
+        // into the switch statement's default branch ("Unknown maintenance
+        // type") and get silently skipped — real 834 fixtures use "025" for
+        // subscribers being brought back after a prior termination, and they
+        // were never actually landing in member-service.
+        var (svc, _, _, memberClient, _) = Build();
+
+        memberClient.Setup(m => m.ExistsAsync("t1", "M-reinstate", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        UpdateMemberRequestDto? updated = null;
+        memberClient.Setup(m => m.UpdateAsync("t1", "M-reinstate", It.IsAny<UpdateMemberRequestDto>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, UpdateMemberRequestDto, CancellationToken>((_, _, req, _) => updated = req)
+            .Returns(Task.CompletedTask);
+
+        var reinstate = NewSubscriber("M-reinstate");
+        reinstate.MaintenanceType = "025";
+        reinstate.BenefitStatus = "A";
+
+        var result = await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-reinstate",
+            Enrollments = new() { reinstate }
+        }, "t1");
+
+        result.SkippedCount.Should().Be(0);
+        result.MembersUpdated.Should().Be(1);
+        updated.Should().NotBeNull();
+        updated!.Status.Should().Be("Active");
+        memberClient.Verify(m => m.CreateAsync(It.IsAny<string>(), It.IsAny<CreateMemberRequestDto>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Import_Reinstatement_OfUnknownMember_CreatesRatherThanSkips()
+    {
+        var (svc, _, _, memberClient, _) = Build();
+        // Build() defaults ExistsAsync to false — member is unknown to member-service.
+
+        var reinstate = NewSubscriber("M-reinstate-new");
+        reinstate.MaintenanceType = "025";
+
+        var result = await svc.ImportEnrollmentAsync(new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-reinstate-new",
+            Enrollments = new() { reinstate }
+        }, "t1");
+
+        result.SkippedCount.Should().Be(0);
+        result.MembersCreated.Should().Be(1);
+        memberClient.Verify(m => m.CreateAsync(
+            "t1",
+            It.Is<CreateMemberRequestDto>(r => r.MemberId == "M-reinstate-new"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public void ClassifyEvent_TerminationWithCobra_IsCobraTerminated()
     {
         var e = NewSubscriber("M-1");

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -291,9 +291,15 @@ public class EnrollmentImportService : IEnrollmentImportService
                 break;
 
             case "001": // Change
+            case "025": // Reinstatement — same member-sync shape as a Change:
+                        // create if this is the first we've seen of them,
+                        // otherwise update. UpdateMemberFromEnrollmentAsync
+                        // derives Status from BenefitStatus, which a
+                        // reinstatement's "A" correctly flips back to Active
+                        // (or "C" to COBRA) without any special-casing here.
                 if (!memberExists)
                 {
-                    _logger.LogWarning("Member {SubscriberId} not found for change, creating new",
+                    _logger.LogWarning("Member {SubscriberId} not found for change/reinstatement, creating new",
                         SanitizeForLog(enrollment.SubscriberId));
                     await CreateMemberFromEnrollmentAsync(memberId, enrollment, tenantId);
                     result.MembersCreated++;


### PR DESCRIPTION
## Summary
- `ProcessMemberEnrollmentAsync`'s switch statement only handled maintenance types `021` (Addition), `001` (Change), and `024` (Termination) — `025` (Reinstatement) fell into the `default` branch and was silently skipped, never reaching member-service.
- `EnrollmentEventClassifier` already correctly classified `025` as `ReinstatementApproved`, and `EnrollmentValidator` already allowed it — only the actual member sync was missing this case, which made the gap easy to miss.
- The checked-in test fixture (`docs/testing/test-x12-834-enrollment-sample.edi`) uses `INS03=025` for two of its three subscribers, so they've never actually been importable through this service.
- `025` now shares the same create-if-missing/update-if-known path as `001` (Change): a reinstatement for a member already on file updates their status (`BenefitStatus="A"` correctly resolves to `"Active"` via the existing status derivation); a reinstatement for a member not yet on file creates them like any other first-sight enrollment.

## Test plan
- [x] Added 2 regression tests; confirmed both **fail** against the pre-fix code (`SkippedCount` was 1 instead of 0) before confirming they pass post-fix
- [x] `EnrollmentImportService.Tests` — 43/43 passing
- [x] Live: rebuilt and redeployed to the local cluster, re-ran the real 834 fixture — the two previously-skipped subscribers (SMITH, JOHNSON, both `025`) now create successfully in member-service with the correct sponsor/group linkage

🤖 Generated with [Claude Code](https://claude.com/claude-code)