### PR TITLE
Fix Cosmos MongoDB application compatibility

### DIFF
--- a/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
+++ b/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
@@ -7,7 +7,8 @@ services continue to run in local Kubernetes.
 The deployment is intentionally separate from
 `modules/cosmos-db.bicep`, which provisions the Cosmos DB for NoSQL API.
 The MongoDB module is opt-in, enables the lifetime free-tier discount when
-the account is created, and fixes shared database throughput at 1,000 RU/s.
+the account is created, uses the MongoDB 5.0 API required by the repository's
+MongoDB.Driver version, and fixes shared database throughput at 1,000 RU/s.
 
 Azure permits one free-tier Cosmos DB account per subscription. The free
 allowance covers the first 1,000 RU/s and 25 GB of storage. Throughput or

--- a/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
+++ b/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
@@ -52,7 +52,9 @@ resource cosmosMongoAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' =
       }
     ]
     apiProperties: {
-      serverVersion: '4.2'
+      // MongoDB.Driver 3.x requires wire version 9 or newer. Cosmos DB for
+      // MongoDB 4.2 reports wire version 8, so use 5.0 for compatibility.
+      serverVersion: '5.0'
     }
     enableFreeTier: true
     enableAutomaticFailover: false

--- a/src/engines/CloudHealthOffice.NcciEngine/CloudHealthOffice.NcciEngine.csproj
+++ b/src/engines/CloudHealthOffice.NcciEngine/CloudHealthOffice.NcciEngine.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="MongoDB.Driver" Version="3.10.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
   </ItemGroup>

--- a/src/engines/CloudHealthOffice.NcciEngine/Configuration/NcciEngineRegistration.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Configuration/NcciEngineRegistration.cs
@@ -4,6 +4,7 @@ using CloudHealthOffice.NcciEngine.Persistence;
 using CloudHealthOffice.NcciEngine.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace CloudHealthOffice.NcciEngine.Configuration;
@@ -111,6 +112,11 @@ public class NcciEngineBuilder
     public NcciEngineBuilder UseMongoRepository()
     {
         _services.AddScoped<INcciRepository, NcciRepositoryMongo>();
+        _services.AddSingleton<IHostedService>(sp =>
+            new NcciMongoIndexInitializer(
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetRequiredService<ILogger<NcciMongoIndexInitializer>>()));
         return this;
     }
 

--- a/src/engines/CloudHealthOffice.NcciEngine/Persistence/NcciMongoIndexInitializer.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Persistence/NcciMongoIndexInitializer.cs
@@ -1,0 +1,71 @@
+using CloudHealthOffice.NcciEngine.Domain;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+
+namespace CloudHealthOffice.NcciEngine.Persistence;
+
+/// <summary>
+/// Ensures NCCI lookup indexes once during host startup instead of from every
+/// scoped repository construction on the claim-processing hot path.
+/// </summary>
+internal sealed class NcciMongoIndexInitializer : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<NcciMongoIndexInitializer> _logger;
+
+    public NcciMongoIndexInitializer(
+        IServiceScopeFactory scopeFactory,
+        IConfiguration configuration,
+        ILogger<NcciMongoIndexInitializer> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    internal static CreateIndexModel<NcciEditPair> BuildPairIndex() =>
+        new(
+            Builders<NcciEditPair>.IndexKeys
+                .Ascending(pair => pair.TenantId)
+                .Ascending(pair => pair.Column1Code)
+                .Ascending(pair => pair.Column2Code)
+                .Ascending(pair => pair.EffectiveDate),
+            new CreateIndexOptions { Name = "ix_ncci_pair_lookup" });
+
+    internal static CreateIndexModel<MueEntry> BuildMueIndex() =>
+        new(
+            Builders<MueEntry>.IndexKeys
+                .Ascending(entry => entry.TenantId)
+                .Ascending(entry => entry.ProcedureCode)
+                .Ascending(entry => entry.EffectiveDate),
+            new CreateIndexOptions { Name = "ix_ncci_mue_lookup" });
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var database = scope.ServiceProvider.GetService<IMongoDatabase>();
+        if (database is null)
+        {
+            _logger.LogDebug("Skipping NCCI Mongo index setup because IMongoDatabase is not registered.");
+            return;
+        }
+
+        var pairCollectionName = _configuration["NcciEngine:MongoPairCollection"] ?? "ncci_pairs";
+        var mueCollectionName = _configuration["NcciEngine:MongoMueCollection"] ?? "mue_entries";
+
+        await database.GetCollection<NcciEditPair>(pairCollectionName)
+            .Indexes.CreateOneAsync(BuildPairIndex(), cancellationToken: cancellationToken);
+        await database.GetCollection<MueEntry>(mueCollectionName)
+            .Indexes.CreateOneAsync(BuildMueIndex(), cancellationToken: cancellationToken);
+
+        _logger.LogInformation(
+            "NCCI Mongo lookup indexes ensured on database '{Database}'.",
+            database.DatabaseNamespace.DatabaseName);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/engines/CloudHealthOffice.NcciEngine/Persistence/NcciRepositoryMongo.cs
+++ b/src/engines/CloudHealthOffice.NcciEngine/Persistence/NcciRepositoryMongo.cs
@@ -37,25 +37,6 @@ internal class NcciRepositoryMongo : INcciRepository
             configuration["NcciEngine:MongoVersionCollection"] ?? "ncci_version");
 
         _logger = logger;
