### PR TITLE
Reconcile late Service Bus claim outcomes

### DIFF
--- a/docs/million-claim-challenge/podcast/episode-017/README.txt
+++ b/docs/million-claim-challenge/podcast/episode-017/README.txt
@@ -1,0 +1,34 @@
+# Episode 017 — The Timeout Was Not the Outcome
+
+Status: in progress
+
+Episode 017 begins with the evidence limitation disclosed in Episode 016: 122 claims completed
+after the validator's fixed observation window, but the run artifact could not re-score their
+workflow outcomes or payments. Manual MongoDB inspection proved the claims were terminal; it did
+not repair the validator's evidence.
+
+This work adds automatic post-window reconciliation for Service Bus-only runs. A timed-out claim
+now retains its submitted claim ID, is classified as an observation timeout, and is revisited
+after timed throughput stops. A terminal result found in that pass restores the persisted
+disposition, denial code, payer payment, and workflow score.
+
+The first controlled-overload smoke test forced 936/1,000 claims outside a one-second observation
+window. All 936 were reconciled from claims-service in 1.49 seconds. The final run summary reported
+1,000/1,000 processed, 130/130 workflow matches, 20/20 exact payment comparisons, and zero
+unresolved claims.
+
+This is implementation and smoke-test evidence, not the final Episode 017 million-claim result.
+The next benchmark should repeat the full Service Bus corpus with the normal three claims-service
+replicas and preserve both in-window and post-window completion counts.
+
+Primary sources:
+
+- `benchmark-results.txt` — controlled live smoke measurements and limitations
+- `pr-summary.txt` — implementation scope
+
+Next scale exercise:
+
+- Run the local Kubernetes services against Azure Cosmos DB's MongoDB-compatible endpoint.
+- Treat it as a hybrid local-to-Azure persistence benchmark, not an all-local comparison.
+- Capture RU provisioning, throttling, server-side retry delay, Mongo error codes, network
+  latency, and per-service persistence configuration with the result.

--- a/docs/million-claim-challenge/podcast/episode-017/benchmark-results.txt
+++ b/docs/million-claim-challenge/podcast/episode-017/benchmark-results.txt
@@ -1,0 +1,75 @@
+# Episode 017 benchmark results
+
+## Run A — normal three-pod smoke
+
+- Date: 2026-07-28
+- Tenant: `mcc-reconcile-smoke-20260728`
+- Environment: local Docker Desktop Kubernetes
+- Messaging: Azure Service Bus
+- Persistence: local MongoDB
+- Claims-service replicas: 3
+- Validator parallelism: 96
+- Claims: 1,000
+- Initial observation window: 1 second
+- Post-window reconciliation limit: 60 seconds
+
+Result:
+
+  Processed:                    1,000/1,000
+  Initial observation timeouts: 0
+  Workflow checks:              130/130 matched
+  Payment gate:                 20/20 exact within $0.01
+  Platform failures:            0
+  Throughput:                   185.67 claims/sec
+  P95 / P99:                    790 / 894 ms
+
+Purpose: confirm the change does not alter a clean asynchronous result when every claim completes
+inside the initial window.
+
+## Run B — controlled overload to force post-window reconciliation
+
+- Date: 2026-07-28
+- Tenant: `mcc-reconcile-overload-20260728`
+- Environment: local Docker Desktop Kubernetes
+- Messaging: Azure Service Bus
+- Persistence: local MongoDB
+- Claims-service replicas: temporarily reduced from 3 to 1, then restored to 3
+- Validator parallelism: 96
+- Claims: 1,000
+- Initial observation window: 1 second
+- Post-window reconciliation limit: 60 seconds
+
+Timed-window result:
+
+  Completed inside window:      64
+  Observation timeouts:         936
+  Timed throughput:             79.46 claims/sec
+  P95 / P99:                    1,296 / 1,333 ms
+
+Post-window result:
+
+  Reconciled late:              936/936
+  Reconciliation duration:      1.49 seconds
+  Unresolved:                   0
+  Final processed:              1,000/1,000
+  Final paid:                   815
+  Final pended:                 18
+  Final business denials:       167
+  Workflow checks:              130/130 matched
+  Workflow timeouts:            0
+  Payment gate:                 20/20 exact within $0.01
+  Platform failures:            0
+  Final observation timeouts:   0
+
+Operational verification:
+
+- claims-service restored to 3 desired / 3 ready replicas
+- all three restored pods reported zero restarts
+
+Interpretation:
+
+- The initial timeout count remains visible as a measurement of work completing outside the
+  configured window.
+- Reconciliation changes the final evidence, not timed throughput or latency.
+- A claim that remains nonterminal after reconciliation still produces a nonzero validator exit.
+- This controlled overload proves the reconciliation mechanism; it is not a capacity result.

--- a/docs/million-claim-challenge/podcast/episode-017/pr-summary.txt
+++ b/docs/million-claim-challenge/podcast/episode-017/pr-summary.txt
@@ -1,0 +1,35 @@
+# Episode 017 implementation summary
+
+## Validator
+
+- Preserve the submitted claim ID when Service Bus observation reaches its deadline.
+- Classify the event as `ObservationTimeout`, distinct from a submission or platform exception.
+- Revisit timed-out claims after the timed benchmark phase.
+- Re-score terminal persisted outcomes, denial codes, payer payments, and workflow evidence.
+- Keep unresolved claims as observation timeouts and return a nonzero process exit.
+- Add separate summary counts for initial Service Bus timeouts, reconciled late completions, and
+  unreconciled claims.
+- Record reconciliation as an Observation lifecycle phase excluded from throughput.
+
+## Published evidence
+
+- Persist the new run-level counts in claims-service.
+- Publish claim-level flags identifying a timed-out observation and successful late
+  reconciliation.
+- Display Service Bus window timeouts, late completions, and unresolved claims in the Mass
+  Adjudication console.
+
+## Local automation
+
+- Add `SERVICEBUS_ONLY` to the run and sweep scripts.
+- Add `SERVICEBUS_RECONCILIATION_ENABLED`.
+- Add `SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS`.
+
+## Verification
+
+- Validator tests cover late paid, late business-denial, payment, unresolved, ignored, summary,
+  and option-parsing behavior.
+- Claims-service repository tests cover persistence of run-level and claim-level reconciliation
+  evidence.
+- A live controlled-overload run reconciled 936/936 delayed claims and restored complete workflow
+  and payment scoring.

