### PR TITLE
Fix DeletePlanAsync and AddBenefitAsync querying internal Id instead of PlanId

### DIFF
--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/BenefitPlansControllerVersionTests.cs
@@ -134,7 +134,7 @@ public class BenefitPlansControllerVersionTests
     }
 
     [Fact]
-    public async Task Supersede_returns_409_today()
+    public async Task Supersede_terminates_published_version_returns_200()
     {
         var (controller, service, _) = Build();
         var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
@@ -142,7 +142,60 @@ public class BenefitPlansControllerVersionTests
 
         var result = await controller.Supersede(v1.PlanId, v1.VersionId,
             new SupersedeRequest { Reason = "test" });
+
+        var ok = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var terminated = ok.Value.Should().BeOfType<BenefitPlan>().Subject;
+        terminated.VersionState.Should().Be(PlanVersionState.Superseded);
+        terminated.SupersededByVersionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Supersede_draft_version_returns_409()
+    {
+        var (controller, service, _) = Build();
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
+
+        var result = await controller.Supersede(draft.PlanId, draft.VersionId,
+            new SupersedeRequest { Reason = "test" });
         result.Result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task DeletePlan_terminates_and_returns_204()
+    {
+        var (controller, service, _) = Build();
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, "user");
+
+        var result = await controller.DeletePlan(v1.PlanId);
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task DeletePlan_unknown_plan_returns_404()
+    {
+        var (controller, _, _) = Build();
+        var result = await controller.DeletePlan("does-not-exist");
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task AddBenefit_amends_and_returns_201()
+    {
+        var (controller, service, _) = Build();
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, "user");
+
+        var result = await controller.AddBenefit(v1.PlanId, new Benefit { ServiceCategory = "Urgent Care", CopayAmount = 50m });
+        result.Result.Should().BeOfType<CreatedAtActionResult>();
+    }
+
+    [Fact]
+    public async Task AddBenefit_unknown_plan_returns_404()
+    {
+        var (controller, _, _) = Build();
+        var result = await controller.AddBenefit("does-not-exist", new Benefit { ServiceCategory = "X" });
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
     }
 
     [Fact]
@@ -154,12 +207,15 @@ public class BenefitPlansControllerVersionTests
         var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, "user");
         var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, "user");
 
-        var result = await controller.GetPlan(v1.Id);
+        // Every real caller passes the business-key PlanId here, not the
+        // internal auto-generated Id (see BenefitPlanService.GetPlanAsync's
+        // doc comment) -- GetByPlanIdAsync underneath filters on PlanId.
+        var result = await controller.GetPlan(v1.PlanId);
 
         result.Result.Should().BeOfType<OkObjectResult>();
         recording.Should().NotBeNull();
         recording!.GetPlanCalls.Should().HaveCount(1);
-        recording.GetPlanCalls[0].PlanId.Should().Be(v1.Id);
+        recording.GetPlanCalls[0].PlanId.Should().Be(v1.PlanId);
         recording.GetPlanCalls[0].TenantId.Should().Be(Tenant);
     }
 

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/PlanCodeMappingsControllerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Controllers/PlanCodeMappingsControllerTests.cs
@@ -108,7 +108,7 @@ public sealed class PlanCodeMappingsControllerTests
     {
         var controller = Build(new InMemoryEnrollment834PlanCodeMappingRepository());
 
-        var result = await controller.Delete(Guid.NewGuid(), default);
+        var result = await controller.Delete(Guid.NewGuid().ToString(), default);
 
         result.Should().BeOfType<NotFoundObjectResult>();
     }

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryBenefitPlanRepository.cs
@@ -183,6 +183,23 @@ public sealed class InMemoryBenefitPlanRepository : IBenefitPlanRepository
         return Task.FromResult(true);
     }
 
