### PR TITLE
Simplify the homepage around a single dominant Founding Client CTA

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Cloud Health Office — Evidence-Led Payer Platform</title>
-  <meta name="description" content="Cloud Health Office is a source-available payer platform with inspectable evidence: a 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <title>Cloud Health Office — Meet CMS-0057-F Without Replacing Your Core</title>
+  <meta name="description" content="Deploy a CMS-0057-F compliance and modernization layer alongside QNXT, Facets, or HealthEdge — meet the mandate in weeks, then modernize on your timeline. Source-available, evidence-led, deploy in your own cloud." />
   <meta name="keywords" content="CMS-0057-F compliance, healthcare payer integration platform, FHIR R4 API health plan, X12 EDI to FHIR, healthcare clearinghouse integration, health plan modernization" />
   <link rel="canonical" href="https://cloudhealthoffice.com/" />
 
@@ -12,15 +12,15 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Cloud Health Office" />
   <meta property="og:url" content="https://cloudhealthoffice.com/" />
-  <meta property="og:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
-  <meta property="og:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <meta property="og:title" content="Cloud Health Office — Meet CMS-0057-F Without Replacing Your Core" />
+  <meta property="og:description" content="Deploy a CMS-0057-F compliance and modernization layer alongside QNXT, Facets, or HealthEdge — meet the mandate in weeks, then modernize on your timeline. Source-available, deploy in your own cloud." />
   <meta property="og:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="https://cloudhealthoffice.com/" />
-  <meta name="twitter:title" content="Cloud Health Office — Evidence-Led Payer Platform" />
-  <meta name="twitter:description" content="Source-available payer infrastructure with inspectable benchmark evidence: 1,000,000-claim local Kubernetes validation, CMS-0057-F APIs, X12/FHIR workflows, and your-cloud deployment." />
+  <meta name="twitter:title" content="Cloud Health Office — Meet CMS-0057-F Without Replacing Your Core" />
+  <meta name="twitter:description" content="Deploy a CMS-0057-F compliance and modernization layer alongside QNXT, Facets, or HealthEdge — meet the mandate in weeks, then modernize on your timeline. Source-available, deploy in your own cloud." />
   <meta name="twitter:image" content="https://cloudhealthoffice.com/graphics/logo-cloudhealthoffice-sentinel-primary.svg" />
 
   <!-- JSON-LD Structured Data -->
@@ -203,13 +203,13 @@
     gap: 10px;
     flex-wrap: wrap;
   ">
-    <span>Latest proof: 1,000,000 claims through asynchronous Service Bus adjudication at 155.89 claims/sec, with every claim eventually terminal.</span>
-    <a href="/docs/million-claim-challenge/evidence#episode-016" style="
+    <span>Founding Client Program: one health plan, zero licensing cost, deployed in your own cloud.</span>
+    <a href="#founding-partner-form" style="
       color: #00ff88;
       font-weight: 600;
       text-decoration: none;
       white-space: nowrap;
-    " aria-label="Inspect the Million Claim Challenge evidence archive">Inspect evidence &rarr;</a>
+    " aria-label="Apply for the Founding Client Program">Apply now &rarr;</a>
     <button id="fp-banner-dismiss" aria-label="Dismiss founding client banner" style="
       background: none;
       border: none;
@@ -300,55 +300,46 @@
         <div class="hero-badge">Source-Available &nbsp;&middot;&nbsp; Evidence-Led &nbsp;&middot;&nbsp; Kubernetes-Native</div>
 
         <h1 class="hero-headline">
-          Claims platform evidence<br>
-          you can inspect.
+          Meet CMS-0057-F without<br>
+          replacing your core system.
         </h1>
 
         <p class="hero-subheadline">
-          Cloud Health Office is source-available payer infrastructure with published local Kubernetes evidence:
-          1,000,000 claims through asynchronous Service Bus adjudication at 155.89 claims/sec, every claim eventually terminal,
-          and a separate 100,000-claim raw X12 837 run at 199.42 claims/sec end-to-end.
-          <br>
-          Deployable in your cloud for technical evaluation and pilot-scoped engagements.
+          Cloud Health Office deploys a compliance and modernization layer alongside QNXT, Facets, or HealthEdge &mdash;
+          so you can meet the mandate in weeks, then modernize on your own timeline. No multi-year replatform.
         </p>
 
         <div class="hero-cta">
-          <a href="/docs/million-claim-challenge/evidence#episode-016"
+          <a href="#founding-partner-form"
              class="button"
