### PR TITLE
Apply the real idcard-service manifest, skip comments-only alias files

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -659,14 +659,21 @@ jobs:
         run: |
           ACR="${{ env.REGISTRY }}"
           SHA="sha-${{ github.sha }}"
-          for manifest in src/services/*/k8s/*.yaml; do
-            echo "Applying ${manifest}..."
-            sed \
+          # idcard-service/k8s/idcard-service-deployment.yaml is a
+          # comments-only alias pointing at the authoritative copy below --
+          # apply the real one instead of the placeholder the glob picks up.
+          for manifest in src/services/*/k8s/*.yaml k8s/idcard-service.yaml; do
+            transformed=$(sed \
               -e "s|clouhealthoffice.azurecr.io/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|ghcr.io/aurelianware/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|:latest|:${SHA}|g" \
-              "$manifest" \
-              | kubectl apply -f -
+              "$manifest")
+            if ! grep -q "^kind:" <<< "$transformed"; then
+              echo "Skipping ${manifest} (no Kubernetes objects -- alias/placeholder file)"
+              continue
+            fi
+            echo "Applying ${manifest}..."
+            kubectl apply -f - <<< "$transformed"
           done
 
       - name: Deploy api-docs (Swagger UI + OpenAPI specs)


### PR DESCRIPTION
## Summary
Diagnosed from the first full end-to-end AKS deploy run since fixing the tenant/subscription/SP mismatch — 17 services deployed successfully before failing on `idcard-service`.

`src/services/idcard-service/k8s/idcard-service-deployment.yaml` is a comments-only alias pointing at the authoritative manifest at `k8s/idcard-service.yaml` (per its own header comment — matches the pattern `deploy-local.sh` already handles via a separate explicit `deploy_service` call). The AKS deploy loop's glob picked it up anyway, `sed`'d it (no-op, since it's just comments), and piped empty-of-resources output to `kubectl apply -f -`, which correctly refused with `"no objects passed to apply"` — failing the whole step and leaving every service after `idcard-service` alphabetically (most of the fleet) undeployed.

Two changes:
- The loop now also applies `k8s/idcard-service.yaml` (the real manifest) alongside the per-service glob.
- Skips any transformed manifest that doesn't contain a top-level `kind:` rather than failing outright — future-proofs against any other alias/placeholder files following this same convention.

Checked `k8s/idcard-service.yaml`'s other dependencies (`database-secret`, `servicebus-secret`, `keyvault-config`, `provider-jwt-config`) — all either already created elsewhere in the workflow or explicitly `optional: true`.

## Test plan
- [ ] Retrigger the full deploy after merge and confirm it proceeds past idcard-service to the remaining services (kafka-secret consumers, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)