### PR TITLE
Platform page: reconcile MCC stats and drop internal positioning language

### DIFF
--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -257,34 +257,30 @@
             <div class="stat-label">Local Kubernetes<br>Benchmark</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">129,981/130,000</div>
+            <div class="stat-number">129,980/130,000</div>
             <div class="stat-label">Workflow Checks<br>Matched</div>
           </div>
           <div class="stat-card">
-            <div class="stat-number">20,000</div>
-            <div class="stat-label">Payments Within<br>One Cent</div>
+            <div class="stat-number">19,982/19,982</div>
+            <div class="stat-label">Observed Payments<br>Exact</div>
           </div>
           <div class="stat-card">
             <div class="stat-number">Pilot</div>
-            <div class="stat-label">Current Platform<br>Engagement Stage</div>
+            <div class="stat-label">Current Deployment<br>Stage</div>
           </div>
         </div>
       </section>
 
-      <!-- ===== PRODUCT LINE CONTEXT (W3.2) ===== -->
+      <!-- ===== WHAT'S READY TODAY ===== -->
       <section class="assessment-section">
-        <div class="section-label" style="color:#00ffff; font-size:0.85rem; letter-spacing:2px; text-transform:uppercase; margin-bottom:16px;">Product Line Context</div>
-        <h2>One Platform. Four Product Lines.</h2>
-        <p>The Cloud Health Office (CHO) repository contains the technical building blocks planned for four product lines. Availability differs by product: some capabilities are usable today, while subscription packaging, customer integrations, SLAs, and production validation remain pilot- or roadmap-scoped.</p>
-        <p style="margin-top:16px;"><strong>Public Tools</strong> &mdash; free fee-schedule lookup and free-tier claims repricing &mdash; run on the platform's <code>Pricing API</code> and <code>FeeScheduleEngine</code>. Same code, free tier.</p>
-        <p style="margin-top:12px;"><strong>Transactional Services</strong> &mdash; claims repricing and pricing APIs are implemented in the repository. Self-service API-key provisioning, billing activation, and public production SLAs are still being completed.</p>
-        <p style="margin-top:12px;"><strong>Managed Data Services</strong> &mdash; ingestion, provider-verification, terminology, and fee-schedule components exist in code; subscriber packaging, update cadences, pricing, and SLAs are not yet generally available.</p>
-        <p style="margin-top:12px;"><strong>Platform Engagement</strong> &mdash; pilot-scoped payer deployments follow three intended layers: <strong>Layer 1 &mdash; Compliance Accelerator</strong>, <strong>Layer 2 &mdash; Progressive Modernization</strong>, and <strong>Layer 3 &mdash; Full CAPS Platform</strong>. Layer 3 is the long-term product direction, not evidence of a completed customer cutover.</p>
-        <p style="margin-top:16px; color:#aaa;">The capabilities documented on this page are the substrate. The four product lines are the commercial surfaces. Read the rest of this page as the architecture; read the links below for how it sells.</p>
+        <div class="section-label" style="color:#00ffff; font-size:0.85rem; letter-spacing:2px; text-transform:uppercase; margin-bottom:16px;">What's ready today</div>
+        <h2>What Runs Today &mdash; and What Doesn't Yet.</h2>
+        <p>This page documents the platform's building blocks. Availability differs by capability: some run today, while production integrations, SLAs, and customer validation remain pilot- or roadmap-scoped. We'd rather draw that line clearly than blur it.</p>
+        <p style="margin-top:16px;"><strong>Usable now:</strong> the claims adjudication, pricing, and fee-schedule engines are implemented and inspectable in the repository &mdash; including the free fee-schedule lookup and claims-repricing tools that run on the same code.</p>
+        <p style="margin-top:12px;"><strong>Pilot-scoped:</strong> payer deployments start with a CMS-0057-F compliance layer alongside your existing core, then modernize domain by domain on your timeline. Your system of record stays authoritative until you choose to cut over a domain.</p>
+        <p style="margin-top:12px;"><strong>Roadmap:</strong> subscription packaging, update cadences, and public production SLAs for the data and API services are still being completed.</p>
         <p style="margin-top:20px;">