-             style="font-size:1.05rem; padding:15px 38px;">Inspect the 1M evidence &rarr;</a>
-          <a href="/insights/million-claim-challenge/part-16-the-million-went-through-the-bus"
+             style="font-size:1.05rem; padding:15px 38px;">Apply for the Founding Client Program &rarr;</a>
+          <a href="/docs/million-claim-challenge/evidence#episode-016"
              class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;">Read Part 16 &rarr;</a>
-          <a href="https://github.com/aurelianware/cloudhealthoffice"
-             class="button button-secondary"
-             style="font-size:1.05rem; padding:15px 38px;"
-             target="_blank" rel="noopener noreferrer">View Source &rarr;</a>
+             style="font-size:1.05rem; padding:15px 38px;">View the public evidence &rarr;</a>
         </div>
       </div>
 
       <div class="hero-scroll-hint" aria-hidden="true">&darr; SCROLL</div>
     </section>
 
-    <!-- ===== CMS-0057-F EXPLAINER STRIP ===== -->
-    <section id="cms-explainer" aria-label="Why CMS-0057-F changes everything" style="
+    <!-- ===== PROBLEM + SOLUTION STATEMENT ===== -->
+    <section id="cms-explainer" aria-label="The CMS-0057-F problem and the low-risk path" style="
       background: linear-gradient(90deg, #000d1a 0%, #001a0a 50%, #000d1a 100%);
       border-top: 1px solid rgba(0,255,136,0.2);
       border-bottom: 1px solid rgba(0,255,136,0.2);
       padding: 40px 24px;
     ">
       <div style="max-width: 860px; margin: 0 auto; text-align: center;">
-        <span class="section-eyebrow" style="color:#00ff88;">CMS-0057-F</span>
+        <span class="section-eyebrow" style="color:#00ff88;">The problem &mdash; and the low-risk path</span>
         <h2 style="font-size: clamp(1.4rem, 3vw, 2rem); color:#00ff88; text-shadow:0 0 20px rgba(0,255,136,0.3); margin: 12px 0 20px 0;">
-          Compliance still matters. Evidence makes it credible.
+          The deadline is real. A full core replacement isn&rsquo;t the only answer.
         </h2>
         <p style="font-size: 1rem; color: rgba(200,200,200,0.85); line-height: 1.75; margin: 0 auto 24px auto; max-width: 720px;">
-          CMS-0057-F raises the bar for payer interoperability, prior authorization APIs, payer-to-payer exchange,
-          and operational auditability. Teams that wait until the compliance window is fully open will spend the following year
-          reconciling vendors, interfaces, and evidence after the fact.
+          CMS-0057-F requires new FHIR APIs for patient access, prior authorization, and payer-to-payer exchange.
+          Waiting risks a scramble; ripping out your core admin system risks a multi-year, high-stakes project you don&rsquo;t have time for.
           <br><br>
-          The organizations that engage now &mdash; validating workflows, building attribution logic, proving
-          interoperability, and testing real adjudication behavior &mdash; will enter the compliance window with evidence,
-          not only vendor promises.
+          Cloud Health Office is the low-risk path: a compliance layer that sits <strong>alongside</strong> your existing core.
+          You meet the mandate in weeks &mdash; then modernize domain by domain, at your own pace, with your system of record intact.
         </p>
         <a href="/cms-0057f-compliance" class="button button-secondary" style="font-size:0.95rem; padding:12px 28px;">
           Read the CMS-0057-F Summary &rarr;
@@ -378,38 +369,26 @@
         <div class="feature-grid">
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x2601;&#xFE0F;</div>
-            <h3 style="color:#00ff88;">Zero Software Licensing</h3>
-            <p>No licensing fees during the founding engagement. Host on your Azure, AWS, or GCP subscription. You own your data &mdash; and retain full ownership permanently, regardless of the vendor relationship.</p>
+            <h3 style="color:#00ff88;">Zero Licensing, Your Cloud</h3>
+            <p>No licensing fees during the founding engagement. Deploy in your own Azure, AWS, or GCP subscription. You own your data and retain that ownership permanently.</p>
           </div>
 
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x1F4CB;</div>
             <h3 style="color:#00ff88;">Direct Engineering Access</h3>
-            <p>Work side-by-side with the product engineering team. Your operational priorities become sprint priorities. Implementation assistance and priority support are included throughout the engagement.</p>
+            <p>Work side-by-side with the engineers building the platform. Your operational priorities become their sprint priorities, with implementation help throughout.</p>
           </div>
 
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x1F9ED;</div>
             <h3 style="color:#00ff88;">Roadmap Influence</h3>
-            <p>Shape the direction of the platform from the inside. As our Founding Client, you gain early access to new capabilities and the opportunity to help define what gets built next.</p>
+            <p>Shape the platform from the inside. As our Founding Client you get early access to new capabilities and help define what gets built next.</p>
           </div>
 
           <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
             <div class="feature-icon" aria-hidden="true">&#x2705;</div>
             <h3 style="color:#00ff88;">CMS-0057-F Pilot Path</h3>
-            <p>Validate documented, tested implementations of prior authorization APIs, payer-to-payer exchange, and provider access APIs &mdash; before the compliance window closes.</p>
-          </div>
-
-          <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
-            <div class="feature-icon" aria-hidden="true">&#x1F3C6;</div>
-            <h3 style="color:#00ff88;">Early Adopter Advantage</h3>
-            <p>Be first to market with a fully integrated, cloud-native health plan administration platform. Optional opportunity to serve as a reference customer and establish category leadership.</p>
-          </div>
-
-          <div class="feature-card" style="border-color: rgba(0,255,136,0.2);">
-            <div class="feature-icon" aria-hidden="true">&#x1F512;</div>
-            <h3 style="color:#00ff88;">Enterprise-Grade Controls</h3>
-            <p>HIPAA-oriented controls, RBAC, audit logging, and deployment isolation from day one. Built for health plan compliance requirements &mdash; not retrofitted after the fact.</p>
+            <p>Validate documented, tested implementations of the prior authorization, payer-to-payer, and provider access APIs &mdash; before the compliance window closes.</p>
           </div>
         </div>
 
@@ -519,56 +498,6 @@
               logic, and prioritize your roadmap based on measurable findings.
             </p>
             <p style="font-size: 0.82rem; color: rgba(0,255,136,0.5); margin-top: 14px; font-weight: 600;">Ongoing collaboration</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ===== WHO IS THIS FOR? ===== -->
-    <section aria-labelledby="audience-heading" style="padding: 0 24px 20px; background: #000;">
-      <div class="section-wrapper" style="padding-bottom: 32px;">
-        <div class="section-header" style="margin-bottom: 40px;">
-          <span class="section-eyebrow">Who is this for?</span>
-          <h2 id="audience-heading" class="section-title">Built for payer infrastructure.</h2>
-          <p class="section-subtitle">Cloud Health Office is the compliance and modernization layer for health plans, TPAs, and payer operations teams running on legacy core admin systems.</p>
-        </div>
-      </div>
-      <div class="audience-tabs">
-        <div class="feature-grid">
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#9889;</div>
-            <h3>CMS-0057-F Compliance</h3>
-            <p>Compliance surface for the CMS Interoperability and Prior Authorization Rule, deployable alongside existing core admin systems without replacing the adjudication path.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128279;</div>
-            <h3>Multi-Clearinghouse EDI</h3>
-            <p>Multi-clearinghouse integration patterns for Availity, Change Healthcare, Optum, and Inovalon, with source-visible implementation and configurable routing.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128260;</div>
-            <h3>X12 to FHIR R4 Transformation</h3>
-            <p>Automated transformation of X12 EDI transactions (270/837/278/835) to FHIR R4 resources, designed for repeatable validation and tenant-aware operation.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#127973;</div>
-            <h3>Legacy Core Augmentation</h3>
-            <p>Sits alongside QNXT, Facets, HealthEdge, or Amisys. Reads from your existing system, exposes FHIR R4 APIs &mdash; without touching your core operations.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128274;</div>
-            <h3>HIPAA-Grade Security</h3>
-            <p>BAA-ready operating model, automated dependency scanning, encryption, PHI-aware telemetry controls, audit trails, and compliance reporting foundations.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#127760;</div>
-            <h3>Flexible Deployment</h3>
-            <p>Kubernetes-native architecture with Argo Workflows on AKS, EKS, or GKE. Container-based microservices with full infrastructure ownership. Deploy to your own subscription.</p>
-          </div>
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128184;</div>
-            <h3>Premium Billing &amp; ACH</h3>
-            <p>Automated monthly premium invoicing with NACHA/ACH file generation, EFT draft lifecycle management, and Stripe ACH integration. Batch billing runs with sponsor-level invoicing and audit trails.</p>
           </div>
         </div>
       </div>
@@ -897,250 +826,53 @@
 
     </script>
 
-    <!-- ===== PORTFOLIO ===== -->
-    <section aria-label="Four product lines portfolio">
+    <!-- ===== WHO IS THIS FOR + CORE VALUE ===== -->
+    <section aria-labelledby="audience-heading">
       <div class="section-wrapper">
         <div class="section-header">
-          <span class="section-eyebrow">The Portfolio</span>
-          <h2 class="section-title">Four product lines.<br><span>One platform.</span></h2>
-          <p class="section-subtitle">Cloud Health Office engages customers across four complementary product lines, each a coherent offering on its own, each connecting naturally to the next. Enter where the pain is. Expand where the leverage is.</p>
+          <span class="section-eyebrow">Who it's for</span>
+          <h2 id="audience-heading" class="section-title">Built for payer operations teams.</h2>
+          <p class="section-subtitle">For Medicaid MCOs, Medicare Advantage plans, and TPAs running on QNXT, Facets, HealthEdge, or Amisys &mdash; four outcomes, all alongside your existing core.</p>
         </div>
 
         <div class="feature-grid">
           <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128221;</div>
-            <h3>Public Tools</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Free utilities. No signup.</strong></p>
-            <p>Fee schedule lookup and free-tier claims repricing. Verify the calculation engines before any commercial conversation begins.</p>
+            <div class="feature-icon" aria-hidden="true">&#9889;</div>
+            <h3>CMS-0057-F Compliance Surface</h3>
+            <p>The FHIR APIs the mandate requires &mdash; patient access, prior authorization, payer-to-payer &mdash; running alongside your core without replacing the adjudication path.</p>
           </div>
-
           <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128640;</div>
-            <h3>Transactional Services</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Per-call APIs. Self-serve subscription.</strong></p>
-            <p>Claims Repricing API and Pricing API for developers, billing companies, TPAs, and integrators. Free tier flows to paid tier on usage.</p>
+            <div class="feature-icon" aria-hidden="true">&#128279;</div>
+            <h3>Multi-Clearinghouse EDI + Prior Auth</h3>
+            <p>One connection across Availity, Change Healthcare, Optum, and Inovalon, with automated prior authorization workflows that replace manual and fax-based review.</p>
           </div>
-
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128202;</div>
-            <h3>Managed Data Services</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Subscription data. Recurring value.</strong></p>
-            <p>State Medicaid compliance updates, CMS fee schedule updates, provider verification, terminology mapping. Healthcare data that changes constantly &mdash; tracked for you.</p>
-          </div>
-
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#127970;</div>
-            <h3>Platform Engagement</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Payer-scale. Priced PMPM.</strong></p>
-            <p>Multi-year relationships priced per member per month, across three layers: Compliance Accelerator, Progressive Modernization, and Full CAPS Platform.</p>
-          </div>
-        </div>
-
-        <p style="text-align:center; margin-top:32px; font-size:0.95rem; color:rgba(176,176,176,0.7);">
-          See <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">POSITIONING.md</a> for the canonical framing.
-        </p>
-      </div>
-    </section>
-
-    <!-- ===== CHOOSE YOUR ENTRY POINT ===== -->
-    <section aria-label="Platform Engagement three-layer structure">
-      <div class="section-wrapper">
-        <div class="section-header">
-          <span class="section-eyebrow">Choose your entry point</span>
-          <h2 class="section-title">Three layers.<br><span>One Platform Engagement.</span></h2>
-          <p class="section-subtitle">Within Platform Engagement, Cloud Health Office engages customers at three layers, each a coherent product on its own, each containing the previous. Meet us where your constraints are.</p>
-        </div>
-
-        <div class="feature-grid">
-          <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#128737;</div>
-            <h3>Layer 1 &mdash; Compliance Accelerator</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Meet CMS-0057-F without replacing your core.</strong></p>
-            <p>FHIR compliance surface deployable alongside your existing QNXT, HealthEdge, or Facets. Weeks-to-deploy pilot path.</p>
-            <p style="margin-top:20px;">
-              <a href="/cms-0057f-compliance" class="button button-secondary" style="font-size:0.9rem; padding:10px 22px;">See compliance details &rarr;</a>
-            </p>
-          </div>
-
           <div class="feature-card">
             <div class="feature-icon" aria-hidden="true">&#128260;</div>
-            <h3>Layer 2 &mdash; Progressive Modernization</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">Replace your legacy core, one domain at a time.</strong></p>
-            <p>The strangler-fig path &mdash; your system of record stays stable while Cloud Health Office takes over appeals, then capitation, then claims, at your pace. Appeals shipped and validated first.</p>
-            <p style="margin-top:20px;">
-              <a href="/platform" class="button button-secondary" style="font-size:0.9rem; padding:10px 22px;">See the appeals reference implementation &rarr;</a>
-            </p>
+            <h3>Progressive Modernization</h3>
+            <p>A strangler-fig path to replace your legacy core one domain at a time, on your schedule. Your system of record stays authoritative until you choose to cut over.</p>
           </div>
-
           <div class="feature-card">
-            <div class="feature-icon" aria-hidden="true">&#9729;&#65039;</div>
-            <h3>Layer 3 &mdash; Full CAPS Platform</h3>
-            <p style="color:rgba(176,176,176,0.7); font-size:0.95rem; margin-bottom:8px;"><strong style="color:#00ffff;">End-to-end cloud-native claims administration.</strong></p>
-            <p>36 services, 9 engines, Argo-orchestrated adjudication, full X12 EDI. For new entrants today; for established payers, the milestone after Layer 2.</p>
-            <p style="margin-top:20px;">
-              <a href="/platform" class="button button-secondary" style="font-size:0.9rem; padding:10px 22px;">See the platform inventory &rarr;</a>
-            </p>
+            <div class="feature-icon" aria-hidden="true">&#127760;</div>
+            <h3>Source-Available, Your Cloud</h3>
+            <p>Inspect every line and deploy in your own Azure, AWS, or GCP subscription. No black-box vendor lock-in; your data never leaves your walls.</p>
           </div>
-        </div>
-
-        <p style="text-align:center; margin-top:32px; font-size:0.95rem; color:rgba(176,176,176,0.7);">
-          Not sure where to start? See <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">POSITIONING.md</a>.
-        </p>
-      </div>
-    </section>
-
-    <!-- ===== PLATFORM PREVIEW SCREENSHOT ===== -->
-    <section id="platform-preview" style="
-      padding: 4rem 2rem 2rem;
-      max-width: 1200px;
-      margin: 0 auto;
-      text-align: center;
-    ">
-      <div style="
-        display: inline-block;
-        padding: 0.25rem 1rem;
-        border: 1px solid rgba(0, 240, 255, 0.2);
-        border-radius: 100px;
-        font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
-        font-size: 0.7rem;
-        letter-spacing: 0.15em;
-        color: rgba(0, 240, 255, 0.7);
-        text-transform: uppercase;
-        margin-bottom: 1.5rem;
-      ">Platform Engagement · Layer 1 to Layer 3</div>
-
-      <div style="
-        max-width: 1100px;
-        margin: 0 auto;
-        border-radius: 12px;
-        overflow: hidden;
-        box-shadow:
-          0 0 0 1px rgba(0, 240, 255, 0.08),
-          0 25px 80px rgba(0, 0, 0, 0.6),
-          0 0 60px rgba(0, 240, 255, 0.04);
-        position: relative;
-      ">
-        <div style="
-          background: #0d1117;
-          padding: 12px 16px;
-          display: flex;
-          align-items: center;
-          gap: 8px;
-          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-        ">
-          <div style="display: flex; gap: 6px; margin-right: 12px;">
-            <div style="width: 10px; height: 10px; border-radius: 50%; background: #ff5f57;"></div>
-            <div style="width: 10px; height: 10px; border-radius: 50%; background: #febc2e;"></div>
-            <div style="width: 10px; height: 10px; border-radius: 50%; background: #28c840;"></div>
-          </div>
-          <div style="
-            flex: 1;
-            background: rgba(255, 255, 255, 0.05);
-            border: 1px solid rgba(255, 255, 255, 0.08);
-            border-radius: 6px;
-            padding: 5px 14px;
-            font-family: 'JetBrains Mono', 'SF Mono', monospace;
-            font-size: 0.7rem;
-            color: rgba(255, 255, 255, 0.4);
-            display: flex;
-            align-items: center;
-            gap: 6px;
-          ">
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" style="flex-shrink: 0;">
-              <path d="M8 1a5 5 0 0 0-5 5v2a2 2 0 0 0-2 2v3a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2V6a5 5 0 0 0-5-5zm3 7V6a3 3 0 1 0-6 0v2h6z" fill="rgba(40,200,64,0.7)"/>
-            </svg>
-            local-demo/operations/work-queues
-          </div>
-        </div>
-
-        <img
-          src="/graphics/platform-work-queues.png"
-          alt="Cloud Health Office Claims Work Queues — showing NCCI/MUE Edit Failures, Missing Prior Auth, Provider Not Contracted, COB/Other Payer, and Medical Review queues with real claim data"
-          style="
-            width: 100%;
-            display: block;
-            background: #080c14;
-          "
-          loading="lazy"
-        />
-      </div>
-
-      <p style="
-        margin-top: 1.25rem;
-        font-family: 'Inter', -apple-system, sans-serif;
-        font-size: 0.8rem;
-        color: rgba(255, 255, 255, 0.35);
-        letter-spacing: 0.02em;
-      ">
-        Claims Work Queues — NCCI/MUE edits, prior auth, COB, provider contracting, and medical review.
-        <span style="color: rgba(0, 240, 255, 0.5);">Cloud Health Office</span>
-      </p>
-    </section>
-    <style>
-      @media (max-width: 768px) {
-        #platform-preview {
-          padding: 2rem 1rem 1rem !important;
-        }
-      }
-    </style>
-
-    <!-- ===== TICKER ===== -->
-    <div class="ticker-section" aria-label="Platform highlights">
-      <div class="ticker-track" aria-hidden="true">
-        <span class="ticker-item"><span>Source-Available on GitHub</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Automated Dependency &amp; Secret Scanning</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Automated Test Suite</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>CMS-0057-F Readiness Surface</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>36 Microservices, 9 Engines</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Weeks-to-Deploy Pilot Path</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>HIPAA-Oriented Infrastructure</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Source-Available on GitHub</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Automated Dependency &amp; Secret Scanning</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Automated Test Suite</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>CMS-0057-F Readiness Surface</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>36 Microservices, 9 Engines</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Multi-Tenant Architecture</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>Weeks-to-Deploy Pilot Path</span><span class="ticker-dot">&#9670;</span></span>
-        <span class="ticker-item"><span>HIPAA-Oriented Infrastructure</span><span class="ticker-dot">&#9670;</span></span>
-      </div>
-    </div>
-
-    <!-- ===== STATS ===== -->
-    <section class="stats-section" aria-label="Platform statistics">
-      <div class="stats-inner">
-        <div class="stat-item">
-          <span class="stat-number">1M</span>
-          <span class="stat-label">Local<br>Validation</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-number">0</span>
-          <span class="stat-label">Platform<br>Failures</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-number">99.99%</span>
-          <span class="stat-label">Scoreable<br>Match Rate</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-number">20,000</span>
-          <span class="stat-label">Payment Checks<br>Within One Cent</span>
         </div>
       </div>
     </section>
 
