### PR TITLE
Harden Cosmos MongoDB benchmark runs

### DIFF
--- a/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
+++ b/infrastructure/azure/COSMOS-MONGODB-FREE-TIER.md
@@ -43,6 +43,10 @@ controls a separate, non-free-tier NoSQL API account and defaults to `true`;
 disable it when the MongoDB free-tier account is the only Cosmos resource you
 want.
 
+The module defaults to 1,000 RU/s, but `throughput` can be raised for a
+billable benchmark deployment. The lifetime-free discount still applies to
+the first 1,000 RU/s.
+
 ## Connect local Kubernetes
 
 Use the account name printed by the provision command:
@@ -87,6 +91,22 @@ The free tier is a useful throttling and retry-resilience exercise, but its
 Report initial observation timeouts, reconciled completions, unresolved
 claims, Mongo error `16500`, and overall completion time alongside the normal
 Million Claim Challenge correctness score.
+
+For a temporary benchmark, use the guarded wrapper. It records the current
+manual throughput, scales up, runs the supplied command, and restores the
+original value on success, failure, interruption, or terminal disconnect:
+
+```bash
+COSMOS_MONGODB_ACCOUNT=<account-name> \
+RESOURCE_GROUP=cho-mcc \
+TARGET_THROUGHPUT=10000 \
+./scripts/azure/with-cosmos-mongodb-benchmark-throughput.sh -- \
+env CLAIMS=1000 MAX_CLAIMS=1000 PARALLELISM=12 \
+  ./scripts/run-mcc-local-k8s.sh
+```
+
+The wrapper rejects values above 20,000 RU/s unless `MAX_THROUGHPUT` is
+explicitly increased.
 
 As a planning baseline, the July 2026 local benchmark database held about
 60.5 GB of logical document data for 9.6 million retained claims plus their

