### PR TITLE
Point CI and deployment manifests at the new Azure Container Registry

### DIFF
--- a/.github/workflows/_build-service-image.yml
+++ b/.github/workflows/_build-service-image.yml
@@ -83,12 +83,12 @@ on:
         required: false
         default: false
       registry:
-        description: "ACR login server (e.g. choacrhy6h2vdulfru6.azurecr.io). Empty default falls back to vars.ACR_LOGIN_SERVER, then to the hardcoded production literal. See header comment item 1 for why default resolution lives in a step, not here."
+        description: "ACR login server (e.g. clouhealthoffice.azurecr.io). Empty default falls back to vars.ACR_LOGIN_SERVER, then to the hardcoded production literal. See header comment item 1 for why default resolution lives in a step, not here."
         type: string
         required: false
         default: ""
       registry_name:
-        description: "ACR short name used by `az acr login` (e.g. choacrhy6h2vdulfru6). Empty default falls back to vars.ACR_NAME, then to the hardcoded production literal."
+        description: "ACR short name used by `az acr login` (e.g. clouhealthoffice). Empty default falls back to vars.ACR_NAME, then to the hardcoded production literal."
         type: string
         required: false
         default: ""
@@ -233,8 +233,8 @@ jobs:
           #   1. caller's input (if non-empty)
           #   2. org/repo variable (if set)
           #   3. hardcoded production literal (last resort)
-          REGISTRY="${{ inputs.registry || vars.ACR_LOGIN_SERVER || 'choacrhy6h2vdulfru6.azurecr.io' }}"
-          REGISTRY_NAME="${{ inputs.registry_name || vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}"
+          REGISTRY="${{ inputs.registry || vars.ACR_LOGIN_SERVER || 'clouhealthoffice.azurecr.io' }}"
+          REGISTRY_NAME="${{ inputs.registry_name || vars.ACR_NAME || 'clouhealthoffice' }}"
 
           # image_name: when caller provides one, it's used VERBATIM (no
           # double-prefixing). This matches the convention deploy-azure-aks.yml