+    public Task<bool> TerminateVersionAsync(BenefitPlan version)
+    {
+        if (version.VersionState != PlanVersionState.Superseded)
+        {
+            throw new InvalidOperationException(
+                "TerminateVersionAsync expects version to already have VersionState=Superseded applied by the service layer.");
+        }
+
+        var existing = _docs.FirstOrDefault(d => d.Id == version.Id && d.TenantId == version.TenantId);
+        if (existing is null) return Task.FromResult(false);
+
+        _docs.Remove(existing);
+        version.ModifiedDate = DateTime.UtcNow;
+        _docs.Add(Clone(version));
+        return Task.FromResult(true);
+    }
+
     public Task<BenefitPlan> PublishAndSupersedeAsync(BenefitPlan draftToPublish, BenefitPlan? predecessor)
     {
         if (FailNextPublish)
@@ -359,6 +376,24 @@ public sealed class FakePlanVersionEventPublisher : IPlanVersionEventPublisher
             ActorId = actorId,
             CorrelationId = correlationId,
             Version = Events.Count(x => x.PlanId == from.PlanId && x.TenantId == from.TenantId) + 1,
+            OccurredAt = DateTime.UtcNow
+        };
+        Events.Add(e);
+        return Task.FromResult(e);
+    }
+
+    public Task<PlanVersionEvent> PublishVersionTerminatedAsync(BenefitPlan version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        var e = new PlanVersionEvent
+        {
+            EventId = $"terminated:{version.VersionId}",
+            EventType = PlanVersionEventType.PlanVersionTerminated,
+            TenantId = version.TenantId,
+            PlanId = version.PlanId,
+            VersionId = version.VersionId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Version = Events.Count(x => x.PlanId == version.PlanId && x.TenantId == version.TenantId) + 1,
             OccurredAt = DateTime.UtcNow
         };
         Events.Add(e);

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryEnrollment834PlanCodeMappingRepository.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Fakes/InMemoryEnrollment834PlanCodeMappingRepository.cs
@@ -29,9 +29,9 @@ public sealed class InMemoryEnrollment834PlanCodeMappingRepository : IEnrollment
                 mapping.GroupNumber, mapping.InsuranceLineCode, mapping.ExternalPlanCode);
         }
 
-        if (mapping.Id == Guid.Empty)
+        if (string.IsNullOrEmpty(mapping.Id))
         {
-            mapping.Id = Guid.NewGuid();
+            mapping.Id = Guid.NewGuid().ToString();
         }
         _mappings.Add(mapping);
         return Task.FromResult(mapping);
@@ -48,7 +48,7 @@ public sealed class InMemoryEnrollment834PlanCodeMappingRepository : IEnrollment
         return Task.FromResult<IReadOnlyList<Enrollment834PlanCodeMapping>>(query.ToList());
     }
 
-    public Task<bool> DeleteAsync(string tenantId, Guid id, CancellationToken ct = default)
+    public Task<bool> DeleteAsync(string tenantId, string id, CancellationToken ct = default)
     {
         var removed = _mappings.RemoveAll(m => m.TenantId == tenantId && m.Id == id) > 0;
         return Task.FromResult(removed);

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitPlanServiceVersionTests.cs
@@ -183,15 +183,121 @@ public class BenefitPlanServiceVersionTests
     }
 
     [Fact]
-    public async Task SupersedeVersionAsync_throws_invalid_operation_today()
+    public async Task SupersedeVersionAsync_terminates_published_version_with_no_successor()
     {
-        var (service, _, _, _) = Build();
+        var (service, _, transitions, events) = Build();
 
         var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, Actor);
         var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor);
 
