### PR TITLE
Rename Enhanced Claim Status (ECS) to Claim Status on website

### DIFF
--- a/src/site/assessment.html
+++ b/src/site/assessment.html
@@ -194,7 +194,7 @@
 <li>99.9% uptime SLA target</li>
 <li>Automated retry with exponential backoff</li>
 </ul>
-<h4>4. Enhanced Claim Status (ECS)</h4>
+<h4>4. Claim Status</h4>
 <p><strong>X215 Authorization Inquiry:</strong></p>
 <ul>
 <li>Real-time authorization status</li>
@@ -468,7 +468,7 @@ cd generated/your-payer/infrastructure &amp;&amp; ./deploy.sh
 <ul>
 <li><input disabled="" type="checkbox"> Additional payer tenant onboarding</li>
 <li><input disabled="" type="checkbox"> Performance optimization</li>
-<li><input disabled="" type="checkbox"> Advanced features activation (ECS, Appeals)</li>
+<li><input disabled="" type="checkbox"> Advanced features activation (Claim Status, Appeals)</li>
 <li><input disabled="" type="checkbox"> Cost optimization</li>
 </ul>
 <p><strong>Timeline:</strong> 6 weeks from decision to multi-payer production deployment</p>

--- a/src/site/assets/cho-assessment.md
+++ b/src/site/assets/cho-assessment.md
@@ -102,7 +102,7 @@ Cloud Health Office deploys HIPAA-oriented EDI infrastructure through a focused,
 - 99.9% uptime SLA
 - Automated retry with exponential backoff
 
-#### 4. Enhanced Claim Status (ECS)
+#### 4. Claim Status
 
 **X215 Authorization Inquiry:**
 - Real-time authorization status
@@ -368,7 +368,7 @@ cd generated/your-payer/infrastructure && ./deploy.sh
 
 - [ ] Additional payer tenant onboarding
 - [ ] Performance optimization
-- [ ] Advanced features activation (ECS, Appeals)
+- [ ] Advanced features activation (Claim Status, Appeals)
 - [ ] Cost optimization
 
 **Timeline:** 6 weeks from decision to multi-payer production deployment

--- a/src/site/platform.html
+++ b/src/site/platform.html
@@ -383,7 +383,7 @@
           </div>
 
           <div class="capability-card">
-            <h3>Enhanced Claim Status (ECS)</h3>
+            <h3>Claim Status</h3>
             <ul>
               <li>276 claim-status inquiry</li>
               <li>277 claim-status response</li>


### PR DESCRIPTION
Drop the Availity product name from the customer-facing site. The
capability heading on platform.html, the assessment page/asset feature
section, and the advanced-features activation lists now read 'Claim
Status' instead of 'Enhanced Claim Status (ECS)'.

Scope: website UI only. Backend identifiers, schemas, config module
keys, API paths, and infrastructure module names are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y783UMfcFx9XjFairZcc9h