--- a/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
+++ b/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep
@@ -19,10 +19,9 @@ param accountName string = take(toLower('${baseName}-mongo-${uniqueString(subscr
 @description('MongoDB database name')
 param databaseName string = 'cloudhealthoffice'
 
-@description('Shared database throughput. Free-tier deployments are intentionally fixed at 1,000 RU/s.')
-@allowed([
-  1000
-])
+@description('Shared database throughput. The first 1,000 RU/s receives the free-tier discount; higher benchmark values are billable.')
+@minValue(1000)
+@maxValue(100000)
 param throughput int = 1000
 
 resource cosmosMongoAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {

--- a/scripts/azure/provision-cosmos-mongodb-free-tier.sh
+++ b/scripts/azure/provision-cosmos-mongodb-free-tier.sh
@@ -8,12 +8,15 @@
 #
 # Optional env vars:
 #   BASE_NAME      — resource name prefix (default: cho-mcc)
+#   THROUGHPUT     — shared database RU/s (default: 1000; values above
+#                    1000 are billable)
 set -euo pipefail
 
 : "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
 : "${LOCATION:?LOCATION is required}"
 
 BASE_NAME="${BASE_NAME:-cho-mcc}"
+THROUGHPUT="${THROUGHPUT:-1000}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TEMPLATE_FILE="${REPO_ROOT}/infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep"
@@ -64,7 +67,7 @@ account_name="$(
     --name "$DEPLOYMENT_NAME" \
     --resource-group "$RESOURCE_GROUP" \
     --template-file "$TEMPLATE_FILE" \
-    --parameters baseName="$BASE_NAME" location="$LOCATION" \
+    --parameters baseName="$BASE_NAME" location="$LOCATION" throughput="$THROUGHPUT" \
     --query properties.outputs.cosmosMongoAccountName.value \
     --output tsv
 )"
@@ -75,7 +78,7 @@ if [[ -z "$account_name" ]]; then
 fi
 
 echo "==> Cosmos DB for MongoDB free-tier account ready: ${account_name}"
-echo "==> Database: cloudhealthoffice; shared throughput: 1000 RU/s"
+echo "==> Database: cloudhealthoffice; shared throughput: ${THROUGHPUT} RU/s"
 echo
 echo "Connect local Kubernetes with:"
 echo "  COSMOS_MONGODB_ACCOUNT=${account_name} \\"

--- a/scripts/azure/with-cosmos-mongodb-benchmark-throughput.sh
+++ b/scripts/azure/with-cosmos-mongodb-benchmark-throughput.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Temporarily scale an RU-based Cosmos DB for MongoDB database for a
+# benchmark command, then restore the original throughput on every normal,
+# failed, interrupted, or terminal-disconnect exit path.
+#
+# Required env vars:
+#   COSMOS_MONGODB_ACCOUNT
+#   RESOURCE_GROUP
+#   TARGET_THROUGHPUT
+#
+# Optional env vars:
+#   DATABASE_NAME       (default: cloudhealthoffice)
+#   MAX_THROUGHPUT      (default: 20000)
+#   THROUGHPUT_UPDATE_ATTEMPTS       (default: 6)
+#   THROUGHPUT_UPDATE_RETRY_SECONDS  (default: 15)
+#
+# Usage:
+#   COSMOS_MONGODB_ACCOUNT=... RESOURCE_GROUP=... TARGET_THROUGHPUT=10000 \
+#     ./scripts/azure/with-cosmos-mongodb-benchmark-throughput.sh -- \
+#     env CLAIMS=1000 ./scripts/run-mcc-local-k8s.sh
+set -euo pipefail
+
+: "${COSMOS_MONGODB_ACCOUNT:?COSMOS_MONGODB_ACCOUNT is required}"
+: "${RESOURCE_GROUP:?RESOURCE_GROUP is required}"
+: "${TARGET_THROUGHPUT:?TARGET_THROUGHPUT is required}"
+
+DATABASE_NAME="${DATABASE_NAME:-cloudhealthoffice}"
+MAX_THROUGHPUT="${MAX_THROUGHPUT:-20000}"
+THROUGHPUT_UPDATE_ATTEMPTS="${THROUGHPUT_UPDATE_ATTEMPTS:-6}"
+THROUGHPUT_UPDATE_RETRY_SECONDS="${THROUGHPUT_UPDATE_RETRY_SECONDS:-15}"
+
+if [[ "${1:-}" != "--" || "$#" -lt 2 ]]; then
+  echo "Usage: $0 -- <benchmark command> [args...]" >&2
+  exit 2
+fi
+shift
+
+if ! [[ "$TARGET_THROUGHPUT" =~ ^[0-9]+$ ]] \
+  || (( TARGET_THROUGHPUT < 1000 || TARGET_THROUGHPUT > MAX_THROUGHPUT || TARGET_THROUGHPUT % 100 != 0 )); then
+  echo "TARGET_THROUGHPUT must be a multiple of 100 between 1000 and ${MAX_THROUGHPUT}" >&2
+  exit 2
+fi
+if ! [[ "$THROUGHPUT_UPDATE_ATTEMPTS" =~ ^[1-9][0-9]*$ ]] \
+  || ! [[ "$THROUGHPUT_UPDATE_RETRY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "THROUGHPUT_UPDATE_ATTEMPTS must be positive and THROUGHPUT_UPDATE_RETRY_SECONDS must be non-negative" >&2
+  exit 2
+fi
+
+command -v az >/dev/null 2>&1 || {
+  echo "Azure CLI (az) is required" >&2
+  exit 1
+}
+az account show >/dev/null
+
+update_throughput() {
+  local requested_throughput="$1"
+  local attempt
+
+  for ((attempt = 1; attempt <= THROUGHPUT_UPDATE_ATTEMPTS; attempt++)); do
+    if az cosmosdb mongodb database throughput update \
+      --account-name "$COSMOS_MONGODB_ACCOUNT" \
+      --resource-group "$RESOURCE_GROUP" \
+      --name "$DATABASE_NAME" \
+      --throughput "$requested_throughput" \
+      --output none; then
+      return 0
+    fi
+
+    if (( attempt < THROUGHPUT_UPDATE_ATTEMPTS )); then
+      echo "Throughput update attempt ${attempt}/${THROUGHPUT_UPDATE_ATTEMPTS} failed; retrying in ${THROUGHPUT_UPDATE_RETRY_SECONDS}s" >&2
+      sleep "$THROUGHPUT_UPDATE_RETRY_SECONDS"
+    fi
+  done
+
+  return 1
+}
+
+current_throughput="$(
+  az cosmosdb mongodb database throughput show \
+    --account-name "$COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$DATABASE_NAME" \
+    --query resource.throughput \
+    --output tsv
+)"
+
+if ! [[ "$current_throughput" =~ ^[0-9]+$ ]]; then
+  echo "Could not determine current manual throughput for ${DATABASE_NAME}" >&2
+  exit 1
+fi
+
+restore_throughput() {
+  local exit_code=$?
+  trap - EXIT INT TERM HUP
+
+  if [[ "$current_throughput" != "$TARGET_THROUGHPUT" ]]; then
+    echo "==> Restoring Cosmos MongoDB throughput to ${current_throughput} RU/s"
+    update_throughput "$current_throughput" \
+      || echo "WARNING: automatic throughput restore failed; restore ${DATABASE_NAME} to ${current_throughput} RU/s manually" >&2
+  fi
+
+  exit "$exit_code"
+}
+trap restore_throughput EXIT INT TERM HUP
+
+if [[ "$current_throughput" != "$TARGET_THROUGHPUT" ]]; then
+  echo "==> Scaling Cosmos MongoDB throughput: ${current_throughput} -> ${TARGET_THROUGHPUT} RU/s"
+  update_throughput "$TARGET_THROUGHPUT"
+fi
+
+applied_throughput="$(
+  az cosmosdb mongodb database throughput show \
+    --account-name "$COSMOS_MONGODB_ACCOUNT" \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$DATABASE_NAME" \
+    --query resource.throughput \
+    --output tsv
+)"
+
+if [[ "$applied_throughput" != "$TARGET_THROUGHPUT" ]]; then
+  echo "Cosmos MongoDB reported ${applied_throughput} RU/s after requesting ${TARGET_THROUGHPUT}" >&2
+  exit 1
+fi
+
+echo "==> Running benchmark at ${applied_throughput} RU/s"
+"$@"

--- a/scripts/run-mcc-local-k8s.sh
+++ b/scripts/run-mcc-local-k8s.sh
@@ -23,6 +23,7 @@ SERVICEBUS_ONLY="${SERVICEBUS_ONLY:-false}"
 SERVICEBUS_RECONCILIATION_ENABLED="${SERVICEBUS_RECONCILIATION_ENABLED:-true}"
 SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS="${SERVICEBUS_RECONCILIATION_TIMEOUT_SECONDS:-300}"
 CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS="${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS:-15}"
+ADJUDICATION_MAX_CONCURRENT_CALLS="${ADJUDICATION_MAX_CONCURRENT_CALLS:-}"
 SERVICE_CATEGORY_ADMIN_WRITE_ENABLED="${SERVICE_CATEGORY_ADMIN_WRITE_ENABLED:-true}"
 PEND_OBSERVATION_ENABLED="${PEND_OBSERVATION_ENABLED:-true}"
 PEND_OBSERVATION_TIMEOUT_SECONDS="${PEND_OBSERVATION_TIMEOUT_SECONDS:-45}"
@@ -33,13 +34,37 @@ PEND_OBSERVATION_INTERVAL_MS="${PEND_OBSERVATION_INTERVAL_MS:-1000}"
 PEND_DIAGNOSTICS_PATH="${PEND_DIAGNOSTICS_PATH:-}"
 PEND_DIAGNOSTICS_NCCI_SAMPLE="${PEND_DIAGNOSTICS_NCCI_SAMPLE:-200}"
 PARALLELISM="${PARALLELISM:-10}"
+SEED_PARALLELISM="${SEED_PARALLELISM:-$PARALLELISM}"
 PROGRESS_EVERY="${PROGRESS_EVERY:-500}"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-docker-desktop}"
 SKIP_BUILD="${SKIP_BUILD:-false}"
 JOB_TIMEOUT="${JOB_TIMEOUT:-30m}"
+ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS=""
 
 log() {
   printf '\033[1;34m==>\033[0m %s\n' "$*"
+}
+
+restore_claims_concurrency() {
+  local exit_code=$?
+  trap - EXIT INT TERM HUP
+
+  if [[ -n "$ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS" \
+    && "$ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS" != "$ADJUDICATION_MAX_CONCURRENT_CALLS" ]]; then
+    log "Restoring claims-service Service Bus concurrency to ${ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS} per replica"
+    if kubectl patch configmap claims-service-config \
+      -n "$NAMESPACE" \
+      --type merge \
+      -p "{\"data\":{\"Messaging__AdjudicationMaxConcurrentCalls\":\"${ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS}\"}}" >/dev/null; then
+      kubectl rollout restart deployment/claims-service -n "$NAMESPACE" >/dev/null
+      kubectl rollout status deployment/claims-service -n "$NAMESPACE" --timeout=180s >/dev/null \
+        || echo "WARNING: claims-service rollout did not complete after restoring concurrency" >&2
+    else
+      echo "WARNING: failed to restore claims-service concurrency to ${ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS}" >&2
+    fi
+  fi
+
+  exit "$exit_code"
 }
 
 if [[ "$SKIP_BUILD" != "true" ]]; then
@@ -57,6 +82,22 @@ if command -v kind >/dev/null 2>&1 && kind get clusters | grep -qx "$KIND_CLUSTE
 fi
 
 if kubectl get deployment -n "$NAMESPACE" claims-service >/dev/null 2>&1; then
+  if [[ -n "$ADJUDICATION_MAX_CONCURRENT_CALLS" ]]; then
+    ORIGINAL_ADJUDICATION_MAX_CONCURRENT_CALLS="$(
+      kubectl get configmap claims-service-config \
+        -n "$NAMESPACE" \
+        -o jsonpath='{.data.Messaging__AdjudicationMaxConcurrentCalls}'
+    )"
+    trap restore_claims_concurrency EXIT INT TERM HUP
+
+    log "Setting claims-service Service Bus concurrency to ${ADJUDICATION_MAX_CONCURRENT_CALLS} per replica"
+    kubectl patch configmap claims-service-config \
+      -n "$NAMESPACE" \
+      --type merge \
+      -p "{\"data\":{\"Messaging__AdjudicationMaxConcurrentCalls\":\"${ADJUDICATION_MAX_CONCURRENT_CALLS}\"}}" >/dev/null
+    kubectl rollout restart deployment/claims-service -n "$NAMESPACE" >/dev/null
+  fi
+
   log "Setting claims-service benefit-plan timeout to ${CLAIMS_SERVICE_BENEFIT_TIMEOUT_SECONDS}s"
   kubectl set env deployment/claims-service \
     -n "$NAMESPACE" \