-        EnsureIndexes();
-    }
-
-    private void EnsureIndexes()
-    {
-        _pairs.Indexes.CreateOne(new CreateIndexModel<NcciEditPair>(
-            Builders<NcciEditPair>.IndexKeys
-                .Ascending(p => p.TenantId)
-                .Ascending(p => p.Column1Code)
-                .Ascending(p => p.Column2Code)
-                .Ascending(p => p.EffectiveDate),
-            new CreateIndexOptions { Background = true }));
-
-        _mues.Indexes.CreateOne(new CreateIndexModel<MueEntry>(
-            Builders<MueEntry>.IndexKeys
-                .Ascending(m => m.TenantId)
-                .Ascending(m => m.ProcedureCode)
-                .Ascending(m => m.EffectiveDate),
-            new CreateIndexOptions { Background = true }));
     }
 
     // ── NCCI Edit Pairs ────────────────────────────────────────────

--- a/src/services/benefit-plan-service/BenefitPlanService.Tests/HostedServices/BenefitPlanIndexInitializerTests.cs
+++ b/src/services/benefit-plan-service/BenefitPlanService.Tests/HostedServices/BenefitPlanIndexInitializerTests.cs
@@ -1,0 +1,44 @@
+using BenefitPlanService.HostedServices;
+using BenefitPlanService.Models;
+using BenefitPlanService.Repositories;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.Tests.HostedServices;
+
+public class BenefitPlanIndexInitializerTests
+{
+    [Fact]
+    public void BuildIndexes_covers_every_sorted_benefit_plan_query()
+    {
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<BenefitPlan>();
+        var rendered = BenefitPlanIndexInitializer.BuildIndexes()
+            .ToDictionary(
+                index => index.Options.Name!,
+                index => index.Keys.Render(
+                    new RenderArgs<BenefitPlan>(
+                        serializer,
+                        BsonSerializer.SerializerRegistry)));
+
+        rendered["ix_benefitplans_VersionNumber_desc"]["VersionNumber"].AsInt32
+            .Should().Be(-1);
+        rendered["ix_benefitplans_PlanName_asc"]["PlanName"].AsInt32
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public void ServiceCategoryMappingIndexes_cover_newest_first_reads()
+    {
+        var serializer = BsonSerializer.SerializerRegistry
+            .GetSerializer<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>();
+        var index = ServiceCategoryMappingIndexInitializer.BuildIndexes().Single();
+        var rendered = index.Keys.Render(
+            new RenderArgs<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>(
+                serializer,
+                BsonSerializer.SerializerRegistry));
+
+        index.Options.Name.Should().Be("ix_service_category_mappings_createdAt_desc");
+        rendered["createdAt"].AsInt32.Should().Be(-1);
+    }
+}

--- a/src/services/benefit-plan-service/HostedServices/BenefitPlanIndexInitializer.cs
+++ b/src/services/benefit-plan-service/HostedServices/BenefitPlanIndexInitializer.cs
@@ -1,0 +1,50 @@
+using BenefitPlanService.Models;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.HostedServices;
+
+/// <summary>
+/// Creates indexes required by sorted BenefitPlans queries. Azure Cosmos DB
+/// for MongoDB rejects an ORDER BY when the corresponding index path is
+/// absent, while local MongoDB can satisfy the same query with an in-memory
+/// sort.
+/// </summary>
+public sealed class BenefitPlanIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _database;
+    private readonly string _collectionName;
+    private readonly ILogger<BenefitPlanIndexInitializer> _logger;
+
+    public BenefitPlanIndexInitializer(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<BenefitPlanIndexInitializer> logger)
+    {
+        _database = database;
+        _collectionName = configuration["CosmosDb:ContainerName"] ?? "BenefitPlans";
+        _logger = logger;
+    }
+
+    internal static IReadOnlyList<CreateIndexModel<BenefitPlan>> BuildIndexes() =>
+        new[]
+        {
+            new CreateIndexModel<BenefitPlan>(
+                Builders<BenefitPlan>.IndexKeys.Descending(x => x.VersionNumber),
+                new CreateIndexOptions { Name = "ix_benefitplans_VersionNumber_desc" }),
+            new CreateIndexModel<BenefitPlan>(
+                Builders<BenefitPlan>.IndexKeys.Ascending(x => x.PlanName),
+                new CreateIndexOptions { Name = "ix_benefitplans_PlanName_asc" })
+        };
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection = _database.GetCollection<BenefitPlan>(_collectionName);
+        await collection.Indexes.CreateManyAsync(BuildIndexes(), cancellationToken);
+
+        _logger.LogInformation(
+            "BenefitPlan query indexes ensured on collection '{Collection}'.",
+            _collectionName);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/benefit-plan-service/HostedServices/ServiceCategoryMappingIndexInitializer.cs
+++ b/src/services/benefit-plan-service/HostedServices/ServiceCategoryMappingIndexInitializer.cs
@@ -1,0 +1,49 @@
+using BenefitPlanService.Repositories;
+using CloudHealthOffice.BenefitEngine.Persistence;
+using MongoDB.Driver;
+
+namespace BenefitPlanService.HostedServices;
+
+/// <summary>
+/// Creates the index required by newest-first service-category mapping reads
+/// when the Mongo endpoint is backed by Azure Cosmos DB.
+/// </summary>
+public sealed class ServiceCategoryMappingIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _database;
+    private readonly string _collectionName;
+    private readonly ILogger<ServiceCategoryMappingIndexInitializer> _logger;
+
+    public ServiceCategoryMappingIndexInitializer(
+        IMongoDatabase database,
+        IConfiguration configuration,
+        ILogger<ServiceCategoryMappingIndexInitializer> logger)
+    {
+        _database = database;
+        _collectionName = configuration["CosmosDb:ServiceCategoryMappingsContainerName"]
+            ?? ChoServiceCategoryMappingRepository.DefaultContainerName;
+        _logger = logger;
+    }
+
+    internal static IReadOnlyList<CreateIndexModel<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>>
+        BuildIndexes() =>
+        [
+            new(
+                Builders<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>.IndexKeys
+                    .Descending(x => x.CreatedAt),
+                new CreateIndexOptions { Name = "ix_service_category_mappings_createdAt_desc" })
+        ];
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var collection =
+            _database.GetCollection<ChoServiceCategoryMappingRepositoryMongo.MappingDocument>(_collectionName);
+        await collection.Indexes.CreateManyAsync(BuildIndexes(), cancellationToken);
+
+        _logger.LogInformation(
+            "Service-category mapping query indexes ensured on collection '{Collection}'.",
+            _collectionName);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/benefit-plan-service/Program.cs
+++ b/src/services/benefit-plan-service/Program.cs
@@ -48,6 +48,20 @@ if (useMongo)
     builder.Services.AddScoped<IPlanVersionEventPublisher, MongoPlanVersionEventPublisher>();
     builder.Services.AddScoped<IPlanYearTransitionPublisher, MongoPlanYearTransitionPublisher>();
     builder.Services.AddScoped<IPlanYearScheduleSource, MongoPlanYearScheduleSource>();
+    // Cosmos DB for MongoDB requires explicit indexes for ORDER BY paths.
+    // Local MongoDB can otherwise conceal the missing-index incompatibility.
+    builder.Services.AddSingleton<IHostedService>(sp =>
+        new BenefitPlanIndexInitializer(
+            sp.GetRequiredService<IMongoClient>()
+              .GetDatabase(builder.Configuration["MongoDb:DatabaseName"]),
+            sp.GetRequiredService<IConfiguration>(),
+            sp.GetRequiredService<ILogger<BenefitPlanIndexInitializer>>()));
+    builder.Services.AddSingleton<IHostedService>(sp =>
+        new ServiceCategoryMappingIndexInitializer(
+            sp.GetRequiredService<IMongoClient>()
+              .GetDatabase(builder.Configuration["MongoDb:DatabaseName"]),
+            sp.GetRequiredService<IConfiguration>(),
+            sp.GetRequiredService<ILogger<ServiceCategoryMappingIndexInitializer>>()));
     // Ensures (TenantId, PlanId, EventId) and (TenantId, PlanId, Version)
     // unique indexes exist on the events collection — the publisher's
     // retry-on-duplicate loop depends on them.

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -236,8 +236,11 @@ builder.Services.AddHttpClient(HttpBenefitPlanResolver.HttpClientName, client =>
     client.Timeout = TimeSpan.FromSeconds(benefitPlanServiceTimeoutSeconds);
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 }).SetHandlerLifetime(TimeSpan.FromMinutes(5));
-builder.Services.AddScoped<HttpBenefitPlanResolver>();
-builder.Services.AddScoped<IBenefitPlanResolver>(sp =>
+// Both resolver layers are stateless/thread-safe. Singleton lifetime lets the
+// caching decorator coalesce concurrent first reads for a newly published
+// plan across claim-processing scopes in this replica.
+builder.Services.AddSingleton<HttpBenefitPlanResolver>();
+builder.Services.AddSingleton<IBenefitPlanResolver>(sp =>
     new CachingBenefitPlanResolver(
         sp.GetRequiredService<HttpBenefitPlanResolver>(),
         sp.GetRequiredService<Microsoft.Extensions.Caching.Memory.IMemoryCache>()));

--- a/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
+++ b/src/services/claims-service/Repositories/MassAdjudicationRunRepository.cs
@@ -28,6 +28,8 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 {
     internal const string CollectionName = "MassAdjudicationRuns";
     internal const string ClaimResultsCollectionName = "MassAdjudicationClaimResults";
+    internal const int ClaimResultInsertBatchSize = 50;
+    private const int MaxRateLimitAttempts = 6;
     private readonly IMongoCollection<MassAdjudicationRunSummary> _collection;
     private readonly IMongoCollection<MassAdjudicationClaimResult> _claimResults;
 
@@ -73,7 +75,11 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
         if (claimResults.Count > 0)
         {
-            await _claimResults.InsertManyAsync(claimResults, cancellationToken: ct);
+            foreach (var batch in claimResults.Chunk(ClaimResultInsertBatchSize))
+            {
+                await InsertClaimResultBatchAsync(batch, ct);
+            }
+
             var newResultIds = claimResults.Select(x => x.Id).ToArray();
             var staleResultFilter = Builders<MassAdjudicationClaimResult>.Filter.And(
                 Builders<MassAdjudicationClaimResult>.Filter.Eq(x => x.TenantId, summary.Run.TenantId),
@@ -84,6 +90,41 @@ public sealed class MassAdjudicationRunRepositoryMongo : IMassAdjudicationRunRep
 
         return summary;
     }
+
+    private async Task InsertClaimResultBatchAsync(
+        IReadOnlyCollection<MassAdjudicationClaimResult> batch,
+        CancellationToken ct)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await _claimResults.InsertManyAsync(
+                    batch,
+                    new InsertManyOptions { IsOrdered = true },
+                    ct);
+                return;
+            }
+            catch (Exception ex) when (IsCosmosRateLimit(ex) && attempt < MaxRateLimitAttempts)
+            {
+                // Cosmos DB for MongoDB reports throttling as code 16500.
+                // Keep retries local to a small batch so a free-tier account
+                // can recover without replaying the entire run summary.
+                var delay = TimeSpan.FromMilliseconds(50 * (1 << (attempt - 1)));
+                await Task.Delay(delay, ct);
+            }
+        }
+    }
+
+    internal static bool IsCosmosRateLimit(Exception exception) =>
+        exception switch
+        {
+            MongoCommandException command => command.Code == 16500,
+            MongoWriteException write => write.WriteError?.Code == 16500,
+            MongoBulkWriteException<MassAdjudicationClaimResult> bulk =>
+                bulk.WriteErrors.Any(error => error.Code == 16500),
+            _ => false
+        };
 
     public async Task<IReadOnlyList<MassAdjudicationRunSummary>> ListAsync(
         string tenantId,

--- a/src/services/claims-service/Services/Resolution/CachingBenefitPlanResolver.cs
+++ b/src/services/claims-service/Services/Resolution/CachingBenefitPlanResolver.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using System.Collections.Concurrent;
 
 namespace ClaimsService.Services.Resolution;
 
@@ -30,6 +31,7 @@ public sealed class CachingBenefitPlanResolver : IBenefitPlanResolver
     private readonly IBenefitPlanResolver _inner;
     private readonly IMemoryCache _cache;
     private readonly TimeSpan _ttl;
+    private readonly ConcurrentDictionary<string, Lazy<Task<ResolvedBenefitPlan?>>> _inflight = new();
 
     public CachingBenefitPlanResolver(IBenefitPlanResolver inner, IMemoryCache cache)
         : this(inner, cache, DefaultTtl) { }
@@ -45,6 +47,42 @@ public sealed class CachingBenefitPlanResolver : IBenefitPlanResolver
         string tenantId, string planId, CancellationToken ct = default)
     {
         var key = BuildCacheKey(tenantId, planId);
+        if (_cache.TryGetValue<ResolvedBenefitPlan>(key, out var cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        // A newly published plan causes many claims to miss together. Without
+        // single-flight coalescing, every miss reaches benefit-plan-service
+        // and can exhaust a Cosmos free-tier RU budget before the first result
+        // populates the cache.
+        var candidate = new Lazy<Task<ResolvedBenefitPlan?>>(
+            () => ResolveAndCacheAsync(key, tenantId, planId, ct),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        var inflight = _inflight.GetOrAdd(key, candidate);
+
+        try
+        {
+            return await inflight.Value.WaitAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (_inflight.TryGetValue(key, out var current)
+                && ReferenceEquals(current, inflight))
+            {
+                _inflight.TryRemove(key, out _);
+            }
+        }
+    }
+
+    private async Task<ResolvedBenefitPlan?> ResolveAndCacheAsync(
+        string key,
+        string tenantId,
+        string planId,
+        CancellationToken ct)
+    {
+        // A previous flight may have filled the cache between the caller's
+        // initial check and this lazy operation beginning.
         if (_cache.TryGetValue<ResolvedBenefitPlan>(key, out var cached) && cached is not null)
         {
             return cached;

--- a/src/services/provider-service/HostedServices/ProviderQueryIndexInitializer.cs
+++ b/src/services/provider-service/HostedServices/ProviderQueryIndexInitializer.cs
@@ -1,0 +1,101 @@
+using MongoDB.Driver;
+using ProviderService.Models;
+
+namespace ProviderService.HostedServices;
+
+/// <summary>
+/// Ensures provider and organization query indexes once at startup. Keeping
+/// index administration out of scoped repository constructors prevents
+/// transient Cosmos connection failures from failing ordinary API writes.
+/// </summary>
+public sealed class ProviderQueryIndexInitializer : IHostedService
+{
+    private readonly IMongoDatabase _database;
+    private readonly ILogger<ProviderQueryIndexInitializer> _logger;
+
+    public ProviderQueryIndexInitializer(
+        IMongoDatabase database,
+        ILogger<ProviderQueryIndexInitializer> logger)
+    {
+        _database = database;
+        _logger = logger;
+    }
+
+    internal static IReadOnlyList<CreateIndexModel<Provider>> BuildProviderIndexes()
+    {
+        var keys = Builders<Provider>.IndexKeys;
+        return
+        [
+            new(keys.Ascending(p => p.TenantId).Ascending(p => p.NPI)),
+            new(keys.Ascending(p => p.TenantId).Ascending(p => p.LastName)),
+            new(keys.Ascending(p => p.TenantId).Ascending(p => p.OrganizationName)),
+            new(keys.Ascending(p => p.TenantId).Ascending(p => p.ZipCode)),
+            new(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.PlanId")),
+            new(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.NetworkId")),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending("NetworkParticipations.NetworkId")
+                .Ascending("NetworkParticipations.NetworkTier")),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.ProviderId)
+                .Ascending(p => p.VersionNumber)),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.ProviderId)
+                .Ascending(p => p.VersionId)),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.ProviderId)
+                .Ascending(p => p.VersionState)),
+            // Cosmos DB for MongoDB requires composite indexes matching
+            // multi-field sort shapes.
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.NPI)
+                .Descending(p => p.VersionNumber)),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.LastName)
+                .Ascending(p => p.OrganizationName)
+                .Ascending(p => p.Id)),
+            new(keys.Ascending(p => p.TenantId)
+                .Ascending(p => p.ProviderId)
+                .Ascending(p => p.Id)),
+            // Cosmos matches the ORDER BY document itself, not an
+            // equality-filter prefix as MongoDB does.
+            new(keys.Ascending(p => p.ProviderId).Ascending(p => p.Id)),
+            new(keys.Ascending(p => p.LastName)
+                .Ascending(p => p.OrganizationName)
+                .Ascending(p => p.Id)),
+            new(keys.Descending(p => p.VersionNumber))
+        ];
+    }
+
+    internal static IReadOnlyList<CreateIndexModel<Organization>> BuildOrganizationIndexes()
+    {
+        var keys = Builders<Organization>.IndexKeys;
+        return
+        [
+            new(keys.Ascending(o => o.TenantId)
+                .Ascending(o => o.OrganizationId)
+                .Ascending(o => o.VersionNumber)),
+            new(keys.Ascending(o => o.TenantId)
+                .Ascending(o => o.OrganizationId)
+                .Ascending(o => o.VersionId)),
+            new(keys.Ascending(o => o.TenantId).Ascending(o => o.NetworkType)),
+            new(keys.Ascending(o => o.TenantId).Ascending(o => o.LineOfBusiness)),
+            new(keys.Ascending(o => o.TenantId).Ascending(o => o.ParentOrganizationId)),
+            new(keys.Ascending(o => o.TenantId).Ascending(o => o.VersionState)),
+            new(keys.Ascending(o => o.TenantId).Ascending(o => o.Name)),
+            new(keys.Descending(o => o.VersionNumber)),
+            new(keys.Ascending(o => o.Name))
+        ];
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await _database.GetCollection<Provider>("Providers").Indexes
+            .CreateManyAsync(BuildProviderIndexes(), cancellationToken);
+        await _database.GetCollection<Organization>("Organizations").Indexes
+            .CreateManyAsync(BuildOrganizationIndexes(), cancellationToken);
+
+        _logger.LogInformation("Provider and organization query indexes ensured.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/services/provider-service/Program.cs
+++ b/src/services/provider-service/Program.cs
@@ -56,6 +56,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     builder.Services.AddScoped<INetworkParticipationEventPublisher, MongoNetworkParticipationEventPublisher>();
     builder.Services.AddScoped<ICredentialingEventPublisher, MongoCredentialingEventPublisher>();
     builder.Services.AddScoped<ICredentialingEventRepository, MongoCredentialingEventRepository>();
+    builder.Services.AddHostedService<ProviderQueryIndexInitializer>();
     builder.Services.AddHostedService<ProviderVersionEventIndexInitializer>();
     builder.Services.AddHostedService<ProviderVerificationEventIndexInitializer>();
     builder.Services.AddHostedService<NetworkParticipationEventIndexInitializer>();

--- a/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/OrganizationRepositoryMongo.cs
@@ -25,23 +25,6 @@ public class OrganizationRepositoryMongo : IOrganizationRepository
         _collection = database.GetCollection<Organization>("Organizations");
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
-
-        CreateIndexes();
-    }
-
-    private void CreateIndexes()
-    {
-        var keys = Builders<Organization>.IndexKeys;
-        var models = new List<CreateIndexModel<Organization>>
-        {
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.OrganizationId).Ascending(o => o.VersionNumber)),
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.OrganizationId).Ascending(o => o.VersionId)),
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.NetworkType)),
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.LineOfBusiness)),
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.ParentOrganizationId)),
-            new CreateIndexModel<Organization>(keys.Ascending(o => o.TenantId).Ascending(o => o.VersionState))
-        };
-        _collection.Indexes.CreateMany(models);
     }
 
     private string GetTenantId()

