### PR TITLE
Persist 834/837 import transaction logs and admin list endpoints

### DIFF
--- a/src/services/claims-service/Controllers/ClaimsV1Controller.cs
+++ b/src/services/claims-service/Controllers/ClaimsV1Controller.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using ClaimsService.Adapters;
 using ClaimsService.Fhir;
 using ClaimsService.Models;
+using ClaimsService.Repositories;
 using ClaimsService.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -44,17 +45,20 @@ public class ClaimsV1Controller : ControllerBase
     private readonly ClaimAdapterFactory _adapterFactory;
     private readonly IClaimSubmissionService _submissionService;
     private readonly IExplanationOfBenefitProjector _eobProjector;
+    private readonly IClaimImportTransactionRepository _importTransactions;
     private readonly ILogger<ClaimsV1Controller> _logger;
 
     public ClaimsV1Controller(
         ClaimAdapterFactory adapterFactory,
         IClaimSubmissionService submissionService,
         IExplanationOfBenefitProjector eobProjector,
+        IClaimImportTransactionRepository importTransactions,
         ILogger<ClaimsV1Controller> logger)
     {
         _adapterFactory = adapterFactory;
         _submissionService = submissionService;
         _eobProjector = eobProjector;
+        _importTransactions = importTransactions;
         _logger = logger;
     }
 
@@ -161,15 +165,42 @@ public class ClaimsV1Controller : ControllerBase
             var adapterClaim = ClaimsService.EDI.Inbound.X12837ClaimMapper.Map(parsed, tenantId);
             var result = await _submissionService.SubmitAsync(adapterClaim, tenantId, actorId, correlationId, ct);
 
+            var errors = result.Success
+                ? []
+                : result.Errors.Select(e => $"{e.Field}: {e.Message}").ToList();
+
             results.Add(new Raw837ClaimResult
             {
                 ClaimNumber = parsed.ClaimId,
                 Success = result.Success,
                 ClaimId = result.Claim?.Id,
-                Errors = result.Success
-                    ? []
-                    : [.. result.Errors.Select(e => $"{e.Field}: {e.Message}")]
+                Errors = errors
             });
+
+            // Persisted regardless of outcome — a rejected claim is exactly
+            // what an evaluator troubleshooting a dropped file needs to see.
+            try
+            {
+                await _importTransactions.CreateAsync(new ClaimImportTransaction
+                {
+                    TenantId = tenantId,
+                    ClaimNumber = parsed.ClaimId,
+                    ClaimId = result.Claim?.Id,
+                    MemberId = adapterClaim.MemberId,
+                    FileName = file.FileName,
+                    Status = result.Success ? "Accepted" : "Rejected",
+                    Errors = errors
+                });
+            }
+            catch (Exception ex)
+            {
+                // Transaction-log failures must not break the import — log
+                // and move on, same posture as enrollment-import-service's
+                // RecordTransactionAsync.
+                _logger.LogWarning(ex,
+                    "Failed to persist ClaimImportTransaction for claim {ClaimNumber}",
+                    SanitizeForLog(parsed.ClaimId));
+            }
         }
 
         return Ok(new Raw837ImportResult
@@ -179,6 +210,28 @@ public class ClaimsV1Controller : ControllerBase
             SucceededCount = results.Count(r => r.Success),
             Results = results
         });
