### PR TITLE
Add 834 import runs view — batch-level summaries, not just per-member rows

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/EdiTransactionsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/EdiTransactionsServiceTests.cs
@@ -101,4 +101,49 @@ public class EdiTransactionsServiceTests
         handler.CapturedUrls.Should().ContainSingle(u =>
             u.Contains("/v1/claims/import-transactions") && u.Contains("limit=50"));
     }
+
+    // ── GetEnrollmentImportRunsAsync ──
+
+    [Fact]
+    public async Task GetEnrollmentImportRunsAsync_WhenApiFails_ThrowsServiceUnavailableException()
+    {
+        var sut = CreateService();
+        var ex = await Assert.ThrowsAsync<ServiceUnavailableException>(
+            () => sut.GetEnrollmentImportRunsAsync());
+        ex.ServiceName.Should().Be("Enrollment Import Service");
+    }
+
+    [Fact]
+    public async Task GetEnrollmentImportRunsAsync_ParsesResponse_AndHitsExpectedUrl()
+    {
+        var body = """
+            [
+              { "id": "RUN-1", "batchId": "B1", "fileName": "test.834", "successCount": 3, "failedCount": 1,
+                "membersCreated": 2, "membersUpdated": 1, "coverageRecordsCreated": 2,
+                "coverageMappingsUnresolved": 0, "errors": [] }
+            ]
+            """;
+        var handler = new FakeHandler(HttpStatusCode.OK, body);
+        var sut = CreateService(new HttpClient(handler));
+
+        var result = await sut.GetEnrollmentImportRunsAsync(50);
+
+        result.Should().ContainSingle();
+        result[0].BatchId.Should().Be("B1");
+        result[0].SuccessCount.Should().Be(3);
+        result[0].FailedCount.Should().Be(1);
+        handler.CapturedUrls.Should().ContainSingle(u =>
+            u.Contains("/v1/enrollment/import-runs") && u.Contains("limit=50"));
+    }
+
+    [Fact]
+    public async Task GetEnrollmentImportRunsAsync_ClampsLimitTo500()
+    {
+        var handler = new FakeHandler(HttpStatusCode.OK, "[]");
+        var sut = CreateService(new HttpClient(handler));
+
+        await sut.GetEnrollmentImportRunsAsync(99999);
+
+        handler.CapturedUrls.Should().ContainSingle(u => u.Contains("limit=500"));
+    }
 }

--- a/src/portal/CloudHealthOffice.Portal/Pages/EdiTransactions.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/EdiTransactions.razor
@@ -28,7 +28,7 @@
     <MudTabPanel Text="834 Enrollment" Icon="@Icons.Material.Filled.HowToReg">
         <div class="d-flex align-center gap-3 my-3">
             <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Refresh"
-                       OnClick="@(() => LoadEnrollmentTransactions())" Disabled="_enrollmentLoading">
+                       OnClick="@(() => LoadEnrollmentData())" Disabled="_enrollmentLoading">
                 Refresh
             </MudButton>
             <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.55);">@EnrollmentStatus</MudText>
@@ -37,7 +37,70 @@
         {
             <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="mb-3" />
         }
