### PR TITLE
Add EDI Transactions console — view 834/837 import history in the portal

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/EdiTransactionsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/EdiTransactionsServiceTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using CloudHealthOffice.Portal.Services;
+
+namespace CloudHealthOffice.Portal.Tests.Services;
+
+public class EdiTransactionsServiceTests
+{
+    private readonly Mock<ILogger<EdiTransactionsService>> _logger = new();
+    private readonly IConfiguration _configuration;
+
+    public EdiTransactionsServiceTests()
+    {
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Services:ClaimsService"] = "http://localhost:5001",
+                ["Services:EnrollmentImportService"] = "http://localhost:5011",
+            })
+            .Build();
+    }
+
+    private EdiTransactionsService CreateService(HttpClient? httpClient = null)
+    {
+        httpClient ??= new HttpClient(new FakeHandler(HttpStatusCode.InternalServerError));
+        return new EdiTransactionsService(httpClient, _configuration, _logger.Object);
+    }
+
+    // ── GetEnrollment834TransactionsAsync ──
+
+    [Fact]
+    public async Task GetEnrollment834TransactionsAsync_WhenApiFails_ThrowsServiceUnavailableException()
+    {
+        var sut = CreateService();
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetEnrollment834TransactionsAsync());
+        ex.ServiceName.Should().Be("Enrollment Import Service");
+    }
+
+    [Fact]
+    public async Task GetEnrollment834TransactionsAsync_ParsesResponse_AndHitsExpectedUrl()
+    {
+        var body = """
+            [
+              { "transactionId": "T1", "batchId": "B1", "memberId": "M-001", "memberName": "John Smith",
+                "maintenanceTypeCode": "021", "status": "Accepted", "errors": [] }
+            ]
+            """;
+        var handler = new FakeHandler(HttpStatusCode.OK, body);
+        var sut = CreateService(new HttpClient(handler));
+
+        var result = await sut.GetEnrollment834TransactionsAsync(50);
+
+        result.Should().ContainSingle();
+        result[0].MemberId.Should().Be("M-001");
+        result[0].Status.Should().Be("Accepted");
+        handler.CapturedUrls.Should().ContainSingle(u =>
+            u.Contains("/v1/enrollment/transactions/recent") && u.Contains("limit=50"));
+    }
+
+    [Fact]
+    public async Task GetEnrollment834TransactionsAsync_ClampsLimitTo500()
+    {
+        var handler = new FakeHandler(HttpStatusCode.OK, "[]");
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.GetEnrollment834TransactionsAsync(99999);
+
+        handler.CapturedUrls.Should().ContainSingle(u => u.Contains("limit=500"));
+    }
+
+    // ── GetClaimImportTransactionsAsync ──
+
+    [Fact]
+    public async Task GetClaimImportTransactionsAsync_WhenApiFails_ThrowsServiceUnavailableException()
+    {
+        var sut = CreateService();
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetClaimImportTransactionsAsync());
+        ex.ServiceName.Should().Be("Claims Service");
+    }
+
+    [Fact]
+    public async Task GetClaimImportTransactionsAsync_ParsesResponse_AndHitsExpectedUrl()
+    {
+        var body = """
+            [
+              { "id": "TX-1", "claimNumber": "CLM-1", "claimId": "claim-1", "memberId": "M-001",
+                "fileName": "test.837", "status": "Accepted", "errors": [] }
+            ]
+            """;
+        var handler = new FakeHandler(HttpStatusCode.OK, body);
+        var sut = CreateService(new HttpClient(handler));
+
+        var result = await sut.GetClaimImportTransactionsAsync(50);
+
+        result.Should().ContainSingle();
+        result[0].ClaimNumber.Should().Be("CLM-1");
+        result[0].ClaimId.Should().Be("claim-1");
+        handler.CapturedUrls.Should().ContainSingle(u =>
+            u.Contains("/v1/claims/import-transactions") && u.Contains("limit=50"));
+    }
+}