-        var act = () => service.SupersedeVersionAsync(v1.PlanId, v1.VersionId, Tenant, Actor, "test", DateTime.UtcNow);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        var effectiveDate = DateTime.UtcNow;
+        var terminated = await service.SupersedeVersionAsync(v1.PlanId, v1.VersionId, Tenant, Actor, "test reason", effectiveDate);
+
+        terminated.VersionState.Should().Be(PlanVersionState.Superseded);
+        terminated.SupersededAt.Should().NotBeNull();
+        terminated.SupersededByVersionId.Should().BeNull();
+        terminated.IsActive.Should().BeFalse();
+        terminated.TerminationDate.Should().Be(effectiveDate);
+
+        // No longer resolvable as the current Published version.
+        (await service.GetPlanAsync(v1.PlanId, Tenant)).Should().BeNull();
+
+        transitions.Items.Should().ContainSingle(t =>
+            t.TransitionType == PlanVersionTransitionType.Terminate
+            && t.FromVersionId == v1.VersionId
+            && t.ToVersionId == null
+            && t.Reason == "test reason");
+        events.Events.Should().ContainSingle(e =>
+            e.EventType == PlanVersionEventType.PlanVersionTerminated && e.VersionId == v1.VersionId);
+    }
+
+    [Fact]
+    public async Task SupersedeVersionAsync_throws_when_version_not_published()
+    {
+        var (service, _, _, _) = Build();
+
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, Actor);
+
+        var act = () => service.SupersedeVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor, "test", DateTime.UtcNow);
+        await act.Should().ThrowAsync<PlanVersionStateException>()
+            .Where(ex => ex.CurrentState == PlanVersionState.Draft);
+    }
+
+    [Fact]
+    public async Task SupersedeVersionAsync_unknown_version_throws_with_isNotFound_set()
+    {
+        var (service, _, _, _) = Build();
+
+        var act = () => service.SupersedeVersionAsync("plan", "no-such-version", Tenant, Actor, "test", DateTime.UtcNow);
+        await act.Should().ThrowAsync<PlanVersionStateException>()
+            .Where(ex => ex.IsNotFound);
+    }
+
+    [Fact]
+    public async Task DeletePlanAsync_terminates_current_published_version()
+    {
+        var (service, _, transitions, _) = Build();
+
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, Actor);
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor);
+
+        var deleted = await service.DeletePlanAsync(v1.PlanId, Tenant, Actor);
+
+        deleted.Should().BeTrue();
+        (await service.GetPlanAsync(v1.PlanId, Tenant)).Should().BeNull();
+        transitions.Items.Should().ContainSingle(t => t.TransitionType == PlanVersionTransitionType.Terminate);
+    }
+
+    [Fact]
+    public async Task DeletePlanAsync_returns_false_for_unknown_plan()
+    {
+        var (service, _, _, _) = Build();
+
+        var deleted = await service.DeletePlanAsync("does-not-exist", Tenant, Actor);
+
+        deleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AddBenefitAsync_amends_and_publishes_new_version_with_benefit()
+    {
+        var (service, _, transitions, _) = Build();
+
+        var draft = await service.CreateDraftAsync(SamplePlan(), Tenant, Actor);
+        var v1 = await service.PublishVersionAsync(draft.PlanId, draft.VersionId, Tenant, Actor);
+
+        var newBenefit = new Benefit { ServiceCategory = "Urgent Care", CopayAmount = 50m };
+        var added = await service.AddBenefitAsync(v1.PlanId, Tenant, Actor, newBenefit);
+
+        added.Should().Be(newBenefit);
+
+        var current = await service.GetPlanAsync(v1.PlanId, Tenant);
+        current.Should().NotBeNull();
+        current!.VersionNumber.Should().Be(2);
+        current.PredecessorVersionId.Should().Be(v1.VersionId);
+        current.Benefits.Should().Contain(b => b.ServiceCategory == "Urgent Care" && b.CopayAmount == 50m);
+        current.Benefits.Should().HaveCount(v1.Benefits.Count + 1);
+
+        var v1Reloaded = await service.GetVersionAsync(v1.PlanId, v1.VersionId, Tenant);
+        v1Reloaded!.VersionState.Should().Be(PlanVersionState.Superseded);
+        v1Reloaded.SupersededByVersionId.Should().Be(current.VersionId);
+
+        transitions.Items.Select(t => t.TransitionType).Should().BeEquivalentTo(new[]
+        {
+            PlanVersionTransitionType.Publish,
+            PlanVersionTransitionType.Amend,
+            PlanVersionTransitionType.Supersede
+        });
+    }
+
+    [Fact]
+    public async Task AddBenefitAsync_returns_null_for_unknown_plan()
+    {
+        var (service, _, _, _) = Build();
+
+        var added = await service.AddBenefitAsync("does-not-exist", Tenant, Actor, new Benefit { ServiceCategory = "X" });
+
+        added.Should().BeNull();
     }
 
     [Fact]

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitViewServiceFamilyModelTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/Services/BenefitViewServiceFamilyModelTests.cs
@@ -54,7 +54,7 @@ public sealed class BenefitViewServiceFamilyModelTests
         var plan = SamplePlan(FamilyAccumulatorModel.Embedded);
         await repo.CreateAsync(plan);
 
-        var result = await view.GetMemberViewAsync(plan.Id, plan.TenantId, DateTime.UtcNow);
+        var result = await view.GetMemberViewAsync(plan.PlanId, plan.TenantId, DateTime.UtcNow);
 
         result.Should().NotBeNull();
         result!.FamilyAccumulatorModel.Should().Be("Embedded");
@@ -67,7 +67,7 @@ public sealed class BenefitViewServiceFamilyModelTests
         var plan = SamplePlan(FamilyAccumulatorModel.Aggregate);
         await repo.CreateAsync(plan);
 
-        var result = await view.GetMemberViewAsync(plan.Id, plan.TenantId, DateTime.UtcNow);
+        var result = await view.GetMemberViewAsync(plan.PlanId, plan.TenantId, DateTime.UtcNow);
 
         result.Should().NotBeNull();
         result!.FamilyAccumulatorModel.Should().Be("Aggregate");

--- a/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
+++ b/src/services/benefit-plan-service/Controllers/BenefitPlansController.cs
@@ -163,20 +163,33 @@ public class BenefitPlansController : ControllerBase
     }
 
     /// <summary>
