### PR TITLE
Fix Enrollment834PlanCodeMapping GuidSerializer crash on Mongo insert

### DIFF
--- a/src/services/benefit-plan-service/Controllers/PlanCodeMappingsController.cs
+++ b/src/services/benefit-plan-service/Controllers/PlanCodeMappingsController.cs
@@ -201,7 +201,7 @@ public class PlanCodeMappingsController : ControllerBase
     [HttpDelete("{id}")]
     [ProducesResponseType(204)]
     [ProducesResponseType(404)]
-    public async Task<IActionResult> Delete([FromRoute] Guid id, CancellationToken ct)
+    public async Task<IActionResult> Delete([FromRoute] string id, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(TenantId))
         {
@@ -238,7 +238,7 @@ public class CreatePlanCodeMappingRequest
 
 public class PlanCodeMappingResponse
 {
-    public Guid Id { get; set; }
+    public string Id { get; set; } = string.Empty;
     public string GroupNumber { get; set; } = string.Empty;
     public string InsuranceLineCode { get; set; } = string.Empty;
     public string ExternalPlanCode { get; set; } = string.Empty;

--- a/src/services/benefit-plan-service/Models/Enrollment834PlanCodeMapping.cs
+++ b/src/services/benefit-plan-service/Models/Enrollment834PlanCodeMapping.cs
@@ -16,7 +16,7 @@ namespace BenefitPlanService.Models;
 public class Enrollment834PlanCodeMapping
 {
     [JsonPropertyName("id")]
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Id { get; set; } = Guid.NewGuid().ToString();
 
     [Required]
     [JsonPropertyName("tenantId")]

--- a/src/services/benefit-plan-service/Repositories/Enrollment834PlanCodeMappingRepositoryMongo.cs
+++ b/src/services/benefit-plan-service/Repositories/Enrollment834PlanCodeMappingRepositoryMongo.cs
@@ -45,9 +45,9 @@ public class Enrollment834PlanCodeMappingRepositoryMongo : IEnrollment834PlanCod
     public async Task<Enrollment834PlanCodeMapping> CreateAsync(
         Enrollment834PlanCodeMapping mapping, CancellationToken ct = default)
     {
-        if (mapping.Id == Guid.Empty)
+        if (string.IsNullOrEmpty(mapping.Id))
         {
-            mapping.Id = Guid.NewGuid();
+            mapping.Id = Guid.NewGuid().ToString();
         }
 
         try
@@ -74,7 +74,7 @@ public class Enrollment834PlanCodeMappingRepositoryMongo : IEnrollment834PlanCod
         return await _collection.Find(filter).ToListAsync(ct);
     }
 
-    public async Task<bool> DeleteAsync(string tenantId, Guid id, CancellationToken ct = default)
+    public async Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default)
     {
         var b = Builders<Enrollment834PlanCodeMapping>.Filter;
         var filter = b.And(b.Eq(m => m.TenantId, tenantId), b.Eq(m => m.Id, id));

--- a/src/services/benefit-plan-service/Repositories/IEnrollment834PlanCodeMappingRepository.cs
+++ b/src/services/benefit-plan-service/Repositories/IEnrollment834PlanCodeMappingRepository.cs
@@ -23,7 +23,7 @@ public interface IEnrollment834PlanCodeMappingRepository
         string tenantId, string? groupNumber, CancellationToken ct = default);
 
     /// <summary>Returns false when no matching row existed (tenant mismatch counts as not-found).</summary>
-    Task<bool> DeleteAsync(string tenantId, Guid id, CancellationToken ct = default);
+    Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/services/benefit-plan-service/Repositories/NullEnrollment834PlanCodeMappingRepository.cs
+++ b/src/services/benefit-plan-service/Repositories/NullEnrollment834PlanCodeMappingRepository.cs
@@ -25,6 +25,6 @@ public sealed class NullEnrollment834PlanCodeMappingRepository : IEnrollment834P
         string tenantId, string? groupNumber, CancellationToken ct = default) =>
         Task.FromResult<IReadOnlyList<Enrollment834PlanCodeMapping>>(Array.Empty<Enrollment834PlanCodeMapping>());
 
-    public Task<bool> DeleteAsync(string tenantId, Guid id, CancellationToken ct = default) =>
+    public Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default) =>
         Task.FromResult(false);
 }


### PR DESCRIPTION
## Summary
- `Enrollment834PlanCodeMapping.Id` was `Guid`-typed — the only model in the codebase using `Guid` instead of `string` for `Id`.
- MongoDB's C# driver throws `BsonSerializationException: GuidSerializer cannot serialize a Guid when GuidRepresentation is Unspecified` on insert unless `GuidRepresentation` is explicitly configured, which this codebase's driver setup never does.
- Every other model in the platform already sidesteps this by using `string Id = Guid.NewGuid().ToString()`. This brings the mapping model in line with that convention.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/CloudHealthOffice.EligibilityService.Tests` — no regressions (this touches BenefitPlanService, not eligibility, but ran as a sanity check on shared conventions)
- [x] `dotnet test` for benefit-plan-service — all 25 tests pass
- [x] Verified via local cluster: POST `/api/v1/plan-code-mappings` no longer throws on insert; 834 import flow can now create crosswalk rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)