### PR TITLE
Provision free-tier Cosmos DB for MongoDB

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,6 +6,11 @@
 MONGO_USER=admin
 MONGO_PASS=localdev123
 
+# Optional: point local Kubernetes services at Azure Cosmos DB for MongoDB.
+# Leave both blank to use the local MongoDB StatefulSet.
+LOCAL_COSMOS_MONGODB_ACCOUNT=
+LOCAL_COSMOS_MONGODB_RESOURCE_GROUP=
+
 # Azure AD (from your app registration)
 AZURE_AD_CLIENT_ID=
 AZURE_AD_CLIENT_SECRET=

--- a/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
+++ b/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
@@ -1,0 +1,94 @@
+# Cosmos DB for MongoDB free-tier benchmark
+
+CloudHealthOffice can use an Azure Cosmos DB for MongoDB account as the
+persistence layer for the Million Claim Challenge while the application
+services continue to run in local Kubernetes.
+
+The deployment is intentionally separate from
+`modules/cosmos-db.bicep`, which provisions the Cosmos DB for NoSQL API.
+The MongoDB module is opt-in, enables the lifetime free-tier discount when
+the account is created, and fixes shared database throughput at 1,000 RU/s.
+
+Azure permits one free-tier Cosmos DB account per subscription. The free
+allowance covers the first 1,000 RU/s and 25 GB of storage. Throughput or
+storage beyond those limits is billable.
+
+## Provision the account
+
+```bash
+RESOURCE_GROUP=cho-mcc \
+LOCATION=westus2 \
+BASE_NAME=cho-mcc \
+./scripts/azure/provision-cosmos-mongodb-free-tier.sh
+```
+
+The script creates the resource group when needed, checks for another
+free-tier account, deploys the Bicep module, and prints the generated account
+name. It never prints or saves account keys.
+
+To include the account in the full Azure deployment instead, set:
+
+```json
+"enableCosmosDb": {
+  "value": false
+},
+"enableCosmosMongoFreeTier": {
+  "value": true
+}
+```
+
+The MongoDB option defaults to `false`. The existing `enableCosmosDb` option
+controls a separate, non-free-tier NoSQL API account and defaults to `true`;
+disable it when the MongoDB free-tier account is the only Cosmos resource you
+want.
+
+## Connect local Kubernetes
+
+Use the account name printed by the provision command:
+
+```bash
+COSMOS_MONGODB_ACCOUNT=<account-name> \
+RESOURCE_GROUP=cho-mcc \
+./scripts/azure/bootstrap-local-cosmos-mongodb.sh
+```
+
+The bootstrap reads the primary MongoDB connection string directly from
+Azure and installs it as `cosmos-mongodb-secret` and `database-secret` in the
+`cloudhealthoffice` namespace. It then restarts the installed services used
+by the Million Claim Challenge so environment-variable secret references are
+reloaded.
+
+The local MongoDB StatefulSet is left intact. To switch the services back to
+local MongoDB, clear `LOCAL_COSMOS_MONGODB_ACCOUNT` and
+`LOCAL_COSMOS_MONGODB_RESOURCE_GROUP` from `.env.local`, then run:
+
+```bash
+./scripts/deploy-local.sh --skip-build
+```
+
+## Deploy local Kubernetes directly against Cosmos DB
+
+Set both values in `.env.local` before running `deploy-local.sh`:
+
+```bash
+LOCAL_COSMOS_MONGODB_ACCOUNT=<account-name>
+LOCAL_COSMOS_MONGODB_RESOURCE_GROUP=cho-mcc
+```
+
+The deployment retrieves the connection string without printing or storing it
+on disk. If the variables are omitted, local Kubernetes continues to use its
+MongoDB StatefulSet.
+
+## Benchmark interpretation
+
+The free tier is a useful throttling and retry-resilience exercise, but its
+1,000 RU/s ceiling is not a maximum-throughput comparison with local MongoDB.
+Report initial observation timeouts, reconciled completions, unresolved
+claims, Mongo error `16500`, and overall completion time alongside the normal
+Million Claim Challenge correctness score.
+
+As a planning baseline, the July 2026 local benchmark database held about
+60.5 GB of logical document data for 9.6 million retained claims plus their
+members, providers, and event history. That suggests a clean one-million-claim
+run should fit inside 25 GB, but accumulated runs should be deleted or deployed
+to a fresh database before the free storage allowance is approached.

