### PR TITLE
Persist orchestrator-resolved BenefitPlanId in adjudication projection write

### DIFF
--- a/src/services/claims-service/Repositories/ClaimRepository.cs
+++ b/src/services/claims-service/Repositories/ClaimRepository.cs
@@ -187,7 +187,8 @@ public interface IClaimRepository
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
         bool isPend = false,
-        ClaimStatus? resolvedStatus = null);
+        ClaimStatus? resolvedStatus = null,
+        string? resolvedBenefitPlanId = null);
 
     /// <summary>
     /// Fast claim-level adjudication projection for direct local workflow
@@ -1222,7 +1223,8 @@ public class ClaimRepository : IClaimRepository
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
         bool isPend = false,
-        ClaimStatus? resolvedStatus = null)
+        ClaimStatus? resolvedStatus = null,
+        string? resolvedBenefitPlanId = null)
     {
         // Resolve the head (non-terminal-but-adjudicatable) row by chain key.
         // PatchItemAsync is keyed on the per-row document Id, so we look up
@@ -1311,6 +1313,18 @@ public class ClaimRepository : IClaimRepository
         if (pendDetails is not null)
         {
             ops.Add(PatchOperation.Set("/pendDetails", pendDetails));
+        }
+
+        // The orchestrator resolves BenefitPlanId in-memory from the
+        // member's active coverage for X12 837 claims that arrive without
+        // one (see ClaimAdjudicationOrchestrator), but that in-memory claim
+        // is never otherwise persisted — this bypass write is the only path
+        // back to the row. Only patch when the row doesn't already carry a
+        // BenefitPlanId, since a claim that already had one skips the
+        // orchestrator's resolution step entirely and this stays null.
+        if (!string.IsNullOrWhiteSpace(resolvedBenefitPlanId) && string.IsNullOrWhiteSpace(head.BenefitPlanId))
+        {
+            ops.Add(PatchOperation.Set("/benefitPlanId", resolvedBenefitPlanId));
         }
 
         try

--- a/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
+++ b/src/services/claims-service/Repositories/ClaimRepositoryMongo.cs
@@ -513,7 +513,8 @@ public class ClaimRepositoryMongo : IClaimRepository
         CancellationToken ct = default,
         PendDetails? pendDetails = null,
         bool isPend = false,
-        ClaimStatus? resolvedStatus = null)
+        ClaimStatus? resolvedStatus = null,
+        string? resolvedBenefitPlanId = null)
     {
         var b = Builders<Claim>.Filter;
 
@@ -568,6 +569,14 @@ public class ClaimRepositoryMongo : IClaimRepository
         if (pendDetails is not null)
         {
             update = update.Set(c => c.PendDetails, pendDetails);
+        }
+
+        // See Cosmos sibling for why this bypass write is the only path
+        // back to the row for the orchestrator's in-memory-resolved
+        // BenefitPlanId. Only patch when the row doesn't already carry one.
+        if (!string.IsNullOrWhiteSpace(resolvedBenefitPlanId) && string.IsNullOrWhiteSpace(head.BenefitPlanId))
+        {
+            update = update.Set(c => c.BenefitPlanId, resolvedBenefitPlanId);
         }
 
         var rowFilter = b.And(b.Eq(c => c.TenantId, tenantId), b.Eq(c => c.Id, head.Id));

--- a/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
+++ b/src/services/claims-service/Services/Adjudication/Stages/PersistenceStage.cs
@@ -74,7 +74,8 @@ public sealed class PersistenceStage : IClaimAdjudicationStage
                     ct,
                     pendDetails: context.PendDetails,
                     isPend: isPend,
-                    resolvedStatus: resolvedStatus)
+                    resolvedStatus: resolvedStatus,
+                    resolvedBenefitPlanId: context.Claim.BenefitPlanId)
                 .ConfigureAwait(false);
 
             if (!written)

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Integration/AdjudicationEndToEndTests.cs
@@ -170,7 +170,8 @@ public class AdjudicationEndToEndTests : IAsyncLifetime
                     Arg.Any<CancellationToken>(),
                     Arg.Any<PendDetails?>(),
                     Arg.Any<bool>(),
-                    Arg.Any<ClaimStatus?>())
+                    Arg.Any<ClaimStatus?>(),
+                    Arg.Any<string?>())
                 .Returns(ci =>
                 {
                     ProjectionWrites.Add(new ProjectionWrite(


### PR DESCRIPTION
## Summary
- `ClaimAdjudicationOrchestrator` resolves `BenefitPlanId` in-memory from the member's active coverage for X12 837 claims that arrive without one, then uses it for the rest of the pipeline (benefit-plan lookup, benefit calculation) — but never persists it.
- `PersistenceStage`'s projection-bypass write (`UpdateAdjudicationProjectionAsync`) only patched `AdjudicationResult`, `ClaimLines`, `LastUpdatedDate`, and `PendDetails`. The claim looked fully resolved in every log trace (coverage-service and benefit-plan-service HTTP calls both returned 200), but `GET /api/claims/{id}` always returned `benefitPlanId: null`, because nothing ever wrote the resolved value back to the row.
- Threaded an optional `resolvedBenefitPlanId` parameter through `UpdateAdjudicationProjectionAsync` (Cosmos and Mongo implementations), patched only when the row doesn't already carry a `BenefitPlanId` — claims that already had one (JSON import, MCC) are untouched.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` for claims-service — 607/607 pass (had to update a test double's `Arg.Any<>()` matcher for the new parameter)
- [x] Verified via direct Mongo query and curl against local cluster: `BenefitPlanId` is now correctly persisted and returned on the settled claim
- [x] Confirmed end-to-end via `scripts/smoke/834-to-837-e2e-smoke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)