+    }
+
+    /// <summary>
+    /// Most recent 837 import transactions for the tenant, newest first —
+    /// the admin-console read path (mirrors enrollment-import-service's
+    /// <c>GET /api/v1/enrollment/transactions/recent</c>). Includes
+    /// rejected imports, not just successful ones.
+    /// </summary>
+    [HttpGet("import-transactions")]
+    [ProducesResponseType(typeof(List<ClaimImportTransaction>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ListImportTransactions([FromQuery] int limit = 100)
+    {
+        var tenantId = TryGetTenantId();
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            return BadRequest(new { error = "X-Tenant-ID header is required" });
+        }
+        if (limit < 1 || limit > 500) limit = 100;
+
+        var transactions = await _importTransactions.ListRecentAsync(tenantId, limit);
+        return Ok(transactions);
     }
 
     /// <summary>

--- a/src/services/claims-service/HostedServices/ClaimIndexInitializer.cs
+++ b/src/services/claims-service/HostedServices/ClaimIndexInitializer.cs
@@ -58,6 +58,14 @@ public sealed class ClaimIndexInitializer : IHostedService
 
         collection.Indexes.CreateMany(indexes, cancellationToken);
 
+        var txnCollection = _db.GetCollection<ClaimImportTransaction>(
+            Repositories.ClaimImportTransactionRepositoryMongo.CollectionName);
+        txnCollection.Indexes.CreateOne(new CreateIndexModel<ClaimImportTransaction>(
+            Builders<ClaimImportTransaction>.IndexKeys
+                .Ascending(t => t.TenantId)
+                .Descending(t => t.ReceivedAt)),
+            cancellationToken: cancellationToken);
+
         _logger.LogInformation("Claim indexes ensured on collection 'Claims'.");
         return Task.CompletedTask;
     }

--- a/src/services/claims-service/Models/ClaimImportTransaction.cs
+++ b/src/services/claims-service/Models/ClaimImportTransaction.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClaimsService.Models;
+
+/// <summary>
+/// Single 837 import transaction (one CLM segment out of a raw837 upload)
+/// persisted for audit + an admin console view — the 837-side counterpart
+/// of enrollment-import-service's <c>EnrollmentTransaction</c>. Written
+/// once per parsed claim at <c>ClaimsV1Controller.ImportRaw837</c>,
+/// regardless of whether submission succeeded, so a rejected claim is still
+/// visible to whoever is troubleshooting an evaluator's file drop.
+/// </summary>
+public class ClaimImportTransaction
+{
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public string ClaimNumber { get; set; } = string.Empty;
+
+    public string? ClaimId { get; set; }
+
+    public string MemberId { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public DateTime ReceivedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>"Accepted" or "Rejected" — mirrors EnrollmentTransaction.Status.</summary>
+    public string Status { get; set; } = "Accepted";
+
+    public List<string> Errors { get; set; } = [];
+}

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -39,6 +39,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddHostedService<ClaimIndexInitializer>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryMongo>();
     builder.Services.AddScoped<IMassAdjudicationRunRepository, MassAdjudicationRunRepositoryMongo>();
+    builder.Services.AddScoped<IClaimImportTransactionRepository, ClaimImportTransactionRepositoryMongo>();
     builder.Services.AddHostedService<MassAdjudicationRunIndexInitializer>();
 
     // Claim version event publisher (5.1) — Mongo append-only stream is the
@@ -72,6 +73,7 @@ else
     builder.Services.AddScoped<IClaimRepository, ClaimRepository>();
     builder.Services.AddScoped<IAiExaminationAuditRepository, AiExaminationAuditRepositoryCosmos>();
     builder.Services.AddSingleton<IMassAdjudicationRunRepository, InMemoryMassAdjudicationRunRepository>();
+    builder.Services.AddSingleton<IClaimImportTransactionRepository, InMemoryClaimImportTransactionRepository>();
 
     // 5.1b — Cosmos partition-key migration tooling. Resolves the source
     // (legacy /memberId Bicep / /Id runtime) and target (canonical

--- a/src/services/claims-service/Repositories/ClaimImportTransactionRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimImportTransactionRepositoryMongo.cs
@@ -1,0 +1,37 @@
+using ClaimsService.Models;
+using MongoDB.Driver;
+
+namespace ClaimsService.Repositories;
+
+/// <summary>
+/// MongoDB repository for individual 837 import transaction records.
+/// Indexed on (tenantId, receivedAt) by <c>ClaimIndexInitializer</c>.
+/// </summary>
+public class ClaimImportTransactionRepositoryMongo : IClaimImportTransactionRepository
+{
+    public const string CollectionName = "claim-import-transactions";
+
+    private readonly IMongoCollection<ClaimImportTransaction> _collection;
+
+    public ClaimImportTransactionRepositoryMongo(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<ClaimImportTransaction>(CollectionName);
+    }
+
+    public async Task<ClaimImportTransaction> CreateAsync(ClaimImportTransaction txn)
+    {
+        if (string.IsNullOrEmpty(txn.Id)) txn.Id = Guid.NewGuid().ToString();
+        await _collection.InsertOneAsync(txn);
+        return txn;
+    }
+
+    public async Task<IReadOnlyList<ClaimImportTransaction>> ListRecentAsync(string tenantId, int limit = 100)
+    {
+        var filter = Builders<ClaimImportTransaction>.Filter.Eq(x => x.TenantId, tenantId);
+
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.ReceivedAt)
+            .Limit(limit)
+            .ToListAsync();
+    }
+}

--- a/src/services/claims-service/Repositories/IClaimImportTransactionRepository.cs
+++ b/src/services/claims-service/Repositories/IClaimImportTransactionRepository.cs
@@ -1,0 +1,11 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Repositories;
+
+public interface IClaimImportTransactionRepository
+{
+    Task<ClaimImportTransaction> CreateAsync(ClaimImportTransaction txn);
+
+    /// <summary>Most recent transactions for a tenant, newest first — the admin-console read path.</summary>
+    Task<IReadOnlyList<ClaimImportTransaction>> ListRecentAsync(string tenantId, int limit = 100);
+}

--- a/src/services/claims-service/Repositories/InMemoryClaimImportTransactionRepository.cs
+++ b/src/services/claims-service/Repositories/InMemoryClaimImportTransactionRepository.cs
@@ -1,0 +1,41 @@
+using ClaimsService.Models;
+
+namespace ClaimsService.Repositories;
+
+/// <summary>
+/// In-process fallback for Cosmos-configured deployments — mirrors
+/// <c>InMemoryMassAdjudicationRunRepository</c>'s precedent for capabilities
+/// that haven't gotten a Cosmos-backed implementation yet. Per-pod only;
+/// acceptable because this collection backs an admin diagnostic view, not
+/// anything transactionally load-bearing.
+/// </summary>
+public sealed class InMemoryClaimImportTransactionRepository : IClaimImportTransactionRepository
+{
+    private readonly List<ClaimImportTransaction> _transactions = [];
+    private readonly object _sync = new();
+
+    public Task<ClaimImportTransaction> CreateAsync(ClaimImportTransaction txn)
+    {
+        if (string.IsNullOrEmpty(txn.Id)) txn.Id = Guid.NewGuid().ToString();
+
+        lock (_sync)
+        {
+            _transactions.Add(txn);
+        }
+
+        return Task.FromResult(txn);
+    }
+
+    public Task<IReadOnlyList<ClaimImportTransaction>> ListRecentAsync(string tenantId, int limit = 100)
+    {
+        lock (_sync)
+        {
+            IReadOnlyList<ClaimImportTransaction> result = _transactions
+                .Where(t => t.TenantId == tenantId)
+                .OrderByDescending(t => t.ReceivedAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/services/enrollment-import-service/Controllers/TransactionsController.cs
+++ b/src/services/enrollment-import-service/Controllers/TransactionsController.cs
@@ -39,4 +39,24 @@ public class TransactionsController : ControllerBase
         var list = await _transactions.ListByMemberAsync(tenantId, memberId, limit);
         return Ok(list);
     }
+
+    /// <summary>
+    /// Most recent 834 transactions for the tenant, newest first — the
+    /// admin-console read path (no memberId filter, unlike
+    /// <see cref="ListTransactions"/> above).
+    /// </summary>
+    [HttpGet("transactions/recent")]
+    [ProducesResponseType(typeof(List<EnrollmentTransaction>), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> ListRecentTransactions(
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId,
+        [FromQuery] int limit = 100)
+    {
+        if (string.IsNullOrWhiteSpace(tenantId))
+            return BadRequest("X-Tenant-ID header is required");
+        if (limit < 1 || limit > 500) limit = 100;
+
+        var list = await _transactions.ListRecentAsync(tenantId, limit);
+        return Ok(list);
+    }
 }

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/TransactionsControllerTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/TransactionsControllerTests.cs
@@ -58,4 +58,42 @@ public class TransactionsControllerTests
         await ctl.ListTransactions("t1", "M-001", 0);
         repo.Verify(r => r.ListByMemberAsync("t1", "M-001", 100), Times.Exactly(2));
     }
+
+    [Fact]
+    public async Task ListRecentTransactions_ReturnsRepoResult()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.ListRecentAsync("t1", 100))
+            .ReturnsAsync(new List<EnrollmentTransaction>
+            {
+                new() { TenantId = "t1", MemberId = "M-001", BatchId = "B1", TransactionId = "T1" },
+                new() { TenantId = "t1", MemberId = "M-002", BatchId = "B1", TransactionId = "T2" }
+            });
+
+        var resp = await ctl.ListRecentTransactions("t1", 100);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var list = (IReadOnlyList<EnrollmentTransaction>)ok.Value!;
+        list.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListRecentTransactions_MissingTenant_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        (await ctl.ListRecentTransactions("")).Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ListRecentTransactions_LimitOutOfRange_ClampsTo100()
+    {
+        var (ctl, repo) = Build();
+        repo.Setup(r => r.ListRecentAsync("t1", 100))
+            .ReturnsAsync(new List<EnrollmentTransaction>());
+
+        await ctl.ListRecentTransactions("t1", 99999);
+        repo.Verify(r => r.ListRecentAsync("t1", 100), Times.Once);
+
+        await ctl.ListRecentTransactions("t1", 0);
+        repo.Verify(r => r.ListRecentAsync("t1", 100), Times.Exactly(2));
+    }
 }

--- a/src/services/enrollment-import-service/Services/EnrollmentTransactionRepository.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentTransactionRepository.cs
@@ -10,6 +10,9 @@ public interface IEnrollmentTransactionRepository
         string tenantId,
         string memberId,
         int limit = 100);
+
+    /// <summary>Most recent transactions for a tenant, newest first — the admin-console read path.</summary>
+    Task<IReadOnlyList<EnrollmentTransaction>> ListRecentAsync(string tenantId, int limit = 100);
 }
 
 /// <summary>