--- a/infrastructure/azure/main.bicep
+++ b/infrastructure/azure/main.bicep
@@ -534,6 +534,24 @@ module cosmosDb 'modules/cosmos-db.bicep' = if (enableCosmosDb) {
   }
 }
 
+// =========================
+// Cosmos DB for MongoDB lifetime free tier
+// =========================
+// Separate from the NoSQL API account above. This is opt-in because Azure
+// permits only one free-tier Cosmos DB account per subscription.
+param enableCosmosMongoFreeTier bool = false
+param cosmosMongoDatabaseName string = 'cloudhealthoffice'
+
+module cosmosMongoFreeTier 'modules/cosmos-mongodb-free-tier.bicep' = if (enableCosmosMongoFreeTier) {
+  name: 'cosmos-mongodb-free-tier-module'
+  params: {
+    baseName: baseName
+    location: location
+    databaseName: cosmosMongoDatabaseName
+    throughput: 1000
+  }
+}
+
 // Cosmos DB managed API connection (legacy Logic App connector)
 resource connCosmosDb 'Microsoft.Web/connections@2016-06-01' = if (enableManagedApiConnections && enableCosmosDb) {
   name: 'documentdb'
@@ -603,6 +621,12 @@ output cosmosDbDatabaseName string = enableCosmosDb ? cosmosDb.outputs.cosmosDat
 output priorAuthContainerName string = enableCosmosDb ? cosmosDb.outputs.priorAuthContainerName : 'disabled'
 output providerDirectoryContainerName string = enableCosmosDb ? cosmosDb.outputs.providerDirectoryContainerName : 'disabled'
 output cosmosDbConnectionId string = enableManagedApiConnections && enableCosmosDb ? connCosmosDb.id : 'disabled'
+
+// Cosmos DB for MongoDB free-tier outputs (connection strings are deliberately
+// excluded; retrieve them directly into the target secret store).
+output cosmosMongoFreeTierAccountName string = enableCosmosMongoFreeTier ? cosmosMongoFreeTier!.outputs.cosmosMongoAccountName : 'disabled'
+output cosmosMongoFreeTierEndpoint string = enableCosmosMongoFreeTier ? cosmosMongoFreeTier!.outputs.cosmosMongoEndpoint : 'disabled'
+output cosmosMongoFreeTierDatabaseName string = enableCosmosMongoFreeTier ? cosmosMongoFreeTier!.outputs.cosmosMongoDatabaseName : 'disabled'
 
 // ClaimRiskScorer outputs
 output claimRiskScorerFunctionName string = enableClaimRiskScorer ? claimRiskScorerFunc.name : 'disabled'

--- a/infrastructure/azure/main.parameters.example.json
+++ b/infrastructure/azure/main.parameters.example.json
@@ -55,6 +55,12 @@
     "serviceBusName": {
       "value": "cho-prod-servicebus"
     },
+    "enableCosmosMongoFreeTier": {
+      "value": false
+    },
+    "cosmosMongoDatabaseName": {
+      "value": "cloudhealthoffice"
+    },
     "enableEcs": {
       "value": true
     },

--- a/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
+++ b/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
@@ -1,0 +1,82 @@
+// Azure Cosmos DB for MongoDB account intended for development and
+// Million Claim Challenge persistence experiments.
+//
+// Free tier must be selected when the account is created. Keeping shared
+// database throughput at 1,000 RU/s and storage below 25 GB keeps this module
+// within the lifetime free-tier allowance.
+
+@description('Base name used to derive a globally unique Cosmos DB account name')
+param baseName string
+
+@description('Azure region for the Cosmos DB account')
+param location string = resourceGroup().location
+
+@description('Cosmos DB for MongoDB account name')
+@minLength(3)
+@maxLength(44)
+param accountName string = take(toLower('${baseName}-mongo-${uniqueString(subscription().id, resourceGroup().id)}'), 44)
+
+@description('MongoDB database name')
+param databaseName string = 'cloudhealthoffice'
+
+@description('Shared database throughput. Free-tier deployments are intentionally fixed at 1,000 RU/s.')
+@allowed([
+  1000
+])
+param throughput int = 1000
+
+resource cosmosMongoAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
+  name: accountName
+  location: location
+  kind: 'MongoDB'
+  tags: {
+    ManagedBy: 'Bicep'
+    Purpose: 'MccCosmosMongo'
+    Tier: 'Free'
+  }
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    capabilities: [
+      {
+        name: 'EnableMongo'
+      }
+    ]
+    apiProperties: {
+      serverVersion: '4.2'
+    }
+    enableFreeTier: true
+    enableAutomaticFailover: false
+    enableMultipleWriteLocations: false
+    publicNetworkAccess: 'Enabled'
+    disableLocalAuth: false
+  }
+}
+
+resource mongoDatabase 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2024-11-15' = {
+  parent: cosmosMongoAccount
+  name: databaseName
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: {
+      throughput: throughput
+    }
+  }
+}
+
+output cosmosMongoAccountName string = cosmosMongoAccount.name
+output cosmosMongoEndpoint string = cosmosMongoAccount.properties.documentEndpoint
+output cosmosMongoDatabaseName string = mongoDatabase.name
+output freeTierEnabled bool = cosmosMongoAccount.properties.enableFreeTier
+output sharedThroughput int = throughput

