### PR TITLE
Deploy sponsor-service, attachment-service, provider-verification-service to AKS

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -662,7 +662,17 @@ jobs:
           # idcard-service/k8s/idcard-service-deployment.yaml is a
           # comments-only alias pointing at the authoritative copy below --
           # apply the real one instead of the placeholder the glob picks up.
-          for manifest in src/services/*/k8s/*.yaml k8s/idcard-service.yaml; do
+          #
+          # attachment-service, sponsor-service, and provider-verification-service
+          # each live outside src/services/<name>/k8s/ (deploy-local.sh has
+          # always applied them as explicit extra paths for the same reason) --
+          # the glob alone silently skipped all three, so sponsor-service in
+          # particular was never deployed to AKS at all despite being on the
+          # 834 enrollment on-ramp's critical path.
+          for manifest in src/services/*/k8s/*.yaml k8s/idcard-service.yaml \
+            infrastructure/k8s/services/attachment-service.yaml \
+            infrastructure/k8s/sponsor-service-deployment.yaml \
+            infrastructure/k8s/provider-verification-service-deployment.yaml; do
             transformed=$(sed \
               -e "s|clouhealthoffice.azurecr.io/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \
               -e "s|ghcr.io/aurelianware/cloudhealthoffice-|${ACR}/cloudhealthoffice-|g" \


### PR DESCRIPTION
## Summary
Found while checking whether the 834/837 evaluator on-ramp can actually be exercised against this environment right now — it can't yet, for two reasons, and this fixes one of them.

`sponsor-service` — on the 834 enrollment on-ramp's critical path — had **no Deployment on the cluster at all**. Its manifest (and `attachment-service`'s, and `provider-verification-service`'s) lives outside `src/services/<name>/k8s/`, so the "Apply backend service manifests" loop's glob silently skipped all three. `deploy-local.sh` has always applied these as explicit extra paths for exactly this reason; the AKS workflow never did. Same class of gap as `idcard-service` (#1028), just three more instances of it.

## Test plan
- [x] Confirmed all three manifests are real, multi-document, and already use `ghcr.io/aurelianware/cloudhealthoffice-*` image references — no new `sed` rule needed, the existing rewrite already handles that prefix.
- [ ] Not yet re-deployed — worth confirming `kubectl get deployment sponsor-service -n cloudhealthoffice` exists after the next full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)