-    <!-- ===== MILLION CLAIM CHALLENGE + RECENT ACTIVITY ===== -->
-    <section class="compliance-section" aria-label="Million Claim Challenge and recent platform activity">
+    <!-- ===== PROOF (MILLION CLAIM CHALLENGE) ===== -->
+    <section class="compliance-section" aria-label="Million Claim Challenge proof">
       <div class="section-wrapper">
         <div class="section-header">
           <span class="section-eyebrow" style="color:#00ffff;">Million Claim Challenge</span>
-          <h2 class="section-title">The proof ladder is public.</h2>
-          <p class="section-subtitle">The Million Claim Challenge is designed for one million deterministic synthetic claims across professional, institutional, dental, and 29 named edge-case scenarios. The latest run moved the full corpus onto asynchronous Service Bus adjudication: 155.89 claims/sec, all 1,000,000 eventually terminal, 2,000,000 lifecycle events, zero dead letters, and 19,982/19,982 observed payment comparisons exact.</p>
+          <h2 class="section-title">The proof is public.</h2>
+          <p class="section-subtitle">We validated adjudication at one million deterministic synthetic claims &mdash; and we publish the honest limits alongside the numbers.</p>
         </div>
 
         <div class="stats-inner" style="margin: 32px 0;">
           <div class="stat-item">