--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -19,6 +19,9 @@ AUTHORIZATION_URL="${AUTHORIZATION_URL:-http://authorization-service}"
 SEED_MEMBERS="${SEED_MEMBERS:-true}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
 SEED_AUTHORIZATIONS="${SEED_AUTHORIZATIONS:-true}"
+SERVICEBUS_ONLY="${SERVICEBUS_ONLY:-false}"
+SERVICEBUS_RECONCILIATION_ENABLED="${SERVICEBUS_RECONCILIATION_ENABLED:-true}"
+SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS="${SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS:-300}"
 CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS="${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS:-15}"
 SERVICE_CATEGORY_ADMIN_WRITE_ENABLED="${SERVICE_CATEGORY_ADMIN_WRITE_ENABLED:-true}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
@@ -111,6 +114,10 @@ spec:
             $(if [[ "$SEED_MEMBERS" != "true" ]]; then printf -- '- --no-seed-members\n'; fi)
             $(if [[ "$SEED_PROVIDERS" != "true" ]]; then printf -- '- --no-seed-providers\n'; fi)
             $(if [[ "$SEED_AUTHORIZATIONS" != "true" ]]; then printf -- '- --no-seed-authorizations\n'; fi)
+            $(if [[ "$SERVICEBUS_ONLY" == "true" ]]; then printf -- '- --servicebus-only\n'; fi)
+            $(if [[ "$SERVICEBUS_RECONCILIATION_ENABLED" != "true" ]]; then printf -- '- --no-servicebus-reconciliation\n'; fi)
+            - --servicebus-reconciliation-timeout
+            - "${SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS}"
             $(if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then printf -- '- --no-pend-observation\n'; fi)
             - --pend-observation-timeout
             - "${PEND_OBSERVATION_TIMEOUT_SECONDS}"

--- a/scripts/sweep-mcc-local-k8s.sh
+++ b/scripts/sweep-mcc-local-k8s.sh
@@ -19,6 +19,9 @@ MAX_CLAIMS="${MAX_CLAIMS:-$CLAIMS}"
 TENANT="${TENANT:-demo}"
 SEED_MEMBERS="${SEED_MEMBERS:-true}"
 SEED_PROVIDERS="${SEED_PROVIDERS:-true}"
+SERVICEBUS_ONLY="${SERVICEBUS_ONLY:-false}"
+SERVICEBUS_RECONCILIATION_ENABLED="${SERVICEBUS_RECONCILIATION_ENABLED:-true}"
+SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS="${SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS:-300}"
 CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS="${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS:-15}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
 PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
@@ -99,6 +102,8 @@ run_case() {
   local json_file="$OUTPUT_DIR/${job_name}.json"
   local seed_member_arg=""
   local seed_provider_arg=""
+  local servicebus_only_arg=""
+  local servicebus_reconciliation_arg=""
   local pend_observation_arg=""
   local status="ok"
 
@@ -107,6 +112,12 @@ run_case() {
   fi
   if [[ "$SEED_PROVIDERS" != "true" ]]; then
     seed_provider_arg='                --no-seed-providers \'
+  fi
+  if [[ "$SERVICEBUS_ONLY" == "true" ]]; then
+    servicebus_only_arg='                --servicebus-only \'
+  fi
+  if [[ "$SERVICEBUS_RECONCILIATION_ENABLED" != "true" ]]; then
+    servicebus_reconciliation_arg='                --no-servicebus-reconciliation \'
   fi
   if [[ "$PEND_OBSERVATION_ENABLED" != "true" ]]; then
     pend_observation_arg='                --no-pend-observation \'
@@ -146,11 +157,14 @@ spec:
                 --benefit-url http://benefit-plan-service \
                 --member-url http://member-service \
                 --provider-url http://provider-service \
+                --servicebus-reconciliation-timeout "${SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS}" \
                 --pend-observation-timeout "${PEND_OBSERVATION_TIMEOUT_SECONDS}" \
                 --pend-observation-interval-ms "${PEND_OBSERVATION_INTERVAL_MS}" \
                 --progress-every "${PROGRESS_EVERY}" \
 ${seed_member_arg}
 ${seed_provider_arg}
+${servicebus_only_arg}
+${servicebus_reconciliation_arg}
 ${pend_observation_arg}
                 --summary-json /tmp/mcc-summary.json
               status=\$?

--- a/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
+++ b/src/portal/CloudHealthOffice.Portal/Pages/MassAdjudicationRuns.razor
@@ -220,6 +220,12 @@
                     <MudItem xs="6" md="4">@Metric("Business Denials", $"{_selectedRun.BusinessDenials:N0}", "#ffca28")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Platform Failures", $"{_selectedRun.PlatformFailures:N0}", "#ff0055")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Observation Timeouts", $"{_selectedRun.ObservationTimeouts:N0}", _selectedRun.ObservationTimeouts == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    @if (_selectedRun.ServiceBusObservationTimeouts > 0)
+                    {
+                        <MudItem xs="6" md="4">@Metric("SB Window Timeouts", $"{_selectedRun.ServiceBusObservationTimeouts:N0}", "#ffca28")</MudItem>
+                        <MudItem xs="6" md="4">@Metric("SB Late Completions", $"{_selectedRun.ServiceBusLateCompletions:N0}", _selectedRun.ServiceBusLateCompletions == _selectedRun.ServiceBusObservationTimeouts ? "#00ff88" : "#ffca28")</MudItem>
+                        <MudItem xs="6" md="4">@Metric("SB Unreconciled", $"{_selectedRun.ServiceBusUnreconciledClaims:N0}", _selectedRun.ServiceBusUnreconciledClaims == 0 ? "#00ff88" : "#ff0055")</MudItem>
+                    }
                     <MudItem xs="6" md="4">@Metric("Claims/sec", $"{_selectedRun.ThroughputClaimsPerSecond:N2}/s", "#7dd3fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("P95 / P99", $"{_selectedRun.P95LatencyMilliseconds:N0} / {_selectedRun.P99LatencyMilliseconds:N0} ms", "#c084fc")</MudItem>
                     <MudItem xs="6" md="4">@Metric("Workflow Checks", $"{_selectedRun.WorkflowMatches:N0} / {_selectedRun.WorkflowScenarios:N0}", "#00ff88")</MudItem>

--- a/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/IServices.cs
@@ -141,6 +141,9 @@ public class MassAdjudicationRunSummary
     public int BusinessDenials { get; set; }
     public int ObservationTimeouts { get; set; }
     public int PlatformFailures { get; set; }
+    public int ServiceBusObservationTimeouts { get; set; }
+    public int ServiceBusLateCompletions { get; set; }
+    public int ServiceBusUnreconciledClaims { get; set; }
     public int WorkflowScenarios { get; set; }
     public int WorkflowMatches { get; set; }
     public int WorkflowMismatches { get; set; }
@@ -300,6 +303,8 @@ public class MassAdjudicationClaimResult
     public double AdjudicationMilliseconds { get; set; }
     public double WritebackMilliseconds { get; set; }
     public Dictionary<string, double> AdjudicationStepMilliseconds { get; set; } = new();
+    public bool ServiceBusObservationTimedOut { get; set; }
+    public bool ReconciledAfterObservationTimeout { get; set; }
     public DateTime CreatedAtUtc { get; set; }
 }
 

--- a/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
+++ b/src/services/claims-service/Models/MassAdjudicationRunSummary.cs
@@ -14,6 +14,9 @@ public class MassAdjudicationRunSummary
     public int BusinessDenials { get; set; }
     public int ObservationTimeouts { get; set; }
     public int PlatformFailures { get; set; }
+    public int ServiceBusObservationTimeouts { get; set; }
+    public int ServiceBusLateCompletions { get; set; }
+    public int ServiceBusUnreconciledClaims { get; set; }
     public int WorkflowScenarios { get; set; }
     public int WorkflowMatches { get; set; }
     public int WorkflowMismatches { get; set; }
@@ -173,5 +176,7 @@ public class MassAdjudicationClaimResult
     public double AdjudicationMilliseconds { get; set; }
     public double WritebackMilliseconds { get; set; }
     public Dictionary<string, double> AdjudicationStepMilliseconds { get; set; } = new();
+    public bool ServiceBusObservationTimedOut { get; set; }
+    public bool ReconciledAfterObservationTimeout { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 }

--- a/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
+++ b/src/tools/mcc-platform-validator/MccRunSummaryBuilder.cs
@@ -20,12 +20,17 @@ internal static class MccRunSummaryBuilder
         MassAdjudicationFixturePreparation? fixturePreparation = null)
     {
         var totalClaims = Math.Max(results.Count, totalClaimsOverride ?? results.Count);
-        var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+        var processed = results.Count(r =>
+            r.Outcome is not ClaimValidationOutcome.PlatformFailure
+                and not ClaimValidationOutcome.ObservationTimeout);
         var adjudicated = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
         var pended = results.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
         var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
         var observationTimeouts = results.Count(r => r.Outcome is ClaimValidationOutcome.ObservationTimeout);
         var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+        var serviceBusObservationTimeouts = results.Count(r => r.ServiceBusObservationTimedOut);
+        var serviceBusLateCompletions = results.Count(r => r.ReconciledAfterObservationTimeout);
+        var serviceBusUnreconciledClaims = serviceBusObservationTimeouts - serviceBusLateCompletions;
         var validationScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
         var validationMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
         var validationMismatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MismatchedStatus);
@@ -97,7 +102,9 @@ internal static class MccRunSummaryBuilder
                 r.SubmitElapsed.TotalMilliseconds,
                 r.AdjudicationElapsed.TotalMilliseconds,
                 r.UpdateElapsed.TotalMilliseconds,
-                r.AdjudicationStepTimings))
+                r.AdjudicationStepTimings,
+                r.ServiceBusObservationTimedOut,
+                r.ReconciledAfterObservationTimeout))
             .ToList()
             : new List<MassAdjudicationClaimResult>();
 
