### PR TITLE
Scale raw 837 adjudication over Azure Service Bus

### DIFF
--- a/scripts/azure/provision-servicebus-claim-events.sh
+++ b/scripts/azure/provision-servicebus-claim-events.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Provisions the Azure Service Bus namespace + the claim-version-events
+# topic/subscription/rule that claims-service's adjudication pipeline
+# (capability 5.5) consumes via IMessageBus. Mirrors the resource shapes
+# already declared in infrastructure/azure/main.bicep (sbTopicClaimVersionEvents
+# / sbTopicClaimVersionEventsSubAdjudication / ...Rule) so a targeted CLI
+# provision here and a future full Bicep deploy converge on the same config.
+#
+# Idempotent: re-running against existing resources updates mutable fields
+# without erroring.
+#
+# Required env vars:
+#   SERVICEBUS_NAMESPACE  — the SB namespace name (created if missing)
+#   RESOURCE_GROUP        — the resource group to create it in
+#   LOCATION              — region for a new namespace (ignored if it exists)
+set -euo pipefail
+
+: "${SERVICEBUS_NAMESPACE:?SERVICEBUS_NAMESPACE is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+: "${LOCATION:?LOCATION is required}"
+
+TOPIC_NAME="claim-version-events"
+SUBSCRIPTION_NAME="adjudication-orchestrator"
+RULE_NAME="submitted-only"
+DEDUP_WINDOW_ISO="PT1H"
+MESSAGE_TTL_ISO="P14D"
+LOCK_DURATION_ISO="PT5M"
+MAX_DELIVERY=10
+
+echo "==> Service Bus namespace: ${SERVICEBUS_NAMESPACE} (${RESOURCE_GROUP}/${LOCATION})"
+if az servicebus namespace show \
+    --name "$SERVICEBUS_NAMESPACE" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "    exists"
+else
+  echo "    creating (Standard tier — required for topics/subscriptions)"
+  az servicebus namespace create \
+    --name "$SERVICEBUS_NAMESPACE" \
+    --resource-group "$RESOURCE_GROUP" \
+    --location "$LOCATION" \
+    --sku Standard >/dev/null
+fi
+
+echo "==> Topic: ${TOPIC_NAME}"
+if az servicebus topic show \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$TOPIC_NAME" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "    exists; updating mutable fields"
+  az servicebus topic update \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$TOPIC_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --max-size 1024 \
+    --default-message-time-to-live "$MESSAGE_TTL_ISO" >/dev/null
+else
+  echo "    creating"
+  az servicebus topic create \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$TOPIC_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --max-size 1024 \
+    --default-message-time-to-live "$MESSAGE_TTL_ISO" \
+    --enable-duplicate-detection true \
+    --duplicate-detection-history-time-window "$DEDUP_WINDOW_ISO" >/dev/null
+fi
+
+echo "==> Subscription: ${SUBSCRIPTION_NAME}"
+if az servicebus topic subscription show \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --topic-name "$TOPIC_NAME" \
+    --name "$SUBSCRIPTION_NAME" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "    exists; updating mutable fields"
+  az servicebus topic subscription update \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --topic-name "$TOPIC_NAME" \
+    --name "$SUBSCRIPTION_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --max-delivery-count "$MAX_DELIVERY" \
+    --lock-duration "$LOCK_DURATION_ISO" \
+    --enable-dead-lettering-on-message-expiration true \
+    --dead-letter-on-filter-exceptions true >/dev/null
+else
+  echo "    creating"
+  az servicebus topic subscription create \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --topic-name "$TOPIC_NAME" \
+    --name "$SUBSCRIPTION_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --max-delivery-count "$MAX_DELIVERY" \
+    --lock-duration "$LOCK_DURATION_ISO" \
+    --enable-dead-lettering-on-message-expiration true \
+    --dead-letter-on-filter-exceptions true >/dev/null
+fi
+
+# The default $Default rule (match-all) ships with every new subscription.
+# Replace it with the MessageType correlation filter so this subscription
+# only ever receives ClaimVersionSubmitted messages -- Adjudicated/Reversed
+# messages on the same topic are for future subscriptions (5.10/5.12), not
+# this one.
+echo "==> Subscription rule: ${RULE_NAME} (MessageType=ClaimVersionSubmitted)"
+if az servicebus topic subscription rule show \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --topic-name "$TOPIC_NAME" \
+    --subscription-name "$SUBSCRIPTION_NAME" \
+    --name "$RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "    exists"
+else
+  echo "    creating"
+  az servicebus topic subscription rule create \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --topic-name "$TOPIC_NAME" \
+    --subscription-name "$SUBSCRIPTION_NAME" \
+    --name "$RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --filter-type CorrelationFilter \
+    --correlation-filter-property MessageType=ClaimVersionSubmitted >/dev/null
+
+  if az servicebus topic subscription rule show \
+      --namespace-name "$SERVICEBUS_NAMESPACE" \
+      --topic-name "$TOPIC_NAME" \
+      --subscription-name "$SUBSCRIPTION_NAME" \
+      --name '$Default' \
+      --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+    echo "    removing default match-all rule"
+    az servicebus topic subscription rule delete \
+      --namespace-name "$SERVICEBUS_NAMESPACE" \
+      --topic-name "$TOPIC_NAME" \
+      --subscription-name "$SUBSCRIPTION_NAME" \
+      --name '$Default' \
+      --resource-group "$RESOURCE_GROUP" >/dev/null
+  fi
+fi
+
+echo "==> Done."

