### PR TITLE
Refresh /founder sitemap lastmod

### DIFF
--- a/src/site/sitemap.xml
+++ b/src/site/sitemap.xml
@@ -27,7 +27,7 @@
   </url>
   <url>
     <loc>https://cloudhealthoffice.com/founder</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>


### PR DESCRIPTION
## Summary

The founder page (`/founder`) is already listed in `sitemap.xml`, so no new URL is needed. This bumps its `<lastmod>` from `2026-07-28` to `2026-07-29` to reflect the recent bio update (the QNXT-lineage tenure correction), prompting search engines to re-crawl the current content. No other entries changed.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Benchmark/evidence
- [ ] Deployment/operations
- [x] SEO / website metadata

## Validation

```text
# sitemap.xml well-formed: 55 <url> open/close tags balanced; /founder lastmod = 2026-07-29
```

## Evidence And Limitations

- Metadata-only change to `sitemap.xml`. No page content, navigation, or product behavior changed.

## Security And Privacy

- [x] No PHI, real member data, real claim data, tenant data, or secrets included.
- [x] Logs and screenshots are synthetic or sanitized.
- [x] Security-sensitive behavior is documented. (N/A — sitemap metadata only.)

## Docs

- [x] Docs updated, or not needed. (Not needed.)
- [x] Links checked for files changed in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q61UBnuxN6MHBFHPtGHTCW)_