--- a/src/portal/CloudHealthOffice.Portal/Pages/EdiTransactions.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/EdiTransactions.razor
@@ -1,0 +1,221 @@
+@page "/edi-transactions"
+@attribute [Authorize]
+@using CloudHealthOffice.Portal.Services
+@inject IEdiTransactionsService EdiTransactionsService
+@inject ISnackbar Snackbar
+
+<PageTitle>EDI Transactions — Cloud Health Office</PageTitle>
+
+<PermissionGate Permission="claims:read" RoleName="ClaimsSupervisor">
+<div class="edi-transactions-page">
+<MudText Typo="Typo.h4" Class="mb-1" Style="color: #00ffff; font-weight: 700;">
+    <MudIcon Icon="@Icons.Material.Filled.SwapHoriz" Class="mr-2" Style="vertical-align: middle;" />
+    EDI Transactions
+</MudText>
+<MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.55);" Class="mb-4">
+    Every 834 enrollment and 837 claim file dropped through the evaluator on-ramp, accepted or rejected — the audit
+    trail behind the 834-to-837 loop.
+</MudText>
+
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error" Variant="Variant.Outlined" Class="mb-4" ShowCloseIcon="true" CloseIconClicked="() => _error = null">
+        @_error
+    </MudAlert>
+}
+
+<MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-0">
+    <MudTabPanel Text="834 Enrollment" Icon="@Icons.Material.Filled.HowToReg">
+        <div class="d-flex align-center gap-3 my-3">
+            <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Refresh"
+                       OnClick="@(() => LoadEnrollmentTransactions())" Disabled="_enrollmentLoading">
+                Refresh
+            </MudButton>
+            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">@EnrollmentStatus</MudText>
+        </div>
+        @if (_enrollmentLoading)
+        {
+            <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-3" />
+        }
+        <MudTable Items="_enrollmentTransactions" Dense="true" Hover="true" T="Enrollment834Record" RowsPerPage="25"
+                  Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+            <HeaderContent>
+                <MudTh>Received</MudTh>
+                <MudTh>Member</MudTh>
+                <MudTh>Batch</MudTh>
+                <MudTh>Maintenance</MudTh>
+                <MudTh>Status</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Received">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.TransactionDate.ToLocalTime().ToString("MM/dd HH:mm:ss")</MudText>
+                </MudTd>
+                <MudTd DataLabel="Member">
+                    <MudText Typo="Typo.body2">@context.MemberName</MudText>
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); font-family: monospace;">@context.MemberId</MudText>
+                </MudTd>
+                <MudTd DataLabel="Batch">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.BatchId</MudText>
+                </MudTd>
+                <MudTd DataLabel="Maintenance">
+                    <MudText Typo="Typo.body2">@context.MaintenanceTypeCode</MudText>
+                </MudTd>
+                <MudTd DataLabel="Status">
+                    <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+                    @if (context.Errors.Count > 0)
+                    {
+                        <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55); display: block;">@string.Join("; ", context.Errors)</MudText>
+                    }
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <div class="pa-8 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.HowToReg" Style="font-size: 3rem; color: rgba(0,255,255,0.3);" />
+                    <MudText Typo="Typo.body1" Class="mt-2" Style="color: rgba(255,255,255,0.55);">No 834 transactions found</MudText>
+                </div>
+            </NoRecordsContent>
+            <PagerContent>
+                <MudTablePager PageSizeOptions="new[] { 10, 25, 50, 100 }" />
+            </PagerContent>
+        </MudTable>
+    </MudTabPanel>
+
+    <MudTabPanel Text="837 Claims" Icon="@Icons.Material.Filled.Receipt">
+        <div class="d-flex align-center gap-3 my-3">
+            <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Refresh"
+                       OnClick="@(() => LoadClaimTransactions())" Disabled="_claimLoading">
+                Refresh
+            </MudButton>
+            <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">@ClaimStatus</MudText>
+        </div>
+        @if (_claimLoading)
+        {
+            <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-3" />
+        }
+        <MudTable Items="_claimTransactions" Dense="true" Hover="true" T="ClaimImportTransactionRecord" RowsPerPage="25"
+                  Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
+            <HeaderContent>
+                <MudTh>Received</MudTh>
+                <MudTh>Claim</MudTh>
+                <MudTh>Member</MudTh>
+                <MudTh>File</MudTh>
+                <MudTh>Status</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Received">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.ReceivedAt.ToLocalTime().ToString("MM/dd HH:mm:ss")</MudText>
+                </MudTd>
+                <MudTd DataLabel="Claim">
+                    @if (!string.IsNullOrWhiteSpace(context.ClaimId))
+                    {
+                        <MudLink Href="@($"/claims/{Uri.EscapeDataString(context.ClaimId)}")" Color="Color.Primary" Style="font-family: monospace; font-weight: 700;">
+                            @context.ClaimNumber
+                        </MudLink>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.body2" Style="font-family: monospace; font-weight: 700;">@context.ClaimNumber</MudText>
+                    }
+                </MudTd>
+                <MudTd DataLabel="Member">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.MemberId</MudText>
+                </MudTd>
+                <MudTd DataLabel="File">
+                    <MudText Typo="Typo.body2">@context.FileName</MudText>
+                </MudTd>
+                <MudTd DataLabel="Status">
+                    <MudChip T="string" Size="Size.Small" Color="@StatusColor(context.Status)">@context.Status</MudChip>
+                    @if (context.Errors.Count > 0)
+                    {
+                        <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55); display: block;">@string.Join("; ", context.Errors)</MudText>
+                    }
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <div class="pa-8 text-center">
+                    <MudIcon Icon="@Icons.Material.Filled.Receipt" Style="font-size: 3rem; color: rgba(0,255,255,0.3);" />
+                    <MudText Typo="Typo.body1" Class="mt-2" Style="color: rgba(255,255,255,0.55);">No 837 import transactions found</MudText>
+                </div>
+            </NoRecordsContent>
+            <PagerContent>
+                <MudTablePager PageSizeOptions="new[] { 10, 25, 50, 100 }" />
+            </PagerContent>
+        </MudTable>
+    </MudTabPanel>
+</MudTabs>
+</div>
+</PermissionGate>
+
+@code {
+    private readonly List<Enrollment834Record> _enrollmentTransactions = new();
+    private readonly List<ClaimImportTransactionRecord> _claimTransactions = new();
+    private bool _enrollmentLoading;
+    private bool _claimLoading;
+    private string? _error;
+    private DateTimeOffset? _enrollmentLastRefreshedAt;
+    private DateTimeOffset? _claimLastRefreshedAt;
+
+    private string EnrollmentStatus
+        => _enrollmentLastRefreshedAt is null ? "Not checked yet" : $"Last checked {_enrollmentLastRefreshedAt.Value.LocalDateTime:HH:mm:ss}";
+
+    private string ClaimStatus
+        => _claimLastRefreshedAt is null ? "Not checked yet" : $"Last checked {_claimLastRefreshedAt.Value.LocalDateTime:HH:mm:ss}";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadEnrollmentTransactions();
+        await LoadClaimTransactions();
+    }
+
+    private async Task LoadEnrollmentTransactions()
+    {
+        _enrollmentLoading = true;
+        _error = null;
+        try
+        {
+            var records = await EdiTransactionsService.GetEnrollment834TransactionsAsync(100);
+            _enrollmentTransactions.Clear();
+            _enrollmentTransactions.AddRange(records);
+            _enrollmentLastRefreshedAt = DateTimeOffset.Now;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            Snackbar.Add("Unable to load 834 transactions", Severity.Error);
+        }
+        finally
+        {
+            _enrollmentLoading = false;
+        }
+    }
+
+    private async Task LoadClaimTransactions()
+    {
+        _claimLoading = true;
+        _error = null;
+        try
+        {
+            var records = await EdiTransactionsService.GetClaimImportTransactionsAsync(100);
+            _claimTransactions.Clear();
+            _claimTransactions.AddRange(records);
+            _claimLastRefreshedAt = DateTimeOffset.Now;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            Snackbar.Add("Unable to load 837 import transactions", Severity.Error);
+        }
+        finally
+        {
+            _claimLoading = false;
+        }
+    }
+
+    private static Color StatusColor(string status) => status switch
+    {
+        "Accepted" => Color.Success,
+        "Rejected" => Color.Error,
+        "Pending" => Color.Warning,
+        _ => Color.Default
+    };
+}

