### PR TITLE
Provision claims Service Bus credentials for AKS and local Kubernetes

### DIFF
--- a/.github/workflows/deploy-azure-aks.yml
+++ b/.github/workflows/deploy-azure-aks.yml
@@ -25,6 +25,7 @@ env:
   AKS_NAME: ${{ vars.AKS_NAME || 'cho-aks' }}
   ACA_SITE_NAME: ${{ vars.ACA_SITE_NAME || 'cho-site' }}
   RESOURCE_GROUP: ${{ vars.AZURE_RG_NAME || 'rg-cloudhealthoffice-prod' }}
+  SERVICEBUS_NAMESPACE: ${{ vars.SERVICEBUS_NAMESPACE || 'clouhealthoffice-messaging' }}
   IMAGE_PREFIX: cloudhealthoffice
   # Azure Key Vault secret provider — set these GitHub settings to enable:
   # Repository variable: KEY_VAULT_NAME        Application Key Vault name (empty = use GitHub Secrets only)
@@ -451,6 +452,9 @@ jobs:
             # Redis
             fetch_secret "Redis--ConnectionString"       "KV_REDIS_CONNECTION_STRING"
 
+            # Service Bus
+            fetch_secret "ServiceBus--ConnectionString"  "KV_SERVICEBUS_CONNECTION_STRING"
+
             # Kafka
             fetch_secret "Kafka--SaslUsername"            "KV_KAFKA_SASL_USERNAME"
             fetch_secret "Kafka--SaslPassword"            "KV_KAFKA_SASL_PASSWORD"
@@ -500,6 +504,46 @@ jobs:
       - name: Create namespace
         run: |
           kubectl create namespace ${{ env.NAMESPACE }} \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create Service Bus secret
