### PR TITLE
Founder page: fix homepage mobile nav + correct tenure details

### DIFF
--- a/src/site/founder.html
+++ b/src/site/founder.html
@@ -13,7 +13,7 @@
     ============================================================================
   -->
 
-  <meta name="description" content="Mark Phillips, founder of Cloud Health Office — 25+ years in healthcare payer systems, including eleven years at TriZetto (the maker of QNXT), QNXT modernization at Cognizant, and core-systems architecture at Molina Healthcare. Deep expertise in QNXT, Azure, claims, authorizations, interoperability, and CMS-0057-F." />
+  <meta name="description" content="Mark Phillips, founder of Cloud Health Office — 25+ years in healthcare payer systems, including nearly two decades across QCSI, TriZetto, and Cognizant (the lineage that created QNXT) and five years at Invidasys, plus core-systems architecture at Molina Healthcare. Deep expertise in QNXT, Azure, claims, authorizations, interoperability, and CMS-0057-F." />
   <meta name="keywords" content="Cloud Health Office founder, healthcare payer solution architect, QNXT expert, Azure healthcare, CMS-0057-F, claims processing expert, payer modernization" />
   <link rel="canonical" href="https://cloudhealthoffice.com/founder" />
 
@@ -22,14 +22,14 @@
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="og:url" content="https://cloudhealthoffice.com/founder" />
   <meta property="og:title" content="Mark Phillips, Founder — Cloud Health Office" />
-  <meta property="og:description" content="25+ years in payer systems: eleven years at TriZetto (the maker of QNXT), QNXT modernization at Cognizant, and core-systems architecture at Molina Healthcare — now turned into an evidence-led platform." />
+  <meta property="og:description" content="25+ years in payer systems: nearly two decades across QCSI, TriZetto, and Cognizant (the lineage that created QNXT), five years at Invidasys, and core-systems architecture at Molina Healthcare — now turned into an evidence-led platform." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="https://cloudhealthoffice.com/founder" />
   <meta name="twitter:title" content="Mark Phillips, Founder — Cloud Health Office" />
-  <meta name="twitter:description" content="25+ years in payer systems: TriZetto (maker of QNXT), QNXT modernization at Cognizant, and architecture at Molina Healthcare — now an evidence-led platform." />
+  <meta name="twitter:description" content="25+ years in payer systems: ~20 across QCSI, TriZetto & Cognizant (the QNXT lineage), 5 at Invidasys, and architecture at Molina Healthcare — now an evidence-led platform." />
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- JSON-LD Structured Data -->
@@ -41,13 +41,14 @@
       "@type": "Person",
       "name": "Mark Phillips",
       "jobTitle": "Founder & Solution Architect",