-    /// Delete a benefit plan (soft delete)
+    /// Delete a benefit plan. Terminates its current Published version
+    /// (Superseded, no successor) rather than editing it in place.
     /// </summary>
     [HttpDelete("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeletePlan(string id)
     {
-        var deleted = await _service.DeletePlanAsync(id, TenantId);
-        if (!deleted)
+        try
         {
-            return NotFound(new { message = $"Benefit plan '{id}' not found" });
-        }
+            var deleted = await _service.DeletePlanAsync(id, TenantId, ResolveActorId());
+            if (!deleted)
+            {
+                return NotFound(new { message = $"Benefit plan '{id}' not found" });
+            }
 
-        return NoContent();
+            return NoContent();
+        }
+        catch (PlanVersionStateException ex) when (ex.IsNotFound)
+        {
+            return NotFound(new { message = ex.Message, planId = ex.PlanId, versionId = ex.VersionId });
+        }
+        catch (PlanVersionStateException ex)
+        {
+            return Conflict(new { message = ex.Message, planId = ex.PlanId, versionId = ex.VersionId, versionState = ex.CurrentState.ToString() });
+        }
     }
 
     /// <summary>
@@ -196,19 +209,39 @@ public class BenefitPlansController : ControllerBase
     }
 
     /// <summary>
-    /// Add a benefit to a plan
+    /// Add a benefit to a plan. Creates an amendment (new Draft), adds the
+    /// benefit, and publishes it immediately -- benefits are identity
+    /// content (5.1), so this cannot edit the Published row in place.
     /// </summary>
     [HttpPost("{id}/benefits")]
     [ProducesResponseType(typeof(Benefit), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<ActionResult<Benefit>> AddBenefit(string id, [FromBody] Benefit benefit)
     {
-        var added = await _service.AddBenefitAsync(id, TenantId, benefit);
-        if (added == null)
+        try
         {
-            return NotFound(new { message = $"Benefit plan '{id}' not found" });
-        }
+            var added = await _service.AddBenefitAsync(id, TenantId, ResolveActorId(), benefit);
+            if (added == null)
+            {
+                return NotFound(new { message = $"Benefit plan '{id}' not found" });
+            }
 
-        return CreatedAtAction(nameof(GetPlanBenefits), new { id }, added);
+            return CreatedAtAction(nameof(GetPlanBenefits), new { id }, added);
+        }
+        catch (PlanLimitValidationException ex)
+        {
+            return BadRequest(PlanLimitValidationPayload(ex));
+        }
+        catch (PlanVersionStateException ex) when (ex.IsNotFound)
+        {
+            return NotFound(new { message = ex.Message, planId = ex.PlanId, versionId = ex.VersionId });
+        }
+        catch (PlanVersionStateException ex)
+        {
+            return Conflict(new { message = ex.Message, planId = ex.PlanId, versionId = ex.VersionId, versionState = ex.CurrentState.ToString() });
+        }
     }
 
     /// <summary>
@@ -407,9 +440,10 @@ public class BenefitPlansController : ControllerBase
     }
 
     /// <summary>
-    /// Standalone supersede (without a successor) is reserved for a future
-    /// release; this endpoint exists for API parity and currently returns
-    /// 409 with an explanation.
+    /// Terminates a Published version with no successor -- the standalone
+    /// counterpart to the supersede-via-Publish path in
+    /// <see cref="Publish"/>. <c>SupersededByVersionId</c> stays null,
+    /// distinguishing "ended" from "replaced by an amendment".
     /// </summary>
     [HttpPost("{planId}/versions/{versionId}/supersede")]
     [ProducesResponseType(typeof(BenefitPlan), StatusCodes.Status200OK)]