@@ -37,6 +40,16 @@ public class EnrollmentTransactionRepository : IEnrollmentTransactionRepository
     {
         var filter = Builders<EnrollmentTransaction>.Filter.Eq(x => x.TenantId, tenantId) &
                      Builders<EnrollmentTransaction>.Filter.Eq(x => x.MemberId, memberId);
+
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.ReceivedAt)
+            .Limit(limit)
+            .ToListAsync();
+    }
+
+    public async Task<IReadOnlyList<EnrollmentTransaction>> ListRecentAsync(string tenantId, int limit = 100)
+    {
+        var filter = Builders<EnrollmentTransaction>.Filter.Eq(x => x.TenantId, tenantId);
 
         return await _collection.Find(filter)
             .SortByDescending(x => x.ReceivedAt)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -26,6 +26,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
     public IClaimFinalizationService FinalizationService { get; } = Substitute.For<IClaimFinalizationService>();
     public IClaimAdjustmentRepository AdjustmentRepository { get; } = Substitute.For<IClaimAdjustmentRepository>();
     public IClaimAdjustmentService AdjustmentService { get; } = Substitute.For<IClaimAdjustmentService>();
+    public IClaimImportTransactionRepository ImportTransactionRepository { get; } = Substitute.For<IClaimImportTransactionRepository>();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -59,6 +60,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType == typeof(IClaimFinalizationService)
                          || d.ServiceType == typeof(IClaimAdjustmentService)
                          || d.ServiceType == typeof(IClaimAdjustmentRepository)
+                         || d.ServiceType == typeof(IClaimImportTransactionRepository)
                          || d.ServiceType == typeof(IClaimAdapter)
                          || d.ServiceType == typeof(ClaimAdapterFactory)
                          || d.ServiceType == typeof(ClaimTenantConfigCache))