-        <MudTable Items="_enrollmentTransactions" Dense="true" Hover="true" T="Enrollment834Record" RowsPerPage="25"
+
+        <MudText Typo="Typo.subtitle2" Class="mb-2" Style="font-weight: 700;">Runs</MudText>
+        <MudTable Items="_enrollmentRuns" Dense="true" Hover="true" T="EnrollmentImportRunRecord" RowsPerPage="10"
+                  Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;" Class="mb-4">
+            <HeaderContent>
+                <MudTh>Started</MudTh>
+                <MudTh>Batch / File</MudTh>
+                <MudTh>Accepted / Failed</MudTh>
+                <MudTh>Members</MudTh>
+                <MudTh>Coverage</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Started">
+                    <MudText Typo="Typo.body2" Style="font-family: monospace;">@context.StartedAt.ToLocalTime().ToString("MM/dd HH:mm:ss")</MudText>
+                </MudTd>
+                <MudTd DataLabel="Batch / File">
+                    <MudLink Style="font-family: monospace; font-weight: 700; cursor: pointer;" OnClick="@(() => SelectRun(context))">
+                        @context.BatchId
+                    </MudLink>
+                    @if (!string.IsNullOrWhiteSpace(context.FileName))
+                    {
+                        <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.45); display: block;">@context.FileName</MudText>
+                    }
+                </MudTd>
+                <MudTd DataLabel="Accepted / Failed">
+                    <MudText Typo="Typo.body2">
+                        <span style="color: #00ff88;">@context.SuccessCount</span> / <span style="color: @(context.FailedCount > 0 ? "#ff0055" : "rgba(255,255,255,0.55)")">@context.FailedCount</span>
+                    </MudText>
+                </MudTd>
+                <MudTd DataLabel="Members">
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65);">
+                        +@context.MembersCreated / ~@context.MembersUpdated / -@context.MembersTerminated · @context.DependentsCreated deps
+                    </MudText>
+                </MudTd>
+                <MudTd DataLabel="Coverage">
+                    <MudText Typo="Typo.caption" Style="color: rgba(255,255,255,0.65);">
+                        @context.CoverageRecordsCreated created
+                        @if (context.CoverageMappingsUnresolved > 0)
+                        {
+                            <span style="color: #ffca28;"> · @context.CoverageMappingsUnresolved unresolved</span>
+                        }
+                    </MudText>
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <div class="pa-6 text-center">
+                    <MudText Typo="Typo.body2" Style="color: rgba(255,255,255,0.55);">No 834 import runs found</MudText>
+                </div>
+            </NoRecordsContent>
+            <PagerContent>
+                <MudTablePager PageSizeOptions="new[] { 10, 25, 50 }" />
+            </PagerContent>
+        </MudTable>
+
+        <div class="d-flex align-center gap-2 mb-2">
+            <MudText Typo="Typo.subtitle2" Style="font-weight: 700;">Transactions</MudText>
+            @if (!string.IsNullOrWhiteSpace(_selectedBatchId))
+            {
+                <MudChip T="string" Size="Size.Small" Color="Color.Info" OnClose="@(() => _selectedBatchId = null)">
+                    Batch: @_selectedBatchId
+                </MudChip>
+            }
+        </div>
+        <MudTable Items="FilteredEnrollmentTransactions" Dense="true" Hover="true" T="Enrollment834Record" RowsPerPage="25"
                   Style="background: rgba(10,10,10,0.9); border: 1px solid rgba(0,255,255,0.15); border-radius: 8px;">
             <HeaderContent>
                 <MudTh>Received</MudTh>
