### PR TITLE
Founder page: link from nav/footer + correct tenure details

### DIFF
--- a/src/site/assessment.html
+++ b/src/site/assessment.html
@@ -67,7 +67,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -597,6 +597,7 @@ cd generated/your-payer/infrastructure &amp;&amp; ./deploy.sh
       <a href="/docs">Docs</a> • 
       <a href="mailto:mark@aurelianware.com">Contact</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>

--- a/src/site/claims-repricing.html
+++ b/src/site/claims-repricing.html
@@ -283,7 +283,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -585,6 +585,7 @@
       <a href="mailto:mark@aurelianware.com">Contact</a> &bull;
       <a href="/legal/privacy-policy">Privacy</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 
   <script>

--- a/src/site/cms-0057f-compliance.html
+++ b/src/site/cms-0057f-compliance.html
@@ -278,6 +278,7 @@
       <a href="https://cloudhealthoffice.com/pricing">Pricing</a>
       <a href="https://cloudhealthoffice.com/docs">Docs</a>
       <a href="https://github.com/aurelianware/cloudhealthoffice">GitHub</a>
+      <a href="/founder">Founder</a>
       <a href="/contact" class="nav-cta">Contact Sales →</a>
     </div>
   </div>
@@ -1407,7 +1408,8 @@
 <footer>
   <p>&copy; 2026 Cloud Health Office — <a href="https://github.com/aurelianware">Aurelianware, Inc.</a> &nbsp;·&nbsp; Source-available platform (BSL 1.1) &nbsp;·&nbsp; Free for non-production use &nbsp;·&nbsp; <a href="mailto:licensing@cloudhealthoffice.com" style="color:rgba(0,255,255,0.6);">Commercial licensing</a></p>
   <p style="margin-top:.4rem"><a href="https://cloudhealthoffice.com/pricing">Pricing</a> &nbsp;·&nbsp; <a href="https://cloudhealthoffice.com/platform">Platform</a> &nbsp;·&nbsp; <a href="https://cloudhealthoffice.com/docs">Docs</a> &nbsp;·&nbsp; <a href="mailto:sales@cloudhealthoffice.com">sales@cloudhealthoffice.com</a></p>
-</footer>
+    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
 
 <!-- ═══════════════ SCROLL REVEAL ═══════════════ -->
 

--- a/src/site/contact.html
+++ b/src/site/contact.html
@@ -227,7 +227,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" aria-current="page" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" aria-current="page" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -435,7 +435,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:clients@cloudhealthoffice.com">Founding Client Program</a></li>

--- a/src/site/docs.html
+++ b/src/site/docs.html
@@ -61,7 +61,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -357,7 +357,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/api.html
+++ b/src/site/docs/api.html
@@ -23,7 +23,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-to-main">Skip to main content</a>
-  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
+  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
   <script>document.addEventListener('DOMContentLoaded',()=>{updateNavigation('#mainNav')});</script>
 
   <main id="main-content">
@@ -145,7 +145,8 @@ curl -X POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token \
 
   <button class="docs-mobile-toggle" id="docsMobileToggle" aria-label="Toggle docs navigation">&#9776;</button>
   <div class="docs-sidebar-overlay" id="docsSidebarOverlay"></div>
-  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div></footer>
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div>    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
   <script>const t=document.getElementById('docsMobileToggle'),s=document.getElementById('docsSidebar'),o=document.getElementById('docsSidebarOverlay');if(t&&s){t.addEventListener('click',()=>{s.classList.toggle('open');o.classList.toggle('open')});o.addEventListener('click',()=>{s.classList.remove('open');o.classList.remove('open')})}</script>
 </body>
 </html>

--- a/src/site/docs/architecture.html
+++ b/src/site/docs/architecture.html
@@ -23,7 +23,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-to-main">Skip to main content</a>
-  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
+  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
   <script>document.addEventListener('DOMContentLoaded',()=>{updateNavigation('#mainNav')});</script>
 
   <main id="main-content">
