### PR TITLE
Add Service Bus-only MCC validation

### DIFF
--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -267,13 +267,15 @@ internal sealed record ObservedClaimStatus(
     string RawStatus,
     string? PendCode,
     bool IsTerminal,
-    string? BusinessDenialCode = null)
+    string? BusinessDenialCode = null,
+    decimal? PlanPayment = null)
 {
     public static ObservedClaimStatus FromClaimJson(JsonElement root)
     {
         var rawStatus = TryReadStringOrNumber(root, "status") ?? string.Empty;
         var pendCode = TryReadPendCode(root);
         var businessDenialCode = MccWorkflowValidation.NormalizeBusinessDenialCode(TryReadBusinessDenialCode(root));
+        var planPayment = TryReadPlanPayment(root);
         var outcome = rawStatus.Trim() switch
         {
             "4" => ClaimValidationOutcome.Pended,
@@ -295,7 +297,8 @@ internal sealed record ObservedClaimStatus(
             outcome is ClaimValidationOutcome.Pended
                 or ClaimValidationOutcome.Paid
                 or ClaimValidationOutcome.BusinessDenial,
-            businessDenialCode);
+            businessDenialCode,
+            planPayment);
     }
 
     private static string? TryReadStringOrNumber(JsonElement root, string propertyName)
@@ -341,6 +344,27 @@ internal sealed record ObservedClaimStatus(
             JsonValueKind.Number => denialReasonCode.TryGetInt32(out var number)
                 ? number.ToString()
                 : denialReasonCode.GetRawText(),
+            _ => null
+        };
+    }
+
+    private static decimal? TryReadPlanPayment(JsonElement root)
+    {
+        if (!root.TryGetProperty("adjudicationResult", out var adjudicationResult)
+            || adjudicationResult.ValueKind is not JsonValueKind.Object
+            || !adjudicationResult.TryGetProperty("payerPayment", out var payerPayment))
+        {
+            return null;
+        }
+
+        return payerPayment.ValueKind switch
+        {
+            JsonValueKind.Number when payerPayment.TryGetDecimal(out var amount) => amount,
+            JsonValueKind.String when decimal.TryParse(
+                payerPayment.GetString(),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var amount) => amount,
             _ => null
         };
     }

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -50,6 +50,7 @@ Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
 Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
 Console.WriteLine($"  Auth fixtures:{(options.SeedAuthorizations ? " enabled" : " disabled")}");
+Console.WriteLine($"  Adjudication:{(options.ServiceBusOnly ? " Service Bus only (persisted outcome)" : " synchronous + workflow observation")}");
 Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled ({options.PendObservationTimeoutSeconds}s/{options.PendObservationIntervalMilliseconds}ms)" : " disabled")}");
 Console.WriteLine($"  Pend diag:   {(options.PendDiagnosticsPath is not null ? $"enabled -> {options.PendDiagnosticsPath}" : "disabled")}");
 Console.WriteLine();
@@ -79,11 +80,16 @@ await MeasureLifecyclePhaseAsync(lifecycleTimings, "Reference rule seeding", "Pr
 });
 
 var validationPlanId = Guid.NewGuid();