--- a/src/portal/CloudHealthOffice.Portal/Program.cs
+++ b/src/portal/CloudHealthOffice.Portal/Program.cs
@@ -256,6 +256,7 @@ builder.Services.AddScoped<IMemberNoteService, MemberNoteService>();
 builder.Services.AddScoped<IFamilyRelationshipService, FamilyRelationshipService>();
 builder.Services.AddScoped<ICoverageService, CoverageService>();
 builder.Services.AddScoped<IClaimsService, ClaimsService>();
+builder.Services.AddScoped<IEdiTransactionsService, EdiTransactionsService>();
 builder.Services.AddScoped<IEligibilityService, EligibilityService>();
 builder.Services.AddScoped<IAuthorizationService, AuthorizationService>();
 builder.Services.AddScoped<IAttachmentService, AttachmentService>();

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -32,6 +32,34 @@ public interface IClaimsService
     Task<EobSearchResponse> SearchClaimsByMemberAsync(string memberId, MemberClaimsFilter filter);
 }
 
+/// <summary>
+/// Admin-console read path for raw EDI import outcomes — 834 enrollment
+/// batches (enrollment-import-service) and 837 claim imports
+/// (claims-service). Distinct from <see cref="IMemberService.GetMember834TransactionsAsync"/>,
+/// which is member-scoped and proxied through member-service; this is a
+/// tenant-wide admin view, so it calls both owning services directly, same
+/// as <see cref="IClaimsService.GetMassAdjudicationRunsAsync"/> does for
+/// claims-service.
+/// </summary>
+public interface IEdiTransactionsService
+{
+    Task<List<Enrollment834Record>> GetEnrollment834TransactionsAsync(int limit = 100);
+    Task<List<ClaimImportTransactionRecord>> GetClaimImportTransactionsAsync(int limit = 100);
+}
+
+/// <summary>Portal projection of claims-service's ClaimImportTransaction.</summary>
+public class ClaimImportTransactionRecord
+{
+    public string Id { get; set; } = string.Empty;
+    public string ClaimNumber { get; set; } = string.Empty;
+    public string? ClaimId { get; set; }
+    public string MemberId { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public DateTime ReceivedAt { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public List<string> Errors { get; set; } = new();
+}
+
 public interface IEligibilityService
 {
     Task<EligibilityResponse> CheckEligibilityAsync(object request);

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -338,6 +338,53 @@ public class ClaimsService : IClaimsService
     }
 }
 
+public class EdiTransactionsService : IEdiTransactionsService
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<EdiTransactionsService> _logger;
+
+    public EdiTransactionsService(HttpClient httpClient, IConfiguration configuration, ILogger<EdiTransactionsService> logger)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<List<Enrollment834Record>> GetEnrollment834TransactionsAsync(int limit = 100)
+    {
+        var baseUrl = _configuration["Services:EnrollmentImportService"];
+        try
+        {
+            var records = await _httpClient.GetFromJsonAsync<List<Enrollment834Record>>(
+                $"{baseUrl}/v1/enrollment/transactions/recent?limit={Math.Clamp(limit, 1, 500)}", JsonOptions);
+            return records ?? new List<Enrollment834Record>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Enrollment Import Service");
+            throw new ServiceUnavailableException("Enrollment Import Service", ex);
+        }
+    }
+
+    public async Task<List<ClaimImportTransactionRecord>> GetClaimImportTransactionsAsync(int limit = 100)
+    {
+        var baseUrl = _configuration["Services:ClaimsService"];
+        try
+        {
+            var records = await _httpClient.GetFromJsonAsync<List<ClaimImportTransactionRecord>>(
+                $"{baseUrl}/v1/claims/import-transactions?limit={Math.Clamp(limit, 1, 500)}", JsonOptions);
+            return records ?? new List<ClaimImportTransactionRecord>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
+            throw new ServiceUnavailableException("Claims Service", ex);
+        }
+    }
+}
+
 public sealed class FlexibleClaimTypeJsonConverter : JsonConverter<string>
 {
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
+++ b/src/portal/CloudHealthOffice.Portal/Shared/MainLayout.razor
@@ -129,6 +129,10 @@
                                     Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
                             Claims
                         </MudNavLink>
+                        <MudNavLink Href="/edi-transactions" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.SwapHoriz"
+                                    Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
+                            EDI Transactions
+                        </MudNavLink>
                         <MudNavLink Href="/mass-adjudication-runs" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Assessment"
                                     Style="border-left: 3px solid transparent; transition: all 0.3s ease;">
                             Mass Adjudication

--- a/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
+++ b/src/portal/CloudHealthOffice.Portal/appsettings.Development.json
@@ -32,6 +32,7 @@
     "ClaimsService": "http://localhost:5001/api",
     "BenefitPlanService": "http://localhost:5002/api",
     "MemberService": "http://localhost:5003/api",
+    "EnrollmentImportService": "http://localhost:5011/api",
     "ProviderService": "http://localhost:5004/api",
     "AuthorizationService": "http://localhost:5005/api",
     "PaymentService": "http://localhost:5006/api",

--- a/src/portal/CloudHealthOffice.Portal/appsettings.json
+++ b/src/portal/CloudHealthOffice.Portal/appsettings.json
@@ -35,6 +35,7 @@
     "MemberService": "http://member-service.cloudhealthoffice/api/v1",
     "CoverageService": "http://coverage-service.cloudhealthoffice/api",
     "ClaimsService": "http://claims-service.cloudhealthoffice/api",
+    "EnrollmentImportService": "http://enrollment-import-service.cloudhealthoffice/api",
     "EligibilityService": "http://eligibility-service.cloudhealthoffice/api",
     "AuthorizationService": "http://authorization-service.cloudhealthoffice/api",
     "ProviderService": "http://provider-service.cloudhealthoffice/api",


### PR DESCRIPTION
## Summary
The frontend piece of the EDI transactions console discussed earlier — #1014 added the backend transaction logs and admin endpoints; this wires up the actual page.

- New `/edi-transactions` page, modeled on `MassAdjudicationRuns.razor`'s master-list structure but sized to what's actually needed here: two tabs (834 enrollment, 837 claims), each a `MudTable` reading from the admin-scoped transaction-log endpoints added in #1014. Status chips flag Accepted vs. Rejected; rejected rows show their error text inline.
- New portal-side `IEdiTransactionsService`/`EdiTransactionsService`, calling claims-service and enrollment-import-service **directly** (same pattern as `IClaimsService`'s mass-adjudication calls) rather than proxied through member-service — this is tenant-wide admin data, not member-scoped, so the existing member-service-proxy pattern (used for `GetMember834TransactionsAsync`) doesn't fit.
- Reuses the existing `Enrollment834Record` DTO for the 834 side; adds `ClaimImportTransactionRecord` for the 837 side.
- Adds `Services:EnrollmentImportService` to both appsettings files — the portal had no config entry for that service at all before this.
- Nav link added alongside Mass Adjudication in `MainLayout.razor`.

## Verification caveats (being upfront about what I could and couldn't check)
- `dotnet build`/`dotnet test` pass cleanly, including 5 new service-layer tests (HTTP mocked via the existing `FakeHandler` test helper).
- I started the portal dev server locally and confirmed it boots with no DI/startup exceptions and the new route responds. I could **not** do a full authenticated browser click-through — the page is behind `[Authorize]` and there's no live claims-service/enrollment-import-service in this environment to actually populate data against. Worth a manual look once deployed somewhere with both.

## Test plan
- [x] `dotnet test src/portal/CloudHealthOffice.Portal.Tests` — 716/716 passing
- [x] Dev server startup sanity check (no exceptions, route resolves)
- [ ] Manual browser verification against a real deployment (not done — no live backend in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)