@@ -121,7 +121,8 @@
 
   <button class="docs-mobile-toggle" id="docsMobileToggle" aria-label="Toggle docs navigation">&#9776;</button>
   <div class="docs-sidebar-overlay" id="docsSidebarOverlay"></div>
-  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div></footer>
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div>    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
   <script>const t=document.getElementById('docsMobileToggle'),s=document.getElementById('docsSidebar'),o=document.getElementById('docsSidebarOverlay');if(t&&s){t.addEventListener('click',()=>{s.classList.toggle('open');o.classList.toggle('open')});o.addEventListener('click',()=>{s.classList.remove('open');o.classList.remove('open')})}</script>
 </body>
 </html>

--- a/src/site/docs/benefit-plan-guide.html
+++ b/src/site/docs/benefit-plan-guide.html
@@ -68,7 +68,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -643,7 +643,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/claims-guide.html
+++ b/src/site/docs/claims-guide.html
@@ -69,7 +69,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -732,7 +732,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/commercial-licensing.html
+++ b/src/site/docs/commercial-licensing.html
@@ -61,7 +61,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -285,7 +285,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/compliance.html
+++ b/src/site/docs/compliance.html
@@ -37,7 +37,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-to-main">Skip to main content</a>
-  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
+  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
   <script>document.addEventListener('DOMContentLoaded',()=>{updateNavigation('#mainNav')});</script>
 
   <main id="main-content">
@@ -351,7 +351,8 @@ curl http://localhost:5029/api/providers/1234567890/verify | jq '.integrityScore
 
   <button class="docs-mobile-toggle" id="docsMobileToggle" aria-label="Toggle docs navigation">&#9776;</button>
   <div class="docs-sidebar-overlay" id="docsSidebarOverlay"></div>
-  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div></footer>
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div>    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
   <script>const t=document.getElementById('docsMobileToggle'),s=document.getElementById('docsSidebar'),o=document.getElementById('docsSidebarOverlay');if(t&&s){t.addEventListener('click',()=>{s.classList.toggle('open');o.classList.toggle('open')});o.addEventListener('click',()=>{s.classList.remove('open');o.classList.remove('open')})}</script>
 </body>
 </html>

--- a/src/site/docs/deployment.html
+++ b/src/site/docs/deployment.html
@@ -23,7 +23,7 @@
 </head>
 <body>
   <a href="#main-content" class="skip-to-main">Skip to main content</a>
-  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
+  <nav><div class="nav-inner"><a href="/" class="nav-logo" aria-label="Home"><img src="/graphics/logo-cloudhealthoffice-sentinel-primary.svg" alt="" class="nav-logo-img" aria-hidden="true" /><span class="nav-logo-text">Cloud Health Office</span></a><div class="nav-right"><button class="mobile-menu-toggle" aria-label="Toggle menu" aria-expanded="false" id="mobileMenuToggle">&#9776;</button><ul id="mainNav"><li><a href="/solutions-payers">Solutions</a></li><li><a href="/cms-0057f-compliance">CMS Compliance</a></li><li><a href="/pricing">Pricing</a></li><li><a href="/platform">Platform</a></li><li><a href="/docs" style="color:#00ffff;font-weight:bold;">Docs</a></li><li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li><li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff;font-weight:bold;">Contact Sales</a></li></ul></div></div></nav>
   <script>document.addEventListener('DOMContentLoaded',()=>{updateNavigation('#mainNav')});</script>
 
   <main id="main-content">
@@ -263,7 +263,8 @@ curl https://api.your-domain.example/fhir/r4/metadata | jq .status</code></pre>
 
   <button class="docs-mobile-toggle" id="docsMobileToggle" aria-label="Toggle docs navigation">&#9776;</button>
   <div class="docs-sidebar-overlay" id="docsSidebarOverlay"></div>