--- a/src/services/claims-service/Controllers/ClaimsV1Controller.cs
+++ b/src/services/claims-service/Controllers/ClaimsV1Controller.cs
@@ -47,12 +47,14 @@ public class ClaimsV1Controller : ControllerBase
     private readonly IExplanationOfBenefitProjector _eobProjector;
     private readonly IClaimImportTransactionRepository _importTransactions;
     private readonly ILogger<ClaimsV1Controller> _logger;
+    private readonly int _raw837MaxConcurrency;
 
     public ClaimsV1Controller(
         ClaimAdapterFactory adapterFactory,
         IClaimSubmissionService submissionService,
         IExplanationOfBenefitProjector eobProjector,
         IClaimImportTransactionRepository importTransactions,
+        IConfiguration configuration,
         ILogger<ClaimsV1Controller> logger)
     {
         _adapterFactory = adapterFactory;
@@ -60,6 +62,10 @@ public class ClaimsV1Controller : ControllerBase
         _eobProjector = eobProjector;
         _importTransactions = importTransactions;
         _logger = logger;
+        _raw837MaxConcurrency = Math.Clamp(
+            configuration.GetValue("ClaimsImport:Raw837MaxConcurrency", 16),
+            1,
+            64);
     }
 
     /// <summary>
@@ -156,26 +162,39 @@ public class ClaimsV1Controller : ControllerBase
         var correlationId = ResolveCorrelationId();
 
         _logger.LogInformation(
-            "Parsed uploaded 837 file {FileName} for tenant {TenantId}: {Count} claim(s)",
-            SanitizeForLog(file.FileName), SanitizeForLog(tenantId), parsedClaims.Count);
+            "Parsed uploaded 837 file {FileName} for tenant {TenantId}: {Count} claim(s), submitting with max concurrency {MaxConcurrency}",
+            SanitizeForLog(file.FileName), SanitizeForLog(tenantId), parsedClaims.Count, _raw837MaxConcurrency);
 
-        var results = new List<Raw837ClaimResult>(parsedClaims.Count);
-        foreach (var parsed in parsedClaims)
+        var results = new Raw837ClaimResult[parsedClaims.Count];
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, parsedClaims.Count),
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = _raw837MaxConcurrency,
+                CancellationToken = ct
+            },
+            async (index, cancellationToken) =>
         {
+            var parsed = parsedClaims[index];
             var adapterClaim = ClaimsService.EDI.Inbound.X12837ClaimMapper.Map(parsed, tenantId);
-            var result = await _submissionService.SubmitAsync(adapterClaim, tenantId, actorId, correlationId, ct);
+            var result = await _submissionService.SubmitAsync(
+                adapterClaim,
+                tenantId,
+                actorId,
+                correlationId,
+                cancellationToken);
 
             var errors = result.Success
                 ? []
                 : result.Errors.Select(e => $"{e.Field}: {e.Message}").ToList();
 
-            results.Add(new Raw837ClaimResult
+            results[index] = new Raw837ClaimResult
             {
                 ClaimNumber = parsed.ClaimId,
                 Success = result.Success,
                 ClaimId = result.Claim?.Id,
                 Errors = errors
-            });
+            };
 
             // Persisted regardless of outcome — a rejected claim is exactly
             // what an evaluator troubleshooting a dropped file needs to see.
@@ -201,14 +220,14 @@ public class ClaimsV1Controller : ControllerBase
                     "Failed to persist ClaimImportTransaction for claim {ClaimNumber}",
                     SanitizeForLog(parsed.ClaimId));
             }
-        }
+        });
 
         return Ok(new Raw837ImportResult
         {
             FileName = file.FileName,
             TotalClaims = parsedClaims.Count,
             SucceededCount = results.Count(r => r.Success),
-            Results = results
+            Results = results.ToList()
         });
     }
 

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -12,6 +12,7 @@ data:
   Services__ProviderService: "http://provider-service"
   Services__AuthorizationService: "http://authorization-service"
   Services__BenefitPlanServiceTimeoutSeconds: "5"