--- a/scripts/azure/bootstrap-local-cosmos-mongodb.sh
+++ b/scripts/azure/bootstrap-local-cosmos-mongodb.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Point the Million Claim Challenge services in a local Kubernetes cluster at
+# an Azure Cosmos DB for MongoDB account. The connection string is retrieved
+# directly from Azure, installed as Kubernetes secrets, and never printed.
+#
+# Required env vars:
+#   COSMOS_MONGODB_ACCOUNT — Cosmos DB for MongoDB account name
+#   RESOURCE_GROUP         — resource group containing the account
+#
+# Optional env vars:
+#   K8S_NAMESPACE      — Kubernetes namespace (default: cloudhealthoffice)
+#   RESTART_WORKLOADS  — restart MCC deployments after secret update (default: true)
+set -euo pipefail
+
+: "${COSMOS_MONGODB_ACCOUNT:?COSMOS_MONGODB_ACCOUNT is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+
+K8S_NAMESPACE="${K8S_NAMESPACE:-cloudhealthoffice}"
+RESTART_WORKLOADS="${RESTART_WORKLOADS:-true}"
+
+command -v az >/dev/null 2>&1 || {
+  echo "Azure CLI (az) is required" >&2
+  exit 1
+}
+command -v kubectl >/dev/null 2>&1 || {
+  echo "kubectl is required" >&2
+  exit 1
+}
+
+account_kind="$(
+  az cosmosdb show \
+    --name "$COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query kind \
+    --output tsv
+)"
+
+if [[ "$account_kind" != "MongoDB" ]]; then
+  echo "Cosmos DB account ${COSMOS_MONGODB_ACCOUNT} is '${account_kind}', not 'MongoDB'" >&2
+  exit 1
+fi
+
+connection_string="$(
+  az cosmosdb keys list \
+    --name "$COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$RESOURCE_GROUP" \
+    --type connection-strings \
+    --query 'connectionStrings[0].connectionString' \
+    --output tsv
+)"
+
+if [[ -z "$connection_string" ]]; then
+  echo "Azure CLI returned an empty Cosmos DB for MongoDB connection string" >&2
+  exit 1
+fi
+
+kubectl create namespace "$K8S_NAMESPACE" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+kubectl create secret generic cosmos-mongodb-secret \
+  --namespace "$K8S_NAMESPACE" \
+  --from-literal=connectionString="$connection_string" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# The core services consume database-secret. Keep endpoint/key keys for
+# manifests that declare them even though the Mongo path uses connectionString.
+kubectl create secret generic database-secret \
+  --namespace "$K8S_NAMESPACE" \
+  --from-literal=connectionString="$connection_string" \
+  --from-literal=endpoint= \
+  --from-literal=key= \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+unset connection_string
+
+if [[ "$RESTART_WORKLOADS" == "true" ]]; then
+  mcc_deployments=(
+    authorization-service
+    benefit-plan-service
+    claims-examiner-service
+    claims-service
+    coverage-service
+    eligibility-service
+    member-service
+    provider-service
+  )
+
+  for deployment in "${mcc_deployments[@]}"; do
+    if kubectl get deployment "$deployment" --namespace "$K8S_NAMESPACE" >/dev/null 2>&1; then
+      kubectl rollout restart deployment "$deployment" \
+        --namespace "$K8S_NAMESPACE" >/dev/null
+    fi
+  done
+fi
+
+echo "==> Installed Cosmos DB for MongoDB connection in namespace ${K8S_NAMESPACE}"
+if [[ "$RESTART_WORKLOADS" == "true" ]]; then
+  echo "==> Restarted installed Million Claim Challenge services"
+fi