-  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div></footer>
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-bottom"><p>&copy; 2026 Cloud Health Office &mdash; Aurelianware, Inc.</p></div></div>    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
   <script>const t=document.getElementById('docsMobileToggle'),s=document.getElementById('docsSidebar'),o=document.getElementById('docsSidebarOverlay');if(t&&s){t.addEventListener('click',()=>{s.classList.toggle('open');o.classList.toggle('open')});o.addEventListener('click',()=>{s.classList.remove('open');o.classList.remove('open')})}</script>
 </body>
 </html>

--- a/src/site/docs/eligibility-guide.html
+++ b/src/site/docs/eligibility-guide.html
@@ -68,7 +68,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -577,7 +577,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/fee-schedule-engine.html
+++ b/src/site/docs/fee-schedule-engine.html
@@ -70,7 +70,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -414,7 +414,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/fee-schedule-guide.html
+++ b/src/site/docs/fee-schedule-guide.html
@@ -69,7 +69,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -575,7 +575,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/finance-guide.html
+++ b/src/site/docs/finance-guide.html
@@ -68,7 +68,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -674,7 +674,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/florida-compliance.html
+++ b/src/site/docs/florida-compliance.html
@@ -68,7 +68,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -529,7 +529,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/index.html
+++ b/src/site/docs/index.html
@@ -61,7 +61,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -357,7 +357,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/million-claim-challenge.html
+++ b/src/site/docs/million-claim-challenge.html
@@ -206,7 +206,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -1494,7 +1494,7 @@ dotnet run --project src/tools/mcc-runner -- --claims 10000 --seed 42</code></pr
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
           </ul>

--- a/src/site/docs/prior-auth-guide.html
+++ b/src/site/docs/prior-auth-guide.html
@@ -69,7 +69,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -702,7 +702,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/provider-enrollment-guide.html
+++ b/src/site/docs/provider-enrollment-guide.html
@@ -69,7 +69,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -496,7 +496,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/provider-verification-guide.html
+++ b/src/site/docs/provider-verification-guide.html
@@ -69,7 +69,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -527,7 +527,7 @@ ProviderVerification__MaxConcurrentVerifications=10</code></pre>
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/quickstart-kubernetes.html
+++ b/src/site/docs/quickstart-kubernetes.html
@@ -60,7 +60,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -484,7 +484,7 @@ docker volume prune -f</code></pre>
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
           </ul>

--- a/src/site/docs/quickstart.html
+++ b/src/site/docs/quickstart.html
@@ -60,7 +60,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -466,7 +466,7 @@ kubectl logs -n cloudhealthoffice --all-containers --tail=20 | grep -i error || 
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
           </ul>

--- a/src/site/docs/terminology-guide.html
+++ b/src/site/docs/terminology-guide.html
@@ -61,7 +61,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -630,7 +630,7 @@ curl -s -X POST http://localhost:5010/fhir/ConceptMap/\$batch-translate \
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/texas-compliance.html
+++ b/src/site/docs/texas-compliance.html
@@ -71,7 +71,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -549,7 +549,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/docs/texas-tmppm-pa-rules.html
+++ b/src/site/docs/texas-tmppm-pa-rules.html
@@ -107,7 +107,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs" style="color:#00ffff; font-weight:bold;">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -479,7 +479,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -264,7 +264,7 @@
           </li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="#founding-partner" style="color:#00ff88; font-weight:bold;">Founding Client</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -1246,7 +1246,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:clients@cloudhealthoffice.com">Founding Client Program</a></li>

--- a/src/site/insights.html
+++ b/src/site/insights.html
@@ -252,7 +252,7 @@
           <li><span aria-current="page" style="color:#00ffff;">Market Insights</span></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -521,6 +521,7 @@
       <a href="/docs">Docs</a> • 
       <a href="mailto:mark@aurelianware.com">Contact</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>