@@ -99,6 +140,8 @@ spec:
             - "${SEED}"
             - --parallelism
             - "${PARALLELISM}"
+            - --seed-parallelism
+            - "${SEED_PARALLELISM}"
             - --claims-url
             - "${CLAIMS_URL}"
             - --benefit-url

--- a/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
+++ b/src/tools/mcc-platform-validator/MccClaimStatusObservation.cs
@@ -30,6 +30,15 @@ internal sealed class HttpClaimStatusSource : IClaimStatusSource
         var body = await response.Content.ReadAsStringAsync(cancellationToken);
         if (!response.IsSuccessStatusCode)
         {
+            if (response.StatusCode is HttpStatusCode.RequestTimeout
+                or HttpStatusCode.TooManyRequests
+                || (int)response.StatusCode >= 500)
+            {
+                // A transient read failure means the persisted outcome is not
+                // observable yet; callers retain it for bounded reconciliation.
+                return null;
+            }
+
             throw new InvalidOperationException(
                 $"claim status read failed ({submittedClaimId}): {(int)response.StatusCode} {body}");
         }

--- a/src/tools/mcc-platform-validator/MccFixtureScope.cs
+++ b/src/tools/mcc-platform-validator/MccFixtureScope.cs
@@ -1,0 +1,21 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+/// <summary>
+/// Produces a stable fixture identity scope for repeat runs of the same
+/// tenant and seed. Validation plans remain run-specific, while synthetic
+/// member/provider identities can be safely verified and reused.
+/// </summary>
+internal static class MccFixtureScope
+{
+    internal static Guid Create(string tenantId, int seed)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        var input = Encoding.UTF8.GetBytes($"{tenantId.Trim()}:{seed}");
+        var hash = SHA256.HashData(input);
+        return new Guid(hash.AsSpan(0, 16));
+    }
+}