-            <span class="stat-number">129,980</span>
-            <span class="stat-label">Workflow Checks<br>Matched</span>
+            <span class="stat-number">1M</span>
+            <span class="stat-label">Claims<br>Adjudicated</span>
           </div>
           <div class="stat-item">
             <span class="stat-number">155.89</span>
@@ -1156,51 +888,50 @@
           </div>
         </div>
 
-        <div style="text-align:center; margin-bottom:48px;">
-          <a href="/docs/million-claim-challenge/evidence#episode-016" class="button">Inspect the Latest Evidence &rarr;</a>
-          <a href="/docs/million-claim-challenge" class="button button-secondary">Explore the Benchmark Methodology &rarr;</a>
-        </div>
-
-        <div class="section-header">
-          <span class="section-eyebrow" style="color:#00ff88;">What the Evidence Says</span>
-          <h2 class="section-title" style="font-size:1.4rem;">Faster, asynchronous, and still disclosed honestly.</h2>
-        </div>
-        <p style="text-align:center; color:#999; max-width:700px; margin:0 auto 24px;">
-          The latest 1M result is local Docker Desktop Kubernetes validation, not a production-cloud capacity claim. The validator
-          recorded 122 claims outside its 180-second observation window; post-run verification found all 1,000,000 terminal,
-          with zero dead letters, pod restarts, or claims-service error logs. Part 15's 123.81 claims/sec run remains the strict
-          zero-platform-failure baseline; Part 16 records the faster 155.89 claims/sec asynchronous path and its limitation.
+        <p style="text-align:center; color:#999; max-width:720px; margin:0 auto 28px;">
+          These figures are from local Docker Desktop Kubernetes validation, not a production-cloud capacity claim.
+          Every one of the 1,000,000 claims was verified terminal, with zero dead letters or pod restarts.
         </p>