--- a/src/site/legal/privacy-policy.html
+++ b/src/site/legal/privacy-policy.html
@@ -186,7 +186,7 @@
           <li><a href="../platform.html">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -653,6 +653,7 @@
         <div class="footer-col">
           <h5>Product</h5>
           <ul>
+            <li><a href="/founder">Founder</a></li>
             <li><a href="../solutions-payers.html">Solutions</a></li>
             <li><a href="../platform.html">Platform</a></li>
             <li><a href="../pricing.html">Pricing</a></li>

--- a/src/site/login.html
+++ b/src/site/login.html
@@ -184,7 +184,7 @@
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank"
               rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -252,6 +252,7 @@
       <a href="https://github.com/aurelianware/cloudhealthoffice">GitHub</a> •
       <a href="mailto:mark@aurelianware.com">Contact</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 
   <script>

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -222,7 +222,7 @@
           <li><a href="/platform" style="color:#00ffff;" aria-current="page">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -1603,6 +1603,7 @@ cd generated/your-payer/infrastructure && ./deploy.sh
       <a href="/docs">Docs</a> • 
       <a href="mailto:mark@aurelianware.com">Contact</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>

--- a/src/site/portal/api-docs.html
+++ b/src/site/portal/api-docs.html
@@ -27,7 +27,7 @@
       <li><a href="api-docs.html" class="active">FHIR APIs</a></li>
       <li><a href="/platform">Platform</a></li>
       <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
     </ul>
   </nav>
 
@@ -440,6 +440,7 @@ Console.WriteLine(patient.Name[0].Given.First());</code></pre>
       <a href="mailto:api@cloudhealthoffice.com">Contact</a> •
       <a href="/pricing">Pricing</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>

--- a/src/site/portal/index.html
+++ b/src/site/portal/index.html
@@ -28,7 +28,7 @@
       <li><a href="/platform">Platform</a></li>
       <li><a href="/docs">Docs</a></li>
       <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
     </ul>
   </nav>
 
@@ -218,6 +218,7 @@
       <a href="mailto:contact@cloudhealthoffice.com">Contact</a> •
       <a href="/pricing">Pricing</a>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 
   <script>

--- a/src/site/pricing-api.html
+++ b/src/site/pricing-api.html
@@ -443,7 +443,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -744,7 +744,7 @@
         </div>
         <div class="footer-col">
           <h5>Contact</h5>
-          <ul>
+          <ul><li><a href="/founder">Founder</a></li>
             <li><a href="/contact">Contact Sales</a></li>
             <li><a href="mailto:enterprise@cloudhealthoffice.com">Enterprise Support</a></li>
             <li><a href="mailto:partners@cloudhealthoffice.com">Partner Program</a></li>

--- a/src/site/pricing.html
+++ b/src/site/pricing.html
@@ -638,6 +638,7 @@
     <a href="/platform">Platform</a>
     <a href="/docs">Docs</a>
     <a href="/docs/api">API Reference</a>
+    <a href="/founder">Founder</a>
     <a href="/contact" class="nav-cta">Contact Sales</a>
   </div>
 </nav>
@@ -910,7 +911,8 @@
 
 <footer class="footer">
   <p>&copy; 2026 Aurelianware, Inc. &middot; <a href="/legal/privacy-policy">Privacy</a> &middot; <a href="/docs">Docs</a> &middot; <a href="/docs/api">API docs</a></p>
-</footer>
+    <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
+  </footer>
 
 </div>
 

--- a/src/site/release-notes.html
+++ b/src/site/release-notes.html
@@ -289,7 +289,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/release-notes" style="color:#00ffff;" aria-current="page">Versions</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -701,6 +701,7 @@ npm install &amp;&amp; npm test
       <a href="mailto:sales@cloudhealthoffice.com" style="color: #00ffe7;"><strong>sales@cloudhealthoffice.com</strong></a><br>
       <em>Cloud Health Office: The payer platform that starts where your core admin stops.</em>
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>

