### PR TITLE
Add missing batch-eligibility-secret to local deploy script

### DIFF
--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -236,6 +236,19 @@ kubectl create secret generic azure-storage-secret \
   --dry-run=client -o yaml | kubectl apply -f -
 ok "azure-storage-secret"
 
+# eligibility-service's BatchEligibility feature. Left empty on purpose --
+# ASPNETCORE_ENVIRONMENT is patched to Development below, so an empty
+# connection string here just means it resolves to the InMemory backend
+# (see BatchEligibilityServiceCollectionExtensions) rather than crashing.
+# The secret still needs to exist, though: a missing secretKeyRef target
+# fails pod startup outright (CreateContainerConfigError), regardless of
+# what the application code would otherwise tolerate.
+kubectl create secret generic batch-eligibility-secret \
+  --namespace "$NAMESPACE" \
+  --from-literal=cosmosConnectionString="" \
+  --dry-run=client -o yaml | kubectl apply -f -
+ok "batch-eligibility-secret"
+
 # Stripe API keys
 kubectl create secret generic stripe-api-keys \
   --namespace "$NAMESPACE" \


### PR DESCRIPTION
## Summary
Answering "does local k8s deploy still work" — checked `scripts/deploy-local.sh` against today's manifest changes (#1020). Good news: it already creates the shared `azure-storage-secret` and `kafka-secret` with matching keys, so `member-document-service` and the Kafka-consuming services are unaffected.

One real gap: `eligibility-service`'s manifest now references a `batch-eligibility-secret` (Cosmos DB for NoSQL connection string) that `deploy-local.sh` never creates. A missing `secretKeyRef` target fails pod startup outright (`CreateContainerConfigError`) — independent of the app code's own graceful InMemory fallback for `Development` environments, since that fallback never gets a chance to run if the pod can't even start.

Fixed by creating the secret with an empty connection string, matching the existing pattern for `azure-storage-secret`/`kafka-secret`. `deploy-local.sh` already patches this service's `ASPNETCORE_ENVIRONMENT` to `Development`, so the empty string resolves to the intended InMemory backend.

## Test plan
- [ ] Not run against an actual local cluster in this session — worth a real `./scripts/deploy-local.sh` smoke test when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)