--- a/scripts/azure/provision-cosmos-mongodb-free-tier.sh
+++ b/scripts/azure/provision-cosmos-mongodb-free-tier.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Provision the opt-in Azure Cosmos DB for MongoDB lifetime free-tier account.
+# No keys or connection strings are printed or written to disk.
+#
+# Required env vars:
+#   RESOURCE_GROUP — Azure resource group
+#   LOCATION       — Azure region
+#
+# Optional env vars:
+#   BASE_NAME      — resource name prefix (default: cho-mcc)
+set -euo pipefail
+
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+: "${LOCATION:?LOCATION is required}"
+
+BASE_NAME="${BASE_NAME:-cho-mcc}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEMPLATE_FILE="${REPO_ROOT}/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep"
+DEPLOYMENT_NAME="cosmos-mongodb-free-tier"
+
+command -v az >/dev/null 2>&1 || {
+  echo "Azure CLI (az) is required" >&2
+  exit 1
+}
+
+az account show >/dev/null
+
+if ! az group show --name "$RESOURCE_GROUP" >/dev/null 2>&1; then
+  echo "==> Creating resource group ${RESOURCE_GROUP} in ${LOCATION}"
+  az group create \
+    --name "$RESOURCE_GROUP" \
+    --location "$LOCATION" \
+    --output none
+fi
+
+existing_free_tier="$(
+  az cosmosdb list \
+    --query "[?enableFreeTier == \`true\`].{name:name,resourceGroup:resourceGroup,purpose:tags.Purpose}" \
+    --output tsv
+)"
+
+if [[ -n "$existing_free_tier" ]]; then
+  managed_free_tier="$(
+    az cosmosdb list \
+      --query "[?enableFreeTier == \`true\` && tags.Purpose == 'MccCosmosMongo' && resourceGroup == '${RESOURCE_GROUP}'].name | [0]" \
+      --output tsv
+  )"
+
+  if [[ -z "$managed_free_tier" ]]; then
+    echo "==> Subscription already contains a different Cosmos DB free-tier account:"
+    echo "$existing_free_tier"
+    echo "Azure permits one free-tier Cosmos DB account per subscription." >&2
+    echo "Delete that account or reuse it before running this deployment." >&2
+    exit 1
+  fi
+
+  echo "==> Reusing managed free-tier account ${managed_free_tier}"
+fi
+
+echo "==> Provisioning Cosmos DB for MongoDB free tier"
+account_name="$(
+  az deployment group create \
+    --name "$DEPLOYMENT_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --template-file "$TEMPLATE_FILE" \
+    --parameters baseName="$BASE_NAME" location="$LOCATION" \
+    --query properties.outputs.cosmosMongoAccountName.value \
+    --output tsv
+)"
+
+if [[ -z "$account_name" ]]; then
+  echo "Deployment completed without returning a Cosmos DB account name" >&2
+  exit 1
+fi
+
+echo "==> Cosmos DB for MongoDB free-tier account ready: ${account_name}"
+echo "==> Database: cloudhealthoffice; shared throughput: 1000 RU/s"
+echo
+echo "Connect local Kubernetes with:"
+echo "  COSMOS_MONGODB_ACCOUNT=${account_name} \\"
+echo "  RESOURCE_GROUP=${RESOURCE_GROUP} \\"
+echo "  ./scripts/azure/bootstrap-local-cosmos-mongodb.sh"

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -42,6 +42,8 @@ REDIS_CONNECTION_STRING=""  # auto-set below if empty
 LOCAL_SERVICEBUS_NAMESPACE=""
 LOCAL_SERVICEBUS_RESOURCE_GROUP=""
 LOCAL_SERVICEBUS_LOCATION=""
+LOCAL_COSMOS_MONGODB_ACCOUNT=""
+LOCAL_COSMOS_MONGODB_RESOURCE_GROUP=""
 
 # Source local overrides (real credentials for auth/payments)
 if [[ -f .env.local ]]; then
@@ -211,6 +213,32 @@ fi
 # ── Create secrets ────────────────────────────────────────────────────────────
 log "Creating secrets"
 MONGO_CONN="mongodb://${MONGO_USER}:${MONGO_PASS}@mongodb.${NAMESPACE}.svc.cluster.local:27017/?authSource=admin"
