### PR TITLE
TEMP: debug CI service principal identity

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -75,6 +75,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Debug - whoami (temporary)
+        run: |
+          appid=$(az account show --query user.name -o tsv)
+          echo "Authenticated app id ends with: ...${appid: -6}"
+          echo "Principal type: $(az account show --query user.type -o tsv)"
+
       - name: Import .NET 8 base images from MCR
         env:
           ACR_NAME: ${{ vars.ACR_NAME }}


### PR DESCRIPTION
Diagnostic-only. Prints the last 6 characters of the authenticated app id (not enough to match GitHub's secret masking) to confirm which SP AZURE_CLIENT_ID actually resolves to. Will revert in a follow-up once confirmed.