+
         <div style="text-align:center;">
-          <a href="/insights/million-claim-challenge/part-16-the-million-went-through-the-bus" class="button button-secondary">Read Part 16 &rarr;</a>
+          <a href="/docs/million-claim-challenge/evidence#episode-016" class="button">Inspect the Evidence Archive &rarr;</a>
+          <a href="/insights/million-claim-challenge/part-16-the-million-went-through-the-bus" class="button button-secondary">Read the Part 16 Write-up &rarr;</a>
         </div>
       </div>
     </section>
 
-    <!-- ===== PLATFORM FEATURES ===== -->
-
-    <!-- ===== CMS-0057-F COMPLIANCE ===== -->
-    <section class="compliance-section">
+    <!-- ===== THREE LAYERS (SECONDARY) ===== -->
+    <section aria-label="Three-layer engagement model">
       <div class="section-wrapper">
         <div class="section-header">
-          <span class="section-eyebrow" style="color:#00ff88;">CMS-0057-F</span>
-          <h2 class="section-title" style="color:#00ff88; text-shadow:0 0 30px rgba(0,255,136,0.35);">CMS-0057-F Surface, Source Visible.</h2>
-          <p class="section-subtitle">The compliance APIs are implemented and inspectable today. Production readiness, integrations, and operating evidence should be validated in each payer environment.</p>
+          <span class="section-eyebrow">Where you start</span>
+          <h2 class="section-title">Three layers, at your pace.</h2>
+          <p class="section-subtitle">Most established payers start at Layer 1 &mdash; compliance &mdash; and expand only when they're ready. Same platform, same team, no new vendor.</p>
         </div>
 