--- a/src/tools/mcc-platform-validator/MccServiceBusReconciliation.cs
+++ b/src/tools/mcc-platform-validator/MccServiceBusReconciliation.cs
@@ -69,7 +69,36 @@ internal sealed class MccServiceBusReconciler
         {
             while (true)
             {
-                var observed = await _source.GetAsync(result.SubmittedClaimId!, cancellationToken);
+                var remaining = deadline - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return result with
+                    {
+                        Error =
+                            $"Claim remained nonterminal after the initial observation timeout and " +
+                            $"{timeout.TotalSeconds:N0}s post-window reconciliation"
+                    };
+                }
+
+                ObservedClaimStatus? observed;
+                using (var attemptTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    attemptTimeout.CancelAfter(
+                        remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5));
+                    try
+                    {
+                        observed = await _source.GetAsync(result.SubmittedClaimId!, attemptTimeout.Token);
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        observed = null;
+                    }
+                    catch (HttpRequestException)
+                    {
+                        observed = null;
+                    }
+                }
+
                 if (observed?.IsTerminal is true)
                 {
                     var businessDenialCode = observed.Outcome is ClaimValidationOutcome.BusinessDenial
@@ -96,7 +125,7 @@ internal sealed class MccServiceBusReconciler
                     };
                 }
 
-                var remaining = deadline - DateTimeOffset.UtcNow;
+                remaining = deadline - DateTimeOffset.UtcNow;
                 if (remaining <= TimeSpan.Zero)
                 {
                     return result with

--- a/src/tools/mcc-platform-validator/Program.cs
+++ b/src/tools/mcc-platform-validator/Program.cs
@@ -47,6 +47,7 @@ Console.WriteLine($"  Auth URL:    {options.AuthorizationUrl}");
 Console.WriteLine($"  Claims:      {options.Claims:N0}");
 Console.WriteLine($"  Seed:        {options.Seed}");
 Console.WriteLine($"  Parallelism: {options.Parallelism:N0}");
+Console.WriteLine($"  Seed workers:{options.SeedParallelism:N0}");
 Console.WriteLine($"  LOB:         {LineOfBusinessName(options.LineOfBusiness)} ({options.LineOfBusiness})");
 Console.WriteLine($"  PA scenarios:{(options.PriorAuthScenariosEnabled ? $" enabled ({options.PriorAuthScenarioRate:P0})" : " disabled")}");
 Console.WriteLine($"  Auth fixtures:{(options.SeedAuthorizations ? " enabled" : " disabled")}");
@@ -101,19 +102,20 @@ var claims = await MeasureLifecycleValuePhaseAsync(
     "Preparation",
     () => GenerateClaimsAsync(options));
 
+var fixtureScopeId = MccFixtureScope.Create(options.TenantId, options.Seed);
 var providerPool = await MeasureLifecycleValuePhaseAsync(lifecycleTimings, "Fixture normalization", "Preparation", () =>
 {
     NormalizePriorAuthEdgeCases(claims, options);
     MccValidationProviderNormalizer.Normalize(
         claims,
         options.Seed,
-        validationPlanId,
+        fixtureScopeId,
         new MccWorkflowValidationCapabilities(
             ScorePriorAuthValidationEvidence: options.SeedAuthorizations,
             ScorePriorAuthProviderValidationEvidence: options.SeedAuthorizations));
-    MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, validationPlanId);
+    MccFixtureIsolation.IsolateValidationMembers(claims, options.Seed, fixtureScopeId);
     MccCleanPaidFixture.NormalizeClaims(claims);
-    return Task.FromResult(MccProviderFixturePool.Apply(claims, options.Seed, validationPlanId));
+    return Task.FromResult(MccProviderFixturePool.Apply(claims, options.Seed, fixtureScopeId));
 });
 Console.WriteLine($"Generated {claims.Count:N0} MCC claims in memory");
 Console.WriteLine(
@@ -338,7 +340,7 @@ if (options.ServiceBusOnly && options.ServiceBusReconciliationEnabled)
             orderedResults,
             TimeSpan.FromSeconds(options.ServiceBusReconciliationTimeoutSeconds),
             TimeSpan.FromMilliseconds(options.PendObservationIntervalMilliseconds),
-            Math.Max(options.Parallelism, 64));
+            options.Parallelism);
         orderedResults = reconciliation.Results;
 
         if (reconciliation.Candidates > 0)