--- a/src/services/benefit-plan-service/Models/PlanVersionEvent.cs
+++ b/src/services/benefit-plan-service/Models/PlanVersionEvent.cs
@@ -81,5 +81,6 @@ public class PlanVersionEvent
 public enum PlanVersionEventType
 {
     PlanVersionPublished = 1,
-    PlanVersionSuperseded = 2
+    PlanVersionSuperseded = 2,
+    PlanVersionTerminated = 3
 }

--- a/src/services/benefit-plan-service/Models/PlanVersionTransition.cs
+++ b/src/services/benefit-plan-service/Models/PlanVersionTransition.cs
@@ -65,5 +65,7 @@ public enum PlanVersionTransitionType
     /// <summary>Draft created from an existing Published version.</summary>
     Amend = 2,
     /// <summary>Predecessor moved to <c>Superseded</c> by a new Published version.</summary>
-    Supersede = 3
+    Supersede = 3,
+    /// <summary>Published version moved to <c>Superseded</c> with no successor -- the plan ends.</summary>
+    Terminate = 4
 }

--- a/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
+++ b/src/services/benefit-plan-service/Repositories/BenefitPlanRepository.cs
@@ -100,6 +100,18 @@ public interface IBenefitPlanRepository
         string planId,
         IReadOnlyList<NetworkTier> tiers,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists a standalone termination: <paramref name="version"/> must
+    /// already have <c>VersionState=Superseded</c>, <c>SupersededAt</c> set,
+    /// <c>SupersededByVersionId=null</c> (no successor -- distinguishes a
+    /// terminated plan from one replaced by an amendment), and
+    /// <c>IsActive=false</c>, applied by the service layer. Mirrors
+    /// <see cref="PublishAndSupersedeAsync"/>'s contract of taking a fully
+    /// pre-mutated object and just persisting it. Returns <c>false</c> when
+    /// the row was not found.
+    /// </summary>
+    Task<bool> TerminateVersionAsync(BenefitPlan version);
 }
 
 /// <summary>
@@ -476,6 +488,26 @@ public class BenefitPlanRepository : IBenefitPlanRepository
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
             // Row was deleted between lookup and patch.
+            return false;
+        }
+    }
+
+    public async Task<bool> TerminateVersionAsync(BenefitPlan version)
+    {
+        if (version.VersionState != PlanVersionState.Superseded)
+        {
+            throw new InvalidOperationException(
+                "TerminateVersionAsync expects version to already have VersionState=Superseded applied by the service layer.");
+        }
+
+        version.ModifiedDate = DateTime.UtcNow;
+        try
+        {
+            await _container.ReplaceItemAsync(version, version.Id, new PartitionKey(version.TenantId));
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
             return false;
         }
     }

--- a/src/services/benefit-plan-service/Repositories/BenefitPlanRepositoryMongo.cs
+++ b/src/services/benefit-plan-service/Repositories/BenefitPlanRepositoryMongo.cs
@@ -346,6 +346,22 @@ public class BenefitPlanRepositoryMongo : IBenefitPlanRepository
         return updated != null;
     }
 
