### PR TITLE
Resolve BenefitPlanId from active coverage for claims that arrive without one

### DIFF
--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -343,6 +343,16 @@ builder.Services.AddScoped<ICoverageClient>(sp =>
         sp.GetRequiredService<HttpCoverageClient>(),
         sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
 
+// Coverage-to-plan resolver — lets a claim that arrives without a
+// BenefitPlanId (the X12 837 on-ramp; see X12837ClaimMapper) still find the
+// member's active plan before BenefitCalculationStage runs. Reuses the same
+// CoverageService named HttpClient as HttpCoverageClient above.
+builder.Services.AddScoped<HttpCoverageResolver>();
+builder.Services.AddScoped<ICoverageResolver>(sp =>
+    new CachingCoverageResolver(
+        sp.GetRequiredService<HttpCoverageResolver>(),
+        sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));
+
 // Prior-authorization validation. The stage treats lookup degradation as
 // "not enough evidence to deny" while honoring known invalid auth responses.
 builder.Services.AddHttpClient(UpstreamClientNames.AuthorizationService, client =>

--- a/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
+++ b/src/services/claims-service/Services/Adjudication/ClaimAdjudicationOrchestrator.cs
@@ -21,6 +21,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
     private readonly ClaimAdapterFactory _adapterFactory;
     private readonly IBenefitPlanResolver _planResolver;
     private readonly IMemberResolver _memberResolver;
+    private readonly ICoverageResolver _coverageResolver;
     private readonly IReadOnlyList<IClaimAdjudicationStage> _stages;
     private readonly IClaimVersionEventPublisher _eventPublisher;
     private readonly IMessageBus _messageBus;
@@ -33,6 +34,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         ClaimAdapterFactory adapterFactory,
         IBenefitPlanResolver planResolver,
         IMemberResolver memberResolver,
+        ICoverageResolver coverageResolver,
         IEnumerable<IClaimAdjudicationStage> stages,
         IClaimVersionEventPublisher eventPublisher,
         IMessageBus messageBus,
@@ -44,6 +46,7 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         _adapterFactory = adapterFactory;
         _planResolver = planResolver;
         _memberResolver = memberResolver;
+        _coverageResolver = coverageResolver;
         _stages = stages.OrderBy(s => s.Order).ToList();
         _eventPublisher = eventPublisher;
         _messageBus = messageBus;
@@ -113,6 +116,27 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
             ActorId = message.ActorId,
             CorrelationId = message.CorrelationId ?? messageContext.CorrelationId,
         };
+
+        // The X12 837 on-ramp (ClaimsV1Controller.ImportRaw837 ->
+        // X12837ClaimMapper) deliberately leaves BenefitPlanId blank rather
+        // than guessing — resolve it from the member's active coverage here,
+        // before plan resolution below, so a correctly-enrolled member's
+        // claim still reaches BenefitCalculationStage with a real plan
+        // instead of rejecting on "missing BenefitPlanId". Claims that
+        // already carry a BenefitPlanId (JSON /import, MCC) are untouched.
+        if (string.IsNullOrWhiteSpace(claim.BenefitPlanId) && !string.IsNullOrWhiteSpace(claim.MemberId))
+        {
+            var resolvedPlanId = await _coverageResolver
+                .ResolveBenefitPlanIdAsync(
+                    message.TenantId, claim.MemberId, claim.ServiceDateFrom,
+                    MapInsuranceLineCode(claim.ClaimType), ct)
+                .ConfigureAwait(false);
+
+            if (!string.IsNullOrWhiteSpace(resolvedPlanId))
+            {
+                claim.BenefitPlanId = resolvedPlanId;
+            }
+        }
 
         if (!string.IsNullOrWhiteSpace(claim.BenefitPlanId))
         {
@@ -337,6 +361,20 @@ public sealed class ClaimAdjudicationOrchestrator : IClaimAdjudicationOrchestrat
         if (_options.EnabledStages is null || _options.EnabledStages.Count == 0) return true;
         return !_options.EnabledStages.TryGetValue(stage.Name, out var enabled) || enabled;
     }
+
+    /// <summary>
+    /// Maps a claim's type to coverage-service's InsuranceLineCode filter
+    /// (HLT/DEN/VIS/LIF) so active-coverage resolution matches the right
+    /// line when a member carries more than one. Professional and
+    /// Institutional both mean medical (HLT) — the distinction is
+    /// place-of-care, not benefit line.
+    /// </summary>
+    private static string? MapInsuranceLineCode(ClaimType claimType) => claimType switch
+    {
+        ClaimType.Professional or ClaimType.Institutional => "HLT",
+        ClaimType.Dental => "DEN",
+        _ => null,
+    };
 
     private static string SanitizeForLog(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");

--- a/src/services/claims-service/Services/Resolution/CachingCoverageResolver.cs
+++ b/src/services/claims-service/Services/Resolution/CachingCoverageResolver.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Decorator over <see cref="ICoverageResolver"/> with the same 5-minute TTL
+/// and day-collapsed cache key as <see cref="CachingCoverageClient"/> —
+/// coverage records can terminate without an explicit signal, so a longer
+/// cache risks resolving a stale plan for claims submitted right after a
+/// coverage change. Negative results (no active coverage, or transport
+/// failure) are not cached, matching <see cref="CachingMemberResolver"/>.
+/// </summary>
+public sealed class CachingCoverageResolver : ICoverageResolver
+{
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly ICoverageResolver _inner;
+    private readonly IMemoryCache _cache;
+    private readonly TimeSpan _ttl;
+
+    public CachingCoverageResolver(ICoverageResolver inner, IMemoryCache cache)
+        : this(inner, cache, DefaultTtl) { }
+
+    public CachingCoverageResolver(ICoverageResolver inner, IMemoryCache cache, TimeSpan ttl)
+    {
+        _inner = inner;
+        _cache = cache;
+        _ttl = ttl;
+    }
+
+    public async Task<string?> ResolveBenefitPlanIdAsync(
+        string tenantId,
+        string memberId,
+        DateTime serviceDate,
+        string? insuranceLineCode = null,
+        CancellationToken ct = default)
+    {
+        var key = BuildCacheKey(tenantId, memberId, serviceDate, insuranceLineCode);
+        if (_cache.TryGetValue<string>(key, out var cached) && !string.IsNullOrEmpty(cached))
+        {
+            return cached;
+        }
+
+        var fresh = await _inner
+            .ResolveBenefitPlanIdAsync(tenantId, memberId, serviceDate, insuranceLineCode, ct)
+            .ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(fresh) && _ttl > TimeSpan.Zero)
+        {
+            _cache.Set(key, fresh, _ttl);
+        }
+        return fresh;
+    }
+
+    internal static string BuildCacheKey(
+        string tenantId, string memberId, DateTime serviceDate, string? insuranceLineCode)
+    {
+        var dayKey = serviceDate.ToUniversalTime().Date.ToString("yyyyMMdd");
+        var line = string.IsNullOrWhiteSpace(insuranceLineCode) ? "any" : insuranceLineCode;
+        return $"coverage-plan:{tenantId}:{memberId}:{dayKey}:{line}";
+    }
+}

--- a/src/services/claims-service/Services/Resolution/HttpCoverageResolver.cs
+++ b/src/services/claims-service/Services/Resolution/HttpCoverageResolver.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ClaimsService.Services;
+
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// HTTP-backed <see cref="ICoverageResolver"/> calling coverage-service's
+/// <c>GET /api/v1/coverage/member/{memberId}/active</c>. Reuses the same
+/// named client as <see cref="HttpCoverageClient"/> (<see cref="UpstreamClientNames.CoverageService"/>)
+/// — same base address, just a different endpoint on the same downstream.
+/// </summary>
+public class HttpCoverageResolver : ICoverageResolver
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<HttpCoverageResolver> _logger;
+
+    public HttpCoverageResolver(
+        IHttpClientFactory httpClientFactory,
+        ILogger<HttpCoverageResolver> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<string?> ResolveBenefitPlanIdAsync(
+        string tenantId,
+        string memberId,
+        DateTime serviceDate,
+        string? insuranceLineCode = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(memberId)) return null;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(UpstreamClientNames.CoverageService);
+            var encodedId = Uri.EscapeDataString(memberId);
+            var serviceDateQuery = serviceDate.ToUniversalTime()
+                .ToString("o", CultureInfo.InvariantCulture);
+
+            var url = $"/api/v1/coverage/member/{encodedId}/active" +
+                      $"?serviceDate={Uri.EscapeDataString(serviceDateQuery)}";
+            if (!string.IsNullOrWhiteSpace(insuranceLineCode))
+            {
+                url += $"&insuranceLineCode={Uri.EscapeDataString(insuranceLineCode)}";
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add("X-Tenant-ID", tenantId);
+
+            using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // No active coverage on record for this member/date/line —
+                // a definitive answer, not a degradation signal.
+                return null;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Coverage service returned {StatusCode} resolving active coverage for member {Member}",
+                    response.StatusCode, SanitizeForLog(memberId));
+                return null;
+            }
+
+            var coverages = await response.Content
+                .ReadFromJsonAsync<List<CoverageSummaryDto>>(JsonOptions, ct)
+                .ConfigureAwait(false);
+
+            return coverages?.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.PlanId))?.PlanId;
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                    or TaskCanceledException
+                                    or JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Active-coverage lookup failed for member {Member} tenant {Tenant}",
+                SanitizeForLog(memberId), SanitizeForLog(tenantId));
+            return null;
+        }
+    }
+
+    private static string SanitizeForLog(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", "").Replace("\n", "");
+
+    private sealed class CoverageSummaryDto
+    {
+        [JsonPropertyName("planId")]
+        public string? PlanId { get; set; }
+    }
+}

