### PR TITLE
Raise namespace ResourceQuota to fit the full service fleet

### DIFF
--- a/infrastructure/k8s/namespaces.yaml
+++ b/infrastructure/k8s/namespaces.yaml
@@ -16,11 +16,11 @@ metadata:
   namespace: cloudhealthoffice
 spec:
   hard:
-    requests.cpu: "8"
-    requests.memory: 16Gi
-    limits.cpu: "20"
-    limits.memory: 32Gi
-    pods: "50"
+    requests.cpu: "12"
+    requests.memory: 24Gi
+    limits.cpu: "40"
+    limits.memory: 64Gi
+    pods: "80"
 ---
 # Network Policies (optional - for production security)
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## Summary
Diagnosed while chasing why the portal's rolling-restart deployment couldn't create new pods after a full deploy of the ~30-service fleet: `compute-resources` ResourceQuota was sized (`limits.cpu: 20`) for a much smaller service count, and was fully exhausted the moment the real fleet deployed at once.

```
Warning  FailedCreate  replicaset-controller  Error creating: pods "portal-..." is forbidden:
exceeded quota: compute-resources, requested: limits.cpu=500m, used: limits.cpu=20, limited: limits.cpu=20
```

Already applied directly to the live cluster to unblock today's deploy — this PR just persists it so it's not tribal knowledge on a running namespace.

## Test plan
- [x] Confirmed live: `kubectl get resourcequota` showed headroom immediately after applying, and the next portal rollout attempt created a pod for the first time (subsequently blocked on an unrelated, disclosed Azure trial-subscription vCPU cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)