### PR TITLE
Scale local claims validation

### DIFF
--- a/src/services/claims-service/Controllers/ClaimsV1Controller.cs
+++ b/src/services/claims-service/Controllers/ClaimsV1Controller.cs
@@ -63,7 +63,7 @@ public class ClaimsV1Controller : ControllerBase
         _importTransactions = importTransactions;
         _logger = logger;
         _raw837MaxConcurrency = Math.Clamp(
-            configuration.GetValue("ClaimsImport:Raw837MaxConcurrency", 16),
+            configuration.GetValue("ClaimsImport:Raw837MaxConcurrency", 32),
             1,
             64);
     }

--- a/src/services/claims-service/k8s/claims-service-deployment.yaml
+++ b/src/services/claims-service/k8s/claims-service-deployment.yaml
@@ -12,7 +12,7 @@ data:
   Services__ProviderService: "http://provider-service"
   Services__AuthorizationService: "http://authorization-service"
   Services__BenefitPlanServiceTimeoutSeconds: "5"
-  ClaimsImport__Raw837MaxConcurrency: "16"
+  ClaimsImport__Raw837MaxConcurrency: "32"
   Messaging__AdjudicationMaxConcurrentCalls: "32"
   Messaging__Backend: "Auto"
 ---

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -1809,6 +1809,8 @@ static async Task<bool> SeedPriorAuthAuthorizationFixturesAsync(
     IReadOnlyCollection<SyntheticClaim> claims,
     JsonSerializerOptions json)
 {
+    const int batchSize = 500;
+
     if (!options.PriorAuthScenariosEnabled)
     {
         Console.WriteLine("Authorization fixtures: skipped (prior-auth scenarios disabled)");
@@ -1835,45 +1837,77 @@ static async Task<bool> SeedPriorAuthAuthorizationFixturesAsync(
         return false;
     }
 
-    var payload = new
-    {
-        authorizations = fixtureClaims.Select(claim => BuildPriorAuthAuthorizationFixture(claim, options)).ToList()
-    };
-
     try
     {
-        using var response = await http.PostAsJsonAsync($"{options.AuthorizationUrl}/api/authorizations/dev-seed", payload, json);
-        var body = await response.Content.ReadAsStringAsync();
+        var totalSeeded = 0;
+        var totalCreated = 0;
+        var totalUpdated = 0;
+        var batches = (fixtureClaims.Count + batchSize - 1) / batchSize;
 
-        if (response.StatusCode is System.Net.HttpStatusCode.NotFound
-            or System.Net.HttpStatusCode.Unauthorized
-            or System.Net.HttpStatusCode.Forbidden)
+        for (var offset = 0; offset < fixtureClaims.Count; offset += batchSize)
         {
-            Console.WriteLine($"Authorization fixtures: skipped ({(int)response.StatusCode} from authorization-service)");
-            return false;
-        }
+            var batchNumber = (offset / batchSize) + 1;
+            var payload = new
+            {
+                authorizations = fixtureClaims
+                    .Skip(offset)
+                    .Take(batchSize)
+                    .Select(claim => BuildPriorAuthAuthorizationFixture(claim, options))
+                    .ToList()
+            };
 
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException($"Authorization fixture seed failed: {(int)response.StatusCode} {body}");
-        }
+            using var response = await http.PostAsJsonAsync(
+                $"{options.AuthorizationUrl}/api/authorizations/dev-seed",
+                payload,
+                json);
+            var body = await response.Content.ReadAsStringAsync();
 
-        if (!TryReadAuthorizationFixtureSeedResponse(body, out var total, out var created, out var updated))
-        {
-            Console.WriteLine("Authorization fixtures: skipped (authorization-service did not expose compatible dev-seed evidence)");
-            return false;
+            if (response.StatusCode is System.Net.HttpStatusCode.NotFound
+                or System.Net.HttpStatusCode.Unauthorized
+                or System.Net.HttpStatusCode.Forbidden)
+            {
+                Console.WriteLine($"Authorization fixtures: skipped ({(int)response.StatusCode} from authorization-service)");
+                return false;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Authorization fixture seed batch {batchNumber:N0}/{batches:N0} failed: " +
+                    $"{(int)response.StatusCode} {body}");
+            }
+
+            if (!TryReadAuthorizationFixtureSeedResponse(body, out var total, out var created, out var updated))
+            {
+                Console.WriteLine(
+                    "Authorization fixtures: skipped " +
+                    "(authorization-service did not expose compatible dev-seed evidence)");
+                return false;
+            }
+
+            totalSeeded += total;
+            totalCreated += created;
+            totalUpdated += updated;
+
+            if (batches > 1 && (batchNumber == batches || batchNumber % 5 == 0))
+            {
+                Console.WriteLine(
+                    $"Authorization fixtures: seeded batch {batchNumber:N0}/{batches:N0} " +
+                    $"({totalSeeded:N0}/{fixtureClaims.Count:N0})");
+            }
         }
 
         Console.WriteLine(
-            $"Authorization fixtures: seeded {total:N0} prior authorization fixtures ({created:N0} new, {updated:N0} updated)");
-        return total > 0;
+            $"Authorization fixtures: seeded {totalSeeded:N0} prior authorization fixtures " +
+            $"({totalCreated:N0} new, {totalUpdated:N0} updated)");
+        return totalSeeded > 0;
     }
     catch (HttpRequestException ex)
     {
         Console.WriteLine($"Authorization fixtures: skipped ({ex.Message})");
         return false;
     }
-    catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+    catch (TaskCanceledException ex)
     {
         Console.WriteLine($"Authorization fixtures: skipped ({ex.Message})");
         return false;


### PR DESCRIPTION
## What changed

- raise the raw 837 importer fallback and Kubernetes default concurrency from 16 to the validated value of 32
- seed MCC prior-authorization fixtures in bounded batches of 500
- aggregate batch evidence and print progress for large validator runs
- handle authorization seed request cancellation without crashing the validator

## Why

Raw 837 tests showed that concurrency 32 improves local ingestion without queue or adjudication failures. The first 1M MCC attempt also exposed a separate scale limit: sending all 6,376 authorization fixtures in one request exceeded the validator's 60-second HTTP timeout. Bounded batches completed reliably.

## Validation

- raw 837 and V1 controller tests: 12/12 passed
- MCC validator tests: 113/113 passed
- Kubernetes manifest client dry-run passed
- 10K raw 837 import at concurrency 32:
  - 10,000/10,000 terminal
  - 139.09 claims/sec
  - 0 active and 0 dead-letter messages
- 1M mixed MCC JSON submission through Azure Service Bus:
  - timed throughput: 155.89 claims/sec
  - p95 910 ms; p99 1,205 ms
  - 999,878 observed terminal inside the 180-second per-claim window
  - 122 clustered observation timeouts; all later reached terminal state
  - post-run Mongo count: 1,000,000/1,000,000 terminal and 2,000,000 lifecycle events
  - 19,982/19,982 observed payment checks exact
  - Service Bus drained to 0 active and 0 dead-letter messages
  - all three claims-service pods had 0 restarts
  - no claims-service error/exception log matches across the run

The 1M MCC workload submits JSON to `POST /api/v1/claims` and measures asynchronous Service Bus adjudication. It is distinct from the raw 837 import benchmark.
