### PR TITLE
Fix missing Kafka bootstrapServers key in deploy workflow

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -510,7 +510,13 @@ jobs:
 
       - name: Create Kafka secret
         run: |
+          # bootstrapServers isn't actually sensitive (it's the in-cluster
+          # Strimzi bootstrap address), but 5 service manifests already
+          # source Kafka__BootstrapServers from this secret via
+          # secretKeyRef, so it's added here rather than introducing a
+          # second config path just for this one key.
           kubectl create secret generic kafka-secret \
+            --from-literal=bootstrapServers="kafka.cloudhealthoffice:9092" \
             --from-literal=saslUsername="${KV_KAFKA_SASL_USERNAME:-${{ secrets.KAFKA_SASL_USERNAME }}}" \
             --from-literal=saslPassword="${KV_KAFKA_SASL_PASSWORD:-${{ secrets.KAFKA_SASL_PASSWORD }}}" \
             -n ${{ env.NAMESPACE }} \


### PR DESCRIPTION
## Summary
- 5 service manifests (`accumulator-service`, `appeals-service`, `consent-service`, `encounter-submission-service`, `personal-representative-service`) source `Kafka__BootstrapServers` from `kafka-secret`'s `bootstrapServers` key via `secretKeyRef`.
- `deploy-azure-aks.yml`'s "Create Kafka secret" step only ever populated `saslUsername`/`saslPassword` — the `bootstrapServers` key never existed, so those 5 services' `Kafka__BootstrapServers` env var would fail to resolve at deploy time, independent of whether a real Kafka cluster was even reachable.
- Added the key with the literal in-cluster Strimzi bootstrap address (`kafka.cloudhealthoffice:9092`, matching the ExternalName shim service and what `claims-examiner-service`'s ConfigMap already hardcodes). Not treated as a secret value elsewhere in the repo either, so no Key Vault/GitHub secret indirection needed — it's a stable in-cluster hostname, not sensitive.

## Test plan
- [x] Config-only change (workflow YAML), no application code touched.
- [ ] Not yet exercised end-to-end (`AZURE_DEPLOYMENTS_ENABLED` still off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)