@@ -680,13 +682,37 @@ static async Task<ObservedClaimStatus> ObserveServiceBusOutcomeAsync(
 
     while (true)
     {
-        var observed = await source.GetAsync(submittedClaimId, CancellationToken.None);
+        var remaining = deadline - DateTimeOffset.UtcNow;
+        if (remaining <= TimeSpan.Zero)
+        {
+            throw new TimeoutException(
+                $"Timed out waiting {timeout.TotalSeconds:N0}s for Service Bus adjudication of claim {submittedClaimId}");
+        }
+
+        ObservedClaimStatus? observed;
+        using (var attemptTimeout = new CancellationTokenSource(
+                   remaining < TimeSpan.FromSeconds(5) ? remaining : TimeSpan.FromSeconds(5)))
+        {
+            try
+            {
+                observed = await source.GetAsync(submittedClaimId, attemptTimeout.Token);
+            }
+            catch (OperationCanceledException) when (attemptTimeout.IsCancellationRequested)
+            {
+                observed = null;
+            }
+            catch (HttpRequestException)
+            {
+                observed = null;
+            }
+        }
+
         if (observed?.IsTerminal is true)
         {
             return observed;
         }
 
-        var remaining = deadline - DateTimeOffset.UtcNow;
+        remaining = deadline - DateTimeOffset.UtcNow;
         if (remaining <= TimeSpan.Zero)
         {
             throw new TimeoutException(
@@ -699,11 +725,25 @@ static async Task<ObservedClaimStatus> ObserveServiceBusOutcomeAsync(
 
 static async Task RequireHealthyAsync(HttpClient http, string url, string serviceName)
 {
-    using var response = await http.GetAsync(url);
-    if (!response.IsSuccessStatusCode)
-    {
-        throw new InvalidOperationException($"{serviceName} health check failed: {(int)response.StatusCode} {response.ReasonPhrase}");
-    }
+    await ProviderSeedRetryPolicy.ExecuteAsync(
+        async () =>
+        {
+            using var attemptTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            using var response = await http.GetAsync(url, attemptTimeout.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new ProviderSeedRequestException(
+                    $"{serviceName} health check failed",
+                    response.StatusCode,
+                    response.ReasonPhrase ?? string.Empty);
+            }
+        },
+        CancellationToken.None,
+        (attempt, delay, exception) =>
+            Console.WriteLine(
+                $"  Transient {serviceName} health failure; " +
+                $"retry {attempt}/{ProviderSeedRetryPolicy.MaxAttempts} in {delay.TotalMilliseconds:N0} ms: " +
+                exception.Message));
 
     Console.WriteLine($"healthy: {serviceName}");
 }
@@ -1531,7 +1571,7 @@ static async Task<MemberFixturePreparation> SeedMembersAsync(
 
     await Parallel.ForEachAsync(
         members,
-        new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
+        new ParallelOptions { MaxDegreeOfParallelism = options.SeedParallelism },
         async (member, _) =>
         {
             if (await MemberExistsAsync(http, options, member.MemberId))
@@ -2270,41 +2310,56 @@ static async Task<FixtureCount> SeedProvidersAsync(
 
     await Parallel.ForEachAsync(
         providers,
-        new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism },
-        async (provider, _) =>
+        new ParallelOptions { MaxDegreeOfParallelism = options.SeedParallelism },
+        async (provider, cancellationToken) =>
         {
-            var providerId = await GetProviderIdByNpiAsync(http, options, provider.Npi);
-            if (providerId is not null)
+            var providerWasCreated = false;
+            await ProviderSeedRetryPolicy.ExecuteAsync(
+                async () =>
+                {
+                    var providerId = await GetProviderIdByNpiAsync(http, options, provider.Npi);
+                    if (providerId is null)
+                    {
+                        providerId = await CreateProviderAsync(http, options, provider, validationPlanId, json);
+                        providerWasCreated = true;
+                    }
+
+                    if (!IsProviderExcluded(provider))
+                    {
+                        await EnsureProviderCredentialingAsync(
+                            http,
+                            options,
+                            providerId,
+                            EffectiveDateForProvider(provider),
+                            json);
+                        await EnsureProviderNetworkParticipationAsync(
+                            http,
+                            options,
+                            providerId,
+                            provider,
+                            json);
+                        await EnsureProviderVerificationFreshnessAsync(http, options, providerId, json);
+                    }
+                    else
+                    {
+                        await EnsureProviderExclusionAsync(http, options, providerId, json);
+                    }
+                },
+                cancellationToken,
+                (attempt, delay, exception) =>
+                    Console.WriteLine(
+                        $"\n  Transient provider seed failure ({provider.Npi}); " +
+                        $"retry {attempt}/{ProviderSeedRetryPolicy.MaxAttempts} in {delay.TotalMilliseconds:N0} ms: " +
+                        exception.Message));
+
+            if (providerWasCreated)
+            {
+                Interlocked.Increment(ref created);
+            }
+            else
             {
                 Interlocked.Increment(ref existing);
             }
-            else
-            {
-                providerId = await CreateProviderAsync(http, options, provider, validationPlanId, json);
-                Interlocked.Increment(ref created);
-            }
-
-            if (!IsProviderExcluded(provider))
-            {
-                await EnsureProviderCredentialingAsync(
-                    http,
-                    options,
-                    providerId,
-                    EffectiveDateForProvider(provider),
-                    json);
-                await EnsureProviderNetworkParticipationAsync(
-                    http,
-                    options,
-                    providerId,
-                    provider,
-                    json);
-                await EnsureProviderVerificationFreshnessAsync(http, options, providerId, json);
-            }
-            else
-            {
-                await EnsureProviderExclusionAsync(http, options, providerId, json);
-            }
-
             WriteSeedingProgress("providers", Interlocked.Increment(ref processed), providers.Count, progressInterval, progressLock);
         });
 
@@ -2359,7 +2414,8 @@ static async Task<bool> ProviderNetworkExistsAsync(HttpClient http, ValidatorOpt
     }
 
     var body = await response.Content.ReadAsStringAsync();
-    throw new InvalidOperationException($"provider network lookup failed ({networkId}): {(int)response.StatusCode} {body}");
+    throw new ProviderSeedRequestException(
+        $"provider network lookup failed ({networkId})", response.StatusCode, body);
 }
 
 static async Task EnsureProviderNetworkParticipationAsync(
@@ -2406,8 +2462,10 @@ static async Task EnsureProviderNetworkParticipationAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode && response.StatusCode is not System.Net.HttpStatusCode.Conflict)
     {
-        throw new InvalidOperationException(
-            $"provider network participation seed failed ({providerId}/{provider.Npi}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider network participation seed failed ({providerId}/{provider.Npi})",
+            response.StatusCode,
+            body);
     }
 }
 
@@ -2430,8 +2488,10 @@ static async Task<bool> ProviderHasActiveNetworkParticipationAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider network membership lookup failed ({networkId}/{npi}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider network membership lookup failed ({networkId}/{npi})",
+            response.StatusCode,
+            body);
     }
 
     using var document = JsonDocument.Parse(body);
@@ -2473,7 +2533,8 @@ static async Task CreateProviderNetworkAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode && response.StatusCode is not System.Net.HttpStatusCode.Conflict)
     {
-        throw new InvalidOperationException($"provider network seed failed ({networkId}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider network seed failed ({networkId})", response.StatusCode, body);
     }
 }
 
@@ -2493,7 +2554,8 @@ static async Task<string?> GetProviderIdByNpiAsync(HttpClient http, ValidatorOpt
     }
 
     var failureBody = await response.Content.ReadAsStringAsync();
-    throw new InvalidOperationException($"provider lookup failed ({npi}): {(int)response.StatusCode} {failureBody}");
+    throw new ProviderSeedRequestException(
+        $"provider lookup failed ({npi})", response.StatusCode, failureBody);
 }
 
 static string? ExtractProviderId(string body)
@@ -2550,8 +2612,8 @@ static async Task EnsureProviderCredentialingAsync(
     var updateBody = await update.Content.ReadAsStringAsync();
     if (!update.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider credentialing seed failed ({providerId}): {(int)update.StatusCode} {updateBody}");
+        throw new ProviderSeedRequestException(
+            $"provider credentialing seed failed ({providerId})", update.StatusCode, updateBody);
     }
 }
 
@@ -2580,8 +2642,8 @@ static async Task EnsureProviderExclusionAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider fetch failed for exclusion check ({providerId}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider fetch failed for exclusion check ({providerId})", response.StatusCode, body);
     }
 
     var node = JsonNode.Parse(body)
@@ -2606,8 +2668,8 @@ static async Task EnsureProviderExclusionAsync(
     var updateBody = await update.Content.ReadAsStringAsync();
     if (!update.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider exclusion correction failed ({providerId}): {(int)update.StatusCode} {updateBody}");
+        throw new ProviderSeedRequestException(
+            $"provider exclusion correction failed ({providerId})", update.StatusCode, updateBody);
     }
 }
 
@@ -2634,8 +2696,10 @@ static async Task EnsureProviderVerificationFreshnessAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider fetch failed for verification freshness check ({providerId}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider fetch failed for verification freshness check ({providerId})",
+            response.StatusCode,
+            body);
     }
 
     var node = JsonNode.Parse(body)
@@ -2655,8 +2719,10 @@ static async Task EnsureProviderVerificationFreshnessAsync(
     var updateBody = await update.Content.ReadAsStringAsync();
     if (!update.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException(
-            $"provider verification freshness refresh failed ({providerId}): {(int)update.StatusCode} {updateBody}");
+        throw new ProviderSeedRequestException(
+            $"provider verification freshness refresh failed ({providerId})",
+            update.StatusCode,
+            updateBody);
     }
 }
 
@@ -2745,7 +2811,8 @@ static async Task<string> CreateProviderAsync(
     var body = await response.Content.ReadAsStringAsync();
     if (!response.IsSuccessStatusCode)
     {
-        throw new InvalidOperationException($"provider seed failed ({provider.Npi}): {(int)response.StatusCode} {body}");
+        throw new ProviderSeedRequestException(
+            $"provider seed failed ({provider.Npi})", response.StatusCode, body);
     }
 
     return ExtractProviderId(body)
@@ -3675,6 +3742,8 @@ static void PrintUsage()
       --timeout <seconds>        Per-request timeout (default: 60)
       --progress-every <count>   Report progress every N claims (default: 10)
       -p, --parallelism <count>  Number of claims to process concurrently (default: 10)
+      --seed-parallelism <count> Number of member/provider fixtures to seed concurrently
+                                 (default: same as --parallelism)
       --max-claims <count>       Maximum accepted --claims value before local safety capping (default: 10000)
       --line-of-business <code>  Adjudication line of business: 1 Commercial, 2 Medicare, 3 Medicaid, 4 CHIP, 5 Exchange (default: 3)
       --no-prior-auth-scenarios  Disable deterministic PA-required claim scenarios

--- a/src/tools/mcc-platform-validator/ProviderSeedRetryPolicy.cs
+++ b/src/tools/mcc-platform-validator/ProviderSeedRetryPolicy.cs
@@ -1,0 +1,67 @@
+using System.Net;
+
+namespace CloudHealthOffice.Tools.MccPlatformValidator;
+
+internal sealed class ProviderSeedRequestException : InvalidOperationException
+{
+    public ProviderSeedRequestException(string operation, HttpStatusCode statusCode, string responseBody)
+        : base($"{operation}: {(int)statusCode} {responseBody}")
+    {
+        StatusCode = statusCode;
+    }
+
+    public HttpStatusCode StatusCode { get; }
+}
+
+internal static class ProviderSeedRetryPolicy
+{
+    // A transient Cosmos outage can make every provider-service pod fail
+    // readiness at once. Kubernetes then removes all service endpoints until
+    // the dependency recovers, so retries must span more than a few seconds.
+    internal const int MaxAttempts = 10;
+
+    internal static async Task ExecuteAsync(
+        Func<Task> operation,
+        CancellationToken cancellationToken,
+        Action<int, TimeSpan, Exception>? onRetry = null)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                await operation();
+                return;
+            }
+            catch (Exception exception) when (
+                attempt < MaxAttempts
+                && !cancellationToken.IsCancellationRequested
+                && IsTransient(exception))
+            {
+                var delay = RetryDelay(attempt);
+                onRetry?.Invoke(attempt + 1, delay, exception);
+                await Task.Delay(delay, cancellationToken);
+            }
+        }
+    }
+
+    internal static bool IsTransient(Exception exception) =>
+        exception switch
+        {
+            ProviderSeedRequestException requestException => IsTransient(requestException.StatusCode),
+            HttpRequestException requestException when requestException.StatusCode is not null =>
+                IsTransient(requestException.StatusCode.Value),
+            HttpRequestException => true,
+            TaskCanceledException => true,
+            _ => false
+        };
+
+    internal static bool IsTransient(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.RequestTimeout
+            or HttpStatusCode.TooManyRequests
+        || (int)statusCode >= 500;
+
+    internal static TimeSpan RetryDelay(int failedAttempt) =>
+        TimeSpan.FromMilliseconds(Math.Min(
+            15_000,
+            250 * Math.Pow(2, failedAttempt - 1)));
+}

