### PR TITLE
Wire blob storage and BatchEligibility Cosmos DB into deployment manifests

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -425,6 +425,11 @@ jobs:
             # Azure Storage
             fetch_secret "Azure--StorageConnectionString" "KV_AZURE_STORAGE_CONNECTION_STRING"
 
+            # BatchEligibility (eligibility-service) — Cosmos DB for NoSQL
+            # (Core/SQL API), distinct from the general MongoDb__ConnectionString
+            # above which expects a Mongo-driver-compatible connection string.
+            fetch_secret "BatchEligibility--CosmosDb--ConnectionString" "KV_BATCH_ELIGIBILITY_COSMOS_CONNECTION_STRING"
+
             # Azure AD
             fetch_secret "AzureAd--TenantId"             "KV_AZURE_AD_TENANT_ID"
             fetch_secret "AzureAd--ClientId"             "KV_AZURE_AD_CLIENT_ID"
@@ -515,6 +520,13 @@ jobs:
         run: |
           kubectl create secret generic azure-storage-secret \
             --from-literal=connectionString="${KV_AZURE_STORAGE_CONNECTION_STRING:-${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}}" \
+            -n ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create BatchEligibility Cosmos secret
+        run: |
+          kubectl create secret generic batch-eligibility-secret \
+            --from-literal=cosmosConnectionString="${KV_BATCH_ELIGIBILITY_COSMOS_CONNECTION_STRING:-${{ secrets.BATCH_ELIGIBILITY_COSMOS_CONNECTION_STRING }}}" \
             -n ${{ env.NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/src/services/eligibility-service/k8s/eligibility-service-deployment.yaml
+++ b/src/services/eligibility-service/k8s/eligibility-service-deployment.yaml
@@ -50,6 +50,16 @@ spec:
             configMapKeyRef:
               name: eligibility-service-config
               key: MongoDb__DatabaseName
+        - name: BatchEligibility__CosmosDb__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: batch-eligibility-secret
+              key: cosmosConnectionString
+        - name: BatchEligibility__BlobStorage__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: azure-storage-secret
+              key: connectionString
         resources:
           requests:
             cpu: 100m

--- a/src/services/encounter-submission-service/k8s/encounter-submission-service-deployment.yaml
+++ b/src/services/encounter-submission-service/k8s/encounter-submission-service-deployment.yaml
@@ -53,6 +53,11 @@ spec:
               key: connectionString
         - name: MongoDb__DatabaseName
           value: "cloudhealthoffice"
+        - name: AzureStorage__ConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: azure-storage-secret
+              key: connectionString
         - name: Kafka__BootstrapServers
           valueFrom:
             secretKeyRef:

--- a/src/services/member-document-service/k8s/member-document-service-deployment.yaml
+++ b/src/services/member-document-service/k8s/member-document-service-deployment.yaml
@@ -8,15 +8,6 @@ data:
   MongoDb__DatabaseName: "cloudhealthoffice"
   BlobStorage__ContainerName: "member-documents"
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: member-document-service-secret
-  namespace: cloudhealthoffice
-type: Opaque
-stringData:
-  BlobStorage__ConnectionString: "UseDevelopmentStorage=true"
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,8 +54,8 @@ spec:
         - name: BlobStorage__ConnectionString
           valueFrom:
             secretKeyRef:
-              name: member-document-service-secret
-              key: BlobStorage__ConnectionString
+              name: azure-storage-secret
+              key: connectionString
         - name: BlobStorage__ContainerName
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
## Summary
Follow-up to standing up the new `clouhealthoffice.azurecr.io` registry / `cho-aks` cluster / `cho-kv` Key Vault: created a real Azure Storage account (`cloudhealthofficestg`) and traced through what actually consumes it before wiring the connection string in.

- **member-document-service**: was hardcoded to the Azurite dev-emulator placeholder (`UseDevelopmentStorage=true`) in its own committed `Secret` — never actually pointed at real storage. Now sources `BlobStorage__ConnectionString` from the shared `azure-storage-secret`.
- **eligibility-service**: its `BatchEligibility` feature requires *both* a Blob Storage connection string and a Cosmos DB for NoSQL (Core/SQL API) connection string once outside `Development` (see `BatchEligibilityServiceCollectionExtensions`) — neither was wired into its manifest at all, so it would crash-loop the moment it was deployed. Added a dedicated `batch-eligibility-secret` (Cosmos Core/SQL API — distinct from the fleet-wide `MongoDb__ConnectionString`, which expects a Mongo-driver-compatible string, not a Core/SQL API one) plus the shared `azure-storage-secret`.
- **encounter-submission-service**: optional `AzureStorage__ConnectionString` wiring for its FMMIS staging blob path (already degraded gracefully when unset — this lets it actually work).

Also created the Cosmos `cho`/`batch-jobs` container (partition key `/tenantId`, per `CosmosBatchJobStore`'s doc comment) directly against the existing `cloudhealthoffice` Cosmos account, and populated Key Vault (`Azure--StorageConnectionString`, `BatchEligibility--CosmosDb--ConnectionString`).

## Test plan
- [x] Manifest changes are config-only (env var sourcing), no application code touched.
- [x] Verified the Cosmos account (`cloudhealthoffice`, Central US) is `GlobalDocumentDB` kind (Core/SQL API) — correct for `Microsoft.Azure.Cosmos.CosmosClient`, and confirmed *not* reused for the generic Mongo-driver `database-secret` (would have broken every Mongo-based service).
- [ ] Not yet exercised end-to-end (`AZURE_DEPLOYMENTS_ENABLED` is still off) — worth watching the first real deploy once enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)