-      "description": "Healthcare payer-systems architect with 25+ years of experience, including eleven years at The TriZetto Group (the maker of QNXT), QNXT modernization at Cognizant, and core-systems architecture at Molina Healthcare.",
+      "description": "Healthcare payer-systems architect with 25+ years of experience, including nearly two decades across QCSI, The TriZetto Group, and Cognizant (the lineage that created QNXT), five years at Invidasys, and core-systems architecture at Molina Healthcare.",
       "worksFor": {
         "@type": "Organization",
         "name": "Aurelianware, Inc.",
         "url": "https://cloudhealthoffice.com"
       },
       "alumniOf": [
+        { "@type": "Organization", "name": "QCSI (Quality Care Solutions)" },
         { "@type": "Organization", "name": "The TriZetto Group" },
         { "@type": "Organization", "name": "Cognizant" },
         { "@type": "Organization", "name": "Molina Healthcare" },
@@ -236,12 +237,12 @@
         <p class="role">Mark Phillips — Founder &amp; Solution Architect, Cloud Health Office</p>
         <p>
           Most payer software is sold by people who have never had to make a legacy core-admin
-          system pass an audit at 2&nbsp;a.m. I have. I spent eleven years at The&nbsp;TriZetto
-          Group — the company that created QNXT — went on to lead QNXT modernization at
-          Cognizant, and architected core systems on the payer side at Molina&nbsp;Healthcare.
-          Cloud Health Office is that quarter-century of claims, authorizations,
-          interoperability, and cloud experience turned into a platform you can inspect —
-          not a sales deck.
+          system pass an audit at 2&nbsp;a.m. I have. I spent nearly two decades across QCSI,
+          TriZetto, and Cognizant — the lineage that created and evolved QNXT — followed by five
+          years at Invidasys, and I architected core systems on the payer side at
+          Molina&nbsp;Healthcare. Cloud Health Office is that quarter-century of claims,
+          authorizations, interoperability, and cloud experience turned into a platform you can
+          inspect — not a sales deck.
         </p>
       </div>
       <div class="founder-portrait">
@@ -257,12 +258,12 @@
           <span class="stat-label">Years in healthcare payer systems</span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">11</span>
-          <span class="stat-label">Years at TriZetto<span class="stat-note">The maker of QNXT</span></span>
+          <span class="stat-number">~20</span>
+          <span class="stat-label">Years on the QNXT lineage<span class="stat-note">QCSI · TriZetto · Cognizant</span></span>
         </div>
         <div class="stat-item">
-          <span class="stat-number">2001</span>
-          <span class="stat-label">Building payer platforms since</span>
+          <span class="stat-number">5</span>
+          <span class="stat-label">Years at Invidasys</span>
         </div>
         <div class="stat-item">
           <span class="stat-number">1M+</span>
@@ -276,6 +277,7 @@
       <div class="pedigree">
         <p class="pedigree-label">A career spanning the companies that define payer technology</p>
         <div class="pedigree-logos">
+          <span class="pedigree-pill">QCSI</span>
           <span class="pedigree-pill">The TriZetto Group</span>
           <span class="pedigree-pill">Cognizant</span>
           <span class="pedigree-pill">Molina Healthcare</span>
@@ -299,10 +301,10 @@
       <div class="feature-grid">
         <div class="feature-card">
           <h3>QNXT &amp; legacy core-admin modernization</h3>
-          <p>Eleven years at The TriZetto Group — where QNXT was built — and QNXT modernization
-          leadership at Cognizant. I know these platforms and their Facets-class peers from the
-          inside: how to modernize them without ripping them out, and exactly which decisions
-          are safe to make and which aren't.</p>
+          <p>Nearly two decades across QCSI, TriZetto, and Cognizant — the lineage that created
+          and evolved QNXT — including modernization leadership at Cognizant. I know these
+          platforms and their Facets-class peers from the inside: how to modernize them without
+          ripping them out, and exactly which decisions are safe to make and which aren't.</p>
         </div>
         <div class="feature-card">
           <h3>Azure &amp; cloud-native delivery</h3>
@@ -341,8 +343,8 @@
     <section class="section" style="max-width:860px; margin:0 auto; padding:20px 40px 40px;">
       <h2 style="color:#fff;">Why I built Cloud Health Office</h2>
       <p style="line-height:1.8; color:rgba(200,200,200,0.9); font-size:1.06rem;">
-        I've spent my whole career in payer core administration — building it at The&nbsp;TriZetto
-        Group, modernizing QNXT at Cognizant, and architecting systems inside a health plan at
+        I've spent my whole career in payer core administration — building QNXT across QCSI,
+        TriZetto, and Cognizant, and architecting systems inside a health plan at
         Molina&nbsp;Healthcare. Everywhere I went, the pattern was the same: a capable platform
         that predates the regulations now being written for it, an urgent compliance deadline,
         and a gap in the middle that gets filled with consulting hours instead of software. I

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -172,6 +172,15 @@
       .proof-quote {
         padding-left: 20px;
       }
+
+      /* Mobile menu: lay the open menu out as block flow rather than a flex
+         column. The homepage nav contains the "Platform" dropdown, and under
+         flex-column + max-height the submenu was compressed out of flow and
+         overlapped the links below it (Docs, Founding Client, Founder,
+         Contact Sales). Block flow lets the submenu push those items down. */
+      nav ul#mainNav.mobile-menu-open {
+        display: block;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

Follow-up to #1053 (which landed the site-wide "Founder" nav/footer links). These changes were pushed after that PR merged, so they need a fresh PR:

1. **Homepage mobile nav fix.** On mobile, the homepage nav is a flex column with a capped height, which compressed the "Platform" dropdown submenu out of flow so it rendered on top of the links below it — hiding Docs, Founding Client, Founder, and Contact Sales. Laying the open menu out as block flow (scoped to the homepage, the only page with the dropdown) fixes it. Verified in a 390px mobile viewport: all 15 links stack in order with no overlap, and the menu scrolls to reach Contact Sales.

2. **Correct the founder's tenure.** Reflect the real history: **nearly two decades across QCSI, TriZetto, and Cognizant** — the lineage that created and evolved QNXT — plus **five years at Invidasys**. Updates the hero, stats tiles (QNXT-lineage and Invidasys, replacing the earlier "11 years at TriZetto" tile), pedigree band (adds QCSI), QNXT expertise card, narrative, SEO meta/OG/Twitter, and the `Person` schema `alumniOf`.

## Type

- [x] Bug fix (homepage mobile nav)
- [ ] Feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Benchmark/evidence
- [ ] Deployment/operations
- [x] Website content

## Validation

Commands run:

```text
# Homepage mobile menu rendered in a 390px viewport (headless Chromium):
#   15 links, 0 overlap, scrollable, Founder + Contact Sales reachable
# founder.html JSON-LD parses; accessibility validator unchanged (36 pre-existing)
node src/site/js/validate-accessibility.js
```

## Evidence And Limitations

- Affects the homepage's mobile nav CSS and the founder page's own copy only. No benchmark claims, product docs, or other pages changed.
- Tenure figures reflect the founder's own account of his history; client engagements remain unnamed.
- No new product capabilities.

## Security And Privacy

- [x] No PHI, real member data, real claim data, tenant data, or secrets included.
- [x] Logs and screenshots are synthetic or sanitized.
- [x] Security-sensitive behavior is documented. (N/A — nav CSS and marketing copy only.)

## Docs

- [x] Docs updated, or not needed. (Not needed.)
- [x] Links checked for files changed in this PR.