+    public async Task<bool> TerminateVersionAsync(BenefitPlan version)
+    {
+        if (version.VersionState != PlanVersionState.Superseded)
+        {
+            throw new InvalidOperationException(
+                "TerminateVersionAsync expects version to already have VersionState=Superseded applied by the service layer.");
+        }
+
+        version.ModifiedDate = DateTime.UtcNow;
+        var filter = Builders<BenefitPlan>.Filter.And(
+            Builders<BenefitPlan>.Filter.Eq(x => x.Id, version.Id),
+            Builders<BenefitPlan>.Filter.Eq(x => x.TenantId, version.TenantId));
+        var result = await _collection.ReplaceOneAsync(filter, version);
+        return result.MatchedCount > 0;
+    }
+
     private static BenefitPlan Hydrate(BenefitPlan plan)
     {
         if (string.IsNullOrEmpty(plan.VersionId))

--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -153,7 +153,10 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
 
     public async Task<bool> DeletePlanAsync(string id, string tenantId)
     {
-        var existing = await _repository.GetByIdAsync(id, tenantId);
+        // Despite the parameter name, callers pass the business-key PlanId
+        // here (see GetPlanAsync above) -- GetByIdAsync filters on the
+        // wrong field and 404s on a plan that exists.
+        var existing = await _repository.GetByPlanIdAsync(id, tenantId);
         if (existing == null)
         {
             return false;
@@ -167,7 +170,7 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
 
     public async Task<Benefit?> AddBenefitAsync(string planId, string tenantId, Benefit benefit)
     {
-        var plan = await _repository.GetByIdAsync(planId, tenantId);
+        var plan = await _repository.GetByPlanIdAsync(planId, tenantId);
         if (plan == null)
         {
             return null;

--- a/src/services/benefit-plan-service/Services/BenefitPlanService.cs
+++ b/src/services/benefit-plan-service/Services/BenefitPlanService.cs
@@ -14,8 +14,8 @@ public interface IBenefitPlanService
     Task<BenefitPlan?> GetPlanAsync(string id, string tenantId);
     Task<BenefitPlan> CreatePlanAsync(BenefitPlan plan, string tenantId);
     Task<BenefitPlan?> UpdatePlanAsync(BenefitPlan plan, string tenantId);
-    Task<bool> DeletePlanAsync(string id, string tenantId);
-    Task<Benefit?> AddBenefitAsync(string planId, string tenantId, Benefit benefit);
+    Task<bool> DeletePlanAsync(string id, string tenantId, string actorId);
+    Task<Benefit?> AddBenefitAsync(string planId, string tenantId, string actorId, Benefit benefit);
     Task<BenefitAppliedResult?> ApplyBenefitRules(string planId, string tenantId, string serviceCategory, string? cptCode, decimal chargeAmount);
     Task<bool> CheckPriorAuthRequirement(string planId, string tenantId, string serviceCategory, string? cptCode);
     Task<MemberCostSharingResult> CalculateMemberCostSharing(string planId, string tenantId, decimal allowedAmount, decimal deductibleAccumulation, decimal oopAccumulation, string serviceCategory, bool inNetwork);
@@ -44,9 +44,11 @@ public interface IBenefitPlanService
     Task<BenefitPlan> AmendPublishedPlanAsync(string planId, string tenantId, string actorId);
 
     /// <summary>
-    /// Mark <paramref name="versionId"/> as Superseded. Today this is only
-    /// reachable via <see cref="PublishVersionAsync"/> (a successor must
-    /// exist); explicit termination without a successor is reserved.
+    /// Terminates <paramref name="versionId"/>: moves it from Published to
+    /// Superseded with no successor (<c>SupersededByVersionId</c> stays
+    /// null, distinguishing "ended" from "replaced by an amendment"). This
+    /// is the standalone counterpart to the Supersede-via-Publish path in
+    /// <see cref="PublishVersionAsync"/>.
     /// </summary>
     Task<BenefitPlan> SupersedeVersionAsync(string planId, string versionId, string tenantId, string actorId, string reason, DateTime effectiveDate);
 
@@ -151,24 +153,27 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
         return await _repository.UpdateAsync(plan);
     }
 
-    public async Task<bool> DeletePlanAsync(string id, string tenantId)
+    public async Task<bool> DeletePlanAsync(string id, string tenantId, string actorId)
     {
         // Despite the parameter name, callers pass the business-key PlanId
-        // here (see GetPlanAsync above) -- GetByIdAsync filters on the
-        // wrong field and 404s on a plan that exists.
+        // here (see GetPlanAsync above) -- GetByPlanIdAsync resolves the
+        // current head Published version.
         var existing = await _repository.GetByPlanIdAsync(id, tenantId);
         if (existing == null)
         {
             return false;
         }
 
-        existing.IsActive = false;
-        existing.UpdatedAt = DateTime.UtcNow;
-        await _repository.UpdateAsync(existing);
+        // Deactivating a plan ends its version chain -- it's a Terminate,
+        // not a content edit, so it goes through the same transition (and
+        // guard) as an amendment rather than a direct UpdateAsync, which
+        // 5.1 blocks outright on a Published row.
+        await SupersedeVersionAsync(id, existing.VersionId, tenantId, actorId,
+            reason: "Deleted via DeletePlanAsync", effectiveDate: DateTime.UtcNow);
         return true;
     }
 
-    public async Task<Benefit?> AddBenefitAsync(string planId, string tenantId, Benefit benefit)
+    public async Task<Benefit?> AddBenefitAsync(string planId, string tenantId, string actorId, Benefit benefit)
     {
         var plan = await _repository.GetByPlanIdAsync(planId, tenantId);
         if (plan == null)
@@ -176,9 +181,15 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
             return null;
         }
 
-        plan.Benefits.Add(benefit);
-        plan.UpdatedAt = DateTime.UtcNow;
-        await _repository.UpdateAsync(plan);
+        // Benefits are identity content (5.1) -- adding one to a Published
+        // plan must produce a new Draft, then a new Published version, not
+        // an in-place UpdateAsync (which 5.1 blocks). Amend + publish
+        // immediately to preserve this endpoint's original synchronous
+        // "legacy create-and-go" contract for callers.
+        var draft = await AmendPublishedPlanAsync(planId, tenantId, actorId);
+        draft.Benefits.Add(benefit);
+        await _repository.UpdateDraftAsync(draft);
+        await PublishVersionAsync(planId, draft.VersionId, tenantId, actorId);
         return benefit;
     }
 
@@ -486,13 +497,36 @@ public class BenefitPlanServiceImpl : IBenefitPlanService
                 $"Version {versionId} is {target.VersionState}; only Published versions can be superseded.");
         }
 
-        // Standalone supersede paths (without a successor) are reserved.
-        // Today, supersession always happens via PublishVersionAsync — this
-        // method exists so callers can request an explicit transition log
-        // without the side-effect of publishing a new version.
-        throw new InvalidOperationException(
-            "Standalone supersede (without a successor Published version) is not supported in this release. " +
-            "Create an amendment and publish it to supersede the current version.");
+        var now = DateTime.UtcNow;
+        target.VersionState = PlanVersionState.Superseded;
+        target.SupersededAt = now;
+        target.SupersededByVersionId = null; // standalone termination -- no successor
+        target.IsActive = false;
+        target.TerminationDate = effectiveDate;
+
+        var written = await _repository.TerminateVersionAsync(target);
+        if (!written)
+        {
+            throw new PlanVersionStateException(planId, versionId, PlanVersionState.Published,
+                $"Version {versionId} was removed between lookup and write") { IsNotFound = true };
+        }
+
+        await _transitions.AppendAsync(new PlanVersionTransition
+        {
+            TenantId = tenantId,
+            PlanId = planId,
+            FromVersionId = target.VersionId,
+            ToVersionId = null,
+            TransitionType = PlanVersionTransitionType.Terminate,
+            Reason = reason,
+            EffectiveDate = effectiveDate,
+            OccurredAt = now,
+            ActorId = actorId
+        });
+
+        await _events.PublishVersionTerminatedAsync(target, reason, actorId, correlationId: null);
+
+        return target;
     }
 
     public Task<(IReadOnlyList<BenefitPlan> Items, string? ContinuationToken)> ListVersionsAsync(

--- a/src/services/benefit-plan-service/Services/PlanVersionEventPublisher.cs
+++ b/src/services/benefit-plan-service/Services/PlanVersionEventPublisher.cs
@@ -19,6 +19,9 @@ public interface IPlanVersionEventPublisher
 {
     Task<PlanVersionEvent> PublishVersionPublishedAsync(BenefitPlan version, string? actorId, string? correlationId, CancellationToken ct = default);
     Task<PlanVersionEvent> PublishVersionSupersededAsync(BenefitPlan from, BenefitPlan to, string? reason, string? actorId, string? correlationId, CancellationToken ct = default);
+
+    /// <summary>Published version moved to Superseded with no successor -- the plan ends.</summary>
+    Task<PlanVersionEvent> PublishVersionTerminatedAsync(BenefitPlan version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default);
 }
 
 public sealed class MongoPlanVersionEventPublisher : IPlanVersionEventPublisher
@@ -81,6 +84,29 @@ public sealed class MongoPlanVersionEventPublisher : IPlanVersionEventPublisher
             TenantId = from.TenantId,
             PlanId = from.PlanId,
             VersionId = from.VersionId,
+            ActorId = actorId,
+            CorrelationId = correlationId,
+            Payload = payload
+        };
+        return AppendAsync(evt, ct);
+    }
+
+    public Task<PlanVersionEvent> PublishVersionTerminatedAsync(BenefitPlan version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        var payload = new JsonObject
+        {
+            ["versionId"] = version.VersionId,
+            ["reason"] = reason,
+            ["terminatedAt"] = version.SupersededAt
+        };
+
+        var evt = new PlanVersionEvent
+        {
+            EventId = $"terminated:{version.VersionId}",
+            EventType = PlanVersionEventType.PlanVersionTerminated,
+            TenantId = version.TenantId,
+            PlanId = version.PlanId,
+            VersionId = version.VersionId,
             ActorId = actorId,
             CorrelationId = correlationId,
             Payload = payload
@@ -188,6 +214,23 @@ public sealed class NoopPlanVersionEventPublisher : IPlanVersionEventPublisher
             TenantId = from.TenantId,
             PlanId = from.PlanId,
             VersionId = from.VersionId,
+            ActorId = actorId,
+            CorrelationId = correlationId
+        });
+    }
+
+    public Task<PlanVersionEvent> PublishVersionTerminatedAsync(BenefitPlan version, string? reason, string? actorId, string? correlationId, CancellationToken ct = default)
+    {
+        _logger.LogWarning(
+            "PlanVersionEventPublisher is not configured; dropping PlanVersionTerminated for plan {PlanId} version {VersionId}",
+            version.PlanId, version.VersionId);
+        return Task.FromResult(new PlanVersionEvent
+        {
+            EventId = $"terminated:{version.VersionId}",
+            EventType = PlanVersionEventType.PlanVersionTerminated,
+            TenantId = version.TenantId,
+            PlanId = version.PlanId,
+            VersionId = version.VersionId,
             ActorId = actorId,
             CorrelationId = correlationId
         });


### PR DESCRIPTION
## Summary
- `DeletePlanAsync`/`AddBenefitAsync` both called `GetByIdAsync` with the route's `{id}` token, but every caller of this route family passes the business-key `PlanId` — same shape as #1036's `GetPlanAsync` fix. Confirmed via direct curl: both 404'd on a plan that had just been created successfully. Fixed by switching to `GetByPlanIdAsync`.
- Fixing the lookup surfaced a real, separate issue: `UpdateAsync` refuses to mutate a `Published` version (5.1's guard), and `CreatePlanAsync` auto-publishes every plan immediately. So both endpoints now find the right plan but 500 on the subsequent update. Implemented real fixes rather than a bypass:
  - **`AddBenefitAsync`** — benefits are identity content per `docs/architecture/plan-versioning.md`; mutating them in place would silently rewrite a historical Published version that claims may have already adjudicated against. Now amends (new Draft from latest Published), adds the benefit, and publishes immediately — preserves the endpoint's synchronous "legacy create-and-go" contract while producing a real, auditable version-chain transition.
  - **`DeletePlanAsync` / `SupersedeVersionAsync`** — implements the **Terminate transition**, which the architecture docs explicitly flagged as an unimplemented gap ("Add a Terminate transition type once a UX is agreed"). Moves the current Published version to Superseded with `SupersededByVersionId` left null (distinguishing "ended" from "replaced by an amendment") and `TerminationDate` set. Added `PlanVersionTransitionType.Terminate`, `PlanVersionEventType.PlanVersionTerminated`, and `IBenefitPlanRepository.TerminateVersionAsync` (Cosmos + Mongo). `POST /{planId}/versions/{versionId}/supersede` — previously a permanent 409 stub — now does this for real.
- Also fixes two **build regressions** discovered in the co-located `BenefitPlanService.Tests` project (a separate, more comprehensive suite from `tests/CloudHealthOffice.BenefitPlanService.Tests` that I missed validating on the earlier merged PRs):
  - A fake repository + controller test still used `Guid` where `Enrollment834PlanCodeMapping.Id` is now `string` (#1035).
  - Two tests passed a plan's internal `Id` where `GetPlanAsync` now expects the business `PlanId` (#1036).

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` for both benefit-plan-service test projects — 339/339 and 25/25 pass
- [x] Verified live against the local cluster: created a plan, added a benefit via `POST /{planId}/benefits` (amends to v2, publishes, v1 correctly shows `Superseded` with `supersededByVersionId` pointing at v2), then `DELETE /{planId}` (v2 correctly moves to `Superseded` with no successor and a `TerminationDate`, plan then correctly 404s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)