--- a/src/services/claims-service/Services/Resolution/ICoverageResolver.cs
+++ b/src/services/claims-service/Services/Resolution/ICoverageResolver.cs
@@ -1,0 +1,34 @@
+namespace ClaimsService.Services.Resolution;
+
+/// <summary>
+/// Resolves the member's own (CHO) active benefit-plan id from coverage-service
+/// for claims that arrive without one — the X12 837 on-ramp (<c>ImportRaw837</c>)
+/// intentionally leaves <c>AdapterClaim.BenefitPlanId</c> blank rather than
+/// guessing (see <c>X12837ClaimMapper</c>'s doc comment), so an unrecognized
+/// member surfaces as a real pend instead of silently defaulting. This resolver
+/// is what lets a correctly-enrolled member's claim still find its plan.
+///
+/// <para>
+/// Distinct from <see cref="ICoverageClient"/>, which resolves other-insurance
+/// (COB) entries for capability 5.8 — this resolves CHO's own coverage record,
+/// not third-party payers.
+/// </para>
+/// </summary>
+public interface ICoverageResolver
+{
+    /// <summary>
+    /// Returns the PlanId of the member's active coverage as of
+    /// <paramref name="serviceDate"/>, or <c>null</c> when no active coverage
+    /// is found, the member is missing, or the lookup degrades (transport
+    /// failure). Non-throwing, same posture as <see cref="IMemberResolver"/>
+    /// and <see cref="IBenefitPlanResolver"/> — callers treat null identically
+    /// regardless of cause and let <c>BenefitCalculationStage</c>'s existing
+    /// "missing BenefitPlanId" reject carry the signal forward.
+    /// </summary>
+    Task<string?> ResolveBenefitPlanIdAsync(
+        string tenantId,
+        string memberId,
+        DateTime serviceDate,
+        string? insuranceLineCode = null,
+        CancellationToken ct = default);
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationPendPersistenceEndToEndTests.cs
@@ -44,6 +44,7 @@ public class AdjudicationPendPersistenceEndToEndTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly ClaimAdapterFactory _factory;
@@ -150,6 +151,7 @@ public class AdjudicationPendPersistenceEndToEndTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             stages,
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithCobEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithCobEndToEndTests.cs
@@ -35,6 +35,7 @@ public class AdjudicationWithCobEndToEndTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly ICoverageClient _coverageClient = Substitute.For<ICoverageClient>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
@@ -223,6 +224,7 @@ public class AdjudicationWithCobEndToEndTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             stages,
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithNcciEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithNcciEndToEndTests.cs
@@ -37,6 +37,7 @@ public class AdjudicationWithNcciEndToEndTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly ClaimAdapterFactory _factory;
@@ -175,6 +176,7 @@ public class AdjudicationWithNcciEndToEndTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             new IClaimAdjudicationStage[] { ncciStage, new TestPersistenceStage() },
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithScrubbingEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationWithScrubbingEndToEndTests.cs
@@ -34,6 +34,7 @@ public class AdjudicationWithScrubbingEndToEndTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly ClaimAdapterFactory _factory;
@@ -166,6 +167,7 @@ public class AdjudicationWithScrubbingEndToEndTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             new IClaimAdjudicationStage[] { scrubbing, persistence },
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/AdjudicationWithEnforcementEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/AdjudicationWithEnforcementEndToEndTests.cs
@@ -34,6 +34,7 @@ public class AdjudicationWithEnforcementEndToEndTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly IProviderMembershipClient _membership = Substitute.For<IProviderMembershipClient>();
@@ -249,6 +250,7 @@ public class AdjudicationWithEnforcementEndToEndTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             new IClaimAdjudicationStage[] { stage, persistence },
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Adjudication/ClaimAdjudicationOrchestratorTests.cs
@@ -29,6 +29,7 @@ public class ClaimAdjudicationOrchestratorTests
     private readonly IClaimAdapter _adapter = Substitute.For<IClaimAdapter>();
     private readonly IBenefitPlanResolver _planResolver = Substitute.For<IBenefitPlanResolver>();
     private readonly IMemberResolver _memberResolver = Substitute.For<IMemberResolver>();
+    private readonly ICoverageResolver _coverageResolver = Substitute.For<ICoverageResolver>();
     private readonly IClaimVersionEventPublisher _eventPublisher = Substitute.For<IClaimVersionEventPublisher>();
     private readonly IMessageBus _messageBus = Substitute.For<IMessageBus>();
     private readonly ClaimAdapterFactory _factory;
@@ -315,6 +316,71 @@ public class ClaimAdjudicationOrchestratorTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task Adjudicate_ClaimWithoutBenefitPlanId_ResolvesViaCoverage_ThenResolvesPlan()
+    {
+        // The X12 837 on-ramp submits claims with a blank BenefitPlanId
+        // (X12837ClaimMapper deliberately doesn't guess it) — the
+        // orchestrator must resolve it from the member's active coverage
+        // before plan resolution runs, so a correctly-enrolled member's
+        // claim still reaches a real plan instead of rejecting.
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        var claim = BuildAdapterClaim();
+        claim.BenefitPlanId = null;
+        SetupAdapterReturning(claim);
+        _coverageResolver
+            .ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", claim.ServiceDateFrom, "HLT", Arg.Any<CancellationToken>())
+            .Returns("resolved-plan-guid");
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Equal("resolved-plan-guid", claim.BenefitPlanId);
+        await _planResolver.Received(1).GetPlanAsync("tenant-1", "resolved-plan-guid", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Adjudicate_ClaimWithoutBenefitPlanId_NoActiveCoverage_LeavesBenefitPlanIdBlank()
+    {
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        var claim = BuildAdapterClaim();
+        claim.BenefitPlanId = null;
+        SetupAdapterReturning(claim);
+        _coverageResolver
+            .ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", claim.ServiceDateFrom, "HLT", Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        Assert.Null(claim.BenefitPlanId);
+        await _planResolver.DidNotReceiveWithAnyArgs().GetPlanAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task Adjudicate_ClaimWithExistingBenefitPlanId_DoesNotCallCoverageResolver()
+    {
+        // JSON /import and MCC submissions already carry BenefitPlanId —
+        // coverage resolution must not override or even query in that case.
+        var stages = new IClaimAdjudicationStage[]
+        {
+            new RecordingStage("Persistence", 999, isRequired: true, new List<string>()),
+        };
+        SetupAdapterReturningClaim();
+
+        var orch = BuildOrchestrator(stages);
+        await orch.AdjudicateAsync(BuildSubmittedMessage(), BuildContext(), CancellationToken.None);
+
+        await _coverageResolver.DidNotReceiveWithAnyArgs()
+            .ResolveBenefitPlanIdAsync(default!, default!, default, default, default);
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────
 
     private ClaimAdjudicationOrchestrator BuildOrchestrator(
@@ -325,6 +391,7 @@ public class ClaimAdjudicationOrchestratorTests
             _factory,
             _planResolver,
             _memberResolver,
+            _coverageResolver,
             stages,
             _eventPublisher,
             _messageBus,

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingCoverageResolverTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingCoverageResolverTests.cs
@@ -1,0 +1,78 @@
+using ClaimsService.Services.Resolution;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests.Services.Resolution;
+
+public class CachingCoverageResolverTests
+{
+    private readonly ICoverageResolver _inner = Substitute.For<ICoverageResolver>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private static readonly DateTime ServiceDate = new(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Resolve_CacheMiss_HitsInner_AndCachesResult()
+    {
+        var sut = new CachingCoverageResolver(_inner, _cache);
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>())
+            .Returns("plan-guid-123");
+
+        var first = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+        var second = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+
+        Assert.Equal("plan-guid-123", first);
+        Assert.Equal("plan-guid-123", second);
+        await _inner.Received(1).ResolveBenefitPlanIdAsync(
+            "tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Resolve_NullResult_NotCached()
+    {
+        var sut = new CachingCoverageResolver(_inner, _cache);
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>())
+            .Returns((string?)null, "plan-guid-123");
+
+        var first = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+        var second = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+
+        Assert.Null(first);
+        Assert.Equal("plan-guid-123", second);
+        await _inner.Received(2).ResolveBenefitPlanIdAsync(
+            "tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Resolve_DifferentInsuranceLineCodes_DoNotShareCacheEntries()
+    {
+        var sut = new CachingCoverageResolver(_inner, _cache);
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>())
+            .Returns("medical-plan");
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "DEN", Arg.Any<CancellationToken>())
+            .Returns("dental-plan");
+
+        var medical = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+        var dental = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "DEN");
+
+        Assert.Equal("medical-plan", medical);
+        Assert.Equal("dental-plan", dental);
+    }
+
+    [Fact]
+    public async Task Resolve_DifferentServiceDates_DoNotShareCacheEntries()
+    {
+        var sut = new CachingCoverageResolver(_inner, _cache);
+        var laterDate = ServiceDate.AddYears(1);
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT", Arg.Any<CancellationToken>())
+            .Returns("old-plan");
+        _inner.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", laterDate, "HLT", Arg.Any<CancellationToken>())
+            .Returns("new-plan");
+
+        var old = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", ServiceDate, "HLT");
+        var current = await sut.ResolveBenefitPlanIdAsync("tenant-1", "MEM-1", laterDate, "HLT");
+
+        Assert.Equal("old-plan", old);
+        Assert.Equal("new-plan", current);
+    }
+}


### PR DESCRIPTION
## Summary
This is item 1 from the MCC/837 gap list — the blocking gap on the "evaluator drops 837 files" goal.

- The X12 837 on-ramp (`ClaimsV1Controller.ImportRaw837` → `X12837ClaimMapper`) deliberately leaves `BenefitPlanId` blank rather than guessing — an unrecognized member should surface as a real pend, not a silent default. But `BenefitCalculationStage` hard-rejects any claim with an empty `BenefitPlanId`, and nothing resolved one from the member's actual coverage. **Net effect: every 837 dropped through the evaluator on-ramp pended before pricing, regardless of how correctly the member was enrolled via the 834 pipeline.**
- Adds `ICoverageResolver` (`HttpCoverageResolver` + `CachingCoverageResolver`, mirroring the existing `IMemberResolver`/`IBenefitPlanResolver` shape and the 5-min TTL of the sibling `ICoverageClient`) that looks up the member's active coverage PlanId from coverage-service by member + service date + insurance line (mapped from claim type: Professional/Institutional → HLT, Dental → DEN).
- `ClaimAdjudicationOrchestrator` now resolves `BenefitPlanId` from coverage **before** plan resolution runs, but only when it's already blank — claims that arrive with one (JSON `/import`, MCC) are untouched.

## Test plan
- [x] `dotnet test tests/CloudHealthOffice.ClaimsService.Tests` — 599/599 passing, including 3 new orchestrator-level tests (resolves via coverage, no active coverage leaves it blank and doesn't call plan resolver, existing BenefitPlanId skips coverage lookup entirely) and 4 new `CachingCoverageResolver` tests
- [x] Repo-wide sweep for other `ClaimAdjudicationOrchestrator` construction sites — updated all 6 (5 end-to-end test files + the main test file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)