--- a/src/tools/mcc-platform-validator/ValidatorOptions.cs
+++ b/src/tools/mcc-platform-validator/ValidatorOptions.cs
@@ -25,6 +25,7 @@ public sealed record ValidatorOptions(
     int TimeoutSeconds,
     int ProgressEvery,
     int Parallelism,
+    int SeedParallelism,
     int LineOfBusiness,
     string? SummaryJsonPath,
     bool NoPublishSummary,
@@ -117,6 +118,9 @@ public sealed record ValidatorOptions(
                 case "--parallelism" or "-p" when i + 1 < args.Length:
                     options.Parallelism = int.Parse(args[++i]);
                     break;
+                case "--seed-parallelism" when i + 1 < args.Length:
+                    options.SeedParallelism = int.Parse(args[++i]);
+                    break;
                 case "--max-claims" when i + 1 < args.Length:
                     options.MaxClaims = int.Parse(args[++i]);
                     break;
@@ -184,6 +188,9 @@ public sealed record ValidatorOptions(
             Math.Max(5, options.TimeoutSeconds),
             Math.Max(1, options.ProgressEvery),
             Math.Max(1, options.Parallelism),
+            options.SeedParallelism > 0
+                ? Math.Clamp(options.SeedParallelism, 1, MaxParallelism)
+                : Math.Max(1, options.Parallelism),
             Math.Clamp(options.LineOfBusiness, 1, 5),
             options.SummaryJsonPath,
             options.NoPublishSummary,
@@ -219,6 +226,7 @@ public sealed record ValidatorOptions(
         public int TimeoutSeconds { get; set; } = 60;
         public int ProgressEvery { get; set; } = 10;
         public int Parallelism { get; set; } = 10;
+        public int SeedParallelism { get; set; }
         public int MaxClaims { get; set; } = DefaultMaxClaims;
         public int LineOfBusiness { get; set; } = 3;
         public string? SummaryJsonPath { get; set; }

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureScopeTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/MccFixtureScopeTests.cs
@@ -1,0 +1,24 @@
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class MccFixtureScopeTests
+{
+    [Fact]
+    public void Create_IsStableForSameTenantAndSeed()
+    {
+        var first = MccFixtureScope.Create("tenant-a", 42);
+        var second = MccFixtureScope.Create("tenant-a", 42);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Create_IsolatesTenantsAndSeeds()
+    {
+        var baseline = MccFixtureScope.Create("tenant-a", 42);
+
+        Assert.NotEqual(baseline, MccFixtureScope.Create("tenant-b", 42));
+        Assert.NotEqual(baseline, MccFixtureScope.Create("tenant-a", 43));
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ProviderSeedRetryPolicyTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ProviderSeedRetryPolicyTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using CloudHealthOffice.Tools.MccPlatformValidator;
+
+namespace CloudHealthOffice.MccPlatformValidator.Tests;
+
+public class ProviderSeedRetryPolicyTests
+{
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public void IsTransient_ReturnsTrueForRetryableStatus(HttpStatusCode statusCode)
+    {
+        Assert.True(ProviderSeedRetryPolicy.IsTransient(statusCode));
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Conflict)]
+    public void IsTransient_ReturnsFalseForNonRetryableStatus(HttpStatusCode statusCode)
+    {
+        Assert.False(ProviderSeedRetryPolicy.IsTransient(statusCode));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RetriesTransientFailuresUntilSuccess()
+    {
+        var attempts = 0;
+
+        await ProviderSeedRetryPolicy.ExecuteAsync(
+            () =>
+            {
+                attempts++;
+                return attempts < 3
+                    ? Task.FromException(new ProviderSeedRequestException(
+                        "seed failed", HttpStatusCode.InternalServerError, "temporary"))
+                    : Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotRetryNonTransientFailures()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<ProviderSeedRequestException>(() =>
+            ProviderSeedRetryPolicy.ExecuteAsync(
+                () =>
+                {
+                    attempts++;
+                    return Task.FromException(new ProviderSeedRequestException(
+                        "seed failed", HttpStatusCode.BadRequest, "invalid"));
+                },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public void RetryDelay_CapsExtendedOutageBackoff()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(15), ProviderSeedRetryPolicy.RetryDelay(10));
+    }
+}

--- a/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
+++ b/tests/CloudHealthOffice.MccPlatformValidator.Tests/ValidatorOptionsTests.cs
@@ -30,6 +30,19 @@ public class ValidatorOptionsTests
 
         Assert.Equal(ValidatorOptions.MaxParallelism, options.Parallelism);
         Assert.Equal(96, options.Parallelism);
+        Assert.Equal(options.Parallelism, options.SeedParallelism);
+    }
+
+    [Fact]
+    public void Parse_WhenSeedParallelismProvided_SeparatesFixtureAndClaimConcurrency()
+    {
+        var options = ValidatorOptions.Parse([
+            "--parallelism", "56",
+            "--seed-parallelism", "4"
+        ]);
+
+        Assert.Equal(56, options.Parallelism);
+        Assert.Equal(4, options.SeedParallelism);
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- Separate fixture-seeding concurrency from claim submission concurrency with `--seed-parallelism`.
- Reuse deterministic member/provider fixture identities for the same tenant and seed.
- Retry transient provider-service and health-check failures caused by Cosmos throttling or temporary dependency outages.
- Treat transient claim-status read failures as unresolved observations and reconcile them within a bounded post-window.
- Allow configurable Cosmos MongoDB RU/s for benchmarks while retaining the 1,000 RU/s free-tier default.
- Add guarded benchmark automation that restores Cosmos throughput and claims-service consumer concurrency after success, failure, interruption, or disconnect. Azure throughput updates retry transient scale-operation locks.

## Why

The local Kubernetes validator was correct against Cosmos DB for MongoDB, but remote database latency and throttling exposed brittle fixture setup and claim observation behavior. It also needed explicit cost and rollback guardrails before temporarily using paid throughput.

## Benchmark evidence

Using 1,000 claims from the same tenant/seed with Service Bus adjudication:

| Configuration | Processed | Workflow checks | Platform failures | Throughput |
| --- | ---: | ---: | ---: | ---: |
| Cosmos 10k RU/s, P12 | 1,000/1,000 | 130/130 | 0 | 3.14 claims/s |
| Cosmos 10k RU/s, P56 | 1,000/1,000 | 130/130 | 0 | 9.91 claims/s |
| Cosmos 20k RU/s, P56 | 1,000/1,000 | 130/130 | 0 | 10.37 claims/s |

Doubling throughput from 10k to 20k RU/s improved P56 throughput by only 4.6%, suggesting the next performance comparison should run the services in AKS near Cosmos to remove local-to-Azure network latency.

After benchmarking, Cosmos was confirmed restored to 1,000 RU/s and claims-service to 2 consumers per replica with 3/3 replicas ready.

## Validation

- `dotnet test tests/CloudHealthOffice.MccPlatformValidator.Tests/CloudHealthOffice.MccPlatformValidator.Tests.csproj --no-restore` — 133 passed
- `az bicep build --file infrastructure/azure/modules/cosmos-mongodb-free-tier.bicep --stdout`
- `bash -n` for all changed shell scripts
- `shellcheck` for all changed shell scripts
- `git diff --check`