+
+if [[ -n "$LOCAL_COSMOS_MONGODB_ACCOUNT" || -n "$LOCAL_COSMOS_MONGODB_RESOURCE_GROUP" ]]; then
+  [[ -n "$LOCAL_COSMOS_MONGODB_ACCOUNT" ]] \
+    || err "LOCAL_COSMOS_MONGODB_ACCOUNT is required when LOCAL_COSMOS_MONGODB_RESOURCE_GROUP is set"
+  [[ -n "$LOCAL_COSMOS_MONGODB_RESOURCE_GROUP" ]] \
+    || err "LOCAL_COSMOS_MONGODB_RESOURCE_GROUP is required when LOCAL_COSMOS_MONGODB_ACCOUNT is set"
+  command -v az >/dev/null 2>&1 || err "Azure CLI is required for Cosmos DB for MongoDB"
+
+  account_kind="$(az cosmosdb show \
+    --name "$LOCAL_COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$LOCAL_COSMOS_MONGODB_RESOURCE_GROUP" \
+    --query kind --output tsv)"
+  [[ "$account_kind" == "MongoDB" ]] \
+    || err "Cosmos account '$LOCAL_COSMOS_MONGODB_ACCOUNT' is '$account_kind', not 'MongoDB'"
+
+  MONGO_CONN="$(az cosmosdb keys list \
+    --name "$LOCAL_COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$LOCAL_COSMOS_MONGODB_RESOURCE_GROUP" \
+    --type connection-strings \
+    --query 'connectionStrings[0].connectionString' \
+    --output tsv)"
+  [[ -n "$MONGO_CONN" ]] || err "Azure CLI returned an empty Cosmos DB for MongoDB connection string"
+  ok "MongoDB persistence: Azure Cosmos DB for MongoDB"
+else
+  ok "MongoDB persistence: local StatefulSet"
+fi
 
 # MongoDB auth
 kubectl create secret generic mongodb-auth \


### PR DESCRIPTION
## What changed

- Add a dedicated Bicep module for Azure Cosmos DB for MongoDB 4.2 with the lifetime free-tier discount enabled.
- Fix shared database throughput at 1,000 RU/s so the infrastructure definition remains within the free throughput allowance.
- Keep the MongoDB account separate from the existing Cosmos DB for NoSQL module and disabled by default in the full deployment.
- Add an idempotent provisioning script that checks the subscription's single free-tier slot and never prints or persists account keys.
- Add a local Kubernetes bootstrap that installs the connection string directly from Azure into Kubernetes secrets and optionally restarts the Million Claim Challenge services.
- Let `deploy-local.sh` opt into Cosmos DB for MongoDB through `.env.local`; without those settings it continues using the local MongoDB StatefulSet.
- Document provisioning, switching, rollback, sizing, and benchmark interpretation.

## Why

The next Million Claim Challenge exercise needs to run local Kubernetes adjudication against Azure-hosted Mongo-compatible persistence. The repository's existing Cosmos module provisions the NoSQL API and cannot represent a MongoDB-native driver deployment. A dedicated opt-in module makes the experiment reproducible without adding cost to normal deployments.

The free tier is intended as a backpressure, retry, Service Bus buffering, and post-window reconciliation exercise. Its 1,000 RU/s limit is not presented as a peak-throughput comparison with local MongoDB.

## Live deployment proof

Provisioned in the trial subscription:

- Account: `cho-mcc-mongo-vwckcgcxziggo`
- Resource group: `cho`
- Region: Central US
- API: MongoDB 4.2
- Free tier: enabled
- Database: `cloudhealthoffice`
- Shared throughput: 1,000 RU/s
- Provisioning state: succeeded
- MongoDB driver TLS/authentication ping: succeeded

The running Kubernetes services remain on local MongoDB until the bootstrap is explicitly invoked.

## Validation

- `az deployment group validate` succeeded against resource group `cho`
- New Bicep module compiled successfully
- Full `infrastructure/azure/main.bicep` compiled successfully; only pre-existing repository warnings remain
- `bash -n` passed for both new scripts and `deploy-local.sh`
- `shellcheck` passed for both new scripts
- Provisioning script's managed-account idempotency guard recognized the deployed account
- `git diff --check` passed