@@ -148,10 +211,12 @@
 
 @code {
     private readonly List<Enrollment834Record> _enrollmentTransactions = new();
+    private readonly List<EnrollmentImportRunRecord> _enrollmentRuns = new();
     private readonly List<ClaimImportTransactionRecord> _claimTransactions = new();
     private bool _enrollmentLoading;
     private bool _claimLoading;
     private string? _error;
+    private string? _selectedBatchId;
     private DateTimeOffset? _enrollmentLastRefreshedAt;
     private DateTimeOffset? _claimLastRefreshedAt;
 
@@ -161,27 +226,39 @@
     private string ClaimStatus
         => _claimLastRefreshedAt is null ? "Not checked yet" : $"Last checked {_claimLastRefreshedAt.Value.LocalDateTime:HH:mm:ss}";
 
+    private IEnumerable<Enrollment834Record> FilteredEnrollmentTransactions
+        => string.IsNullOrWhiteSpace(_selectedBatchId)
+            ? _enrollmentTransactions
+            : _enrollmentTransactions.Where(t => string.Equals(t.BatchId, _selectedBatchId, StringComparison.OrdinalIgnoreCase));
+
     protected override async Task OnInitializedAsync()
     {
-        await LoadEnrollmentTransactions();
+        await LoadEnrollmentData();
         await LoadClaimTransactions();
     }
 
-    private async Task LoadEnrollmentTransactions()
+    private void SelectRun(EnrollmentImportRunRecord run) => _selectedBatchId = run.BatchId;
+
+    private async Task LoadEnrollmentData()
     {
         _enrollmentLoading = true;
         _error = null;
         try
         {
+            var runs = await EdiTransactionsService.GetEnrollmentImportRunsAsync(100);
+            _enrollmentRuns.Clear();
+            _enrollmentRuns.AddRange(runs);
+
             var records = await EdiTransactionsService.GetEnrollment834TransactionsAsync(100);
             _enrollmentTransactions.Clear();
             _enrollmentTransactions.AddRange(records);
+
             _enrollmentLastRefreshedAt = DateTimeOffset.Now;
         }
         catch (Exception ex)
         {
             _error = ex.Message;
-            Snackbar.Add("Unable to load 834 transactions", Severity.Error);
+            Snackbar.Add("Unable to load 834 data", Severity.Error);
         }
         finally
         {

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -45,6 +45,9 @@ public interface IEdiTransactionsService
 {
     Task<List<Enrollment834Record>> GetEnrollment834TransactionsAsync(int limit = 100);
     Task<List<ClaimImportTransactionRecord>> GetClaimImportTransactionsAsync(int limit = 100);
+
+    /// <summary>Batch-level 834 run summaries — one row per import, not per member. See <see cref="EnrollmentImportRunRecord"/>.</summary>
+    Task<List<EnrollmentImportRunRecord>> GetEnrollmentImportRunsAsync(int limit = 100);
 }
 
 /// <summary>Portal projection of claims-service's ClaimImportTransaction.</summary>
@@ -57,6 +60,26 @@ public class ClaimImportTransactionRecord
     public string? FileName { get; set; }
     public DateTime ReceivedAt { get; set; }
     public string Status { get; set; } = string.Empty;
+    public List<string> Errors { get; set; } = new();
+}
+
+/// <summary>Portal projection of enrollment-import-service's EnrollmentImportRun — one row per 834 batch.</summary>
+public class EnrollmentImportRunRecord
+{
+    public string Id { get; set; } = string.Empty;
+    public string BatchId { get; set; } = string.Empty;
+    public string? FileName { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public int SuccessCount { get; set; }
+    public int FailedCount { get; set; }
+    public int SkippedCount { get; set; }
+    public int MembersCreated { get; set; }
+    public int MembersUpdated { get; set; }
+    public int MembersTerminated { get; set; }
+    public int DependentsCreated { get; set; }
+    public int CoverageRecordsCreated { get; set; }
+    public int CoverageMappingsUnresolved { get; set; }
     public List<string> Errors { get; set; } = new();
 }
 

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -383,6 +383,22 @@ public class EdiTransactionsService : IEdiTransactionsService
             throw new ServiceUnavailableException("Claims Service", ex);
         }
     }
+
+    public async Task<List<EnrollmentImportRunRecord>> GetEnrollmentImportRunsAsync(int limit = 100)
+    {
+        var baseUrl = _configuration["Services:EnrollmentImportService"];
+        try
+        {
+            var records = await _httpClient.GetFromJsonAsync<List<EnrollmentImportRunRecord>>(
+                $"{baseUrl}/v1/enrollment/import-runs?limit={Math.Clamp(limit, 1, 500)}", JsonOptions);
+            return records ?? new List<EnrollmentImportRunRecord>();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Service unavailable: {ServiceName}", "Enrollment Import Service");
+            throw new ServiceUnavailableException("Enrollment Import Service", ex);
+        }
+    }
 }
 
 public sealed class FlexibleClaimTypeJsonConverter : JsonConverter<string>

--- a/src/services/enrollment-import-service/Controllers/EnrollmentController.cs
+++ b/src/services/enrollment-import-service/Controllers/EnrollmentController.cs
@@ -12,17 +12,20 @@ public class EnrollmentController : ControllerBase
     private readonly IEnrollmentImportService _importService;
     private readonly IEnrollment834EdiParser _ediParser;
     private readonly IPlanCodeGapReportService _gapReportService;
+    private readonly IEnrollmentImportRunRepository _importRuns;
     private readonly ILogger<EnrollmentController> _logger;
 
     public EnrollmentController(
         IEnrollmentImportService importService,
         IEnrollment834EdiParser ediParser,
         IPlanCodeGapReportService gapReportService,
+        IEnrollmentImportRunRepository importRuns,
         ILogger<EnrollmentController> logger)
     {
         _importService = importService;
         _ediParser = ediParser;
         _gapReportService = gapReportService;
+        _importRuns = importRuns;
         _logger = logger;
     }
 
@@ -151,6 +154,31 @@ public class EnrollmentController : ControllerBase
 
         var report = await _gapReportService.BuildReportAsync(enrollment, tenantId, ct);
         return Ok(report);