+  ClaimsImport__Raw837MaxConcurrency: "16"
   Messaging__AdjudicationMaxConcurrentCalls: "32"
   Messaging__Backend: "ServiceBus"
 ---
@@ -88,6 +89,11 @@ spec:
             configMapKeyRef:
               name: claims-service-config
               key: Services__BenefitPlanServiceTimeoutSeconds
+        - name: ClaimsImport__Raw837MaxConcurrency
+          valueFrom:
+            configMapKeyRef:
+              name: claims-service-config
+              key: ClaimsImport__Raw837MaxConcurrency
         - name: Messaging__AdjudicationMaxConcurrentCalls
           valueFrom:
             configMapKeyRef:

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -13,6 +13,7 @@ data:
   Services__AuthorizationService: "http://authorization-service"
   Services__BenefitPlanServiceTimeoutSeconds: "5"
   Messaging__AdjudicationMaxConcurrentCalls: "32"
+  Messaging__Backend: "ServiceBus"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -92,6 +93,16 @@ spec:
             configMapKeyRef:
               name: claims-service-config
               key: Messaging__AdjudicationMaxConcurrentCalls
+        - name: Messaging__Backend
+          valueFrom:
+            configMapKeyRef:
+              name: claims-service-config
+              key: Messaging__Backend
+        - name: Messaging__ServiceBusConnectionString
+          valueFrom:
+            secretKeyRef:
+              name: servicebus-secret
+              key: connectionString
         - name: Redis__ConnectionString
           valueFrom:
             secretKeyRef:

--- a/src/services/member-service/MemberService.Tests/Models/MemberEventTests.cs
+++ b/src/services/member-service/MemberService.Tests/Models/MemberEventTests.cs
@@ -11,6 +11,20 @@ public class MemberEventTests
     }
 
     [Fact]
+    public void BuildMongoDocumentId_ScopesEventIdByTenantAndMember()
+    {
+        var first = MemberEvent.BuildMongoDocumentId("tenant-a", "member-1", "same-event");
+        var repeat = MemberEvent.BuildMongoDocumentId("tenant-a", "member-1", "same-event");
+        var otherTenant = MemberEvent.BuildMongoDocumentId("tenant-b", "member-1", "same-event");
+        var otherMember = MemberEvent.BuildMongoDocumentId("tenant-a", "member-2", "same-event");
+
+        first.Should().Be(repeat);
+        first.Should().NotBe(otherTenant);
+        first.Should().NotBe(otherMember);
+        first.Should().HaveLength(64);
+    }
+
+    [Fact]
     public void Event_Defaults_SchemaVersion_One_And_OccurredAt_Recent()
     {
         var before = DateTime.UtcNow.AddSeconds(-1);

--- a/src/services/member-service/Models/MemberEvent.cs
+++ b/src/services/member-service/Models/MemberEvent.cs
@@ -1,5 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
@@ -104,6 +106,24 @@ public class MemberEvent
 
     public static string BuildPartitionKey(string tenantId, string memberId) =>
         $"{tenantId}:{memberId}";
+
+    /// <summary>
+    /// Builds the globally unique document id required by MongoDB's <c>_id</c>
+    /// index. Event ids are only unique within a tenant/member stream, so using
+    /// <see cref="EventId"/> directly would make otherwise independent tenants
+    /// collide. Length-prefixing keeps the hash input unambiguous even when an
+    /// identifier contains separator characters.
+    /// </summary>
+    public static string BuildMongoDocumentId(string tenantId, string memberId, string eventId)
+    {
+        ArgumentNullException.ThrowIfNull(tenantId);
+        ArgumentNullException.ThrowIfNull(memberId);
+        ArgumentNullException.ThrowIfNull(eventId);
+
+        var scopedId =
+            $"{tenantId.Length}:{tenantId}{memberId.Length}:{memberId}{eventId.Length}:{eventId}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(scopedId)));
+    }
 }
 
 public enum MemberEventType

--- a/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
+++ b/src/services/member-service/Repositories/MemberEventRepositoryMongo.cs
@@ -72,8 +72,11 @@ public class MemberEventRepositoryMongo : IMemberEventRepository
         if (string.IsNullOrEmpty(evt.TenantId) || string.IsNullOrEmpty(evt.MemberId))
             throw new ArgumentException("TenantId and MemberId are required");
 
