### PR TITLE
Fix MemberService.Tests build break from deleted IEnrollmentRepository

### DIFF
--- a/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
@@ -64,11 +64,13 @@ public class DownstreamRouteContractTests
             });
             builder.ConfigureServices(services =>
             {
-                RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(services);
+                // Coverage moved from a directly-owned Mongo repository
+                // (IEnrollmentRepository) to coverage-service via
+                // ICoverageServiceClient — nothing left here that needs a
+                // Mongo-backed mock. See EnrollmentImportService.cs's own
+                // doc comments on the Member/Sponsor/Coverage delegation.
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(services);
-                services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>(
-                    new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentRepository>().Object);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
                     new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(


### PR DESCRIPTION
## Summary
- #1010 merged with a broken \`main\`: it deleted \`EnrollmentImportService.Services.IEnrollmentRepository\` (Coverage moved to coverage-service via \`ICoverageServiceClient\`) but missed \`member-service\`'s \`DownstreamRouteContractTests\`, which referenced that type directly via \`extern alias\` to mock it out for its \`WebApplicationFactory\`.
- Removes the dead mock — nothing needs to replace it, since the new HTTP client registrations (\`ICoverageServiceClient\`, \`IBenefitPlanServiceClient\`) construct lazily and don't need a stand-in for the test host to boot.

## Test plan
- [x] \`dotnet test src/services/member-service/MemberService.Tests\` — 152/152 passing, including both \`DownstreamRouteContractTests\` cases