@@ -126,6 +128,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(FinalizationService);
             services.AddSingleton(AdjustmentRepository);
             services.AddSingleton(AdjustmentService);
+            services.AddSingleton(ImportTransactionRepository);
 
             // 5.7 — NcciEngine's repository implementation got removed by
             // the Cosmos/Mongo filter above. The engine's INcciEditService

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerRaw837Tests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerRaw837Tests.cs
@@ -1,0 +1,164 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using ClaimsService.Controllers;
+using ClaimsService.Models;
+using ClaimsService.Repositories;
+using ClaimsService.Services;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using Xunit;
+
+namespace CloudHealthOffice.ClaimsService.Tests;
+
+/// <summary>
+/// Coverage for <c>POST /api/v1/claims/import/raw837</c> — the evaluator
+/// on-ramp for dropping a raw X12 837 file — and its sibling
+/// <c>GET /api/v1/claims/import-transactions</c>, which was added
+/// alongside a <see cref="ClaimImportTransaction"/> log so a rejected
+/// or accepted import is visible after the fact, not just in the
+/// synchronous response.
+/// </summary>
+public class ClaimsV1ControllerRaw837Tests : IClassFixture<ClaimsApiFactory>
+{
+    // One CLM segment, professional, POS 11, CPT 99213 — same shape as
+    // scripts/smoke/834-to-837-e2e-smoke.sh's payload.
+    private const string SingleClaimSample =
+        "ISA*00*          *00*          *ZZ*SENDER         *ZZ*RECEIVER       *260101*0000*^*00501*000000001*0*P*:~GS*HC*SENDER*RECEIVER*20260101*0000*1*X*005010X222A1~ST*837*0001*005010X222A1~BHT*0019*18*CLM-RAW837-0001*20260101*0000*CH~NM1*41*2*SUBMITTER*****46*SENDER~PER*IC*SUBMITTER*TE*0000000000~NM1*40*2*RECEIVER*****46*RECEIVER~HL*1**20*1~NM1*85*2*MEDICAL GROUP*****XX*1234567890~N3*ADDRESS ON FILE~N4*CITY*CA*94102~HL*2*1*22*0~SBR*P*18*****CI~NM1*IL*1*SMITH*JOHN****MI*MEM-RAW837~NM1*PR*2*PAYER*****PI*PAYERID~CLM*CLM-RAW837-0001*150.00***11:B:1*Y*A*Y*Y~DTP*472*RD8*20260101-20260101~HI*ABK:J06.9~LX*1~SV1*HC:99213*150.00*UN*1*11**1~DTP*472*RD8*20260101-20260101~SE*17*0001~GE*1*1~IEA*1*000000001~";
+
+    private readonly ClaimsApiFactory _factory;
+    private readonly HttpClient _client;
+    private readonly IClaimSubmissionService _service;
+    private readonly IClaimImportTransactionRepository _transactions;
+
+    public ClaimsV1ControllerRaw837Tests(ClaimsApiFactory factory)
+    {
+        _factory = factory;
+        _service = factory.SubmissionService;
+        _transactions = factory.ImportTransactionRepository;
+        _client = factory.CreateClient();
+        _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
+
+        _service.ClearSubstitute();
+        _transactions.ClearSubstitute();
+    }
+
+    [Fact]
+    public async Task ImportRaw837_ValidClaim_SubmitsAndPersistsAcceptedTransaction()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), "test-tenant",
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var c = ci.Arg<AdapterClaim>();
+                c.Id = "claim-id-raw837";
+                return ClaimSubmissionResult.Ok(c);
+            });
+
+        var response = await _client.PostAsync(
+            "/api/v1/claims/import/raw837", BuildFileContent(SingleClaimSample));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<Raw837ImportResult>();
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.SucceededCount);
+        Assert.Equal("claim-id-raw837", result.Results[0].ClaimId);
+
+        await _transactions.Received(1).CreateAsync(Arg.Is<ClaimImportTransaction>(t =>
+            t.TenantId == "test-tenant"
+            && t.ClaimNumber == "CLM-RAW837-0001"
+            && t.ClaimId == "claim-id-raw837"
+            && t.MemberId == "MEM-RAW837"
+            && t.Status == "Accepted"
+            && t.Errors.Count == 0));
+    }
+
+    [Fact]
+    public async Task ImportRaw837_ValidationFailure_PersistsRejectedTransactionWithErrors()
+    {
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ClaimSubmissionResult.ValidationFailed(new[]
+            {
+                new ValidationError { Field = "MemberId", Code = "NotFound", Message = "Member not recognized" }
+            }));
+
+        var response = await _client.PostAsync(
+            "/api/v1/claims/import/raw837", BuildFileContent(SingleClaimSample));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<Raw837ImportResult>();
+        Assert.Equal(0, result!.SucceededCount);
+        Assert.False(result.Results[0].Success);
+
+        await _transactions.Received(1).CreateAsync(Arg.Is<ClaimImportTransaction>(t =>
+            t.Status == "Rejected"
+            && t.ClaimId == null
+            && t.Errors.Any(e => e.Contains("Member not recognized"))));
+    }
+
+    [Fact]
+    public async Task ImportRaw837_NoFile_ReturnsBadRequest()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/claims/import/raw837", new MultipartFormDataContent());
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await _transactions.DidNotReceiveWithAnyArgs().CreateAsync(default!);
+    }
+
+    [Fact]
+    public async Task ImportRaw837_MalformedEdi_ReturnsBadRequest_AndDoesNotPersistAnything()
+    {
+        var response = await _client.PostAsync(
+            "/api/v1/claims/import/raw837", BuildFileContent("NOT AN 837 FILE"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        await _transactions.DidNotReceiveWithAnyArgs().CreateAsync(default!);
+    }
+
+    [Fact]
+    public async Task ListImportTransactions_NoTenantHeader_FallsBackToDefaultTenant()
+    {
+        // Claims-service's tenant middleware runs in lenient mode
+        // (RequireTenantId=false) — a missing header resolves to
+        // "default-tenant" rather than blocking the request, same as
+        // SearchMemberClaims's existing TryGetTenantId() usage in this
+        // controller. TryGetTenantId() only returns empty when the
+        // middleware itself is configured strict, which this service isn't.
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/claims/import-transactions");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _transactions.Received(1).ListRecentAsync("default-tenant", 100);
+    }
+
+    [Fact]
+    public async Task ListImportTransactions_ReturnsRepositoryResult()
+    {
+        _transactions.ListRecentAsync("test-tenant", 100).Returns(new List<ClaimImportTransaction>
+        {
+            new() { TenantId = "test-tenant", ClaimNumber = "CLM-1", Status = "Accepted" }
+        });
+
+        var response = await _client.GetAsync("/api/v1/claims/import-transactions");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<List<ClaimImportTransaction>>();
+        Assert.NotNull(body);
+        Assert.Single(body!);
+        Assert.Equal("CLM-1", body![0].ClaimNumber);
+    }
+
+    private static MultipartFormDataContent BuildFileContent(string ediContent, string fileName = "test.837")
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(System.Text.Encoding.UTF8.GetBytes(ediContent));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        content.Add(fileContent, "file", fileName);
+        return content;
+    }
+}

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -227,6 +227,13 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                 services.AddSingleton(Substitute.For<IClaimAdjustmentRepository>());
                 services.AddSingleton(Substitute.For<IClaimAdjustmentService>());
 