--- a/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
+++ b/src/services/provider-service/Repositories/ProviderRepositoryMongo.cs
@@ -22,33 +22,6 @@ public class ProviderRepositoryMongo : IProviderRepository
         _collection = database.GetCollection<Provider>("Providers");
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
-
-        CreateIndexes();
-    }
-
-    private void CreateIndexes()
-    {
-        var keys = Builders<Provider>.IndexKeys;
-        var models = new List<CreateIndexModel<Provider>>
-        {
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.NPI)),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.LastName)),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.OrganizationName)),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ZipCode)),
-            // Multikey index for network participations
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.PlanId")),
-            // Network roster (capability 5.4) — multikey on the new
-            // NetworkParticipation.NetworkId, scoped under TenantId for
-            // partition-aware lookups. Tier secondary key keeps the
-            // common (network + tier) filter index-only.
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.NetworkId")),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending("NetworkParticipations.NetworkId").Ascending("NetworkParticipations.NetworkTier")),
-            // Version-chain indexes
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ProviderId).Ascending(p => p.VersionNumber)),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ProviderId).Ascending(p => p.VersionId)),
-            new CreateIndexModel<Provider>(keys.Ascending(p => p.TenantId).Ascending(p => p.ProviderId).Ascending(p => p.VersionState))
-        };
-        _collection.Indexes.CreateMany(models);
     }
 
     private string GetTenantId()

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Repositories/MassAdjudicationRunRepositoryTests.cs
@@ -507,6 +507,55 @@ public class MassAdjudicationRunRepositoryTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task SaveAsync_inserts_large_claim_result_sets_in_cosmos_safe_batches()
+    {
+        var database = Substitute.For<IMongoDatabase>();
+        var runs = Substitute.For<IMongoCollection<MassAdjudicationRunSummary>>();
+        var claimResults = Substitute.For<IMongoCollection<MassAdjudicationClaimResult>>();
+
+        database.GetCollection<MassAdjudicationRunSummary>(
+                MassAdjudicationRunRepositoryMongo.CollectionName,
+                Arg.Any<MongoCollectionSettings?>())
+            .Returns(runs);
+        database.GetCollection<MassAdjudicationClaimResult>(
+                MassAdjudicationRunRepositoryMongo.ClaimResultsCollectionName,
+                Arg.Any<MongoCollectionSettings?>())
+            .Returns(claimResults);
+        runs.ReplaceOneAsync(
+                Arg.Any<FilterDefinition<MassAdjudicationRunSummary>>(),
+                Arg.Any<MassAdjudicationRunSummary>(),
+                Arg.Any<ReplaceOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Substitute.For<ReplaceOneResult>()));
+        claimResults.InsertManyAsync(
+                Arg.Any<IEnumerable<MassAdjudicationClaimResult>>(),
+                Arg.Any<InsertManyOptions?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        claimResults.DeleteManyAsync(
+                Arg.Any<FilterDefinition<MassAdjudicationClaimResult>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Substitute.For<DeleteResult>()));
+
+        var summary = CreateSummary();
+        summary.ClaimResults.AddRange(
+            Enumerable.Range(1, 125).Select(index => new MassAdjudicationClaimResult
+            {
+                GeneratedClaimId = $"GEN-{index:D3}",
+                ClaimType = "Professional",
+                Outcome = "Paid"
+            }));
+
+        await new MassAdjudicationRunRepositoryMongo(database).SaveAsync(summary);
+
+        var insertedBatches = claimResults.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(IMongoCollection<MassAdjudicationClaimResult>.InsertManyAsync))
+            .Select(call => ((IEnumerable<MassAdjudicationClaimResult>)call.GetArguments()[0]!).Count())
+            .ToArray();
+        insertedBatches.Should().Equal(50, 50, 25);
+    }
+
     private static MassAdjudicationRunSummary CreateSummary() => new()
     {
         Run = new MassAdjudicationRunMetadata

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingBenefitPlanResolverTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Services/Resolution/CachingBenefitPlanResolverTests.cs
@@ -68,4 +68,28 @@ public class CachingBenefitPlanResolverTests
 
         await _inner.Received(2).GetPlanAsync("tenant-1", "p1", Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task GetPlan_ConcurrentCacheMisses_AreCoalesced()
+    {
+        var sut = new CachingBenefitPlanResolver(_inner, _cache);
+        var release = new TaskCompletionSource<ResolvedBenefitPlan?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _inner.GetPlanAsync("tenant-1", "new-plan", Arg.Any<CancellationToken>())
+            .Returns(_ => release.Task);
+
+        var requests = Enumerable.Range(0, 20)
+            .Select(_ => sut.GetPlanAsync("tenant-1", "new-plan"))
+            .ToArray();
+
+        await _inner.Received(1)
+            .GetPlanAsync("tenant-1", "new-plan", Arg.Any<CancellationToken>());
+        release.SetResult(new ResolvedBenefitPlan { Id = "new-plan" });
+
+        var results = await Task.WhenAll(requests);
+
+        Assert.All(results, result => Assert.Equal("new-plan", result?.Id));
+        await _inner.Received(1)
+            .GetPlanAsync("tenant-1", "new-plan", Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/CloudHealthOffice.NcciEngine.Tests/NcciMongoIndexInitializerTests.cs
+++ b/tests/CloudHealthOffice.NcciEngine.Tests/NcciMongoIndexInitializerTests.cs
@@ -1,0 +1,31 @@
+using CloudHealthOffice.NcciEngine.Domain;
+using CloudHealthOffice.NcciEngine.Persistence;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using Xunit;
+
+namespace CloudHealthOffice.NcciEngine.Tests;
+
+public class NcciMongoIndexInitializerTests
+{
+    [Fact]
+    public void Lookup_indexes_match_sorted_query_shapes()
+    {
+        var registry = BsonSerializer.SerializerRegistry;
+        var pairSerializer = registry.GetSerializer<NcciEditPair>();
+        var mueSerializer = registry.GetSerializer<MueEntry>();
+
+        var pair = NcciMongoIndexInitializer.BuildPairIndex().Keys.Render(
+            new RenderArgs<NcciEditPair>(pairSerializer, registry));
+        var mue = NcciMongoIndexInitializer.BuildMueIndex().Keys.Render(
+            new RenderArgs<MueEntry>(mueSerializer, registry));
+
+        Assert.Equal(1, pair["TenantId"].AsInt32);
+        Assert.Equal(1, pair["Column1Code"].AsInt32);
+        Assert.Equal(1, pair["Column2Code"].AsInt32);
+        Assert.Equal(1, pair["EffectiveDate"].AsInt32);
+        Assert.Equal(1, mue["TenantId"].AsInt32);
+        Assert.Equal(1, mue["ProcedureCode"].AsInt32);
+        Assert.Equal(1, mue["EffectiveDate"].AsInt32);
+    }
+}

--- a/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/ProviderQueryIndexInitializerTests.cs
+++ b/tests/CloudHealthOffice.ProviderService.Tests/HostedServices/ProviderQueryIndexInitializerTests.cs
@@ -1,0 +1,34 @@
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using ProviderService.HostedServices;
+using ProviderService.Models;
+
+namespace CloudHealthOffice.ProviderService.Tests.HostedServices;
+
+public class ProviderQueryIndexInitializerTests
+{
+    [Fact]
+    public void Provider_indexes_cover_integrity_and_roster_sort_shapes()
+    {
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<Provider>();
+        var rendered = ProviderQueryIndexInitializer.BuildProviderIndexes()
+            .Select(index => index.Keys.Render(
+                new RenderArgs<Provider>(serializer, BsonSerializer.SerializerRegistry)))
+            .ToList();
+
+        rendered.Should().Contain(index =>
+            index.ElementCount == 2
+            && index.Contains("ProviderId")
+            && index.Contains("_id")
+            && index["ProviderId"] == 1
+            && index["_id"] == 1);
+        rendered.Should().Contain(index =>
+            index.ElementCount == 3
+            && index.Contains("LastName")
+            && index.Contains("OrganizationName")
+            && index.Contains("_id")
+            && index["LastName"] == 1
+            && index["OrganizationName"] == 1
+            && index["_id"] == 1);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the existing MongoDB.Driver repository paths work correctly against Azure Cosmos DB for MongoDB while the application services continue to run in local Kubernetes.

- provisions the free-tier Cosmos Mongo account with MongoDB API 5.0, which supplies the wire protocol required by the current driver
- adds startup-managed indexes for benefit plans, service-category mappings, provider/organization queries, and NCCI lookups
- removes index creation from scoped provider, organization, and NCCI repository constructors so ordinary requests do not perform database administration
- coalesces concurrent benefit-plan cache misses per replica to prevent a newly published plan from causing a Cosmos read stampede
- writes mass-adjudication claim evidence in 50-document batches with bounded retries for Cosmos error 16500 throttling

## Root cause

Local MongoDB concealed several portability gaps: it could execute unindexed sorts in memory, and repository constructors could repeatedly issue idempotent index commands without exhausting the local database. Cosmos DB for MongoDB rejects uncovered `ORDER BY` paths, requires matching composite indexes for multi-field sorts, and throttled the original 1,000-document dashboard insert on the free-tier RU budget. Concurrent first reads of a new benefit plan also produced avoidable load before the shared cache was populated.

## Impact

The hybrid MCC path can now submit claims from an 837 through Azure Service Bus, adjudicate them in local Kubernetes, persist application data through the MongoDB driver to Azure Cosmos DB, and publish the run dashboard without the previous unknown denials or persistence failure. Provider integrity projections and NCCI setup are also removed from claim/write hot paths.

## Validation

- clean-tenant 25-claim 837 run: 25/25 processed, 0 platform failures, 0 unresolved Service Bus messages, 5/5 workflow checks matched, dashboard published
- 100-claim run verified the batched dashboard path publishes successfully
- BenefitPlanService.Tests: 341 passed
- CloudHealthOffice.ClaimsService.Tests: 610 passed
- CloudHealthOffice.ProviderService.Tests: 389 passed
- CloudHealthOffice.NcciEngine.Tests: 30 passed
- Bicep compilation passed
- final claims, benefit-plan, and provider Docker images built and rolled out successfully against the Azure Cosmos Mongo endpoint