+        run: |
+          set -euo pipefail
+
+          # Prefer an operator-managed Key Vault/GitHub secret. On a fresh
+          # environment, create a least-privilege namespace authorization rule
+          # and retrieve its key through the already-authenticated Azure CLI.
+          CONN="${KV_SERVICEBUS_CONNECTION_STRING:-${{ secrets.SERVICEBUS_CONNECTION_STRING }}}"
+          if [ -z "$CONN" ]; then
+            az servicebus namespace show \
+              --name "${{ env.SERVICEBUS_NAMESPACE }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --output none
+
+            az servicebus namespace authorization-rule create \
+              --name claims-service \
+              --namespace-name "${{ env.SERVICEBUS_NAMESPACE }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --rights Listen Send \
+              --output none
+
+            CONN=$(az servicebus namespace authorization-rule keys list \
+              --name claims-service \
+              --namespace-name "${{ env.SERVICEBUS_NAMESPACE }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --query primaryConnectionString \
+              --output tsv)
+          fi
+
+          if [ -z "$CONN" ]; then
+            echo "::error::Unable to resolve a Service Bus connection string"
+            exit 1
+          fi
+
+          echo "::add-mask::$CONN"
+          kubectl create secret generic servicebus-secret \
+            --from-literal=connectionString="$CONN" \
+            -n ${{ env.NAMESPACE }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Create database secret (MongoDB or CosmosDB)

--- a/docs/quickstart-kubernetes-local.md
+++ b/docs/quickstart-kubernetes-local.md
@@ -255,6 +255,30 @@ After editing a k8s manifest (e.g. ConfigMap or deployment):
 kubectl apply -f src/services/claims-service/k8s/claims-service-deployment.yaml
 ```
 
+### Use Azure Service Bus for local claims adjudication
+
+Claims adjudication uses the in-memory message bus by default. To exercise the
+durable Azure Service Bus path from local Kubernetes, add these non-secret
+settings to `.env.local`:
+
+```bash
+LOCAL_SERVICEBUS_NAMESPACE=your-service-bus-namespace
+LOCAL_SERVICEBUS_RESOURCE_GROUP=your-resource-group
+LOCAL_SERVICEBUS_LOCATION=your-azure-region
+```
+
+Then run the normal deployment:
+
+```bash
+./scripts/deploy-local.sh --skip-build
+```
+
+The deployment uses your current Azure CLI login to provision the claims topic
+and subscription, creates a namespace authorization rule with only `Listen` and
+`Send` rights, and installs its connection string as `servicebus-secret` in the
+`cloudhealthoffice` namespace. The credential is not stored in `.env.local`.
+Remove all three settings to return to the in-memory message bus.
+
 ---
 
 ## Troubleshooting

--- a/scripts/azure/bootstrap-local-servicebus.sh
+++ b/scripts/azure/bootstrap-local-servicebus.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Opt-in Azure Service Bus bootstrap for a local Kubernetes deployment.
+#
+# Provisions the claims topic/subscription, creates a namespace authorization
+# rule with only Listen + Send rights, and installs its connection string in
+# the local cluster. Nothing is written to disk and the connection string is
+# never printed.
+#
+# Required env vars:
+#   SERVICEBUS_NAMESPACE — Azure Service Bus namespace
+#   RESOURCE_GROUP       — resource group containing the namespace
+#   LOCATION             — Azure region (used only if the namespace is absent)
+#
+# Optional env vars:
+#   K8S_NAMESPACE        — Kubernetes namespace (default: cloudhealthoffice)
+#   AUTH_RULE_NAME       — authorization rule name (default: claims-service-local)
+set -euo pipefail
+
+: "${SERVICEBUS_NAMESPACE:?SERVICEBUS_NAMESPACE is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+: "${LOCATION:?LOCATION is required}"
+
+K8S_NAMESPACE="${K8S_NAMESPACE:-cloudhealthoffice}"
+AUTH_RULE_NAME="${AUTH_RULE_NAME:-claims-service-local}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+command -v az >/dev/null 2>&1 || {
+  echo "Azure CLI (az) is required" >&2
+  exit 1
+}
+command -v kubectl >/dev/null 2>&1 || {
+  echo "kubectl is required" >&2
+  exit 1
+}
+
+"${SCRIPT_DIR}/provision-servicebus-claim-events.sh"
+
+echo "==> Namespace authorization rule: ${AUTH_RULE_NAME} (Listen + Send)"
+if az servicebus namespace authorization-rule show \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$AUTH_RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  az servicebus namespace authorization-rule update \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$AUTH_RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --rights Listen Send >/dev/null
+else
+  az servicebus namespace authorization-rule create \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$AUTH_RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --rights Listen Send >/dev/null
+fi
+
+CONNECTION_STRING="$(
+  az servicebus namespace authorization-rule keys list \
+    --namespace-name "$SERVICEBUS_NAMESPACE" \
+    --name "$AUTH_RULE_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query primaryConnectionString \
+    --output tsv
+)"
+
+if [[ -z "$CONNECTION_STRING" ]]; then
+  echo "Azure CLI returned an empty Service Bus connection string" >&2
+  exit 1
+fi
+
+kubectl create namespace "$K8S_NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl create secret generic servicebus-secret \
+  --namespace "$K8S_NAMESPACE" \
+  --from-literal=connectionString="$CONNECTION_STRING" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+unset CONNECTION_STRING
+echo "==> Installed servicebus-secret in Kubernetes namespace ${K8S_NAMESPACE}"

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -39,6 +39,9 @@ AZURE_STORAGE_CONNECTION_STRING="UseDevelopmentStorage=true"
 PRICING_API_KEY="local-dev-key"
 PRICING_API_ADMIN_SECRET="local-dev-admin"
 REDIS_CONNECTION_STRING=""  # auto-set below if empty
+LOCAL_SERVICEBUS_NAMESPACE=""
+LOCAL_SERVICEBUS_RESOURCE_GROUP=""
+LOCAL_SERVICEBUS_LOCATION=""
 
 # Source local overrides (real credentials for auth/payments)
 if [[ -f .env.local ]]; then
@@ -177,6 +180,33 @@ ok "$NAMESPACE"
 kubectl delete resourcequota compute-resources -n "$NAMESPACE" 2>/dev/null || true
 kubectl delete networkpolicy allow-ingress-from-portal -n "$NAMESPACE" 2>/dev/null || true
 ok "removed ResourceQuota and NetworkPolicy (not needed locally)"
+
+# ── Configure claims messaging ───────────────────────────────────────────────
+# Azure Service Bus is opt-in for local development. Configure all three
+# LOCAL_SERVICEBUS_* values in .env.local to provision the claims entities,
+# create a least-privilege Listen/Send rule, and install servicebus-secret.
+# With no configuration, claims-service explicitly uses its in-process bus.
+CLAIMS_MESSAGING_BACKEND="InMemory"
+if [[ -n "$LOCAL_SERVICEBUS_NAMESPACE" ||
+      -n "$LOCAL_SERVICEBUS_RESOURCE_GROUP" ||
+      -n "$LOCAL_SERVICEBUS_LOCATION" ]]; then
+  if [[ -z "$LOCAL_SERVICEBUS_NAMESPACE" ||
+        -z "$LOCAL_SERVICEBUS_RESOURCE_GROUP" ||
+        -z "$LOCAL_SERVICEBUS_LOCATION" ]]; then
+    err "Set LOCAL_SERVICEBUS_NAMESPACE, LOCAL_SERVICEBUS_RESOURCE_GROUP, and LOCAL_SERVICEBUS_LOCATION together"
+  fi
+
+  log "Configuring Azure Service Bus for local claims messaging"
+  SERVICEBUS_NAMESPACE="$LOCAL_SERVICEBUS_NAMESPACE" \
+    RESOURCE_GROUP="$LOCAL_SERVICEBUS_RESOURCE_GROUP" \
+    LOCATION="$LOCAL_SERVICEBUS_LOCATION" \
+    K8S_NAMESPACE="$NAMESPACE" \
+    ./scripts/azure/bootstrap-local-servicebus.sh
+  CLAIMS_MESSAGING_BACKEND="ServiceBus"
+  ok "claims messaging: Azure Service Bus"
+else
+  ok "claims messaging: InMemory (set LOCAL_SERVICEBUS_* in .env.local to opt in)"
+fi
 
 # ── Create secrets ────────────────────────────────────────────────────────────
 log "Creating secrets"
@@ -394,10 +424,12 @@ deploy_service() {
     fi
 
     # Replace imagePullPolicy: Always with Never for local images
+    local backend="$CLAIMS_MESSAGING_BACKEND"
     sed \
       -e 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' \
       -e 's/storageClassName: azurefile-csi/storageClassName: standard/g' \
       -e 's/ReadWriteMany/ReadWriteOnce/g' \
+      -e "s/Messaging__Backend: \"Auto\"/Messaging__Backend: \"$backend\"/g" \
       "$manifest" \
       | kubectl apply -f - 2>/dev/null \
       && ok "$name" || warn "$name failed"

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -14,7 +14,7 @@ data:
   Services__BenefitPlanServiceTimeoutSeconds: "5"
   ClaimsImport__Raw837MaxConcurrency: "16"
   Messaging__AdjudicationMaxConcurrentCalls: "32"
-  Messaging__Backend: "ServiceBus"
+  Messaging__Backend: "Auto"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -109,6 +109,7 @@ spec:
             secretKeyRef:
               name: servicebus-secret
               key: connectionString
+              optional: true
         - name: Redis__ConnectionString
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary

- Create/update the Kubernetes `servicebus-secret` before applying service manifests in the AKS deployment workflow.
- Prefer an operator-managed connection string from Key Vault (`ServiceBus--ConnectionString`) or the `SERVICEBUS_CONNECTION_STRING` GitHub secret.
- When no managed AKS secret is configured, create a dedicated `claims-service` namespace authorization rule with only `Listen` and `Send`, retrieve its connection string through the authenticated Azure CLI, mask it, and write it to Kubernetes.
- Add an opt-in local bootstrap that provisions the claims topic/subscription, creates the `claims-service-local` `Listen`/`Send` rule, and installs its credential in local Kubernetes without writing it to disk.
- Make the shared claims manifest use messaging `Auto` with an optional secret reference. `deploy-local.sh` explicitly selects Service Bus when all `LOCAL_SERVICEBUS_*` settings are present and otherwise selects the in-memory bus.
- Document the three non-secret `.env.local` settings used to opt in locally.

## Root cause

PR #1040 made the claims-service deployment require `servicebus-secret`, but neither the AKS workflow nor a fresh local deployment created that secret. A new claims-service ReplicaSet could therefore fail with `CreateContainerConfigError`. Local development also had no repeatable way to replace the broad `RootManageSharedAccessKey` credential or fall back cleanly when Azure Service Bus was not configured.

## Impact

AKS can roll out the Service Bus-backed claims-service without manually pre-seeding a Kubernetes secret. Local Kubernetes defaults to in-memory messaging, while developers can opt into the real Azure transport using an Azure CLI-authenticated, least-privilege bootstrap.

## Validation

- [x] `actionlint .github/workflows/deploy-azure-aks.yml`
- [x] `bash -n` for all changed and invoked shell scripts
- [x] ShellCheck (no new warnings; informational findings are pre-existing)
- [x] `kubectl apply --dry-run=client` for the claims manifest
- [x] `git diff --check`
- [x] Confirmed Azure CLI accepts and reports only `Listen` and `Send` on `claims-service-local`
- [x] Ran the local bootstrap twice successfully to verify idempotency
- [x] Replaced the local Kubernetes secret and successfully rolled all 3 claims-service pods
- [x] Passed the live 834 → 837 smoke test through Azure Service Bus with the restricted credential; the claim reached terminal status with `BenefitPlanId` resolved