-await MeasureLifecyclePhaseAsync(lifecycleTimings, "Validation plan setup", "Preparation", async () =>
-{
-    await CreateValidationPlanAsync(http, options, validationPlanId, json);
-    await SeedValidationPlanServiceCategoryOverridesAsync(http, options, validationPlanId, json);
-});
+var validationPlanBusinessId = await MeasureLifecycleValuePhaseAsync(
+    lifecycleTimings,
+    "Validation plan setup",
+    "Preparation",
+    async () =>
+    {
+        var planId = await CreateValidationPlanAsync(http, options, validationPlanId, json);
+        await SeedValidationPlanServiceCategoryOverridesAsync(http, options, validationPlanId, json);
+        return planId;
+    });
 
 var claims = await MeasureLifecycleValuePhaseAsync(
     lifecycleTimings,
@@ -226,7 +232,14 @@ await Parallel.ForEachAsync(
     new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
     async (claim, _) =>
     {
-        var result = await ProcessClaimAsync(http, options, claim, validationPlanId, answerKey, json);
+        var result = await ProcessClaimAsync(
+            http,
+            options,
+            claim,
+            validationPlanId,
+            validationPlanBusinessId,
+            answerKey,
+            json);
         results.Add(result);
 
         var done = Interlocked.Increment(ref completed);
@@ -312,7 +325,7 @@ var orderedResults = results
 postProcessingStopwatch.Stop();
 postProcessingTimings.Add(("Result ordering", postProcessingStopwatch.Elapsed));
 
-if (options.PendObservationEnabled)
+if (options.PendObservationEnabled && !options.ServiceBusOnly)
 {
     await MeasureLifecyclePhaseAsync(lifecycleTimings, "Expected-pend observation", "Observation", async () =>
     {
@@ -441,6 +454,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     ValidatorOptions options,
     SyntheticClaim claim,
     Guid validationPlanId,
+    string validationPlanBusinessId,
     MccAnswerKey answerKey,
     JsonSerializerOptions json)
 {
@@ -459,9 +473,49 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         var networkTier = NetworkTier(claim);
         failureStage = "submit";
         var stage = Stopwatch.StartNew();
-        var submitted = await SubmitClaimAsync(http, options, claim, validationPlanId, json);
+        var submitted = await SubmitClaimAsync(
+            http,
+            options,
+            claim,
+            validationPlanBusinessId,
+            json);
         stage.Stop();
         submitElapsed = stage.Elapsed;
+
+        if (options.ServiceBusOnly)
+        {
+            failureStage = "servicebus-observation";
+            stage.Restart();
+            var observed = await ObserveServiceBusOutcomeAsync(http, options, submitted.Id);
+            stage.Stop();
+            adjudicationElapsed = stage.Elapsed;
+            sw.Stop();
+
+            var observedDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
+                ? observed.BusinessDenialCode
+                : null;
+
+            return new ClaimValidationResult(
+                claim.ClaimId,
+                submitted.Id,
+                claim.ClaimType,
+                expectedValidation.Scenario,
+                expectedValidation.ExpectedOutcome?.ToString(),
+                expectedValidation.ExpectedBusinessDenialCode,
+                MccWorkflowValidation.ValidationStatus(expectedValidation, observed.Outcome, observedDenialCode),
+                observed.Outcome,
+                observed.Outcome is ClaimValidationOutcome.Paid,
+                observed.PlanPayment,
+                expectedPlanPayment,
+                sw.Elapsed,
+                submitElapsed,
+                adjudicationElapsed,
+                TimeSpan.Zero,
+                new Dictionary<string, double>(),
+                observedDenialCode,
+                null,
+                null);
+        }
 
         failureStage = "adjudicate";
         stage.Restart();
@@ -551,6 +605,35 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             null,
             failureStage,
             ex.Message);
+    }
+}
+
+static async Task<ObservedClaimStatus> ObserveServiceBusOutcomeAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    string submittedClaimId)
+{
+    var source = new HttpClaimStatusSource(http, options.ClaimsUrl);
+    var timeout = TimeSpan.FromSeconds(options.PendObservationTimeoutSeconds);
+    var interval = TimeSpan.FromMilliseconds(options.PendObservationIntervalMilliseconds);
+    var deadline = DateTimeOffset.UtcNow.Add(timeout);
+
+    while (true)
+    {
+        var observed = await source.GetAsync(submittedClaimId, CancellationToken.None);
+        if (observed?.IsTerminal is true)
+        {
+            return observed;
+        }
+
+        var remaining = deadline - DateTimeOffset.UtcNow;
+        if (remaining <= TimeSpan.Zero)
+        {
+            throw new TimeoutException(
+                $"Timed out waiting {timeout.TotalSeconds:N0}s for Service Bus adjudication of claim {submittedClaimId}");
+        }
+
+        await Task.Delay(interval < remaining ? interval : remaining);
     }
 }
 
@@ -666,13 +749,18 @@ static bool IsMccBehavioralHealthMappingPresent(ServiceCategoryMappingSeedView m
             && string.Equals(rule.CodeRangeEnd, "90899", StringComparison.OrdinalIgnoreCase));
 }
 
-static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions options, Guid planGuid, JsonSerializerOptions json)
+static async Task<string> CreateValidationPlanAsync(
+    HttpClient http,
+    ValidatorOptions options,
+    Guid planGuid,
+    JsonSerializerOptions json)
 {
+    var businessPlanId = $"MCC-LOCAL-{DateTime.UtcNow:yyyyMMddHHmmss}";
     var plan = new
     {
         id = planGuid.ToString(),
         tenantId = options.TenantId,
-        planId = $"MCC-LOCAL-{DateTime.UtcNow:yyyyMMddHHmmss}",
+        planId = businessPlanId,
         planName = "MCC Local Validation PPO",
         payer = "Cloud Health Office MCC",
         effectiveDate = "2025-01-01T00:00:00Z",
@@ -752,6 +840,7 @@ static async Task CreateValidationPlanAsync(HttpClient http, ValidatorOptions op
     }
 
     Console.WriteLine($"created: validation benefit plan {planGuid}");
+    return businessPlanId;
 }
 
 // Plan-specific ServiceCategoryMapping overrides for the validation plan. The
@@ -2585,7 +2674,7 @@ static async Task<SubmittedClaim> SubmitClaimAsync(
     HttpClient http,
     ValidatorOptions options,
     SyntheticClaim claim,
-    Guid validationPlanId,
+    string validationPlanBusinessId,
     JsonSerializerOptions json)
 {
     var payload = new
@@ -2594,7 +2683,7 @@ static async Task<SubmittedClaim> SubmitClaimAsync(
         claimNumber = claim.ClaimId,
         memberId = claim.Member.MemberId,
         subscriberId = claim.Member.SubscriberId,
-        benefitPlanId = validationPlanId.ToString(),
+        benefitPlanId = validationPlanBusinessId,
         subscriberFirstName = claim.Member.FirstName,
         subscriberLastName = claim.Member.LastName,
         patientFirstName = claim.Member.FirstName,
@@ -3457,6 +3546,8 @@ static void PrintUsage()
       --no-seed-providers        Skip synthetic provider seeding
       --no-seed-authorizations   Skip prior authorization fixture seeding
       --skip-claim-update        Do not write adjudication projection back to claims-service
+      --servicebus-only          Submit claims and score only the persisted asynchronous Service Bus outcome;
+                                 skips synchronous benefit adjudication and writeback
       --no-pend-observation      Do not poll claims-service for expected-pend claim status
       --pend-observation-timeout <seconds>
                                  Max wait for expected-pend claims after benchmark timing stops (default: 45)

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -14,6 +14,7 @@ public sealed record ValidatorOptions(
     bool SeedProviders,
     bool SeedAuthorizations,
     bool SkipClaimUpdate,
+    bool ServiceBusOnly,
     bool PendObservationEnabled,
     int PendObservationTimeoutSeconds,
     int PendObservationIntervalMilliseconds,
@@ -31,7 +32,9 @@ public sealed record ValidatorOptions(
     bool ShowHelp)
 {
     public const int DefaultMaxClaims = 10_000;
-    public const int MaxParallelism = 64;
+    // Three local claims-service replicas default to 32 Service Bus calls each.
+    // Allow the validator to keep that 96-call consumer pool fed.
+    public const int MaxParallelism = 96;
 
     public static ValidatorOptions Parse(string[] args)
     {
@@ -78,6 +81,9 @@ public sealed record ValidatorOptions(
                     break;
                 case "--skip-claim-update":
                     options.SkipClaimUpdate = true;
+                    break;
+                case "--servicebus-only":
+                    options.ServiceBusOnly = true;
                     break;
                 case "--no-pend-observation":
                     options.PendObservationEnabled = false;
@@ -159,6 +165,7 @@ public sealed record ValidatorOptions(
             options.SeedProviders,
             options.SeedAuthorizations,
             options.SkipClaimUpdate,
+            options.ServiceBusOnly,
             options.PendObservationEnabled,
             Math.Clamp(options.PendObservationTimeoutSeconds, 1, 300),
             Math.Clamp(options.PendObservationIntervalMilliseconds, 100, 30_000),
@@ -191,6 +198,7 @@ public sealed record ValidatorOptions(
         public bool SeedProviders { get; set; } = true;
         public bool SeedAuthorizations { get; set; } = true;
         public bool SkipClaimUpdate { get; set; }
+        public bool ServiceBusOnly { get; set; }
         public bool PendObservationEnabled { get; set; } = true;
         public int PendObservationTimeoutSeconds { get; set; } = 45;
         public int PendObservationIntervalMilliseconds { get; set; } = 1000;

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccClaimStatusObserverTests.cs
@@ -127,6 +127,25 @@ public class MccClaimStatusObserverTests
     }
 
     [Fact]
+    public void FromClaimJson_ParsesPersistedPlanPayment()
+    {
+        using var document = System.Text.Json.JsonDocument.Parse("""
+        {
+          "status": 5,
+          "adjudicationResult": {
+            "payerPayment": 123.45
+          }
+        }
+        """);
+
+        var observed = ObservedClaimStatus.FromClaimJson(document.RootElement);
+
+        Assert.Equal(ClaimValidationOutcome.Paid, observed.Outcome);
+        Assert.Equal(123.45m, observed.PlanPayment);
+        Assert.True(observed.IsTerminal);
+    }
+
+    [Fact]
     public async Task DetectUnexpectedPendAsync_WhenExpectedPaidPersistedPended_ReturnsMismatch()
     {
         var observer = new MccClaimStatusObserver(new FakeClaimStatusSource([

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -24,6 +24,15 @@ public class ValidatorOptionsTests
     }
 
     [Fact]
+    public void Parse_WhenParallelismExceedsLocalConsumerCapacity_CapsAtMaximum()
+    {
+        var options = ValidatorOptions.Parse(["--parallelism", "128"]);
+
+        Assert.Equal(ValidatorOptions.MaxParallelism, options.Parallelism);
+        Assert.Equal(96, options.Parallelism);
+    }
+
+    [Fact]
     public void Parse_WhenNoSeedProvidersProvided_DisablesProviderSeeding()
     {
         var options = ValidatorOptions.Parse(["--no-seed-providers"]);
@@ -37,6 +46,15 @@ public class ValidatorOptionsTests
         var options = ValidatorOptions.Parse(["--no-seed-members"]);
 
         Assert.False(options.SeedMembers);
+    }
+
+    [Fact]
+    public void Parse_WhenServiceBusOnlyProvided_EnablesAsynchronousAdjudicationMode()
+    {
+        var options = ValidatorOptions.Parse(["--servicebus-only"]);
+
+        Assert.True(options.ServiceBusOnly);
+        Assert.False(ValidatorOptions.Parse([]).ServiceBusOnly);
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- add a `--servicebus-only` MCC validator mode that submits through claims-service and scores the persisted asynchronous adjudication outcome
- capture persisted payer payment for payment-gate validation
- submit the benefit plan business identifier expected by the asynchronous plan resolver
- allow up to 96 validator workers to match three local claims-service replicas with 32 Service Bus calls each
- add option parsing and persisted payment tests

## Why

The existing validator always invoked synchronous adjudication after claim submission, so it could not measure the real Service Bus-backed claims path. It also submitted the plan document GUID while the asynchronous resolver expects the business `planId`, causing otherwise valid asynchronous claims to miss their configured network tier.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 113 passed
- 100,000-claim mixed local Kubernetes run through Azure Service Bus:
  - 100,000/100,000 terminal
  - 141.90 claims/sec
  - p95 1,038 ms; p99 1,298 ms
  - 0 platform failures and 0 observation timeouts
  - 13,000/13,000 workflow checks matched
  - 2,000/2,000 payment checks exact
  - Service Bus subscription drained to 0 active and 0 dead-letter messages
  - all three claims-service pods had 0 restarts and no matching error/exception logs