--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -611,7 +611,7 @@ jobs:
           for manifest in src/services/*/k8s/*.yaml; do
             echo "Applying ${manifest}..."
             sed \
-              -e "s|choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
+              -e "s|clouhealthoffice.azurecr.io/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|ghcr.io/aurelianware/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|:latest|:${SHA}|g" \
               "$manifest" \

--- a/.github/workflows/deploy-sandbox.yml
+++ b/.github/workflows/deploy-sandbox.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  ACR_REGISTRY: choacrhy6h2vdulfru6.azurecr.io
+  ACR_REGISTRY: ${{ vars.ACR_LOGIN_SERVER || 'clouhealthoffice.azurecr.io' }}
   IMAGE_NAME: hapi-fhir-sandbox
   ACA_NAME: hapi-fhir-sandbox
   ACA_ENV: cho-aca-env

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: ${{ vars.ACR_LOGIN_SERVER || 'choacrhy6h2vdulfru6.azurecr.io' }}
+  REGISTRY: ${{ vars.ACR_LOGIN_SERVER || 'clouhealthoffice.azurecr.io' }}
   IMAGE_PREFIX: cloudhealthoffice
 
 jobs:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Log in to Azure Container Registry
         if: github.event_name != 'pull_request'
-        run: az acr login --name ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
+        run: az acr login --name ${{ vars.ACR_NAME || 'clouhealthoffice' }}
 
       # PR builds cannot use OIDC (no push), but should use ACR mirrored .NET
       # base images only when Azure deploys are active. While Azure is paused,
@@ -96,7 +96,7 @@ jobs:
       - name: Fail if ACR login didn't succeed on PR
         if: github.event_name == 'pull_request' && vars.AZURE_DEPLOYMENTS_ENABLED == 'true' && steps.acr-pr-login.outcome != 'success'
         env:
-          ACR_SHORT_NAME: ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
+          ACR_SHORT_NAME: ${{ vars.ACR_NAME || 'clouhealthoffice' }}
         run: |
           echo "::error::PR base-image pulls require the ACR_USERNAME / ACR_PASSWORD repo secrets."
           echo "::error::Without them, PR builds and main deploys exercise different container"
@@ -167,7 +167,7 @@ jobs:
 
       - name: Log in to Azure Container Registry
         if: github.event_name != 'pull_request'
-        run: az acr login --name ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
+        run: az acr login --name ${{ vars.ACR_NAME || 'clouhealthoffice' }}
 
       - name: Extract metadata
         id: meta
@@ -350,7 +350,7 @@ jobs:
 
       - name: Log in to Azure Container Registry
         if: github.event_name != 'pull_request'
-        run: az acr login --name ${{ vars.ACR_NAME || 'choacrhy6h2vdulfru6' }}
+        run: az acr login --name ${{ vars.ACR_NAME || 'clouhealthoffice' }}
 
       - name: Extract metadata
         id: meta

--- a/docs/deployment/DOCKER-BUILD-STATUS.md
+++ b/docs/deployment/DOCKER-BUILD-STATUS.md
@@ -96,25 +96,25 @@ All .NET microservice Dockerfiles pull base images from Azure Container Registry
 **One-time setup** — import the required .NET base images into ACR:
 
 ```bash
-az acr import --name choacrhy6h2vdulfru6 \
+az acr import --name clouhealthoffice \
   --source mcr.microsoft.com/dotnet/sdk:8.0 \
   --image dotnet/sdk:8.0
 
-az acr import --name choacrhy6h2vdulfru6 \
+az acr import --name clouhealthoffice \
   --source mcr.microsoft.com/dotnet/aspnet:8.0 \
   --image dotnet/aspnet:8.0
 
 # Alpine variants (used by CHO.TerminologyService)
-az acr import --name choacrhy6h2vdulfru6 \
+az acr import --name clouhealthoffice \
   --source mcr.microsoft.com/dotnet/sdk:8.0-alpine \
   --image dotnet/sdk:8.0-alpine
 
-az acr import --name choacrhy6h2vdulfru6 \
+az acr import --name clouhealthoffice \
   --source mcr.microsoft.com/dotnet/aspnet:8.0-alpine \
   --image dotnet/aspnet:8.0-alpine
 ```
 
-Each Dockerfile exposes an `ARG REGISTRY` (defaulting to `choacrhy6h2vdulfru6.azurecr.io`) so local builds can override:
+Each Dockerfile exposes an `ARG REGISTRY` (defaulting to `clouhealthoffice.azurecr.io`) so local builds can override:
 
 ```bash
 # Local build using MCR directly (no ACR needed)

--- a/docs/quickstart-kubernetes-local.md
+++ b/docs/quickstart-kubernetes-local.md
@@ -218,7 +218,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error
 
 ```bash
 # Rebuild just the claims service
-docker build -t choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-claims-service:latest \
+docker build -t clouhealthoffice.azurecr.io/cloudhealthoffice-claims-service:latest \
   -f src/services/claims-service/Dockerfile .
 
 # Restart the deployment to pick up the new image

--- a/k8s/idcard-service.yaml
+++ b/k8s/idcard-service.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: idcard-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-idcard-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-idcard-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -151,7 +151,7 @@ if [[ "$SKIP_BUILD" == false ]]; then
     fi
 
     # Tag with both ACR and GHCR names so k8s manifests find the image
-    acr_tag="choacrhy6h2vdulfru6.azurecr.io/${IMAGE_PREFIX}-${svc}:latest"
+    acr_tag="clouhealthoffice.azurecr.io/${IMAGE_PREFIX}-${svc}:latest"
     ghcr_tag="ghcr.io/aurelianware/${IMAGE_PREFIX}-${svc}:latest"
 
     docker build -t "$acr_tag" -t "$ghcr_tag" \

--- a/scripts/deploy/deploy-core-services.sh
+++ b/scripts/deploy/deploy-core-services.sh
@@ -14,7 +14,7 @@
 #   ./scripts/deploy/deploy-core-services.sh --skip-seed      # skip seed data
 #
 # Environment variables:
-#   ACR_NAME        — ACR login server (default: choacrhy6h2vdulfru6.azurecr.io)
+#   ACR_NAME        — ACR login server (default: clouhealthoffice.azurecr.io)
 #   K8S_NAMESPACE   — Kubernetes namespace (default: cloudhealthoffice)
 #   IMAGE_TAG       — Image tag (default: latest)
 #   SEED_TENANT_ID  — Tenant ID for seed data (default: dev-tenant)
@@ -24,7 +24,7 @@ set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────────
 
-ACR_NAME="${ACR_NAME:-choacrhy6h2vdulfru6.azurecr.io}"
+ACR_NAME="${ACR_NAME:-clouhealthoffice.azurecr.io}"
 K8S_NAMESPACE="${K8S_NAMESPACE:-cloudhealthoffice}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 SEED_TENANT_ID="${SEED_TENANT_ID:-dev-tenant}"

--- a/src/portal/CloudHealthOffice.Portal/Dockerfile
+++ b/src/portal/CloudHealthOffice.Portal/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 # Stage 1: Build
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo

--- a/src/services/CHO.TerminologyService/Dockerfile
+++ b/src/services/CHO.TerminologyService/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0-alpine AS build
 WORKDIR /repo
 

--- a/src/services/CHO.TerminologyService/k8s/deployment.yaml
+++ b/src/services/CHO.TerminologyService/k8s/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: terminology-service
-          image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-terminology-service:latest
+          image: clouhealthoffice.azurecr.io/cloudhealthoffice-terminology-service:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 5080

--- a/src/services/CloudHealthOffice.PricingApi/Dockerfile
+++ b/src/services/CloudHealthOffice.PricingApi/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/CloudHealthOffice.PricingApi/k8s/pricing-api-deployment.yaml
+++ b/src/services/CloudHealthOffice.PricingApi/k8s/pricing-api-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: pricing-api
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-pricing-api:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-pricing-api:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/accumulator-service/Dockerfile
+++ b/src/services/accumulator-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/accumulator-service/k8s/accumulator-service-deployment.yaml
+++ b/src/services/accumulator-service/k8s/accumulator-service-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: accumulator-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-accumulator-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-accumulator-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/appeals-service/Dockerfile
+++ b/src/services/appeals-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/appeals-service/k8s/appeals-service-deployment.yaml
+++ b/src/services/appeals-service/k8s/appeals-service-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: appeals-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-appeals-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-appeals-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/ar-service/Dockerfile
+++ b/src/services/ar-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/ar-service/k8s/ar-service-deployment.yaml
+++ b/src/services/ar-service/k8s/ar-service-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: ar-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-ar-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-ar-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/attachment-service/Dockerfile
+++ b/src/services/attachment-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/authorization-service/Dockerfile
+++ b/src/services/authorization-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/authorization-service/k8s/authorization-service-deployment.yaml
+++ b/src/services/authorization-service/k8s/authorization-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: authorization-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-authorization-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-authorization-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/benefit-plan-service/Dockerfile
+++ b/src/services/benefit-plan-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/benefit-plan-service/k8s/benefit-plan-service-deployment.yaml
+++ b/src/services/benefit-plan-service/k8s/benefit-plan-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: benefit-plan-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-benefit-plan-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-benefit-plan-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/capitation-service/Dockerfile
+++ b/src/services/capitation-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/capitation-service/k8s/capitation-service-deployment.yaml
+++ b/src/services/capitation-service/k8s/capitation-service-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: capitation-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-capitation-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-capitation-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/claims-examiner-service/Dockerfile
+++ b/src/services/claims-examiner-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/claims-examiner-service/k8s/claims-examiner-service-deployment.yaml
+++ b/src/services/claims-examiner-service/k8s/claims-examiner-service-deployment.yaml
@@ -59,7 +59,7 @@ spec:
                       - spot
       containers:
       - name: claims-examiner-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-claims-examiner-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-claims-examiner-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/claims-service/Dockerfile
+++ b/src/services/claims-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: claims-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-claims-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-claims-service:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/src/services/consent-service/Dockerfile
+++ b/src/services/consent-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/consent-service/k8s/consent-service-deployment.yaml
+++ b/src/services/consent-service/k8s/consent-service-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: consent-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-consent-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-consent-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/coverage-service/Dockerfile
+++ b/src/services/coverage-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/coverage-service/k8s/coverage-service-deployment.yaml
+++ b/src/services/coverage-service/k8s/coverage-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: coverage-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-coverage-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-coverage-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/eligibility-service/Dockerfile
+++ b/src/services/eligibility-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/eligibility-service/k8s/eligibility-service-deployment.yaml
+++ b/src/services/eligibility-service/k8s/eligibility-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: eligibility-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-eligibility-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-eligibility-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/encounter-service/Dockerfile
+++ b/src/services/encounter-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/encounter-service/k8s/encounter-service-deployment.yaml
+++ b/src/services/encounter-service/k8s/encounter-service-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: encounter-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-encounter-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-encounter-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/encounter-submission-service/Dockerfile
+++ b/src/services/encounter-submission-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/encounter-submission-service/k8s/encounter-submission-service-deployment.yaml
+++ b/src/services/encounter-submission-service/k8s/encounter-submission-service-deployment.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: encounter-submission-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-encounter-submission-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-encounter-submission-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/enrollment-import-service/Dockerfile
+++ b/src/services/enrollment-import-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/enrollment-import-service/k8s/enrollment-import-service-deployment.yaml
+++ b/src/services/enrollment-import-service/k8s/enrollment-import-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: enrollment-import-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-enrollment-import-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-enrollment-import-service:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/src/services/fhir-service/Dockerfile
+++ b/src/services/fhir-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/fhir-service/k8s/fhir-service-deployment.yaml
+++ b/src/services/fhir-service/k8s/fhir-service-deployment.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: fhir-service
-          image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-fhir-service:latest
+          image: clouhealthoffice.azurecr.io/cloudhealthoffice-fhir-service:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/src/services/idcard-service/Dockerfile
+++ b/src/services/idcard-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/member-document-service/Dockerfile
+++ b/src/services/member-document-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/member-document-service/k8s/member-document-service-deployment.yaml
+++ b/src/services/member-document-service/k8s/member-document-service-deployment.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: member-document-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-member-document-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-member-document-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/member-service/Dockerfile
+++ b/src/services/member-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/member-service/k8s/member-service-deployment.yaml
+++ b/src/services/member-service/k8s/member-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: member-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-member-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-member-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/payment-service/Dockerfile
+++ b/src/services/payment-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/payment-service/k8s/payment-service-deployment.yaml
+++ b/src/services/payment-service/k8s/payment-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: payment-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-payment-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-payment-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/personal-representative-service/Dockerfile
+++ b/src/services/personal-representative-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/personal-representative-service/k8s/personal-representative-service-deployment.yaml
+++ b/src/services/personal-representative-service/k8s/personal-representative-service-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: personal-representative-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-personal-representative-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-personal-representative-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/premium-billing-service/Dockerfile
+++ b/src/services/premium-billing-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/premium-billing-service/k8s/premium-billing-service-deployment.yaml
+++ b/src/services/premium-billing-service/k8s/premium-billing-service-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: premium-billing-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-premium-billing-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-premium-billing-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/provider-contracts-service/Dockerfile
+++ b/src/services/provider-contracts-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/provider-contracts-service/k8s/provider-contracts-service-deployment.yaml
+++ b/src/services/provider-contracts-service/k8s/provider-contracts-service-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: provider-contracts-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-provider-contracts-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-provider-contracts-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/provider-service/Dockerfile
+++ b/src/services/provider-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/provider-service/k8s/provider-service-deployment.yaml
+++ b/src/services/provider-service/k8s/provider-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: provider-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-provider-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-provider-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/provider-verification-service/Dockerfile
+++ b/src/services/provider-verification-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/reference-data-service/Dockerfile
+++ b/src/services/reference-data-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/rfai-service/Dockerfile
+++ b/src/services/rfai-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/rfai-service/k8s/rfai-service-deployment.yaml
+++ b/src/services/rfai-service/k8s/rfai-service-deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: rfai-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-rfai-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-rfai-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/risk-adjustment-service/Dockerfile
+++ b/src/services/risk-adjustment-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/risk-adjustment-service/k8s/risk-adjustment-service-deployment.yaml
+++ b/src/services/risk-adjustment-service/k8s/risk-adjustment-service-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: risk-adjustment-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-risk-adjustment-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-risk-adjustment-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/smart-auth-service/Dockerfile
+++ b/src/services/smart-auth-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/smart-auth-service/k8s/smart-auth-service-deployment.yaml
+++ b/src/services/smart-auth-service/k8s/smart-auth-service-deployment.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
         - name: smart-auth-service
-          image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-smart-auth-service:latest
+          image: clouhealthoffice.azurecr.io/cloudhealthoffice-smart-auth-service:latest
           ports:
             - containerPort: 8080
           envFrom:

--- a/src/services/sponsor-service/Dockerfile
+++ b/src/services/sponsor-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/tenant-service/Dockerfile
+++ b/src/services/tenant-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/services/tenant-service/k8s/tenant-service-deployment.yaml
+++ b/src/services/tenant-service/k8s/tenant-service-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: tenant-service
-        image: choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-tenant-service:latest
+        image: clouhealthoffice.azurecr.io/cloudhealthoffice-tenant-service:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/src/services/trading-partner-service/Dockerfile
+++ b/src/services/trading-partner-service/Dockerfile
@@ -1,4 +1,4 @@
-ARG REGISTRY=choacrhy6h2vdulfru6.azurecr.io
+ARG REGISTRY=clouhealthoffice.azurecr.io
 FROM ${REGISTRY}/dotnet/sdk:8.0 AS build
 WORKDIR /repo
 

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -357,7 +357,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error</co
 
         <h3>Rebuild and redeploy a single service</h3>
 <pre><code><span class="code-comment"># Rebuild just the claims service</span>
-docker build -t choacrhy6h2vdulfru6.azurecr.io/cloudhealthoffice-claims-service:latest \
+docker build -t clouhealthoffice.azurecr.io/cloudhealthoffice-claims-service:latest \
   -f src/services/claims-service/Dockerfile .
 
 <span class="code-comment"># Restart the deployment to pick up the new image</span>


### PR DESCRIPTION
## Summary
- The old ACR (`choacrhy6h2vdulfru6`) was retired; a new registry was created at `clouhealthoffice.azurecr.io`.
- Updates the `ACR_NAME` / `ACR_LOGIN_SERVER` repo variables (done directly via `gh variable set`, not part of this diff) plus every hardcoded fallback literal and manifest reference to the old registry: `docker-build.yml`, `_build-service-image.yml`, `deploy-sandbox.yml`, `deploy-azure-aks.yml`'s manifest-rewrite `sed`, every service `Dockerfile`'s `ARG REGISTRY` default, every `k8s/*.yaml` image reference, plus a couple of docs/scripts that mentioned the old hostname.
- Also granted the `CLOUDHEALTHOFFICE` CI service principal an `AcrPush` role on the new registry (it had zero role assignments anywhere in the subscription — this looks like a freshly rebuilt Azure environment) and set the `ACR_USERNAME`/`ACR_PASSWORD` repo secrets for the PR-time read-only base-image-pull path.

## Test plan
- [x] Mechanical string replacement verified via `grep` — zero remaining references to the old registry name/hostname repo-wide.
- [x] `az role assignment list` on the new registry confirms `AcrPush` is granted to the CI SP.
- [ ] Next push to `main` will exercise `docker-build.yml`'s `az acr login` against the new registry — worth watching that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)