@@ -127,6 +134,9 @@ internal static class MccRunSummaryBuilder
             businessDenials,
             observationTimeouts,
             platformFailures,
+            serviceBusObservationTimeouts,
+            serviceBusLateCompletions,
+            serviceBusUnreconciledClaims,
             validationScenarios,
             validationMatches,
             validationMismatches,
@@ -272,10 +282,15 @@ internal static class MccRunSummaryBuilder
             return 2;
         }
 
+        if (result.ReconciledAfterObservationTimeout)
+        {
+            return 3;
+        }
+
         var paymentDelta = PaymentDelta(result);
         if (paymentDelta.HasValue && paymentDelta.Value > PaymentTolerance)
         {
-            return 3;
+            return 4;
         }
 
         return 100;

--- a/src/tools/mcc-platform-validator/MccServiceBusReconciliation.cs
+++ b/src/tools/mcc-platform-validator/MccServiceBusReconciliation.cs
@@ -1,0 +1,142 @@
+using System.Collections.Concurrent;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal sealed class MccServiceBusReconciler
+{
+    private readonly IClaimStatusSource _source;
+
+    public MccServiceBusReconciler(IClaimStatusSource source)
+    {
+        _source = source;
+    }
+
+    public async Task<ServiceBusReconciliationResult> ReconcileAsync(
+        IReadOnlyList<ClaimValidationResult> results,
+        TimeSpan timeout,
+        TimeSpan interval,
+        int maxParallelism,
+        CancellationToken cancellationToken = default)
+    {
+        var candidates = results
+            .Where(IsCandidate)
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return new ServiceBusReconciliationResult(results.ToList(), 0, 0, 0);
+        }
+
+        var reconciled = new ConcurrentDictionary<string, ClaimValidationResult>(StringComparer.Ordinal);
+        await Parallel.ForEachAsync(
+            candidates,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = Math.Min(candidates.Count, Math.Max(1, maxParallelism)),
+                CancellationToken = cancellationToken
+            },
+            async (candidate, ct) =>
+            {
+                reconciled[candidate.GeneratedClaimId] = await ReconcileOneAsync(
+                    candidate,
+                    timeout,
+                    interval,
+                    ct);
+            });
+
+        var updated = results
+            .Select(result => reconciled.TryGetValue(result.GeneratedClaimId, out var replacement)
+                ? replacement
+                : result)
+            .OrderBy(result => result.GeneratedClaimId, StringComparer.Ordinal)
+            .ToList();
+        var lateCompletions = reconciled.Values.Count(result => result.ReconciledAfterObservationTimeout);
+
+        return new ServiceBusReconciliationResult(
+            updated,
+            candidates.Count,
+            lateCompletions,
+            candidates.Count - lateCompletions);
+    }
+
+    private async Task<ClaimValidationResult> ReconcileOneAsync(
+        ClaimValidationResult result,
+        TimeSpan timeout,
+        TimeSpan interval,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        try
+        {
+            while (true)
+            {
+                var observed = await _source.GetAsync(result.SubmittedClaimId!, cancellationToken);
+                if (observed?.IsTerminal is true)
+                {
+                    var businessDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
+                        ? observed.BusinessDenialCode
+                        : null;
+                    var expected = new ExpectedValidation(
+                        result.ValidationScenario,
+                        ParseExpectedOutcome(result.ExpectedOutcome),
+                        result.ExpectedBusinessDenialCode);
+
+                    return result with
+                    {
+                        Outcome = observed.Outcome,
+                        AdjudicationSuccess = observed.Outcome is ClaimValidationOutcome.Paid,
+                        ActualPlanPayment = observed.PlanPayment,
+                        BusinessDenialCode = businessDenialCode,
+                        ValidationStatus = MccWorkflowValidation.ValidationStatus(
+                            expected,
+                            observed.Outcome,
+                            businessDenialCode),
+                        FailureStage = null,
+                        Error = null,
+                        ReconciledAfterObservationTimeout = true
+                    };
+                }
+
+                var remaining = deadline - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return result with
+                    {
+                        Error =
+                            $"Claim remained nonterminal after the initial observation timeout and " +
+                            $"{timeout.TotalSeconds:N0}s post-window reconciliation"
+                    };
+                }
+
+                var delay = interval <= TimeSpan.Zero || interval < remaining ? interval : remaining;
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, cancellationToken);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return result with
+            {
+                Error = $"Post-window reconciliation failed: {ex.Message}"
+            };
+        }
+    }
+
+    private static bool IsCandidate(ClaimValidationResult result)
+        => result.ServiceBusObservationTimedOut
+            && !result.ReconciledAfterObservationTimeout
+            && result.Outcome is ClaimValidationOutcome.ObservationTimeout
+            && !string.IsNullOrWhiteSpace(result.SubmittedClaimId);
+
+    private static ClaimValidationOutcome? ParseExpectedOutcome(string? expectedOutcome)
+        => Enum.TryParse<ClaimValidationOutcome>(expectedOutcome, ignoreCase: true, out var parsed)
+            ? parsed
+            : null;
+}
+
+internal sealed record ServiceBusReconciliationResult(
+    List<ClaimValidationResult> Results,
+    int Candidates,
+    int Reconciled,
+    int Unreconciled);

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -51,6 +51,10 @@ Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} 
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
 Console.WriteLine($"  Auth fixtures:{(options.SeedAuthorizations ? " enabled" : " disabled")}");
 Console.WriteLine($"  Adjudication:{(options.ServiceBusOnly ? " Service Bus only (persisted outcome)" : " synchronous + workflow observation")}");
