### PR TITLE
Fix GET /api/v1/plans/{id} querying internal Id instead of business-key PlanId

### DIFF
--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -106,7 +106,12 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
 
     public Task<BenefitPlan?> GetPlanAsync(string id, string tenantId)
     {
-        return _repository.GetByIdAsync(id, tenantId);
+        // Despite the parameter name, every real caller (claims-service's
+        // benefit-plan resolver, ChoBenefitPlanAdapter, GetAccumulation)
+        // passes the plan's business-key PlanId here, not the internal
+        // auto-generated Id -- GetByIdAsync filters on the wrong field and
+        // 404s on a plan that was just created successfully.
+        return _repository.GetByPlanIdAsync(id, tenantId);
     }
 
     public async Task<BenefitPlan> CreatePlanAsync(BenefitPlan plan, string tenantId)


### PR DESCRIPTION
## Summary
- `BenefitPlanService.GetPlanAsync(id, tenantId)` called `_repository.GetByIdAsync(id, tenantId)`, which filters Mongo on the model's auto-generated internal `Id` GUID-string.
- Every real external caller — claims-service's `HttpBenefitPlanResolver`, `ChoBenefitPlanAdapter`, `GetAccumulation` — passes the business-key `PlanId` instead, so the endpoint 404'd on plans that had just been created successfully.
- A correctly-scoped `GetByPlanIdAsync(planId, tenantId)` already existed (filters by `PlanId` + `VersionState==Published` within the effective/termination window) but was never wired to this endpoint. Switched `GetPlanAsync` to call it.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` for benefit-plan-service — all 25 tests pass, no regressions
- [x] Verified via direct curl against local cluster: `GET /api/v1/plans/{planId}` returns 200 with full plan payload for a freshly-created plan
- [x] Confirmed end-to-end via `scripts/smoke/834-to-837-e2e-smoke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)