### PR TITLE
Add claim audit event timeline

### DIFF
--- a/src/portal/CloudHealthOffice.Portal.Tests/FakeHandler.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/FakeHandler.cs
@@ -24,10 +24,13 @@ public class FakeHandler : HttpMessageHandler
     }
 
     public FakeHandler(HttpStatusCode statusCode, string responseBody)
-        : this(_ =>
+        : this(request =>
         {
             var response = new HttpResponseMessage(statusCode);
-            response.Content = new StringContent(responseBody, Encoding.UTF8, "application/json");
+            var body = request.RequestUri?.AbsolutePath.EndsWith("/audit-timeline", StringComparison.Ordinal) == true
+                ? "[]"
+                : responseBody;
+            response.Content = new StringContent(body, Encoding.UTF8, "application/json");
             return response;
         })
     {

--- a/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
+++ b/src/portal/CloudHealthOffice.Portal.Tests/Services/ClaimsServiceTests.cs
@@ -261,6 +261,29 @@ public class ClaimsServiceTests
     }
 
     [Fact]
+    public async Task GetClaimByIdAsync_LoadsAuditTimelineForClaimDetails()
+    {
+        var handler = new FakeHandler(request =>
+        {
+            var isTimeline = request.RequestUri!.AbsolutePath.EndsWith("/audit-timeline", StringComparison.Ordinal);
+            var json = isTimeline
+                ? """[{"timestamp":"2026-03-02T10:00:00Z","action":"Claim submitted","changedBy":"837-ingress","newValue":"Submitted"}]"""
+                : """{"id":"claim-100","claimNumber":"CLM-100","status":"Submitted"}""";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+        var sut = CreateService(new HttpClient(handler));
+
+        var result = await sut.GetClaimByIdAsync("claim-100");
+
+        result!.AuditTrail.Should().ContainSingle()
+            .Which.ChangedBy.Should().Be("837-ingress");
+        handler.CapturedUrls.Should().Contain(url => url.EndsWith("/claims/claim-100/audit-timeline"));
+    }
+
+    [Fact]
     public async Task GetClaimByIdAsync_WhenApiReturnsMassAdjudicationClaimShape_DeserializesSafely()
     {
         const string json = """

--- a/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
+++ b/src/portal/CloudHealthOffice.Portal/Services/ServiceImplementations.cs
@@ -47,13 +47,19 @@ public class ClaimsService : IClaimsService
             // Try by ID first, then fall back to claim number lookup
             var response = await _httpClient.GetAsync($"{baseUrl}/claims/{claimId}");
             if (response.IsSuccessStatusCode)
-                return await response.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
+            {
+                var claim = await response.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
+                return await AddAuditTrailAsync(baseUrl, claim);
+            }
 
             if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
                 var fallback = await _httpClient.GetAsync($"{baseUrl}/claims/number/{claimId}");
                 if (fallback.IsSuccessStatusCode)
-                    return await fallback.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
+                {
+                    var claim = await fallback.Content.ReadFromJsonAsync<ClaimDetails>(JsonOptions);
+                    return await AddAuditTrailAsync(baseUrl, claim);
+                }
                 if (fallback.StatusCode == System.Net.HttpStatusCode.NotFound)
                     return null;
                 fallback.EnsureSuccessStatusCode();
@@ -67,6 +73,20 @@ public class ClaimsService : IClaimsService
             _logger.LogError(ex, "Service unavailable: {ServiceName}", "Claims Service");
             throw new ServiceUnavailableException("Claims Service", ex);
         }
+    }
+
+    private async Task<ClaimDetails?> AddAuditTrailAsync(string? baseUrl, ClaimDetails? claim)
+    {
+        if (claim is null || string.IsNullOrWhiteSpace(claim.ClaimId)) return claim;
+
+        var response = await _httpClient.GetAsync(
+            $"{baseUrl}/claims/{Uri.EscapeDataString(claim.ClaimId)}/audit-timeline");
+        if (response.StatusCode == HttpStatusCode.NotFound) return claim;
+
+        response.EnsureSuccessStatusCode();
+        var timeline = await response.Content.ReadFromJsonAsync<List<ClaimAudit>>(JsonOptions);
+        if (timeline is { Count: > 0 }) claim.AuditTrail = timeline;
+        return claim;
     }
 
     public async Task<string?> GetExplanationOfBenefitJsonAsync(string claimId)

--- a/src/services/claims-service/Controllers/ClaimsController.cs
+++ b/src/services/claims-service/Controllers/ClaimsController.cs
@@ -18,6 +18,8 @@ public class ClaimsController : ControllerBase
     private readonly IClaimAcknowledgmentService _ackService;
     private readonly IMpipAdjudicationEnhancer _mpipEnhancer;
     private readonly IClaimEventPublisher _eventPublisher;
+    private readonly IClaimVersionEventPublisher _versionEventPublisher;
+    private readonly IClaimVersionEventReader _versionEventReader;
     private readonly IClaimSubmissionService _submissionService;
     private readonly IClaimFinalizationService _finalizationService;
     private readonly IClaimDiagnosisMetadataEnricher _diagnosisMetadataEnricher;
@@ -31,6 +33,8 @@ public class ClaimsController : ControllerBase
         IClaimAcknowledgmentService ackService,
         IMpipAdjudicationEnhancer mpipEnhancer,
         IClaimEventPublisher eventPublisher,
+        IClaimVersionEventPublisher versionEventPublisher,
+        IClaimVersionEventReader versionEventReader,
         IClaimSubmissionService submissionService,
         IClaimFinalizationService finalizationService,
         IClaimDiagnosisMetadataEnricher diagnosisMetadataEnricher,
@@ -43,6 +47,8 @@ public class ClaimsController : ControllerBase
         _ackService = ackService;
         _mpipEnhancer = mpipEnhancer;
         _eventPublisher = eventPublisher;
+        _versionEventPublisher = versionEventPublisher;
+        _versionEventReader = versionEventReader;
         _submissionService = submissionService;
         _finalizationService = finalizationService;
         _diagnosisMetadataEnricher = diagnosisMetadataEnricher;
@@ -210,6 +216,85 @@ public class ClaimsController : ControllerBase
 
         await _diagnosisMetadataEnricher.EnrichAsync(claim);
         return Ok(claim);
+    }
+
+    /// <summary>
+    /// Returns the tenant-scoped, chronological audit history for a claim.
+    /// The read model combines the append-only version stream with the
+    /// structured pend snapshot, which is intentionally not a version event.
+    /// </summary>
+    [HttpGet("{id}/audit-timeline")]
+    [ProducesResponseType(typeof(IReadOnlyList<ClaimAuditTimelineEntry>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IReadOnlyList<ClaimAuditTimelineEntry>>> GetAuditTimeline(
+        string id,
+        CancellationToken ct)
+    {
+        var claim = await _claimRepository.GetByIdAsync(id);
+        if (claim == null) return NotFound($"Claim {id} not found");
+
+        var events = string.IsNullOrWhiteSpace(claim.ClaimVersionId)
+            ? Array.Empty<ClaimVersionEvent>()
+            : await _versionEventReader.GetAsync(GetTenantId(), claim.ClaimVersionId, ct);
+
+        var timeline = events.Select(MapAuditEvent).ToList();
+        if (claim.PendDetails is not null)
+        {
+            timeline.Add(new ClaimAuditTimelineEntry
+            {
+                Timestamp = claim.PendDetails.PendedAt,
+                Action = "Claim pended for review",
+                ChangedBy = "adjudication-engine",
+                OldValue = "Submitted",
+                NewValue = "Pended",
+                Notes = string.IsNullOrWhiteSpace(claim.PendDetails.PendReason)
+                    ? claim.PendDetails.PendCode
+                    : $"{claim.PendDetails.PendCode}: {claim.PendDetails.PendReason}"
+            });
+
+            foreach (var entry in timeline.Where(entry =>
+                         (entry.EventType == ClaimVersionEventType.ClaimVersionAdjudicated.ToString()
+                          || entry.EventType == ClaimVersionEventType.ClaimVersionDenied.ToString())
+                         && entry.Timestamp >= claim.PendDetails.PendedAt))
+            {
+                entry.OldValue = "Pended";
+            }
+        }
+
+        return Ok(timeline.OrderBy(entry => entry.Timestamp).ToList());
+    }
+
+    private static ClaimAuditTimelineEntry MapAuditEvent(ClaimVersionEvent evt)
+    {
+        var (action, oldValue, newValue) = evt.EventType switch
+        {
+            ClaimVersionEventType.ClaimVersionSubmitted => ("Claim submitted", (string?)null, "Submitted"),
+            ClaimVersionEventType.ClaimVersionAdjudicated => ("Claim adjudicated", "Submitted", "Approved"),
+            ClaimVersionEventType.ClaimVersionPaid => ("Payment recorded", "Approved", "Paid"),
+            ClaimVersionEventType.ClaimVersionDenied => ("Claim denied", "Submitted", "Denied"),
+            ClaimVersionEventType.ClaimVersionSuperseded => ("Claim version superseded", (string?)null, "Superseded"),
+            ClaimVersionEventType.ClaimVersionVoided => ("Claim voided", (string?)null, "Voided"),
+            ClaimVersionEventType.ClaimVersionReversed => ("Claim reversed", (string?)null, "Reversed"),
+            _ => (evt.EventType.ToString(), (string?)null, (string?)null)
+        };
+
+        var reason = evt.Payload?["reason"]?.ToString()
+            ?? evt.Payload?["adjustmentReason"]?.ToString()
+            ?? evt.Payload?["denialReasonCode"]?.ToString()
+            ?? evt.Payload?["notes"]?.ToString();
+
+        return new ClaimAuditTimelineEntry
+        {
+            Timestamp = evt.OccurredAt,
+            Action = action,
+            ChangedBy = string.IsNullOrWhiteSpace(evt.ActorId) ? "system" : evt.ActorId,
+            OldValue = oldValue,
+            NewValue = newValue,
+            Notes = reason,
+            EventType = evt.EventType.ToString(),
+            Version = evt.Version,
+            CorrelationId = evt.CorrelationId
+        };
     }
 
     /// <summary>
@@ -1315,6 +1400,19 @@ public class ClaimsController : ControllerBase
 
         var updated = await _claimRepository.UpdateAsync(claim);
 
+        var examinerUserId = request.ExaminerUserId ?? "portal-examiner";
+        var correlationId = Activity.Current?.TraceId.ToString() ?? HttpContext.TraceIdentifier;
+        if (disposition == ClaimStatus.Denied)
+        {
+            await _versionEventPublisher.PublishVersionDeniedAsync(
+                updated, request.Reason, examinerUserId, correlationId, HttpContext.RequestAborted);
+        }
+        else
+        {
+            await _versionEventPublisher.PublishVersionAdjudicatedAsync(
+                updated, examinerUserId, correlationId, HttpContext.RequestAborted);
+        }
+
         if (claim.AiExamination is not null && !string.IsNullOrWhiteSpace(request.AiExaminerAgreement))
         {
             var auditUpdated = await _auditRepository.SetExaminerAgreementAsync(
@@ -1430,6 +1528,19 @@ public class ResolvePendedClaimRequest
     public string? Reason { get; set; }
     public string? AiExaminerAgreement { get; set; }
     public string? ExaminerUserId { get; set; }
+}
+
+public class ClaimAuditTimelineEntry
+{
+    public DateTime Timestamp { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public string ChangedBy { get; set; } = string.Empty;
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+    public string? Notes { get; set; }
+    public string? EventType { get; set; }
+    public int? Version { get; set; }
+    public string? CorrelationId { get; set; }
 }
 
 /// <summary>

--- a/src/services/claims-service/Program.cs
+++ b/src/services/claims-service/Program.cs
@@ -46,6 +46,7 @@ if (!string.IsNullOrEmpty(mongoConnectionString))
     // system-of-record for the version chain. Mirrors
     // MongoProviderVersionEventPublisher / MongoPlanVersionEventPublisher.
     builder.Services.AddScoped<IClaimVersionEventPublisher, MongoClaimVersionEventPublisher>();
+    builder.Services.AddScoped<IClaimVersionEventReader, MongoClaimVersionEventReader>();
     builder.Services.AddHostedService<ClaimVersionEventIndexInitializer>();
 
     // 5.12a — ClaimAdjustment aggregate persistence (Mongo per Gap 4
@@ -90,6 +91,7 @@ else
     // Noop publisher logs a warning so ops can spot the missing wiring
     // without breaking the lifecycle path.
     builder.Services.AddScoped<IClaimVersionEventPublisher, NoopClaimVersionEventPublisher>();
+    builder.Services.AddScoped<IClaimVersionEventReader, NoopClaimVersionEventReader>();
 
     // 5.12a — Cosmos-only deployments throw on adjustment writes per
     // Gap 4 ratification. Reads return null/empty; the noop is fail-loud

--- a/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
+++ b/src/services/claims-service/Services/ClaimVersionEventPublisher.cs
@@ -50,6 +50,45 @@ public interface IClaimVersionEventPublisher
         CancellationToken ct = default);
 }
 
+/// <summary>Reads the append-only version stream for a single tenant-owned claim chain.</summary>
+public interface IClaimVersionEventReader
+{
+    Task<IReadOnlyList<ClaimVersionEvent>> GetAsync(
+        string tenantId,
+        string claimVersionId,
+        CancellationToken ct = default);
+}
+
+public sealed class MongoClaimVersionEventReader : IClaimVersionEventReader
+{
+    private readonly IMongoCollection<ClaimVersionEvent> _collection;
+
+    public MongoClaimVersionEventReader(IMongoDatabase database, IConfiguration configuration)
+    {
+        var collectionName = configuration["CosmosDb:ClaimVersionEventsContainer"] ?? "ClaimVersionEvents";
+        _collection = database.GetCollection<ClaimVersionEvent>(collectionName);
+    }
+
+    public async Task<IReadOnlyList<ClaimVersionEvent>> GetAsync(
+        string tenantId,
+        string claimVersionId,
+        CancellationToken ct = default) =>
+        await _collection
+            .Find(evt => evt.TenantId == tenantId && evt.ClaimVersionId == claimVersionId)
+            .SortBy(evt => evt.Version)
+            .ThenBy(evt => evt.OccurredAt)
+            .ToListAsync(ct);
+}
+
+public sealed class NoopClaimVersionEventReader : IClaimVersionEventReader
+{
+    public Task<IReadOnlyList<ClaimVersionEvent>> GetAsync(
+        string tenantId,
+        string claimVersionId,
+        CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<ClaimVersionEvent>>(Array.Empty<ClaimVersionEvent>());
+}
+
 public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublisher
 {
     private const int MaxRetries = 5;
@@ -101,7 +140,8 @@ public sealed class MongoClaimVersionEventPublisher : IClaimVersionEventPublishe
             ["adjudicatedDate"] = version.AdjudicatedDate,
             ["allowedAmount"] = version.AdjudicationResult?.AllowedAmount,
             ["payerPayment"] = version.AdjudicationResult?.PayerPayment,
-            ["patientResponsibility"] = version.AdjudicationResult?.PatientResponsibility
+            ["patientResponsibility"] = version.AdjudicationResult?.PatientResponsibility,
+            ["notes"] = version.ClaimNotes
         };
 
         var evt = new ClaimVersionEvent

--- a/src/site/docs/review-resolve-pended-claim.html
+++ b/src/site/docs/review-resolve-pended-claim.html
@@ -246,6 +246,7 @@
           </tbody>
         </table>
         <p>After resolution, refresh the queue and claim detail. The item should leave the active queue, while the claim retains its original <code>PendDetails</code>, examiner notes, adjudicated timestamp, and any advisory record for audit.</p>
+        <p>Open <strong>Change History</strong> to verify the chronological record. It combines the append-only claim-version stream with the structured pend snapshot, showing submission, the human-review gate, and the examiner's final approved or denied decision. The final entry identifies the examiner and retains the decision reason; normal adjudication entries continue to identify the system actor.</p>
         <figure class="guide-screenshot">
           <img src="/graphics/user-guides/pended-claim/examiner-disposition.png" alt="Resolved synthetic claim showing its final examiner disposition, original pend reason, examiner notes, pend code, and retained AI feedback." loading="lazy" />
           <figcaption>The resolved view keeps the human decision beside the original exception context, even after the claim leaves the active work queue.</figcaption>

--- a/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/ClaimsApiFactory.cs
@@ -23,6 +23,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
     public IClaimSubmissionService SubmissionService { get; } = Substitute.For<IClaimSubmissionService>();
     public IClaimAdapter ClaimAdapter { get; } = CreateChoStubAdapter();
     public IClaimVersionEventPublisher VersionEventPublisher { get; } = Substitute.For<IClaimVersionEventPublisher>();
+    public IClaimVersionEventReader VersionEventReader { get; } = Substitute.For<IClaimVersionEventReader>();
     public IClaimFinalizationService FinalizationService { get; } = Substitute.For<IClaimFinalizationService>();
     public IClaimAdjustmentRepository AdjustmentRepository { get; } = Substitute.For<IClaimAdjustmentRepository>();
     public IClaimAdjustmentService AdjustmentService { get; } = Substitute.For<IClaimAdjustmentService>();
@@ -61,6 +62,7 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
                          || d.ServiceType == typeof(IClaimAdjustmentService)
                          || d.ServiceType == typeof(IClaimAdjustmentRepository)
                          || d.ServiceType == typeof(IClaimImportTransactionRepository)
+                         || d.ServiceType == typeof(IClaimVersionEventReader)
                          || d.ServiceType == typeof(IClaimAdapter)
                          || d.ServiceType == typeof(ClaimAdapterFactory)
                          || d.ServiceType == typeof(ClaimTenantConfigCache))
@@ -125,6 +127,10 @@ public class ClaimsApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(Substitute.For<ITenantComplianceConfigService>());
             services.AddSingleton(AuditRepository);
             services.AddSingleton(VersionEventPublisher);
+            services.AddSingleton(VersionEventReader);
+            VersionEventReader
+                .GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Array.Empty<ClaimVersionEvent>());
             services.AddSingleton(FinalizationService);
             services.AddSingleton(AdjustmentRepository);
             services.AddSingleton(AdjustmentService);

--- a/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
+++ b/tests/CloudHealthOffice.ClaimsService.Tests/Controllers/WorkQueueVisibilityTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using ClaimsService.Models;
 using ClaimsService.Repositories;
+using ClaimsService.Services;
 using NSubstitute;
 using Xunit;
 
@@ -23,13 +24,21 @@ public class WorkQueueVisibilityTests : IClassFixture<ClaimsApiFactory>
 
     private readonly HttpClient _client;
     private readonly IClaimRepository _repo;
+    private readonly IClaimVersionEventPublisher _versionPublisher;
+    private readonly IClaimVersionEventReader _versionReader;
 
     public WorkQueueVisibilityTests(ClaimsApiFactory factory)
     {
         _repo = factory.ClaimRepository;
+        _versionPublisher = factory.VersionEventPublisher;
+        _versionReader = factory.VersionEventReader;
         _client = factory.CreateClient();
         _client.DefaultRequestHeaders.Add("X-Tenant-ID", "test-tenant");
         _repo.ClearReceivedCalls();
+        _versionPublisher.ClearReceivedCalls();
+        _versionReader.ClearReceivedCalls();
+        _versionReader.GetAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ClaimVersionEvent>());
     }
 
     private static Claim NcciPendedClaim() => new()
@@ -174,6 +183,45 @@ public class WorkQueueVisibilityTests : IClassFixture<ClaimsApiFactory>
             && saved.VersionState == ClaimVersionState.Adjudicated
             && saved.AiExamination!.ExaminerAgreement == "Overridden"
             && saved.AiExamination.ExaminerUserId == "examiner-1"));
+        await _versionPublisher.Received(1).PublishVersionAdjudicatedAsync(
+            Arg.Is<Claim>(saved => saved.Id == claim.Id),
+            "examiner-1",
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AuditTimeline_CombinesVersionEventsWithStructuredPend_InChronologicalOrder()
+    {
+        var claim = NcciPendedClaim();
+        claim.ClaimVersionId = "chain-1";
+        _repo.GetByIdAsync(claim.Id).Returns(claim);
+        _versionReader.GetAsync("test-tenant", "chain-1", Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new ClaimVersionEvent
+                {
+                    EventType = ClaimVersionEventType.ClaimVersionSubmitted,
+                    OccurredAt = claim.PendDetails!.PendedAt.AddMinutes(-1),
+                    ActorId = "837-ingress",
+                    Version = 1
+                }
+            });
+
+        var response = await _client.GetAsync($"/api/claims/{claim.Id}/audit-timeline");
+        response.EnsureSuccessStatusCode();
+
+        var timeline = await response.Content.ReadFromJsonAsync<List<AuditEntryDto>>(Json);
+        Assert.Collection(timeline!,
+            submitted => Assert.Equal("Claim submitted", submitted.Action),
+            pended =>
+            {
+                Assert.Equal("Claim pended for review", pended.Action);
+                Assert.Equal("Pended", pended.NewValue);
+                Assert.Contains("NCCI", pended.Notes);
+            });
+        await _versionReader.Received(1).GetAsync(
+            "test-tenant", "chain-1", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -206,5 +254,12 @@ public class WorkQueueVisibilityTests : IClassFixture<ClaimsApiFactory>
         public string QueueReason { get; set; } = string.Empty;
         public string QueueReasonCode { get; set; } = string.Empty;
         public List<string> ProcedureCodes { get; set; } = new();
+    }
+
+    private sealed class AuditEntryDto
+    {
+        public string Action { get; set; } = string.Empty;
+        public string? NewValue { get; set; }
+        public string? Notes { get; set; }
     }
 }


### PR DESCRIPTION
## What changed

- add a tenant-scoped claim audit timeline endpoint backed by the append-only Mongo claim-version stream
- combine version events with structured pend details for a chronological Submitted → Pended → Approved/Denied history
- publish examiner adjudication or denial events when pended claims are resolved
- hydrate the portal Change History from the claims API
- update the pended-claim evaluator guide and add focused API and portal coverage

## Why

The portal already rendered a Change History panel, but the claims API did not project the claim-version stream into that model. Human pend resolutions also bypassed the version-event publisher, leaving the examiner decision absent from the durable history.

## Impact

Evaluators and operators can now see the actual claim lifecycle, including the human-review gate, examiner identity, decision reason, event version, and correlation identifier. Cosmos-only deployments retain an empty timeline through the explicit no-op reader until that event store is provisioned.

## Validation

- claims-service and portal builds succeeded
- 13 focused claims-service tests passed
- 10 focused portal claim-detail tests passed
- site accessibility validation completed successfully (existing advisory findings remain)
- git diff --check passed