-        <figure style="margin:0 auto 40px auto; max-width:1000px;">
-          <img src="graphics/cms-0057f-compliance.svg"
-               alt="CMS-0057-F compliance diagram showing Patient Access API, Provider Access API, Prior Authorization, Payer-to-Payer API, and Provider Directory API — all complete"
-               style="width:100%; height:auto; border-radius:12px; border:1px solid rgba(0,255,136,0.15);" />
-        </figure>
+        <div class="feature-grid">
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#128737;</div>
+            <h3>Layer 1 &mdash; Compliance Accelerator</h3>
+            <p>Meet CMS-0057-F without replacing your core. FHIR compliance surface deployable alongside QNXT, HealthEdge, or Facets, on a weeks-to-deploy pilot path. <strong style="color:#00ffff;">Most payers start here.</strong></p>
+          </div>
 
-        <div class="compliance-badges" role="list" aria-label="Compliance certifications">
-          <span class="compliance-badge-item" role="listitem">&#10003; Patient Access API</span>
-          <span class="compliance-badge-item" role="listitem">&#10003; Provider Access API</span>
-          <span class="compliance-badge-item" role="listitem">&#10003; Prior Authorization API</span>
-          <span class="compliance-badge-item" role="listitem">&#10003; Payer-to-Payer API</span>
-          <span class="compliance-badge-item" role="listitem">&#10003; Da Vinci IGs</span>
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#128260;</div>
+            <h3>Layer 2 &mdash; Progressive Modernization</h3>
+            <p>Replace your legacy core one domain at a time. Your system of record stays stable while Cloud Health Office takes over a domain at your pace. Appeals shipped and validated first.</p>
+          </div>
+
+          <div class="feature-card">
+            <div class="feature-icon" aria-hidden="true">&#9729;&#65039;</div>
+            <h3>Layer 3 &mdash; Full Platform</h3>
+            <p>End-to-end cloud-native claims administration. For new entrants today; for established payers, the eventual milestone once earlier domains have cut over.</p>
+          </div>
         </div>