+    }
+
+    /// <summary>
+    /// Most recent 834 import runs for the tenant, newest first — one row
+    /// per batch (raw834 upload or structured /import call), with the same
+    /// counts <see cref="ImportResult"/> already returns synchronously. The
+    /// admin-console read path for "what happened the last time this
+    /// employer's file was dropped," without needing to have watched the
+    /// original API response.
+    /// </summary>
+    [HttpGet("import-runs")]
+    [ProducesResponseType(typeof(List<EnrollmentImportRun>), 200)]
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> ListImportRuns(
+        [FromHeader(Name = "X-Tenant-ID")] string tenantId,
+        [FromQuery] int limit = 100)
+    {
+        if (string.IsNullOrEmpty(tenantId))
+        {
+            return BadRequest("X-Tenant-ID header is required");
+        }
+        if (limit < 1 || limit > 500) limit = 100;
+
+        var runs = await _importRuns.ListRecentAsync(tenantId, limit);
+        return Ok(runs);
     }
 
     [HttpGet("health")]

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/EnrollmentControllerTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Controllers/EnrollmentControllerTests.cs
@@ -1,0 +1,65 @@
+using EnrollmentImportService.Controllers;
+using EnrollmentImportService.Models;
+using EnrollmentImportService.Services;
+using EnrollmentImportService.Services.Edi;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace EnrollmentImportService.Tests.Controllers;
+
+/// <summary>Covers the run-history read path added alongside <see cref="EnrollmentImportRun"/>.</summary>
+public class EnrollmentControllerTests
+{
+    private static (EnrollmentController ctl, Mock<IEnrollmentImportRunRepository> runs) Build()
+    {
+        var importService = new Mock<IEnrollmentImportService>();
+        var ediParser = new Mock<IEnrollment834EdiParser>();
+        var gapReportService = new Mock<IPlanCodeGapReportService>();
+        var runs = new Mock<IEnrollmentImportRunRepository>();
+
+        var ctl = new EnrollmentController(
+            importService.Object, ediParser.Object, gapReportService.Object, runs.Object,
+            NullLogger<EnrollmentController>.Instance);
+
+        return (ctl, runs);
+    }
+
+    [Fact]
+    public async Task ListImportRuns_ReturnsRepoResult()
+    {
+        var (ctl, runs) = Build();
+        runs.Setup(r => r.ListRecentAsync("t1", 100))
+            .ReturnsAsync(new List<EnrollmentImportRun>
+            {
+                new() { TenantId = "t1", BatchId = "B1", SuccessCount = 2 },
+                new() { TenantId = "t1", BatchId = "B2", SuccessCount = 5 }
+            });
+
+        var resp = await ctl.ListImportRuns("t1", 100);
+        var ok = resp.Should().BeOfType<OkObjectResult>().Subject;
+        var list = (IReadOnlyList<EnrollmentImportRun>)ok.Value!;
+        list.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListImportRuns_MissingTenant_ReturnsBadRequest()
+    {
+        var (ctl, _) = Build();
+        (await ctl.ListImportRuns("")).Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task ListImportRuns_LimitOutOfRange_ClampsTo100()
+    {
+        var (ctl, runs) = Build();
+        runs.Setup(r => r.ListRecentAsync("t1", 100))
+            .ReturnsAsync(new List<EnrollmentImportRun>());
+
+        await ctl.ListImportRuns("t1", 99999);
+        runs.Verify(r => r.ListRecentAsync("t1", 100), Times.Once);
+
+        await ctl.ListImportRuns("t1", 0);
+        runs.Verify(r => r.ListRecentAsync("t1", 100), Times.Exactly(2));
+    }
+}

--- a/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
+++ b/src/services/enrollment-import-service/EnrollmentImportService.Tests/Services/EnrollmentImportServiceTests.cs
@@ -18,7 +18,8 @@ public class EnrollmentImportServiceTests
         Mock<ICoverageServiceClient> coverageClient,
         Mock<IMemberServiceClient> memberClient,
         Mock<ISponsorServiceClient> sponsorClient,
-        Mock<IBenefitPlanServiceClient> benefitPlanClient)
+        Mock<IBenefitPlanServiceClient> benefitPlanClient,
+        Mock<IEnrollmentImportRunRepository> importRuns)
         Build()
     {
         var coverageClient = new Mock<ICoverageServiceClient>();
@@ -53,14 +54,19 @@ public class EnrollmentImportServiceTests
         txns.Setup(t => t.CreateAsync(It.IsAny<EnrollmentTransaction>()))
             .ReturnsAsync((EnrollmentTransaction t) => t);
 
+        var importRuns = new Mock<IEnrollmentImportRunRepository>();
+        importRuns.Setup(r => r.CreateAsync(It.IsAny<EnrollmentImportRun>()))
+            .ReturnsAsync((EnrollmentImportRun r) => r);
+
         var events = new InMemoryEnrollmentEventRepository();
         var publisher = new EnrollmentEventPublisher(events, NullLogger<EnrollmentEventPublisher>.Instance);
         var validator = new EnrollmentValidator();
 
         var svc = new ImportSvc(
-            memberClient.Object, sponsorClient.Object, benefitPlanClient.Object, coverageClient.Object, txns.Object, publisher, validator,
+            memberClient.Object, sponsorClient.Object, benefitPlanClient.Object, coverageClient.Object,
+            txns.Object, importRuns.Object, publisher, validator,
             NullLogger<ImportSvc>.Instance);
-        return (svc, events, coverageClient, memberClient, sponsorClient, benefitPlanClient);
+        return (svc, events, coverageClient, memberClient, sponsorClient, benefitPlanClient, importRuns);
     }
 
     private static MemberEnrollment NewSubscriber(string subscriberId) => new()