+Console.WriteLine(
+    $"  SB reconcile:{(options.ServiceBusOnly && options.ServiceBusReconciliationEnabled
+        ? $" enabled ({options.ServiceBusReconciliationTimeoutSeconds}s)"
+        : " disabled")}");
 Console.WriteLine($"  Pend observe:{(options.PendObservationEnabled ? $" enabled ({options.PendObservationTimeoutSeconds}s/{options.PendObservationIntervalMilliseconds}ms)" : " disabled")}");
 Console.WriteLine($"  Pend diag:   {(options.PendDiagnosticsPath is not null ? $"enabled -> {options.PendDiagnosticsPath}" : "disabled")}");
 Console.WriteLine();
@@ -201,7 +205,7 @@ var fixturePreparation = new MassAdjudicationFixturePreparation(
 var results = new ConcurrentBag<ClaimValidationResult>();
 var total = new Stopwatch();
 var completed = 0;
-var platformFailures = 0;
+var incompleteClaims = 0;
 var lastProgressPublishTicks = 0L;
 var progressLock = new object();
 var progressPublishGate = new SemaphoreSlim(1, 1);
@@ -243,9 +247,9 @@ await Parallel.ForEachAsync(
         results.Add(result);
 
         var done = Interlocked.Increment(ref completed);
-        if (result.Outcome is ClaimValidationOutcome.PlatformFailure)
+        if (result.Outcome is ClaimValidationOutcome.PlatformFailure or ClaimValidationOutcome.ObservationTimeout)
         {
-            Interlocked.Increment(ref platformFailures);
+            Interlocked.Increment(ref incompleteClaims);
         }
 
         if (done % options.ProgressEvery == 0 || done == claims.Count)
@@ -253,8 +257,8 @@ await Parallel.ForEachAsync(
             lock (progressLock)
             {
                 var currentDone = Volatile.Read(ref completed);
-                var failures = Math.Min(Volatile.Read(ref platformFailures), currentDone);
-                Console.Write($"\r  Processed: {currentDone:N0}/{claims.Count:N0}  processed={currentDone - failures:N0}  platformFailures={failures:N0}");
+                var incomplete = Math.Min(Volatile.Read(ref incompleteClaims), currentDone);
+                Console.Write($"\r  Processed: {currentDone:N0}/{claims.Count:N0}  terminal={currentDone - incomplete:N0}  incomplete={incomplete:N0}");
             }
 
             if (!options.NoPublishSummary
@@ -325,6 +329,28 @@ var orderedResults = results
 postProcessingStopwatch.Stop();
 postProcessingTimings.Add(("Result ordering", postProcessingStopwatch.Elapsed));
 
+if (options.ServiceBusOnly && options.ServiceBusReconciliationEnabled)
+{
+    await MeasureLifecyclePhaseAsync(lifecycleTimings, "Service Bus post-window reconciliation", "Observation", async () =>
+    {
+        var reconciler = new MccServiceBusReconciler(new HttpClaimStatusSource(http, options.ClaimsUrl));
+        var reconciliation = await reconciler.ReconcileAsync(
+            orderedResults,
+            TimeSpan.FromSeconds(options.ServiceBusReconciliationTimeoutSeconds),
+            TimeSpan.FromMilliseconds(options.PendObservationIntervalMilliseconds),
+            Math.Max(options.Parallelism, 64));
+        orderedResults = reconciliation.Results;
+
+        if (reconciliation.Candidates > 0)
+        {
+            Console.WriteLine(
+                $"  Service Bus reconciliation: {reconciliation.Reconciled:N0}/{reconciliation.Candidates:N0} late claims reconciled, " +
+                $"{reconciliation.Unreconciled:N0} still unresolved");
+            Console.WriteLine();
+        }
+    });
+}
+
 if (options.PendObservationEnabled && !options.ServiceBusOnly)
 {
     await MeasureLifecyclePhaseAsync(lifecycleTimings, "Expected-pend observation", "Observation", async () =>
@@ -387,7 +413,7 @@ if (!options.NoPublishSummary)
 
 WritePostProcessingTimings(postProcessingTimings, lifecycleTimings, runStartedAtUtc);
 
-if (orderedResults.Any(r => r.Outcome is ClaimValidationOutcome.PlatformFailure))
+if (orderedResults.Any(r => r.Outcome is ClaimValidationOutcome.PlatformFailure or ClaimValidationOutcome.ObservationTimeout))
 {
     Environment.ExitCode = 1;
 }
@@ -464,6 +490,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
     var updateElapsed = TimeSpan.Zero;
     var failureStage = "unknown";
     var expectedValidation = answerKey.ExpectedValidationFor(claim);
+    string? submittedClaimId = null;
     var expectedPlanPayment = expectedValidation.ExpectedOutcome is not ClaimValidationOutcome.Paid
         ? null
         : claim.ExpectedOutcome?.ExpectedPaidAmount;
@@ -479,6 +506,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
             claim,
             validationPlanBusinessId,
             json);
+        submittedClaimId = submitted.Id;
         stage.Stop();
         submitElapsed = stage.Elapsed;
 
@@ -486,7 +514,39 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         {
             failureStage = "servicebus-observation";
             stage.Restart();
-            var observed = await ObserveServiceBusOutcomeAsync(http, options, submitted.Id);
+            ObservedClaimStatus observed;
+            try
+            {
+                observed = await ObserveServiceBusOutcomeAsync(http, options, submitted.Id);
+            }
+            catch (TimeoutException ex)
+            {
+                stage.Stop();
+                adjudicationElapsed = stage.Elapsed;
+                sw.Stop();
+
+                return new ClaimValidationResult(
+                    claim.ClaimId,
+                    submitted.Id,
+                    claim.ClaimType,
+                    expectedValidation.Scenario,
+                    expectedValidation.ExpectedOutcome?.ToString(),
+                    expectedValidation.ExpectedBusinessDenialCode,
+                    MccWorkflowValidation.ObservationTimeoutStatus,
+                    ClaimValidationOutcome.ObservationTimeout,
+                    false,
+                    null,
+                    expectedPlanPayment,
+                    sw.Elapsed,
+                    submitElapsed,
+                    adjudicationElapsed,
+                    TimeSpan.Zero,
+                    new Dictionary<string, double>(),
+                    null,
+                    failureStage,
+                    ex.Message,
+                    ServiceBusObservationTimedOut: true);
+            }
             stage.Stop();
             adjudicationElapsed = stage.Elapsed;
             sw.Stop();
@@ -587,7 +647,7 @@ static async Task<ClaimValidationResult> ProcessClaimAsync(
         sw.Stop();
         return new ClaimValidationResult(
             claim.ClaimId,
-            null,
+            submittedClaimId,
             claim.ClaimType,
             expectedValidation.Scenario,
             expectedValidation.ExpectedOutcome?.ToString(),
@@ -3236,6 +3296,9 @@ static void WriteSummary(MassAdjudicationRunSummary summary)
     Console.WriteLine($"  Business denials:   {summary.BusinessDenials:N0}");
     Console.WriteLine($"  Platform failures:  {summary.PlatformFailures:N0}");
     Console.WriteLine($"  Observation timeout: {summary.ObservationTimeouts:N0}");
+    Console.WriteLine(
+        $"  SB post-window:     {summary.ServiceBusLateCompletions:N0}/{summary.ServiceBusObservationTimeouts:N0} reconciled late, " +
+        $"{summary.ServiceBusUnreconciledClaims:N0} unresolved");
     Console.WriteLine($"  Workflow checks:    {summary.WorkflowMatches:N0}/{summary.WorkflowScenarios:N0} matched ({summary.WorkflowMismatches:N0} mismatched, {summary.WorkflowUnsupported:N0} unsupported, {summary.WorkflowObservationTimeouts:N0} observation timeouts)");
     Console.WriteLine($"  Elapsed:            {summary.Elapsed:mm\\:ss\\.fff}");
     Console.WriteLine($"  Throughput:         {summary.ThroughputClaimsPerSecond:N2} claims/sec");
@@ -3371,12 +3434,17 @@ static MassAdjudicationRunSummary BuildProgressSummary(
     MassAdjudicationFixturePreparation fixturePreparation)
 {
     var runCompletedAtUtc = DateTimeOffset.UtcNow;
-    var processed = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+    var processed = results.Count(r =>
+        r.Outcome is not ClaimValidationOutcome.PlatformFailure
+            and not ClaimValidationOutcome.ObservationTimeout);
     var paid = results.Count(r => r.Outcome is ClaimValidationOutcome.Paid);
     var pended = results.Count(r => r.Outcome is ClaimValidationOutcome.Pended);
     var businessDenials = results.Count(r => r.Outcome is ClaimValidationOutcome.BusinessDenial);
     var observationTimeouts = results.Count(r => r.Outcome is ClaimValidationOutcome.ObservationTimeout);
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
+    var serviceBusObservationTimeouts = results.Count(r => r.ServiceBusObservationTimedOut);
+    var serviceBusLateCompletions = results.Count(r => r.ReconciledAfterObservationTimeout);
+    var serviceBusUnreconciledClaims = serviceBusObservationTimeouts - serviceBusLateCompletions;
     var workflowScenarios = results.Count(r => r.ValidationStatus is not "Unspecified");
     var workflowMatches = results.Count(r => r.ValidationStatus == MccWorkflowValidation.MatchedStatus);
     var workflowMismatches = results.Count(r =>
@@ -3412,6 +3480,9 @@ static MassAdjudicationRunSummary BuildProgressSummary(
         businessDenials,
         observationTimeouts,
         platformFailures,
+        serviceBusObservationTimeouts,
+        serviceBusLateCompletions,
+        serviceBusUnreconciledClaims,
         workflowScenarios,
         workflowMatches,
         workflowMismatches,
@@ -3455,7 +3526,9 @@ static MassAdjudicationRunProgress CreateProgress(
         .Order()
         .ToArray();
     var completedClaims = results.Count;
-    var processedClaims = results.Count(r => r.Outcome is not ClaimValidationOutcome.PlatformFailure);
+    var processedClaims = results.Count(r =>
+        r.Outcome is not ClaimValidationOutcome.PlatformFailure
+            and not ClaimValidationOutcome.ObservationTimeout);
     var platformFailures = results.Count(r => r.Outcome is ClaimValidationOutcome.PlatformFailure);
     var pendingExpectedPendObservations = results.Count(r => MccRunSummaryBuilder.IsExpectedPendObservationPending(r, phase));
     var pendingTerminalStatusObservations = results.Count(r => MccRunSummaryBuilder.IsTerminalStatusObservationPending(r, phase));
@@ -3582,6 +3655,10 @@ static void PrintUsage()
       --skip-claim-update        Do not write adjudication projection back to claims-service
       --servicebus-only          Submit claims and score only the persisted asynchronous Service Bus outcome;
                                  skips synchronous benefit adjudication and writeback
+      --no-servicebus-reconciliation
+                                 Do not revisit Service Bus observation timeouts after the timed pass
+      --servicebus-reconciliation-timeout <seconds>
+                                 Maximum post-window reconciliation wait (default: 300)
       --no-pend-observation      Do not poll claims-service for expected-pend claim status
       --pend-observation-timeout <seconds>
                                  Max wait for expected-pend claims after benchmark timing stops (default: 45)
@@ -3661,7 +3738,9 @@ internal sealed record ClaimValidationResult(
     string? BusinessDenialCode,
     string? FailureStage,
     string? Error,
-    JsonElement? SyncAdjudicationSnapshot = null);
+    JsonElement? SyncAdjudicationSnapshot = null,
+    bool ServiceBusObservationTimedOut = false,
+    bool ReconciledAfterObservationTimeout = false);
 
 internal sealed record MassAdjudicationRunSummary(
     string Id,
@@ -3674,6 +3753,9 @@ internal sealed record MassAdjudicationRunSummary(
     int BusinessDenials,
     int ObservationTimeouts,
     int PlatformFailures,
+    int ServiceBusObservationTimeouts,
+    int ServiceBusLateCompletions,
+    int ServiceBusUnreconciledClaims,
     int WorkflowScenarios,
     int WorkflowMatches,
     int WorkflowMismatches,
@@ -3833,7 +3915,9 @@ internal sealed record MassAdjudicationClaimResult(
     double SubmitMilliseconds,
     double AdjudicationMilliseconds,
     double WritebackMilliseconds,
-    IReadOnlyDictionary<string, double> AdjudicationStepMilliseconds);
+    IReadOnlyDictionary<string, double> AdjudicationStepMilliseconds,
+    bool ServiceBusObservationTimedOut,
+    bool ReconciledAfterObservationTimeout);
 
 internal sealed record AdjudicationResponseDto(
     string ClaimId,

--- a/src/tools/mcc-platform-validator/README.md
+++ b/src/tools/mcc-platform-validator/README.md
@@ -74,6 +74,40 @@ Expected-pend scenarios score as:
 - `Unsupported` only when a future expected-pend subtype requires a signal the
   validator still cannot distinguish from persisted claim state.
 
+## Service Bus Post-Window Reconciliation
+
+`--servicebus-only` polls each submitted claim for a persisted terminal outcome
+inside the configured observation window. If that window expires, the validator
+preserves the submitted claim ID and marks the result as an observation timeout
+instead of discarding the ID as a generic platform failure.
+
+After the timed benchmark stops, the validator revisits those claims in bounded
+parallel. A terminal result found during this pass is fully re-scored from
+persisted state, including:
+
+- workflow outcome and business-denial code;
+- payer payment and the payment-accuracy gate;
+- paid, pended, and business-denial summary counts.
+
+The run summary reports the initial Service Bus observation timeouts, late
+completions reconciled after the window, and claims still unresolved after
+reconciliation as separate values. Timed throughput, P95, and P99 remain based
+on the original observation window; reconciliation is recorded as a separate
+post-window lifecycle phase.
+
+Defaults:
+
+- Reconciliation is enabled whenever `--servicebus-only` is active.
+- `--servicebus-reconciliation-timeout 300`
+- The poll interval comes from `--pend-observation-interval-ms`.
+- Pass `--no-servicebus-reconciliation` only to reproduce the pre-reconciliation
+  behavior intentionally.
+
+For `scripts/run-mcc-local-k8s.sh` and `scripts/sweep-mcc-local-k8s.sh`, set
+`SERVICEBUS_ONLY=true` to select the asynchronous path. Reconciliation can be
+controlled with `SERVICEBUS_RECONCILIATION_ENABLED` and
+`SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS`.
+
 ## Pend Diagnostics (`--pend-diagnostics`)
 
 Off by default. When given a path, the validator captures, for every

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -15,6 +15,8 @@ public sealed record ValidatorOptions(
     bool SeedAuthorizations,
     bool SkipClaimUpdate,
     bool ServiceBusOnly,
+    bool ServiceBusReconciliationEnabled,
+    int ServiceBusReconciliationTimeoutSeconds,
     bool PendObservationEnabled,
     int PendObservationTimeoutSeconds,
     int PendObservationIntervalMilliseconds,
@@ -84,6 +86,12 @@ public sealed record ValidatorOptions(
                     break;
                 case "--servicebus-only":
                     options.ServiceBusOnly = true;
+                    break;
+                case "--no-servicebus-reconciliation":
+                    options.ServiceBusReconciliationEnabled = false;
+                    break;
+                case "--servicebus-reconciliation-timeout" when i + 1 < args.Length:
+                    options.ServiceBusReconciliationTimeoutSeconds = int.Parse(args[++i]);
                     break;
                 case "--no-pend-observation":
                     options.PendObservationEnabled = false;
@@ -166,6 +174,8 @@ public sealed record ValidatorOptions(
             options.SeedAuthorizations,
             options.SkipClaimUpdate,
             options.ServiceBusOnly,
+            options.ServiceBusReconciliationEnabled,
+            Math.Clamp(options.ServiceBusReconciliationTimeoutSeconds, 1, 900),
             options.PendObservationEnabled,
             Math.Clamp(options.PendObservationTimeoutSeconds, 1, 300),
             Math.Clamp(options.PendObservationIntervalMilliseconds, 100, 30_000),
@@ -199,6 +209,8 @@ public sealed record ValidatorOptions(
         public bool SeedAuthorizations { get; set; } = true;
         public bool SkipClaimUpdate { get; set; }
         public bool ServiceBusOnly { get; set; }
+        public bool ServiceBusReconciliationEnabled { get; set; } = true;
+        public int ServiceBusReconciliationTimeoutSeconds { get; set; } = 300;
         public bool PendObservationEnabled { get; set; } = true;
         public int PendObservationTimeoutSeconds { get; set; } = 45;
         public int PendObservationIntervalMilliseconds { get; set; } = 1000;

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -26,7 +26,9 @@ public class MassAdjudicationRunRepositoryTests
             ExpectedBusinessDenialCode = "PRIOR_AUTH_REQUIRED",
             ValidationStatus = "Matched",
             Outcome = "Paid",
-            AdjudicationSuccess = true
+            AdjudicationSuccess = true,
+            ServiceBusObservationTimedOut = true,
+            ReconciledAfterObservationTimeout = true
         });
 
         var saved = await repo.SaveAsync(summary);
@@ -39,6 +41,8 @@ public class MassAdjudicationRunRepositoryTests
         saved.ClaimResults[0].CreatedAtUtc.Should().Be(saved.CreatedAtUtc);
         saved.ClaimResults[0].ValidationScenario.Should().Be("TxStarInpatientNoAuth");
         saved.ClaimResults[0].ValidationStatus.Should().Be("Matched");
+        saved.ClaimResults[0].ServiceBusObservationTimedOut.Should().BeTrue();
+        saved.ClaimResults[0].ReconciledAfterObservationTimeout.Should().BeTrue();
     }
 
     [Fact]
@@ -48,6 +52,9 @@ public class MassAdjudicationRunRepositoryTests
         var summary = CreateSummary();
         summary.Pended = 46;
         summary.ObservationTimeouts = 1;
+        summary.ServiceBusObservationTimeouts = 122;
+        summary.ServiceBusLateCompletions = 121;
+        summary.ServiceBusUnreconciledClaims = 1;
         summary.WorkflowUnsupported = 73;
         summary.WorkflowObservationTimeouts = 2;
         summary.AveragePaymentDelta = 59.36m;
@@ -97,6 +104,9 @@ public class MassAdjudicationRunRepositoryTests
         reread.Should().NotBeNull();
         reread.Pended.Should().Be(46);
         reread.ObservationTimeouts.Should().Be(1);
+        reread.ServiceBusObservationTimeouts.Should().Be(122);
+        reread.ServiceBusLateCompletions.Should().Be(121);
+        reread.ServiceBusUnreconciledClaims.Should().Be(1);
         reread.WorkflowUnsupported.Should().Be(73);
         reread.WorkflowObservationTimeouts.Should().Be(2);
         reread.AveragePaymentDelta.Should().Be(59.36m);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccRunSummaryBuilderTests.cs
@@ -106,6 +106,45 @@ public class MccRunSummaryBuilderTests
     }
 
     [Fact]
+    public void Build_ReportsServiceBusPostWindowReconciliationSeparately()
+    {
+        var options = ValidatorOptions.Parse(["--claims", "3"]);
+        var results = new List<ClaimValidationResult>
+        {
+            Result("IN-WINDOW", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid),
+            Result("LATE", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.MatchedStatus, ClaimValidationOutcome.Paid)
+                with
+                {
+                    ServiceBusObservationTimedOut = true,
+                    ReconciledAfterObservationTimeout = true
+                },
+            Result("UNRESOLVED", MccWorkflowValidation.CleanProfessionalPaidScenario, MccWorkflowValidation.ObservationTimeoutStatus, ClaimValidationOutcome.ObservationTimeout)
+                with
+                {
+                    ServiceBusObservationTimedOut = true,
+                    FailureStage = "servicebus-observation"
+                }
+        };
+
+        var summary = MccRunSummaryBuilder.Build(
+            results,
+            TimeSpan.FromSeconds(1),
+            options,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        Assert.Equal(2, summary.Processed);
+        Assert.Equal(2, summary.ServiceBusObservationTimeouts);
+        Assert.Equal(1, summary.ServiceBusLateCompletions);
+        Assert.Equal(1, summary.ServiceBusUnreconciledClaims);
+        Assert.Equal(1, summary.ObservationTimeouts);
+        Assert.Contains(
+            summary.ClaimResults,
+            result => result.GeneratedClaimId == "LATE"
+                && result.ReconciledAfterObservationTimeout);
+    }
+
+    [Fact]
     public void Build_GroupsPaymentDeltaDistributionForComparableRowsOnly()
     {
         var options = ValidatorOptions.Parse(["--claims", "6"]);

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccServiceBusReconcilerTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccServiceBusReconcilerTests.cs
@@ -1,0 +1,167 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccServiceBusReconcilerTests
+{
+    [Fact]
+    public async Task ReconcileAsync_WhenLatePaidOutcomeExists_RescoresWorkflowAndPayment()
+    {
+        var reconciler = new MccServiceBusReconciler(new SequenceClaimStatusSource([
+            new ObservedClaimStatus(
+                ClaimValidationOutcome.Paid,
+                "Paid",
+                null,
+                IsTerminal: true,
+                PlanPayment: 123.45m)
+        ]));
+
+        var result = await reconciler.ReconcileAsync(
+            [TimedOutResult() with
+            {
+                ExpectedOutcome = ClaimValidationOutcome.Paid.ToString(),
+                ExpectedPlanPayment = 123.45m
+            }],
+            TimeSpan.FromSeconds(1),
+            TimeSpan.Zero,
+            maxParallelism: 1);
+
+        var claim = Assert.Single(result.Results);
+        Assert.Equal(1, result.Candidates);
+        Assert.Equal(1, result.Reconciled);
+        Assert.Equal(0, result.Unreconciled);
+        Assert.Equal(ClaimValidationOutcome.Paid, claim.Outcome);
+        Assert.Equal(123.45m, claim.ActualPlanPayment);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, claim.ValidationStatus);
+        Assert.True(claim.ServiceBusObservationTimedOut);
+        Assert.True(claim.ReconciledAfterObservationTimeout);
+        Assert.Null(claim.FailureStage);
+        Assert.Null(claim.Error);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_WhenLateBusinessDenialExists_PreservesDenialEvidence()
+    {
+        var reconciler = new MccServiceBusReconciler(new SequenceClaimStatusSource([
+            new ObservedClaimStatus(
+                ClaimValidationOutcome.BusinessDenial,
+                "Denied",
+                null,
+                IsTerminal: true,
+                BusinessDenialCode: MccWorkflowValidation.PriorAuthRequiredCode)
+        ]));
+
+        var result = await reconciler.ReconcileAsync(
+            [TimedOutResult() with
+            {
+                ExpectedOutcome = ClaimValidationOutcome.BusinessDenial.ToString(),
+                ExpectedBusinessDenialCode = MccWorkflowValidation.PriorAuthRequiredCode
+            }],
+            TimeSpan.FromSeconds(1),
+            TimeSpan.Zero,
+            maxParallelism: 1);
+
+        var claim = Assert.Single(result.Results);
+        Assert.Equal(ClaimValidationOutcome.BusinessDenial, claim.Outcome);
+        Assert.Equal(MccWorkflowValidation.PriorAuthRequiredCode, claim.BusinessDenialCode);
+        Assert.Equal(MccWorkflowValidation.MatchedStatus, claim.ValidationStatus);
+        Assert.True(claim.ReconciledAfterObservationTimeout);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_WhenClaimRemainsNonterminal_PreservesUnresolvedTimeout()
+    {
+        var reconciler = new MccServiceBusReconciler(new SequenceClaimStatusSource([
+            new ObservedClaimStatus(
+                ClaimValidationOutcome.PlatformFailure,
+                "InAdjudication",
+                null,
+                IsTerminal: false)
+        ]));
+
+        var result = await reconciler.ReconcileAsync(
+            [TimedOutResult()],
+            TimeSpan.Zero,
+            TimeSpan.Zero,
+            maxParallelism: 1);
+
+        var claim = Assert.Single(result.Results);
+        Assert.Equal(1, result.Candidates);
+        Assert.Equal(0, result.Reconciled);
+        Assert.Equal(1, result.Unreconciled);
+        Assert.Equal(ClaimValidationOutcome.ObservationTimeout, claim.Outcome);
+        Assert.False(claim.ReconciledAfterObservationTimeout);
+        Assert.Contains("remained nonterminal", claim.Error);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_IgnoresResultsThatDidNotTimeOutInServiceBusObservation()
+    {
+        var source = new SequenceClaimStatusSource([]);
+        var reconciler = new MccServiceBusReconciler(source);
+        var paid = TimedOutResult() with
+        {
+            Outcome = ClaimValidationOutcome.Paid,
+            ServiceBusObservationTimedOut = false
+        };
+
+        var result = await reconciler.ReconcileAsync(
+            [paid],
+            TimeSpan.Zero,
+            TimeSpan.Zero,
+            maxParallelism: 1);
+
+        Assert.Equal(0, result.Candidates);
+        Assert.Equal(paid, Assert.Single(result.Results));
+        Assert.Equal(0, source.ReadCount);
+    }
+
+    private static ClaimValidationResult TimedOutResult()
+        => new(
+            "MCC-LATE-0001",
+            "submitted-MCC-LATE-0001",
+            "Professional",
+            MccWorkflowValidation.CleanProfessionalPaidScenario,
+            ClaimValidationOutcome.Paid.ToString(),
+            null,
+            MccWorkflowValidation.ObservationTimeoutStatus,
+            ClaimValidationOutcome.ObservationTimeout,
+            false,
+            null,
+            123.45m,
+            TimeSpan.FromSeconds(180),
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromSeconds(180),
+            TimeSpan.Zero,
+            new Dictionary<string, double>(),
+            null,
+            "servicebus-observation",
+            "Timed out waiting for Service Bus adjudication",
+            ServiceBusObservationTimedOut: true);
+
+    private sealed class SequenceClaimStatusSource : IClaimStatusSource
+    {
+        private readonly Queue<ObservedClaimStatus?> _statuses;
+        private ObservedClaimStatus? _last;
+
+        public SequenceClaimStatusSource(IEnumerable<ObservedClaimStatus?> statuses)
+        {
+            _statuses = new Queue<ObservedClaimStatus?>(statuses);
+        }
+
+        public int ReadCount { get; private set; }
+
+        public Task<ObservedClaimStatus?> GetAsync(
+            string submittedClaimId,
+            CancellationToken cancellationToken)
+        {
+            ReadCount++;
+            if (_statuses.Count > 0)
+            {
+                _last = _statuses.Dequeue();
+            }
+
+            return Task.FromResult(_last);
+        }
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -58,6 +58,21 @@ public class ValidatorOptionsTests
     }
 
     [Fact]
+    public void Parse_WhenServiceBusReconciliationOptionsProvided_AppliesOverrides()
+    {
+        var defaults = ValidatorOptions.Parse([]);
+        var disabled = ValidatorOptions.Parse([
+            "--no-servicebus-reconciliation",
+            "--servicebus-reconciliation-timeout", "120"
+        ]);
+
+        Assert.True(defaults.ServiceBusReconciliationEnabled);
+        Assert.Equal(300, defaults.ServiceBusReconciliationTimeoutSeconds);
+        Assert.False(disabled.ServiceBusReconciliationEnabled);
+        Assert.Equal(120, disabled.ServiceBusReconciliationTimeoutSeconds);
+    }
+
+    [Fact]
     public void Parse_WhenMemberUrlProvided_AppliesOverride()
     {
         var options = ValidatorOptions.Parse(["--member-url", "http://member-service/"]);


### PR DESCRIPTION
## What changed

- Preserve submitted claim IDs when Service Bus observation times out.
- Add a bounded post-window reconciliation phase that polls timed-out claims and rebuilds their terminal outcome, payment, denial, and workflow score.
- Track initial observation timeouts, late completions, and claims still unresolved after reconciliation separately from the timed benchmark window.
- Persist and display the new metrics in claims-service and the portal.
- Add reconciliation controls to the local Kubernetes runner and sweep scripts.
- Add the Episode 17 starter packet and benchmark evidence.

## Why

An observation timeout describes what the validator saw during the benchmark window; it does not prove that adjudication failed. Previously, the generic exception path discarded the submitted claim ID and classified these claims as platform failures, making later verification impossible and conflating benchmark-window latency with final correctness.

## Impact

The timed throughput and latency window remains unchanged. After it closes, Service Bus runs can reconcile late terminal outcomes without retroactively changing the timed measurement. A run still fails when claims remain unresolved after the configured reconciliation timeout.

Reconciliation is enabled by default with a 300-second timeout and can be controlled with:

- `--no-servicebus-reconciliation`
- `--servicebus-reconciliation-timeout <seconds>`
- `SERVICEBUS_RECONCILIATION_ENABLED`
- `SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS`

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 119 passed
- `dotnet test tests/CloudHealthOffice.ClaimsService.Tests/CloudHealthOffice.ClaimsService.Tests.csproj --no-restore --filter FullyQualifiedName~MassAdjudicationRunRepositoryTests` — 8 passed
- `dotnet build src/portal/CloudHealthOffice.Portal/CloudHealthOffice.Portal.csproj --no-restore` — succeeded with 0 warnings/errors
- `bash -n scripts/run-mcc-local-k8s.sh scripts/sweep-mcc-local-k8s.sh`
- `git diff --check`

### Live local Kubernetes overload proof

With claims-service deliberately reduced from three pods to one, a 1,000-claim Service Bus run at p96 and a one-second observation window produced 936 initial timeouts. Post-window reconciliation recovered all 936 in 1.489 seconds, leaving 0 unresolved claims and restoring 1,000/1,000 terminal outcomes, 130/130 exact adjudication results, and 20/20 workflow points. The deployment was restored to three ready pods afterward.