+
+        <p style="text-align:center; margin-top:32px; font-size:0.95rem; color:rgba(176,176,176,0.7);">
+          <a href="/platform" style="color:#00ffff;">See the full platform &rarr;</a>
+        </p>
       </div>
     </section>
 
@@ -1211,8 +942,7 @@
         Deploy in your cloud. Go live with your team. Move without betting your operations on a replatform.
       </p>
       <div>
-        <a href="#founding-partner-form" class="button">Become Our Founding Client &rarr;</a>
-        <a href="/cms-0057f-compliance" class="button button-secondary">Read the CMS-0057-F Guide &rarr;</a>
+        <a href="#founding-partner-form" class="button">Apply for the Founding Client Program &rarr;</a>
       </div>
       <div>
         <a href="/schedule-demo" class="schedule-link">Prefer to talk first? Schedule a discovery call &rarr;</a>


### PR DESCRIPTION
## Summary

Restructures the homepage (`/`) into a clear **problem → solution → offer → proof** hierarchy so a busy payer executive can scan it in under 45 seconds, and makes the **Founding Client Program** the unmistakable primary conversion path. The page previously ran several competing narratives (evidence-led hero, four product lines, three layers, a portfolio, a screenshot, a ticker, and duplicate proof/stat blocks) that diluted the offer and repeated the same benchmark numbers four times. It drops from 1274 to ~1000 lines (86 insertions, 356 deletions).