--- a/src/site/schedule-demo/index.html
+++ b/src/site/schedule-demo/index.html
@@ -174,6 +174,7 @@
 <body>
   <nav class="nav" aria-label="Demo scheduling navigation">
     <a class="brand" href="/">Cloud Health Office</a>
+    <a href="/founder">Founder</a>
     <a href="/contact">Contact Sales</a>
   </nav>
 

--- a/src/site/solutions-payers.html
+++ b/src/site/solutions-payers.html
@@ -94,7 +94,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -412,6 +412,7 @@ Claims Platform → Cloud Health Office → Clearinghouses
     <p style="opacity:0.6; font-size:0.9rem; margin-top:20px;">
       © 2026 Cloud Health Office • Built by healthcare payer system experts
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 
 </body>

--- a/src/site/solutions-providers.html
+++ b/src/site/solutions-providers.html
@@ -35,7 +35,7 @@
           <li><a href="/platform">Platform</a></li>
           <li><a href="/docs">Docs</a></li>
           <li><a href="https://github.com/aurelianware/cloudhealthoffice" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-          <li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
+          <li><a href="/founder">Founder</a></li><li><a href="/contact" style="color:#00ffff; font-weight:bold;">Contact Sales</a></li>
         </ul>
       </div>
     </div>
@@ -82,6 +82,7 @@
     <p style="opacity:0.6; font-size:0.9rem; margin-top:20px;">
       © 2026 Cloud Health Office • Built by healthcare payer system experts
     </p>
+      <p style="margin-top:18px;"><a href="/founder">Meet the founder &rarr;</a></p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Two related improvements to the founder page (`/founder`):

**1. Reachability — link the page from the whole site.** The founder page shipped previously but was only reachable by direct URL. This adds a **"Founder" link to the primary navigation and the footer on every page** that carries them (40 pages), so the page is reachable from anywhere.

- **Nav:** "Founder" inserted immediately before "Contact Sales" on all pages — the standard `mainNav` list pages plus the custom navs on the CMS-0057-F, Pricing, and Schedule-Demo pages.
- **Grid footers:** "Founder" added as the first link in the Contact column (Product column on the legal page, which has no Contact column).
- **Simple footers:** a "Meet the founder →" line added before the closing tag.

**2. Accuracy — correct the founder's tenure.** Updates the bio to reflect the real career history: **nearly two decades across QCSI, TriZetto, and Cognizant** — the lineage that created and evolved QNXT — plus **five years at Invidasys**. Touches the hero, stats tiles, pedigree band (adds QCSI), QNXT expertise card, narrative, SEO meta/OG/Twitter tags, and the `Person` schema `alumniOf`.

Changes are additive to navigation and content-only to the founder page — no existing links or content removed.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Benchmark/evidence
- [ ] Deployment/operations
- [x] Website navigation / content

## Validation

Commands run:

```text
# Every primary nav and every footer now links to /founder (scripted scan, 0 misses)
# founder.html JSON-LD parses; no stale tenure references remain
# Accessibility validator: 36 issues before and after (all pre-existing) — no new issues
node src/site/js/validate-accessibility.js
```

## Evidence And Limitations

- Affects website navigation and the founder page's own copy only. No benchmark claims, product docs, or screenshots are changed.
- Tenure figures ("nearly two decades", "five years") reflect the founder's own account of his history; client engagements remain unnamed.
- No new product capabilities — only links to, and copy on, an existing live page.

## Security And Privacy

- [x] No PHI, real member data, real claim data, tenant data, or secrets included.
- [x] Logs and screenshots are synthetic or sanitized.
- [x] Security-sensitive behavior is documented. (N/A — navigation and marketing copy only.)

## Docs

- [x] Docs updated, or not needed. (Not needed — no doc content changed.)
- [x] Links checked for files changed in this PR.