+                // ClaimImportTransactionRepositoryMongo is caught by the
+                // "Mongo" substring filter above (nothing 837-related runs
+                // in this test — it only exercises POST /api/v1/claims —
+                // but ClaimsV1Controller's constructor still needs every
+                // dependency resolvable to construct the controller at all).
+                services.AddSingleton(Substitute.For<IClaimImportTransactionRepository>());
+
                 // 5.7 — NcciEngine's repository implementation gets removed
                 // by the Cosmos/Mongo filter above. INcciEditService still
                 // depends on INcciRepository — register a substitute so


### PR DESCRIPTION
## Summary
First backend step toward an EDI transactions console (mirroring the existing `MassAdjudicationRuns.razor` portal page — see conversation for the fuller design discussion). Neither 834 nor 837 had a queryable record of raw import outcomes that a console could page through.

- **claims-service** (net new): `ClaimImportTransaction` model + repository (Mongo, with an in-memory fallback for Cosmos-configured deployments — mirrors `IMassAdjudicationRunRepository`'s existing precedent). Written once per parsed claim in `ImportRaw837`, regardless of success/failure, so a rejected claim from an evaluator's file drop is still visible after the fact. New admin-scoped `GET /api/v1/claims/import-transactions`.
- **enrollment-import-service**: `IEnrollmentTransactionRepository` gains `ListRecentAsync` (tenant-scoped, no `memberId` filter) alongside the existing member-scoped `ListByMemberAsync`. New `GET /api/v1/enrollment/transactions/recent`.
- Adds controller-level test coverage for `ImportRaw837` itself, which had none before this (flagged as a gap earlier in this work).
- Fixed two existing test factories (`AdjudicationEndToEndTests`'s inline factory) that construct `ClaimsV1Controller` through the real DI graph — their "remove anything with Mongo in the type name" filter also caught my new Mongo repository and needed an explicit substitute registered, same as every other capability added to that controller.

## Not included
The actual console UI page — this is backend-only, sized to land and be reviewed on its own before building the frontend on top of it.

## Test plan
- [x] `dotnet test tests/CloudHealthOffice.ClaimsService.Tests` — 607/607 passing
- [x] `dotnet test src/services/enrollment-import-service/EnrollmentImportService.Tests` — 54/54 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)