-        if (string.IsNullOrEmpty(evt.Id))
-            evt.Id = evt.EventId;
+        // Mongo's _id index is global to the collection, while EventId is only
+        // unique within (TenantId, MemberId). Always replace the publisher's
+        // Cosmos-compatible Id so the same idempotency key can be reused safely
+        // by another tenant or member.
+        evt.Id = MemberEvent.BuildMongoDocumentId(evt.TenantId, evt.MemberId, evt.EventId);
         if (string.IsNullOrEmpty(evt.PartitionKey))
             evt.PartitionKey = MemberEvent.BuildPartitionKey(evt.TenantId, evt.MemberId);
     }

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerRaw837Tests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsV1ControllerRaw837Tests.cs
@@ -100,6 +100,54 @@ public class ClaimsV1ControllerRaw837Tests : IClassFixture<ClaimsApiFactory>
     }
 
     [Fact]
+    public async Task ImportRaw837_MultipleClaims_SubmitsConcurrentlyAndPreservesFileOrder()
+    {
+        var secondClaim = SingleClaimSample.Replace(
+            "CLM-RAW837-0001",
+            "CLM-RAW837-0002",
+            StringComparison.Ordinal);
+        var bothStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+
+        _service
+            .SubmitAsync(Arg.Any<AdapterClaim>(), "test-tenant",
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var claim = call.Arg<AdapterClaim>();
+                if (Interlocked.Increment(ref started) == 2)
+                {
+                    bothStarted.TrySetResult();
+                }
+
+                await release.Task;
+                claim.Id = $"id-{claim.ClaimNumber}";
+                return ClaimSubmissionResult.Ok(claim);
+            });
+
+        var responseTask = _client.PostAsync(
+            "/api/v1/claims/import/raw837",
+            BuildFileContent($"{SingleClaimSample}{secondClaim}", "batch.837"));
+
+        await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        release.TrySetResult();
+
+        var response = await responseTask;
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<Raw837ImportResult>();
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.SucceededCount);
+        Assert.Collection(
+            result.Results,
+            first => Assert.Equal("CLM-RAW837-0001", first.ClaimNumber),
+            second => Assert.Equal("CLM-RAW837-0002", second.ClaimNumber));
+    }
+
+    [Fact]
     public async Task ImportRaw837_NoFile_ReturnsBadRequest()
     {
         var response = await _client.PostAsync(


### PR DESCRIPTION
## Summary

- Wire the local Kubernetes claims-service replicas to a shared Azure Service Bus `claim-version-events` topic and `adjudication-orchestrator` subscription.
- Add idempotent Azure CLI provisioning for the namespace, topic, subscription, and submitted-event filter, matching the existing Bicep resource shapes.
- Fix Mongo member-event document IDs so client event IDs can be reused safely across tenants without colliding on Mongo's global `_id` index.
- Submit claims parsed from a multi-claim raw 837 with configurable bounded concurrency (`ClaimsImport:Raw837MaxConcurrency`, default/local value 16), while preserving file order in the API response and writing one import-audit record per claim.

## Why

`InMemoryMessageBus` is isolated to each process, so multiple local claims-service replicas could not share adjudication work. Once Service Bus made that distribution possible, the raw 837 importer became the bottleneck because it awaited each claim insert, event write, Service Bus send, and audit write before starting the next claim.

The first 5,000-claim validation also exposed a separate Mongo issue during member seeding: `MemberEvent.Id` was set to the client `EventId`, although `EventId` is only scoped to `(TenantId, MemberId)`. Reusing deterministic fixture event IDs in a new tenant collided with Mongo's collection-wide `_id` index and was misreported as repeated version conflicts.

## Impact

- A raw multi-claim 837 can feed all local Kubernetes adjudication consumers through the shared Service Bus subscription.
- Raw 837 import throughput improved from 8.6 claims/sec to 111.4 claims/sec in the local 5,000-claim comparison.
- Mongo-backed member creation now supports the same event idempotency key in independent tenants.
- Concurrency is bounded and configurable from Kubernetes rather than unbounded.

## Validation

- [x] Member-service tests: 153/153 passed
- [x] Claims-service tests: 608/608 passed
- [x] Real `834-to-837-e2e-smoke.sh`: raw 834 created coverage; raw 837 was accepted; `BenefitPlanId` resolved; claim reached terminal status
- [x] Fresh 5,000-member Mongo seed completed with no member-event conflicts
- [x] Sequential raw 837 baseline: 5,000/5,000 accepted and terminal in 581.7s (8.6 claims/sec)
- [x] Bounded-concurrency raw 837: 5,000/5,000 accepted, audited, and terminal in 44.9s (111.4 claims/sec)
- [x] Response retained original 837 claim order
- [x] Zero Service Bus send failures and zero unhandled exceptions
- [x] Adjudication distribution across three local claims-service pods: 1,730 / 1,691 / 1,579

The 5,000-claim transport test used unique claim IDs against one active member/coverage/provider to isolate raw-file import and message-distribution throughput. All claims reached a legitimate network-credentialing business denial because the selected provider had no in-network tier for the resolved plan; there were no platform failures.