### PR TITLE
Fix az acr import missing --resource-group

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -114,6 +114,7 @@ jobs:
             echo "::group::Importing mcr.microsoft.com/${img} → ${ACR_NAME}.azurecr.io/${img}"
             az acr import \
               --name "$ACR_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
               --source "mcr.microsoft.com/${img}" \
               --image "${img}" \
               --force


### PR DESCRIPTION
## Summary
This was accidentally dropped from PR #1023 — I pushed it to that branch after the PR had already been merged, so it never landed on `main`. Recreating cleanly here.

`az acr import` resolves the destination registry via a control-plane ARM lookup. Without `--resource-group`, that requires subscription- or resource-group-wide list/read permission to discover which RG the registry lives in — a role scoped directly to the registry resource itself (which the CI SP correctly has: `AcrPush` + `Contributor`) doesn't grant that discovery step, even though it fully authorizes the import once the resource is resolved.

This is consistent with every observed failure this session: `"could not be found in subscription"` despite confirmed-correct RBAC on the confirmed-correct service principal in the confirmed-correct subscription.

## Test plan
- [ ] Retrigger `deploy-azure-aks.yml` after merge and confirm the base-image import step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)