New order:
- **Hero** — leads with the problem/outcome ("Meet CMS-0057-F without replacing your core system") instead of raw evidence; primary CTA is *Apply for the Founding Client Program*, with public evidence secondary.
- **Top banner** — repurposed from a repeated benchmark stat into the Founding Client announcement.
- **Problem + Solution** — one tight section pairing the deadline urgency with the low-risk path (a compliance layer alongside the existing core).
- **Founding Client Program** (hero offer) — honest "one client, pre-pilot" framing kept; benefit cards reduced from six to four (zero licensing/your cloud, direct engineering access, roadmap influence, CMS-0057-F pilot path); the 3-step How It Works and the application form + its JavaScript are preserved intact.
- **Who it's for + core value** — the seven-card grid collapsed to four outcome-focused points and moved below the offer.
- **Proof** — condensed to a single Million Claim Challenge section with the strongest numbers and the honest local-Kubernetes disclosure, linking out to the evidence archive and Part 16.
- **Three layers** — kept but compact and secondary, noting most payers start at Layer 1.
- **Bottom CTA** — single dominant action (Founding Client) with a discovery-call fallback.

Removed or relocated: the "Four product lines" portfolio, the platform screenshot, the highlights ticker, the duplicate top stats row, the second "what the evidence says" block, the standalone CMS-0057-F diagram section, and internal positioning language ("Platform Engagement", POSITIONING.md links). Title, meta description, and OG/Twitter tags updated to the pain-led framing.

This follows the same simplification approach recently applied to `/solutions-payers`.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Benchmark/evidence
- [ ] Deployment/operations

## Validation

Static marketing page; no build or test step. Verified `<section>`/`<form>` tag balance, that the Founding Client anchors (`#founding-partner`, `#founding-partner-form`) and the Formspree application form + its submit script are intact, and that no internal-language or removed-asset references remain.

```text
grep -nE 'Platform Engagement|Four product lines|POSITIONING\.md|platform-work-queues|ticker-section|Portfolio' src/site/index.html   # none found
python3 tag-balance check   # section: 10/10, form: 1/1; anchors + form action present
wc -l src/site/index.html   # 1274 -> 1004
```

## Evidence And Limitations

- Yes — this changes homepage messaging. No new claims were introduced and no readiness was inflated; the honest "one Founding Client, pre-pilot" framing is preserved, as is the disclosure that the Million Claim Challenge numbers are local Docker Desktop Kubernetes validation, not a production-cloud capacity claim.
- The 155.89 claims/sec and 1,000,000-claim figures are existing claims carried over from the prior page, now cited once (in the proof section) rather than repeated across the banner, hero, and two proof blocks.
- The three-layer model is presented with the same honest maturity framing (appeals shipped first; full platform is the eventual milestone), not as fully delivered today.

## Security And Privacy

- [x] No PHI, real member data, real claim data, tenant data, or secrets included.
- [x] Logs and screenshots are synthetic or sanitized.
- [x] Security-sensitive behavior is documented.

## Docs

- [x] Docs updated, or not needed.
- [x] Links checked for files changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf73TCPTRMPzjWxxUQP4Qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf73TCPTRMPzjWxxUQP4Qo)_