-          <a href="/pricing" style="color:#00ffff;">See full pricing across all four product lines &rarr;</a>
-          &nbsp;&middot;&nbsp;
-          <a href="https://github.com/aurelianware/cloudhealthoffice/blob/main/docs/POSITIONING.md" target="_blank" rel="noopener noreferrer" style="color:#00ffff;">Canonical positioning (POSITIONING.md) &rarr;</a>
+          <a href="/pricing" style="color:#00ffff;">See pricing &rarr;</a>
         </p>
       </section>
 
@@ -954,8 +950,8 @@
               <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">CLASS LIBRARIES</div>
             </div>
             <div style="text-align: center;">
-              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">20,000</div>
-              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">PAYMENT CHECKS</div>
+              <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #34d399;">19,982</div>
+              <div style="font-size: 0.65rem; color: rgba(255,255,255,0.3); letter-spacing: 0.1em;">PAYMENTS EXACT</div>
             </div>
             <div style="text-align: center;">
               <div style="font-family: 'JetBrains Mono', monospace; font-size: 1.4rem; font-weight: 700; color: #e5e7eb;">1M</div>


### PR DESCRIPTION
## Summary

A light consistency/accuracy pass on `/platform` to align it with the recently simplified `/` and `/solutions-payers` pages — **without cutting its intended technical depth**. By design, `/platform` is now the one-click-away deep dive both front-door pages point to, so the portal tour, the 31-service inventory, the financial-ops walkthrough, and the architecture detail are deliberately preserved.

Two things were off:

1. **Drifted Million Claim Challenge stats.** The top stat grid (and the services summary bar) quoted the earlier synchronous run, not the latest Part 16 / episode-016 async run that the page's own proof strip already cites. Reconciled to the canonical figures in `docs/million-claim-challenge.html`:
   - `129,981/130,000` → **`129,980/130,000`** workflow checks matched
   - `20,000` "payments within one cent" → **`19,982/19,982`** observed payments exact (top grid and summary bar)
   - The core throughput/reliability numbers (155.89 claims/sec, 1M claims, latency, zero dead letters) were already current and are unchanged.

2. **Stale internal positioning language**, inconsistent with the plain-language voice now on `/` and `/solutions-payers`. Replaced the *"One Platform. Four Product Lines."* section (Public Tools / Transactional Services / Managed Data Services / Platform Engagement with Layer 1-2-3, plus the POSITIONING.md link) with a plain-language **"What Runs Today — and What Doesn't Yet"** section that keeps the honest *usable-now / pilot-scoped / roadmap* framing a first-time visitor actually needs. Also relabeled the *"Current Platform Engagement Stage"* stat to *"Current Deployment Stage."*

Honest maturity disclaimers and the demo-data labels are untouched.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Benchmark/evidence
- [ ] Deployment/operations

## Validation

Static marketing page; no build or test step. Verified `<section>` tag balance (11/11), that the reconciled figures now match the proof strip and `docs/million-claim-challenge.html`, and that no internal-positioning markers (Product Line / Four Product Lines / Platform Engagement / Layer 1-2-3 / POSITIONING) remain.

```text
grep -nE 'Product Line|Four Product Lines|Platform Engagement|Layer [123] &mdash;|POSITIONING' src/site/platform.html   # none
grep -nE '129,98[0-9]|19,982' src/site/platform.html   # 129,980/130,000; 19,982/19,982; 19,982
```

## Evidence And Limitations

- Yes — this changes website messaging on `/platform`, but it makes the page *more* accurate: the two reconciled figures now match the latest Part 16 / episode-016 run already documented on the page's proof strip and in `docs/million-claim-challenge.html`, rather than an earlier run.
- No new claims were introduced and no readiness was inflated. The honest "usable now / pilot-scoped / roadmap" framing and the local-Kubernetes validation disclosures are preserved.
- Throughput and reliability numbers were already current; no benchmark figures were changed upward.

## Security And Privacy

- [x] No PHI, real member data, real claim data, tenant data, or secrets included.
- [x] Logs and screenshots are synthetic or sanitized.
- [x] Security-sensitive behavior is documented.

## Docs

- [x] Docs updated, or not needed.
- [x] Links checked for files changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf73TCPTRMPzjWxxUQP4Qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sf73TCPTRMPzjWxxUQP4Qo)_