@@ -76,7 +82,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_EmitsOneEvent_PerAcceptedTransaction()
     {
-        var (svc, events, _, _, _, _) = Build();
+        var (svc, events, _, _, _, _, _) = Build();
 
         var batch = new Enrollment834
         {
@@ -98,7 +104,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_RejectedValidation_DoesNotEmitEvent()
     {
-        var (svc, events, _, _, _, _) = Build();
+        var (svc, events, _, _, _, _, _) = Build();
 
         var bad = new MemberEnrollment(); // no required fields
         var batch = new Enrollment834
@@ -116,7 +122,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_ReplayingSameBatch_ProducesNoDuplicateEvents()
     {
-        var (svc, events, _, _, _, _) = Build();
+        var (svc, events, _, _, _, _, _) = Build();
 
         var batch = new Enrollment834
         {
@@ -135,7 +141,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_ManualSource_UsesManualPrefix_AndDoesNotAccidentallyDedupe()
     {
-        var (svc, events, _, _, _, _) = Build();
+        var (svc, events, _, _, _, _, _) = Build();
 
         // Two manual enrollments for the same subscriber but with distinct EventIds —
         // each should produce a separate event even if the synthesized batch ids
@@ -173,7 +179,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_ManualSource_SameRequestEventId_IsIdempotent()
     {
-        var (svc, events, _, _, _, _) = Build();
+        var (svc, events, _, _, _, _, _) = Build();
 
         var e1 = NewSubscriber("M-idem");
         e1.EventId = "stable-key";
@@ -206,7 +212,7 @@ public class EnrollmentImportServiceTests
         // separators, e.g. "19780922"), which DateTime.TryParse silently fails
         // to recognize as a date at all (confirmed empirically: it returns
         // false, not an exception) rather than a differently-formatted date.
-        var (svc, _, _, memberClient, _, _) = Build();
+        var (svc, _, _, memberClient, _, _, _) = Build();
 
         CreateMemberRequestDto? created = null;
         memberClient.Setup(m => m.CreateAsync(It.IsAny<string>(), It.IsAny<CreateMemberRequestDto>(), It.IsAny<CancellationToken>()))
@@ -236,7 +242,7 @@ public class EnrollmentImportServiceTests
         // must go through IMemberServiceClient rather than writing directly
         // to Mongo — see IMemberServiceClient's doc comment for why
         // Member/Sponsor/Coverage all moved to their owning services.
-        var (svc, _, _, memberClient, _, _) = Build();
+        var (svc, _, _, memberClient, _, _, _) = Build();
 
         var batch = new Enrollment834
         {
@@ -255,7 +261,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_Termination_CallsMemberServiceTerminate()
     {
-        var (svc, _, _, memberClient, _, _) = Build();
+        var (svc, _, _, memberClient, _, _, _) = Build();
 
         // First: create the member (existence check defaults to false via Build()).
         var create = NewSubscriber("M-term");
@@ -294,7 +300,7 @@ public class EnrollmentImportServiceTests
         // type") and get silently skipped — real 834 fixtures use "025" for
         // subscribers being brought back after a prior termination, and they
         // were never actually landing in member-service.
-        var (svc, _, _, memberClient, _, _) = Build();
+        var (svc, _, _, memberClient, _, _, _) = Build();
 
         memberClient.Setup(m => m.ExistsAsync("t1", "M-reinstate", It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
@@ -325,7 +331,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_Reinstatement_OfUnknownMember_CreatesRatherThanSkips()
     {
-        var (svc, _, _, memberClient, _, _) = Build();
+        var (svc, _, _, memberClient, _, _, _) = Build();
         // Build() defaults ExistsAsync to false — member is unknown to member-service.
 
         var reinstate = NewSubscriber("M-reinstate-new");
@@ -379,7 +385,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_CoverageWithMappedPlanCode_CreatesCoverageUsingResolvedPlanId()
     {
-        var (svc, _, coverageClient, _, _, benefitPlanClient) = Build();
+        var (svc, _, coverageClient, _, _, benefitPlanClient, _) = Build();
         benefitPlanClient.Setup(b => b.ResolvePlanIdAsync(
                 "t1", "GRP0001", "HLT", "PPO2026", It.IsAny<CancellationToken>()))
             .ReturnsAsync("benefit-plan-guid-123");
@@ -409,7 +415,7 @@ public class EnrollmentImportServiceTests
         // This is the regression guard for the original bug: an unresolved
         // 834 plan code must NOT fall back to a literal "DEFAULT" PlanId —
         // it should be skipped and counted so the gap is visible in ImportResult.
-        var (svc, _, coverageClient, _, _, benefitPlanClient) = Build();
+        var (svc, _, coverageClient, _, _, benefitPlanClient, _) = Build();
         benefitPlanClient.Setup(b => b.ResolvePlanIdAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
@@ -434,7 +440,7 @@ public class EnrollmentImportServiceTests
     [Fact]
     public async Task Import_CoverageMissingGroupNumber_SkipsResolution_WithoutCallingBenefitPlanClient()
     {
-        var (svc, _, coverageClient, _, _, benefitPlanClient) = Build();
+        var (svc, _, coverageClient, _, _, benefitPlanClient, _) = Build();
 
         var enrollment = NewSubscriber("M-nogroup");
         enrollment.GroupNumber = null;
@@ -453,5 +459,51 @@ public class EnrollmentImportServiceTests
         benefitPlanClient.Verify(b => b.ResolvePlanIdAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Import_PersistsRunSummary_MatchingTheReturnedImportResult()
+    {
+        var (svc, _, _, _, _, _, importRuns) = Build();
+
+        var batch = new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-run-summary",
+            Enrollments = new()
+            {
+                NewSubscriber("M-run-1"),
+                NewSubscriber("M-run-2")
+            }
+        };
+        var result = await svc.ImportEnrollmentAsync(batch, "t1");
+
+        importRuns.Verify(r => r.CreateAsync(It.Is<EnrollmentImportRun>(run =>
+            run.TenantId == "t1"
+            && run.BatchId == result.BatchId
+            && run.FileName == result.FileName
+            && run.SuccessCount == result.SuccessCount
+            && run.FailedCount == result.FailedCount
+            && run.StartedAt == result.StartedAt
+            && run.CompletedAt == result.CompletedAt)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Import_RunPersistenceFailure_DoesNotFailTheImport()
+    {
+        var (svc, events, _, _, _, _, importRuns) = Build();
+        importRuns.Setup(r => r.CreateAsync(It.IsAny<EnrollmentImportRun>()))
+            .ThrowsAsync(new InvalidOperationException("Mongo down"));
+
+        var batch = new Enrollment834
+        {
+            FileName = "test.834",
+            BatchId = "B-run-failure",
+            Enrollments = new() { NewSubscriber("M-run-failure") }
+        };
+        var result = await svc.ImportEnrollmentAsync(batch, "t1");
+
+        result.SuccessCount.Should().Be(1);
+        events.AllEvents.Should().HaveCount(1);
     }
 }

--- a/src/services/enrollment-import-service/HostedServices/EnrollmentIndexInitializer.cs
+++ b/src/services/enrollment-import-service/HostedServices/EnrollmentIndexInitializer.cs
@@ -40,6 +40,14 @@ public sealed class EnrollmentIndexInitializer : IHostedService
             new CreateIndexOptions { Name = "ix_tenant_member_received" }),
             cancellationToken: cancellationToken);
 
+        var importRuns = _db.GetCollection<EnrollmentImportRun>("enrollment-import-runs");
+        importRuns.Indexes.CreateOne(new CreateIndexModel<EnrollmentImportRun>(
+            Builders<EnrollmentImportRun>.IndexKeys
+                .Ascending(x => x.TenantId)
+                .Descending(x => x.StartedAt),
+            new CreateIndexOptions { Name = "ix_tenant_started" }),
+            cancellationToken: cancellationToken);
+
         var events = _db.GetCollection<EnrollmentEvent>("enrollment-events");
         events.Indexes.CreateOne(new CreateIndexModel<EnrollmentEvent>(
             Builders<EnrollmentEvent>.IndexKeys

--- a/src/services/enrollment-import-service/Models/EnrollmentImportRun.cs
+++ b/src/services/enrollment-import-service/Models/EnrollmentImportRun.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace EnrollmentImportService.Models;
+
+/// <summary>
+/// Persisted summary of one 834 import batch — the run-level counterpart to
+/// <see cref="EnrollmentTransaction"/>'s per-member rows. Written once per
+/// batch, at the end of <c>EnrollmentImportService.ImportEnrollmentAsync</c>,
+/// from the same <see cref="ImportResult"/> already returned synchronously to
+/// the caller; this is what lets that result be looked up again later instead
+/// of only existing for the moment of the API call.
+/// </summary>
+public class EnrollmentImportRun
+{
+    [Required]
+    public string TenantId { get; set; } = string.Empty;
+
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    public string BatchId { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public DateTime StartedAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+
+    public int SuccessCount { get; set; }
+    public int FailedCount { get; set; }
+    public int SkippedCount { get; set; }
+    public int MembersCreated { get; set; }
+    public int MembersUpdated { get; set; }
+    public int MembersTerminated { get; set; }
+    public int DependentsCreated { get; set; }
+    public int CoverageRecordsCreated { get; set; }
+    public int CoverageMappingsUnresolved { get; set; }
+
+    public List<string> Errors { get; set; } = new();
+}

--- a/src/services/enrollment-import-service/Program.cs
+++ b/src/services/enrollment-import-service/Program.cs
@@ -40,6 +40,7 @@ builder.Services.AddSingleton<IMongoDatabase>(sp =>
 // creation happens in EnrollmentIndexInitializer below), so these can be
 // singletons rather than scoped — same pattern as member-service.
 builder.Services.AddSingleton<IEnrollmentTransactionRepository, EnrollmentTransactionRepository>();
+builder.Services.AddSingleton<IEnrollmentImportRunRepository, EnrollmentImportRunRepository>();
 builder.Services.AddSingleton<IEnrollmentEventRepository, EnrollmentEventRepository>();
 builder.Services.AddScoped<IEnrollmentEventPublisher, EnrollmentEventPublisher>();
 builder.Services.AddSingleton<IEnrollmentValidator, EnrollmentValidator>();

--- a/src/services/enrollment-import-service/Services/EnrollmentImportRunRepository.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportRunRepository.cs
@@ -1,0 +1,43 @@
+using EnrollmentImportService.Models;
+using MongoDB.Driver;
+
+namespace EnrollmentImportService.Services;
+
+public interface IEnrollmentImportRunRepository
+{
+    Task<EnrollmentImportRun> CreateAsync(EnrollmentImportRun run);
+
+    /// <summary>Most recent import runs for a tenant, newest first — the admin-console read path.</summary>
+    Task<IReadOnlyList<EnrollmentImportRun>> ListRecentAsync(string tenantId, int limit = 100);
+}
+
+/// <summary>
+/// MongoDB repository for 834 import run summaries. Indexed on
+/// (tenantId, startedAt) by <c>EnrollmentIndexInitializer</c>.
+/// </summary>
+public class EnrollmentImportRunRepository : IEnrollmentImportRunRepository
+{
+    private readonly IMongoCollection<EnrollmentImportRun> _collection;
+
+    public EnrollmentImportRunRepository(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<EnrollmentImportRun>("enrollment-import-runs");
+    }
+
+    public async Task<EnrollmentImportRun> CreateAsync(EnrollmentImportRun run)
+    {
+        if (string.IsNullOrEmpty(run.Id)) run.Id = Guid.NewGuid().ToString();
+        await _collection.InsertOneAsync(run);
+        return run;
+    }
+
+    public async Task<IReadOnlyList<EnrollmentImportRun>> ListRecentAsync(string tenantId, int limit = 100)
+    {
+        var filter = Builders<EnrollmentImportRun>.Filter.Eq(x => x.TenantId, tenantId);
+
+        return await _collection.Find(filter)
+            .SortByDescending(x => x.StartedAt)
+            .Limit(limit)
+            .ToListAsync();
+    }
+}

--- a/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
+++ b/src/services/enrollment-import-service/Services/EnrollmentImportService.cs
@@ -25,6 +25,7 @@ public class EnrollmentImportService : IEnrollmentImportService
     private readonly IBenefitPlanServiceClient _benefitPlanClient;
     private readonly ICoverageServiceClient _coverageClient;
     private readonly IEnrollmentTransactionRepository _transactions;
+    private readonly IEnrollmentImportRunRepository _importRuns;
     private readonly IEnrollmentEventPublisher _eventPublisher;
     private readonly IEnrollmentValidator _validator;
     private readonly ILogger<EnrollmentImportService> _logger;
@@ -35,6 +36,7 @@ public class EnrollmentImportService : IEnrollmentImportService
         IBenefitPlanServiceClient benefitPlanClient,
         ICoverageServiceClient coverageClient,
         IEnrollmentTransactionRepository transactions,
+        IEnrollmentImportRunRepository importRuns,
         IEnrollmentEventPublisher eventPublisher,
         IEnrollmentValidator validator,
         ILogger<EnrollmentImportService> logger)
@@ -44,6 +46,7 @@ public class EnrollmentImportService : IEnrollmentImportService
         _benefitPlanClient = benefitPlanClient;
         _coverageClient = coverageClient;
         _transactions = transactions;
+        _importRuns = importRuns;
         _eventPublisher = eventPublisher;
         _validator = validator;
         _logger = logger;
@@ -115,7 +118,47 @@ public class EnrollmentImportService : IEnrollmentImportService
             "Import completed: {SuccessCount} success, {FailedCount} failed, {SkippedCount} skipped",
             result.SuccessCount, result.FailedCount, result.SkippedCount);
 
+        await RecordRunAsync(tenantId, result);
+
         return result;
+    }
+
+    /// <summary>
+    /// Persists the batch-level summary so it can be looked up again later —
+    /// the same shape as <see cref="ImportResult"/> already returned
+    /// synchronously to the caller, which otherwise only existed for the
+    /// moment of the API call. Failure here must not fail the import itself;
+    /// same posture as <see cref="RecordTransactionAsync"/>.
+    /// </summary>
+    private async Task RecordRunAsync(string tenantId, ImportResult result)
+    {
+        try
+        {
+            await _importRuns.CreateAsync(new EnrollmentImportRun
+            {
+                TenantId = tenantId,
+                BatchId = result.BatchId,
+                FileName = result.FileName,
+                StartedAt = result.StartedAt,
+                CompletedAt = result.CompletedAt,
+                SuccessCount = result.SuccessCount,
+                FailedCount = result.FailedCount,
+                SkippedCount = result.SkippedCount,
+                MembersCreated = result.MembersCreated,
+                MembersUpdated = result.MembersUpdated,
+                MembersTerminated = result.MembersTerminated,
+                DependentsCreated = result.DependentsCreated,
+                CoverageRecordsCreated = result.CoverageRecordsCreated,
+                CoverageMappingsUnresolved = result.CoverageMappingsUnresolved,
+                Errors = result.Errors
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to persist EnrollmentImportRun for batch {BatchId}",
+                SanitizeForLog(result.BatchId));
+        }
     }
 
     private async Task PublishEnrollmentEventAsync(

--- a/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
+++ b/src/services/member-service/MemberService.Tests/Integration/DownstreamRouteContractTests.cs
@@ -71,10 +71,13 @@ public class DownstreamRouteContractTests
                 // doc comments on the Member/Sponsor/Coverage delegation.
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(services);
                 RemoveAll<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(services);
+                RemoveAll<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentImportRunRepository>(services);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>(
                     new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentTransactionRepository>().Object);
                 services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>(
                     new Mock<EnrollmentSvc::EnrollmentImportService.Repositories.IEnrollmentEventRepository>().Object);
+                services.AddSingleton<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentImportRunRepository>(
+                    new Mock<EnrollmentSvc::EnrollmentImportService.Services.IEnrollmentImportRunRepository>().Object);
 
                 // Remove the Mongo index initializer that would try to connect to
                 // the fake MongoDB host at startup. Don't use RemoveAll<IHostedService>()


### PR DESCRIPTION
## Summary
Answers "is there a way to view 834 runs" — the EDI Transactions console (#1015) only showed a flat per-member transaction list. There was no batch-level summary anywhere to look up later: `ImportResult` (success/failed counts, members created/updated/terminated, coverage records created/unresolved) only ever existed for the moment of the synchronous API response — the same gap 837 had before its transaction log in #1014.

- **enrollment-import-service**: new `EnrollmentImportRun` model + repository, written once per batch at the end of `ImportEnrollmentAsync` from the same `ImportResult` already returned to the caller. New admin-scoped `GET /api/v1/enrollment/import-runs`.
- **Portal**: EDI Transactions console's 834 tab now shows a **Runs** table above the existing **Transactions** table — batch ID, file, accepted/failed, member create/update/terminate counts, coverage created/unresolved. Clicking a run filters the transaction list to that batch (client-side, no extra round-trip).
- Preemptively updated `MemberService.Tests`' `DownstreamRouteContractTests` (its cross-service `WebApplicationFactory` resolves `EnrollmentController`'s real DI graph) instead of discovering the break after merge — learned that lesson twice already this session.

## Test plan
- [x] `dotnet test` enrollment-import-service — 59/59 passing
- [x] `dotnet test` member-service — 152/152 passing (no cross-service regression)
- [x] `dotnet test` portal — 719/719 passing
- [x] `dotnet build` portal — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)